### PR TITLE
Duplicating repository value into change dict

### DIFF
--- a/master/contrib/bitbucket_buildbot.py
+++ b/master/contrib/bitbucket_buildbot.py
@@ -90,6 +90,7 @@ class BitBucketBuildBot(resource.Resource):
                 'who': commit['author'],
                 'files': files,
                 'links': [revlink],
+                'repository': repo_url,
                 'properties': dict(repository=repo_url),
                 }
             changes.append(change)


### PR DESCRIPTION
It seems that buildbot 0.8.5's ChangeFilter is unable to access the repository name. This change fixed that for me.
