### PR TITLE
add args for lostDelay and failedDelay, fixes #1970

### DIFF
--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -1195,6 +1195,15 @@ build. So instead of seeing `build #253 of ...`, you would see something like
 shortened to 7 characters in length, as multiple revisions can be contained in one
 build and may exceed the IRC message length limit.
 
+Two additional arguments can be set to control how fast the IRC bot tries to
+reconnect when it encounters connection issues. ``lostDelay`` is the number of
+of seconds the bot will wait to reconnect when the connection is lost, where as
+``failedDelay`` is the number of seconds until the bot tries to reconnect when
+the connection failed. ``lostDelay`` defaults to a random number between 1 and 5,
+while ``failedDelay`` defaults to a random one between 45 and 60. Setting random
+defaults like this means multiple IRC bots are less likely to deny each other
+by flooding the server.
+
 .. bb:status:: PBListener
 
 PBListener


### PR DESCRIPTION
This allows the IRC bot to have configurable lostDelay
and failedDelay values to use when reconnecting. The
defaults have also been changed to random numbers around
the same range as the old defaults.
