### PR TITLE
Improvements for MasterShellCommand's env.

### DIFF
--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -29,7 +29,7 @@ class MasterShellCommand(BuildStep):
     name='MasterShellCommand'
     description='Running'
     descriptionDone='Ran'
-    renderables = [ 'command' ]
+    renderables = [ 'command', 'env' ]
     haltOnFailure = True
     flunkOnFailure = True
 
@@ -106,17 +106,13 @@ class MasterShellCommand(BuildStep):
             env = os.environ
         else:
             assert isinstance(self.env, dict)
-            env = properties.render(self.env.copy())
+            env = self.env
 
-            # do substitution on variable values matching patern: ${name}
+            # do substitution on variable values matching pattern: ${name}
             p = re.compile('\${([0-9a-zA-Z_]*)}')
             def subst(match):
                 return os.environ.get(match.group(1), "")
             newenv = {}
-            for key in os.environ.keys():
-                # setting a key to None will delete it from the slave environment
-                if key not in env or env[key] is not None:
-                    newenv[key] = os.environ[key]
             for key in env.keys():
                 if env[key] is not None:
                     newenv[key] = p.sub(subst, env[key])

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -1321,7 +1321,7 @@ The :bb:step:`ShellCommand` arguments are:
     Those variables support expansion so that if you just want to prepend
     :file:`/home/buildbot/bin` to the :envvar:`PATH` environment variable, you can do
     it by putting the value ``${PATH}`` at the end of the value like
-    in the example below. Variables that doesn't exists on the slave will be
+    in the example below. Variables that don't exist on the slave will be
     replaced by ``""``. ::
     
         from buildbot.steps.shell import ShellCommand
@@ -2286,6 +2286,22 @@ In this example, the step renames a tarball based on the day of the week. ::
 .. note:: By default, this step passes a copy of the buildmaster's environment
    variables to the subprocess.  To pass an explicit environment instead, add an
    ``env={..}`` argument.
+
+Environment variables constructed using the ``env`` argument support expansion
+so that if you just want to prepend  :file:`/home/buildbot/bin` to the
+:envvar:`PATH` environment variable, you can do it by putting the value
+``${PATH}`` at the end of the value like in the example below.
+Variables that don't exist on the master will be replaced by ``""``. ::
+
+    from buildbot.steps.master import MasterShellCommand
+    f.addStep(MasterShellCommand(
+                  command=["make", "www"],
+                  env={'PATH': ["/home/buildbot/bin",
+                                "${PATH}"]}))
+
+Note that environment values must be strings (or lists that are turned into
+strings).  In particular, numeric properties such as ``buildnumber`` must
+be substituted using :ref:`WithProperties`.
 
 .. index:: Properties; from steps
 

--- a/slave/buildslave/runprocess.py
+++ b/slave/buildslave/runprocess.py
@@ -296,7 +296,7 @@ class RunProcess:
             if environ.has_key('PYTHONPATH'):
                 environ['PYTHONPATH'] += os.pathsep + "${PYTHONPATH}"
 
-            # do substitution on variable values matching patern: ${name}
+            # do substitution on variable values matching pattern: ${name}
             p = re.compile('\${([0-9a-zA-Z_]*)}')
             def subst(match):
                 return os.environ.get(match.group(1), "")


### PR DESCRIPTION
Adds support for properties and variables' substitution for
MasterShellCommand's env parameter.
Largely inspired by the buildslave's RunProcess class.
