### PR TITLE
Fix population of slave properties on initial config.

### DIFF
--- a/master/buildbot/buildslave.py
+++ b/master/buildbot/buildslave.py
@@ -214,8 +214,9 @@ class AbstractBuildSlave(config.ReconfigurableServiceMixin, pb.Avatar,
             if running_missing_timer:
                 self.startMissingTimer()
 
-        self.properties = Properties()
-        self.properties.updateFromProperties(new.properties)
+        properties = Properties()
+        properties.updateFromProperties(new.properties)
+        self.properties = properties
 
         self.updateLocks()
 


### PR DESCRIPTION
reconfigService is called on slaves when they are first added, with
the new BuildSlave instance equal to the current instance. We didn't
check this, and didn't properly handle properties in that case.

We can't just skip reconfig in that case, though, since reconfigService
also handles initial PB registration, and informing the slave about
configured builders.
