### PR TITLE
Fix 1774 (pbchangesource w/ empty file list)

### DIFF
--- a/master/buildbot/changes/pb.py
+++ b/master/buildbot/changes/pb.py
@@ -43,10 +43,9 @@ class ChangePerspective(NewCredPerspective):
             files.append(path)
         changedict['files'] = files
 
-        if files:
-            return self.master.addChange(**changedict)
-        else:
-            return defer.succeed(None)
+        if not files:
+            log.msg("No files listed in change... bit strange, but not fatal.")
+        return self.master.addChange(**changedict)
 
 class PBChangeSource(base.ChangeSource):
     compare_attrs = ["user", "passwd", "port", "prefix", "port"]


### PR DESCRIPTION
This is a resolution to 1774:

   http://trac.buildbot.net/ticket/1774

as discussed on IRC.
