### PR TITLE
Deduce buildbot's version from GIT.

### DIFF
--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -1,1 +1,29 @@
+# strategy:
+#
+# if there is a VERSION file, use its contents. otherwise, call git to
+# get a version string. if that also fails, use 'latest'.
+#
+import os
+
 version = "latest"
+
+try:
+    fn = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'VERSION')
+    version = open(fn).read().strip()
+
+except IOError:
+    from subprocess import Popen, PIPE
+    import re
+
+    VERSION_MATCH = re.compile(r'\d+\.\d+\.\d+(\w|-)*')
+
+    try:
+        p = Popen(['git', 'describe', '--tags', '--always', '--dirty'], stdout=PIPE)
+        out = p.communicate()[0]
+
+        if (not p.returncode) and out:
+            v = VERSION_MATCH.search(out)
+            if v:
+                version = v.group()
+    except OSError:
+        pass

--- a/master/setup.py
+++ b/master/setup.py
@@ -19,6 +19,7 @@ from distutils.core import setup, Command
 from buildbot import version
 
 from distutils.command.install_data import install_data
+from distutils.command.sdist import sdist
 
 def include(d, e):
     """Generate a pair of (directory, file-list) for installation.
@@ -142,6 +143,19 @@ class install_data_twisted(install_data):
         )
         install_data.finalize_options(self)
 
+    def run(self):
+        install_data.run(self)
+        # ensure there's a buildbot/VERSION file
+        open(os.path.join(self.install_dir, 'buildbot', 'VERSION'), 'w').write(version)
+
+class our_sdist(sdist):
+
+    def make_release_tree(self, base_dir, files):
+        sdist.make_release_tree(self, base_dir, files)
+        # ensure there's a buildbot/VERSION file
+        open(os.path.join(base_dir, 'buildbot', 'VERSION'), 'w').write(version)
+
+
 long_description="""
 The BuildBot is a system to automate the compile/test cycle required by
 most software projects to validate code changes. By automatically
@@ -221,7 +235,8 @@ setup_args = {
     'scripts': scripts,
     'cmdclass': {'install_data': install_data_twisted,
                  'test': TestCommand,
-                 'sdist_test': SdistTestCommand},
+                 'sdist_test': SdistTestCommand,
+                 'sdist': our_sdist},
     }
 
 # set zip_safe to false to force Windows installs to always unpack eggs


### PR DESCRIPTION
With this patch, buildbot gets its version from GIT. A VERSION file is written and installed resp. put into the created archives for setup.py sdist or bdist.

Tags are expected have the format X.Y.Z. A prefix like 'v' or 'buildbot-' is stripped, while postfixes (like 'rc3') and also are retained.
