### PR TITLE
Added optional progress and reference options for Git

### DIFF
--- a/master/buildbot/steps/source.py
+++ b/master/buildbot/steps/source.py
@@ -766,6 +766,7 @@ class Git(Source):
                  branch="master",
                  submodules=False,
                  ignore_ignores=None,
+                 reference=None,
                  shallow=False,
                  progress=False,
                  **kwargs):
@@ -782,6 +783,10 @@ class Git(Source):
         @param submodules: Whether or not to update (and initialize)
                        git submodules.
 
+        @type  reference: string
+        @param reference: The path to a reference repository to obtain
+                          objects from, if any.
+
         @type  shallow: boolean
         @param shallow: Use a shallow or clone, if possible
 
@@ -796,12 +801,14 @@ class Git(Source):
                                  branch=branch,
                                  submodules=submodules,
                                  ignore_ignores=ignore_ignores,
+                                 reference=reference,
                                  shallow=shallow,
                                  progress=progress,
                                  )
         self.args.update({'branch': branch,
                           'submodules': submodules,
                           'ignore_ignores': ignore_ignores,
+                          'reference': reference,
                           'shallow': shallow,
                           'progress': progress,
                           })

--- a/master/docs/cfg-buildsteps.texinfo
+++ b/master/docs/cfg-buildsteps.texinfo
@@ -867,6 +867,11 @@ branch will be used.
 (optional): when initializing/updating a Git repository, this decides whether
 or not buildbot should consider git submodules.  Default: False.
 
+@item reference
+(optional): use the specified string as a path to a reference repository on the
+local machine. Git will try to grab objects from this path first instead of the
+main repository, if they exist.
+
 @item shallow
 (optional): instructs git to attempt shallow clones (@code{--depth 1}).  If the
 user/scheduler asks for a specific revision, this parameter is ignored.


### PR DESCRIPTION
progress option: As discussed in IRC; requires Git 1.7.2 but helps prevent long fetches from being killed.
reference option: See git-clone man entry for '--reference'.
