### PR TITLE
Don't rebuild slaves just because the identity of their __class__ has cha

### DIFF
--- a/master/buildbot/buildslave.py
+++ b/master/buildbot/buildslave.py
@@ -91,6 +91,17 @@ class AbstractBuildSlave(pb.Avatar, service.MultiService):
 
         self._old_builder_list = None
 
+    def identity(self):
+        """
+        Return a tuple describing this slave.  After reconfiguration a
+        new slave with the same identity will update this one, rather
+        than replacing it, thereby avoiding an interruption of current
+        activity.
+        """
+        return (self.slavename, self.password, 
+                '%s.%s' % (self.__class__.__module__,
+                           self.__class__.__name__))
+
     def update(self, new):
         """
         Given a new BuildSlave, configure this one identically.  Because
@@ -100,7 +111,7 @@ class AbstractBuildSlave(pb.Avatar, service.MultiService):
         # the reconfiguration logic should guarantee this:
         assert self.slavename == new.slavename
         assert self.password == new.password
-        assert self.__class__ == new.__class__
+        assert self.identity() == new.identity()
         self.max_builds = new.max_builds
         self.access = new.access
         self.notify_on_missing = new.notify_on_missing

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -145,12 +145,13 @@ class BotMaster(service.MultiService):
         # old BuildSlave instance in place. If the name has changed, of
         # course, it looks exactly the same as deleting one slave and adding
         # an unrelated one.
+
         old_t = {}
         for s in old_slaves:
-            old_t[(s.slavename, s.password, s.__class__)] = s
+            old_t[s.identity()] = s
         new_t = {}
         for s in new_slaves:
-            new_t[(s.slavename, s.password, s.__class__)] = s
+            new_t[s.identity()] = s
         removed = [old_t[t]
                    for t in old_t
                    if t not in new_t]
@@ -175,6 +176,7 @@ class BotMaster(service.MultiService):
         def update_remaining(_):
             for t in remaining_t:
                 old_t[t].update(new_t[t])
+
         d.addCallback(update_remaining)
 
         return d


### PR DESCRIPTION
Don't rebuild slaves just because the identity of their **class** has changed

If the user has subclassed BuildSlave, a reconfig will likely reload
their subclass
