### PR TITLE
Fix web-status buildstep status.

### DIFF
--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -832,7 +832,7 @@ class BuildStepStatus(styles.Versioned):
     finished = None
     progress = None
     text = []
-    results = (None, [])
+    results = None
     text2 = []
     watchers = []
     updates = {}


### PR DESCRIPTION
The tuple is created in getResults(), with results as the first element. This
was exposed by 3ca22de3c0bd61adca1c4959ef95b13cd93bf2e3 actually using the
step status. This was only a problem on steps that hadn't finished.

Signed-off-by: Tom Prince tom.prince@ualberta.net
