### PR TITLE
Document the deprecation of the old step factory interface to BuildFactory.

### DIFF
--- a/master/buildbot/process/factory.py
+++ b/master/buildbot/process/factory.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.python import deprecate, versions
 
 from buildbot import util
 from buildbot.process.build import Build
@@ -21,6 +22,7 @@ from buildbot.steps.source import CVS, SVN
 from buildbot.steps.shell import Configure, Compile, Test, PerlModuleTest
 
 # deprecated, use BuildFactory.addStep
+@deprecate.deprecated(versions.Version("buildbot", 0, 8, 6))
 def s(steptype, **kwargs):
     # convenience function for master.cfg files, to create step
     # specification tuples
@@ -57,6 +59,9 @@ class BuildFactory(util.ComparableMixin):
     def _makeStepFactory(self, step_or_factory):
         if isinstance(step_or_factory, BuildStep):
             return step_or_factory.getStepFactory()
+        deprecate.warnAboutFunction(BuildFactory.__init__,
+                "Passing a BuildStep subclass to factory.addStep is deprecated.  " +
+                "Please pass a BuildStep instance instead.  Support will be dropped in v0.8.7.")
         return step_or_factory
 
     def newBuild(self, requests):
@@ -79,6 +84,9 @@ class BuildFactory(util.ComparableMixin):
         elif type(step_or_factory) == type(BuildStep) and \
                 issubclass(step_or_factory, BuildStep):
             s = (step_or_factory, dict(kwargs))
+            deprecate.warnAboutFunction(BuildFactory.addStep,
+                    "Passing a BuildStep subclass to factory.addStep is deprecated.  " +
+                    "Please pass a BuildStep instance instead.  Support will be dropped in v0.8.7.")
         else:
             raise ValueError('%r is not a BuildStep nor BuildStep subclass' % step_or_factory)
         self.steps.append(s)

--- a/master/buildbot/test/unit/test_process_factory.py
+++ b/master/buildbot/test/unit/test_process_factory.py
@@ -1,0 +1,57 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.trial import unittest
+from mock import Mock
+
+from buildbot.process.factory import BuildFactory, ArgumentsInTheWrongPlace, s
+from buildbot.process.buildstep import BuildStep
+
+class TestBuildFactory(unittest.TestCase):
+
+    def test_init(self):
+        step = BuildStep()
+        factory = BuildFactory([step])
+        self.assertEqual(factory.steps, [(BuildStep, {})])
+
+    def test_init_deprecated(self):
+        factory = BuildFactory([s(BuildStep)])
+        self.assertEqual(factory.steps, [(BuildStep, {})])
+        self.assertEqual(len(self.flushWarnings([BuildFactory.__init__])), 1)
+
+    def test_addStep(self):
+        step = BuildStep()
+        factory = BuildFactory()
+        factory.addStep(step)
+        self.assertEqual(factory.steps, [(BuildStep, {})])
+
+    def test_addStep_deprecated(self):
+        factory = BuildFactory()
+        factory.addStep(BuildStep)
+        self.assertEqual(factory.steps, [(BuildStep, {})])
+        self.assertEqual(len(self.flushWarnings([BuildFactory.addStep])), 1)
+
+    def test_addStep_notAStep(self):
+        factory = BuildFactory()
+        self.assertRaises(ValueError, factory.addStep, Mock())
+
+    def test_addStep_ArgumentsInTheWrongPlace(self):
+        factory = BuildFactory()
+        self.assertRaises(ArgumentsInTheWrongPlace, factory.addStep, BuildStep(), name="name")
+
+    def test_addSteps(self):
+        factory = BuildFactory()
+        factory.addSteps([BuildStep(), BuildStep()])
+        self.assertEqual(factory.steps, [(BuildStep, {}), (BuildStep, {})])

--- a/master/docs/release-notes.rst
+++ b/master/docs/release-notes.rst
@@ -79,6 +79,10 @@ Deprecations, Removals, and Non-Compatible Changes
   with ``repourl`` parameter. The behavior of the step is already controled by
   ``branchType`` parameter, so just use a single argument to specify the repository.
 
+* Passing a :py:class:`buildbot.process.buildstep.BuildStep` subclass (rather than
+  instance) to :py:meth:`buildbot.process.factory.BuildFactory.addStep` has long been
+  deprecated, and will be removed in version 0.8.7.
+
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This has been deprecated for a long time. Warn people that we are removing it.
The motivation for this is that we are changing how we are representing step
factories, and don't want to expose that representation to the user.
