### PR TITLE
added the buildStepStatus object to the stepbox so the jinja template can use it

### DIFF
--- a/master/buildbot/status/web/waterfall.py
+++ b/master/buildbot/status/web/waterfall.py
@@ -173,7 +173,7 @@ class StepBox(components.Adapter):
         text = text[:]
         logs = self.original.getLogs()
         
-        cxt = dict(text=text, logs=[], urls=[])
+        cxt = dict(text=text, logs=[], urls=[], stepinfo=self)
 
         for num in range(len(logs)):
             name = logs[num].getName()


### PR DESCRIPTION
I needed this info for some customization of the templates.

I figured others may find it useful as well.

For example I added divs with names of builder and build # via:

```
 <div id="{{stepinfo.original.build.builder.name}}{{stepinfo.original.build.getNumber()}}" style="display:none;">
```
