### PR TITLE
ShellCommand.describe(): Ignore AttributeError

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -171,6 +171,11 @@ class ShellCommand(buildstep.LoggingBuildStep):
             words = self.command
             if isinstance(words, (str, unicode)):
                 words = words.split()
+            try:
+                len(words)
+            except AttributeError:
+                # WithProperties and Property don't have __len__
+                return ["???"]
             if len(words) < 1:
                 return ["???"]
             if len(words) == 1:

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -23,6 +23,7 @@ from buildbot.test.util import steps, compat
 from buildbot.test.fake.remotecommand import ExpectShell, Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot import config
+from buildbot.process import properties
 
 class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase):
 
@@ -107,6 +108,11 @@ class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase):
                         description=["echoing"], descriptionDone=["echoed"])
         self.assertEqual((step.describe(), step.describe(done=True)),
                          (['echoing'], ['echoed']))
+
+    def test_describe_unrendered_WithProperties(self):
+        step = shell.ShellCommand(command=properties.WithProperties(''))
+        self.assertEqual((step.describe(), step.describe(done=True)),
+                         (['???'],)*2)
 
     @compat.usesFlushLoggedErrors
     def test_describe_fail(self):


### PR DESCRIPTION
We blindly call len on self.command. This will fail occasionally if
self.command is renderable, but has not yet been rendered. This is harmless,
and is just a transient lack of information in the WebStatus.

Fixes #2122
