### PR TITLE
Include log names and URLs in build step's asDict method

### DIFF
--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -1154,9 +1154,9 @@ class BuildStepStatus(styles.Versioned):
         result['eta'] = self.getETA()
         result['urls'] = self.getURLs()
         result['step_number'] = self.step_number
-        # TODO(maruel): Move that to a sub-url or just publish the log_url
-        # instead.
-        #result['logs'] = self.getLogs()
+        result['logs'] = [[l.getName(),
+            self.build.builder.status.getURLForThing(l)]
+                for l in self.getLogs()]
         return result
 
 
@@ -1587,8 +1587,8 @@ class BuildStatus(styles.Versioned):
         result['slave'] = self.getSlavename()
         # TODO(maruel): Add.
         #result['test_results'] = self.getTestResults()
-        # TODO(maruel): Include the url? It's too heavy otherwise.
-        #result['logs'] = self.getLogs()
+        result['logs'] = [[l.getName(),
+            self.builder.status.getURLForThing(l)] for l in self.getLogs()]
         result['eta'] = self.getETA()
         result['steps'] = [bss.asDict() for bss in self.steps]
         if self.getCurrentStep():

--- a/master/buildbot/test/unit/test_status_builder.py
+++ b/master/buildbot/test/unit/test_status_builder.py
@@ -15,6 +15,7 @@
 
 import os
 
+from mock import Mock
 from buildbot.status import builder
 #from buildbot.util import json
 
@@ -30,6 +31,14 @@ class TestBuildStepStatus(unittest.TestCase):
         b.determineNextBuildNumber()
         return b
 
+    def setupStatus(self, b):
+        botmaster = Mock()
+        botmaster.parent = Mock()
+        botmaster.parent.buildbotURL = 'http://buildbot:8010/'
+        s = builder.Status(botmaster=botmaster, basedir=b.basedir)
+        b.status = s
+        return s
+
     def testBuildStepNumbers(self):
         b = self.setupBuilder('builder_1')
         bs = b.newBuild()
@@ -41,3 +50,13 @@ class TestBuildStepStatus(unittest.TestCase):
         self.assertEquals('step_2', bss2.getName())
         self.assertEquals(1, bss2.asDict()['step_number'])
         self.assertEquals([bss1, bss2], bs.getSteps())
+
+    def testLogDict(self):
+        b = self.setupBuilder('builder_1')
+        self.setupStatus(b)
+        bs = b.newBuild()
+        bss1 = bs.addStepWithName('step_1')
+        bss1.stepStarted()
+        bss1.addLog('log_1')
+        self.assertEquals([['log_1', ('http://buildbot:8010/builders/builder_1/'
+            'builds/0/steps/step_1/logs/log_1')]], bss1.asDict()['logs'])


### PR DESCRIPTION
That patch resolves two FIXMEs and allows for retrieving a list of log files from builds via JSON
