### PR TITLE
assert so the hg step setup fails early in valueError conditions

### DIFF
--- a/master/buildbot/steps/source/mercurial.py
+++ b/master/buildbot/steps/source/mercurial.py
@@ -21,12 +21,16 @@ from twisted.internet import defer
 from buildbot.process import buildstep
 from buildbot.steps.source import Source
 from buildbot.interfaces import BuildSlaveTooOldError
+from buildbot.config import ConfigErrors
 
 class Mercurial(Source):
     """ Class for Mercurial with all the smarts """
     name = "hg"
 
     renderables = [ "repourl", "baseURL" ]
+    possible_modes = ('incremental', 'full')
+    possible_methods = (None, 'clean', 'fresh', 'clobber')
+    possible_branchTypes = ('inrepo', 'dirname')
 
     def __init__(self, repourl=None, baseURL=None, mode='incremental',
                  method=None, defaultBranch=None, branchType='dirname',
@@ -84,17 +88,25 @@ class Mercurial(Source):
                                  clobberOnBranchChange,
                                  )
 
-        assert self.mode in ['incremental', 'full']
-        assert self.method in [None, 'clean', 'fresh', 'clobber']
-        assert self.branchType in ['inrepo', 'dirname']
+        errors = []
+        if self.mode not in self.possible_modes:
+            errors.append("mode %s is not one of %" %
+                            (self.mode, self.possible_modes))
+        if self.method not in self.possible_methods:
+            errors.append("method %s is not one of %s" %
+                            (self.method, self.possible_methods))
+        if self.branchType not in self.possible_branchTypes:
+            errors.append("branchType %s is not one of %s" %
+                            (self.branchType, self.possible_branchTypes))
 
         if repourl and baseURL:
-            raise ValueError("you must provide exactly one of repourl and"
-                             " baseURL")
+            errors.append("you must provide exactly one of repourl and baseURL")
 
         if repourl is None and baseURL is None:
-            raise ValueError("you must privide at least one of repourl and"
-                             " baseURL")
+            errors.append("you must privide at least one of repourl and baseURL")
+        
+        if errors:
+            raise ConfigErrors(errors)
 
     def startVC(self, branch, revision, patch):
         self.revision = revision

--- a/master/buildbot/test/unit/test_steps_source_mercurial.py
+++ b/master/buildbot/test/unit/test_steps_source_mercurial.py
@@ -18,6 +18,7 @@ from buildbot.steps.source import mercurial
 from buildbot.status.results import SUCCESS, FAILURE
 from buildbot.test.util import sourcesteps
 from buildbot.test.fake.remotecommand import ExpectShell, Expect
+from buildbot import config
 
 class TestMercurial(sourcesteps.SourceStepMixin, unittest.TestCase):
 
@@ -28,13 +29,28 @@ class TestMercurial(sourcesteps.SourceStepMixin, unittest.TestCase):
         return self.tearDownSourceStep()
 
     def test_repourl_and_baseURL(self):
-        self.assertRaises(ValueError, lambda :
+        self.assertRaises(config.ConfigErrors, lambda :
                 mercurial.Mercurial(repourl='http://hg.mozilla.org',
                                     baseURL="http://hg.mozilla.org"))
 
     def test_neither_repourl_nor_baseURL(self):
-        self.assertRaises(ValueError, lambda :
+        self.assertRaises(config.ConfigErrors, lambda :
                 mercurial.Mercurial(mode="full"))
+
+    def test_incorrect_mode(self):
+        self.assertRaises(config.ConfigErrors, lambda :
+                mercurial.Mercurial(repourl='http://hg.mozilla.org',
+                                    mode='invalid'))
+
+    def test_incorrect_method(self):
+        self.assertRaises(config.ConfigErrors, lambda :
+                mercurial.Mercurial(repourl='http://hg.mozilla.org',
+                                    method='invalid'))
+
+    def test_incorrect_branchType(self):
+        self.assertRaises(config.ConfigErrors, lambda :
+                mercurial.Mercurial(repourl='http://hg.mozilla.org',
+                                    branchType='invalid'))
 
     def test_mode_full_clean(self):
         self.setupStep(

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -19,6 +19,7 @@ from buildbot.status.results import SUCCESS, FAILURE
 from buildbot.test.util import sourcesteps
 from buildbot.process import buildstep
 from buildbot.test.fake.remotecommand import ExpectShell, Expect
+from buildbot import config
 
 class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
 
@@ -55,13 +56,23 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
         svn.SVN.slaveVersionIsOlderThan = lambda x, y, z: result
 
     def test_repourl_and_baseURL(self):
-        self.assertRaises(ValueError, lambda :
+        self.assertRaises(config.ConfigErrors, lambda :
                 svn.SVN(svnurl='http://svn.local/app/trunk@HEAD',
                         baseURL='http://svn.local/app/trunk@HEAD'))
 
     def test_no_repourl_and_baseURL(self):
-        self.assertRaises(ValueError, lambda :
+        self.assertRaises(config.ConfigErrors, lambda :
                 svn.SVN())
+
+    def test_incorrect_mode(self):
+        self.assertRaises(config.ConfigErrors, lambda :
+                svn.SVN(svnurl='http://svn.local/app/trunk@HEAD',
+                        mode='invalid'))
+
+    def test_incorrect_method(self):
+        self.assertRaises(config.ConfigErrors, lambda :
+                svn.SVN(svnurl='http://svn.local/app/trunk@HEAD',
+                        method='invalid'))
 
     def test_mode_incremental(self):
         self.setupStep(


### PR DESCRIPTION
This makes it so that the cases that Hg would throw because of simple ValueErrors are not deferred until the step runs, but caught at reconfig time.
