### PR TITLE
Svn checkout fix

### DIFF
--- a/slave/buildslave/commands/svn.py
+++ b/slave/buildslave/commands/svn.py
@@ -76,7 +76,7 @@ class SVN(SourceBaseCommand):
 
     def doVCFull(self):
         revision = self.args['revision'] or 'HEAD'
-        args = ['--revision', str(revision), self.svnurl, self.srcdir]
+        args = ['--revision', str(revision), "%s@%s" % (self.svnurl, str(revision)), self.srcdir]
 
         if self.mode == 'export':
             if revision == 'HEAD': return self.doSVNExport()

--- a/slave/buildslave/test/unit/test_commands_svn.py
+++ b/slave/buildslave/test/unit/test_commands_svn.py
@@ -35,7 +35,7 @@ class TestSVN(SourceCommandTestMixin, unittest.TestCase):
                 self.basedir)
                 + 0,
             Expect([ 'path/to/svn', 'checkout', '--non-interactive', '--no-auth-cache',
-                     '--revision', 'HEAD', 'http://svn.local/app/trunk', 'source' ],
+                     '--revision', 'HEAD', 'http://svn.local/app/trunk@HEAD', 'source' ],
                 self.basedir,
                 sendRC=False, timeout=120, usePTY=False, environ=exp_environ)
                 + 0,


### PR DESCRIPTION
Check the commit comment for an explanation :).

Basically, the svn checkout operation as it stands is not robust in the presence of branches which are created, deleted, and then recreated. This branch contains a simple fix to make the svn checkout operation behave the way that buildbot expects it to.
