### PR TITLE
Added maxWarnCount to WarningCountingShellCommand's factory arguments

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -394,6 +394,7 @@ class WarningCountingShellCommand(ShellCommand):
                                  directoryEnterPattern=directoryEnterPattern,
                                  directoryLeavePattern=directoryLeavePattern,
                                  warningExtractor=warningExtractor,
+                                 maxWarnCount=maxWarnCount,
                                  suppressionFile=suppressionFile)
         self.suppressions = []
         self.directoryStack = []


### PR DESCRIPTION
Fixed an error in the max warning count patch
