### PR TITLE
Fix AttributeError in BuilderStatus.prune

### DIFF
--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -219,7 +219,7 @@ class BuilderStatus(styles.Versioned):
         # get the horizons straight
         buildHorizon = self.master.config.buildHorizon
         if buildHorizon is not None:
-            earliest_build = self.nextBuildNumber - self.buildHorizon
+            earliest_build = self.nextBuildNumber - buildHorizon
         else:
             earliest_build = 0
 


### PR DESCRIPTION
Fix bug introduced by b4fb9fbf22 (Refactor configuration handling,
2011-11-12), which removed the BuilderStatus.buildHorizon attribute.
