### PR TITLE
Warn about non-jsonable properties.

### DIFF
--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -15,8 +15,10 @@
 
 import collections
 import re
+import warnings
 import weakref
 from buildbot import config, util
+from buildbot.util import json
 from buildbot.interfaces import IRenderable, IProperties
 from twisted.internet import defer
 from twisted.python.components import registerAdapter
@@ -119,6 +121,14 @@ class Properties(util.ComparableMixin):
     has_key = hasProperty
 
     def setProperty(self, name, value, source, runtime=False):
+        try:
+            json.dumps(value)
+        except TypeError:
+            warnings.warn(
+                    "Non jsonable properties are not explicitly supported and" +
+                    "will be explicitly disallowed in a future version.",
+                    DeprecationWarning, stacklevel=2)
+
         self.properties[name] = (value, source)
         if runtime:
             self.runtime.add(name)

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -497,31 +497,12 @@ class TestInterpolateProperties(unittest.TestCase):
                              "echo projectdefined")
         return d
 
-    def test_property_renderable(self):
-        self.props.setProperty("project", FakeRenderable('testing'), "test")
-        command = Interpolate("echo '%(prop:project)s'")
-        d = self.build.render(command)
-        d.addCallback(self.failUnlessEqual,
-                            "echo 'testing'")
-        return d
-
     def test_nested_property(self):
         self.props.setProperty("project", "so long!", "test")
         command = Interpolate("echo '%(prop:missing:~%(prop:project)s)s'")
         d = self.build.render(command)
         d.addCallback(self.failUnlessEqual,
                             "echo 'so long!'")
-        return d
-
-    def test_nested_property_deferred(self):
-        renderable = DeferredRenderable()
-        self.props.setProperty("missing", renderable, "test")
-        self.props.setProperty("project", "so long!", "test")
-        command = Interpolate("echo '%(prop:missing:~%(prop:project)s)s'")
-        d = self.build.render(command)
-        d.addCallback(self.failUnlessEqual,
-                            "echo 'so long!'")
-        renderable.callback(False)
         return d
 
     def test_property_substitute_recursively(self):
@@ -1066,6 +1047,11 @@ class TestProperties(unittest.TestCase):
         self.failUnlessEqual(self.props.getPropertySource('d'), 'new')
         self.failUnlessEqual(self.props.getProperty('x'), 24)
         self.failUnlessEqual(self.props.getPropertySource('x'), 'old')
+
+    def test_setProperty_notJsonable(self):
+        self.props.setProperty("project", FakeRenderable('testing'), "test")
+        self.props.setProperty("project", object, "test")
+        self.assertEqual(len(self.flushWarnings([self.test_setProperty_notJsonable])), 2)
 
     # IProperties methods
 


### PR DESCRIPTION
Once builds are stored in the database, properties that are not
jsonable won't be supported. As it is, there are many places that
don't like non-jsonable properties. Provide a warning for now, to
allow people notice of the change.
