### PR TITLE
vstudio: Add some parameters to the 'renderables'

### DIFF
--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -96,6 +96,8 @@ class VisualStudio(ShellCommand):
     INCLUDE = []
     LIB = []
     
+    renderables = [projectfile, config, project]
+    
     def __init__(self, 
                 installdir = None,
                 mode = "rebuild", 
@@ -204,11 +206,6 @@ class VC6(VisualStudio):
 
     default_installdir = 'C:\\Program Files\\Microsoft Visual Studio'
 
-    def __init__(self, **kwargs):  
-
-        # always upcall !
-        VisualStudio.__init__(self, **kwargs)
-
     def setupEnvironment(self, cmd):
         VisualStudio.setupEnvironment(self, cmd)
 
@@ -248,11 +245,6 @@ class VC6(VisualStudio):
 
 class VC7(VisualStudio):
     default_installdir = 'C:\\Program Files\\Microsoft Visual Studio .NET 2003'
-
-    def __init__(self, **kwargs):  
-
-        # always upcall !
-        VisualStudio.__init__(self, **kwargs)
 
     def setupEnvironment(self, cmd):
         VisualStudio.setupEnvironment(self, cmd)
@@ -300,6 +292,8 @@ class VC8(VC7):
     # Our ones
     arch = "x86"
     default_installdir = 'C:\\Program Files\\Microsoft Visual Studio 8'
+
+    renderables = [arch]
 
     def __init__(self, arch = "x86", **kwargs):
         self.arch = arch


### PR DESCRIPTION
That 'renderables' stuff is breaking lot of code, especially in custom / not often used steps.

Even when writing a new step, it is easy to forget to set it ... This kind of error is really similar to forgeting the call to "addFactoryArgument" in the constructor ...
