### PR TITLE
fixes a bug in bzr_buildbot.py.

### DIFF
--- a/master/contrib/bzr_buildbot.py
+++ b/master/contrib/bzr_buildbot.py
@@ -152,9 +152,9 @@ def generate_change(branch,
     if blame_merge_author:
         # this is a pqm commit or something like it
         change['who'] = repository.get_revision(
-            new_rev.parent_ids[-1]).get_apparent_author()
+            new_rev.parent_ids[-1]).get_apparent_authors()[0]
     else:
-        change['who'] = new_rev.get_apparent_author()
+        change['who'] = new_rev.get_apparent_authors()[0]
     # maybe useful to know:
     # name, email = bzrtools.config.parse_username(change['who'])
     change['comments'] = new_rev.message


### PR DESCRIPTION
The call to get_apparent_author() changed to get_apparent_authors()[0]
since the Bazaar API changed and returns now a list of authors.
get_apparent_author() is not part of the API anymore.
This simply uses the first list entry of the authors list.
The bug has been discussed in #buildbot and #bzr on IRC.
