### PR TITLE
Fix typo that prevents upgrading existing master

### DIFF
--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -483,7 +483,7 @@ def upgradeMaster(config):
 
     if rc == 0:
         from buildbot.db import connector
-        from buildbot.buildmaster import BuildMaster
+        from buildbot.master import BuildMaster
 
         if not config['quiet']: print "upgrading database"
         db = connector.DBConnector(BuildMaster(config['basedir']),


### PR DESCRIPTION
This is quick fix. Hope to see it in 0.8.4...
