### PR TITLE
Tidy up the loose ends on #2126

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -373,7 +373,7 @@ def ns(s):
     return "%d:%s," % (len(s), s)
 
 
-def createJobfile(bsid, branch, baserev, patchlevel, diff, repository,
+def createJobfile(jobid, branch, baserev, patch_level, patch_body, repository,
                   project, who, comment, builderNames, properties):
     #Determine job file version from provided arguments
     if properties:
@@ -387,11 +387,11 @@ def createJobfile(bsid, branch, baserev, patchlevel, diff, repository,
     job = ""
     job += ns(str(version))
     if version < 5:
-        job += ns(bsid)
+        job += ns(jobid)
         job += ns(branch)
         job += ns(str(baserev))
-        job += ns("%d" % patchlevel)
-        job += ns(diff)
+        job += ns("%d" % patch_level)
+        job += ns(patch_body)
         job += ns(repository)
         job += ns(project)
         if (version >= 3):
@@ -403,8 +403,8 @@ def createJobfile(bsid, branch, baserev, patchlevel, diff, repository,
     else:
         job += ns(
             json.dumps({
-                'bsid': bsid, 'branch': branch, 'baserev': str(baserev),
-                'patchlevel': patchlevel, 'diff': diff,
+                'jobid': jobid, 'branch': branch, 'baserev': str(baserev),
+                'patch_level': patch_level, 'patch_body': patch_body,
                 'repository': repository, 'project': project, 'who': who,
                 'comment': comment, 'builderNames': builderNames,
                 'properties': properties,

--- a/master/buildbot/test/unit/test_clients_tryclient.py
+++ b/master/buildbot/test/unit/test_clients_tryclient.py
@@ -29,11 +29,11 @@ class createJobfile(unittest.TestCase):
     # version 1 is deprecated and not produced by the try client
 
     def test_createJobfile_v2_one_builder(self):
-        bsid = '123-456'
+        jobid = '123-456'
         branch = 'branch'
         baserev = 'baserev'
-        patchlevel = 0
-        diff = 'diff...'
+        patch_level = 0
+        patch_body = 'diff...'
         repository = 'repo'
         project = 'proj'
         who = None
@@ -41,19 +41,19 @@ class createJobfile(unittest.TestCase):
         builderNames = ['runtests']
         properties = {}
         job = tryclient.createJobfile(
-            bsid, branch, baserev, patchlevel, diff, repository, project, who,
-            comment, builderNames, properties)
+            jobid, branch, baserev, patch_level, patch_body, repository,
+            project, who, comment, builderNames, properties)
         jobstr = self.makeNetstring(
-            '2', bsid, branch, baserev, str(patchlevel), diff, repository,
-            project, builderNames[0])
+            '2', jobid, branch, baserev, str(patch_level), patch_body,
+            repository, project, builderNames[0])
         self.assertEqual(job, jobstr)
 
     def test_createJobfile_v2_two_builders(self):
-        bsid = '123-456'
+        jobid = '123-456'
         branch = 'branch'
         baserev = 'baserev'
-        patchlevel = 0
-        diff = 'diff...'
+        patch_level = 0
+        patch_body = 'diff...'
         repository = 'repo'
         project = 'proj'
         who = None
@@ -61,19 +61,19 @@ class createJobfile(unittest.TestCase):
         builderNames = ['runtests', 'moretests']
         properties = {}
         job = tryclient.createJobfile(
-            bsid, branch, baserev, patchlevel, diff, repository, project, who,
-            comment, builderNames, properties)
+            jobid, branch, baserev, patch_level, patch_body, repository,
+            project, who, comment, builderNames, properties)
         jobstr = self.makeNetstring(
-            '2', bsid, branch, baserev, str(patchlevel), diff, repository,
-            project, builderNames[0], builderNames[1])
+            '2', jobid, branch, baserev, str(patch_level), patch_body,
+            repository, project, builderNames[0], builderNames[1])
         self.assertEqual(job, jobstr)
 
     def test_createJobfile_v3(self):
-        bsid = '123-456'
+        jobid = '123-456'
         branch = 'branch'
         baserev = 'baserev'
-        patchlevel = 0
-        diff = 'diff...'
+        patch_level = 0
+        patch_body = 'diff...'
         repository = 'repo'
         project = 'proj'
         who = 'someuser'
@@ -81,19 +81,19 @@ class createJobfile(unittest.TestCase):
         builderNames = ['runtests']
         properties = {}
         job = tryclient.createJobfile(
-            bsid, branch, baserev, patchlevel, diff, repository, project, who,
-            comment, builderNames, properties)
+            jobid, branch, baserev, patch_level, patch_body, repository,
+            project, who, comment, builderNames, properties)
         jobstr = self.makeNetstring(
-            '3', bsid, branch, baserev, str(patchlevel), diff, repository,
-            project, who, builderNames[0])
+            '3', jobid, branch, baserev, str(patch_level), patch_body,
+            repository, project, who, builderNames[0])
         self.assertEqual(job, jobstr)
 
     def test_createJobfile_v4(self):
-        bsid = '123-456'
+        jobid = '123-456'
         branch = 'branch'
         baserev = 'baserev'
-        patchlevel = 0
-        diff = 'diff...'
+        patch_level = 0
+        patch_body = 'diff...'
         repository = 'repo'
         project = 'proj'
         who = 'someuser'
@@ -101,19 +101,19 @@ class createJobfile(unittest.TestCase):
         builderNames = ['runtests']
         properties = {}
         job = tryclient.createJobfile(
-            bsid, branch, baserev, patchlevel, diff, repository, project, who,
-            comment, builderNames, properties)
+            jobid, branch, baserev, patch_level, patch_body, repository,
+            project, who, comment, builderNames, properties)
         jobstr = self.makeNetstring(
-            '4', bsid, branch, baserev, str(patchlevel), diff, repository,
-            project, who, comment, builderNames[0])
+            '4', jobid, branch, baserev, str(patch_level), patch_body,
+            repository, project, who, comment, builderNames[0])
         self.assertEqual(job, jobstr)
 
     def test_createJobfile_v5(self):
-        bsid = '123-456'
+        jobid = '123-456'
         branch = 'branch'
         baserev = 'baserev'
-        patchlevel = 0
-        diff = 'diff...'
+        patch_level = 0
+        patch_body = 'diff...'
         repository = 'repo'
         project = 'proj'
         who = 'someuser'
@@ -121,13 +121,13 @@ class createJobfile(unittest.TestCase):
         builderNames = ['runtests']
         properties = {'foo': 'bar'}
         job = tryclient.createJobfile(
-            bsid, branch, baserev, patchlevel, diff, repository, project, who,
-            comment, builderNames, properties)
+            jobid, branch, baserev, patch_level, patch_body, repository,
+            project, who, comment, builderNames, properties)
         jobstr = self.makeNetstring(
             '5',
             json.dumps({
-                'bsid': bsid, 'branch': branch, 'baserev': baserev,
-                'patchlevel': patchlevel, 'diff': diff,
+                'jobid': jobid, 'branch': branch, 'baserev': baserev,
+                'patch_level': patch_level, 'patch_body': patch_body,
                 'repository': repository, 'project': project, 'who': who,
                 'comment': comment, 'builderNames': builderNames,
                 'properties': properties,

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -381,8 +381,8 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
         jobstr = self.makeNetstring(
             '5',
             json.dumps({
-                'bsid': 'extid', 'branch': 'trunk', 'baserev': '1234',
-                'patchlevel': 1, 'diff': 'this is my diff, -- ++, etc.',
+                'jobid': 'extid', 'branch': 'trunk', 'baserev': '1234',
+                'patch_level': 1, 'patch_body': 'this is my diff, -- ++, etc.',
                 'repository': 'repo', 'project': 'proj', 'who': 'who',
                 'comment': 'comment', 'builderNames': ['buildera', 'builderc'],
                 'properties': {'foo': 'bar'},
@@ -421,8 +421,8 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
         jobstr = self.makeNetstring(
             '5',
             json.dumps({
-                'bsid': 'extid', 'branch': 'trunk', 'baserev': '1234',
-                'patchlevel': '1', 'diff': 'this is my diff, -- ++, etc.',
+                'jobid': 'extid', 'branch': 'trunk', 'baserev': '1234',
+                'patch_level': '1', 'diff': 'this is my diff, -- ++, etc.',
                 'repository': 'repo', 'project': 'proj', 'who': 'who',
                 'comment': 'comment', 'builderNames': [],
                 'properties': {'foo': 'bar'},
@@ -436,8 +436,8 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
         jobstr = self.makeNetstring(
             '5',
             json.dumps({
-                'bsid': 'extid', 'branch': 'trunk', 'baserev': '1234',
-                'patchlevel': '1', 'diff': 'this is my diff, -- ++, etc.',
+                'jobid': 'extid', 'branch': 'trunk', 'baserev': '1234',
+                'patch_level': '1', 'diff': 'this is my diff, -- ++, etc.',
                 'repository': 'repo', 'project': 'proj', 'who': 'who',
                 'comment': 'comment', 'builderNames': ['buildera', 'builderb'],
                 'properties': {},


### PR DESCRIPTION
These commits should enable #2126 to be closed.

A side benefit of this work is that the job file format is now easily extensible so Dustin says that formats v1 through v4 can be dropped after a couple of releases. He volunteered to add the entry to the release notes regarding that.

Thanks to Jared for his review of the previous pull request: https://github.com/buildbot/buildbot/pull/352/
