### PR TITLE
Disable checkpoint_fullfsync on all SQLite connections.

### DIFF
--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -87,6 +87,10 @@ class BuildbotEngineStrategy(strategies.ThreadLocalEngineStrategy):
             except:
                 log.msg("failed to set journal mode - database may fail")
 
+            def connect_listener(connection, record):
+                connection.execute("pragma checkpoint_fullfsync = off")
+            sa.event.listen(Pool, 'connect', connect_listener)
+
     def special_case_mysql(self, u, kwargs):
         """For mysql, take max_idle out of the query arguments, and
         use its value for pool_recycle.  Also, force use_unicode and


### PR DESCRIPTION
The checkpoint_fullfsync pragma is enabled by default on the version of SQLite that
ships with OS X Lion and newer. This setting enables use of the F_FULLSYNC fcntl rather
than fsync when transactions are moved from the WAL back in to the database proper. The
fcntl waits until the disk drive reports that all buffered data has been written to
permanent storage, in constrast to fsync which merely waits until the data has reached
the disk controller. F_FULLSYNC is more robust in the face of catastrophic system failure
but incurs a substantial performance hit for being so.

This change reduces the time it takes to run the buildbot.test.integration.test_upgrade
suite of tests on one machine from over 27 seconds to under 7 seconds.

Fixes #2256.
