### PR TITLE
use 'gerrit' as who, when gerrit strem-event does not provide a submitter

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -122,8 +122,13 @@ class GerritChangeSource(base.ChangeSource):
                         properties=properties)
             elif event["type"] == "ref-updated":
                 ref = event["refUpdate"]
+                who = "gerrit"
+
+                if "submitter" in event:
+                    who="%s <%s>" % (event["submitter"]["name"], event["submitter"]["email"])
+
                 chdict = dict(
-                        who="%s <%s>" % (event["submitter"]["name"], event["submitter"]["email"]),
+                        who=who,
                         project=ref["project"],
                         branch=ref["refName"],
                         revision=ref["newRev"],


### PR DESCRIPTION
use 'gerrit' as who, when gerrit strem-event does not provide a submitter

When using "Submit" in gerrit, the "ref-updated" event line
does not contain a submitter and will cause a exception.
