### PR TITLE
Fixes #2214: Add 'codebase' to Source base; add 'descriptionSuffix' to Source and Shell

### DIFF
--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -26,9 +26,13 @@ class Source(LoggingBuildStep):
     starts a RemoteCommand with those arguments.
     """
 
-    renderables = [ 'workdir', 'description', 'descriptionDone' ]
+    renderables = LoggingBuildStep.renderables + [
+                     'description', 'descriptionDone', 'descriptionSuffix',
+                     'workdir' ]
+
     description = None # set this to a list of short strings to override
     descriptionDone = None # alternate description when the step is complete
+    descriptionSuffix = None # extra information to append to suffix
 
     # if the checkout fails, there's no point in doing anything else
     haltOnFailure = True
@@ -39,8 +43,8 @@ class Source(LoggingBuildStep):
 
     def __init__(self, workdir=None, mode='update', alwaysUseLatest=False,
                  timeout=20*60, retry=None, env=None, logEnviron=True,
-                 description=None, descriptionDone=None, codebase='',
-                 **kwargs):
+                 description=None, descriptionDone=None, descriptionSuffix=None,
+                 codebase='', **kwargs):
         """
         @type  workdir: string
         @param workdir: local directory (relative to the Builder's root)
@@ -128,7 +132,7 @@ class Source(LoggingBuildStep):
                            variables on the slave. In situations where the
                            environment is not relevant and is long, it may
                            be easier to set logEnviron=False.
-+
+
         @type codebase: string
         @param codebase: Specifies which changes in a build are processed by
         the step. The default codebase value is ''. The codebase must correspond
@@ -147,7 +151,8 @@ class Source(LoggingBuildStep):
                                  env=env,
                                  description=description,
                                  descriptionDone=descriptionDone,
-                                 codebase=codebase,
+                                 descriptionSuffix=descriptionSuffix,
+                                 codebase=codebase
                                  )
 
         assert mode in ("update", "copy", "clobber", "export")
@@ -164,8 +169,10 @@ class Source(LoggingBuildStep):
         self.workdir = workdir
 
         self.sourcestamp = None
-        # Codebase cannot be set yet
+
         self.codebase = codebase
+        if self.codebase:
+            self.name = ' '.join((self.name, self.codebase))
 
         self.alwaysUseLatest = alwaysUseLatest
 
@@ -183,8 +190,6 @@ class Source(LoggingBuildStep):
         else:
             self.description = [
                 descriptions_for_mode.get(mode, "updating")]
-            if self.codebase:
-                self.description.append(self.codebase)
         if isinstance(self.description, str):
             self.description = [self.description]
 
@@ -193,10 +198,15 @@ class Source(LoggingBuildStep):
         else:
             self.descriptionDone = [
                 descriptionDones_for_mode.get(mode, "update")]
-            if self.codebase:
-                self.descriptionDone.append(self.codebase)
         if isinstance(self.descriptionDone, str):
             self.descriptionDone = [self.descriptionDone]
+
+        if descriptionSuffix:
+            self.descriptionSuffix = descriptionSuffix
+        else:
+            self.descriptionSuffix = self.codebase or None # want None in lieu of ''
+        if isinstance(self.descriptionSuffix, str):
+            self.descriptionSuffix = [self.descriptionSuffix]
 
     def setProperty(self, name, value , source):
         if self.codebase != '':
@@ -219,9 +229,11 @@ class Source(LoggingBuildStep):
         self.workdir = self.workdir or workdir
 
     def describe(self, done=False):
-        if done:
-            return self.descriptionDone
-        return self.description
+        desc = self.descriptionDone if done else self.description
+        if self.descriptionSuffix:
+            desc = desc[:]
+            desc.extend(self.descriptionSuffix)
+        return desc
 
     def computeSourceRevision(self, changes):
         """Each subclass must implement this method to do something more

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -129,6 +129,23 @@ class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase):
         self.assertEqual((step.describe(), step.describe(done=True)),
                          (['echoing'], ['echoed']))
 
+    def test_describe_with_suffix(self):
+        step = shell.ShellCommand(command="echo hello", descriptionSuffix="suffix")
+        self.assertEqual((step.describe(), step.describe(done=True)),
+                        (["'echo", "hello'", 'suffix'],)*2)
+
+    def test_describe_custom_with_suffix(self):
+        step = shell.ShellCommand(command="echo hello",
+                                  description=["echoing"], descriptionDone=["echoed"],
+                                  descriptionSuffix="suffix")
+        self.assertEqual((step.describe(), step.describe(done=True)),
+                         (['echoing', 'suffix'], ['echoed', 'suffix']))
+
+    def test_describe_no_command_with_suffix(self):
+        step = shell.ShellCommand(workdir='build', descriptionSuffix="suffix")
+        self.assertEqual((step.describe(), step.describe(done=True)),
+                         (['???', 'suffix'],)*2)
+
     def test_describe_unrendered_WithProperties(self):
         step = shell.ShellCommand(command=properties.WithProperties(''))
         self.assertEqual((step.describe(), step.describe(done=True)),

--- a/master/buildbot/test/unit/test_steps_source_base_Source.py
+++ b/master/buildbot/test/unit/test_steps_source_base_Source.py
@@ -73,9 +73,14 @@ class TestSource(sourcesteps.SourceStepMixin, unittest.TestCase):
         step.build.getSourceStamp = mock.Mock()
         step.build.getSourceStamp.return_value = None
 
+        self.assertEqual(step.describe(), ['updating'])
+        self.assertEqual(step.name, Source.name)
+
         step.startStep(mock.Mock())
         self.assertEqual(step.build.getSourceStamp.call_args[0], ('',))
         
+        self.assertEqual(step.description, ['updating'])
+
     def test_start_with_codebase(self):
         step = self.setupStep(Source(codebase='codebase'))
         step.branch = 'branch'
@@ -83,8 +88,30 @@ class TestSource(sourcesteps.SourceStepMixin, unittest.TestCase):
         step.build.getSourceStamp = mock.Mock()
         step.build.getSourceStamp.return_value = None
 
+        self.assertEqual(step.describe(), ['updating', 'codebase'])
+        self.assertEqual(step.name, Source.name + " codebase")
+
         step.startStep(mock.Mock())
         self.assertEqual(step.build.getSourceStamp.call_args[0], ('codebase',))        
+
+        self.assertEqual(step.describe(True), ['update', 'codebase'])
+        
+    def test_start_with_codebase_and_descriptionSuffix(self):
+        step = self.setupStep(Source(codebase='my-code',
+                                     descriptionSuffix='suffix'))
+        step.branch = 'branch'
+        step.startVC = mock.Mock()
+        step.build.getSourceStamp = mock.Mock()
+        step.build.getSourceStamp.return_value = None
+
+        self.assertEqual(step.describe(), ['updating', 'suffix'])
+        self.assertEqual(step.name, Source.name + " my-code")
+
+        step.startStep(mock.Mock())
+        self.assertEqual(step.build.getSourceStamp.call_args[0], ('my-code',))        
+        
+        self.assertEqual(step.describe(True), ['update', 'suffix'])
+
 
 class TestSourceDescription(steps.BuildStepMixin, unittest.TestCase):
 
@@ -107,3 +134,4 @@ class TestSourceDescription(steps.BuildStepMixin, unittest.TestCase):
                       descriptionDone=['svn', 'update'])
         self.assertEqual(step.description, ['svn', 'update', '(running)'])
         self.assertEqual(step.descriptionDone, ['svn', 'update'])
+

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -1436,6 +1436,17 @@ The :bb:step:`ShellCommand` arguments are:
                                description=["testing"],
                                descriptionDone=["tests"]))
 
+``descriptionSuffix``
+    This is an optional suffix appended to the end of the description (ie,
+    after ``description`` and ``descriptionDone``). This can be used to distinguish
+    between build steps that would display the same descriptions in the waterfall.
+    This parameter may be set to list of short strings, a single string, or ``None``.
+    
+    For example, a builder might use the ``Compile`` step to build two different
+    codebases. The ``descriptionSuffix`` could be set to `projectFoo` and `projectBar`,
+    respectively for each step, which will result in the full descriptions
+    `compiling projectFoo` and `compiling projectBar` to be shown in the waterfall.
+
 ``logEnviron``
     If this option is ``True`` (the default), then the step's logfile will describe the
     environment variables on the slave.  In situations where the environment is not

--- a/master/docs/release-notes.rst
+++ b/master/docs/release-notes.rst
@@ -66,6 +66,9 @@ Deprecations, Removals, and Non-Compatible Changes
     from buildbot.steps.source.svn import SVN
     factory.append(SVN(repourl=Interpolate("svn://svn.example.org/svn/%(src::branch:-branches/test)s")))
 
+* ``Source`` and ``ShellCommand`` steps now have an optional ``descriptionSuffix``, a suffix to the
+   ``description``/``descriptionDone`` values. For example this can help distinguish between
+    multiple ``Compile`` steps that are applied to different codebases.
 
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This patch does two things:
- it adds 'codebase' as a parameter to Source steps; then the name of the step has the codebase in it ... that way a builder that has multiple source steps wont get names like "git, git_1, git_2" but rather "git foo, git bar, git baz".
- Adds a new 'descriptionSuffix', which is a string (or list of strings) that are appended to the description/descriptionDone attributes. This is useful in the same way as the first point is useful; for example, if you have a builder with 4 codesbases involved, you might have 4 buildsteps that all are "make build", and this will allow you to pass in descriptionSuffix='foo' ('bar', 'baz',...) so that the waterfall view shows which build step is which.

Note that I havent done the doc patch yet; if the consensus is ok on the code itself, I'll prepare that.
