### PR TITLE
Libvirt slaves created with XML don't get shutdown

### DIFF
--- a/master/buildbot/libvirtbuildslave.py
+++ b/master/buildbot/libvirtbuildslave.py
@@ -195,7 +195,12 @@ class LibVirtSlave(AbstractLatentBuildSlave):
 
         def _start(res):
             if self.xml:
-                return self.connection.create(self.xml)
+                d = self.connection.create(self.xml)
+                def _xml_start(res):
+                    self.domain = res
+                    return
+                d.addCallback(_xml_start)
+                return d
             d = self.connection.lookupByName(self.name)
             def _really_start(res):
                 self.domain = res


### PR DESCRIPTION
The LibVirtSlave attribute self.domain does not get set when passing an XML to generate the slave. This results in the virtual slave staying up after the build completes and getting out of sync with the master. So, use a callback just like the lookup case to get the domain set.

when specifying XML for the latent virtual slave, a callback still needs to be used to get the Domain object so the slave can be shutdown when the test is completed
