### PR TITLE
Changed default port to connect to PBChangeListener to 9999

### DIFF
--- a/master/contrib/bitbucket_buildbot.py
+++ b/master/contrib/bitbucket_buildbot.py
@@ -155,8 +155,8 @@ def main():
         " [default: %default]", default=4000, type=int, dest="port")
     parser.add_option(
         "-m", "--buildmaster",
-        help="Buildbot Master host and port. ie: localhost:9999 [default:"
-        + " %default]", default="localhost:9999", dest="buildmaster")
+        help="Buildbot Master host and port. ie: localhost:9989 [default:"
+        + " %default]", default="localhost:9989", dest="buildmaster")
     parser.add_option(
         "-l", "--log",
         help="The absolute path, including filename, to save the log to"


### PR DESCRIPTION
The script had 9989 which is the 'usual' slave connect port and thus it took me a while to figure out the issue.
Also added some logging when trying to connect to the buildbot master.
