### PR TITLE
Disallow crawling /json

### DIFF
--- a/master/buildbot/status/web/files/robots.txt
+++ b/master/buildbot/status/web/files/robots.txt
@@ -8,3 +8,4 @@ Disallow: /one_line_per_build
 Disallow: /builders
 Disallow: /grid
 Disallow: /tgrid
+Disallow: /json


### PR DESCRIPTION
robots.txt didn't include /json, so google smartly crawled the API instead of the web pages :-)

Here /json is added to robots.txt.
