### PR TITLE
Update svnpoller to cache last polled SVN revision

### DIFF
--- a/master/docs/cfg-changesources.texinfo
+++ b/master/docs/cfg-changesources.texinfo
@@ -1098,6 +1098,11 @@ with the portion that will substitute for a revision number replaced by
 could be used to cause revision links to be created to a websvn repository
 viewer.
 
+@item cachepath
+If specified, buildbot will cache processed revisions between restarts. This
+means you don't miss changes that were committed if the master is down for any
+reason.
+
 @end table
 
 @heading Branches


### PR DESCRIPTION
If user specifies a suitable location, svnpoller will now remember the last revision it polled. If the master goes down for maintenance or some other reason then it wont miss revisions when it comes back on. 

If a path isnt specified, the cache is corrupt or there is no cache file yet then it will behave as it does currently.
