### PR TITLE
allow properties in IRC force builds

### DIFF
--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -938,6 +938,10 @@ class ForceOptions(OptionsWithOptionsFile):
         ["branch", None, None, "which branch to build"],
         ["revision", None, None, "which revision to build"],
         ["reason", None, None, "the reason for starting the build"],
+        ["props", None, None,
+         "A set of properties made available in the build environment, "
+         "format is --properties=prop1=value1,prop2=value2,.. "
+         "option can be specified multiple times."],
         ]
 
     def parseArgs(self, *args):

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -1184,12 +1184,13 @@ as shown in the example earlier.
 If the ``allowForce=True`` option was used, some addtional commands
 will be available:
 
-:samp:`force build [--branch={BRANCH}] [--revision={REVISION}] {BUILDER} {REASON}`
+:samp:`force build [--branch={BRANCH}] [--revision={REVISION}] [--props=PROP1=VAL1,PROP2=VAL2...] {BUILDER} {REASON}`
     Tell the given :class:`Builder` to start a build of the latest code. The user
     requesting the build and *REASON* are recorded in the :class:`Build` status. The
     buildbot will announce the build's status when it finishes.The
     user can specify a branch and/or revision with the optional
-    parameters :samp:`--branch={BRANCH}` and :samp:`--revision={REVISION}`.
+    parameters :samp:`--branch={BRANCH}` and :samp:`--revision={REVISION}`. The user
+    can also give a list of properties with :samp:`--props={PROP1=VAL1,PROP2=VAL2..}`.
 
 
 :samp:`stop build {BUILDER} {REASON}`


### PR DESCRIPTION
This adds a `--props=` option with the same syntax as
the `buildbot try --properties=` option to specify a
list of properties for the build that is forced.

fixes #1685
