### PR TITLE
Fix TestFileUpload.testTimestamp fractional support

### DIFF
--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -103,18 +103,11 @@ class TestFileUpload(unittest.TestCase):
         desttimestamp = ( os.path.getatime(self.destfile),
                           os.path.getmtime(self.destfile) )
 
-        # ensure all filesystems involved return float timestamps with
-        # meaningful fractional parts. If not, coerce all to int.
-        # ext3 is one example where the former is true but not the latter
-        all_fs_yield_fract = (os.stat_float_times() and
-                              math.modf(timestamp[0])[0] and
-                              math.modf(desttimestamp[0])[0])
-        if not all_fs_yield_fract:
-            timestamp = map(int, timestamp)
-            desttimestamp = map(int, desttimestamp)
+        timestamp = map(int, timestamp)
+        desttimestamp = map(int, desttimestamp)
 
-        self.assertAlmostEquals(timestamp[0],desttimestamp[0],places=5)
-        self.assertAlmostEquals(timestamp[1],desttimestamp[1],places=5)
+        self.assertEquals(timestamp[0],desttimestamp[0])
+        self.assertEquals(timestamp[1],desttimestamp[1])
 
     def testURL(self):
         s = FileUpload(slavesrc=__file__, masterdest=self.destfile, url="http://server/file")


### PR DESCRIPTION
This test was failing in my ext3 filesystem, which returns timestamps as
float values but their fractional parts are always 0.
