### PR TITLE
Patch 1

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -385,8 +385,7 @@ class WarningCountingShellCommand(ShellCommand):
             self.warningExtractor = warningExtractor
         else:
             self.warningExtractor = WarningCountingShellCommand.warnExtractWholeLine
-        if maxWarnCount:
-            self.maxWarnCount = maxWarnCount
+        self.maxWarnCount = maxWarnCount
 
         # And upcall to let the base class do its work
         ShellCommand.__init__(self, workdir=workdir, **kwargs)


### PR DESCRIPTION
File "/usr/local/lib/python2.6/site-packages/buildbot-0.8.4_pre_642_ga15b123-py2.6.egg/buildbot/steps/shell.py", line 583, in evaluateCommand
    ( self.maxWarnCount != None and self.warnCount > self.maxWarnCount) ):
exceptions.AttributeError: Compile instance has no attribute 'maxWarnCount'
