### PR TITLE
Added support for EC2 regions

### DIFF
--- a/master/buildbot/ec2buildslave.py
+++ b/master/buildbot/ec2buildslave.py
@@ -123,10 +123,9 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                 self.conn = boto.ec2.connect_to_region(region,
                                      aws_access_key_id=identifier,
                                      aws_secret_access_key=secret_identifier)
+            else:
+                raise ValueError('The specified region does not exist: {0}'.format(region))
 
-        if region_found is None and region is not None:
-            log.msg("Warning: The specified region ({0}) was not found. Using " \
-                    "default region.".format(region))
         else:
             self.conn = boto.connect_ec2(identifier, secret_identifier)
 


### PR DESCRIPTION
I've added an extra argument to the function signature for EC2BuildSlave's `__init__` method. This provides the ability to pass a requested region to the constructor. For instance, you might want have an AMI that exists on us-east-1c. In this case, you could pass 'us-east-1' to your EC2BuildSlave's region, and it will connect to that EC2 region instead of the seemingly random default that is currently chosen.
