### PR TITLE
added Users page to WebStatus to display users

### DIFF
--- a/master/buildbot/db/users.py
+++ b/master/buildbot/db/users.py
@@ -145,6 +145,27 @@ class UsersConnectorComponent(base.DBConnectorComponent):
         d = self.db.pool.do(thd)
         return d
 
+    def getUsers(self):
+        """
+        This is used by the C{WebStatus} Users page to get all the entries
+        from the users table. This doesn't bother with grabbing attributes,
+        as those are fetched when loading individual user pages.
+
+        @returns: list of dicts via Deferred
+        """
+        def thd(conn):
+            tbl = self.db.model.users
+            rows = conn.execute(tbl.select()).fetchall()
+
+            dicts = []
+            if rows:
+                for row in rows:
+                    ud = dict(uid=row.uid, identifier=row.identifier)
+                    dicts.append(ud)
+            return dicts
+        d = self.db.pool.do(thd)
+        return d
+
     def updateUser(self, uid=None, identifier=None, attr_type=None,
                    attr_data=None, _race_hook=None):
         """

--- a/master/buildbot/status/web/authz.py
+++ b/master/buildbot/status/web/authz.py
@@ -31,6 +31,7 @@ class Authz(object):
             'cancelPendingBuild',
             'stopChange',
             'cleanShutdown',
+            'showUsersPage',
     ]
 
     def __init__(self,

--- a/master/buildbot/status/web/baseweb.py
+++ b/master/buildbot/status/web/baseweb.py
@@ -41,6 +41,7 @@ from buildbot.status.web.about import AboutBuildbot
 from buildbot.status.web.authz import Authz
 from buildbot.status.web.auth import AuthFailResource
 from buildbot.status.web.root import RootPage
+from buildbot.status.web.users import UsersResource
 from buildbot.status.web.change_hook import ChangeHookResource
 
 # this class contains the WebStatus class.  Basic utilities are in base.py,
@@ -355,7 +356,7 @@ class WebStatus(service.MultiService):
                       OneLinePerBuild(numbuilds=numbuilds))
         self.putChild("about", AboutBuildbot())
         self.putChild("authfail", AuthFailResource())
-
+        self.putChild("users", UsersResource())
 
     def __repr__(self):
         if self.http_port is None:

--- a/master/buildbot/status/web/templates/forms.html
+++ b/master/buildbot/status/web/templates/forms.html
@@ -262,3 +262,14 @@
  </form>
 {% endmacro %}
 
+{% macro show_users(users_url, authz) %}
+  <form method="post" action="{{ users_url }}" class='command show_users'>
+    <p>To show users, press the 'Show Users' button</p>
+
+  {% if authz.needAuthForm('showUsersPage') %}
+    {{ auth() }}
+  {% endif %}
+
+    <input type="submit" value="Show Users" />
+  </form>
+{% endmacro %}

--- a/master/buildbot/status/web/templates/layout.html
+++ b/master/buildbot/status/web/templates/layout.html
@@ -29,6 +29,7 @@
         <a href="{{ path_to_root }}one_line_per_build">Recent Builds</a>
         <a href="{{ path_to_root }}buildslaves">Buildslaves</a>
         <a href="{{ path_to_root }}changes">Changesources</a>
+        <a href="{{ path_to_root }}users">Users</a>
         - <a href="{{ path_to_root }}json/help">JSON API</a>
         - <a href="{{ path_to_root }}about">About</a>
     </div>

--- a/master/buildbot/status/web/templates/user.html
+++ b/master/buildbot/status/web/templates/user.html
@@ -1,0 +1,29 @@
+{% extends "layout.html" %}
+
+{% block content %}
+
+<h1>User: {{ user_identifier|e }}</h1>
+
+<div class="column">
+
+<table class="info">
+
+<tr>
+  <th>Attribute Type</th>
+  <th>Attribute Value</th>
+</tr>
+
+{% for attr in user %}
+  <tr class="{{ loop.cycle('alt','') }}">
+
+  <td>{{ attr|e }}</td>
+  <td>{{ user[attr]|e }}</td>
+
+  </tr>
+{% endfor %}
+
+</table>
+
+</div>
+
+{% endblock %}

--- a/master/buildbot/status/web/templates/users.html
+++ b/master/buildbot/status/web/templates/users.html
@@ -1,0 +1,12 @@
+{% extends "layout.html" %}
+{% import 'forms.html' as forms %}
+
+{% block content %}
+
+<h1>Users</h1>
+
+{%- if authz.needAuthForm('showUsersPage') -%}
+  {{ forms.show_users(table_link, authz) }}
+{% endif %}
+
+{% endblock %}

--- a/master/buildbot/status/web/templates/users_table.html
+++ b/master/buildbot/status/web/templates/users_table.html
@@ -1,0 +1,27 @@
+{% extends "layout.html" %}
+
+{% block content %}
+
+<h1>Users</h1>
+
+<table class="info">
+
+<tr>
+  <th>Uid</th>
+  <th>Identifier</th>
+</tr>
+
+{% for user in users %}
+  <tr class="{{ loop.cycle('alt','') }}">
+
+  <td><b><a href="{{ user.user_link }}">{{ user.uid }}</a></b></td>
+  <td>{{ user.identifier|e }}</td>
+
+  </tr>
+{% endfor %}
+
+</table>
+
+</div>
+
+{% endblock %}

--- a/master/buildbot/status/web/users.py
+++ b/master/buildbot/status/web/users.py
@@ -1,0 +1,131 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import urllib
+from twisted.python import log
+from twisted.internet import defer
+from twisted.web.util import redirectTo
+from buildbot.status.web.base import HtmlResource, path_to_authfail, \
+    path_to_root, ActionResource
+
+class UsersActionResource(ActionResource):
+
+    def __init__(self):
+        self.action = "showUsersPage"
+
+    @defer.deferredGenerator
+    def performAction(self, req):
+        d = self.getAuthz(req).actionAllowed('showUsersPage', req)
+        wfd = defer.waitForDeferred(d)
+        yield wfd
+        res = wfd.getResult()
+        if not res:
+            yield path_to_authfail(req)
+            return
+        # show the table
+        yield path_to_root(req) + "users/table"
+
+# /users/$uid
+class OneUserResource(HtmlResource):
+    addSlash = False
+    def __init__(self, uid):
+        HtmlResource.__init__(self)
+        self.uid = int(uid)
+
+    def getPageTitle (self, req):
+        return "Buildbot User: %s" % self.uid
+
+    def content(self, request, ctx):
+        status = self.getStatus(request)
+
+        d = status.master.db.users.getUser(self.uid)
+        def cb(usdict):
+            ctx['user_identifier'] = usdict['identifier']
+            user = ctx['user'] = {}
+            for attr in usdict:
+                if attr not in ['uid', 'identifier', 'bb_password']:
+                    user[attr] = usdict[attr]
+
+            template = request.site.buildbot_service.templates.get_template("user.html")
+            data = template.render(**ctx)
+            return data
+        d.addCallback(cb)
+        return d
+
+# /users/table
+class UsersTableResource(HtmlResource):
+    pageTitle = "Users Table"
+    addSlash = True
+
+    def __init__(self):
+        HtmlResource.__init__(self)
+
+    def getChild(self, path, req):
+        return OneUserResource(path)
+
+    @defer.deferredGenerator
+    def content(self, req, ctx):
+        d = self.getAuthz(req).actionAllowed('showUsersPage', req)
+        wfd = defer.waitForDeferred(d)
+        yield wfd
+        res = wfd.getResult()
+        if not res:
+            yield redirectTo(path_to_authfail(req), req)
+            return
+
+        s = self.getStatus(req)
+
+        d = s.master.db.users.getUsers()
+        wfd = defer.waitForDeferred(d)
+        yield wfd
+        usdicts = wfd.getResult()
+
+        users = ctx['users'] = usdicts
+        for user in users:
+            user['user_link'] = req.childLink(urllib.quote(str(user['uid']), ''))
+        template = req.site.buildbot_service.templates.get_template(
+                                                              "users_table.html")
+        yield template.render(**ctx)
+
+# /users
+class UsersResource(HtmlResource):
+    pageTitle = "Users"
+    addSlash = True
+
+    def __init__(self):
+        HtmlResource.__init__(self)
+        self.action = "showUsersPage"
+
+    def getChild(self, path, req):
+        if path == "table":
+            return UsersTableResource()
+
+    @defer.deferredGenerator
+    def content(self, req, ctx):
+        # check for False or True on showUsersPage, redirect immediately
+        authz = self.getAuthz(req)
+        if not authz.needAuthForm(self.action):
+            if authz.advertiseAction(self.action):
+                yield redirectTo("users/table", req)
+                return
+            else:
+                yield redirectTo(path_to_authfail(req), req)
+                return
+
+        s = self.getStatus(req)
+        ctx['authz'] = self.getAuthz(req)
+        ctx['table_link'] = req.childLink("table")
+        template = req.site.buildbot_service.templates.get_template("users.html")
+        yield template.render(**ctx)

--- a/master/buildbot/test/unit/test_db_users.py
+++ b/master/buildbot/test/unit/test_db_users.py
@@ -41,7 +41,7 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
     ]
 
     user2_rows = [
-        fakedb.User(uid=2),
+        fakedb.User(uid=2, identifier='lye'),
         fakedb.UserInfo(uid=2, attr_type='git',
                         attr_data='Tyler Durden <tyler@mayhem.net>'),
         fakedb.UserInfo(uid=2, attr_type='irc', attr_data='durden')
@@ -55,7 +55,7 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
 
     user2_dict = {
         'uid': 2,
-        'identifier': u'soap',
+        'identifier': u'lye',
         'irc': u'durden',
         'git': u'Tyler Durden <tyler@mayhem.net>'
     }
@@ -182,6 +182,34 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
         def check3(none):
             self.assertEqual(none, None)
         d.addCallback(check3)
+        return d
+
+    def test_getUsers_none(self):
+        d = self.db.users.getUsers()
+        def check(res):
+            self.assertEqual(res, [])
+        d.addCallback(check)
+        return d
+
+    def test_getUsers(self):
+        d = self.insertTestData(self.user1_rows)
+        def get(_):
+            return self.db.users.getUsers()
+        d.addCallback(get)
+        def check(res):
+            self.assertEqual(res, [dict(uid=1, identifier='soap')])
+        d.addCallback(check)
+        return d
+
+    def test_getUsers_multiple(self):
+        d = self.insertTestData(self.user1_rows + self.user2_rows)
+        def get(_):
+            return self.db.users.getUsers()
+        d.addCallback(get)
+        def check(res):
+            self.assertEqual(res, [dict(uid=1, identifier='soap'),
+                                   dict(uid=2, identifier='lye')])
+        d.addCallback(check)
         return d
 
     def test_updateUser_existing_type(self):

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -351,6 +351,22 @@ be used to access them.
     As with ``/one_line_per_build``, this page will also honor
     ``builder=`` and ``branch=`` arguments.
 
+``/users``
+    This page exists for authentication reasons when checking ``showUsersPage``.
+    It'll redirect to ``/authfail`` on ``False``, ``/users/table`` on ``True``,
+    and give a username/password login prompt on ``'auth'``. Passing or failing
+    results redirect to the same pages as ``False`` and ``True``.
+
+``/users/table``
+    This page shows a table containing users that are stored in the database.
+    It has columns for their respective ``uid`` and ``identifier`` values,
+    with the ``uid`` values being clickable for more detailed information
+    relating to a user.
+
+``/users/table/{NN}``
+    Shows all the attributes stored in the database relating to the user
+    with uid ``{NN}`` in a table.
+
 ``/about``
     This page gives a brief summary of the Buildbot itself: software
     version, versions of some libraries that the Buildbot depends upon,
@@ -437,6 +453,9 @@ authentication.  The actions are:
 
 ``cleanShutdown``
     shut down the master gracefully, without interrupting builds
+
+``showUsersPage``
+    access to page displaying users in the database, see :ref:`User-Objects`
 
 For each of these actions, you can configure buildbot to never allow the
 action, always allow the action, allow the action to any authenticated user, or

--- a/master/docs/manual/concepts.rst
+++ b/master/docs/manual/concepts.rst
@@ -692,6 +692,9 @@ For managing users manually, use the ``buildbot user`` command, which allows
 you to add, remove, update, and show various attributes of users in the Buildbot
 database (see :ref:`Command-line-Tool`).
 
+To show all of the users in the database in a more pretty manner, a page in
+the ``WebStatus``, which is described in :ref:`Buildbot-Web-Resources`.
+
 Uses
 ++++
 


### PR DESCRIPTION
This adds a page to display users that are currently
in the database. The base page has a list of users
by uid and identifier. Each user has their own page
containing all of the attributes they have, which is
clickable through the user's uids on the base page.

numusers is added as a 'magic' url argument to alter
how many users are displayed, which meant adding
getNumUsers to db.users.
