### PR TITLE
added "__file__" to localDict as per #1933

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -204,7 +204,9 @@ class BuildMaster(service.MultiService):
 
             # execute the config file
 
-            localDict = {'basedir': os.path.expanduser(self.basedir)}
+            localDict = {'basedir': os.path.expanduser(self.basedir),
+                         '__file__': os.path.abspath(self.configFileName)}
+            
             try:
                 exec f in localDict
             except:

--- a/master/docs/configuration.texinfo
+++ b/master/docs/configuration.texinfo
@@ -93,6 +93,11 @@ the base directory for the buildmaster. This string has not been
 expanded, so it may start with a tilde. It needs to be expanded before
 use. The config file is located in
 @code{os.path.expanduser(os.path.join(basedir, 'master.cfg'))}
+
+@item __file__
+the absolute path of the config file. The config file's directory is located in
+@code{os.path.dirname(__file__)}.
+
 @end table
 
 @node Loading the Config File


### PR DESCRIPTION
This should solve http://trac.buildbot.net/ticket/1933 by setting a **file** attribute that holds the absolute path of the config file.
