### PR TITLE
[RFC] triggereable: update triggering step with URL for trigged build

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -523,9 +523,6 @@ class Builder(pb.Referenceable, service.MultiService):
             yield False
             return
 
-        # let status know
-        self.master.status.build_started(req.id, self.name, bs)
-
         # start the build. This will first set up the steps, then tell the
         # BuildStatus that it has started, which will announce it to the world
         # (through our BuilderStatus object, which is its parent).  Finally it
@@ -536,6 +533,9 @@ class Builder(pb.Referenceable, service.MultiService):
         d.addCallback(self.buildFinished, slavebuilder, bids)
         # this shouldn't happen. if it does, the slave will be wedged
         d.addErrback(log.err)
+
+        # let status know
+        self.master.status.build_started(req.id, self.name, bs)
 
         # make sure the builder's status is represented correctly
         self.updateBigStatus()

--- a/master/buildbot/schedulers/triggerable.py
+++ b/master/buildbot/schedulers/triggerable.py
@@ -28,7 +28,7 @@ class Triggerable(base.BaseScheduler):
         self._bsc_subscription = None
         self.reason = "Triggerable(%s)" % name
 
-    def trigger(self, ssid, set_props=None):
+    def trigger(self, ssid, set_props=None, update_trigger_step=None):
         """Trigger this scheduler with the given sourcestamp ID. Returns a
         deferred that will fire when the buildset is finished."""
         # properties for this buildset are composed of our own properties,
@@ -46,7 +46,18 @@ class Triggerable(base.BaseScheduler):
                     properties=props)
         else:
             d = self.addBuildsetForLatest(reason=self.reason, properties=props)
+
+        def setup_buildstatus(buildstatus):
+            def build_started(bs):
+                update_trigger_step.addURL(bs.builder.name,
+                                            self.master.status.getURLForThing(bs))
+                buildstatus.unsubscribe(build_started)
+            buildstatus.subscribe(build_started)
         def setup_waiter((bsid,brids)):
+            if update_trigger_step:
+                for bn, brid in brids.iteritems():
+                    d = self.master.status.getBuildRequestStatus(brid)
+                    d.addCallback(setup_buildstatus)
             self._waiters[bsid] = d = defer.Deferred()
             self._updateWaiters()
             return d

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -182,6 +182,15 @@ class Status:
         d.addCallback(make_status_objects)
         return d
 
+    def getBuildRequestStatus(self, brid):
+        db = self.master.db
+        d = db.buildrequests.getBuildRequest(brid)
+        def make_status(br):
+            builder = self.getBuilder(br["buildername"])
+            return buildrequest.BuildRequestStatus(builder.name, brid, self)
+        d.addCallback(make_status)
+        return d
+
     def generateFinishedBuilds(self, builders=[], branches=[],
                                num_builds=None, finished_before=None,
                                max_search=200):

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -167,7 +167,7 @@ class Trigger(LoggingBuildStep):
             dl = []
             for scheduler in triggered_schedulers:
                 sch = all_schedulers[scheduler]
-                dl.append(sch.trigger(ssid, set_props=props_to_set))
+                dl.append(sch.trigger(ssid, set_props=props_to_set, update_trigger_step=self))
             self.step_status.setText(['triggered'] + triggered_schedulers)
 
             d = defer.DeferredList(dl, consumeErrors=1)


### PR DESCRIPTION
When having a lot of parallel build, its difficult to find which
test build is triggered by a compile build.

The triggerable now takes another optional argument which is the
step status that where add the URLforthing(buildstatus) for the
triggered build.

We also remove issue with builder advertising a new build a little
bit early leading the master status not to inform subscribers.

RFC only for now..
This code is a bit at the maximum of my buildbot understanding, so I'd like the maintainers to have a look to see if I missed something, or if this could be done in a more simple way.

Thanks
Pierre
