### PR TITLE
Listen to changeset-merged gerritt events and ignore invalid ref-updated

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -95,7 +95,7 @@ class GerritChangeSource(base.ChangeSource):
             log.msg("bad json line: %s" % (line,))
             return defer.succeed(None)
 
-        if type(event) == type({}) and "type" in event and event["type"] in ["patchset-created", "ref-updated"]:
+        if type(event) == type({}) and "type" in event and event["type"] in ["change-merged", "patchset-created", "ref-updated"]:
             # flatten the event dictionary, for easy access with WithProperties
             def flatten(event, base, d):
                 for k, v in d.items():
@@ -107,7 +107,7 @@ class GerritChangeSource(base.ChangeSource):
             properties = {}
             flatten(properties, "event", event)
 
-            if event["type"] == "patchset-created":
+            if event["type"] in ["patchset-created", "change-merged"]:
                 change = event["change"]
 
                 chdict = dict(
@@ -120,7 +120,7 @@ class GerritChangeSource(base.ChangeSource):
                         files=["unknown"],
                         category=event["type"],
                         properties=properties)
-            elif event["type"] == "ref-updated":
+            elif event["type"] == "ref-updated" and 'submitter' in event:
                 ref = event["refUpdate"]
                 chdict = dict(
                         who="%s <%s>" % (event["submitter"]["name"], event["submitter"]["email"]),


### PR DESCRIPTION
Hi,

In using this against a Gerritt server, I found that it was not listening to the events when changesets were actually merged. This is useful to kick off automatic builds after a change occurred. Also, from our server I saw some ref-updated events without a 'submitter' which caused a master crash. I decided to skip these, as I have not found any use for ref-updated events anyway, and it seemed better than outputting "Unknown User".
