### PR TITLE
(bug 2211) Use 'svn info' to check source dirs' branches

### DIFF
--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+import re
 import xml.dom.minidom
 import xml.parsers.expat
 
@@ -314,8 +315,11 @@ class SVN(Source):
             self._dovccmd(['info'], collectStdout=True))
         yield wfd
         stdout = wfd.getResult()
-        stdout = [ s.strip() for s in stdout.split('\n') ]
-        yield 'URL: %s' % self.repourl in stdout
+
+        # extract the URL, handling whitespace carefully so that \r\n works
+        # is a line terminator
+        mo = re.search('^URL:\s*(.*?)\s*$', stdout, re.M)
+        yield mo and mo.group(1) == self.repourl
         return
 
     def parseGotRevision(self, _):

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -944,8 +944,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             ExpectShell(workdir='source',
                         command=['svn', 'info', '--non-interactive',
                                  '--no-auth-cache' ])
-            + ExpectShell.log('stdio',
-                stdout="URL: http://svn.local/app/trunk")
+            + ExpectShell.log('stdio', # note \r\n here, for variety
+                stdout="URL: http://svn.local/app/trunk\r\nTrailing: ..")
             + 0,
             ExpectShell(workdir='source',
                         command=['svn', 'update', '--non-interactive',


### PR DESCRIPTION
This replaces what is implemented with 'sourcedata' in the source steps,
instead using native svn tools to avoid any disparity between the actual
state of the directory and buildbot's tracking data.
