### PR TITLE
hgbuildbot: Default branchtype to 'inrepo'

### DIFF
--- a/master/buildbot/changes/hgbuildbot.py
+++ b/master/buildbot/changes/hgbuildbot.py
@@ -50,7 +50,7 @@ def hook(ui, repo, hooktype, node=None, source=None, **kwargs):
                             ui.config('web', 'baseurl', ''))
     master = ui.config('hgbuildbot', 'master')
     if master:
-        branchtype = ui.config('hgbuildbot', 'branchtype')
+        branchtype = ui.config('hgbuildbot', 'branchtype', 'inrepo')
         branch = ui.config('hgbuildbot', 'branch')
         fork = ui.configbool('hgbuildbot', 'fork', False)
         # notify also has this setting
@@ -82,11 +82,10 @@ def hook(ui, repo, hooktype, node=None, source=None, **kwargs):
     from twisted.internet import defer, reactor
 
     if branch is None:
-        if branchtype is not None:
-            if branchtype == 'dirname':
-                branch = os.path.basename(repo.root)
-            if branchtype == 'inrepo':
-                branch = workingctx(repo).branch()
+        if branchtype == 'dirname':
+            branch = os.path.basename(repo.root)
+        if branchtype == 'inrepo':
+            branch = workingctx(repo).branch()
 
     if not auth:
         auth = 'change:changepw'


### PR DESCRIPTION
This is more an RFC than an actual patch, see a recent discussion on the ML where the user was lost in the multitude of needed settings. Anyone uses 'inrepo' branchtype nowadays anyway ...
