### PR TITLE
Force build race

### DIFF
--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -286,12 +286,13 @@ class ForceScheduler(base.BaseScheduler):
 
         d = master.db.sourcestampsets.addSourceStampSet()
         def add_master_with_setid(sourcestampsetid):
-            master.db.sourcestamps.addSourceStamp(
+            d = master.db.sourcestamps.addSourceStamp(
                                     sourcestampsetid = sourcestampsetid,
                                     branch=branch,
                                     revision=revision, project=project, 
                                     repository=repository,changeids=changeids)
-            return sourcestampsetid
+            d.addCallback(lambda _: sourcestampsetid)
+            return d
             
         d.addCallback(add_master_with_setid)
         def got_setid(sourcestampsetid):


### PR DESCRIPTION
The force scheduler wasn't waiting for the source stamp to be added
to the database before adding the buildset.

This doesn't have tests, but the only way I can see to test it would be to delay some but not all of the db calls. In particular `addSourceStamp` needs to be delayed, but not `addBuildsetForSourceStamp`.
