### PR TITLE
Add description lines to init scripts

### DIFF
--- a/master/contrib/init-scripts/buildmaster.init.sh
+++ b/master/contrib/init-scripts/buildmaster.init.sh
@@ -10,6 +10,9 @@
 # Required-Stop:     $remote_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
+# Short-Description: Buildbot master init script
+# Description:       This file allows running buildbot master instances at
+#                    startup
 ### END INIT INFO
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin

--- a/slave/contrib/init-scripts/buildslave.init.sh
+++ b/slave/contrib/init-scripts/buildslave.init.sh
@@ -10,6 +10,9 @@
 # Required-Stop:     $remote_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
+# Short-Description: Buildbot slave init script
+# Description:       This file allows running buildbot slave instances at
+#                    startup
 ### END INIT INFO
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin


### PR DESCRIPTION
This will actually fix packaging warnings for Debian. Please add to buildbot-0.8.6 if possible.
