### PR TITLE
add useRevisions option for altered IRC bot messages

### DIFF
--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -475,6 +475,10 @@ class IBuildStatus(Interface):
         """Return a list of Change objects which represent which source
         changes went into the build."""
 
+    def getRevisions():
+        """Returns a string representing the list of revisions that led to
+        the build, rendered from each Change.revision"""
+
     def getResponsibleUsers():
         """Return a list of Users who are to blame for the changes that went
         into this build. If anything breaks (at least anything that wasn't

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -96,6 +96,15 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
     def getChanges(self):
         return self.changes
 
+    def getRevisions(self):
+        revs = []
+        for c in self.changes:
+            rev = str(c.revision)
+            if rev > 7:  # for long hashes
+                rev = rev[:7]
+            revs.append(rev)
+        return ", ".join(revs)
+
     def getResponsibleUsers(self):
         return self.blamelist
 

--- a/master/buildbot/status/client.py
+++ b/master/buildbot/status/client.py
@@ -165,6 +165,9 @@ class RemoteBuild(pb.Referenceable):
     def remote_getChanges(self):
         return [IRemote(c) for c in self.b.getChanges()]
 
+    def remote_getRevisions(self):
+        return self.b.getRevisions()
+
     def remote_getResponsibleUsers(self):
         return self.b.getResponsibleUsers()
 

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -1203,6 +1203,13 @@ If the `categories` is set to a category of builders (see categories
 option in :ref:`Builder-Configuration`) changes related to only that 
 category of builders will be sent to the channel.
 
+If the `useRevisions` option is set to `True`, the IRC bot will send status messages
+that replace the build number with a list of revisions that are contained in that
+build. So instead of seeing `build #253 of ...`, you would see something like
+`build containing revisions [a87b2c4]`. Revisions that are stored as hashes are
+shortened to 7 characters in length, as multiple revisions can be contained in one
+build and may exceed the IRC message length limit.
+
 .. _PBListener:
     
 PBListener


### PR DESCRIPTION
This fixes #1707 by allowing the IRC bot messages to
give a list of revisions instead of the build number
when sending status messages. This also added the
`getRevisions` method to IBuildStatus instances.
