### PR TITLE
added commandline tool to manually manage users

### DIFF
--- a/master/buildbot/clients/usersclient.py
+++ b/master/buildbot/clients/usersclient.py
@@ -1,0 +1,51 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+# this class is known to contain cruft and will be looked at later, so
+# no current implementation utilizes it aside from scripts.runner.
+
+import sys
+from twisted.python import log
+from twisted.spread import pb
+from twisted.cred import credentials
+from twisted.internet import defer, reactor
+
+class UsersClient(object):
+    """
+    Client set up in buildbot.scripts.runner to send `buildbot user` args
+    over a PB connection to perspective_commandline that will execute the
+    args on the database.
+    """
+
+    def __init__(self, master, username, password, port):
+        self.host = master
+        self.username = username
+        self.password = password
+        self.port = int(port)
+
+    def send(self, op, ids, info):
+        f = pb.PBClientFactory()
+        d = f.login(credentials.UsernamePassword(self.username, self.password))
+        reactor.connectTCP(self.host, self.port, f)
+
+        def call_commandline(remote):
+            d = remote.callRemote("commandline", op, ids, info)
+            def returnAndLose(res):
+                remote.broker.transport.loseConnection()
+                return res
+            d.addCallback(returnAndLose)
+            return d
+        d.addCallback(call_commandline)
+        return d

--- a/master/buildbot/db/users.py
+++ b/master/buildbot/db/users.py
@@ -228,3 +228,26 @@ class UsersConnectorComponent(base.DBConnectorComponent):
                 conn.execute(tbl.delete(whereclause=(tbl.c.uid==uid)))
         d = self.db.pool.do(thd)
         return d
+
+    def identifierToUid(self, identifier):
+        """
+        Fetches a uid for a given identifier if one exists for use with the
+        other C{db.users} methods. This is called from the C{buildbot user}
+        command prior to calling one of the other C{db.users} methods.
+
+        @param identifier: identifier to search for and translate into uid
+        @type identifier: string
+
+        @returns: Uid or None via Deferred
+        """
+        def thd(conn):
+            tbl = self.db.model.users
+
+            q = tbl.select(whereclause=(tbl.c.identifier == identifier))
+            row = conn.execute(q).fetchone()
+            if not row:
+                return None
+
+            return row.uid
+        d = self.db.pool.do(thd)
+        return d

--- a/master/buildbot/process/users/manager.py
+++ b/master/buildbot/process/users/manager.py
@@ -1,0 +1,56 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.python import log
+from twisted.internet import defer
+from twisted.application import service
+from buildbot.process.users import manual
+
+class UserManager(service.MultiService):
+    """
+    This is the master-side service that allows manual user management
+    via the commandline. More manual user tools, such as a web interface,
+    will be added in the future by appending them to manual_users in
+    initManualUsers.
+
+    An instance of this manager is at Botmaster.user_manager, which calls
+    setUpManualUsers to initial each user tool, right now just being the
+    commandline tool.
+    """
+
+    name = "user_manager"
+
+    def __init__(self):
+        service.MultiService.__init__(self)
+        self.master = None
+
+    def startService(self):
+        service.MultiService.startService(self)
+        self.master = self.parent
+
+    def addManualComponent(self, comp):
+        """adds user manager component and sets the component's master"""
+        comp.master = self.master
+        comp.setServiceParent(self)
+
+    def removeManualComponent(self, comp):
+        """removes the users manager component, used in reconfig"""
+        assert comp in self
+        d = defer.maybeDeferred(comp.disownServiceParent)
+        def unset_master(x):
+            comp.master = None
+            return x
+        d.addBoth(unset_master)
+        return d

--- a/master/buildbot/process/users/manual.py
+++ b/master/buildbot/process/users/manual.py
@@ -1,0 +1,231 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+# this class is known to contain cruft and will be looked at later, so
+# no current implementation utilizes it aside from scripts.runner.
+
+from twisted.python import log
+from twisted.internet import defer
+from twisted.application import service
+from buildbot import pbutil
+
+class UsersBase(service.MultiService):
+    """
+    Base class for services that manage users manually. This takes care
+    of the service.MultiService work needed by all the services that
+    subclass it.
+    """
+
+    def __init__(self):
+        service.MultiService.__init__(self)
+        self.master = None
+
+    def startService(self):
+        service.MultiService.startService(self)
+
+    def stopService(self):
+        return service.MultiService.stopService(self)
+
+class Commandline_Users_Perspective(pbutil.NewCredPerspective):
+    """
+    Perspective registered in buildbot.pbmanager and contains the real
+    workings of `buildbot user` by working with the database when
+    perspective_commandline is called.
+    """
+
+    def __init__(self, master):
+        self.master = master
+
+    def formatResults(self, op, info, results):
+        """
+        This formats the results of the database operations for printing
+        back to the caller
+
+        @param op: operation to perform (add, remove, update, get)
+        @type op: string
+
+        @param info: type/value pairs for each user that will be added
+                     or updated in the database
+        @type info: list of dictionaries or None
+
+        @param results: results from db queries in perspective_commandline
+        @type results: list
+
+        @returns: string containing formatted results
+        """
+        formatted_results = ""
+
+        if op == 'add':
+            # list, alternating ident, uid
+            formatted_results += "user(s) added:\n"
+            for user in results:
+                if isinstance(user, basestring):
+                    formatted_results += "identifier: %s\n" % user
+                else:
+                    formatted_results += "uid: %d\n\n" % user
+        elif op == 'remove':
+            # list of dictionaries
+            formatted_results += "user(s) removed:\n"
+            for user in results:
+                if user:
+                    formatted_results += "identifier: %s\n" % (user)
+        elif op == 'update':
+            # list, alternating ident, None
+            formatted_results += "user(s) updated:\n"
+            for user in results:
+                if user:
+                    formatted_results += "identifier: %s\n" % (user)
+        elif op == 'get':
+            # list of dictionaries
+            formatted_results += "user(s) found:\n"
+            for user in results:
+                if user:
+                    for key in user:
+                        formatted_results += "%s: %s\n" % (key, user[key])
+                    formatted_results += "\n"
+                else:
+                    formatted_results += "no match found\n"
+        return formatted_results
+
+    @defer.deferredGenerator
+    def perspective_commandline(self, op, ids, info):
+        """
+        This performs the requested operations from the `buildbot user`
+        call by calling the proper buildbot.db.users methods based on
+        the operation. It yields a deferred instance with the results
+        from the database methods.
+
+        @param op: operation to perform (add, remove, update, get)
+        @type op: string
+
+        @param ids: user identifiers used to find existing users
+        @type ids: list of strings or None
+
+        @param info: type/value pairs for each user that will be added
+                     or updated in the database
+        @type info: list of dictionaries or None
+
+        @returns: results from db.users methods via deferred
+        """
+        log.msg("perspective_commandline called")
+        results = []
+
+        if ids:
+            for user in ids:
+                # get identifier, guaranteed to be in user from checks
+                # done in C{scripts.runner}
+                d = self.master.db.users.identifierToUid(identifier=user)
+                wfd = defer.waitForDeferred(d)
+                yield wfd
+                uid = wfd.getResult()
+
+                result = None
+                if op == 'remove':
+                    if uid:
+                        d = self.master.db.users.removeUser(uid)
+                        wfd = defer.waitForDeferred(d)
+                        yield wfd
+                        wfd.getResult()
+                        result = user
+                    else:
+                        log.msg("Unable to find uid for identifier %s" % user)
+                elif op == 'get':
+                    if uid:
+                        d = self.master.db.users.getUser(uid)
+                        wfd = defer.waitForDeferred(d)
+                        yield wfd
+                        result = wfd.getResult()
+                    else:
+                        log.msg("Unable to find uid for identifier %s" % user)
+
+                results.append(result)
+        else:
+            for user in info:
+                # get identifier, guaranteed to be in user from checks
+                # done in C{scripts.runner}
+                ident = user.pop('identifier')
+                d = self.master.db.users.identifierToUid(identifier=ident)
+                wfd = defer.waitForDeferred(d)
+                yield wfd
+                uid = wfd.getResult()
+
+                # when adding, we update the user after the first attr
+                once_through = False
+                for attr in user:
+                    if op == 'update' or once_through:
+                        if uid:
+                            d = self.master.db.users.updateUser(
+                                                         uid=uid,
+                                                         identifier=ident,
+                                                         attr_type=attr,
+                                                         attr_data=user[attr])
+                        else:
+                            log.msg("Unable to find uid for identifier %s"
+                                    % user)
+                    elif op == 'add':
+                        d = self.master.db.users.addUser(identifier=ident,
+                                                         attr_type=attr,
+                                                         attr_data=user[attr])
+                        once_through = True
+                    wfd = defer.waitForDeferred(d)
+                    yield wfd
+                    results.append(ident)
+                    result = wfd.getResult()
+
+                    # result is None from updateUser calls
+                    if result:
+                        results.append(result)
+                        uid = result
+        results = self.formatResults(op, info, results)
+        yield results
+
+class Commandline_Users(UsersBase):
+    """
+    Service that runs to set up and register Commandline_Users_Perspective
+    so `buildbot user` calls get to perspective_commandline.
+    """
+
+    def __init__(self, username=None, passwd=None, port=None):
+        UsersBase.__init__(self)
+        assert username and passwd, ("A username and password pair must be given "
+                                     "to connect and use `buildbot user`")
+        self.username = username
+        self.passwd = passwd
+
+        assert port, "A port must be specified for a PB connection"
+        self.port = int(port)
+        self.registration = None
+
+    def startService(self):
+        UsersBase.startService(self)
+        # check that port is different than c['slavePortnum']
+        slavePort = int(self.master.slavePortnum.split(':')[1])
+        assert self.port != slavePort, ("The port must not be the same as "
+                                        "c['slavePortNum']")
+        # set up factory and register with buildbot.pbmanager
+        def factory(mind, username):
+            return Commandline_Users_Perspective(self.master)
+        self.registration = self.master.pbmanager.register(self.port,
+                                                           self.username,
+                                                           self.passwd,
+                                                           factory)
+
+    def stopService(self):
+        d = defer.maybeDeferred(UsersBase.stopService, self)
+        def unreg(_):
+            if self.registration:
+                return self.registration.unregister()
+        d.addCallback(unreg)
+        return d

--- a/master/buildbot/process/users/users.py
+++ b/master/buildbot/process/users/users.py
@@ -16,7 +16,7 @@
 from twisted.python import log
 from twisted.internet import defer
 
-accepted_sources = ['git', 'svn', 'hg', 'cvs', 'darcs', 'bzr']
+srcs = ['git', 'svn', 'hg', 'cvs', 'darcs', 'bzr']
 
 @defer.deferredGenerator
 def createUserObject(master, author, src=None):
@@ -39,7 +39,7 @@ def createUserObject(master, author, src=None):
         log.msg("No vcs information found, unable to create User Object")
         return
 
-    if src in accepted_sources:
+    if src in srcs:
         log.msg("checking for User Object from %s Change for: %s" % (src,
                                                                      author))
         usdict = dict(identifier=author, attr_type=src, attr_data=author)

--- a/master/buildbot/test/unit/test_clients_usersclient.py
+++ b/master/buildbot/test/unit/test_clients_usersclient.py
@@ -1,0 +1,82 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import mock
+from twisted.trial import unittest
+from twisted.spread import pb
+from twisted.internet import defer, reactor
+from buildbot.clients import usersclient
+
+class TestUsersClient(unittest.TestCase):
+
+    def setUp(self):
+        # patch out some PB components and make up some mocks
+        self.patch(pb, 'PBClientFactory', self._fake_PBClientFactory)
+        self.patch(reactor, 'connectTCP', self._fake_connectTCP)
+
+        self.factory = mock.Mock(name='PBClientFactory')
+        self.factory.login = self._fake_login
+        self.factory.login_d = defer.Deferred()
+
+        self.remote = mock.Mock(name='PB Remote')
+        self.remote.callRemote = self._fake_callRemote
+        self.remote.broker.transport.loseConnection = self._fake_loseConnection
+
+        # results
+        self.conn_host = self.conn_port = None
+        self.lostConnection = False
+
+    def _fake_PBClientFactory(self):
+        return self.factory
+
+    def _fake_login(self, creds):
+        return self.factory.login_d
+
+    def _fake_connectTCP(self, host, port, factory):
+        self.conn_host = host
+        self.conn_port = port
+        self.assertIdentical(factory, self.factory)
+        self.factory.login_d.callback(self.remote)
+
+    def _fake_callRemote(self, method, op, ids, info):
+        self.assertEqual(method, 'commandline')
+        self.called_with = dict(op=op, ids=ids, info=info)
+        return defer.succeed(None)
+
+    def _fake_loseConnection(self):
+        self.lostConnection = True
+
+    def assertProcess(self, host, port, called_with):
+        self.assertEqual([host, port, called_with],
+                         [self.conn_host, self.conn_port, self.called_with])
+
+    def test_usersclient_info(self):
+        uc = usersclient.UsersClient('localhost', "user", "userpw", 1234)
+        d = uc.send('add', None, [{'identifier':'x', 'svn':'x'}])
+        def check(_):
+            self.assertProcess('localhost', 1234,
+                               dict(op='add', ids=None,
+                                    info=[dict(identifier='x', svn='x')]))
+        d.addCallback(check)
+        return d
+
+    def test_usersclient_ids(self):
+        uc = usersclient.UsersClient('localhost', "user", "userpw", 1234)
+        d = uc.send('remove', ['x'], None)
+        def check(_):
+            self.assertProcess('localhost', 1234,
+                               dict(op='remove', ids=['x'], info=None))
+        d.addCallback(check)
+        return d

--- a/master/buildbot/test/unit/test_db_users.py
+++ b/master/buildbot/test/unit/test_db_users.py
@@ -316,3 +316,20 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
             return self.db.users.removeUser(uid=3)
         d.addCallback(check)
         return d
+
+    def test_identifierToUid_NoMatch(self):
+        d = self.db.users.identifierToUid(identifier="soap")
+        def check(res):
+            self.assertEqual(res, None)
+        d.addCallback(check)
+        return d
+
+    def test_identifierToUid_match(self):
+        d = self.insertTestData(self.user1_rows)
+        def ident2uid(_):
+            return self.db.users.identifierToUid(identifier="soap")
+        d.addCallback(ident2uid)
+        def check(res):
+            self.assertEqual(res, 1)
+        d.addCallback(check)
+        return d

--- a/master/buildbot/test/unit/test_process_users_manager.py
+++ b/master/buildbot/test/unit/test_process_users_manager.py
@@ -1,0 +1,42 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import mock
+from twisted.trial import unittest
+from twisted.internet import defer
+from buildbot.process.users import manager, manual
+
+class TestUserManager(unittest.TestCase):
+    def setUp(self):
+        self.master = mock.Mock()
+        self.um = manager.UserManager()
+        self.um.parent = self.master
+        self.um.startService()
+
+    def tearDown(self):
+        self.um.stopService()
+
+    def test_addManualComponent_removeManualComponent(self):
+        class ManualUsers(manual.UsersBase):
+            pass
+
+        mu = ManualUsers()
+        self.um.addManualComponent(mu)
+        assert mu.master is self.um.parent
+
+        d = self.um.removeManualComponent(mu)
+        def check(_):
+            assert mu.master in None
+        return d

--- a/master/buildbot/test/unit/test_process_users_manual.py
+++ b/master/buildbot/test/unit/test_process_users_manual.py
@@ -1,0 +1,270 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+# this class is known to contain cruft and will be looked at later, so
+# no current implementation utilizes it aside from scripts.runner.
+
+import mock
+from twisted.trial import unittest
+from twisted.internet import defer
+
+from buildbot.test.fake import fakedb
+from buildbot.process.users import manual
+
+class ManualUsersMixin(object):
+    """
+    This class fakes out the master/db components to test the manual
+    user managers located in process.users.manual.
+    """
+
+    class FakeMaster(object):
+
+        def __init__(self):
+            self.db = fakedb.FakeDBConnector(self)
+            self.slavePortnum = "tcp:9989"
+            self.caches = mock.Mock(name="caches")
+            self.caches.get_cache = self.get_cache
+
+        def get_cache(self, cache_name, miss_fn):
+            c = mock.Mock(name=cache_name)
+            c.get = miss_fn
+            return c
+
+    def setUpManualUsers(self):
+        self.master = self.FakeMaster()
+
+class TestUsersBase(unittest.TestCase):
+    """
+    Not really sure what there is to test, aside from _setUpManualUsers getting
+    self.master set.
+    """
+    pass
+
+class TestCommandline_Users_Perspective(unittest.TestCase, ManualUsersMixin):
+
+    def setUp(self):
+        self.setUpManualUsers()
+
+    def call_perspective_commandline(self, *args):
+        persp = manual.Commandline_Users_Perspective(self.master)
+        return persp.perspective_commandline(*args)
+
+    def test_perspective_commandline_add(self):
+        d = self.call_perspective_commandline('add', None, [{'identifier':'x',
+                                                             'git': 'x'}])
+        def check_get(_):
+            d = self.master.db.users.getUser(1)
+            def real_check(usdict):
+                self.assertEqual(usdict, dict(uid=1,
+                                              identifier='x',
+                                              git='x'))
+            d.addCallback(real_check)
+            return d
+        d.addCallback(check_get)
+        return d
+
+    def test_perspective_commandline_update(self):
+        d = self.call_perspective_commandline('add', None,
+                                              [{'identifier':'x', 'svn':'x'}])
+        d.addCallback(lambda _ :
+                          self.call_perspective_commandline('update', None,
+                                             [{'identifier':'x', 'svn':'y'}]))
+        def check(_):
+            d = self.master.db.users.getUser(1)
+            def real_check(usdict):
+                self.assertEqual(usdict, dict(uid=1,
+                                              identifier='x',
+                                              svn='y'))
+            d.addCallback(real_check)
+            return d
+        d.addCallback(check)
+        return d
+
+    def test_perspective_commandline_remove(self):
+        d = self.call_perspective_commandline('add', None,
+                                              [{'identifier':'h@c',
+                                                'git': 'hi <h@c>'}])
+        d.addCallback(lambda _ :
+                          self.call_perspective_commandline('remove', ['x'], None))
+        def check(_):
+            d = self.master.db.users.getUser('x')
+            def real_check(res):
+                self.assertEqual(res, None)
+            d.addCallback(real_check)
+            return d
+        d.addCallback(check)
+        return d
+
+    def test_perspective_commandline_get(self):
+        d = self.call_perspective_commandline('add', None,
+                                              [{'identifier':'x',
+                                                'svn':'x'}])
+        d.addCallback(lambda _ :
+                          self.call_perspective_commandline('get', ['x'], None))
+        def check(_):
+            d = self.master.db.users.getUser(1)
+            def real_check(res):
+                self.assertEqual(res, dict(uid=1,
+                                           identifier='x',
+                                           svn='x'))
+            d.addCallback(real_check)
+            return d
+        d.addCallback(check)
+        return d
+
+    def test_perspective_commandline_get_multiple_attrs(self):
+        d = self.call_perspective_commandline('add', None,
+                                              [{'identifier': 'x',
+                                                'svn': 'x',
+                                                'git': 'x@c'}])
+        d.addCallback(lambda _ :
+                          self.call_perspective_commandline('get', ['x'], None))
+        def check(_):
+            d = self.master.db.users.getUser(1)
+            def real_check(res):
+                self.assertEqual(res, dict(uid=1,
+                                           identifier='x',
+                                           svn='x',
+                                           git='x@c'))
+            d.addCallback(real_check)
+            return d
+        d.addCallback(check)
+        return d
+
+    def test_perspective_commandline_add_format(self):
+        d = self.call_perspective_commandline('add', None, [{'identifier':'x',
+                                                             'svn':'x'}])
+        def check(result):
+            exp_format = "user(s) added:\nidentifier: x\nuid: 1\n\n"
+            self.assertEqual(result, exp_format)
+        d.addCallback(check)
+        return d
+
+    def test_perspective_commandline_update_format(self):
+        d = self.call_perspective_commandline('add', None, [{'identifier':'x',
+                                                             'svn':'x'}])
+        d.addCallback(lambda _ :
+                  self.call_perspective_commandline('update', None,
+                                                    [{'identifier':'x',
+                                                      'svn':'y'}]))
+        def check(result):
+            exp_format = 'user(s) updated:\nidentifier: x\n'
+            self.assertEqual(result, exp_format)
+        d.addCallback(check)
+        return d
+
+    def test_perspective_commandline_remove_format(self):
+        d = self.call_perspective_commandline('add', None,
+                                              [{'identifier':'h@c',
+                                                'git': 'hi <h@c>'}])
+        d.addCallback(lambda _ : self.call_perspective_commandline('remove',
+                                                                   ['h@c'],
+                                                                   None))
+        def check(result):
+            exp_format = "user(s) removed:\nidentifier: h@c\n"
+            self.assertEqual(result, exp_format)
+        d.addCallback(check)
+        return d
+
+    def test_perspective_commandline_get_format(self):
+        d = self.call_perspective_commandline('add', None, [{'identifier':'x@y',
+                                                             'git': 'x <x@y>'}])
+        d.addCallback(lambda _ :
+                          self.call_perspective_commandline('get', ['x@y'], None))
+        def check(result):
+            exp_format = 'user(s) found:\ngit: x <x@y>\nidentifier: x@y\n' \
+                         'uid: 1\n\n'
+            self.assertEqual(result, exp_format)
+        d.addCallback(check)
+        return d
+
+    def test_perspective_commandline_remove_no_match_format(self):
+        d = self.call_perspective_commandline('remove', ['x'], None)
+        def check(result):
+            exp_format = "user(s) removed:\n"
+            self.assertEqual(result, exp_format)
+        d.addCallback(check)
+        return d
+
+    def test_perspective_commandline_get_no_match_format(self):
+        d = self.call_perspective_commandline('get', ['x'], None)
+        def check(result):
+            exp_format = "user(s) found:\nno match found\n"
+            self.assertEqual(result, exp_format)
+        d.addCallback(check)
+        return d
+
+class TestCommandline_Users(unittest.TestCase, ManualUsersMixin):
+
+    def setUp(self):
+        self.setUpManualUsers()
+        self.manual_component = manual.Commandline_Users(username="user",
+                                                         passwd="userpw",
+                                                         port="9990")
+        self.manual_component.master = self.master
+
+    def test_no_userpass(self):
+        d = defer.maybeDeferred(lambda : manual.Commandline_Users())
+        def cb(_):
+            self.fail("shouldn't succeed")
+        def eb(f):
+            f.trap(AssertionError)
+            pass # A-OK
+        d.addCallbacks(cb, eb)
+        return d
+
+    def test_no_port(self):
+        d = defer.maybeDeferred(lambda : manual.Commandline_Users(username="x",
+                                                                  passwd="y"))
+        def cb(_):
+            self.fail("shouldn't succeed")
+        def eb(f):
+            f.trap(AssertionError)
+            pass # A-OK
+        d.addCallbacks(cb, eb)
+        return d
+
+    def test_port_slavePortnum_same(self):
+        comp = manual.Commandline_Users(username="x", passwd="y", port="9989")
+        comp.master = self.master
+        d = defer.maybeDeferred(lambda : comp.startService())
+
+        def cb(_):
+            self.fail("shouldn't succeed")
+        def eb(f):
+            f.trap(AssertionError)
+            pass # A-OK
+        d.addCallbacks(cb, eb)
+        return d
+
+    def test_service(self):
+        # patch out the pbmanager's 'register' command both to be sure
+        # the registration is correct and to get a copy of the factory
+        registration = mock.Mock()
+        registration.unregister = lambda : defer.succeed(None)
+        self.master.pbmanager = mock.Mock()
+        def register(portstr, user, passwd, factory):
+            self.assertEqual([portstr, user, passwd],
+                             [9990, 'user', 'userpw'])
+            self.got_factory = factory
+            return registration
+        self.master.pbmanager.register = register
+
+        self.manual_component.startService()
+
+        persp = self.got_factory(mock.Mock(), 'user')
+        self.failUnless(isinstance(persp, manual.Commandline_Users_Perspective))
+
+        return self.manual_component.stopService()

--- a/master/buildbot/test/unit/test_process_users_users.py
+++ b/master/buildbot/test/unit/test_process_users_users.py
@@ -49,8 +49,8 @@ class UsersTests(unittest.TestCase):
             self.assertEqual(self.db.users.users,
                      { 1: dict(identifier='Tyler Durden <tyler@mayhem.net>') })
             self.assertEqual(self.db.users.users_info,
-                     { 1: dict(attr_type="git",
-                               attr_data="Tyler Durden <tyler@mayhem.net>") })
+                     { 1: [dict(attr_type="git",
+                                attr_data="Tyler Durden <tyler@mayhem.net>")]})
         d.addCallback(check)
         return d
 
@@ -60,8 +60,8 @@ class UsersTests(unittest.TestCase):
             self.assertEqual(self.db.users.users,
                              { 1: dict(identifier='tdurden') })
             self.assertEqual(self.db.users.users_info,
-                             { 1: dict(attr_type="svn",
-                                       attr_data="tdurden") })
+                             { 1: [dict(attr_type="svn",
+                                        attr_data="tdurden")]})
         d.addCallback(check)
         return d
 
@@ -72,8 +72,8 @@ class UsersTests(unittest.TestCase):
             self.assertEqual(self.db.users.users,
                      { 1: dict(identifier='Tyler Durden <tyler@mayhem.net>') })
             self.assertEqual(self.db.users.users_info,
-                     { 1: dict(attr_type="hg",
-                               attr_data="Tyler Durden <tyler@mayhem.net>") })
+                     { 1: [dict(attr_type="hg",
+                                attr_data="Tyler Durden <tyler@mayhem.net>")]})
         d.addCallback(check)
         return d
 
@@ -83,8 +83,8 @@ class UsersTests(unittest.TestCase):
             self.assertEqual(self.db.users.users,
                              { 1: dict(identifier='tdurden') })
             self.assertEqual(self.db.users.users_info,
-                             { 1: dict(attr_type="cvs",
-                                       attr_data="tdurden") })
+                             { 1: [dict(attr_type="cvs",
+                                        attr_data="tdurden")]})
         d.addCallback(check)
         return d
 
@@ -94,8 +94,8 @@ class UsersTests(unittest.TestCase):
             self.assertEqual(self.db.users.users,
                      { 1: dict(identifier='tyler@mayhem.net') })
             self.assertEqual(self.db.users.users_info,
-                     { 1: dict(attr_type="darcs",
-                               attr_data="tyler@mayhem.net") })
+                     { 1: [dict(attr_type="darcs",
+                                attr_data="tyler@mayhem.net")]})
         d.addCallback(check)
         return d
 
@@ -105,7 +105,7 @@ class UsersTests(unittest.TestCase):
             self.assertEqual(self.db.users.users,
                      { 1: dict(identifier='Tyler Durden') })
             self.assertEqual(self.db.users.users_info,
-                     { 1: dict(attr_type="bzr",
-                               attr_data="Tyler Durden") })
+                     { 1: [dict(attr_type="bzr",
+                                attr_data="Tyler Durden")]})
         d.addCallback(check)
         return d

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -611,6 +611,43 @@ changed via a reconfig.
 
 Read more about metrics in the :ref:`Metrics` section of the documentation.
 
+.. _Users-Options:
+
+.. index:: c['user_managers']
+
+Users Options
+~~~~~~~~~~~~~
+
+::
+
+    from buildbot.process.users import manual
+    c['user_managers'] = []
+    c['user_managers'].append(manual.Commandline_Users(username="user",
+                                                       passwd="userpw",
+                                                       port=9990))
+
+``c[user_manager]`` contains a list of way to manually manage User Objects
+within Buildbot (see :ref:`User Objects`). Currently implemented is a
+commandline tool `buildbot user`, described at length in :ref:`user`.
+In the future, a web client will also be able to manage User Objects and
+their attributes.
+
+As shown above, to enable the `buildbot user` tool, you must initialize
+a `Commandline_Users` instance in your `master.cfg`. `Commandline_Users`
+instances require the following arguments:
+
+``username``
+    This is the `username` that will be registered on the PB connection
+    and need to be used when calling `buildbot user`.
+
+``passwd``
+    This is the `passwd` that will be registered on the PB connection
+    and need to be used when calling `buildbot user`.
+
+``port``
+    The PB connection `port` must be different than `c['slavePortnum']`
+    and be specified when calling `buildbot user`
+
 .. _Input-Validation:
 
 .. index:: c['validation']

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -606,6 +606,110 @@ buildmaster. The other sections of the tool are as follows:
     :class:`Builder`, but the status-assignment code was changed in an incompatible
     way and these buttons are no longer meaningful.
 
+.. _user:
+
+user
+++++
+
+Note that in order to use this command, you need to configure a
+`Commandline_Users` instance in your `master.cfg` file, which is
+explained in :ref:`Users Options`.
+
+This command allows you to manage users in buildbot's database.
+No extra requirements are needed to use this command, aside from
+the Buildmaster running. For details on how Buildbot manages users,
+see :ref:`Users`.
+
+--master
+    The :command:`user` command can be run virtually anywhere
+    provided a location of the running buildmaster. The :option:`master`
+    argument is of the form ``{MASTERHOST}``, with the port specified
+    in the :option:`port` option.
+
+--port
+    The :option:`port` specifies what PB port to connect to when issuing
+    a :command:`user` command, which should be the same as the port set
+    in the `Commandline_Users` instance. This should be different than
+    `c['slavePortnum']`.
+
+--username
+    PB connection authentication that should match the arguments to
+    `Commandline_Users`.
+
+--passwd
+    PB connection authentication that should match the arguments to
+    `Commandline_Users`.
+
+--op
+    There are four supported values for the :option:`op` argument:
+    :option:`add`, :option:`update`, :option:`remove`, and
+    :option:`show`. Each are described in full in the following sections.
+
+--ids
+    When working with users, you need to be able to refer to them by
+    unique identifiers to find particular users in the database. The
+    :option:`ids` option lets you specify a comma separated list of these
+    identifiers for use with the :command:`user` command.
+
+    The :option:`ids` option is used only when using :option:`remove`
+    or :option:`show`.
+
+--info
+    Users are known in buildbot as a collection of attributes tied
+    together by some unique identifier (see :ref:`User Objects`). These
+    attributes are specified in the form ``{TYPE}={VALUE}`` when
+    using the :option:`info` option. These ``{TYPE}={VALUE}`` pairs
+    are specified in a comma separated list, so for example:
+
+    .. code-block:: none
+
+    --info=svn=jschmo,git='Joe Schmo <joe@schmo.com>'
+
+    The :option:`info` option can be specified multiple times in the
+    :command:`user` command, as each specified option will be interpreted
+    as a new user. Note that :option:`info` is only used with :option:`add`
+    or with :option:`update`, and whenever you use :option:`update` you need
+    to specify the identifier of the user you want to update. This is done
+    by prepending the :option:`info` arguments with ``{ID:}``. If we were
+    to update ``'jschmo'`` from the previous example, it would look like this:
+
+    .. code-block:: none
+
+    --info=jschmo:git='Joseph Schmo <joe@schmo.com>'
+
+Note that :option:`master`, :option:`port`, :option:`username`,
+:option:`passwd`, and :option:`op` are always required to issue
+the :command:`user` command.
+
+Below are examples of how each command should look. Whenever a
+:command:`user` command is successful, results will be shown
+to whoever issued the command.
+
+For :option:`add`:
+
+.. code-block:: none
+
+    buildbot user --master={MASTERHOST} --port={PORT} --username={USER}
+             --passwd={USERPW} --op={OP} --info={TYPE}={VALUE},...
+
+For :option:`update`:
+
+.. code-block:: none
+    buildbot user --master={MASTERHOST} --port={PORT} --username={USER}
+             --passwd={USERPW} --info={ID}:{TYPE}={VALUE},...
+
+For :option:`remove`:
+
+.. code-block:: none
+    buildbot user --master={MASTERHOST} --port={PORT} --username={USER}
+             --passwd={USERPW} --ids={ID1},{ID2},...
+
+For :option:`show`:
+
+.. code-block:: none
+    buildbot user --master={MASTERHOST} --port={PORT} --username={USER}
+             --passwd={USERPW} --ids={ID1},{ID2},...
+
 .. _buildbot-config-directory:
 
 .buildbot config directory

--- a/master/docs/manual/concepts.rst
+++ b/master/docs/manual/concepts.rst
@@ -685,6 +685,13 @@ Change came from.
     ``who`` attributes are free-form strings like ``hg``, and can include a
     ``Username``, ``Email``, and/or ``Full Name``.
 
+Tools
++++++
+
+For managing users manually, use the ``buildbot user`` command, which allows
+you to add, remove, update, and show various attributes of users in the Buildbot
+database (see :ref:`Command-line Tools`).
+
 Uses
 ++++
 


### PR DESCRIPTION
This is available as `buildbot user` and is
structured very similar to `buildbot sendchange`

This allows users to be added, updated, removed,
and shown via the commandline. The structure of
the manager will allow for more user tools to
manually manage them in the future. Tests and
documentation should explain the new commandline
tool concisely.

The fakedb was also refactored, as previously it
was only able to store one attr_type/attr_data
per user. Tests that were affected have been
updated to assert correctly.
