### PR TITLE
Eliminate circular references between JsonResource and HelpResource

### DIFF
--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -139,7 +139,7 @@ class JsonResource(resource.Resource):
         """Adds transparent support for url ending with /"""
         if path == "" and len(request.postpath) == 0:
             return self
-        if path == "path" and self.help:
+        if path == 'help' and self.help:
             pageTitle = ''
             if self.pageTitle:
                 pageTitle = self.pageTitle + ' help'


### PR DESCRIPTION
The json web interface gets a lot of traffic on our waterfall.  A bit of heap profiling using the guppy package shows that we have a huge number (>100K) of unreachable JsonResource and HelpResource objects with circular references to each other (and no other referrers).  It appears that these objects aren't being garbage collected.

The JsonResource objects hold references to 100's of thousands of BuildStatus and BuildStepStatus, which in turn hold references to LogFile and StepProgress objects.  All this adds up to a pretty sizable memory leak which causes the master process to increase in memory consumption linearly over time, without bound.

This patch eliminate the circular references between JsonResource and HelpResource objects.  I don't know yet whether this is sufficient to fix the memory leak; several of the *Status objects also hold circular references to each other.
