### PR TITLE
Allow latent slaves providers to customize slave for a build

### DIFF
--- a/master/buildbot/buildslave.py
+++ b/master/buildbot/buildslave.py
@@ -646,7 +646,7 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
         self.building = set()
         self.build_wait_timeout = build_wait_timeout
 
-    def start_instance(self):
+    def start_instance(self, build):
         # responsible for starting instance that will try to connect with this
         # master.  Should return deferred with either True (instance started)
         # or False (instance not started, so don't run a build here).  Problems
@@ -657,7 +657,7 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
         # responsible for shutting down instance.
         raise NotImplementedError
 
-    def substantiate(self, sb):
+    def substantiate(self, sb, build):
         if self.substantiated:
             self._clearBuildWaitTimer()
             self._setBuildWaitTimer()
@@ -670,15 +670,15 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
                     self._substantiation_failed, defer.TimeoutError())
             self.substantiation_deferred = defer.Deferred()
             if self.slave is None:
-                d = self._substantiate() # start up instance
+                d = self._substantiate(build) # start up instance
                 d.addErrback(log.err, "while substantiating")
             # else: we're waiting for an old one to detach.  the _substantiate
             # will be done in ``detached`` below.
         return self.substantiation_deferred
 
-    def _substantiate(self):
+    def _substantiate(self, build):
         # register event trigger
-        d = self.start_instance()
+        d = self.start_instance(build)
         self._shutdown_callback_handle = reactor.addSystemEventTrigger(
             'before', 'shutdown', self._soft_disconnect, fast=True)
         def start_instance_result(result):

--- a/master/buildbot/ec2buildslave.py
+++ b/master/buildbot/ec2buildslave.py
@@ -214,7 +214,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
         return self.instance.public_dns_name
     dns = property(dns)
 
-    def start_instance(self):
+    def start_instance(self, build):
         if self.instance is not None:
             raise ValueError('instance active')
         return threads.deferToThread(self._start_instance)

--- a/master/buildbot/libvirtbuildslave.py
+++ b/master/buildbot/libvirtbuildslave.py
@@ -178,7 +178,7 @@ class LibVirtSlave(AbstractLatentBuildSlave):
         d.addBoth(_log_result)
         return d
 
-    def start_instance(self):
+    def start_instance(self, build):
         """
         I start a new instance of a VM.
 

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -551,7 +551,7 @@ class Builder(pb.Referenceable, service.MultiService):
         self.building.append(build)
         self.updateBigStatus()
         log.msg("starting build %s using slave %s" % (build, sb))
-        d = sb.prepare(self.builder_status)
+        d = sb.prepare(self.builder_status, build)
 
         def _prepared(ready):
             # If prepare returns True then it is ready and we start a build


### PR DESCRIPTION
This patch is mostly useful for people using latent slaves to run each build in a clean environment, and a no-op for people not subclassing the existing Latent Slaves.

When substantiate happens a build has already been allocated to
the future slave. It would be awesome to be able to customize
the VM libvirt is substantiating based on build properties.

This patch makes it so.

Now I can control the memory, cpu allocation, and base image
for my latent slaves from properties.
