### PR TITLE
Make SVN's purgeAndUpdate not list missing files

### DIFF
--- a/slave/buildslave/commands/svn.py
+++ b/slave/buildslave/commands/svn.py
@@ -99,11 +99,13 @@ class SVN(SourceBaseCommand):
             (wc_status,) = entry.getElementsByTagName('wc-status')
             if wc_status.getAttribute('item') == 'external':
                 continue
+            if wc_status.getAttribute('item') == 'missing':
+                continue
             filename = entry.getAttribute('path')
             if filename in keep_on_purge:
                 continue
             yield filename
-            
+
     def _purgeAndUpdate2(self, res):
         for filename in self.getUnversionedFiles(self.command.stdout, self.keep_on_purge):
             filepath = os.path.join(self.builder.basedir, self.workdir,

--- a/slave/buildslave/test/unit/test_commands_svn.py
+++ b/slave/buildslave/test/unit/test_commands_svn.py
@@ -57,7 +57,7 @@ class TestSVN(SourceCommandTestMixin, unittest.TestCase):
 
 
 class TestGetUnversionedFiles(unittest.TestCase):
-    def test_getUnversionedFIles_does_not_list_externals(self):
+    def test_getUnversionedFiles_does_not_list_externals(self):
         svn_st_xml = """<?xml version="1.0"?>
         <status>
             <target path=".">
@@ -74,4 +74,17 @@ class TestGetUnversionedFiles(unittest.TestCase):
         """
         unversioned_files = list(svn.SVN.getUnversionedFiles(svn_st_xml, []))
         self.assertEquals(["svn_external_path/unversioned_file"], unversioned_files)
-        
+
+    def test_getUnversionedFiles_does_not_list_missing(self):
+        svn_st_xml = """<?xml version="1.0"?>
+        <status>
+            <target path=".">
+                <entry path="missing_file">
+                    <wc-status props="none" item="missing"></wc-status>
+                </entry>
+            </target>
+        </status>
+        """
+        unversioned_files = list(svn.SVN.getUnversionedFiles(svn_st_xml, []))
+        self.assertEquals([], unversioned_files)
+


### PR DESCRIPTION
This is a single commit to make SVN's purgeAndUpdate not list missing files (because it can't delete them, and will traceback). It's very similar to changeset 780a6bc0e.
