### PR TITLE
Fix tests after 82430c when using older versions SQLAlchemy.

### DIFF
--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -81,15 +81,23 @@ class BuildbotEngineStrategy(strategies.ThreadLocalEngineStrategy):
         """Special setup for sqlite engines"""
         # try to enable WAL logging
         if u.database:
+            def connect_listener(connection, record):
+                connection.execute("pragma checkpoint_fullfsync = off")
+
+            if sautils.sa_version() < (0,7,0):
+                class CheckpointFullfsyncDisabler(object):
+                    pass
+                disabler = CheckpointFullfsyncDisabler()
+                disabler.connect = connect_listener
+                engine.pool.add_listener(disabler)
+            else:
+                sa.event.listen(Pool, 'connect', connect_listener)
+
             log.msg("setting database journal mode to 'wal'")
             try:
                 engine.execute("pragma journal_mode = wal")
             except:
                 log.msg("failed to set journal mode - database may fail")
-
-            def connect_listener(connection, record):
-                connection.execute("pragma checkpoint_fullfsync = off")
-            sa.event.listen(Pool, 'connect', connect_listener)
 
     def special_case_mysql(self, u, kwargs):
         """For mysql, take max_idle out of the query arguments, and


### PR DESCRIPTION
Use an object that implements the PoolListener interface to listen
for the connect event when using SQLAlchemy prior to 0.7.

This also moves the registration of the event listener ahead of the
changing of the journal mode to ensure that the database connection
that SQLAlchemy spins up when executing the journal mode pragma also
triggers the event listener, and doesn't miss out on having
checkpoint_fullfsync disabled.
