### PR TITLE
(#2199): in Bzr hook, make user and password for PB configurable

### DIFF
--- a/master/contrib/bzr_buildbot.py
+++ b/master/contrib/bzr_buildbot.py
@@ -50,6 +50,10 @@ with these keys:
   to which you will connect (as of this writing, the same server and port to
   which slaves connect)
 
+- buildbot_auth: (optional, defaults to change:changepw) the credentials
+  expected by the change source configuration in the master. Takes the
+  "user:password" form.
+
 - buildbot_pqm: (optional, defaults to not pqm) Normally, the user that
   commits the revision is the user that is responsible for the change.  When
   run in a pqm (Patch Queue Manager, see https://launchpad.net/pqm)
@@ -309,6 +313,7 @@ if DEFINE_POLLER:
 HOOK_KEY = 'buildbot_on'
 SERVER_KEY = 'buildbot_server'
 PORT_KEY = 'buildbot_port'
+AUTH_KEY = 'buildbot_auth'
 DRYRUN_KEY = 'buildbot_dry_run'
 PQM_KEY = 'buildbot_pqm'
 SEND_BRANCHNAME_KEY = 'buildbot_send_branch_name'
@@ -413,8 +418,13 @@ def send_change(branch, old_revno, old_revid, new_revno, new_revid, hook):
     reactor.resolver = ThreadedResolver(reactor)
     pbcf = twisted.spread.pb.PBClientFactory()
     reactor.connectTCP(server, port, pbcf)
+    auth = config.get_user_option(AUTH_KEY)
+    if auth:
+        user, passwd = [s.strip() for s in auth.split(':', 1)]
+    else:
+        user, passwd = ('change', 'changepw')
     deferred = pbcf.login(
-        twisted.cred.credentials.UsernamePassword('change', 'changepw'))
+        twisted.cred.credentials.UsernamePassword(user, passwd))
 
     def sendChanges(remote):
         """Send changes to buildbot."""


### PR DESCRIPTION
Hello, 

first contribution here, hope it fits the guidelines. 
I updated the embedded documentation, but could not find any test for the bzr_buildbot module.
I noticed also that parts of the documentation about Bzr in buildbot.net are slightly outdated (how to fix that?)

Sincerely
