### PR TITLE
hgbuildbot: reports by default the 'inrepo' type of branch

### DIFF
--- a/master/buildbot/changes/hgbuildbot.py
+++ b/master/buildbot/changes/hgbuildbot.py
@@ -50,7 +50,7 @@ def hook(ui, repo, hooktype, node=None, source=None, **kwargs):
                             ui.config('web', 'baseurl', ''))
     master = ui.config('hgbuildbot', 'master')
     if master:
-        branchtype = ui.config('hgbuildbot', 'branchtype')
+        branchtype = ui.config('hgbuildbot', 'branchtype', 'inrepo')
         branch = ui.config('hgbuildbot', 'branch')
         fork = ui.configbool('hgbuildbot', 'fork', False)
         # notify also has this setting
@@ -82,11 +82,8 @@ def hook(ui, repo, hooktype, node=None, source=None, **kwargs):
     from twisted.internet import defer, reactor
 
     if branch is None:
-        if branchtype is not None:
-            if branchtype == 'dirname':
-                branch = os.path.basename(repo.root)
-            if branchtype == 'inrepo':
-                branch = workingctx(repo).branch()
+        if branchtype == 'dirname':
+            branch = os.path.basename(repo.root)
 
     if not auth:
         auth = 'change:changepw'

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -559,32 +559,32 @@ The ``[hgbuildbot]`` section has two other parameters that you
 might specify, both of which control the name of the branch that is
 attached to the changes coming from this hook.
 
-One common branch naming policy for Mercurial repositories is for
-each branch to go into a separate repository, and
-all the branches for a single project share a common parent directory.
-For example, you might have :file:`/var/repos/{PROJECT}/trunk/` and
-:file:`/var/repos/{PROJECT}/release`. To use this style, use the
-``branchtype = dirname`` setting, which simply uses the last
-component of the repository's enclosing directory as the branch name:
-
-.. code-block:: ini
-
-    [hgbuildbot]
-    branchtype = dirname
-    # ...
-
-Another approach is to use Mercurial's built-in branches (the kind
-created with :command:`hg branch` and listed with :command:`hg
-branches`). This feature associates persistent names with particular
-lines of descent within a single repository. (note that the buildbot
-``source.Mercurial`` checkout step does not yet support this kind
-of branch). To have the commit hook deliver this sort of branch name
-with the Change object, use ``branchtype = inrepo``:
+One common branch naming policy for Mercurial repositories is to use
+Mercurial's built-in branches (the kind created with :command:`hg
+branch` and listed with :command:`hg branches`). This feature
+associates persistent names with particular  lines of descent within a
+single repository. (note that the buildbot ``source.Mercurial``
+checkout step does not yet support this kind of branch). To have the
+commit hook deliver this sort of branch name with the Change object,
+use ``branchtype = inrepo``, this is the default behavior:
 
 .. code-block:: ini
 
     [hgbuildbot]
     branchtype = inrepo
+    # ...
+
+Another approach is for each branch to go into a separate repository,
+and all the branches for a single project share a common parent
+directory. For example, you might have :file:`/var/repos/{PROJECT}/trunk/` and
+:file:`/var/repos/{PROJECT}/release`. To use this style, use the
+``branchtype = dirname`` setting, which simply uses the last component
+of the repository's enclosing directory as the branch name:
+
+.. code-block:: ini
+
+    [hgbuildbot]
+    branchtype = dirname
     # ...
 
 Finally, if you want to simply specify the branchname directly, for


### PR DESCRIPTION
This cannot arms as earlier no branches where reported, we are just
increasing the number of information provided if no specific setting was
set.

This is replacing pull-request #327
