### PR TITLE
added onlyImportant attribute to BaseBasicScheduler and Nightly schedulers

### DIFF
--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -157,7 +157,8 @@ class BaseScheduler(service.MultiService, ComparableMixin):
 
     ## change handling
 
-    def startConsumingChanges(self, fileIsImportant=None, change_filter=None):
+    def startConsumingChanges(self, fileIsImportant=None, change_filter=None,
+                              onlyImportant=False):
         """
         Subclasses should call this method from startService to register to
         receive changes.  The BaseScheduler class will take care of filtering
@@ -171,6 +172,11 @@ class BaseScheduler(service.MultiService, ComparableMixin):
         @param change_filter: a filter to determine which changes are even
         considered by this scheduler, or C{None} to consider all changes
         @type change_filter: L{buildbot.changes.filter.ChangeFilter} instance
+
+        @param onlyImportant: If True, only important changes, as specified by
+        fileIsImportant, will be added to the buildset.
+        @type onlyImportant: boolean
+
         """
         assert fileIsImportant is None or callable(fileIsImportant)
 
@@ -186,6 +192,8 @@ class BaseScheduler(service.MultiService, ComparableMixin):
             if fileIsImportant:
                 try:
                     important = fileIsImportant(change)
+                    if not important and onlyImportant:
+                        return
                 except:
                     log.err(failure.Failure(),
                             'in fileIsImportant check for %s' % change)

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -21,9 +21,16 @@ from buildbot.changes import filter, changes
 from buildbot.schedulers import base, dependent
 
 class BaseBasicScheduler(base.BaseScheduler):
+    """
+    @param onlyImportant: If True, only important changes will be added to the
+                          buildset.
+    @type onlyImportant: boolean
+
+    """
 
     compare_attrs = (base.BaseScheduler.compare_attrs +
-                     ('treeStableTimer', 'change_filter', 'fileIsImportant') )
+                     ('treeStableTimer', 'change_filter', 'fileIsImportant',
+                      'onlyImportant') )
 
     _reactor = reactor # for tests
 
@@ -31,7 +38,7 @@ class BaseBasicScheduler(base.BaseScheduler):
     def __init__(self, name, shouldntBeSet=NotSet, treeStableTimer=None,
                 builderNames=None, branch=NotABranch, branches=NotABranch,
                 fileIsImportant=None, properties={}, categories=None,
-                change_filter=None):
+                change_filter=None, onlyImportant=False):
         assert shouldntBeSet is self.NotSet, \
                 "pass arguments to schedulers using keyword arguments"
         if fileIsImportant:
@@ -42,6 +49,7 @@ class BaseBasicScheduler(base.BaseScheduler):
 
         self.treeStableTimer = treeStableTimer
         self.fileIsImportant = fileIsImportant
+        self.onlyImportant = onlyImportant
         self.change_filter = self.getChangeFilter(branch=branch,
                 branches=branches, change_filter=change_filter,
                 categories=categories)
@@ -58,7 +66,8 @@ class BaseBasicScheduler(base.BaseScheduler):
         base.BaseScheduler.startService(self)
 
         d = self.startConsumingChanges(fileIsImportant=self.fileIsImportant,
-                                       change_filter=self.change_filter)
+                                       change_filter=self.change_filter,
+                                       onlyImportant=self.onlyImportant)
 
         # if treeStableTimer is False, then we don't care about classified
         # changes, so get rid of any hanging around from previous

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -207,7 +207,7 @@ class Periodic(Timed):
     compare_attrs = Timed.compare_attrs + ('periodicBuildTimer', 'branch',)
 
     def __init__(self, name, builderNames, periodicBuildTimer,
-            branch=None, properties={}):
+            branch=None, properties={}, onlyImportant=False):
         Timed.__init__(self, name=name, builderNames=builderNames,
                     properties=properties)
         assert periodicBuildTimer > 0, "periodicBuildTimer must be positive"
@@ -228,14 +228,17 @@ class Nightly(Timed):
     compare_attrs = (Timed.compare_attrs
             + ('minute', 'hour', 'dayOfMonth', 'month',
                'dayOfWeek', 'onlyIfChanged', 'fileIsImportant',
-               'change_filter',))
+               'change_filter', 'onlyImportant',))
 
     class NoBranch: pass
     def __init__(self, name, builderNames, minute=0, hour='*',
                  dayOfMonth='*', month='*', dayOfWeek='*',
                  branch=NoBranch, fileIsImportant=None, onlyIfChanged=False,
-                 properties={}, change_filter=None):
+                 properties={}, change_filter=None, onlyImportant=False):
         Timed.__init__(self, name=name, builderNames=builderNames, properties=properties)
+
+        # If True, only important changes will be added to the buildset.
+        self.onlyImportant = onlyImportant
 
         if fileIsImportant:
             assert callable(fileIsImportant), \
@@ -257,8 +260,9 @@ class Nightly(Timed):
 
     def startTimedSchedulerService(self):
         if self.onlyIfChanged:
-            return self.startConsumingChanges(
-                    fileIsImportant=self.fileIsImportant, change_filter=self.change_filter)
+            return self.startConsumingChanges(fileIsImportant=self.fileIsImportant,
+                                              change_filter=self.change_filter,
+                                              onlyImportant=self.onlyImportant)
         else:
             return self.master.db.schedulers.flushChangeClassifications(self.schedulerid)
 

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -207,6 +207,18 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
                 self.makeFakeChange(),
                 None)
 
+    def test_change_consumption_fileIsImportant_False_onlyImportant(self):
+        return self.do_test_change_consumption(
+                dict(fileIsImportant=lambda c : False, onlyImportant=True),
+                self.makeFakeChange(),
+                None)
+
+    def test_change_consumption_fileIsImportant_True_onlyImportant(self):
+        return self.do_test_change_consumption(
+                dict(fileIsImportant=lambda c : True, onlyImportant=True),
+                self.makeFakeChange(),
+                True)
+
     def test_addBuilsetForLatest_args(self):
         sched = self.makeScheduler(name='xyz', builderNames=['y', 'z'])
         d = sched.addBuildsetForLatest(reason='cuz', branch='default',

--- a/master/buildbot/test/unit/test_schedulers_basic.py
+++ b/master/buildbot/test/unit/test_schedulers_basic.py
@@ -99,7 +99,8 @@ class BaseBasicScheduler(CommonStuffMixin,
         # check that the scheduler has started to consume changes, and the
         # classifications *have* been flushed, since they will not be used
         def check(_):
-            self.assertConsumingChanges(fileIsImportant=fII, change_filter=cf)
+            self.assertConsumingChanges(fileIsImportant=fII, change_filter=cf,
+                                        onlyImportant=False)
             self.db.schedulers.assertClassifications(self.SCHEDULERID, {})
         d.addCallback(check)
         d.addCallback(lambda _ : sched.stopService())
@@ -123,7 +124,8 @@ class BaseBasicScheduler(CommonStuffMixin,
         # classification should have been acted on, so the timer should be
         # running
         def check(_):
-            self.assertConsumingChanges(fileIsImportant=None, change_filter=cf)
+            self.assertConsumingChanges(fileIsImportant=None, change_filter=cf,
+                                        onlyImportant=False)
             self.db.schedulers.assertClassifications(self.SCHEDULERID, { 20 : True })
             self.assertTrue(sched.timer_started)
         d.addCallback(check)

--- a/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
@@ -299,7 +299,8 @@ class Nightly(scheduler.SchedulerMixin, unittest.TestCase):
         sched.startService()
 
         # check that the scheduler has started to consume changes
-        self.assertConsumingChanges(fileIsImportant=fII, change_filter=None)
+        self.assertConsumingChanges(fileIsImportant=fII, change_filter=None,
+                                    onlyImportant=False)
 
         # manually run the clock forward through a half-hour, allowing any
         # excitement to take place

--- a/master/docs/cfg-schedulers.texinfo
+++ b/master/docs/cfg-schedulers.texinfo
@@ -77,6 +77,12 @@ completely ignored by the scheduler.  If a Change is allowed by the change
 filter, but is deemed unimportant, then it will not cause builds to start, but
 will be remembered and shown in status displays.
 
+@item onlyImportant
+A boolean that, when @code{True}, only adds important changes to the buildset as
+sepcified in the @code{fileIsImportant} callable. This means that unimportant
+changes are ignored the same way a @code{change_filter} filters changes. This
+defaults to @code{False} and only applies when @code{fileIsImportant} is given.
+
 @end table
 
 The remaining subsections represent a catalog of the available Scheduler types.
@@ -182,6 +188,8 @@ The arguments to this scheduler are:
 @item change_filter
 @pxref{Configuring Schedulers}
 
+@item onlyImportant
+
 @item treeStableTimer
 The scheduler will wait for this many seconds before starting the
 build. If new changes are made during this interval, the timer will be
@@ -254,6 +262,8 @@ The arguments to this scheduler are:
 
 @item change_filter
 @pxref{Configuring Schedulers}
+
+@item onlyImportant
 
 @item treeStableTimer
 The scheduler will wait for this many seconds before starting the
@@ -352,6 +362,8 @@ The arguments to this scheduler are:
 
 @item properties
 
+@item onlyImportant
+
 @item periodicBuildTimer
 The time, in seconds, after which to start a build.
 @end table
@@ -400,6 +412,8 @@ The full list of parameters is:
 @item properties
 
 @item fileIsImportant
+
+@item onlyImportant
 
 @item branch
 (required) The branch to build when the time comes.  Remember that a value of


### PR DESCRIPTION
The onlyImportant attribute, when True, only adds changes deemed important by fileIsImportant to a buildset, fixes ticket #1957
