### PR TITLE
added support for user objects in MailNotifier

### DIFF
--- a/master/buildbot/process/users/users.py
+++ b/master/buildbot/process/users/users.py
@@ -55,3 +55,25 @@ def createUserObject(master, author, src=None):
     uid = wfd.getResult()
 
     yield uid
+
+def getUserContact(master, contact_type=None, uid=None):
+    """
+    This is a simple getter function that returns a user attribute
+    that matches the contact_type argument, or returns None if no
+    uid/match is found.
+
+    @param master: BuildMaster used to query the database
+    @type master: BuildMaster instance
+
+    @param contact_type: type of contact attribute to look for in
+                         in a given user, such as 'email' or 'nick'
+    @type contact_type: string
+
+    @param uid: user that is searched for the contact_type match
+    @type uid: integer
+
+    @returns: string of contact information or None via deferred
+    """
+    d = master.db.users.getUser(uid)
+    d.addCallback(lambda usdict: usdict and usdict.get(contact_type))
+    return d

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -1222,8 +1222,8 @@ def users_client(config, runReactor=False):
     from buildbot.clients import usersclient
     from buildbot.process.users import users    # for srcs
 
-    # accepted attr_types by runner.users_client, in addition to users.srcs
-    attr_types = ['identifier']
+    # accepted attr_types by `buildbot user`, in addition to users.srcs
+    attr_types = ['identifier', 'email']
 
     master = config.get('master')
     assert master, "you must provide the master location"

--- a/master/buildbot/test/unit/test_process_users_users.py
+++ b/master/buildbot/test/unit/test_process_users_users.py
@@ -109,3 +109,34 @@ class UsersTests(unittest.TestCase):
                                 attr_data="Tyler Durden")]})
         d.addCallback(check)
         return d
+
+    def test_getUserContact_found(self):
+        self.db.insertTestData([fakedb.User(uid=1, identifier='tdurden'),
+                                fakedb.UserInfo(uid=1, attr_type='svn',
+                                                attr_data='tdurden'),
+                                fakedb.UserInfo(uid=1, attr_type='email',
+                                                attr_data='tyler@mayhem.net')])
+        d = users.getUserContact(self.master, contact_type='email', uid=1)
+        def check(contact):
+            self.assertEqual(contact, 'tyler@mayhem.net')
+        d.addCallback(check)
+        return d
+
+    def test_getUserContact_key_not_found(self):
+        self.db.insertTestData([fakedb.User(uid=1, identifier='tdurden'),
+                                fakedb.UserInfo(uid=1, attr_type='svn',
+                                                attr_data='tdurden'),
+                                fakedb.UserInfo(uid=1, attr_type='email',
+                                                attr_data='tyler@mayhem.net')])
+        d = users.getUserContact(self.master, contact_type='blargh', uid=1)
+        def check(contact):
+            self.assertEqual(contact, None)
+        d.addCallback(check)
+        return d
+
+    def test_getUserContact_uid_not_found(self):
+        d = users.getUserContact(self.master, contact_type='email', uid=1)
+        def check(contact):
+            self.assertEqual(contact, None)
+        d.addCallback(check)
+        return d

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -937,8 +937,14 @@ MailNotifier arguments
     (implementor of :class:`IEmailLookup`). Object which provides
     :class:`IEmailLookup`, which is responsible for mapping User names (which come
     from the VC system) into valid email addresses. If not provided, the
-    notifier will only be able to send mail to the addresses in the
-    extraRecipients list. Most of the time you can use a simple Domain
+    ``MailNotifier`` will attempt to build the ``sendToInterestedUsers``
+    from the authors of the Changes that led to the Build via :ref:`User-Objects`.
+    If the author of one of the Build's Changes has an email address stored,
+    it will added to the recipients list. With this method, ``owners`` are still
+    added to the recipients.
+
+    In either case, ``MailNotifier`` will also send mail to addresses in
+    the extraRecipients list. Most of the time you can use a simple Domain
     instance. As a shortcut, you can pass as string: this will be treated
     as if you had provided ``Domain(str)``. For example,
     ``lookup='twistedmatrix.com'`` will allow mail to be sent to all

--- a/master/docs/manual/concepts.rst
+++ b/master/docs/manual/concepts.rst
@@ -699,6 +699,10 @@ Correlating the various bits and pieces that Buildbot views as users also means
 that one attribute of a user can be translated into another. This provides a
 more complete view of users throughout Buildbot.
 
+One such use is being able to find email addresses based on a set of Builds
+to notify users through the ``MailNotifier``. This process is explained
+more clearly in :ref:``Email-Addresses``.
+
 .. _Doing-Things-With-Users:
 
 Doing Things With Users
@@ -748,6 +752,14 @@ configurable when the notifier is created. To create more complex behaviors
 (perhaps using an LDAP lookup, or using ``finger`` on a central host to
 determine a preferred address for the developer), provide a different object
 as the ``lookup`` argument.
+
+If an EmailLookup object isn't given to the MailNotifier, the MailNotifier
+will try to find emails through :ref:`User-Objects`. This will work the
+same as if an EmailLookup object was used if every user in the Build's
+Interested Users list has an email in the database for them. If a user
+whose change led to a Build doesn't have an email attribute, that user
+will not receive an email. If ``extraRecipients`` is given, those users
+are still sent mail when the EmailLookup object is not specified.
 
 In the future, when the Problem mechanism has been set up, the Buildbot
 will need to send mail to arbitrary Users. It will do this by locating a


### PR DESCRIPTION
MailNotifier is now able to render email addresses
for responsible/interested users without being
given an IEmailLookup instance. Instead of just
using extraRecipients, MailNotifier looks through
the builds and finds the change authors, then uses
User Objects to get an email for the author.

Tests and documentation explain these additions,
and MailNotifier behaves the same if an IEmailLookup
instance is given. Note that the only way to store
email attributes currently is `buildbot user`.
