### PR TITLE
typo in subunit patch

### DIFF
--- a/master/buildbot/steps/subunit.py
+++ b/master/buildbot/steps/subunit.py
@@ -55,7 +55,7 @@ class SubunitShellCommand(ShellCommand):
                 text += ["no tests", "run"]
         else:
             results = FAILURE
-            text.append("Total % test(s)" % total)
+            text.append("Total %d test(s)" % total)
             if failures:
                 text.append("%d %s" % \
                             (failures,


### PR DESCRIPTION
I thought the code was deployed and running on our company's buildbot, but apparently I forgot to restart buildmaster, so this silly typo escapes me until now

sorry for the trouble
