### PR TITLE
Factor checking of cmd.rc to allow other successful results.

### DIFF
--- a/master/buildbot/steps/maxq.py
+++ b/master/buildbot/steps/maxq.py
@@ -34,7 +34,7 @@ class MaxQ(ShellCommand):
     def evaluateCommand(self, cmd):
         # treat a nonzero exit status as a failure, if no other failures are
         # detected
-        if not self.failures and cmd.rc != 0:
+        if not self.failures and cmd.didFail():
             self.failures = 1
         if self.failures:
             return FAILURE

--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -58,7 +58,7 @@ class BuildEPYDoc(ShellCommand):
         self.errors = errors
 
     def evaluateCommand(self, cmd):
-        if cmd.rc != 0:
+        if cmd.didFail():
             return FAILURE
         if self.warnings or self.errors:
             return WARNINGS
@@ -118,7 +118,7 @@ class PyFlakes(ShellCommand):
 
 
     def evaluateCommand(self, cmd):
-        if cmd.rc != 0:
+        if cmd.didFail():
             return FAILURE
         for m in self.flunkingIssues:
             if self.getProperty("pyflakes-%s" % m):

--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -86,14 +86,14 @@ class HLint(ShellCommand):
 
     def evaluateCommand(self, cmd):
         # warnings are in stdout, rc is always 0, unless the tools break
-        if cmd.rc != 0:
+        if cmd.didFail():
             return FAILURE
         if self.warnings:
             return WARNINGS
         return SUCCESS
 
     def getText2(self, cmd, results):
-        if cmd.rc != 0:
+        if cmd.didFail():
             return ["hlint"]
         return ["%d hlin%s" % (self.warnings,
                                self.warnings == 1 and 't' or 'ts')]
@@ -409,7 +409,7 @@ class Trial(ShellCommand):
         text = []
         text2 = ""
 
-        if cmd.rc == 0:
+        if not cmd.didFail():
             if parsed:
                 results = SUCCESS
                 if total:

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -287,7 +287,7 @@ class TreeSize(ShellCommand):
             self.setProperty("tree-size-KiB", self.kib, "treesize")
 
     def evaluateCommand(self, cmd):
-        if cmd.rc != 0:
+        if cmd.didFail():
             return FAILURE
         if self.kib is None:
             return WARNINGS # not sure how 'du' could fail, but whatever
@@ -318,7 +318,7 @@ class SetProperty(ShellCommand):
 
     def commandComplete(self, cmd):
         if self.property:
-            if cmd.rc != 0:
+            if cmd.didFail():
                 return
             result = cmd.logs['stdio'].getText()
             if self.strip: result = result.strip()
@@ -585,7 +585,7 @@ class WarningCountingShellCommand(ShellCommand):
 
 
     def evaluateCommand(self, cmd):
-        if ( cmd.rc != 0 or
+        if ( cmd.didFail() or
            ( self.maxWarnCount != None and self.warnCount > self.maxWarnCount ) ):
             return FAILURE
         if self.warnCount:
@@ -661,7 +661,7 @@ class PerlModuleTest(Test):
         passed = 0
         failed = 0
         rc = SUCCESS
-        if cmd.rc > 0:
+        if cmd.didFail():
             rc = FAILURE
 
         # New version of Test::Harness?

--- a/master/buildbot/steps/slave.py
+++ b/master/buildbot/steps/slave.py
@@ -85,7 +85,7 @@ class FileExists(buildstep.BuildStep):
         d.addErrback(self.failed)
 
     def commandComplete(self, cmd):
-        if cmd.rc != 0:
+        if cmd.didFail():
             self.step_status.setText(["File not found."])
             self.finished(FAILURE)
             return
@@ -125,7 +125,7 @@ class RemoveDirectory(buildstep.BuildStep):
         d.addErrback(self.failed)
 
     def commandComplete(self, cmd):
-        if cmd.rc != 0:
+        if cmd.didFail():
             self.step_status.setText(["Delete failed."])
             self.finished(FAILURE)
             return
@@ -159,7 +159,7 @@ class MakeDirectory(buildstep.BuildStep):
         d.addErrback(self.failed)
 
     def commandComplete(self, cmd):
-        if cmd.rc != 0:
+        if cmd.didFail():
             self.step_status.setText(["Create failed."])
             self.finished(FAILURE)
             return

--- a/master/buildbot/steps/source/bzr.py
+++ b/master/buildbot/steps/source/bzr.py
@@ -180,7 +180,7 @@ class Bzr(Source):
         cmd.useLog(self.stdio_log, False)
         d = self.runCommand(cmd)
         def _fail(tmp):
-            if cmd.rc != 0:
+            if cmd.didFail():
                 return False
             return True
         d.addCallback(_fail)
@@ -200,7 +200,7 @@ class Bzr(Source):
         cmd.useLog(self.stdio_log, False)
         d = self.runCommand(cmd)
         def evaluateCommand(cmd):
-            if abandonOnFailure and cmd.rc != 0:
+            if abandonOnFailure and cmd.didFail():
                 log.msg("Source step failed while running command %s" % cmd)
                 raise buildstep.BuildStepFailed()
             if collectStdout:

--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -153,11 +153,11 @@ class CVS(Source):
                                            logEnviron=self.logEnviron)
         cmd.useLog(self.stdio_log, False)
         d = self.runCommand(cmd)
-        def evaluate(rc):
-            if rc != 0:
+        def evaluate(cmd):
+            if cmd.didFail():
                 raise buildstep.BuildStepFailed()
-            return rc
-        d.addCallback(lambda _: evaluate(cmd.rc))
+            return cmd.rc
+        d.addCallback(evaluate)
         return d
         
     def doCheckout(self, dir):

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -300,7 +300,7 @@ class Git(Source):
         log.msg("Starting git command : git %s" % (" ".join(command), ))
         d = self.runCommand(cmd)
         def evaluateCommand(cmd):
-            if abandonOnFailure and cmd.rc != 0:
+            if abandonOnFailure and cmd.didFail():
                 log.msg("Source step failed while running command %s" % cmd)
                 raise buildstep.BuildStepFailed()
             if collectStdout:
@@ -410,7 +410,7 @@ class Git(Source):
         cmd.useLog(self.stdio_log, False)
         d = self.runCommand(cmd)
         def _fail(tmp):
-            if cmd.rc != 0:
+            if cmd.didFail():
                 return False
             return True
         d.addCallback(_fail)

--- a/master/buildbot/steps/source/mercurial.py
+++ b/master/buildbot/steps/source/mercurial.py
@@ -229,7 +229,7 @@ class Mercurial(Source):
         log.msg("Starting mercurial command : hg %s" % (" ".join(command), ))
         d = self.runCommand(cmd)
         def evaluateCommand(cmd):
-            if cmd.rc != 0:
+            if cmd.didFail():
                 log.msg("Source step failed while running command %s" % cmd)
                 raise buildstep.BuildStepFailed()
             if collectStdout:
@@ -276,7 +276,7 @@ class Mercurial(Source):
         cmd.useLog(self.stdio_log, False)
         d = self.runCommand(cmd)
         def _fail(tmp):
-            if cmd.rc != 0:
+            if cmd.didFail():
                 return False
             return True
         d.addCallback(_fail)

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -130,7 +130,7 @@ class SVN(Source):
                                                 'logEnviron': self.logEnviron,})
         cmd.useLog(self.stdio_log, False)
         yield self.runCommand(cmd)
-        if cmd.rc != 0:
+        if cmd.didFail():
             raise buildstep.BuildStepFailed()
         
         checkout_cmd = ['checkout', self.repourl, '.']
@@ -162,7 +162,7 @@ class SVN(Source):
         cmd.useLog(self.stdio_log, False)
         yield self.runCommand(cmd)
 
-        if cmd.rc != 0:
+        if cmd.didFail():
             raise buildstep.BuildStepFailed()
 
         # temporarily set workdir = 'source' and do an incremental checkout
@@ -192,7 +192,7 @@ class SVN(Source):
 
         yield self.runCommand(cmd)
 
-        if cmd.rc != 0:
+        if cmd.didFail():
             raise buildstep.BuildStepFailed()
 
     def finish(self, res):
@@ -210,7 +210,7 @@ class SVN(Source):
                 {'dir': dir, 'logEnviron': self.logEnviron })
         cmd.useLog(self.stdio_log, False)
         yield self.runCommand(cmd)
-        if cmd.rc != 0:
+        if cmd.didFail():
             raise buildstep.BuildStepFailed()
 
     def _dovccmd(self, command, collectStdout=False):
@@ -233,7 +233,7 @@ class SVN(Source):
         log.msg("Starting SVN command : svn %s" % (" ".join(command), ))
         d = self.runCommand(cmd)
         def evaluateCommand(cmd):
-            if cmd.rc != 0:
+            if cmd.didFail():
                 log.msg("Source step failed while running command %s" % cmd)
                 raise buildstep.BuildStepFailed()
             if collectStdout:
@@ -259,7 +259,7 @@ class SVN(Source):
         cmd.useLog(self.stdio_log, False)
         yield self.runCommand(cmd)
 
-        if cmd.rc != 0:
+        if cmd.didFail():
             defer.returnValue(False)
             return
 

--- a/master/buildbot/steps/subunit.py
+++ b/master/buildbot/steps/subunit.py
@@ -81,7 +81,7 @@ class SubunitShellCommand(ShellCommand):
         self.text2 = [text2]
         
     def evaluateCommand(self, cmd):
-        if cmd.rc != 0:
+        if cmd.didFail():
             return FAILURE
         return self.results
 

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -172,7 +172,7 @@ class _DirectoryWriter(_FileWriter):
 
 
 def makeStatusRemoteCommand(step, remote_command, args):
-    self = buildstep.RemoteCommand(remote_command, args)
+    self = buildstep.RemoteCommand(remote_command, args,  successfulRC=(None, 0))
     callback = lambda arg: step.step_status.addLog('stdio')
     self.useLogDelayed('stdio', callback, True)
     return self
@@ -213,9 +213,9 @@ class _TransferBuildStep(BuildStep):
         if result == SKIPPED:
             return BuildStep.finished(self, SKIPPED)
 
-        if self.cmd.rc is None or self.cmd.rc == 0:
-            return BuildStep.finished(self, SUCCESS)
-        return BuildStep.finished(self, FAILURE)
+        if self.cmd.didFail():
+            return BuildStep.finished(self, FAILURE)
+        return BuildStep.finished(self, SUCCESS)
 
 
 class FileUpload(_TransferBuildStep):
@@ -361,11 +361,9 @@ class DirectoryUpload(_TransferBuildStep):
         if result == SKIPPED:
             return BuildStep.finished(self, SKIPPED)
 
-        if self.cmd.rc is None or self.cmd.rc == 0:
-            return BuildStep.finished(self, SUCCESS)
-        return BuildStep.finished(self, FAILURE)
-
-
+        if self.cmd.didFail():
+            return BuildStep.finished(self, FAILURE)
+        return BuildStep.finished(self, SUCCESS)
 
 
 class _FileReader(pb.Referenceable):

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -178,7 +178,7 @@ class VisualStudio(ShellCommand):
         self.step_status.setStatistic('errors', self.logobserver.nbErrors)
 
     def evaluateCommand(self, cmd):
-        if cmd.rc != 0:
+        if cmd.didFail():
             return FAILURE
         if self.logobserver.nbErrors > 0:
             return FAILURE

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -25,7 +25,7 @@ DEFAULT_USEPTY="DEFAULT_USEPTY"
 
 class FakeRemoteCommand:
 
-    def __init__(self, remote_command, args, collectStdout=False, ignore_updates=False):
+    def __init__(self, remote_command, args, collectStdout=False, ignore_updates=False, successfulRC=(0,)):
         # copy the args and set a few defaults
         self.remote_command = remote_command
         self.args = args.copy()
@@ -34,6 +34,7 @@ class FakeRemoteCommand:
         self.rc = -999
         self.collectStdout = collectStdout
         self.updates = {}
+        self.successfulRC = successfulRC
         if collectStdout:
             self.stdout = ''
 
@@ -49,6 +50,9 @@ class FakeRemoteCommand:
         # delegate back to the test case
         return self.testcase._remotecommand_run(self, step, remote)
 
+    def didFail(self):
+        return self.rc not in self.successfulRC
+
 
 class FakeRemoteShellCommand(FakeRemoteCommand):
 
@@ -56,14 +60,15 @@ class FakeRemoteShellCommand(FakeRemoteCommand):
                  want_stdout=1, want_stderr=1,
                  timeout=DEFAULT_TIMEOUT, maxTime=DEFAULT_MAXTIME, logfiles={},
                  initialStdin=None,
-                 usePTY=DEFAULT_USEPTY, logEnviron=True, collectStdout=False):
+                 usePTY=DEFAULT_USEPTY, logEnviron=True, collectStdout=False,
+                 successfulRC=(0,)):
         args = dict(workdir=workdir, command=command, env=env or {},
                 want_stdout=want_stdout, want_stderr=want_stderr,
                 initial_stdin=initialStdin,
                 timeout=timeout, maxTime=maxTime, logfiles=logfiles,
                 usePTY=usePTY, logEnviron=logEnviron)
         FakeRemoteCommand.__init__(self, "shell", args,
-                collectStdout=collectStdout)
+                collectStdout=collectStdout, successfulRC=successfulRC)
 
 
 class FakeLogFile(object):

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -250,5 +250,7 @@ class BuildStepMixin(object):
         self.assertEqual((exp.remote_command, exp.args), got)
 
         # let the Expect object show any behaviors that are required
-        return exp.runBehaviors(command)
+        d = exp.runBehaviors(command)
+        d.addCallback(lambda _: command)
+        return d
 

--- a/master/docs/developer/cls-remotecommands.rst
+++ b/master/docs/developer/cls-remotecommands.rst
@@ -13,7 +13,7 @@ detail in :ref:`master-slave-updates`.
 RemoteCommand
 ~~~~~~~~~~~~~
 
-.. py:class:: RemoteCommand(remote_command, args, collectStdout=False, ignore_updates=False)
+.. py:class:: RemoteCommand(remote_command, args, collectStdout=False, ignore_updates=False, successfulRC=tuple(0))
 
     :param remote_command: command to run on the slave
     :type remote_command: string
@@ -21,6 +21,7 @@ RemoteCommand
     :type args: dictionary
     :param collectStdout: if True, collect the command's stdout
     :param ignore_updates: true to ignore remote updates
+    :param successfulRC: list or tuple of ``rc`` values to treat as successes
 
     This class handles running commands, consisting of a command name and
     a dictionary of arguments.  If true, ``ignore_updates`` will suppress any
@@ -60,6 +61,12 @@ RemoteCommand
         it returns will fire when the interrupt request is received by the
         slave; this may be a long time before the command itself completes, at
         which time the Deferred returned from :meth:`run` will fire.
+
+    .. py:method:: didFail()
+
+        :returns: bool
+
+        This method checks the ``rc`` against the list of successful exit statuses, and returns ``True`` if it is not in the list.
 
     The following methods are invoked from the slave.  They should not be
     called directly.

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -1496,6 +1496,10 @@ The :bb:step:`ShellCommand` arguments are:
     handled as a single string throughout Buildbot -- for example, do not pass
     the contents of a tarball with this parameter.
 
+``successfulRC``
+    This is a list or tuple of the exit codes that should be treated as successful.
+    The default is to treat just 0 as successful.
+
 .. bb:step:: Configure
 
 Configure


### PR DESCRIPTION
This provides an argument successfulRC to RemoteCommand, to specify
some non-zero RCs as successes.

Fixes #2225.
