### PR TITLE
Add handling fror bsdtar

### DIFF
--- a/master/docs/Makefile
+++ b/master/docs/Makefile
@@ -6,8 +6,6 @@ VERSION=$(shell if [ -n "$$VERSION" ]; then echo $$VERSION; else PYTHONPATH=..:$
 
 TAR_TRANSFORM = $(shell if [[ `tar --version` =~ "bsdtar" ]]; then echo "-s '/^html/$(VERSION)/'"; else echo "--transform 's/^html/$(VERSION)/'"; fi)
 
-#TAR_TRANSFORM = $(shell if [[ $(uname) =~ Darwin ]]; then echo "-s '/^html/$(VERSION)/'"; else echo "--transform 's/^html/$(VERSION)/'"; fi)
-
 docs.tgz: clean html singlehtml images-png
 	cp _build/singlehtml/index.html _build/html/full.html
 	tar -C _build $(TAR_TRANSFORM) -zcf $@ html


### PR DESCRIPTION
These changes allow the tar command to work on bsdtar as it does not handle the --transform flag to rename files.
