### PR TITLE
Sort the list of builders returned by master status.

### DIFF
--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -201,7 +201,7 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
 
     def getBuilderNames(self, categories=None):
         if categories == None:
-            return self.botmaster.builderNames[:] # don't let them break it
+            return sorted(self.botmaster.builderNames) # don't let them break it
         
         l = []
         # respect addition order
@@ -209,7 +209,7 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
             bldr = self.botmaster.builders[name]
             if bldr.config.category in categories:
                 l.append(name)
-        return l
+        return sorted(l)
 
     def getBuilder(self, name):
         """


### PR DESCRIPTION
We have a number of places where we use this list as is, for displaying
lists of builders. In previous versions, this list happened to be in
the same order as in the config. Since that is no longer the case,
give at least _some_ ordering of the list, rather than a completely
random seeming order.
