### PR TITLE
getProperty no longer raises KeyError

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -702,7 +702,10 @@ class BuildStep:
             self.progress.setProgress(metric, value)
 
     def getProperty(self, propname):
-        return self.build.getProperty(propname)
+        try:
+            return self.build.getProperty(propname)
+        except KeyError:
+            raise KeyError, 'build is %r' % self.build
 
     def setProperty(self, propname, value, source="Step", runtime=True):
         self.build.setProperty(propname, value, source, runtime=runtime)

--- a/master/buildbot/process/mtrlogobserver.py
+++ b/master/buildbot/process/mtrlogobserver.py
@@ -423,10 +423,8 @@ CREATE TABLE IF NOT EXISTS test_warnings(
 ) ENGINE=innodb
 """)
 
-        revision = None
-        try:
-            revision = self.getProperty("got_revision")
-        except exceptions.KeyError:
+        revision = self.getProperty("got_revision")
+        if revision is None:
             revision = self.getProperty("revision")
         typ = "mtr"
         if self.test_type:

--- a/master/buildbot/status/status_gerrit.py
+++ b/master/buildbot/status/status_gerrit.py
@@ -79,17 +79,12 @@ class GerritStatusPush(StatusReceiverMultiService):
 
     def buildFinished(self, builderName, build, result):
         """Do the SSH gerrit verify command to the server."""
-        repo, git = False, False
 
         # Gerrit + Repo
-        try:
-            downloads = build.getProperty("repo_downloads")
-            downloaded = build.getProperty("repo_downloaded").split(" ")
-            repo = True
-        except KeyError:
-            pass
-
-        if repo:
+        downloads = build.getProperty("repo_downloads")
+        downloaded = build.getProperty("repo_downloaded")
+        if downloads is not None and downloaded is not None: 
+            downloaded = downloaded.split(" ")
             if downloads and 2 * len(downloads) == len(downloaded):
                 message, verified, reviewed = self.reviewCB(builderName, build, result, self.reviewArg)
                 for i in range(0, len(downloads)):
@@ -106,18 +101,13 @@ class GerritStatusPush(StatusReceiverMultiService):
             return
 
         # Gerrit + Git
-        try:
-            build.getProperty("gerrit_branch") # used only to verify Gerrit source
+        if build.getProperty("gerrit_branch") is not None: # used only to verify Gerrit source
             project = build.getProperty("project")
             revision = build.getProperty("got_revision")
-            git = True
-        except KeyError:
-            pass
-
-        if git:
-            message, verified, reviewed = self.reviewCB(builderName, build, result, self.reviewArg)
-            self.sendCodeReview(project, revision, message, verified, reviewed)
-            return
+            if project is not None and revision is not None:
+                message, verified, reviewed = self.reviewCB(builderName, build, result, self.reviewArg)
+                self.sendCodeReview(project, revision, message, verified, reviewed)
+                return
 
     def sendCodeReview(self, project, revision, message=None, verified=0, reviewed=0):
         command = ["ssh", self.gerrit_username + "@" + self.gerrit_server, "-p %d" % self.gerrit_port,

--- a/master/buildbot/status/web/base.py
+++ b/master/buildbot/status/web/base.py
@@ -431,13 +431,7 @@ class BuildLineMixin:
         builder_name = build.getBuilder().getName()
         results = build.getResults()
         text = build.getText()
-        try:
-            rev = build.getProperty("got_revision")
-            if rev is None:
-                rev = "??"
-        except KeyError:
-            rev = "??"
-        rev = str(rev)
+        rev = str(build.getProperty("got_revision", "??"))
         css_class = css_classes.get(results, "")
         repo = build.getSourceStamp().repository
 

--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -77,11 +77,7 @@ class StatusResourceBuild(HtmlResource):
             cxt['most_recent_rev_build'] = True
 
 
-        got_revision = None
-        try:
-            got_revision = b.getProperty("got_revision")
-        except KeyError:
-            pass
+        got_revision = b.getProperty("got_revision")
         if got_revision:
             cxt['got_revision'] = str(got_revision)
 

--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -488,10 +488,7 @@ class BuildersResource(HtmlResource):
             if builds:
                 b = builds[0]
                 bld['build_url'] = (bld['link'] + "/builds/%d" % b.getNumber())
-                try:
-                    label = b.getProperty("got_revision")
-                except KeyError:
-                    label = None
+                label = b.getProperty("got_revision")
                 if not label or len(str(label)) > 20:
                     label = "#%d" % b.getNumber()
 

--- a/master/buildbot/status/web/console.py
+++ b/master/buildbot/status/web/console.py
@@ -244,27 +244,15 @@ class ConsoleStatusResource(HtmlResource):
             # Get the last revision in this build.
             # We first try "got_revision", but if it does not work, then
             # we try "revision".
-            got_rev = -1
-            try:
-                got_rev = build.getProperty("got_revision")
-                if not self.comparator.isValidRevision(got_rev):
-                    got_rev = -1
-            except KeyError:
-                pass
-
-            try:
-                if got_rev == -1:
-                    got_rev = build.getProperty("revision")
-                if not self.comparator.isValidRevision(got_rev):
-                    got_rev = -1
-            except:
-                pass
+            got_rev = build.getProperty("got_revision", build.getProperty("revision", -1))
+            if got_rev != -1 and not self.comparator.isValidRevision(got_rev):
+                got_rev = -1
 
             # We ignore all builds that don't have last revisions.
             # TODO(nsylvain): If the build is over, maybe it was a problem
             # with the update source step. We need to find a way to tell the
             # user that his change might have broken the source update.
-            if got_rev and got_rev != -1:
+            if got_rev != -1:
                 details = self.getBuildDetails(request, builderName, build)
                 devBuild = DevBuild(got_rev, build, details)
                 builds.append(devBuild)

--- a/master/buildbot/status/web/feeds.py
+++ b/master/buildbot/status/web/feeds.py
@@ -191,11 +191,7 @@ class FeedResource(XmlResource):
             if (ss.branch is None and ss.revision is None and ss.patch is None
                 and not ss.changes):
                 source += "Latest revision "
-            got_revision = None
-            try:
-                got_revision = build.getProperty("got_revision")
-            except KeyError:
-                pass
+            got_revision = build.getProperty("got_revision")
             if got_revision:
                 got_revision = str(got_revision)
                 if len(got_revision) > 40:

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -544,9 +544,8 @@ class WarningCountingShellCommand(ShellCommand):
         warnings_stat = self.step_status.getStatistic('warnings', 0)
         self.step_status.setStatistic('warnings', warnings_stat + self.warnCount)
 
-        try:
-            old_count = self.getProperty("warnings-count")
-        except KeyError:
+        old_count = self.getProperty("warnings-count")
+        if old_count is None:
             old_count = 0
         self.setProperty("warnings-count", old_count + self.warnCount, "WarningCountingShellCommand")
 

--- a/master/buildbot/steps/source/oldsource.py
+++ b/master/buildbot/steps/source/oldsource.py
@@ -873,11 +873,12 @@ class Git(Source):
         self.args['patch'] = patch
 
         # check if there is any patchset we should fetch from Gerrit
-        try:
+        gerrit_branch = self.build.getProperty("event.patchSet.ref")
+        if gerrit_branch is not None:
             # GerritChangeSource
-            self.args['gerrit_branch'] = self.build.getProperty("event.patchSet.ref")
-            self.setProperty("gerrit_branch", self.args['gerrit_branch'])
-        except KeyError:
+            self.args['gerrit_branch'] = gerrit_branch
+            self.setProperty("gerrit_branch", gerrit_branch)
+        else:
             try:
                 # forced build
                 change = self.build.getProperty("gerrit_change").split('/')
@@ -966,10 +967,7 @@ class Repo(Source):
         making this a defereable allow config to tweak this
         in order to e.g. manage dependancies
         """
-        try:
-            downloads = self.build.getProperty("repo_downloads")
-        except KeyError:
-            downloads = []
+        downloads = self.build.getProperty("repo_downloads", [])
 
         # download patches based on GerritChangeSource events
         for change in self.build.allChanges():
@@ -984,11 +982,9 @@ class Repo(Source):
         # "repo_download", "repo_download0", .., "repo_download9"
         for propName in ["repo_d"] + ["repo_d%d" % i for i in xrange(0,10)] + \
           ["repo_download"] + ["repo_download%d" % i for i in xrange(0,10)]:
-            try:
-                s = self.build.getProperty(propName)
+            s = self.build.getProperty(propName)
+            if s is not None:
                 downloads.extend(self.parseDownloadProperty(s))
-            except KeyError:
-                pass
 
         if downloads:
             self.args["repo_downloads"] = downloads

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -35,7 +35,7 @@ class FakeBuild(object):
     def getProperties(self):
         return self.properties
     def getProperty(self, key, default=None):
-        return self.properties.getProperty(key)
+        return self.properties.getProperty(key, default)
     def hasProperty(self, key):
         return self.properties.has_key(key)
     def render(self, value):

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -85,7 +85,9 @@ class BuildStepMixin(object):
         def setProperty(propname, value, source=None, runtime=None):
             self.set_properties[propname] = value
         b.setProperty = setProperty
-        b.getProperty = self.set_properties.__getitem__
+        def getProperty(propname, default=None):
+            self.set_properties.get(propname,default)
+        b.getProperty = getProperty
         step.setBuild(b)
 
         # step.progress


### PR DESCRIPTION
I tried to clean everything up as best I could.  Some simplifications are probably still possible, e.g. if you know that valid value of some property all evaluate to true.  Also, a bit of a mystery:

If I change

``` python
        old_count = self.getProperty("warnings-count")
        if old_count is None:
            old_count = 0
```

to 

``` python
        old_count = self.getProperty("warnings-count", 0)
```

the tests fail again.  The only explanation I can come up with is that maybe I didn't fix up enough of the testing stuff.
