### PR TITLE
Fix repository path send for github_buildbot.py

### DIFF
--- a/master/contrib/github_buildbot.py
+++ b/master/contrib/github_buildbot.py
@@ -94,7 +94,7 @@ class GitHubBuildBot(resource.Resource):
                             + " <" + commit['author']['email'] + ">",
                      'files': files,
                      'links': [commit['url']],
-                     'properties': {'repository': repo_url},
+                     'repository': repo_url,
                 }
                 changes.append(change)
         


### PR DESCRIPTION
Now github_buildbot.py sends repository URL in correct way, in case if you use git source for multiple repos.
