### PR TITLE
Missing files in MANIFEST.in

### DIFF
--- a/master/MANIFEST.in
+++ b/master/MANIFEST.in
@@ -28,5 +28,6 @@ include buildbot/buildbot.png
 include buildbot/db/migrate/README buildbot/db/migrate/migrate.cfg
 
 include contrib/* contrib/windows/* contrib/os-x/* contrib/css/* contrib/libvirt/*
+include contrib/blockertest/*
 include contrib/trac/* contrib/trac/bbwatcher/* contrib/trac/bbwatcher/templates/*
 include contrib/init-scripts/*


### PR DESCRIPTION
While I'm not sure if these files are left out of sdist intentionally or not, I'd like to point that out. If you decide these files(or part of them) are mature enough to be included into sdist, please cherry-pick the necessary commit(s). IMHO it's better to have them in the Python (and Debian) distribution than ask users to get them from DVCS.
