### PR TITLE
added user object creation from mercurial changesources

### DIFF
--- a/master/buildbot/changes/hgbuildbot.py
+++ b/master/buildbot/changes/hgbuildbot.py
@@ -133,7 +133,7 @@ def hook(ui, repo, hooktype, node=None, source=None, **kwargs):
             ui.status("rev %s sent\n" % c['revision'])
         return s.send(c['branch'], c['revision'], c['comments'],
                       c['files'], c['username'], category=category,
-                      repository=repository, project=project)
+                      repository=repository, project=project, vc='hg')
 
     try:    # first try Mercurial 1.1+ api
         start = repo[node].rev()

--- a/master/buildbot/process/users/users.py
+++ b/master/buildbot/process/users/users.py
@@ -16,7 +16,7 @@
 from twisted.python import log
 from twisted.internet import defer
 
-accepted_sources = ['git', 'svn']
+accepted_sources = ['git', 'svn', 'hg']
 
 @defer.deferredGenerator
 def createUserObject(master, author, src=None):

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1033,14 +1033,10 @@ class FakeUsersComponent(FakeDBComponent):
         for row in rows:
             if isinstance(row, User):
                 self.users[row.uid] = dict(identifier=row.identifier)
-                if 'full_name' in row:
-                    self.users[row.uid].update(full_name=row.full_name)
-                if 'email' in row:
-                    self.users[row.uid].update(email=row.email)
 
             if isinstance(row, UserInfo):
                 assert row.uid in self.users
-                if not self.users_info[row.uid]:
+                if row.uid not in self.users_info:
                     self.users_info[row.uid] = dict(attr_type=row.attr_type,
                                                     attr_data=row.attr_data)
                 else:
@@ -1070,10 +1066,10 @@ class FakeUsersComponent(FakeDBComponent):
                 return defer.succeed(uid)
 
         uid = self.nextId()
-        self.db.users.insertTestData([User(uid=uid, identifier=identifier)])
-        self.db.users_info.insertTestData([UserInfo(uid=uid,
-                                                    attr_type=attr_type,
-                                                    attr_data=attr_data)])
+        self.db.insertTestData([User(uid=uid, identifier=identifier)])
+        self.db.insertTestData([UserInfo(uid=uid,
+                                         attr_type=attr_type,
+                                         attr_data=attr_data)])
         return defer.succeed(uid)
 
     def getUser(self, uid):

--- a/master/buildbot/test/unit/test_process_users_users.py
+++ b/master/buildbot/test/unit/test_process_users_users.py
@@ -17,44 +17,28 @@ import mock
 from twisted.trial import unittest
 
 from buildbot.process.users import users
-from buildbot.db import users as db_users
-from buildbot.test.util import connector_component
+from buildbot.test.fake import fakedb
 
 
-class UsersTests(connector_component.ConnectorComponentMixin,
-                 unittest.TestCase):
+class UsersTests(unittest.TestCase):
 
     def setUp(self):
-        d = self.setUpConnectorComponent(table_names=['users', 'users_info'])
-        def finish_setup(_):
-            self.master = mock.Mock()
-            self.db.users = db_users.UsersConnectorComponent(self.db)
-            self.master.db.users = self.db.users
-        d.addCallback(finish_setup)
-        return d
-
-    def tearDown(self):
-        return self.tearDownConnectorComponent()
+        self.master = mock.Mock()
+        self.master.db = self.db = fakedb.FakeDBConnector(self)
 
     def test_createUserObject_no_src(self):
         d = users.createUserObject(self.master, "Tyler Durden", None)
         def check(_):
-            def thd(conn):
-                r = conn.execute(self.db.model.users.select())
-                rows = r.fetchall()
-                self.assertEqual(len(rows), 0)
-            return self.db.pool.do(thd)
+            self.assertEqual(self.db.users.users, {})
+            self.assertEqual(self.db.users.users_info, {})
         d.addCallback(check)
         return d
 
     def test_createUserObject_unrecognized_src(self):
         d = users.createUserObject(self.master, "Tyler Durden", 'blah')
         def check(_):
-            def thd(conn):
-                r = conn.execute(self.db.model.users.select())
-                rows = r.fetchall()
-                self.assertEqual(len(rows), 0)
-            return self.db.pool.do(thd)
+            self.assertEqual(self.db.users.users, {})
+            self.assertEqual(self.db.users.users_info, {})
         d.addCallback(check)
         return d
 
@@ -62,43 +46,33 @@ class UsersTests(connector_component.ConnectorComponentMixin,
         d = users.createUserObject(self.master,
                                    "Tyler Durden <tyler@mayhem.net>", 'git')
         def check(_):
-            def thd(conn):
-                r = conn.execute(self.db.model.users.select())
-                rows = r.fetchall()
-                r = conn.execute(self.db.model.users_info.select())
-                info_rows = r.fetchall()
-
-                self.assertEqual(len(rows), 1)
-                self.assertEqual(len(info_rows), 1)
-
-                self.assertEqual(rows[0].uid, 1)
-                self.assertEqual(rows[0].identifier,
-                                 'Tyler Durden <tyler@mayhem.net>')
-                self.assertEqual(info_rows[0].uid, 1)
-                self.assertEqual(info_rows[0].attr_type, 'git')
-                self.assertEqual(info_rows[0].attr_data,
-                                 'Tyler Durden <tyler@mayhem.net>')
-            return self.db.pool.do(thd)
+            self.assertEqual(self.db.users.users,
+                     { 1: dict(identifier='Tyler Durden <tyler@mayhem.net>') })
+            self.assertEqual(self.db.users.users_info,
+                     { 1: dict(attr_type="git",
+                               attr_data="Tyler Durden <tyler@mayhem.net>") })
         d.addCallback(check)
         return d
 
     def test_createUserObject_svn(self):
         d = users.createUserObject(self.master, "tdurden", 'svn')
         def check(_):
-            def thd(conn):
-                r = conn.execute(self.db.model.users.select())
-                rows = r.fetchall()
-                r = conn.execute(self.db.model.users_info.select())
-                info_rows = r.fetchall()
+            self.assertEqual(self.db.users.users,
+                             { 1: dict(identifier='tdurden') })
+            self.assertEqual(self.db.users.users_info,
+                             { 1: dict(attr_type="svn",
+                                       attr_data="tdurden") })
+        d.addCallback(check)
+        return d
 
-                self.assertEqual(len(rows), 1)
-                self.assertEqual(len(info_rows), 1)
-
-                self.assertEqual(rows[0].uid, 1)
-                self.assertEqual(rows[0].identifier, 'tdurden')
-                self.assertEqual(info_rows[0].uid, 1)
-                self.assertEqual(info_rows[0].attr_type, 'svn')
-                self.assertEqual(info_rows[0].attr_data, 'tdurden')
-            return self.db.pool.do(thd)
+    def test_createUserObject_hg(self):
+        d = users.createUserObject(self.master,
+                                   "Tyler Durden <tyler@mayhem.net>", 'hg')
+        def check(_):
+            self.assertEqual(self.db.users.users,
+                     { 1: dict(identifier='Tyler Durden <tyler@mayhem.net>') })
+            self.assertEqual(self.db.users.users_info,
+                     { 1: dict(attr_type="hg",
+                               attr_data="Tyler Durden <tyler@mayhem.net>") })
         d.addCallback(check)
         return d

--- a/master/contrib/bitbucket_buildbot.py
+++ b/master/contrib/bitbucket_buildbot.py
@@ -114,7 +114,7 @@ class BitBucketBuildBot(resource.Resource):
                 % error.getErrorMessage())
         return error
 
-    def addChange(self, dummy, remote, changei):
+    def addChange(self, dummy, remote, changei, src='hg'):
         """
         Sends changes from the commit to the buildmaster.
         """
@@ -129,8 +129,8 @@ class BitBucketBuildBot(resource.Resource):
         for key, value in change.iteritems():
             logging.debug("  %s: %s" % (key, value))
 
-        deferred = remote.callRemote('addChange', change)
-        deferred.addCallback(self.addChange, remote, changei)
+        deferred = remote.callRemote('addChange', change, src=src)
+        deferred.addCallback(self.addChange, remote, changei, src)
         return deferred
 
     def connected(self, remote, changes):

--- a/master/docs/manual/concepts.rst
+++ b/master/docs/manual/concepts.rst
@@ -670,6 +670,10 @@ Change came from.
 ``svn``
     ``who`` attributes are of the form ``Username``.
 
+``hg``
+    ``who`` attributes are free-form strings, but usually adhere to similar
+    conventions as ``git`` attributes (``Full Name <Email>``).
+
 Uses
 ++++
 


### PR DESCRIPTION
The following Mercurial changesources now create user objects:

```
buildbot.changes.hgbuildbot
contrib.bitbucket_buildbot
contrib.googlecode_atom (added in SVN commit)
```

test_process_users_users was also refactored to use fakedb,
which exposed a few bugs in fakedb.FakeUsersComponent.
