### PR TITLE
Mark older gits as unsupported.

### DIFF
--- a/master/docs/cfg-changesources.texinfo
+++ b/master/docs/cfg-changesources.texinfo
@@ -1218,10 +1218,7 @@ processes any changes. It requires its own working directory for operation, whic
 can be specified via the @code{workdir} property. By default a temporary directory will
 be used.
 
-The @code{GitPoller} has mostly been tested with Git version @code{1.7.0.3},
-although it does not use any obscure Git features and should work with any
-version.  If you discover any incopmatibilities, please report them to the
-Buildbot developers.
+The @code{GitPoller} only works with git versions @code{1.7} and up.
 
 @code{GitPoller} accepts the following arguments:
 


### PR DESCRIPTION
I just tried with git 1.5 (still shipping on Debian stable), and the gitpoller failed because it does not support the:

  git init /path/to/new/repo

syntax.  Instead one must do something like:

  (cd /path/to/new/repo && git init)

but I judged putting in a patch like that to be a pain, and there might be other lurking issues as well.  So instead I just upgraded git.

1.6 might work, I don't know.  Instead of being ambiguous and making the gitpoller sound like a Saturday-night hack, though, let's just tell users they need to use 1.7 and be done with it.
