### PR TITLE
if exit status is not 0, return failure status for buildbot subunit step

### DIFF
--- a/master/buildbot/steps/subunit.py
+++ b/master/buildbot/steps/subunit.py
@@ -79,6 +79,8 @@ class SubunitShellCommand(ShellCommand):
         self.text2 = [text2]
         
     def evaluateCommand(self, cmd):
+        if cmd.rc != 0:
+            return FAILURE
         return self.results
 
     def createSummary(self, loog):


### PR DESCRIPTION
if a command returns none-zero exit code, the result should be failure for subunit step
