### PR TITLE
More useful error message for unknown builders

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -444,13 +444,17 @@ class BuildMaster(service.MultiService):
             unscheduled_buildernames = buildernames[:]
             schedulernames = []
             for s in schedulers:
+                ub = []
                 for b in s.listBuilderNames():
                     # Skip checks for builders in multimaster mode
                     if not multiMaster:
-                        assert b in buildernames, \
-                               "%s (%s) uses unknown builder %s" % (s, s.name, b)
+                        if b not in buildernames:
+                            ub.append(b)
                     if b in unscheduled_buildernames:
                         unscheduled_buildernames.remove(b)
+                assert len(ub) is 0, \
+                    "%s (%s) uses unknown builders: %s" % (s, s.name, ', '.join(ub))
+
 
                 if s.name in schedulernames:
                     msg = ("Schedulers must have unique names, but "


### PR DESCRIPTION
The error message for unknown builders on a schedule is not as helpful as it could be.  This pull request prints the scheduler name in addition to its class and address as well as printing all builders on the scheduler that are unknown

The new format would be
AssertionError: <buildbotcustom.scheduler.Scheduler-props instance at 0x10385afc8> (jaegermonkey) uses unknown builders: unknown-builder1, unknown-builder2
