### PR TITLE
fix unicode handling for gerrit stream-events

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -90,7 +90,7 @@ class GerritChangeSource(base.ChangeSource):
 
     def lineReceived(self, line):
         try:
-            event = json.loads(line)
+            event = json.loads(line.decode('utf-8'))
         except ValueError:
             log.msg("bad json line: %s" % (line,))
             return defer.succeed(None)


### PR DESCRIPTION
gerrit streams all events in UTF-8.
Decode the received line before parsing the json object.
