### PR TITLE
Fix *_PREFIXCMD usage in init scripts (Debian bug #627918).

### DIFF
--- a/master/contrib/init-scripts/buildmaster.init.sh
+++ b/master/contrib/init-scripts/buildmaster.init.sh
@@ -112,7 +112,7 @@ function iscallable () { type $1 2>/dev/null | grep -q 'shell function'; }
 function master_op () {
     op=$1 ; mi=$2
 
-    ${MASTER_PREFIXCMD[$1]} \
+    ${MASTER_PREFIXCMD[$mi]} \
     su -s /bin/sh \
     -c "$MASTER_RUNNER $op --quiet ${MASTER_OPTIONS[$mi]} ${MASTER_BASEDIR[$mi]}" \
     - ${MASTER_USER[$mi]}

--- a/slave/contrib/init-scripts/buildslave.init.sh
+++ b/slave/contrib/init-scripts/buildslave.init.sh
@@ -112,7 +112,7 @@ function iscallable () { type $1 2>/dev/null | grep -q 'shell function'; }
 function slave_op () {
     op=$1 ; mi=$2
 
-    ${SLAVE_PREFIXCMD[$1]} \
+    ${SLAVE_PREFIXCMD[$mi]} \
     su -s /bin/sh \
     -c "$SLAVE_RUNNER $op --quiet ${SLAVE_OPTIONS[$mi]} ${SLAVE_BASEDIR[$mi]}" \
     - ${SLAVE_USER[$mi]}


### PR DESCRIPTION
Originally reported and patched by Andreas Beckmann. See
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=627918
