### PR TITLE
Fixed ticket 2060: python_twisted Trial step can now take a property for 

### DIFF
--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -192,6 +192,7 @@ class Trial(ShellCommand):
     logfiles = {"test.log": "_trial_temp/test.log"}
     # we use test.log to track Progress at the end of __init__()
 
+    renderables = ['tests']
     flunkOnFailure = True
     python = None
     trial = "trial"

--- a/master/buildbot/test/unit/test_steps_python_twisted.py
+++ b/master/buildbot/test/unit/test_steps_python_twisted.py
@@ -18,6 +18,9 @@ from buildbot.steps import python_twisted
 from buildbot.status.results import SUCCESS
 from buildbot.test.util import steps
 from buildbot.test.fake.remotecommand import ExpectShell
+from buildbot.process.properties import WithProperties
+from buildbot.process.properties import Property
+
 
 
 class Trial(steps.BuildStepMixin, unittest.TestCase):
@@ -113,4 +116,22 @@ class Trial(steps.BuildStepMixin, unittest.TestCase):
         )
         self.expectOutcome(result=SUCCESS, status_text=['2 tests', 'passed'])
         return self.runStep()
+        
+    def testProperties(self):
+        self.setupStep(python_twisted.Trial(workdir='build',
+                                     tests = Property('test_list'),
+                                     testpath=None))
+        self.properties.setProperty('test_list',['testname'], 'Test')
+
+        self.expectCommands(
+            ExpectShell(workdir='build',
+                        command=['trial', '--reporter=bwverbose', 'testname'],
+                        usePTY="slave-config",
+                        logfiles={'test.log': '_trial_temp/test.log'})
+            + ExpectShell.log('stdio', stdout="Ran 2 tests\n")
+            + 0
+        )
+        self.expectOutcome(result=SUCCESS, status_text=['2 tests', 'passed'])
+        return self.runStep()
+
 


### PR DESCRIPTION
Fixed ticket 2060: python_twisted Trial step can now take a property for the value of tests. Note that tests expects a list, so WithProperties doesn't seem to work
