### PR TITLE
FETCH_HEAD is not used when force-building without defining a revision.

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -267,7 +267,9 @@ class Git(Source):
 
         d = self._dovccmd(command)
         def checkout(_):
-            if self.revision:
+            # If called from a ForceBuild, revision defaults to
+            # an empty string.
+            if self.revision and self.revision != "":
                 rev = self.revision
             else:
                 rev = 'FETCH_HEAD'


### PR DESCRIPTION
When force-building is used on the WebStatus page on a specific branch
but without defining a specific revision, the current master HEAD is used
instead of the branch HEAD.
That's due to the ForceSheduler using a empty string as the default value
for a revision, while the git _fetch() expecting a NULL value to use FETCH_BRANCH.
This patch add a test against the empty string in git _fetch().
