### PR TITLE
Change hook

### DIFF
--- a/master/buildbot/status/web/change_hook.py
+++ b/master/buildbot/status/web/change_hook.py
@@ -20,6 +20,12 @@ class ChangeHookResource(resource.Resource):
     contentType = "text/html; charset=utf-8"
     children    = {}
     def __init__(self, dialects={}):
+        """ 
+        The keys of 'dialects' select a modules to load under 
+        master/buildbot/status/web/hooks/
+        The value is passed to the module's getChanges function, providing
+        configuration options to the dialect.
+        """
         self.dialects = dialects
     
     def getChild(self, name, request):
@@ -42,7 +48,12 @@ class ChangeHookResource(resource.Resource):
                 the http request object
         """
 
-        changes = self.getChanges( request )
+        try:
+            changes = self.getChanges( request )
+        except ValueError as err:
+            request.setResponseCode(400, err.args[0])
+            return err.args[0]
+
         msg("Payload: " + str(request.args))
         
         if not changes:
@@ -69,7 +80,7 @@ class ChangeHookResource(resource.Resource):
         
         if not uriRE:
             msg("URI doesn't match change_hook regex: %s" % request.uri)
-            return
+            raise ValueError("URI doesn't match change_hook regex: %s" % request.uri)
         
         changes = []
         
@@ -86,10 +97,12 @@ class ChangeHookResource(resource.Resource):
             msg("Got the following changes %s" % changes)
 
         else:
-            msg("The dialect specified %s wasn't whitelisted in change_hook" % dialect)
+            m = "The dialect specified, '%s', wasn't whitelisted in change_hook" % dialect
+            msg(m)
             msg("Note: if dialect is 'base' then it's possible your URL is malformed and we didn't regex it properly")
+            raise ValueError(m)
 
-        return changes        
+        return changes
                 
     def submitChanges(self, changes, request):
         # get a control object

--- a/master/buildbot/status/web/hooks/github.py
+++ b/master/buildbot/status/web/hooks/github.py
@@ -120,9 +120,12 @@ def process_change(payload, user, repo, repo_url):
         else: 
             for commit in payload['commits']:
                 files = []
-                files.extend(commit['added'])
-                files.extend(commit['modified'])
-                files.extend(commit['removed'])
+                if 'added' in commit.keys():
+                    files.extend(commit['added'])
+                if 'modified' in commit.keys():
+                    files.extend(commit['modified'])
+                if 'removed' in commit.keys():
+                    files.extend(commit['removed'])
                 when =  convertTime( commit['timestamp'])
                 change = {'revision': commit['id'],
                      'revlink': commit['url'],

--- a/master/buildbot/test/unit/test_status_web_change_hook.py
+++ b/master/buildbot/test/unit/test_status_web_change_hook.py
@@ -1,0 +1,228 @@
+#import buildbot.status.web.base as wb
+import buildbot.status.web.change_hook as ch
+from buildbot.util import json
+#import re
+from mock import Mock
+
+from twisted.trial import unittest
+
+class TestChangeHookUnconfigured(unittest.TestCase):
+    def setUp(self):
+        self.request = Mock()
+        self.changeHook = ch.ChangeHookResource()
+
+    # A bad URI should cause an exception inside check_hook. 
+    # After writing the test, it became apparent this can't happen. 
+    # I'll leave the test anyway
+    def testDialectReMatchFail(self):
+        self.request.uri = "/garbage/garbage"
+        ret = self.changeHook.render_GET(self.request)
+        expected = "URI doesn't match change_hook regex: /garbage/garbage"
+        self.assertEquals(ret, expected)
+        self.request.mockCheckCall(self, 0, "setResponseCode", 400, expected)
+
+    def testUnkownDialect(self):
+        self.request.uri = "/change_hook/garbage"
+        ret = self.changeHook.render_GET(self.request)
+        expected = "The dialect specified, 'garbage', wasn't whitelisted in change_hook"
+        self.assertEquals(ret, expected )
+        self.request.mockCheckCall(self, 0, "setResponseCode", 400, expected)
+
+    def testDefaultDialect(self):
+        self.request.uri = "/change_hook/"
+        ret = self.changeHook.render_GET(self.request)
+        expected = "The dialect specified, 'base', wasn't whitelisted in change_hook"
+        self.assertEquals(ret, expected)
+        self.request.mockCheckCall(self, 0, "setResponseCode", 400, expected)
+
+class MockRequest(Mock):
+    def __init__(self, args={}):
+        self.args = args
+        self.site = Mock()
+        self.site.buildbot_service = Mock()
+        self.site.buildbot_service.master = Mock()
+        self.site.buildbot_service.master.change_svc = Mock()
+        Mock.__init__(self)
+
+class TestChangeHookConfigured(unittest.TestCase):
+    def setUp(self):
+        self.request = MockRequest()
+        self.changeHook = ch.ChangeHookResource(dialects={'base' : True})
+
+    # Test base hook with no attributes. We should get a json string representing 
+    # a Change object as a dictionary. All values except 'when' and 'at' will be null.
+    def testDefaultDialectNullChange(self):
+        self.request.uri = "/change_hook/"
+        ret = self.changeHook.render_GET(self.request)
+        # Change is an array of dicts holding changes. There will normally only be one
+        # changes, thus only one dictionary
+        changeArray = json.loads(ret)
+        change = changeArray[0]
+        self.assertEquals(change["category"], None)
+        self.assertEquals(len(change["files"]), 0)
+        self.assertEquals(change["repository"], None)
+        self.assertNotEquals(change["when"], None)
+        self.assertEquals(change["who"], None)
+        self.assertEquals(change["rev"], None)
+        self.assertEquals(change["number"], None)
+        self.assertEquals(change["comments"], None)
+        self.assertEquals(change["project"], None)
+        self.assertNotEquals(change["at"], None)
+        self.assertEquals(change["branch"], None)
+        self.assertEquals(change["revlink"], None)
+        self.assertEquals(len(change["properties"]), 0)
+        self.assertEquals(change["revision"], None)
+
+
+class TestChangeHookConfiguredWithChange(unittest.TestCase):
+    def setUp(self):
+        changeDict = { "category" : ["mycat"],
+                       "files" : [json.dumps(['file1', 'file2'])],
+                       "repository" : ["myrepo"],
+                       "when" : [1234],
+                       "who" : ["Santa Claus"],
+                       "number" : [2],
+                       "comments" : ["a comment"],
+                       "project" : ["a project"],
+                       "at" : ["sometime"],
+                       "branch" : ["a branch"],
+                       "revlink" : ["a revlink"],
+                       "properties" : [json.dumps( { "prop1" : "val1", "prop2" : "val2" })],
+                       "revision" : [99] }
+        #print changeDict
+        self.request = MockRequest(changeDict)
+        self.changeHook = ch.ChangeHookResource(dialects={'base' : True})
+
+    # Test 'base' hook with attributes. We should get a json string representing 
+    # a Change object as a dictionary. All values show be set.
+    def testDefaultDialectWithChange(self):
+        self.request.uri = "/change_hook/"
+        ret = self.changeHook.render_GET(self.request)
+        # Change is an array of dicts holding changes. There will normally only be one
+        # changes, thus only one dictionary
+        #print ret
+        changeArray = json.loads(ret)
+        change = changeArray[0]
+        self.assertEquals(change["category"], "mycat")
+        files = change["files"]
+        self.assertEquals(len(files), 2)
+        self.assertEquals(files[0]["name"], "file1")
+        self.assertEquals(files[1]["name"], "file2")
+        self.assertEquals(change["repository"], "myrepo")
+        self.assertEquals(change["when"], 1234)
+        self.assertEquals(change["who"], "Santa Claus")
+        self.assertEquals(change["rev"], '99')
+        self.assertEquals(change["number"], None)
+        self.assertEquals(change["comments"], "a comment")
+        self.assertEquals(change["project"], "a project")
+        self.assertNotEquals(change["at"], "sometime")
+        self.assertEquals(change["branch"], "a branch")
+        self.assertEquals(change["revlink"], "a revlink")
+        properties = change["properties"]
+        self.assertEquals(len(properties), 2)
+        self.assertEquals(properties[0][0], "prop1")
+        self.assertEquals(properties[0][1], "val1")
+        self.assertEquals(properties[0][2], "Change")
+        self.assertEquals(properties[1][0], "prop2")
+        self.assertEquals(properties[1][1], "val2")
+        self.assertEquals(properties[1][2], "Change")
+        self.assertEquals(change["revision"], '99')
+
+# Sample GITHUB commit payload from http://help.github.com/post-receive-hooks/
+# Added "modfied" and "removed", and change email
+
+gitJsonPayload = """
+{
+  "before": "5aef35982fb2d34e9d9d4502f6ede1072793222d",
+  "repository": {
+    "url": "http://github.com/defunkt/github",
+    "name": "github",
+    "description": "You're lookin' at it.",
+    "watchers": 5,
+    "forks": 2,
+    "private": 1,
+    "owner": {
+      "email": "fred@flinstone.org",
+      "name": "defunkt"
+    }
+  },
+  "commits": [
+    {
+      "id": "41a212ee83ca127e3c8cf465891ab7216a705f59",
+      "url": "http://github.com/defunkt/github/commit/41a212ee83ca127e3c8cf465891ab7216a705f59",
+      "author": {
+        "email": "fred@flinstone.org",
+        "name": "Fred Flinstone"
+      },
+      "message": "okay i give in",
+      "timestamp": "2008-02-15T14:57:17-08:00",
+      "added": ["filepath.rb"]
+    },
+    {
+      "id": "de8251ff97ee194a289832576287d6f8ad74e3d0",
+      "url": "http://github.com/defunkt/github/commit/de8251ff97ee194a289832576287d6f8ad74e3d0",
+      "author": {
+        "email": "fred@flinstone.org",
+        "name": "Fred Flinstone"
+      },
+      "message": "update pricing a tad",
+      "timestamp": "2008-02-15T14:36:34-08:00",
+      "modified": ["modfile"],
+      "removed": ["removedFile"]
+    }
+  ],
+  "after": "de8251ff97ee194a289832576287d6f8ad74e3d0",
+  "ref": "refs/heads/master"
+}
+"""
+class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
+    def setUp(self):
+        changeDict={"payload" : [gitJsonPayload]}
+        self.request = MockRequest(changeDict)
+        self.changeHook = ch.ChangeHookResource(dialects={'github' : True})
+
+    # Test 'base' hook with attributes. We should get a json string representing 
+    # a Change object as a dictionary. All values show be set.
+    def testGitWithChange(self):
+        self.request.uri = "/change_hook/github"
+        ret = self.changeHook.render_GET(self.request)
+        # Change is an array of dicts holding changes. There may be multiple entries for github
+        changeArray = json.loads(ret)
+        change = changeArray[0]
+        self.assertEquals(change["category"], None)
+        files = change["files"]
+        self.assertEquals(len(files), 1)
+        self.assertEquals(files[0]["name"], "filepath.rb")
+        self.assertEquals(change["repository"], "http://github.com/defunkt/github")
+        self.assertEquals(change["when"], 1203116237)
+        self.assertEquals(change["who"], "Fred Flinstone <fred@flinstone.org>")
+        self.assertEquals(change["rev"], '41a212ee83ca127e3c8cf465891ab7216a705f59')
+        self.assertEquals(change["number"], None)
+        self.assertEquals(change["comments"], "okay i give in")
+        self.assertEquals(change["project"], '')
+        self.assertNotEquals(change["at"], "sometime")
+        self.assertEquals(change["branch"], "master")
+        self.assertEquals(change["revlink"], "http://github.com/defunkt/github/commit/41a212ee83ca127e3c8cf465891ab7216a705f59")
+        properties = change["properties"]
+        self.assertEquals(len(properties), 0)
+        self.assertEquals(change["revision"], '41a212ee83ca127e3c8cf465891ab7216a705f59')
+        # Second change
+        change = changeArray[1]
+        self.assertEquals(change["category"], None)
+        files = change["files"]
+        self.assertEquals(len(files), 2)
+        self.assertEquals(files[0]["name"], "modfile")
+        self.assertEquals(files[1]["name"], "removedFile")
+        self.assertEquals(change["repository"], "http://github.com/defunkt/github")
+        self.assertEquals(change["when"], 1203114994)
+        self.assertEquals(change["who"], "Fred Flinstone <fred@flinstone.org>")
+        self.assertEquals(change["rev"], 'de8251ff97ee194a289832576287d6f8ad74e3d0')
+        self.assertEquals(change["number"], None)
+        self.assertEquals(change["comments"], "update pricing a tad")
+        self.assertEquals(change["project"], '')
+        self.assertNotEquals(change["at"], "sometime")
+        self.assertEquals(change["branch"], "master")
+        self.assertEquals(change["revlink"], "http://github.com/defunkt/github/commit/de8251ff97ee194a289832576287d6f8ad74e3d0")
+        properties = change["properties"]
+        self.assertEquals(len(properties), 0)
+        self.assertEquals(change["revision"], 'de8251ff97ee194a289832576287d6f8ad74e3d0')

--- a/master/docs/cfg-statustargets.texinfo
+++ b/master/docs/cfg-statustargets.texinfo
@@ -390,7 +390,8 @@ by other programs, rather than humans.
 
 @item /change_hook
 
-This provides an endpoint for web-based source change notification (i.e. github).
+This provides an endpoint for web-based source change notification.
+It is used by github and contrib/post_build_request.py.
 See @ref{Change Hooks} for more details.
 
 @end table
@@ -643,6 +644,10 @@ c['status'].append(html.WebStatus(http_port=8010,allowForce=True,
 Within the WebStatus arguments, the @code{change_hook} key enables/disables the module
 and @code{change_hook_dialects} whitelists DIALECTs where the keys are the module names
 and the values are optional arguments which will be passed to the hooks.
+
+The post_build_request.py script in master/contrib allows for the submission of an
+arbitrary change request. Run 'post_build_request.py --help' for more information.
+The 'base' dialect must be enabled for this to work.
 
 @node MailNotifier
 @subsection MailNotifier


### PR DESCRIPTION
Not sure why comments didn't get pushed to github. I'm guessing github only displays the first line.

Anywhere, here is what changed:
- master/buildbuilt/status/web/change_hook.py
  - Raise ValueError on unmatched URL or unconfigured dialect.
  - Set response code to 400 for exceptions.
- master/buildbuilt/status/web/hook/github.py
  
  Make checking for files more robust. Sample commit on github didn't have 'modified' or 'removed' files.
- master/contrib/post_build_request.py
  - Replaced hard-coded url path with command line --urlpath or default of /change_hook/base
  - Changed 'quiet' option to 'verbose'. Without -v flag, script give no output
    with -v, print change number and time. With two -v flags, show all data returned.
  - Exit with status of 1 if change_hook returns a status code other than 200
- master/docs/cfg-statustargest.texinfo
  - Add note refering to post_build_request.py
- master/buildbot/test/unit/test_status_web_change_hook.py
  - Added some simple change_hook tests. Made a stab at testing github.py, using sample
    commit json from github.
