### PR TITLE
integrated users, users_info, and change_users tables to database

### DIFF
--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -18,7 +18,7 @@ from twisted.application import internet, service
 from buildbot.db import enginestrategy
 
 from buildbot.db import pool, model, changes, schedulers, sourcestamps
-from buildbot.db import state, buildsets, buildrequests, builds
+from buildbot.db import state, buildsets, buildrequests, builds, users
 
 class DBConnector(service.MultiService):
     """
@@ -51,6 +51,7 @@ class DBConnector(service.MultiService):
         self.buildrequests = buildrequests.BuildRequestsConnectorComponent(self)
         self.state = state.StateConnectorComponent(self)
         self.builds = builds.BuildsConnectorComponent(self)
+        self.users = users.UsersConnectorComponent(self)
 
         self.cleanup_timer = internet.TimerService(self.CLEANUP_PERIOD, self.doCleanup)
         self.cleanup_timer.setServiceParent(self)

--- a/master/buildbot/db/migrate/versions/012_add_users_table.py
+++ b/master/buildbot/db/migrate/versions/012_add_users_table.py
@@ -1,0 +1,58 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+
+def upgrade(migrate_engine):
+
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+
+    # what defines a user
+    users = sa.Table("users", metadata,
+        sa.Column("uid", sa.Integer, primary_key=True),
+        sa.Column("identifier", sa.String(256)),
+        sa.Column("full_name", sa.Text()),
+        sa.Column("email", sa.Text())
+    )
+    users.create()
+
+    idx = sa.Index('users_uid', users.c.uid)
+    idx.create()
+    idx = sa.Index('users_identifier', users.c.identifier)
+    idx.create()
+
+    # ways buildbot knows about users
+    users_info = sa.Table("users_info", metadata,
+        sa.Column("uid", sa.Integer, sa.ForeignKey('users.uid'), nullable=False),
+        sa.Column("attr_type", sa.Text(), nullable=False),
+        sa.Column("attr_data", sa.Text(), nullable=False)
+    )
+    users_info.create()
+
+    idx = sa.Index('users_info_uid', users_info.c.uid)
+    idx.create()
+
+    # correlates change authors and user uids
+    changes = sa.Table('changes', metadata, autoload=True)
+    change_users = sa.Table("change_users", metadata,
+        sa.Column("changeid", sa.Integer, sa.ForeignKey('changes.changeid'),
+                  nullable=False),
+        sa.Column("uid", sa.Integer, sa.ForeignKey('users.uid'), nullable=False)
+    )
+    change_users.create()
+
+    idx = sa.Index('change_users_changeid', change_users.c.changeid)
+    idx.create()

--- a/master/buildbot/db/users.py
+++ b/master/buildbot/db/users.py
@@ -1,0 +1,308 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+"""
+Support for users in the database
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.sql.expression import and_, or_
+
+from twisted.python import log
+from twisted.internet import defer, reactor
+from buildbot.db import base
+
+class UsDict(dict):
+    pass
+
+class UsersConnectorComponent(base.DBConnectorComponent):
+    """
+    A DBConnectorComponent to handle getting users into and out of the
+    database.  An instance is available at C{master.db.users}.
+
+    """
+
+    known_types = ['full_name', 'email']
+    known_info_types = ['authz_user', 'authz_pass', 'git']
+
+    def addUser(self, identifier=None, user_dict=None):
+        """Adds a User to the database with the passed in attributes; returns
+        the new user's uid via deferred. All arguments are keyword arguments.
+        This performs some checks to make sure there aren't duplicate users
+        created, such as checking for exact matches on attr_data.
+
+        @param identifier: string used as index if uid is not known
+        @type identifier: string
+
+        @param user_dict: dictionary whose key/value pairs are attr_type
+                          and attr_data pairs
+        @type user_dict: dictionary
+
+        @returns: new user's uid via Deferred or None
+        """
+
+        def thd(conn):
+            if not user_dict:
+                return None
+
+            transaction = conn.begin()
+            tbl = self.db.model.users
+            tbl_info = self.db.model.users_info
+            uid, ident = None, None
+
+            # if there's a user with the same identifier already in the
+            # database, we use the existing uid
+            if identifier:
+                res = conn.execute(tbl.select(whereclause=(
+                                      tbl.c.identifier == identifier)))
+                rows = res.fetchall()
+                if rows:
+                    uid = rows[0].uid
+                ident = identifier
+
+            # if no identifier is given, we try to render a decent one
+            elif not ident:
+                if 'email' in user_dict:
+                    ident = user_dict['email']
+                elif 'full_name' in user_dict:
+                    ident = user_dict['full_name']
+                else:
+                    ident = user_dict.values()[0]
+
+            # check for an existing user
+            for attr_type in user_dict:
+                attr_data = user_dict[attr_type]
+
+                q = tbl_info.select(whereclause=(
+                                    and_(tbl_info.c.attr_type == attr_type,
+                                         tbl_info.c.attr_data == attr_data)))
+                rows = conn.execute(q).fetchall()
+
+                if rows:
+                    log.msg("found existing User Object with attribute "
+                            "%r: %r and uid %r" % (attr_type, attr_data,
+                                                   rows[0].uid))
+                    return rows[0].uid
+
+            # insert new uid if needed
+            if not uid:
+                r = conn.execute(tbl.insert(), dict(identifier=ident))
+                uid = r.inserted_primary_key[0]
+
+            # update users table if type is null
+            for attr in user_dict:
+                if attr in self.known_types:
+                    qs = tbl.select(whereclause=(tbl.c.uid == uid))
+                    row = conn.execute(qs).fetchone()
+
+                    qu = tbl.update(whereclause=(tbl.c.uid == uid))
+                    if not row.full_name and attr == 'full_name':
+                        conn.execute(qu, full_name=user_dict[attr])
+                    if not row.email and attr == 'email':
+                        conn.execute(qu, email=user_dict[attr])
+
+            # add new attr_foo to users_info table
+            for attr_type in user_dict:
+                attr_data = user_dict[attr_type]
+                if attr_type in self.known_info_types:
+                    r = conn.execute(tbl_info.insert(),
+                                     dict(uid=uid, attr_type=attr_type,
+                                          attr_data=attr_data))
+
+            log.msg("added User Object to table: %r" % user_dict)
+            transaction.commit()
+            return uid
+        d = self.db.pool.do(thd)
+        return d
+
+    @base.cached("usdicts")
+    def getUser(self, key):
+        """
+        Get a dictionary representing a given user, or None if no matching
+        user is found.
+
+        @param key: to work with the caching decorator, there can only be
+                    one argument given to the method, which is either the
+                    user id (uid) or the string used as index if uid is not
+                    known (identifier)
+        @type key: int or string
+
+        @param no_cache: bypass cache and always fetch from database
+        @type no_cache: boolean
+
+        @returns: User dictionary via deferred
+        """
+        def thd(conn):
+            tbl = self.db.model.users
+            tbl_info = self.db.model.users_info
+            q = None
+
+            if isinstance(key, int):
+                q = tbl.select(whereclause=(tbl.c.uid == key))
+            elif key:
+                q = tbl.select(whereclause=(tbl.c.identifier == key))
+            else:
+                return None
+
+            row = conn.execute(q).fetchone()
+
+            if not row:
+                return None
+
+            # make UsDict to return
+            usdict = UsDict()
+            usdict['uid'] = row.uid
+            usdict['identifier'] = row.identifier
+            usdict['full_name'] = row.full_name
+            usdict['email'] = row.email
+
+            # gather all attr_type and attr_data entries from users_info table
+            q = tbl_info.select(whereclause=(tbl_info.c.uid == usdict['uid']))
+            rows = conn.execute(q).fetchall()
+
+            for row in rows:
+                usdict[row.attr_type] = row.attr_data
+
+            log.msg("got User Object from table: %r" % usdict)
+            return usdict
+        d = self.db.pool.do(thd)
+        return d
+
+    def updateUser(self, uid=None, identifier=None, user_dict=None):
+        """Updates a user's attributes in the database with the given user_dict
+        items. Returns a deferred or None if there is no matching user found.
+        If an item is in user_dict that a matching user does not have yet, that
+        item will be added to the tables.
+
+        @param uid: user id number
+        @type uid: int
+
+        @param identifier: string used as index if uid is not known
+        @type identifier: string
+
+        @param user_dict: dictionary whose key/value pairs are attr_type
+                          and attr_data pairs
+        @type user_dict: dictionary
+
+        @returns: Deferred or None
+        """
+
+        def thd(conn):
+            if not user_dict:
+                return None
+            transaction = conn.begin()
+
+            tbl = self.db.model.users
+            tbl_info = self.db.model.users_info
+
+            if uid:
+                q = tbl.select(whereclause=(tbl.c.uid == uid))
+            elif identifier:
+                q = tbl.select(whereclause=(tbl.c.identifier == identifier))
+            else:
+                return None
+
+            # if no matching user is found, return
+            row = conn.execute(q).fetchone()
+            if not row:
+                return None
+
+            row_uid = row.uid
+            qs = tbl_info.select(whereclause=(tbl_info.c.uid == row_uid))
+            rows = conn.execute(qs).fetchall()
+            if not rows:
+                rows = []
+
+            for attr_type in user_dict:
+                attr_data = user_dict[attr_type]
+
+                # update value if attr_type exists, otherwise add a new row
+                if attr_type in self.known_types:
+                    qu = tbl.update(whereclause=(tbl.c.uid == row_uid))
+                    if row.full_name and attr_type == 'full_name':
+                        conn.execute(qu, full_name=user_dict[attr_type])
+                    if row.email and attr_type == 'email':
+                        conn.execute(qu, email=user_dict[attr_type])
+
+                elif attr_type in self.known_info_types:
+                    for info_row in rows:
+                        if info_row.attr_type == attr_type:
+                            qu = tbl_info.update(whereclause=(
+                                    and_(tbl_info.c.attr_type == attr_type,
+                                         tbl_info.c.uid == info_row_uid)))
+                            conn.execute(qu, attr_data=attr_data)
+                            break
+                    else:
+                        if attr_type in self.known_info_types:
+                            conn.execute(tbl_info.insert(),
+                                         dict(uid=row_uid,
+                                              attr_type=attr_type,
+                                              attr_data=attr_data))
+            transaction.commit()
+            log.msg("updated following attributes of matching User Object in "
+                    "table: %r" % user_dict)
+        d = self.db.pool.do(thd)
+        return d
+
+    def removeUser(self, uid=None, identifier=None):
+        """
+        Remove a user with the given uid from the database, returns a UsDict
+        with the removed user via Deferred if the user was found.
+
+        @param uid: unique user id number
+        @type uid: int
+
+        @param identifier: string used as index if uid is not known
+        @type identifier: string
+
+        @returns: UsDict via Deferred
+        """
+
+        def thd(conn):
+            tbl = self.db.model.users
+            tbl_info = self.db.model.users_info
+
+            if uid:
+                q = tbl.select(whereclause=(tbl.c.uid == uid))
+            elif identifier:
+                q = tbl.select(whereclause=(tbl.c.identifier == identifier))
+            else:
+                return None
+
+            res = conn.execute(q)
+            row = res.fetchone()
+
+            if not row:
+                return None
+
+            qs = tbl_info.select(whereclause=(tbl_info.c.uid == row.uid))
+            info_rows = conn.execute(qs).fetchall()
+
+            conn.execute(tbl_info.delete(whereclause=(tbl_info.c.uid == row.uid)))
+            conn.execute(tbl.delete(whereclause=(tbl.c.uid == row.uid)))
+
+            # gather all attr_type and attr_data entries
+            usdict = {}
+            usdict['uid'] = row.uid
+            usdict['identifier'] = row.identifier
+            usdict['full_name'] = row.full_name
+            usdict['email'] = row.email
+
+            for row in info_rows:
+                usdict[row.attr_type] = row.attr_data
+            log.msg("removed User Object from table: %r" % usdict)
+            return usdict
+        d = self.db.pool.do(thd)
+        return d

--- a/master/buildbot/test/unit/test_db_changes.py
+++ b/master/buildbot/test/unit/test_db_changes.py
@@ -32,7 +32,8 @@ class TestChangesConnectorComponent(
         d = self.setUpConnectorComponent(
             table_names=['changes', 'change_links', 'change_files',
                 'change_properties', 'scheduler_changes', 'schedulers',
-                'sourcestamps', 'sourcestamp_changes', 'patches' ])
+                'sourcestamps', 'sourcestamp_changes', 'patches',
+                'change_users'])
 
         def finish_setup(_):
             self.db.changes = changes.ChangesConnectorComponent(self.db)
@@ -303,6 +304,84 @@ class TestChangesConnectorComponent(
                 self.assertEqual(len(r), 0)
             return self.db.pool.do(thd)
         d.addCallback(check_change_properties)
+        return d
+
+    def test_addChange_with_uid(self):
+        d = self.db.changes.addChange(
+                 author=u'dustin',
+                 files=[],
+                 comments=u'fix spelling',
+                 is_dir=0,
+                 links=[],
+                 revision=u'2d6caa52',
+                 when_timestamp=epoch2datetime(1239898353),
+                 branch=u'master',
+                 category=None,
+                 revlink=None,
+                 properties={},
+                 repository=u'',
+                 project=u'',
+                 uid=1)
+        # check all of the columns of the five relevant tables
+        def check_change(changeid):
+            def thd(conn):
+                r = conn.execute(self.db.model.changes.select())
+                r = r.fetchall()
+                self.assertEqual(len(r), 1)
+                self.assertEqual(r[0].changeid, changeid)
+                self.assertEqual(r[0].when_timestamp, 1239898353)
+            return self.db.pool.do(thd)
+        d.addCallback(check_change)
+        def check_change_links(_):
+            def thd(conn):
+                query = self.db.model.change_links.select()
+                r = conn.execute(query)
+                r = r.fetchall()
+                self.assertEqual(len(r), 0)
+            return self.db.pool.do(thd)
+        d.addCallback(check_change_links)
+        def check_change_files(_):
+            def thd(conn):
+                query = self.db.model.change_files.select()
+                r = conn.execute(query)
+                r = r.fetchall()
+                self.assertEqual(len(r), 0)
+            return self.db.pool.do(thd)
+        d.addCallback(check_change_files)
+        def check_change_properties(_):
+            def thd(conn):
+                query = self.db.model.change_properties.select()
+                r = conn.execute(query)
+                r = r.fetchall()
+                self.assertEqual(len(r), 0)
+            return self.db.pool.do(thd)
+        d.addCallback(check_change_properties)
+        def check_change_users(_):
+            def thd(conn):
+                query = self.db.model.change_users.select()
+                r = conn.execute(query)
+                r = r.fetchall()
+                self.assertEqual(len(r), 1)
+                self.assertEqual(r[0].changeid, 1)
+                self.assertEqual(r[0].uid, 1)
+            return self.db.pool.do(thd)
+        d.addCallback(check_change_users)
+        return d
+
+    def test_getChangeUids_missing(self):
+        d = self.db.changes.getChangeUids(1)
+        def check(res):
+            self.assertEqual(res, None)
+        d.addCallback(check)
+        return d
+
+    def test_getChangeUid_found(self):
+        d = self.insertTestData(self.change14_rows +
+                                [fakedb.ChangeUser(changeid=14, uid=1)])
+        d.addCallback(lambda _ : self.db.changes.getChangeUids(14))
+        def check(res):
+            self.assertEqual(res, [1])
+        d.addCallback(check)
         return d
 
     def test_pruneChanges(self):

--- a/master/buildbot/test/unit/test_db_users.py
+++ b/master/buildbot/test/unit/test_db_users.py
@@ -1,0 +1,277 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+from twisted.trial import unittest
+from twisted.internet import defer, task
+from buildbot.db import users
+from buildbot.test.util import connector_component
+from buildbot.test.fake import fakedb
+
+class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
+                                 unittest.TestCase):
+
+    def setUp(self):
+        d = self.setUpConnectorComponent(table_names=['users', 'users_info'])
+        def finish_setup(_):
+            self.db.users = users.UsersConnectorComponent(self.db)
+        d.addCallback(finish_setup)
+        return d
+
+    def tearDown(self):
+        return self.tearDownConnectorComponent()
+
+    # sample user data
+
+    user1_rows = [
+        fakedb.User(uid=1, identifier='soap', full_name='Tyler Durden',
+                    email='tyler@mayhem.net'),
+        fakedb.UserInfo(uid=1)
+    ]
+
+    user2_rows = [
+        fakedb.User(uid=2),
+        fakedb.UserInfo(uid=2, attr_type='authz_user', attr_data='tdurden'),
+        fakedb.UserInfo(uid=2, attr_type='authz_pass', attr_data='lye')
+    ]
+
+    user1_dict = {
+        'uid': 1,
+        'identifier': u'soap',
+        'full_name': u'Tyler Durden',
+        'email': u'tyler@mayhem.net',
+        'git': u'Tyler Durden <tyler@mayhem.net>'
+    }
+
+    # updated email
+    user1_updated_dict = {
+        'uid': 1,
+        'identifier': u'soap',
+        'full_name': u'Tyler Durden',
+        'email': u'narrator@mayhem.net',
+        'git': u'Tyler Durden <tyler@mayhem.net>'
+    }
+
+    user2_dict = {
+        'uid': 2,
+        'identifier': u'tdurden',
+        'authz_user': u'tdurden',
+        'authz_pass': u'lye'
+    }
+
+    # tests
+
+    def test_addUser(self):
+        d = self.db.users.addUser(user_dict={'full_name': 'tyler durden',
+                                             'email': 'tyler@mayhem.net',
+                                             'authz_user': 'tdurden',
+                                             'authz_pass': 'lye'})
+        def check_user(uid):
+            self.assertEqual(uid, 1)
+            def thd(conn):
+                rows = conn.execute(self.db.model.users.select()).fetchall()
+                infos = conn.execute(self.db.model.users_info.select()).fetchall()
+                self.assertEqual(len(rows), 1)
+                self.assertEqual(rows[0].uid, 1)
+                self.assertEqual(rows[0].identifier, 'tyler@mayhem.net')
+                self.assertEqual(rows[0].full_name, 'tyler durden')
+                self.assertEqual(rows[0].email, 'tyler@mayhem.net')
+                self.assertEqual(len(infos), 2)
+                self.assertEqual(infos[0].uid, 1)
+                self.assertEqual(infos[0].attr_type, 'authz_user')
+                self.assertEqual(infos[0].attr_data, 'tdurden')
+                self.assertEqual(infos[1].uid, 1)
+                self.assertEqual(infos[1].attr_type, 'authz_pass')
+                self.assertEqual(infos[1].attr_data, 'lye')
+            return self.db.pool.do(thd)
+        d.addCallback(check_user)
+        return d
+
+    def test_addUser_existing_identifier(self):
+        d = self.db.users.addUser(identifier='soap',
+                                  user_dict={'authz_user': 'tdurden'})
+        d.addCallback(lambda _ : self.db.users.addUser(
+                                            identifier='soap',
+                                            user_dict={'authz_pass': 'lye'}))
+        def check_user(uid):
+            self.assertEqual(uid, 1)
+            def thd(conn):
+                rows = conn.execute(self.db.model.users.select()).fetchall()
+                infos = conn.execute(self.db.model.users_info.select()).fetchall()
+                self.assertEqual(len(rows), 1)
+                self.assertEqual(rows[0].uid, 1)
+                self.assertEqual(rows[0].identifier, 'soap')
+                self.assertEqual(rows[0].full_name, None)
+                self.assertEqual(rows[0].email, None)
+                self.assertEqual(len(infos), 2)
+                self.assertEqual(infos[0].uid, 1)
+                self.assertEqual(infos[0].attr_type, 'authz_user')
+                self.assertEqual(infos[0].attr_data, 'tdurden')
+                self.assertEqual(infos[1].uid, 1)
+                self.assertEqual(infos[1].attr_type, 'authz_pass')
+                self.assertEqual(infos[1].attr_data, 'lye')
+            return self.db.pool.do(thd)
+        d.addCallback(check_user)
+        return d
+
+    def test_addUser_existing_attr(self):
+        d = self.db.users.addUser(identifier='soap',
+                                  user_dict={'authz_user': 'tdurden'})
+        d.addCallback(lambda _ : self.db.users.addUser(
+                                            identifier='soap',
+                                            user_dict={'authz_user': 'tdurden'}))
+        def check_user(uid):
+            self.assertEqual(uid, 1)
+            def thd(conn):
+                rows = conn.execute(self.db.model.users.select()).fetchall()
+                infos = conn.execute(self.db.model.users_info.select()).fetchall()
+                self.assertEqual(len(rows), 1)
+                self.assertEqual(rows[0].uid, 1)
+                self.assertEqual(rows[0].identifier, 'soap')
+                self.assertEqual(rows[0].full_name, None)
+                self.assertEqual(rows[0].email, None)
+                self.assertEqual(len(infos), 1)
+                self.assertEqual(infos[0].uid, 1)
+                self.assertEqual(infos[0].attr_type, 'authz_user')
+                self.assertEqual(infos[0].attr_data, 'tdurden')
+            return self.db.pool.do(thd)
+        d.addCallback(check_user)
+        return d
+
+    def test_getUser_uid(self):
+        d = self.insertTestData(self.user1_rows)
+        def get1(_):
+            return self.db.users.getUser(1)
+        d.addCallback(get1)
+        def check1(usdict):
+            self.assertEqual(usdict, self.user1_dict)
+        d.addCallback(check1)
+        return d
+
+    def test_getUser_identifier(self):
+        d = self.insertTestData(self.user1_rows)
+        def get1(_):
+            return self.db.users.getUser('soap')
+        d.addCallback(get1)
+        def check1(usdict):
+            self.assertEqual(usdict, self.user1_dict)
+        d.addCallback(check1)
+        return d
+
+    def test_getNoMatch(self):
+        d = self.insertTestData(self.user1_rows)
+        def get3(_):
+            return self.db.users.getUser(3)
+        d.addCallback(get3)
+        def check3(none):
+            self.assertEqual(none, None)
+        d.addCallback(check3)
+        return d
+
+    def test_updateUser_existing_type(self):
+        d = self.insertTestData(self.user1_rows)
+        def update1(_):
+            return self.db.users.updateUser(
+                uid=1, user_dict={'email': 'narrator@mayhem.net'})
+        d.addCallback(update1)
+        def get1(_):
+            return self.db.users.getUser(1)
+        d.addCallback(get1)
+        def check1(usdict):
+            self.assertEqual(usdict, self.user1_updated_dict)
+        d.addCallback(check1)
+        return d
+
+    def test_updateUser_new_type_uid(self):
+        d = self.insertTestData(self.user1_rows)
+        def update1(_):
+            return self.db.users.updateUser(uid=1, user_dict={'authz_user': 'jack'})
+        d.addCallback(update1)
+        def get1(_):
+            return self.db.users.getUser(1)
+        d.addCallback(get1)
+        def check1(usdict):
+            newdict = self.user1_dict
+            newdict['authz_user'] = 'jack'
+            self.assertEqual(usdict, newdict)
+        d.addCallback(check1)
+        return d
+
+    def test_updateUser_new_type_identifier(self):
+        d = self.insertTestData(self.user1_rows)
+        def update1(_):
+            return self.db.users.updateUser(identifier='soap',
+                                            user_dict={'authz_user': 'jack'})
+        d.addCallback(update1)
+        def get1(_):
+            return self.db.users.getUser(1)
+        d.addCallback(get1)
+        def check1(usdict):
+            newdict = self.user1_dict
+            newdict['authz_user'] = 'jack'
+            self.assertEqual(usdict, newdict)
+        d.addCallback(check1)
+        return d
+
+    def test_updateNoMatch(self):
+        d = self.insertTestData(self.user1_rows)
+        def update3(_):
+            return self.db.users.updateUser(
+                uid=3, user_dict={'email': 'narrator@mayhem.net'})
+        d.addCallback(update3)
+        def check3(none):
+            self.assertEqual(none, None)
+        d.addCallback(check3)
+        return d
+
+    def test_removeUser_uid(self):
+        d = self.insertTestData(self.user1_rows)
+        def remove1(_):
+            return self.db.users.removeUser(uid=1)
+        d.addCallback(remove1)
+        def check1(removed):
+            self.assertEqual(removed, self.user1_dict)
+            def thd(conn):
+                r = conn.execute(self.db.model.users.select())
+                r = r.fetchall()
+                self.assertEqual(len(r), 0)
+            return self.db.pool.do(thd)
+        d.addCallback(check1)
+        return d
+
+    def test_removeUser_identifier(self):
+        d = self.insertTestData(self.user1_rows)
+        def remove1(_):
+            return self.db.users.removeUser(identifier='soap')
+        d.addCallback(remove1)
+        def check1(removed):
+            self.assertEqual(removed, self.user1_dict)
+            def thd(conn):
+                r = conn.execute(self.db.model.users.select())
+                r = r.fetchall()
+                self.assertEqual(len(r), 0)
+            return self.db.pool.do(thd)
+        d.addCallback(check1)
+        return d
+
+    def test_removeNoMatch(self):
+        d = self.insertTestData(self.user1_rows)
+        def remove1(_):
+            return self.db.users.removeUser(uid=3)
+        d.addCallback(remove1)
+        def check1(removed):
+            self.assertEqual(removed, None)
+        d.addCallback(check1)
+        return d

--- a/master/docs/cfg-global.texinfo
+++ b/master/docs/cfg-global.texinfo
@@ -333,6 +333,11 @@ configuration with an identity in the database - to cache.  In this version,
 object IDs are not looked up often during runtime, so a relatively low value
 such as 10 is fine.
 
+@item usdicts
+
+The number of rows from the @code{users} table to cache in memory. Note that for
+a given user there will be a row for each attribute that user has.
+
 @end enumerate
 
 The @emph{global} @code{buildCacheSize} parameter gives the number of builds

--- a/master/docs/concepts.texinfo
+++ b/master/docs/concepts.texinfo
@@ -611,9 +611,8 @@ changes to the source code, causing builds which may succeed or fail.
 Each developer is primarily known through the source control system. Each
 Change object that arrives is tagged with a @code{who} field that
 typically gives the account name (on the repository machine) of the user
-responsible for that change. This string is the primary key by which the
-User is known, and is displayed on the HTML status pages and in each Build's
-``blamelist''.
+responsible for that change. This string is displayed on the HTML status
+pages and in each Build's ``blamelist''.
 
 To do more with the User than just refer to them, this username needs to
 be mapped into an address of some sort. The responsibility for this mapping


### PR DESCRIPTION
The users/users_info tables are the main way to store user
information. While the users table is more about what defines
a user, the users_info table is more about how Buildbot refers
to users. The change_users table associates changeids with
user uids corresponding to change authors.

All of buildbot.db should be updated to reflect the new
tables. test.fake.fakedb has also been updated, and unit
tests have been added to cover the additions.

Everything should be rebased on master and pass all unit tests.
