### PR TITLE
Fixed buildmaster's init-script "reload" command.

### DIFF
--- a/master/contrib/init-scripts/buildmaster.init.sh
+++ b/master/contrib/init-scripts/buildmaster.init.sh
@@ -126,7 +126,7 @@ case "$1" in
         exit $?
         ;;
     reload)
-        do_op "master_op" "reload" "Reloading buildmaster"
+        do_op "master_op" "reconfig" "Reloading buildmaster"
         exit $?
         ;;
     restart|force-reload)


### PR DESCRIPTION
buildmaster's init script has option 'reload' which is not working. Iinit script passes "reload" command to buildbot - and buildbot does not have such command. Instead it have "reconfig" command. This patch fixes the problem.
