### PR TITLE
Patch to deal with hg>1.7 local encoding when branch == None

### DIFF
--- a/master/buildbot/changes/hgbuildbot.py
+++ b/master/buildbot/changes/hgbuildbot.py
@@ -154,13 +154,15 @@ def hook(ui, repo, hooktype, node=None, source=None, **kwargs):
         # merges don't always contain files, but at least one file is required by buildbot
         if len(parents) > 1 and not files:
             files = ["merge"]
+        if branch:
+            branch = fromlocal(branch)
         change = {
             'master': master,
             'username': fromlocal(user),
             'revision': hex(node),
             'comments': fromlocal(desc),
             'files': files,
-            'branch': fromlocal(branch)
+            'branch': branch
         }
         d.addCallback(_send, change)
 


### PR DESCRIPTION
re: Dustin's comment  at https://github.com/buildbot/buildbot/commit/df443b6883493129b1f9b23893b4be13872ffbc0#commitcomment-343815
