### PR TITLE
Create option for a BuildStep to be suppressed if skipped (#1743)

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -411,7 +411,7 @@ class BuildStep(properties.PropertiesMixin):
     warnOnFailure = False
     alwaysRun = False
     doStepIf = True
-    hideInWaterfallIf = False
+    hideStepIf = False
 
     # properties set on a build step are, by nature, always runtime properties
     set_runtime_properties = True
@@ -433,7 +433,7 @@ class BuildStep(properties.PropertiesMixin):
              'progressMetrics',
              'useProgress',
              'doStepIf',
-             'hideInWaterfallIf',
+             'hideStepIf',
              ]
 
     name = "generic"
@@ -624,8 +624,8 @@ class BuildStep(properties.PropertiesMixin):
             self.progress.finish()
         self.step_status.stepFinished(results)
         
-        hidden = self._maybeEvaluate(self.hideInWaterfallIf, self.step_status)
-        self.step_status.setHiddenInWaterfall(hidden)
+        hidden = self._maybeEvaluate(self.hideStepIf, results, self)
+        self.step_status.setHidden(hidden)
         
         self.releaseLocks()
         self.deferred.callback(results)
@@ -649,8 +649,8 @@ class BuildStep(properties.PropertiesMixin):
             self.step_status.setText2([self.name])
             self.step_status.stepFinished(EXCEPTION)
 
-            hidden = self._maybeEvaluate(self.hideInWaterfallIf, self.step_status)
-            self.step_status.setHiddenInWaterfall(hidden)       
+            hidden = self._maybeEvaluate(self.hideStepIf, EXCEPTION, self)
+            self.step_status.setHidden(hidden)
         except:
             log.msg("exception during failure processing")
             log.err()

--- a/master/buildbot/status/buildstep.py
+++ b/master/buildbot/status/buildstep.py
@@ -60,13 +60,13 @@ class BuildStepStatus(styles.Versioned):
     finishedWatchers = []
     statistics = {}
     step_number = None
-    hiddenInWaterfall = False
+    hidden = False
 
     def __init__(self, parent, master, step_number):
         assert interfaces.IBuildStatus(parent)
         self.build = parent
         self.step_number = step_number
-        self.hiddenInWaterfall = False
+        self.hidden = False
         self.logs = []
         self.urls = {}
         self.watchers = []
@@ -117,8 +117,8 @@ class BuildStepStatus(styles.Versioned):
     def isFinished(self):
         return (self.finished is not None)
 
-    def isHiddenInWaterfall(self):
-        return self.hiddenInWaterfall
+    def isHidden(self):
+        return self.hidden
 
     def waitUntilFinished(self):
         if self.finished:
@@ -214,8 +214,8 @@ class BuildStepStatus(styles.Versioned):
     def setProgress(self, stepprogress):
         self.progress = stepprogress
 
-    def setHiddenInWaterfall(self, hidden):
-        self.hiddenInWaterfall = hidden
+    def setHidden(self, hidden):
+        self.hidden = hidden
 
     def stepStarted(self):
         self.started = util.now()
@@ -354,8 +354,8 @@ class BuildStepStatus(styles.Versioned):
         self.wasUpgraded = True
 
     def upgradeToVersion4(self):
-        if not hasattr(self, "hiddenInWaterfall"):
-            self.hiddenInWaterfall = False
+        if not hasattr(self, "hidden"):
+            self.hidden = False
         self.wasUpgraded = True
 
     def asDict(self):
@@ -374,7 +374,7 @@ class BuildStepStatus(styles.Versioned):
         result['eta'] = self.getETA()
         result['urls'] = self.getURLs()
         result['step_number'] = self.step_number
-        result['hiddenInWaterfall'] = self.hiddenInWaterfall
+        result['hidden'] = self.hidden
         result['logs'] = [[l.getName(),
             self.build.builder.status.getURLForThing(l)]
                 for l in self.getLogs()]

--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -188,9 +188,11 @@ class StatusResourceBuild(HtmlResource):
 
         for s in b.getSteps():
             step = {'name': s.getName() }
-            cxt['steps'].append(step)
 
             if s.isFinished():
+                if s.isHidden():
+                    continue
+
                 step['css_class'] = css_classes[s.getResults()[0]]
                 (start, end) = s.getTimes()
                 step['time_to_run'] = util.formatInterval(end - start)
@@ -204,6 +206,8 @@ class StatusResourceBuild(HtmlResource):
             else:
                 step['css_class'] = "not_started"
                 step['time_to_run'] = ""
+
+            cxt['steps'].append(step)
 
             step['link'] = req.childLink("steps/%s" % 
                                     urllib.quote(s.getName(), safe=''))

--- a/master/buildbot/status/web/waterfall.py
+++ b/master/buildbot/status/web/waterfall.py
@@ -586,7 +586,7 @@ class WaterfallStatusResource(HtmlResource):
 
                     if isinstance(e, buildstep.BuildStepStatus):
                         # unfinished steps are always shown
-                        if e.isFinished() and e.isHiddenInWaterfall():
+                        if e.isFinished() and e.isHidden():
                             continue
 
                     break

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -160,7 +160,7 @@ class BuildStepMixin(object):
         self.exp_properties = {}
         self.exp_missing_properties = []
         self.exp_logfiles = {}
-        self.exp_hiddenInWaterfall = False
+        self.exp_hidden = False
 
         return step
 
@@ -196,8 +196,8 @@ class BuildStepMixin(object):
         """
         self.exp_logfiles[logfile] = contents
     
-    def expectHiddenInWaterfall(self, hidden):
-        self.exp_hiddenInWaterfall = hidden
+    def expectHidden(self, hidden):
+        self.exp_hidden = hidden
 
     def runStep(self):
         """
@@ -224,7 +224,7 @@ class BuildStepMixin(object):
                 self.failIf(self.properties.hasProperty(pn))
             for log, contents in self.exp_logfiles.iteritems():
                 self.assertEqual(self.step_status.logs[log].stdout, contents)
-            self.step_status.setHiddenInWaterfall.assert_called_once_with(self.exp_hiddenInWaterfall)
+            self.step_status.setHidden.assert_called_once_with(self.exp_hidden)
         d.addCallback(check)
         return d
 

--- a/master/docs/developer/cls-buildsteps.rst
+++ b/master/docs/developer/cls-buildsteps.rst
@@ -10,7 +10,7 @@ described in :doc:`../manual/cfg-buildsteps`.
 BuildStep
 ---------
 
-.. py:class:: BuildStep(name, locks, haltOnFailure, flunkOnWarnings, flunkOnFailure, warnOnWarnings, warnOnFailure, alwaysRun, progressMetrics, useProgress, doStepIf, hideInWaterfallIf)
+.. py:class:: BuildStep(name, locks, haltOnFailure, flunkOnWarnings, flunkOnFailure, warnOnWarnings, warnOnFailure, alwaysRun, progressMetrics, useProgress, doStepIf, hideStepIf)
 
     All constructor arguments must be given as keyword arguments.  Each
     constructor parameter is copied to the corresponding attribute.
@@ -39,10 +39,10 @@ BuildStep
         A callable or bool to determine whether this step should be executed.
         See :ref:`Buildstep-Common-Parameters` for details.
 
-    .. py:attribute:: hideInWaterfallIf
+    .. py:attribute:: hideStepIf
 
         A callable or bool to determine whether this step should be shown in the
-        waterfall view. See :ref:`Buildstep-Common-Parameters` for details.
+        waterfall and build details pages. See :ref:`Buildstep-Common-Parameters` for details.
 
     The following attributes affect the behavior of the containing build:
 
@@ -399,7 +399,7 @@ BuildStep
 LoggingBuildStep
 ----------------
 
-.. py:class:: LoggingBuildStep(logfiles, lazylogfiles, log_eval_func, name, locks, haltOnFailure, flunkOnWarnings, flunkOnFailure, warnOnWarnings, warnOnFailure, alwaysRun, progressMetrics, useProgress, doStepIf, hideInWaterfallIf)
+.. py:class:: LoggingBuildStep(logfiles, lazylogfiles, log_eval_func, name, locks, haltOnFailure, flunkOnWarnings, flunkOnFailure, warnOnWarnings, warnOnFailure, alwaysRun, progressMetrics, useProgress, doStepIf, hideStepIf)
 
     :param logfiles: see :bb:step:`ShellCommand`
     :param lazylogfiles: see :bb:step:`ShellCommand`

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -102,17 +102,17 @@ Arguments common to all :class:`BuildStep` subclasses:
     normally.  If you set ``doStepIf`` to a function, that function should
     accept one parameter, which will be the :class:`Step` object itself.
 
-.. index:: Buildstep Parameter; hideInWaterfallIf
+.. index:: Buildstep Parameter; hideStepIf
 
-``hideInWaterfallIf``
-    A step can be optionally hidden from the waterfall view.  To do this, set
-    the step's ``hideInWaterfallIf`` to a boolean value, or to a function that takes one
+``hideStepIf``
+    A step can be optionally hidden from the waterfall and build details web pages.  To do
+    this, set the step's ``hideStepIf`` to a boolean value, or to a function that takes one
     parameter, the :class:`BuildStepStatus` and returns a boolean value.  Steps are always
-    shown in the waterfall while executing, however after the step as finished, this parameter
-    is evaluated (if a function) and if the value is True, the step is not shown in the waterfall.
+    shown while they execute, however after the step as finished, this parameter
+    is evaluated (if a function) and if the value is True, the step is hidden.
     For example, in order to hide the step if the step has been skipped, ::
 
-        factory.addStep(Foo(..., hideInWaterfallIf=lambda ss: ss.getResults()[0]==SKIPPED))
+        factory.addStep(Foo(..., hideStepIf=lambda s, result: result==SKIPPED))
 
 .. index:: Buildstep Parameter; locks
 

--- a/master/docs/release-notes.rst
+++ b/master/docs/release-notes.rst
@@ -81,8 +81,8 @@ Features
   argument.  This allows substitution of multiple command-line arguments using
   properties.  See :bb:bug:`2150`.
   
-* Steps now take an optional ``hideInWaterfallIf`` parameter to suppress the step
-  from the waterfall view. (:bb:bug:`1743`)
+* Steps now take an optional ``hideStepIf`` parameter to suppress the step
+  from the waterfall and build details in the web. (:bb:bug:`1743`)
 
 Slave
 -----


### PR DESCRIPTION
This patch adds a parameter to BuildStep similar to 'doStepIf' called 'hideInWaterfallIf'. This parameter controls whether the step is shown in the waterfall view. 

Unit tests and docs are updated and I've tested it in a sample buildbot instance.
