### PR TITLE
Updated docs to reflect existing branch and revision options in force build from IRC

### DIFF
--- a/master/buildbot/status/words.py
+++ b/master/buildbot/status/words.py
@@ -432,12 +432,13 @@ class Contact(base.StatusReceiver):
                 self.send("Build details are at %s" % buildurl)
 
     def command_FORCE(self, args, who):
+        errReply = "try 'force build [--branch=BRANCH] [--revision=REVISION] <WHICH> <REASON>'"
         args = shlex.split(args)
         if not args:
-            raise UsageError("try 'force build WHICH <REASON>'")
+            raise UsageError(errReply)
         what = args.pop(0)
         if what != "build":
-            raise UsageError("try 'force build WHICH <REASON>'")
+            raise UsageError(errReply)
         opts = ForceOptions()
         opts.parseOptions(args)
 
@@ -447,8 +448,7 @@ class Contact(base.StatusReceiver):
         reason = opts['reason']
 
         if which is None:
-            raise UsageError("you must provide a Builder, "
-                             "try 'force build WHICH <REASON>'")
+            raise UsageError("you must provide a Builder, " + errReply)
 
         # keep weird stuff out of the branch and revision strings. 
         # TODO:  centralize this somewhere.
@@ -473,7 +473,7 @@ class Contact(base.StatusReceiver):
         d.addErrback(log.err, "while forcing a build")
 
 
-    command_FORCE.usage = "force build <which> <reason> - Force a build"
+    command_FORCE.usage = "force build [--branch=branch] [--revision=revision] <which> <reason> - Force a build"
 
     def command_STOP(self, args, who):
         args = shlex.split(args)

--- a/master/docs/cfg-statustargets.texinfo
+++ b/master/docs/cfg-statustargets.texinfo
@@ -1167,10 +1167,12 @@ If the @code{allowForce=True} option was used, some addtional commands
 will be available:
 
 @table @code
-@item force build BUILDER REASON
+@item force build [--branch=BRANCH] [--revision=REVISION] BUILDER REASON
 Tell the given Builder to start a build of the latest code. The user
 requesting the build and REASON are recorded in the Build status. The
-buildbot will announce the build's status when it finishes.
+buildbot will announce the build's status when it finishes. The user 
+can specify a branch and/or revision with the optional parameters
+@code{--branch=BRANCH} and @code{--revision=REVISION}.
 
 @item stop build BUILDER REASON
 Terminate any running build in the given Builder. REASON will be added


### PR DESCRIPTION
This should close http://trac.buildbot.net/ticket/1949 and I think this does what it should. The options seemed to parse correctly when I was testing things.
