### PR TITLE
Make document generation work on sdist packages

### DIFF
--- a/master/MANIFEST.in
+++ b/master/MANIFEST.in
@@ -18,6 +18,7 @@ include docs/manual/_images/*.ai
 include docs/manual/_images/icon.blend
 include docs/manual/_images/Makefile
 include docs/bbdocs/*
+include docs/developer/*
 
 include buildbot/scripts/sample.cfg
 include buildbot/status/web/files/*


### PR DESCRIPTION
`bbdocs` and `developer` were left out in MANIFEST.in in buildbot-0.8.5.
