### PR TITLE
Libcloud Latent Build Slave

### DIFF
--- a/master/buildbot/lcbuildbslave.py
+++ b/master/buildbot/lcbuildbslave.py
@@ -51,7 +51,7 @@ class LibcloudLatentBuildSlave(AbstractLatentBuildSlave):
         if not self.instance:
             return defer.succeed(None)
 
-        if instance.state not in (NodeState.TERMINATED):
+        if instance.state not in (NodeState.TERMINATED,):
             return threads.deferToThread(self._thd_stop_instance,
                                          instance=instance, fast=fast)
 


### PR DESCRIPTION
This feature is not finished yet. I just wanted to get some initial feedback and see if someone is interested in something like this.

This Latent build slave uses Libcloud library (http://libcloud.apache.org/) which means it can work with a lot of different cloud providers.

This build slave would support two different modes:
1. Using an existing image which has buildbot installed and configured on it

In this mode a user would specify an image which already has buildbot configured and installed on it. 

Not all of the providers support custom images and this is the reason why it would also support simple 'deployment' mode which is described bellow.
1. Using a fresh provider image without a buildbot on it

In this mode Libcloud would create a new server with a base provider image and install and configure buildbot on it.

Because installing and configuring buildbot on multiple operating systems is not trivial and Libcloud is also not a full fledged configuration management tool this means we would need to limit a list of supported operating systems.

If you think something like this is too complicated we could even just stick to mode #1 for the first version.
