### PR TITLE
allow other environments variables to be given a list.

### DIFF
--- a/slave/buildslave/runprocess.py
+++ b/slave/buildslave/runprocess.py
@@ -281,17 +281,17 @@ class RunProcess:
         if not os.path.exists(workdir):
             os.makedirs(workdir)
         if environ:
-            if environ.has_key('PYTHONPATH'):
-                ppath = environ['PYTHONPATH']
-                # Need to do os.pathsep translation.  We could either do that
-                # by replacing all incoming ':'s with os.pathsep, or by
-                # accepting lists.  I like lists better.
-                if not isinstance(ppath, str):
+            for key in environ:
+                if isinstance(environ[key], list):
+                    # Need to do os.pathsep translation.  We could either do that
+                    # by replacing all incoming ':'s with os.pathsep, or by
+                    # accepting lists.  I like lists better.
                     # If it's not a string, treat it as a sequence to be
                     # turned in to a string.
-                    ppath = os.pathsep.join(ppath)
+                    environ[key] = os.pathsep.join(environ[key])
 
-                environ['PYTHONPATH'] = ppath + os.pathsep + "${PYTHONPATH}"
+            if environ.has_key('PYTHONPATH'):
+                environ['PYTHONPATH'] += os.pathsep + "${PYTHONPATH}"
 
             # do substitution on variable values matching patern: ${name}
             p = re.compile('\${([0-9a-zA-Z_]*)}')

--- a/slave/buildslave/test/unit/test_runprocess.py
+++ b/slave/buildslave/test/unit/test_runprocess.py
@@ -251,6 +251,32 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         d.addCallback(check)
         return d
 
+    def testEnvironPythonPath(self):
+        b = FakeSlaveBuilder(False, self.basedir)
+        s = runprocess.RunProcess(b, stdoutCommand('hello'), self.basedir,
+                            environ={"PYTHONPATH":'a'})
+
+        d = s.start()
+        def check(ign):
+            headers = "".join([update.values()[0] for update in b.updates if update.keys() == ["header"] ])
+            self.failUnless(not re.match('\bPYTHONPATH=a%s' % (os.pathsep),headers),
+                            "got:\n" + headers)
+        d.addCallback(check)
+        return d
+
+    def testEnvironArray(self):
+        b = FakeSlaveBuilder(False, self.basedir)
+        s = runprocess.RunProcess(b, stdoutCommand('hello'), self.basedir,
+                            environ={"FOO":['a', 'b']})
+
+        d = s.start()
+        def check(ign):
+            headers = "".join([update.values()[0] for update in b.updates if update.keys() == ["header"] ])
+            self.failUnless(not re.match('\bFOO=a%sb\b' % (os.pathsep),headers),
+                            "got:\n" + headers)
+        d.addCallback(check)
+        return d
+
 class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
 
     if runtime.platformType != "posix":


### PR DESCRIPTION
We got a confusion last week when reading the doc, it is specified that for PYTHONPATH, one can give arrays, so we tried for other variables also, and it didn't worked.

As we do have access to the right os.pathsep, it makes sense to avoid doing that in the master config (or in the step), so I extended the `os.pathsep.join` for all of the variables
