### PR TITLE
Fixes for Debian bug #625555

### DIFF
--- a/master/NEWS
+++ b/master/NEWS
@@ -16,6 +16,11 @@ step's functionality.
 
 ** Deprecations, Removals, and Non-Compatible Changes
 
+*** Init script now uses /etc/default/buildmaster for instance configuration.
+Also MASTER_ENABLED used in /etc/default/buildmaster now accepts 'true|yes|1'
+to enable instance and 'false|no|0' to disable(not case sensitive). Other
+values will be considered as syntax error.
+
 *** 'buildbot.status.words.IRC' now defaults to `AllowForce=False` to prevent
 IRC bots from being allowed to force builds by default.
 

--- a/master/contrib/init-scripts/buildmaster.default
+++ b/master/contrib/init-scripts/buildmaster.default
@@ -1,8 +1,12 @@
 MASTER_RUNNER=/usr/bin/buildbot
 
-MASTER_ENABLED[1]=0                    # 0-enabled, other-disabled
+# NOTE: MASTER_ENABLED has changed its behaviour in version 0.8.4. Use
+# 'true|yes|1' to enable instance and 'false|no|0' to disable. Other
+# values will be considered as syntax error.
+
+MASTER_ENABLED[1]=0                    # 1-enabled, 0-disabled
 MASTER_NAME[1]="buildmaster #1"        # short name printed on start/stop
 MASTER_USER[1]="buildbot"              # user to run master as
 MASTER_BASEDIR[1]=""                   # basedir to master (absolute path)
-MASTER_OPTIONS[1]=""                   # buildbot options  
+MASTER_OPTIONS[1]=""                   # buildbot options
 MASTER_PREFIXCMD[1]=""                 # prefix command, i.e. nice, linux32, dchroot

--- a/slave/NEWS
+++ b/slave/NEWS
@@ -10,6 +10,11 @@ systems.  This means that in most cases child processes are cleaned up
 properly, and removes the most common use for usePTY.  As of this version,
 usePTY should be set to False for almost all users of Buildbot.
 
+** Init script now uses /etc/default/buildslave for instance configuration.
+Also SLAVE_ENABLED used in /etc/default/buildslave now accepts 'true|yes|1'
+to enable instance and 'false|no|0' to disable(not case sensitive). Other
+values will be considered as syntax error.
+
 
 * Buildbot-Slave 0.8.3 (December 19, 2010)
 

--- a/slave/contrib/init-scripts/buildslave.default
+++ b/slave/contrib/init-scripts/buildslave.default
@@ -1,8 +1,12 @@
 SLAVE_RUNNER=/usr/bin/buildslave
 
-SLAVE_ENABLED[1]=0                    # 0-enabled, other-disabled
+# NOTE: SLAVE_ENABLED has changed its behaviour in version 0.8.4. Use
+# 'true|yes|1' to enable instance and 'false|no|0' to disable. Other
+# values will be considered as syntax error.
+
+SLAVE_ENABLED[1]=0                    # 1-enabled, 0-disabled
 SLAVE_NAME[1]="buildslave #1"         # short name printed on start/stop
 SLAVE_USER[1]="buildbot"              # user to run slave as
 SLAVE_BASEDIR[1]=""                   # basedir to slave (absolute path)
-SLAVE_OPTIONS[1]=""                   # buildbot options  
+SLAVE_OPTIONS[1]=""                   # buildbot options
 SLAVE_PREFIXCMD[1]=""                 # prefix command, i.e. nice, linux32, dchroot


### PR DESCRIPTION
Hello, these are fixes for [Debian bug #625555](http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=625555). There is also one fix in question. The original reporter Andreas Beckmann has detected that using "0" to enable buildbot instance is weird. It's rather more useful to use anything like `1|true|yes` to enable instance and `0|false|no` to disable. 

However the init scripts' logic didn't changed for years so there would be backward compatibility problem. Please help me to determine wether this proposed changed would be accepted. If yes, I'd like to add another commit to this pull request before it's merged.
