### PR TITLE
Simple patch to remove trailing spaces from the manual pages.

### DIFF
--- a/master/docs/buildbot.1
+++ b/master/docs/buildbot.1
@@ -37,7 +37,7 @@ create-master
 .I SIZE
 ]
 [
-.BR \-l | \-\-log-count 
+.BR \-l | \-\-log-count
 .I COUNT
 ]
 [
@@ -45,7 +45,7 @@ create-master
 .I CONFIG
 ]
 [
-.BR \-\-db 
+.BR \-\-db
 .I DATABASE
 ]
 [
@@ -330,7 +330,7 @@ Validate buildbot master config file.
 .SS Global options
 .TP
 .BR \-h | \-\-help
-Print the list of available commands and global options. 
+Print the list of available commands and global options.
 All subsequent commands are ignored.
 .TP
 .BR --version
@@ -350,12 +350,12 @@ Re-use an existing directory (will not overwrite master.cfg file)
 .TP
 .BR \-r | \-\-relocatable
 Create a relocatable buildbot.tac
-.TP 
+.TP
 .BR \-n | \-\-no-logrotate
 Do not permit buildmaster rotate logs by itself.
 .TP
 .BR \-c | \-\-config
-Set name of the buildbot master config file to 
+Set name of the buildbot master config file to
 .IR CONFIG .
 Default file name is master.cfg.
 .TP
@@ -365,15 +365,15 @@ Set size at which twisted lof file is rotated to
 bytes.
 Default value is 1000000 bytes.
 .TP
-.BR \-l | \-\-log-count 
-Limit the number of kept old twisted log files to 
+.BR \-l | \-\-log-count
+Limit the number of kept old twisted log files to
 .IR COUNT .
 All files are kept by default.
 .TP
-.BR \-\-db 
+.BR \-\-db
 Set the database connection for storing scheduler/status state to
-.IR DATABASE . 
-Default value is 
+.IR DATABASE .
+Default value is
 .BR "sqlite:///state.sqlite" .
 .TP
 .I PATH
@@ -389,8 +389,8 @@ Replace any modified files without confirmation.
 .TP
 .BR \-\-db
 Set the database connection for storing scheduler/status state to
-.IR DATABASE . 
-Default value is 
+.IR DATABASE .
+Default value is
 .BR "sqlite:///state.sqlite" .
 .TP
 .I PATH
@@ -411,7 +411,7 @@ Set repository URL to
 .IR REPOSITORY .
 .TP
 .BR \-P | \-\-project
-Set project specifier to 
+Set project specifier to
 .IR PROJECT .
 .TP
 .BR \-b | \-\-branch
@@ -423,30 +423,30 @@ Set category of repository to
 .IR CATEGORY .
 .TP
 .BR \-r | \-\-revision
-Set revision being built to 
+Set revision being built to
 .IR REVISION .
 .TP
 .BR \-\-revision-file
 Use
-.I REVISIONFILE 
+.I REVISIONFILE
 file to read revision spec data from.
 .TP
 .BR \-p | \-\-property
-Set property for the change to 
+Set property for the change to
 .IR PROPERTY .
-It should be in format 
+It should be in format
 .IR NAME : VALUE .
 .TP
 .BR \-m | \-\-comments
-Set log message to 
+Set log message to
 .IR MESSAGE .
 .TP
 .BR \-F | \-\-logfile
-Set logfile to 
+Set logfile to
 .IR LOGFILE .
 .TP
 .BR \-w | \-\-when
-Set timestamp used as the change time to 
+Set timestamp used as the change time to
 .IR TIMESTAMP .
 .TP
 .I FILES
@@ -458,7 +458,7 @@ Lis of files have been changed.
 Set the location of buildmaster's PBListener to attach to in form
 .IR HOST : PORT .
 .TP
-.BR \-p | \-\-passwd 
+.BR \-p | \-\-passwd
 Debug password to use.
 
 .SS statuslog command options
@@ -468,15 +468,15 @@ Set the location of buildmaster's PBListener to attach to in form
 .IR HOST : PORT .
 .TP
 .BR \-u | \-\-username
-Set username for PB authentication to 
+Set username for PB authentication to
 .IR USERNAME .
-Default is 
+Default is
 .BR statusClient .
 .TP
 .BR \-p | \-\-passwd
 Set password for PB authentication to
 .IR PASSWORD .
-Default is 
+Default is
 .BR clientpw .
 
 .SS statusgui command options
@@ -486,15 +486,15 @@ Set the location of buildmaster's PBListener to attach to in form
 .IR HOST : PORT .
 .TP
 .BR \-u | \-\-username
-Set username for PB authentication to 
+Set username for PB authentication to
 .IR USERNAME .
-Default is 
+Default is
 .BR statusClient .
 .TP
 .BR \-p | \-\-passwd
 Set password for PB authentication to
 .IR PASSWORD .
-Default is 
+Default is
 .BR clientpw .
 
 .SS try command options
@@ -506,8 +506,8 @@ Wait until the builds have finished.
 Gather info, but don't actually submit.
 .TP
 .BR \-\-get-builder-names
-Get the names of available builders. 
-Doesn't submit anything. 
+Get the names of available builders.
+Doesn't submit anything.
 Only supported for 'pb' connections.
 .TP
 .BR \-c | \-\-connect
@@ -515,7 +515,7 @@ Connection type.
 Can be either \'ssh\' or \'pb\'.
 .TP
 .BR \-\-tryhost
-Set the hostname (used by ssh) for the buildmaster to 
+Set the hostname (used by ssh) for the buildmaster to
 .IR HOSTNAME .
 .TP
 .BR \-\-trydir
@@ -526,7 +526,7 @@ Set the location of the buildmaster's PBListener in form
 .IR HOST : PORT
 .TP
 .BR \-u | \-\-username
-Set the username performing the trial build to 
+Set the username performing the trial build to
 .IR USERNAME .
 .TP
 .BR \-\-passwd
@@ -534,16 +534,16 @@ Set password for PB authentication to
 .IR PASSWORD .
 .TP
 .BR \-\-diff
-Use 
+Use
 .I DIFF
 file to use as a patch instead of scanning a local tree.
 Use \'-\' for stdin.
 .TP
 .BR \-\-patchlevel
-Specify the patchlevel to apply with. 
+Specify the patchlevel to apply with.
 Defaults to 0.
-See 
-.BR patch 
+See
+.BR patch
 for details.
 .TP
 .BR \-\-baserev
@@ -552,7 +552,7 @@ Use
 revision instead of scanning a local tree.
 .TP
 .BR \-\-vc
-Specify version control system in use. 
+Specify version control system in use.
 Possible values: cvs, svn, tla, baz, darcs, p4.
 .TP
 .BR \-\-branch
@@ -562,16 +562,16 @@ Specify the branch in use, for VC systems that can't figure it out themselves.
 Run the trial build on the specified Builder. Can be used multiple times.
 .TP
 .BR \-\-properties
-Specify the set of properties made available in the build environment in format 
+Specify the set of properties made available in the build environment in format
 .IR prop1 = value1 , prop2 = value2 ...
 .TP
 .BR \-\-try-topfile
-Specify name of a file at the top of the tree. 
+Specify name of a file at the top of the tree.
 This option is used to find the top.
 Only needed for SVN and CVS.
 .TP
 .BR \-\-try-topdir
-Specify the path to the top of the working copy. 
+Specify the path to the top of the working copy.
 Only needed for SVN and CVS.
 
 .SS tryserver command options
@@ -579,14 +579,14 @@ Only needed for SVN and CVS.
 .BR \-\-jobdir
 The jobdir (maildir) for submitting jobs
 .SH FILES
-.TP 
+.TP
 master.cfg
 Buildbot master configuration file
 .SH AUTHOR
 \fBAndriy Senkovych\fR <\&andriysenkovych@gmail.com\&>
 .SH "SEE ALSO"
-.BR buildslave (1), 
-.BR patch (1) 
+.BR buildslave (1),
+.BR patch (1)
 .PP
 The complete documentation is available in texinfo format. To use it, run
 .BR "info buildbot" .

--- a/master/docs/buildslave.1
+++ b/master/docs/buildslave.1
@@ -1,4 +1,4 @@
-.\" Based on template /usr/share/man-db/examples/manpage.example provided by 
+.\" Based on template /usr/share/man-db/examples/manpage.example provided by
 .\" Tom Christiansen <tchrist@jhereg.perl.com>.
 .TH BUILDSLAVE "1" "August 2010" "Buildbot" "User Commands"
 .SH NAME
@@ -26,7 +26,7 @@ create-slave
 .BR \-r | \-\-relocatable
 ]
 [
-.BR \-n | \-\-no-logrotate  
+.BR \-n | \-\-no-logrotate
 ]
 [
 .BR \-k | \-\-keepalive
@@ -45,7 +45,7 @@ create-slave
 .I SIZE
 ]
 [
-.BR \-l | \-\-log-count 
+.BR \-l | \-\-log-count
 .I COUNT
 ]
 [
@@ -99,7 +99,7 @@ Restart a buildslave
 .SS Global options
 .TP
 .BR \-h | \-\-help
-Print the list of available commands and global options. 
+Print the list of available commands and global options.
 All subsequent commands are ignored.
 .TP
 .BR --version
@@ -124,7 +124,7 @@ seconds.
 Default value is 600 seconds.
 .TP
 .BR \-l | \-\-log-count
-Limit the number of kept old twisted log files to 
+Limit the number of kept old twisted log files to
 .IR COUNT .
 All files are kept by default.
 .TP
@@ -133,7 +133,7 @@ Do not emit the commands being run.
 .TP
 .BR \-r | \-\-relocatable
 Create a relocatable buildbot.tac.
-.TP 
+.TP
 .BR \-n | \-\-no-logrotate
 Do not permit buildslave rotate logs by itself.
 .TP
@@ -145,8 +145,8 @@ Default value is 1000000 bytes.
 .TP
 .BR \-\-umask
 Set umask for files created by buildslave.
-Default value is 077 which means only owner can access the files. 
-See 
+Default value is 077 which means only owner can access the files.
+See
 .BR umask (2)
 for more details.
 .TP
@@ -173,7 +173,7 @@ This should be provided by buildmaster administrator.
 .SH AUTHOR
 \fBAndriy Senkovych\fR <\&andriysenkovych@gmail.com\&>
 .SH "SEE ALSO"
-.BR buildbot (1), 
+.BR buildbot (1),
 .BR umask (2),
 .PP
 The complete documentation is available in texinfo format. To use it, run


### PR DESCRIPTION
Just removing trailing spaces, nothing more.
