### PR TITLE
Fix the webhooks broken by the fix for #836 (remove Change.links)

### DIFF
--- a/master/buildbot/status/web/hooks/github.py
+++ b/master/buildbot/status/web/hooks/github.py
@@ -143,7 +143,6 @@ def process_change(payload, user, repo, repo_url, project):
                                 + " <" + commit['author']['email'] + ">",
                     files    = files,
                     comments = commit['message'], 
-                    links    = [commit['url']],
                     revision = commit['id'],
                     when     = when,
                     branch   = branch,

--- a/master/buildbot/status/web/hooks/googlecode.py
+++ b/master/buildbot/status/web/hooks/googlecode.py
@@ -53,7 +53,6 @@ class Payload(object):
                 who=r['author'],
                 files=list(files),
                 comments=r['message'],
-                links=[r['url']],
                 revision=r['revision'],
                 when=r['timestamp'],
                 # Let's hope Google add the branch one day:


### PR DESCRIPTION
- The links argument has been removed from addChange() in
  changeset:139222f3d6edb052e6870789e68298ba6cd2811e (see #836);
- Update/Fix the webhooks handlers accordingly.
