### PR TITLE
I think Status.unsubscribe should also unsubscribe from BuilderStatuses?

### DIFF
--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -248,6 +248,8 @@ class Status:
             self.announceNewBuilder(target, name, self.getBuilder(name))
     def unsubscribe(self, target):
         self.watchers.remove(target)
+        for name in self.botmaster.builderNames:
+            self.getBuilder(name).unsubscribe(target)
 
 
     # methods called by upstream objects


### PR DESCRIPTION
I've noticed an issue with IStatusReceiver subscription and reconfig.

After doing reconfig when receiver is supposed to be removed, buildbot.status.master.Status.unsubscribe removes it only from its own watchers list, while BuilderStatus instances keep their lists intact. This causes events still being sent to status receiver even after removing it from master.cfg and reconfiguring.
