### PR TITLE
RFC: Collect all ConfigErrors, rather than raising an exception at the first error.

### DIFF
--- a/master/buildbot/buildslave.py
+++ b/master/buildbot/buildslave.py
@@ -102,8 +102,8 @@ class AbstractBuildSlave(config.ReconfigurableServiceMixin, pb.Avatar,
         self.notify_on_missing = notify_on_missing
         for i in notify_on_missing:
             if not isinstance(i, str):
-                raise config.ConfigErrors([
-                    'notify_on_missing arg %r is not a string' % (i,) ])
+                config.error(
+                    'notify_on_missing arg %r is not a string' % (i,))
         self.missing_timeout = missing_timeout
         self.missing_timer = None
         self.keepalive_interval = keepalive_interval

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -39,6 +39,12 @@ class ConfigErrors(Exception):
     def __nonzero__(self):
         return len(self.errors)
 
+_errors = None
+def error(error):
+    if _errors is not None:
+        _errors.addError(error)
+    else:
+        raise ConfigErrors([error])
 
 class MasterConfig(object):
 
@@ -126,33 +132,41 @@ class MasterConfig(object):
             '__file__': os.path.abspath(filename),
         }
 
+        # from here on out we can batch errors together for the user's
+        # convenience
+        global _errors
+        _errors = errors = ConfigErrors()
+
         old_sys_path = sys.path[:]
         sys.path.append(basedir)
         try:
             try:
                 exec f in localDict
-            except ConfigErrors:
-                raise
+                if errors:
+                    raise ConfigErrors(_errors)
+            except ConfigErrors, e:
+                for error in e.errors:
+                    errors.addError(error)
+                raise errors
             except:
                 log.err(failure.Failure())
-                raise ConfigErrors([
+                errors.addError(
                     "error while parsing config file: %s (traceback in logfile)" %
                         (sys.exc_info()[1],),
-                ])
+                )
+                raise errors
         finally:
             sys.path[:] = old_sys_path
+            _errors = None
 
         if 'BuildmasterConfig' not in localDict:
-            raise ConfigErrors([
+            errors.addError(
                 "Configuration file %r does not define 'BuildmasterConfig'"
                     % (filename,),
-            ])
+            )
+            raise errors
 
         config_dict = localDict['BuildmasterConfig']
-
-        # from here on out we can batch errors together for the user's
-        # convenience
-        errors = ConfigErrors()
 
         # check for unknown keys
         unknown_keys = set(config_dict.keys()) - cls._known_config_keys

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -295,9 +295,9 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
     def reconfigService(self, new_config):
         if self.config.db['db_url'] != new_config.db['db_url']:
-            raise config.ConfigErrors([
+            config.error(
                 "Cannot change c['db']['db_url'] after the master has started",
-            ])
+            )
 
         # adjust the db poller
         if (self.config.db['db_poll_interval']

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -756,8 +756,8 @@ class LoggingBuildStep(BuildStep):
                                  log_eval_func=log_eval_func)
 
         if logfiles and not isinstance(logfiles, dict):
-            raise config.ConfigErrors([
-                "the ShellCommand 'logfiles' parameter must be a dictionary" ])
+            config.error(
+                "the ShellCommand 'logfiles' parameter must be a dictionary")
 
         # merge a class-level 'logfiles' attribute with one passed in as an
         # argument
@@ -765,8 +765,8 @@ class LoggingBuildStep(BuildStep):
         self.logfiles.update(logfiles)
         self.lazylogfiles = lazylogfiles
         if log_eval_func and not callable(log_eval_func):
-            raise config.ConfigErrors([
-                "the 'log_eval_func' paramater must be a callable" ])
+            config.error(
+                "the 'log_eval_func' paramater must be a callable")
         self.log_eval_func = log_eval_func
         self.addLogObserver('stdio', OutputProgressObserver("output"))
 

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -68,9 +68,9 @@ class BaseScheduler(service.MultiService, ComparableMixin):
                 if not isinstance(b, basestring):
                     ok = False
         if not ok:
-            raise config.ConfigErrors([
+            config.error(
                 "The builderNames argument to a scheduler must be a list "
-                  "of Builder names."])
+                  "of Builder names.")
 
         self.builderNames = builderNames
         "list of builder names to start in each buildset"

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -40,11 +40,11 @@ class BaseBasicScheduler(base.BaseScheduler):
                 fileIsImportant=None, properties={}, categories=None,
                 change_filter=None, onlyImportant=False):
         if shouldntBeSet is not self.NotSet:
-            raise config.ConfigErrors([
-                "pass arguments to schedulers using keyword arguments" ])
+            config.error(
+                "pass arguments to schedulers using keyword arguments")
         if fileIsImportant and not callable(fileIsImportant):
-            raise config.ConfigErrors([
-                "fileIsImportant must be a callable" ])
+            config.error(
+                "fileIsImportant must be a callable")
 
         # initialize parent classes
         base.BaseScheduler.__init__(self, name, builderNames, properties)
@@ -218,13 +218,13 @@ class BaseBasicScheduler(base.BaseScheduler):
 class SingleBranchScheduler(BaseBasicScheduler):
     def getChangeFilter(self, branch, branches, change_filter, categories):
         if branch is NotABranch and not change_filter:
-            raise config.ConfigErrors([
+            config.error(
                 "the 'branch' argument to SingleBranchScheduler is " +
-                "mandatory unless change_filter is provided"])
+                "mandatory unless change_filter is provided")
         elif branches is not NotABranch:
-            raise config.ConfigErrors([
+            config.error(
                 "the 'branches' argument is not allowed for " +
-                "SingleBranchScheduler"])
+                "SingleBranchScheduler")
 
 
         return filter.ChangeFilter.fromSchedulerConstructorArgs(

--- a/master/buildbot/schedulers/dependent.py
+++ b/master/buildbot/schedulers/dependent.py
@@ -26,8 +26,8 @@ class Dependent(base.BaseScheduler):
     def __init__(self, name, upstream, builderNames, properties={}):
         base.BaseScheduler.__init__(self, name, builderNames, properties)
         if not interfaces.IScheduler.providedBy(upstream):
-            raise config.ConfigErrors([
-                "upstream must be another Scheduler instance" ])
+            config.error(
+                "upstream must be another Scheduler instance")
         self.upstream_name = upstream.name
         self._buildset_addition_subscr = None
         self._buildset_completion_subscr = None

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -212,8 +212,8 @@ class Periodic(Timed):
         Timed.__init__(self, name=name, builderNames=builderNames,
                     properties=properties)
         if periodicBuildTimer <= 0:
-            raise config.ConfigErrors([
-                "periodicBuildTimer must be positive" ])
+            config.error(
+                "periodicBuildTimer must be positive")
         self.periodicBuildTimer = periodicBuildTimer
         self.branch = branch
         self.reason = "The Periodic scheduler named '%s' triggered this build" % self.name
@@ -244,11 +244,11 @@ class Nightly(Timed):
         self.onlyImportant = onlyImportant
 
         if fileIsImportant and not callable(fileIsImportant):
-            raise config.ConfigErrors([
-                "fileIsImportant must be a callable" ])
+            config.error(
+                "fileIsImportant must be a callable")
         if branch is Nightly.NoBranch:
-            raise config.ConfigErrors([
-                "Nightly parameter 'branch' is required" ])
+            config.error(
+                "Nightly parameter 'branch' is required")
 
         self.minute = minute
         self.hour = hour

--- a/master/buildbot/status/mail.py
+++ b/master/buildbot/status/mail.py
@@ -291,14 +291,12 @@ class MailNotifier(base.StatusReceiverMultiService):
         """
         base.StatusReceiverMultiService.__init__(self)
 
-        errors = []
-
         if not isinstance(extraRecipients, (list, tuple)):
-            errors.append("extraRecipients must be a list or tuple")
+            config.error("extraRecipients must be a list or tuple")
         else:
             for r in extraRecipients:
                 if not isinstance(r, str) or not VALID_EMAIL.search(r):
-                    errors.append(
+                    config.error(
                             "extra recipient %r is not a valid email" % (r,))
         self.extraRecipients = extraRecipients
         self.sendToInterestedUsers = sendToInterestedUsers
@@ -312,7 +310,7 @@ class MailNotifier(base.StatusReceiverMultiService):
                 mode = (mode,)
         for m in mode:
             if m not in self.possible_modes:
-                errors.append(
+                config.error(
                     "mode %s is not a valid mode" % (m,))
         self.mode = mode
         self.categories = categories
@@ -320,7 +318,7 @@ class MailNotifier(base.StatusReceiverMultiService):
         self.addLogs = addLogs
         self.relayhost = relayhost
         if '\n' in subject:
-            errors.append(
+            config.error(
                 'Newlines are not allowed in email subjects')
         self.subject = subject
         if lookup is not None:
@@ -332,7 +330,7 @@ class MailNotifier(base.StatusReceiverMultiService):
         self.messageFormatter = messageFormatter
         if extraHeaders:
             if not isinstance(extraHeaders, dict):
-                errors.append("extraHeaders must be a dictionary")
+                config.error("extraHeaders must be a dictionary")
         self.extraHeaders = extraHeaders
         self.addPatch = addPatch
         self.useTls = useTls
@@ -346,16 +344,13 @@ class MailNotifier(base.StatusReceiverMultiService):
 
         # you should either limit on builders or categories, not both
         if self.builders != None and self.categories != None:
-            errors.append(
+            config.error(
                 "Please specify only builders or categories to include - " +
                 "not both.")
 
         if customMesg:
-            errors.append(
+            config.error(
                 "customMesg is deprecated; use messageFormatter instead")
-
-        if errors:
-            raise config.ConfigErrors(errors)
 
     def setServiceParent(self, parent):
         """

--- a/master/buildbot/status/web/baseweb.py
+++ b/master/buildbot/status/web/baseweb.py
@@ -281,20 +281,20 @@ class WebStatus(service.MultiService):
         self.num_events = num_events
         if num_events_max:
             if num_events_max < num_events:
-                raise config.ConfigErrors([
-                    "num_events_max must be greater than num_events" ])
+                config.error(
+                    "num_events_max must be greater than num_events")
             self.num_events_max = num_events_max
         self.public_html = public_html
 
         # make up an authz if allowForce was given
         if authz:
             if allowForce is not None:
-                raise config.ConfigErrors([
-                    "cannot use both allowForce and authz parameters" ])
+                config.error(
+                    "cannot use both allowForce and authz parameters")
             if auth:
-                raise config.ConfigErrors([
+                config.error(
                     "cannot use both auth and authz parameters (pass " +
-                    "auth as an Authz parameter)" ])
+                    "auth as an Authz parameter)")
         else:
             # invent an authz
             if allowForce and auth:

--- a/master/buildbot/steps/blocker.py
+++ b/master/buildbot/steps/blocker.py
@@ -59,16 +59,16 @@ class Blocker(BuildStep):
     def __init__(self, **kwargs):
         BuildStep.__init__(self, **kwargs)
         if self.upstreamSteps is None:
-            raise config.ConfigErrors([
-                "you must supply upstreamSteps" ])
+            config.error(
+                "you must supply upstreamSteps")
         if len(self.upstreamSteps) < 1:
-            raise config.ConfigErrors([
-                "upstreamSteps must be a non-empty list" ])
+            config.error(
+                "upstreamSteps must be a non-empty list")
         if self.idlePolicy not in self.VALID_IDLE_POLICIES:
-            raise config.ConfigErrors([
+            config.error(
                 "invalid value for idlePolicy: %r (must be one of %s)"
                 % (self.idlePolicy,
-                   ", ".join(map(repr, self.VALID_IDLE_POLICIES)))])
+                   ", ".join(map(repr, self.VALID_IDLE_POLICIES))))
 
         # list of build steps (as BuildStepStatus objects) that we're
         # currently waiting on

--- a/master/buildbot/steps/maxq.py
+++ b/master/buildbot/steps/maxq.py
@@ -23,7 +23,7 @@ class MaxQ(ShellCommand):
 
     def __init__(self, testdir=None, **kwargs):
         if not testdir:
-            raise config.ConfigErrors(["please pass testdir"])
+            config.error("please pass testdir")
         kwargs['command'] = 'run_maxq.py %s' % (testdir,)
         ShellCommand.__init__(self, **kwargs)
         self.addFactoryArguments(testdir=testdir)

--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -225,16 +225,13 @@ class Sphinx(ShellCommand):
                  sphinx_builder=None, sphinx = 'sphinx-build', tags = [],
                  defines = {}, mode='incremental', **kwargs):
 
-        errors = []
         if sphinx_builddir is None:
             # Who the heck is not interested in the built doc ?
-            errors.append("Sphinx argument sphinx_builddir is required")
+            config.error("Sphinx argument sphinx_builddir is required")
 
         if mode not in ('incremental', 'full'):
-            errors.append("Sphinx argument mode has to be 'incremental' or" +
+            config.error("Sphinx argument mode has to be 'incremental' or" +
                           "'full' is required")
-        if errors:
-            raise config.ConfigErrors(errors)
 
         self.warnings = 0
         self.success = False

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -298,8 +298,8 @@ class SetProperty(ShellCommand):
         self.strip = strip
 
         if not ((property is not None) ^ (extract_fn is not None)):
-            raise config.ConfigErrors([
-                "Exactly one of property and extract_fn must be set" ])
+            config.error(
+                "Exactly one of property and extract_fn must be set")
 
         ShellCommand.__init__(self, **kwargs)
 

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -242,8 +242,8 @@ class FileUpload(_TransferBuildStep):
         self.maxsize = maxsize
         self.blocksize = blocksize
         if not isinstance(mode, (int, type(None))):
-            raise config.ConfigErrors([
-                'mode must be an integer or None' ])
+            config.error(
+                'mode must be an integer or None')
         self.mode = mode
         self.keepstamp = keepstamp
         self.url = url
@@ -321,8 +321,8 @@ class DirectoryUpload(_TransferBuildStep):
         self.maxsize = maxsize
         self.blocksize = blocksize
         if compress not in (None, 'gz', 'bz2'):
-            raise config.ConfigErrors([
-                "'compress' must be one of None, 'gz', or 'bz2'" ])
+            config.error(
+                "'compress' must be one of None, 'gz', or 'bz2'")
         self.compress = compress
         self.url = url
 
@@ -441,8 +441,8 @@ class FileDownload(_TransferBuildStep):
         self.maxsize = maxsize
         self.blocksize = blocksize
         if not isinstance(mode, (int, type(None))):
-            raise config.ConfigErrors([
-                'mode must be an integer or None' ])
+            config.error(
+                'mode must be an integer or None')
         self.mode = mode
 
     def start(self):
@@ -512,8 +512,8 @@ class StringDownload(_TransferBuildStep):
         self.maxsize = maxsize
         self.blocksize = blocksize
         if not isinstance(mode, (int, type(None))):
-            raise config.ConfigErrors([
-                'mode must be an integer or None' ])
+            config.error(
+                'mode must be an integer or None')
         self.mode = mode
 
     def start(self):

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -31,18 +31,18 @@ class Trigger(LoggingBuildStep):
     def __init__(self, schedulerNames=[], sourceStamp=None, updateSourceStamp=None, alwaysUseLatest=False,
                  waitForFinish=False, set_properties={}, copy_properties=[], **kwargs):
         if not schedulerNames:
-            raise config.ConfigErrors([
-                "You must specify a scheduler to trigger" ])
+            config.error(
+                "You must specify a scheduler to trigger")
         if sourceStamp and (updateSourceStamp is not None):
-            raise config.ConfigErrors([
-                "You can't specify both sourceStamp and updateSourceStamp" ])
+            config.error(
+                "You can't specify both sourceStamp and updateSourceStamp")
         if sourceStamp and alwaysUseLatest:
-            raise config.ConfigErrors([
-                "You can't specify both sourceStamp and alwaysUseLatest" ])
+            config.error(
+                "You can't specify both sourceStamp and alwaysUseLatest")
         if alwaysUseLatest and (updateSourceStamp is not None):
-            raise config.ConfigErrors([
+            config.error(
                 "You can't specify both alwaysUseLatest and updateSourceStamp"
-            ])
+            )
         self.schedulerNames = schedulerNames
         self.sourceStamp = sourceStamp
         if updateSourceStamp is not None:

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -259,7 +259,7 @@ class StartupAndReconfig(dirs.DirsMixin, unittest.TestCase):
     def patch_loadConfig_fail(self):
         @classmethod
         def loadConfig(cls, b, f):
-            raise config.ConfigErrors(['oh noes'])
+            config.error('oh noes')
         self.patch(config.MasterConfig, 'loadConfig', loadConfig)
 
 

--- a/master/docs/developer/config.rst
+++ b/master/docs/developer/config.rst
@@ -247,10 +247,19 @@ Builder Configuration
 Error Handling
 ==============
 
-Any errors encountered while loading the configuration should be raised as
-:py:exc:`ConfigErrors`.  This can occur both in the configuration-loading code,
+If any errors are encountered while loading the configuration :py:exec:`buildbot.config.error`
+should be called. This can occur both in the configuration-loading code,
 and in the constructors of any objects that are instantiated in the
 configuration - change sources, slaves, schedulers, build steps, and so on.
+
+.. py:function:: error(error)
+    :param string error: error to report
+    :raises: :py:exc:`ConfigErrors` if called at build-time
+
+    This function reports a configuration error. If a config file is being loaded,
+    then the function merely records ther error, and allows he rest of the configuration
+    to be loaded. At any other time, it raises :py:exc:`ConfigErrors`.  This is done
+    so all config erros can be reported, rather than just the first.
 
 .. py:exception:: ConfigErrors([errors])
 

--- a/master/docs/release-notes.rst
+++ b/master/docs/release-notes.rst
@@ -104,6 +104,9 @@ Changes for Developers
   corresponding (undocumented)
   :py:class:`buildbot.db.buildsets.BuildsetsConnector` methods.
 
+* Errors during configuration (in particular in :py:class:`BuildStep` constructors),
+  should be reported by calling :py:function:`buildbot.config.error`.
+
 Features
 ~~~~~~~~
 


### PR DESCRIPTION
Instead of directly raising config.ConfigErrors, code should instead call config.errors. In the case that this is called during config, the errors will be collected, and reported at the end. At any other point, an exception will be raised.

This still needs some tests, and the documentation needs to be updated.
