### PR TITLE
added username in reason for 'try' jobs on build pages, fixes #1886

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -335,18 +335,33 @@ def ns(s):
     return "%d:%s," % (len(s), s)
 
 def createJobfile(bsid, branch, baserev, patchlevel, diff, repository, 
-                  project, builderNames):
-    job = ""
-    job += ns("2")
-    job += ns(bsid)
-    job += ns(branch)
-    job += ns(str(baserev))
-    job += ns("%d" % patchlevel)
-    job += ns(diff)
-    job += ns(repository)
-    job += ns(project)
-    for bn in builderNames:
-        job += ns(bn)
+                  project, who, builderNames):
+    job = None
+    if who:
+        job = ""
+        job += ns("3")
+        job += ns(bsid)
+        job += ns(branch)
+        job += ns(str(baserev))
+        job += ns("%d" % patchlevel)
+        job += ns(diff)
+        job += ns(repository)
+        job += ns(project)
+        job += ns(who)
+        for bn in builderNames:
+            job += ns(bn)
+    else:
+        job = ""
+        job += ns("2")
+        job += ns(bsid)
+        job += ns(branch)
+        job += ns(str(baserev))
+        job += ns("%d" % patchlevel)
+        job += ns(diff)
+        job += ns(repository)
+        job += ns(project)
+        for bn in builderNames:
+            job += ns(bn)
     return job
 
 def getTopdir(topfile, start=None):
@@ -432,6 +447,7 @@ class Try(pb.Referenceable):
         assert self.connect, "you must specify a connect style: ssh or pb"
         self.builderNames = self.getopt('builders')
         self.project = self.getopt('project', '')
+        self.who = self.getopt('who')
 
     def getopt(self, config_name, default=None):
         value = self.config.get(config_name)
@@ -490,7 +506,8 @@ class Try(pb.Referenceable):
             self.jobfile = createJobfile(self.bsid,
                                          ss.branch or "", revspec,
                                          patchlevel, diff, ss.repository,
-                                         self.project, self.builderNames)
+                                         self.project, self.who, 
+                                         self.builderNames)
 
     def fakeDeliverJob(self):
         # Display the job to be delivered, but don't perform delivery.
@@ -538,14 +555,25 @@ class Try(pb.Referenceable):
     def _deliverJob_pb(self, remote):
         ss = self.sourcestamp
 
-        d = remote.callRemote("try",
-                              ss.branch,
-                              ss.revision,
-                              ss.patch,
-                              ss.repository,
-                              self.project,
-                              self.builderNames,
-                              self.config.get('properties', {}))
+        if self.who:
+            d = remote.callRemote("try",
+                                  ss.branch,
+                                  ss.revision,
+                                  ss.patch,
+                                  ss.repository,
+                                  self.project,
+                                  self.builderNames,
+                                  self.who,
+                                  self.config.get('properties', {}))
+        else:
+            d = remote.callRemote("try",
+                                  ss.branch,
+                                  ss.revision,
+                                  ss.patch,
+                                  ss.repository,
+                                  self.project,
+                                  self.builderNames,
+                                  self.config.get('properties', {}))
         d.addCallback(self._deliverJob_pb2)
         return d
     def _deliverJob_pb2(self, status):

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -940,6 +940,8 @@ class TryOptions(OptionsWithOptionsFile):
          "Location of the buildmaster's PBListener (host:port)"],
         ["passwd", None, None,
          "Password for PB authentication"],
+        ["who", "w", None,
+         "Who is responsible for the try build"],
 
         ["diff", None, None,
          "Filename of a patch to use instead of scanning a local tree. "
@@ -999,6 +1001,7 @@ class TryOptions(OptionsWithOptionsFile):
         [ 'try_jobdir', 'jobdir' ],
         [ 'try_password', 'passwd' ],
         [ 'try_master', 'master' ],
+        [ 'try_who', 'who' ],
         #[ 'try_wait', 'wait' ], <-- handled in postOptions
         [ 'try_masterstatus', 'masterstatus' ],
         # Deprecated command mappings from the quirky old days:

--- a/master/docs/cmdline.texinfo
+++ b/master/docs/cmdline.texinfo
@@ -431,6 +431,14 @@ build process' @code{source.Monotone} will use.
 
 @end table
 
+@heading showing who built
+
+You can provide the @option{--who=dev} to designate who is running the
+try build. This will add the @code{dev} to the Reason field on the try
+build's status web page. You can also set @code{try_who = dev} in the
+@file{.buildbot/options} file. Note that @option{--who=dev} will not
+work on version 0.8.3 or earlier masters.
+
 @heading waiting for results
 
 If you provide the @option{--wait} option (or @code{try_wait = True}


### PR DESCRIPTION
This works for `Try_Jobdir` schedulers and apparently already gave the username in `Try_Userpass` schedulers. I'm not entirely sure that `ver="2"` cases are handled, so let me know if anything needs to change. As far as I can tell, username params to `buildbot try` commands are required.
