### PR TITLE
github-hook: Add option to specify project with '?project=projectname'.

### DIFF
--- a/master/buildbot/status/web/hooks/github.py
+++ b/master/buildbot/status/web/hooks/github.py
@@ -90,9 +90,12 @@ def getChanges(request, options = None):
             user = payload['repository']['owner']['name']
             repo = payload['repository']['name']
             repo_url = payload['repository']['url']
+            project = request.args.get('project', None)
+            if project:
+                project = project[0]
             # This field is unused:
             #private = payload['repository']['private']
-            changes = process_change(payload, user, repo, repo_url)
+            changes = process_change(payload, user, repo, repo_url, project)
             log.msg("Received %s changes from github" % len(changes))
             return changes
         except Exception:
@@ -100,7 +103,7 @@ def getChanges(request, options = None):
             for msg in traceback.format_exception(*sys.exc_info()):
                 logging.error(msg.strip())
 
-def process_change(payload, user, repo, repo_url):
+def process_change(payload, user, repo, repo_url, project):
         """
         Consumes the JSON as a python object and actually starts the build.
         
@@ -143,7 +146,8 @@ def process_change(payload, user, repo, repo_url):
                     when     = when,
                     branch   = branch,
                     revlink  = commit['url'], 
-                    repository = repo_url)  
+                    repository = repo_url,
+                    project  = project)
                 changes.append(chdict) 
             return changes
         

--- a/master/contrib/github_buildbot.py
+++ b/master/contrib/github_buildbot.py
@@ -50,14 +50,17 @@ class GitHubBuildBot(resource.Resource):
             repo = payload['repository']['name']
             repo_url = payload['repository']['url']
             self.private = payload['repository']['private']
+            project = request.args.get('project', None)
+            if project:
+                project = project[0]
             logging.debug("Payload: " + str(payload))
-            self.process_change(payload, user, repo, repo_url)
+            self.process_change(payload, user, repo, repo_url, project)
         except Exception:
             logging.error("Encountered an exception:")
             for msg in traceback.format_exception(*sys.exc_info()):
                 logging.error(msg.strip())
 
-    def process_change(self, payload, user, repo, repo_url):
+    def process_change(self, payload, user, repo, repo_url, project):
         """
         Consumes the JSON as a python object and actually starts the build.
         
@@ -95,6 +98,7 @@ class GitHubBuildBot(resource.Resource):
                      'files': files,
                      'links': [commit['url']],
                      'repository': repo_url,
+                     'project': project,
                 }
                 changes.append(change)
         

--- a/master/docs/cfg-statustargets.texinfo
+++ b/master/docs/cfg-statustargets.texinfo
@@ -675,7 +675,8 @@ With this set up, add a Post-Receive URL for the project in the Github
 administrative interface, pointing to @code{/change_hook/github} relative to
 the root of the web status.  For example, if the grid URL is
 @code{http://builds.mycompany.com/bbot/grid}, then point Github to
-@code{http://builds.mycompany.com/bbot/change_hook/github}.
+@code{http://builds.mycompany.com/bbot/change_hook/github}. To specify a project
+assoicated to the repository, append @code{?project=name} to the URL.
 
 Note that there is a standalone HTTP server available for receiving github
 notifications, as well: @code{contrib/github_buildbot.py}.  This script may be


### PR DESCRIPTION
This also add the functionality to github_buildbot.py. The request parsing
should really be refactored between these two.
