### PR TITLE
Start buildslave as windows service

### DIFF
--- a/master/contrib/windows/buildbot_service.py
+++ b/master/contrib/windows/buildbot_service.py
@@ -66,7 +66,6 @@
 import sys
 import os
 import threading
-import re
 
 import pywintypes
 import winerror
@@ -525,10 +524,9 @@ def DetermineRunner(bbdir):
       tacfile = os.path.join(bbdir, 'buildbot.tac')
 
       if os.path.exists(tacfile):
-         rexp = re.compile("BuildSlave")
          with open(tacfile, 'r') as f:
             contents = f.read()
-            if rexp.search(contents):
+            if 'import BuildSlave' in contents:
                return buildslave.scripts.runner.run
 
    except ImportError:


### PR DESCRIPTION
The file buildbot_service.py indicates that it is able to start both a build master and a build slave as a windows service.
This patch fulfills that promise.
