### PR TITLE
[BPB] Fix handling of stdin in master-side git step.

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -344,7 +344,8 @@ class RemoteShellCommand(RemoteCommand):
                  want_stdout=1, want_stderr=1,
                  timeout=20*60, maxTime=None, logfiles={},
                  usePTY="slave-config", logEnviron=True,
-                 collectStdout=False, interruptSignal=None):
+                 collectStdout=False, interruptSignal=None,
+                 initialStdin=None):
 
         self.command = command # stash .command, set it later
         if env is not None:
@@ -361,6 +362,7 @@ class RemoteShellCommand(RemoteCommand):
                 'maxTime': maxTime,
                 'usePTY': usePTY,
                 'logEnviron': logEnviron,
+                'initial_stdin': initialStdin
                 }
         if interruptSignal is not None:
             args['interruptSignal'] = interruptSignal

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -236,12 +236,12 @@ class Git(Source):
         d.addCallback(setrev)
         return d
 
-    def _dovccmd(self, command, abandonOnFailure=True, collectStdout=False, extra_args={}):
+    def _dovccmd(self, command, abandonOnFailure=True, collectStdout=False, initialStdin=None):
         cmd = buildstep.RemoteShellCommand(self.workdir, ['git'] + command,
                                            env=self.env,
                                            logEnviron=self.logEnviron,
                                            collectStdout=collectStdout,
-                                           **extra_args)
+                                           initialStdin=initialStdin)
         cmd.useLog(self.stdio_log, False)
         log.msg("Starting git command : git %s" % (" ".join(command), ))
         d = self.runCommand(cmd)
@@ -288,7 +288,7 @@ class Git(Source):
         return d
 
     def patch(self, _, patch):
-        d = self._dovccmd(['apply', '--index'], extra_args={'initial_stdin': patch})
+        d = self._dovccmd(['apply', '--index'], initialStdin=patch)
         return d
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -54,11 +54,11 @@ class FakeRemoteShellCommand(FakeRemoteCommand):
     def __init__(self, workdir, command, env=None,
                  want_stdout=1, want_stderr=1,
                  timeout=DEFAULT_TIMEOUT, maxTime=DEFAULT_MAXTIME, logfiles={},
-                 initial_stdin=None,
+                 initialStdin=None,
                  usePTY=DEFAULT_USEPTY, logEnviron=True, collectStdout=False):
         args = dict(workdir=workdir, command=command, env=env or {},
                 want_stdout=want_stdout, want_stderr=want_stderr,
-                initial_stdin=initial_stdin,
+                initial_stdin=initialStdin,
                 timeout=timeout, maxTime=maxTime, logfiles=logfiles,
                 usePTY=usePTY, logEnviron=logEnviron)
         FakeRemoteCommand.__init__(self, "shell", args,
@@ -236,12 +236,12 @@ class ExpectShell(Expect):
     non-default arguments must be specified explicitly (e.g., usePTY).
     """
     def __init__(self, workdir, command, env={},
-                 want_stdout=1, want_stderr=1, initial_stdin=None,
+                 want_stdout=1, want_stderr=1, initialStdin=None,
                  timeout=DEFAULT_TIMEOUT, maxTime=DEFAULT_MAXTIME, logfiles={},
                  usePTY=DEFAULT_USEPTY, logEnviron=True):
         args = dict(workdir=workdir, command=command, env=env,
                 want_stdout=want_stdout, want_stderr=want_stderr,
-                initial_stdin=initial_stdin,
+                initial_stdin=initialStdin,
                 timeout=timeout, maxTime=maxTime, logfiles=logfiles,
                 usePTY=usePTY, logEnviron=logEnviron)
         Expect.__init__(self, "shell", args)

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -83,7 +83,7 @@ class TestGit(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'apply', '--index'],
-                        initial_stdin='patch')
+                        initialStdin='patch')
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
@@ -119,7 +119,7 @@ class TestGit(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'apply', '--index'],
-                        initial_stdin='patch')
+                        initialStdin='patch')
             + 1,
         )
         self.expectOutcome(result=FAILURE, status_text=["updating"])


### PR DESCRIPTION
RemoteShellCommand didn't in fact take the extra arguments that
the test fake did, so this wasn't caught by the tests.

Refs #2269.

I'd like to actually test this out against a real repo, before this gets merged. :/
