### PR TITLE
Strike references to "project" where they no longer make sense

### DIFF
--- a/master/docs/cfg-global.texinfo
+++ b/master/docs/cfg-global.texinfo
@@ -3,7 +3,7 @@ The keys in this section affect the operations of the buildmaster globally.
 @menu
 * Database Specification::
 * Multi-master mode::
-* Project Definitions::
+* Site Definition::
 * Log Handling::
 * Data Lifetime::
 * Merging Build Requests (global option)::
@@ -142,18 +142,10 @@ c['multiMaster'] = True
 c['db_poll_interval'] = 60
 @end example
 
-@node Project Definitions
-@subsection Project Definitions
+@node Site Definition
+@subsection Site Definition
 
-There are a couple of basic settings that you use to tell the buildbot what it
-is working on. This information is used by status reporters to let users find
-out more about the codebase being exercised by this particular Buildbot
-installation.
-
-Note that these parameters were added long before Buildbot became able to build
-multiple projects in a single buildmaster, and thus assume that there is only
-one project.  While the configuration parameter names may be confusing, a
-suitable choice of name and URL should help users avoid any confusion.
+Three basic settings describe the buildmaster in status reports.
 
 @example
 c['title'] = "Buildbot"


### PR DESCRIPTION
The section titles and explanations of the codebase's prehistory were more confusing than helpful now.
