### PR TITLE
Correct symlink for NEWS file in master/.

### DIFF
--- a/master/NEWS
+++ b/master/NEWS
@@ -1,1 +1,1 @@
-docs/release-notes.txt
+docs/release-notes.rst


### PR DESCRIPTION
The symlink for the NEWS file currently points to docs/release-notes.txt which doesn't exist.
