### PR TITLE
Force build form can ignore properties

### DIFF
--- a/master/buildbot/status/web/base.py
+++ b/master/buildbot/status/web/base.py
@@ -55,7 +55,7 @@ Return a new Properties object containing each property found in req.
     while True:
         pname = req.args.get("property%dname" % i, [""])[0]
         pvalue = req.args.get("property%dvalue" % i, [""])[0]
-        if not pname or not pvalue:
+        if not pname:
             break
         if not re.match(r'^[\w\.\-\/\~:]*$', pname) \
                 or not re.match(r'^[\w\.\-\/\~:]*$', pvalue):


### PR DESCRIPTION
A while ago we modified the getAndCheckProperties function to allow an unlimited number of properties rather than being hardcoded to 3. Now I have a static HTML form to submit a build with 6 or 7 properties. If property 3 were to be blank, the current loop would ignore property 4 and onwards. Unfortunately 2 of my properties can be blank legitimately. 

I think it is acceptable to look until property name _isnt_ set, and to allow properties to be set to "".

This 1 line change does that.
