### PR TITLE
gitpoller: Make sure the temp polling directory exists.

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -62,6 +62,7 @@ class GitPoller(base.PollingChangeSource):
             self.workdir = tempfile.gettempdir() + '/gitpoller_work'
             log.msg("WARNING: gitpoller using deprecated temporary workdir " +
                     "'%s'; consider setting workdir=" % self.workdir)
+            os.system("git init %s" % self.workdir)
 
     def startService(self):
         # make our workdir absolute, relative to the master's basedir


### PR DESCRIPTION
Had this for a while, figured it should be upstream.

IIRC otherwise the user has to do this "git init" themselves, which is annoying if you have a lot of repos and specify `workdir=` for each; you have to (remember to) create all those dirs external to buildbot.
