### PR TITLE
Pass un-mangled git commit message to the buildbot

### DIFF
--- a/master/contrib/git_buildbot.py
+++ b/master/contrib/git_buildbot.py
@@ -118,11 +118,15 @@ def grab_commit_info(c, rev):
     f = os.popen("git show --raw --pretty=full %s" % rev, 'r')
 
     files = []
+    comments = []
 
     while True:
         line = f.readline()
         if not line:
             break
+
+        if line.startswith(4*' '):
+            comments.append(line[4:])
 
         m = re.match(r"^:.*[MAD]\s+(.+)$", line)
         if m:
@@ -138,6 +142,7 @@ def grab_commit_info(c, rev):
         if re.match(r"^Merge: .*$", line):
             files.append('merge')
 
+    c['comments'] = ''.join(comments)
     c['files'] = files
     status = f.close()
     if status:
@@ -154,7 +159,6 @@ def gen_changes(input, branch):
 
         m = re.match(r"^([0-9a-f]+) (.*)$", line.strip())
         c = {'revision': m.group(1),
-             'comments': unicode(m.group(2), encoding=encoding),
              'branch': unicode(branch, encoding=encoding),
         }
 


### PR DESCRIPTION
Previously commit message was based on output of 'git rev-parse' which stripped
out all "insignificant" whitespace, like newlines. Given grab_commit_info()
already gets other kinds of commit information from 'git show', get the commit
message from it as well, unaltered.
