### PR TITLE
Typo in the documentation.

### DIFF
--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -276,7 +276,7 @@ This can also be provided as ``try_vc`` in
 .. The order of this list comes from the end of scripts/tryclient.py
 
 The following names are recognized: ``bzr`` ``cvs`` ``darcs`` ``hg``
-``git`` `mtn`` ``p4`` ``svn``
+``git`` ``mtn`` ``p4`` ``svn``
 
 
 Finding the top of the tree


### PR DESCRIPTION
There is a missing Grave accent in the documentation which breaks rst formatting.

See last line of section:
http://readthedocs.org/docs/buildbot/en/v0.8.5/manual/cmdline.html#specifying-the-vc-system

> bzr cvs darcs hg git mtn` p4 svn

Regards
Michał
