### PR TITLE
Update PyLint regex (fixes #2049 too)

### DIFF
--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -166,8 +166,8 @@ class PyLint(ShellCommand):
 
     _re_groupname = 'errtype'
     _msgtypes_re_str = '(?P<%s>[%s])' % (_re_groupname, ''.join(MESSAGES.keys()))
-    _default_line_re = re.compile(r'^%s: *\d+:.+' % _msgtypes_re_str)
-    _parseable_line_re = re.compile(r'[^:]+:\d+: \[%s[,\]] .+' % _msgtypes_re_str)
+    _default_line_re = re.compile(r'^%s(\d{4})?: *\d+(,\d+)?:.+' % _msgtypes_re_str)
+    _parseable_line_re = re.compile(r'[^:]+:\d+: \[%s(\d{4})?[,\]] .+' % _msgtypes_re_str)
 
     def createSummary(self, log):
         counts = {}

--- a/master/buildbot/test/unit/test_steps_python.py
+++ b/master/buildbot/test/unit/test_steps_python.py
@@ -15,7 +15,7 @@
 
 from twisted.trial import unittest
 
-from buildbot.status.results import FAILURE, SUCCESS
+from buildbot.status.results import FAILURE, SUCCESS, WARNINGS
 from buildbot.steps import python
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
@@ -91,5 +91,115 @@ class PyLint(steps.BuildStepMixin, unittest.TestCase):
                                         'failed'])
         self.expectProperty('pylint-warning', 1)
         self.expectProperty('pylint-error', 1)
+        return self.runStep()
+
+    def test_regex_text(self):
+        self.setupStep(python.PyLint(command=['pylint']))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['pylint'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                stdout=('W: 11: Bad indentation. Found 6 spaces, expected 4\n'
+                        'C:  1:foo123: Missing docstring\n'))
+            + (python.PyLint.RC_WARNING|python.PyLint.RC_CONVENTION))
+        self.expectOutcome(result=WARNINGS,
+                           status_text=['pylint', 'convention=1', 'warning=1',
+                                        'warnings'])
+        self.expectProperty('pylint-warning', 1)
+        self.expectProperty('pylint-convention', 1)
+        self.expectProperty('pylint-total', 2)
+        return self.runStep()
+
+    def test_regex_text_0_24(self):
+        # pylint >= 0.24.0 prints out column offsets when using text format
+        self.setupStep(python.PyLint(command=['pylint']))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['pylint'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                stdout=('W: 11,0: Bad indentation. Found 6 spaces, expected 4\n'
+                        'C:  3,10:foo123: Missing docstring\n'))
+            + (python.PyLint.RC_WARNING|python.PyLint.RC_CONVENTION))
+        self.expectOutcome(result=WARNINGS,
+                           status_text=['pylint', 'convention=1', 'warning=1',
+                                        'warnings'])
+        self.expectProperty('pylint-warning', 1)
+        self.expectProperty('pylint-convention', 1)
+        self.expectProperty('pylint-total', 2)
+        return self.runStep()
+
+    def test_regex_text_ids(self):
+        self.setupStep(python.PyLint(command=['pylint']))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['pylint'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                stdout=('W0311: 11: Bad indentation.\n'
+                        'C0111:  1:funcName: Missing docstring\n'))
+            + (python.PyLint.RC_WARNING|python.PyLint.RC_CONVENTION))
+        self.expectOutcome(result=WARNINGS,
+                           status_text=['pylint', 'convention=1', 'warning=1',
+                                        'warnings'])
+        self.expectProperty('pylint-warning', 1)
+        self.expectProperty('pylint-convention', 1)
+        self.expectProperty('pylint-total', 2)
+        return self.runStep()
+
+    def test_regex_text_ids_0_24(self):
+        # pylint >= 0.24.0 prints out column offsets when using text format
+        self.setupStep(python.PyLint(command=['pylint']))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['pylint'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                stdout=('W0311: 11,0: Bad indentation.\n'
+                        'C0111:  3,10:foo123: Missing docstring\n'))
+            + (python.PyLint.RC_WARNING|python.PyLint.RC_CONVENTION))
+        self.expectOutcome(result=WARNINGS,
+                           status_text=['pylint', 'convention=1', 'warning=1',
+                                        'warnings'])
+        self.expectProperty('pylint-warning', 1)
+        self.expectProperty('pylint-convention', 1)
+        self.expectProperty('pylint-total', 2)
+        return self.runStep()
+
+    def test_regex_parseable_ids(self):
+        self.setupStep(python.PyLint(command=['pylint']))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['pylint'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                stdout=('test.py:9: [W0311] Bad indentation.\n'
+                        'test.py:3: [C0111, foo123] Missing docstring\n'))
+            + (python.PyLint.RC_WARNING|python.PyLint.RC_CONVENTION))
+        self.expectOutcome(result=WARNINGS,
+                           status_text=['pylint', 'convention=1', 'warning=1',
+                                        'warnings'])
+        self.expectProperty('pylint-warning', 1)
+        self.expectProperty('pylint-convention', 1)
+        self.expectProperty('pylint-total', 2)
+        return self.runStep()
+
+    def test_regex_parseable(self):
+        self.setupStep(python.PyLint(command=['pylint']))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['pylint'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                stdout=('test.py:9: [W] Bad indentation.\n'
+                        'test.py:3: [C, foo123] Missing docstring\n'))
+            + (python.PyLint.RC_WARNING|python.PyLint.RC_CONVENTION))
+        self.expectOutcome(result=WARNINGS,
+                           status_text=['pylint', 'convention=1', 'warning=1',
+                                        'warnings'])
+        self.expectProperty('pylint-warning', 1)
+        self.expectProperty('pylint-convention', 1)
+        self.expectProperty('pylint-total', 2)
         return self.runStep()
 


### PR DESCRIPTION
PyLint adds column offsets to text output in 0.24.0.  In addition this
change fixes #2049 too by adding an optional \d{4} to match ids in
case pylint was called with "--include-ids=y".
