### PR TITLE
added KILL option to ShellCommand to specify what kill signal to use

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -480,7 +480,8 @@ class RemoteShellCommand(LoggedRemoteCommand):
     def __init__(self, workdir, command, env=None,
                  want_stdout=1, want_stderr=1,
                  timeout=20*60, maxTime=None, logfiles={},
-                 usePTY="slave-config", logEnviron=True):
+                 usePTY="slave-config", logEnviron=True,
+                 KILL=None):
         """
         @type  workdir: string
         @param workdir: directory where the command ought to run,
@@ -526,6 +527,10 @@ class RemoteShellCommand(LoggedRemoteCommand):
         @param maxTime: tell the remote that if the command fails to complete
                         in this number of seconds, the command should be
                         killed.  Use None to disable maxTime.
+
+        @type  KILL: string
+        @param KILL: what signal to send to the command if the step should 
+                     be interrupted, Defaults to "KILL"
         """
 
         self.command = command # stash .command, set it later
@@ -544,6 +549,8 @@ class RemoteShellCommand(LoggedRemoteCommand):
                 'usePTY': usePTY,
                 'logEnviron': logEnviron,
                 }
+        if KILL is not None:
+            args['KILL'] = KILL
         LoggedRemoteCommand.__init__(self, "shell", args)
 
     def start(self):

--- a/slave/buildslave/commands/shell.py
+++ b/slave/buildslave/commands/shell.py
@@ -46,6 +46,8 @@ class SlaveShellCommand(base.Command):
                         watched just like 'tail -f', and all changes will be
                         written to 'log' status updates.
         - ['logEnviron']: False to not log the environment variables on the slave
+        - ['KILL']: what signal should be sent to the sub process when 
+                    interrupting this step. Defaults to "KILL"
 
     ShellCommand creates the following status messages:
         - {'stdout': data} : when stdout data is available
@@ -76,6 +78,8 @@ class SlaveShellCommand(base.Command):
                          usePTY=args.get('usePTY', "slave-config"),
                          logEnviron=args.get('logEnviron', True),
                          )
+	if args.get('KILL'):
+            c.KILL = args['KILL']
         c._reactor = self._reactor
         self.command = c
         d = self.command.start()


### PR DESCRIPTION
added KILL option to ShellCommand to specify what kill signal should be send to command to interrupt it

this is useful for command which needs to run some cleanup on exit, or things will be messed up

currently, it always uses kill -9 which gives no chance for a command to shut itself down properly
