### PR TITLE
added user object creation from SVN changesources

### DIFF
--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -349,7 +349,8 @@ class SVNPoller(base.PollingChangeSource, util.ComparableMixin):
     @defer.deferredGenerator
     def submit_changes(self, changes):
         for chdict in changes:
-            wfd = defer.waitForDeferred(self.master.addChange(**chdict))
+            wfd = defer.waitForDeferred(self.master.addChange(src='svn',
+                                                              **chdict))
             yield wfd
             wfd.getResult()
 

--- a/master/buildbot/process/users/users.py
+++ b/master/buildbot/process/users/users.py
@@ -16,6 +16,8 @@
 from twisted.python import log
 from twisted.internet import defer
 
+accepted_sources = ['git', 'svn']
+
 @defer.deferredGenerator
 def createUserObject(master, author, src=None):
     """
@@ -37,9 +39,10 @@ def createUserObject(master, author, src=None):
         log.msg("No vcs information found, unable to create User Object")
         return
 
-    if src == 'git':
-        log.msg("checking for User Object from git Change for: %s" % author)
-        usdict = dict(identifier=author, attr_type='git', attr_data=author)
+    if src in accepted_sources:
+        log.msg("checking for User Object from %s Change for: %s" % (src,
+                                                                     author))
+        usdict = dict(identifier=author, attr_type=src, attr_data=author)
     else:
         log.msg("Unrecognized source argument: %s" % src)
         return

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1024,9 +1024,6 @@ class FakeBuildsComponent(FakeDBComponent):
 
 class FakeUsersComponent(FakeDBComponent):
 
-    known_types = ['full_name', 'email']
-    known_info_types = ['authz_user', 'authz_pass', 'git']
-
     def setUp(self):
         self.users = {}
         self.users_info = {}

--- a/master/buildbot/test/unit/test_changes_mail.py
+++ b/master/buildbot/test/unit/test_changes_mail.py
@@ -63,7 +63,7 @@ class TestMaildirSource(changesource.ChangeSourceMixin, dirs.DirsMixin,
         # monkey-patch in a parse method
         def parse(message, prefix):
             assert 'this is a test' in message.get_payload()
-            return dict(fake_chdict=1)
+            return ('svn', dict(fake_chdict=1))
         mds.parse = parse
 
         d = mds.messageReceived('newmsg')
@@ -71,5 +71,6 @@ class TestMaildirSource(changesource.ChangeSourceMixin, dirs.DirsMixin,
             self.assertMailProcessed()
             self.assertEqual(len(self.changes_added), 1)
             self.assertEqual(self.changes_added[0]['fake_chdict'], 1)
+            self.assertEqual(self.changes_added[0]['src'], 'svn')
         d.addCallback(check)
         return d

--- a/master/buildbot/test/unit/test_changes_mail_CVSMaildirSource.py
+++ b/master/buildbot/test/unit/test_changes_mail_CVSMaildirSource.py
@@ -78,7 +78,7 @@ class TestCVSMaildirSource(unittest.TestCase):
         m = message_from_string(cvs1_11_msg)
         src = CVSMaildirSource('/dev/null', urlmaker=fileToUrl)
         try:
-            chdict = src.parse( m )
+            chdict = src.parse( m )[1]
         except:
             self.fail('Failed to get change from email message.')
         self.assert_(chdict != None)
@@ -100,7 +100,7 @@ class TestCVSMaildirSource(unittest.TestCase):
         m = message_from_string(cvs1_12_msg)
         src = CVSMaildirSource('/dev/null', urlmaker=fileToUrl)
         try:
-            chdict = src.parse( m )
+            chdict = src.parse( m )[1]
         except:
             self.fail('Failed to get change from email message.')
         self.assert_(chdict != None)
@@ -124,7 +124,7 @@ class TestCVSMaildirSource(unittest.TestCase):
         m = message_from_string(msg)
         src = CVSMaildirSource('/dev/null')
         try:
-            assert src.parse( m )
+            assert src.parse( m )[1]
         except ValueError:
             pass
         else:
@@ -136,7 +136,7 @@ class TestCVSMaildirSource(unittest.TestCase):
         m = message_from_string(msg)
         src = CVSMaildirSource('/dev/null')
         try:
-            assert src.parse( m )
+            assert src.parse( m )[1]
         except ValueError:
             pass
         else:
@@ -149,7 +149,7 @@ class TestCVSMaildirSource(unittest.TestCase):
         m = message_from_string(msg)
         src = CVSMaildirSource('/dev/null')
         try:
-            chdict = src.parse( m )
+            chdict = src.parse( m )[1]
         except:
             self.fail('Failed to get change from email message.')
         self.assert_(chdict['branch'] == 'Test_Branch')
@@ -159,7 +159,7 @@ class TestCVSMaildirSource(unittest.TestCase):
         m = message_from_string(msg)
         src = CVSMaildirSource('/dev/null')
         try:
-            chdict = src.parse( m )
+            chdict = src.parse( m )[1]
         except:
             self.fail('Failed to get change from email message.')
         self.assert_(chdict['category'] == 'Test category')
@@ -170,7 +170,7 @@ class TestCVSMaildirSource(unittest.TestCase):
         m = message_from_string(msg)
         src = CVSMaildirSource('/dev/null')
         try:
-            chdict = src.parse( m )
+            chdict = src.parse( m )[1]
         except:
             self.fail('Failed to get change from email message.')
         self.assert_(chdict['comments'] == None )
@@ -191,7 +191,7 @@ class TestCVSMaildirSource(unittest.TestCase):
         m = message_from_string(msg)
         src = CVSMaildirSource('/dev/null')
         try:
-            chdict = src.parse( m )
+            chdict = src.parse( m )[1]
         except:
             self.fail('Failed to get change from email message.')
         self.assert_(chdict['project'] == None )
@@ -201,7 +201,7 @@ class TestCVSMaildirSource(unittest.TestCase):
         m = message_from_string(msg)
         src = CVSMaildirSource('/dev/null')
         try:
-            chdict = src.parse( m )
+            chdict = src.parse( m )[1]
         except:
             self.fail('Failed to get change from email message.')
         self.assert_(chdict['repository'] == None )
@@ -211,7 +211,7 @@ class TestCVSMaildirSource(unittest.TestCase):
         propDict = { 'foo' : 'bar' }
         src = CVSMaildirSource('/dev/null', urlmaker=fileToUrl, properties=propDict)
         try:
-            chdict = src.parse( m )
+            chdict = src.parse( m )[1]
         except:
             self.fail('Failed to get change from email message.')
         self.assert_(chdict['properties']['foo'] == 'bar')

--- a/master/buildbot/test/unit/test_changes_svnpoller.py
+++ b/master/buildbot/test/unit/test_changes_svnpoller.py
@@ -412,6 +412,7 @@ class TestSVNPoller(gpo.GetProcessOutputMixin,
             self.failUnlessEqual(c['revision'], '2')
             self.failUnlessEqual(c['files'], ['']) # signals a new branch
             self.failUnlessEqual(c['comments'], "make_branch")
+            self.failUnlessEqual(c['src'], "svn")
             self.failUnlessEqual(s.last_change, 2)
         d.addCallback(check_third)
 
@@ -428,11 +429,13 @@ class TestSVNPoller(gpo.GetProcessOutputMixin,
             self.failUnlessEqual(c['revision'], '3')
             self.failUnlessEqual(c['files'], ["main.c"])
             self.failUnlessEqual(c['comments'], "commit_on_branch")
+            self.failUnlessEqual(c['src'], "svn")
             c = self.changes_added[1]
             self.failUnlessEqual(c['branch'], None)
             self.failUnlessEqual(c['revision'], '4')
             self.failUnlessEqual(c['files'], ["version.c"])
             self.failUnlessEqual(c['comments'], "revised_to_2")
+            self.failUnlessEqual(c['src'], "svn")
             self.failUnlessEqual(s.last_change, 4)
         d.addCallback(check_fourth)
 

--- a/master/buildbot/test/unit/test_process_users_users.py
+++ b/master/buildbot/test/unit/test_process_users_users.py
@@ -81,3 +81,24 @@ class UsersTests(connector_component.ConnectorComponentMixin,
             return self.db.pool.do(thd)
         d.addCallback(check)
         return d
+
+    def test_createUserObject_svn(self):
+        d = users.createUserObject(self.master, "tdurden", 'svn')
+        def check(_):
+            def thd(conn):
+                r = conn.execute(self.db.model.users.select())
+                rows = r.fetchall()
+                r = conn.execute(self.db.model.users_info.select())
+                info_rows = r.fetchall()
+
+                self.assertEqual(len(rows), 1)
+                self.assertEqual(len(info_rows), 1)
+
+                self.assertEqual(rows[0].uid, 1)
+                self.assertEqual(rows[0].identifier, 'tdurden')
+                self.assertEqual(info_rows[0].uid, 1)
+                self.assertEqual(info_rows[0].attr_type, 'svn')
+                self.assertEqual(info_rows[0].attr_data, 'tdurden')
+            return self.db.pool.do(thd)
+        d.addCallback(check)
+        return d

--- a/master/contrib/googlecode_atom.py
+++ b/master/contrib/googlecode_atom.py
@@ -68,6 +68,14 @@ class GoogleCodeAtomPoller(base.ChangeSource):
         self.pollinterval = pollinterval
         self.lastChange = None
         self.loop = LoopingCall(self.poll)
+        self.src = None
+        for word in self.feedurl.split('/'):
+            if word == 'svnchanges':
+                self.src = 'svn'
+                break
+            elif word == 'hgchanges':
+                self.src = 'hg'
+                break
 
     def startService(self):
         log.msg("GoogleCodeAtomPoller starting")
@@ -166,6 +174,6 @@ class GoogleCodeAtomPoller(base.ChangeSource):
                                    comments = change["comments"],
                                    when = change["when"],
                                    branch = self.branch)
-                self.parent.addChange(c)
+                self.parent.addChange(c, src=self.src)
         if change_list:
             self.lastChange = change_list[-1]["revision"]

--- a/master/contrib/svn_buildbot.py
+++ b/master/contrib/svn_buildbot.py
@@ -231,7 +231,7 @@ class ChangeSender:
         return d
 
     def sendAllChanges(self, remote, changes):
-        dl = [remote.callRemote('addChange', change)
+        dl = [remote.callRemote('addChange', change, src='svn')
               for change in changes]
         return defer.DeferredList(dl)
 

--- a/master/contrib/svn_watcher.py
+++ b/master/contrib/svn_watcher.py
@@ -46,6 +46,7 @@ def sendchange_cmd(master, revisionData):
         "--revision=%s" % revisionData['revision'],
         "--username=%s" % revisionData['author'],
         "--comments=%s" % revisionData['comments'],
+        "--vc=%s" % 'svn',
         ]
     if opts.category:
         cmd.append("--category=%s" % opts.category)

--- a/master/contrib/svnpoller.py
+++ b/master/contrib/svnpoller.py
@@ -81,8 +81,8 @@ if lastrevision != revision:
 
     #comments = codecs.encodings.unicode_escape.encode(comments)
     cmd = "buildbot sendchange --master="+buildmaster+" --branch=trunk \
---revision=\""+revision+"\" --username=\""+author+"\" --comments=\""+\
-comments+"\" "+" ".join(paths)
+--revision=\""+revision+"\" --username=\""+author+"\" --vc=\"svn\" \
+--comments=\""+comments+"\" "+" ".join(paths)
 
     #print cmd
     res = commands.getoutput(cmd)

--- a/master/docs/manual/concepts.rst
+++ b/master/docs/manual/concepts.rst
@@ -662,11 +662,13 @@ which developer is responsible for that Change. When a Change is first
 rendered, the ``who`` attribute is parsed and added to the database if it
 doesn't exist or checked against an existing user. The ``who`` attribute is
 formatted in different ways depending on the version control system that the
-Change came from.  Note that ``git`` is the only version control system
-currently supported for User Object creation.
+Change came from.
 
 ``git``
     ``who`` attributes take the form ``Full Name <Email>``.
+
+``svn``
+	``who`` attributes are of the form ``Username``.
 
 Uses
 ++++


### PR DESCRIPTION
The following SVN changesources now generate user objects:

```
buildbot.changes.mail
buildbot.changes.svnpoller
contrib.svn_watcher
contrib.svn_buildbot
contrib.svnpoller
contrib.googlecode_atom
```

createUserObject in buildbot.process.users.users was also
refactored to be more general for future changesources.

For most contrib scripts, the new --vc option has been
used to let `buildbot sendchange` communicate that the
Changes are from an SVN repo.
