### PR TITLE
Fix MailNotifier crash due to failure to check against NoneType

### DIFF
--- a/master/buildbot/status/mail.py
+++ b/master/buildbot/status/mail.py
@@ -435,7 +435,7 @@ class MailNotifier(base.StatusReceiverMultiService):
         for (builddictlist, builder) in zip(builddicts, builders):
                 for builddict in builddictlist:
                     build = builder.getBuild(builddict['number'])
-                    if self.isMailNeeded(build, build.results):
+                    if build is not None and self.isMailNeeded(build, build.results):
                         builds.append(build)
 
         self.buildMessage("Buildset Complete: " + buildset['reason'], builds,


### PR DESCRIPTION
This is a fix for the following crash:

```
2012-01-06 11:26:29-0700 [-] Unhandled error in Deferred:
2012-01-06 11:26:29-0700 [-] Unhandled Error
    Traceback (most recent call last):
      File "/home/buildbot/sandbox/lib/python2.6/site-packages/Twisted-11.1.0-py2.6-linux-x86_64.egg/twisted/internet/defer.py", line 545, in _runCallbacks
        current.result = callback(current.result, *args, **kw)
      File "/home/buildbot/sandbox/lib/python2.6/site-packages/Twisted-11.1.0-py2.6-linux-x86_64.egg/twisted/internet/defer.py", line 796, in _cbDeferred
        self.callback(self.resultList)
      File "/home/buildbot/sandbox/lib/python2.6/site-packages/Twisted-11.1.0-py2.6-linux-x86_64.egg/twisted/internet/defer.py", line 362, in callback
        self._startRunCallbacks(result)
      File "/home/buildbot/sandbox/lib/python2.6/site-packages/Twisted-11.1.0-py2.6-linux-x86_64.egg/twisted/internet/defer.py", line 458, in _startRunCallbacks
        self._runCallbacks()
    --- <exception caught here> ---
      File "/home/buildbot/sandbox/lib/python2.6/site-packages/Twisted-11.1.0-py2.6-linux-x86_64.egg/twisted/internet/defer.py", line 545, in _runCallbacks
        current.result = callback(current.result, *args, **kw)
File "/home/buildbot/sandbox/lib/python2.6/site-packages/buildbot-0.8.5-py2.6.egg/buildbot/status/mail.py", line 420, in _gotBuilds
        if self.isMailNeeded(build, build.results):
    exceptions.AttributeError: 'NoneType' object has no attribute 'results'
```
