### PR TITLE
Do not rely on BuildRequestStatus._buildrequest being non-None

### DIFF
--- a/master/buildbot/status/buildrequest.py
+++ b/master/buildbot/status/buildrequest.py
@@ -76,6 +76,15 @@ class BuildRequestStatus:
 
     # methods called by our clients
     @defer.deferredGenerator
+    def getBsid(self):
+        wfd = defer.waitForDeferred(
+                self._getBuildRequest())
+        yield wfd
+        br = wfd.getResult()
+
+        yield br.bsid
+
+    @defer.deferredGenerator
     def getSourceStamp(self):
         wfd = defer.waitForDeferred(
                 self._getBuildRequest())

--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -254,7 +254,12 @@ class StatusResourceBuilder(HtmlResource, BuildLineMixin):
             submitTime = wfd.getResult()
 
             wfd = defer.waitForDeferred(
-                pb.master.db.buildsets.getBuildsetProperties(pb._buildrequest.bsid))
+                    pb.getBsid())
+            yield wfd
+            bsid = wfd.getResult()
+
+            wfd = defer.waitForDeferred(
+                pb.master.db.buildsets.getBuildsetProperties(bsid))
             yield wfd
             properties = wfd.getResult()
 


### PR DESCRIPTION
Nor even on _getBuildRequest -- add a getter instead.

This is causing failures for Nate when forcing builds.
