### PR TITLE
Handle displaying of non-ASCII properties

### DIFF
--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -125,7 +125,7 @@ class StatusResourceBuild(HtmlResource):
 
         ps = cxt['properties'] = []
         for name, value, source in b.getProperties().asList():
-            value = str(value)
+            value = unicode(value)
             p = { 'name': name, 'value': value, 'source': source}            
             if len(value) > 500:
                 p['short_value'] = value[:500]


### PR DESCRIPTION
The webstatus page crashed with an UnicodeEncodeError when one of my properties had a non-ASCII character in it (the author name). Here's the one-liner to fix it.
