### PR TITLE
add subject to e-mail notifications with custom messages

### DIFF
--- a/master/buildbot/status/mail.py
+++ b/master/buildbot/status/mail.py
@@ -590,7 +590,8 @@ class MailNotifier(base.StatusReceiverMultiService):
             msgdict['body'] += tmp['body']
             msgdict['body'] += '\n\n'
             msgdict['type'] = tmp['type']
-            
+            if subject in tmp:
+                msgdict['subject'] = tmp['subject'] 
         m = self.createEmail(msgdict, name, self.master_status.getTitle(),
                              results, builds, patches, logs)
 


### PR DESCRIPTION
Without this, you can't set the subject in messageNotifier at all - which is not what is in the code or the documentation.

The only problem with this commit would be the fact that multiple builds could have a subject message, and the message would be overridden with the last subject message. 
