### PR TITLE
add 'project' support to svnpoller

### DIFF
--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -53,7 +53,7 @@ class SVNPoller(base.PollingChangeSource, util.ComparableMixin):
     """
 
     compare_attrs = ["svnurl", "split_file",
-                     "svnuser", "svnpasswd",
+                     "svnuser", "svnpasswd", "project",
                      "pollInterval", "histmax",
                      "svnbin", "category", "cachepath"]
 


### PR DESCRIPTION
When using SVNPoller( ... , project='myproject' ), project is always empty.
This patch fixes it.
