### PR TITLE
added --vc option to `buildbot sendchange`

### DIFF
--- a/master/buildbot/clients/sendchange.py
+++ b/master/buildbot/clients/sendchange.py
@@ -26,7 +26,8 @@ class Sender:
         self.encoding = encoding
 
     def send(self, branch, revision, comments, files, who=None, category=None,
-             when=None, properties={}, repository='', project='', revlink=''):
+             when=None, properties={}, repository='', vc=None, project='',
+             revlink=''):
         change = {'project': project, 'repository': repository, 'who': who,
                   'files': files, 'comments': comments, 'branch': branch,
                   'revision': revision, 'category': category, 'when': when,
@@ -45,7 +46,7 @@ class Sender:
         reactor.connectTCP(self.host, self.port, f)
 
         def call_addChange(remote):
-            d = remote.callRemote('addChange', change)
+            d = remote.callRemote('addChange', change, src=vc)
             d.addCallback(lambda res: remote.broker.transport.loseConnection())
             return d
         d.addCallback(call_addChange)

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -820,6 +820,8 @@ class SendChangeOptions(OptionsWithOptionsFile):
         ("auth", "a", None, "Authentication token - username:password, or prompt for password"),
         ("who", "W", None, "Author of the commit"),
         ("repository", "R", '', "Repository specifier"),
+        ("vc", "s", None, "The VC system in use, one of: cvs, svn, darcs, hg, "
+                           "bzr, git, mtn, p4"),
         ("project", "P", '', "Project specifier"),
         ("branch", "b", None, "Branch specifier"),
         ("category", "C", None, "Category of repository"),
@@ -843,6 +845,7 @@ class SendChangeOptions(OptionsWithOptionsFile):
         [ 'username', 'username' ],
         [ 'branch', 'branch' ],
         [ 'category', 'category' ],
+        [ 'vc', 'vc' ],
     ]
 
     def getSynopsis(self):
@@ -871,6 +874,7 @@ def sendchange(config, runReactor=False):
     revision = config.get('revision')
     properties = config.get('properties', {})
     repository = config.get('repository', '')
+    vc = config.get('vc', None)
     project = config.get('project', '')
     revlink = config.get('revlink', '')
     if config.get('when'):
@@ -892,6 +896,10 @@ def sendchange(config, runReactor=False):
 
     files = config.get('files', ())
 
+    vcs = ['cvs', 'svn', 'darcs', 'hg', 'bzr', 'git', 'mtn', 'p4', None]
+    assert vc in vcs, "vc must be 'cvs', 'svn', 'darcs', 'hg', 'bzr', " \
+        "'git', 'mtn', or 'p4'"
+
     # fix up the auth with a password if none was given
     if not auth:
         auth = 'change:changepw'
@@ -906,7 +914,7 @@ def sendchange(config, runReactor=False):
 
     s = sendchange.Sender(master, auth, encoding=encoding)
     d = s.send(branch, revision, comments, files, who=who, category=category, when=when,
-               properties=properties, repository=repository, project=project,
+               properties=properties, repository=repository, vc=vc, project=project,
                revlink=revlink)
 
     if runReactor:

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -541,6 +541,10 @@ arguments which can influence the ``Change`` that gets submitted:
     Specifies the character encoding for all other parameters,
     defaulting to ``'utf8'``. 
 
+--vc
+	Specifies which VC system the Change is coming from, one of: ``cvs``,
+	``svn``, ``darcs``, ``hg``, ``bzr``, ``git``, ``mtn``, or ``p4``.
+	Defaults to ``None``.
 
 .. _debugclient:
     


### PR DESCRIPTION
This allows whatever script using sendchange to tell the
master what VCS the Change is coming from. This will mainly
be utilized to generate proper User Objects from Changes
that come from contrib scripts that use sendchange.
