### PR TITLE
Add a web hook handler for Google Code push notifications

### DIFF
--- a/master/buildbot/test/unit/test_status_web_change_hooks_googlecode.py
+++ b/master/buildbot/test/unit/test_status_web_change_hooks_googlecode.py
@@ -59,7 +59,12 @@ class TestChangeHookConfiguredWithGoogleCodeChange(unittest.TestCase):
             'Content-Type': 'application/json; charset=UTF-8'
         }
 
-        self.changeHook = change_hook.ChangeHookResource(dialects={'googlecode' : {'secret_key': 'FSP3p-Ghdn4T0oqX'}})
+        self.changeHook = change_hook.ChangeHookResource(dialects={
+                'googlecode': {
+                    'secret_key': 'FSP3p-Ghdn4T0oqX',
+                    'branch': 'test'
+                }
+        })
 
     # Test 'base' hook with attributes. We should get a json string representing
     # a Change object as a dictionary. All values show be set.
@@ -78,7 +83,7 @@ class TestChangeHookConfiguredWithGoogleCodeChange(unittest.TestCase):
             self.assertEquals(change["who"], "Louis Opter <louis@lse.epitech.net>")
             self.assertEquals(change["revision"], '68e5df283a8e751cdbf95516b20357b2c46f93d4')
             self.assertEquals(change["comments"], "Print a message")
-            self.assertEquals(change["branch"], "default")
+            self.assertEquals(change["branch"], "test")
             self.assertEquals(change["revlink"], "http://webhook-test.googlecode.com/hg-history/68e5df283a8e751cdbf95516b20357b2c46f93d4/")
 
         d.addCallback(check_changes)

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -1125,8 +1125,8 @@ Change Hooks (HTTP Notifications)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Buildbot already provides a web frontend, and that frontend can easily be used
-to receive HTTP push notifications of commits from services like GitHub.  See
-:ref:`Change-Hooks` for more information.
+to receive HTTP push notifications of commits from services like GitHub or
+GoogleCode. See :ref:`Change-Hooks` for more information.
 
 .. bb:chsrc:: GoogleCodeAtomPoller
 

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -682,6 +682,33 @@ Note that there is a standalone HTTP server available for receiving GitHub
 notifications, as well: :file:`contrib/github_buildbot.py`.  This script may be
 useful in cases where you cannot expose the WebStatus for public consumption.
 
+Google Code hook
+################
+
+The Google Code hook is quite similar to the GitHub Hook. It has one option
+for the "Post-Commit Authentication Key" used to check if the request is
+legitimate::
+
+    c['status'].append(html.WebStatus(
+        …,
+        change_hook_dialects={'googlecode': {'secret_key': 'FSP3p-Ghdn4T0oqX'}}
+    ))
+
+This will add a "Post-Commit URL" for the project in the Google Code
+administrative interface, pointing to ``/change_hook/googlecode`` relative to
+the root of the web status.
+
+Alternatively, you can use the :ref:`GoogleCodeAtomPoller` :class:`ChangeSource`
+that periodically poll the Google Code commit feed for changes.
+
+.. note::
+
+   Google Code doesn't send the branch on which the changes were made. So, the
+   hook always returns ``'default'`` as the branch, you can override it with the
+   ``'branch'`` option::
+
+      change_hook_dialects={'googlecode': {'secret_key': 'FSP3p-Ghdn4T0oqX', 'branch': 'master'}}
+
 .. bb:status:: MailNotifier
 
 .. index:: single: email; MailNotifier


### PR DESCRIPTION
- Supports authentication;
- Only supports pushes on the `default' branch (Google Code doesn't send
  the branch name);
- Google Code entirely sends the changes as an UTF-8 JSON dictionary (as
  opposed to something like a form-data);
- Very similar to the GitHub web hook handler.
