### PR TITLE
gotAllRevisions now returns an empty dict when the property is not set

### DIFF
--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -89,7 +89,7 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
         return self.builder.getBuild(self.number-1)
 
     def getAllGotRevisions(self):
-        all_got_revisions = self.properties.getProperty('got_revision', None)
+        all_got_revisions = self.properties.getProperty('got_revision', {})
         # For backwards compatibility all_got_revisions is a string if codebases
         # are not used. Convert to the default internal type (dict)
         if isinstance(all_got_revisions, str):

--- a/master/buildbot/status/web/base.py
+++ b/master/buildbot/status/web/base.py
@@ -438,10 +438,7 @@ class BuildLineMixin:
         if ss_list:
             # TODO: support multiple sourcestamps in web interface
             repo = ss_list[0].repository
-            if all_got_revision:
-                rev = all_got_revision[ss_list[0].codebase]
-            else:
-                rev = "??"
+            rev = all_got_revision.get(ss_list[0].codebase, "??")
         else:
             repo = 'unknown, no information in build'
             rev = 'unknown'

--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -167,9 +167,8 @@ class StatusResourceBuild(HtmlResource):
             cxt['most_recent_rev_build'] = True
 
         all_got_revisions = b.getAllGotRevisions()
-        if all_got_revisions:
-            got_revision = all_got_revisions.get(ss.codebase, "??")
-            cxt['got_revision'] = str(got_revision)
+        got_revision = all_got_revisions.get(ss.codebase, "??")
+        cxt['got_revision'] = str(got_revision)
 
         try:
             cxt['slave_url'] = path_to_slave(req, status.getSlave(b.getSlavename()))

--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -515,7 +515,7 @@ class BuildersResource(HtmlResource):
                 b = builds[0]
                 bld['build_url'] = (bld['link'] + "/builds/%d" % b.getNumber())
                 label = None
-                all_got_revisions = b.getAllGotRevisions() or {}
+                all_got_revisions = b.getAllGotRevisions()
                 # If len = 1 then try if revision can be used as label.
                 if len(all_got_revisions) == 1:
                     label = all_got_revisions[all_got_revisions.keys()[0]]

--- a/master/buildbot/status/web/feeds.py
+++ b/master/buildbot/status/web/feeds.py
@@ -179,7 +179,7 @@ class FeedResource(XmlResource):
             # title: trunk r22191 (plus patch) failed on
             # 'i686-debian-sarge1 shared gcc-3.3.5'
             ss_list = build.getSourceStamps()
-            all_got_revisions = build.getAllGotRevisions() or {}
+            all_got_revisions = build.getAllGotRevisions()
             src_cxts = []
             for ss in ss_list:
                 sc = {}


### PR DESCRIPTION
This is a reaction on my comment on the corresponding commit. (https://github.com/buildbot/buildbot/commit/ef6cbca87985d2e78dc08dc9f26526ecc1e76c00)
