### PR TITLE
Make FakeMaster a full class, not a Mock

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -692,21 +692,21 @@ class Builder(config.ReconfigurableServiceMixin,
 class BuilderControl:
     implements(interfaces.IBuilderControl)
 
-    def __init__(self, builder, master):
+    def __init__(self, builder, control):
         self.original = builder
-        self.master = master
+        self.control = control
 
     def submitBuildRequest(self, ss, reason, props=None):
-        d = ss.getSourceStampSetId(self.master.master)
+        d = ss.getSourceStampSetId(self.control.master)
         def add_buildset(sourcestampsetid):
-            return self.master.master.addBuildset(
+            return self.control.master.addBuildset(
                     builderNames=[self.original.name],
                     sourcestampsetid=sourcestampsetid, reason=reason, properties=props)
         d.addCallback(add_buildset)
         def get_brs((bsid,brids)):
             brs = BuildRequestStatus(self.original.name,
                                      brids[self.original.name],
-                                     self.master.master.status)
+                                     self.control.master.status)
             return brs
         d.addCallback(get_brs)
         return d
@@ -727,14 +727,14 @@ class BuilderControl:
         ssList = bs.getSourceStamps(absolute=True)
         
         if ssList:
-            sourcestampsetid = yield  ssList[0].getSourceStampSetId(self.master.master)
+            sourcestampsetid = yield  ssList[0].getSourceStampSetId(self.control.master)
             dl = []
             for ss in ssList[1:]:
                 # add defered to the list
-                dl.append(ss.addSourceStampToDatabase(self.master.master, sourcestampsetid))
+                dl.append(ss.addSourceStampToDatabase(self.control.master, sourcestampsetid))
             yield defer.gatherResults(dl)
 
-            bsid, brids = yield self.master.master.addBuildset(
+            bsid, brids = yield self.control.master.addBuildset(
                     builderNames=[self.original.name],
                     sourcestampsetid=sourcestampsetid, 
                     reason=reason, 
@@ -755,7 +755,7 @@ class BuilderControl:
         buildrequests = [ ]
         for brdict in brdicts:
             br = yield buildrequest.BuildRequest.fromBrdict(
-                    self.master.master, brdict)
+                    self.control.master, brdict)
             buildrequests.append(br)
 
         # and return the corresponding control objects

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -16,7 +16,7 @@
 import weakref
 from twisted.internet import defer
 from buildbot.test.fake import fakedb
-from buildbot.test.fake.pbmanager import FakePBManager
+from buildbot.test.fake import pbmanager
 from buildbot import config
 import mock
 
@@ -37,7 +37,36 @@ class FakeCache(object):
         return d
 
 
-class FakeMaster(mock.Mock):
+class FakeCaches(object):
+
+    def get_cache(self, name, miss_fn):
+        return FakeCache(name, miss_fn)
+
+
+class FakeBotMaster(object):
+
+    pass
+
+
+class FakeStatus(object):
+
+    def builderAdded(self, name, basedir, category=None):
+        return FakeBuilderStatus()
+
+
+class FakeBuilderStatus(object):
+
+    def setSlavenames(self, names):
+        pass
+
+    def setCacheSize(self, size):
+        pass
+
+    def setBigState(self, state):
+        pass
+
+
+class FakeMaster(object):
     """
     Create a fake Master instance: a Mock with some convenience
     implementations:
@@ -46,14 +75,21 @@ class FakeMaster(mock.Mock):
     """
 
     def __init__(self, master_id=fakedb.FakeBuildRequestsComponent.MASTER_ID):
-        mock.Mock.__init__(self, name="fakemaster")
         self._master_id = master_id
         self.config = config.MasterConfig()
-        self.caches.get_cache = FakeCache
-        self.pbmanager = FakePBManager()
+        self.caches = FakeCaches()
+        self.pbmanager = pbmanager.FakePBManager()
+        self.basedir = 'basedir'
+        self.botmaster = FakeBotMaster()
+        self.botmaster.parent = self
+        self.status = FakeStatus()
+        self.status.master = self
 
     def getObjectId(self):
         return defer.succeed(self._master_id)
+
+    def subscribeToBuildRequests(self, callback):
+        pass
 
     # work around http://code.google.com/p/mock/issues/detail?id=105
     def _get_child_mock(self, **kw):

--- a/master/buildbot/test/integration/test_slave_comm.py
+++ b/master/buildbot/test/integration/test_slave_comm.py
@@ -23,6 +23,7 @@ import buildbot
 from buildbot.test.util import compat
 from buildbot.process import botmaster, builder
 from buildbot import pbmanager, buildslave, config
+from buildbot.status import master
 from buildbot.test.fake import fakemaster
 
 class FakeSlaveBuilder(pb.Referenceable):
@@ -114,6 +115,8 @@ class TestSlaveComm(unittest.TestCase):
 
         self.botmaster = botmaster.BotMaster(self.master)
         self.botmaster.startService()
+
+        self.master.status = master.Status(self.master)
 
         self.buildslave = None
         self.port = None

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -19,6 +19,7 @@ from twisted.trial import unittest
 from twisted.python import failure
 from twisted.internet import defer
 from buildbot import config
+from buildbot.status import master
 from buildbot.test.fake import fakedb, fakemaster
 from buildbot.process import builder
 from buildbot.db import buildrequests
@@ -705,6 +706,7 @@ class TestGetOldestRequestTime(unittest.TestCase):
         self.bstatus = mock.Mock()
         self.factory = mock.Mock()
         self.master = fakemaster.make_master()
+        self.master.status = master.Status(self.master)
         # only include the necessary required config
         builder_config = config.BuilderConfig(
                         name=name, slavename="slv", builddir="bdir",
@@ -754,7 +756,8 @@ class TestRebuild(unittest.TestCase):
         self.bldr = builder.Builder(builder_config.name)
         self.master.db = self.db = fakedb.FakeDBConnector(self)
         self.bldr.master = self.master
-        self.bldr.master.master.addBuildset.return_value = (1, [100])
+        self.master.addBuildset = addBuildset = mock.Mock()
+        addBuildset.return_value = (1, [100])
 
     def do_test_rebuild(self,
                         sourcestampsetid,
@@ -778,7 +781,9 @@ class TestRebuild(unittest.TestCase):
             sslist.append(ssx)
 
         self.makeBuilder(name='bldr1', sourcestamps = sslist)
-        self.bldrctrl = builder.BuilderControl(self.bldr, self.master)
+        control = mock.Mock(spec=['master'])
+        control.master = self.master
+        self.bldrctrl = builder.BuilderControl(self.bldr, control)
 
         d = self.bldrctrl.rebuildBuild(self.bstatus, reason = 'unit test', extraProperties = {})
 
@@ -793,7 +798,7 @@ class TestRebuild(unittest.TestCase):
     def test_rebuild_with_single_sourcestamp(self):
         yield self.do_test_rebuild(101, 1)
         self.assertEqual(self.sslist, {1:101})
-        self.master.master.addBuildset.assert_called_with(builderNames=['bldr1'],
+        self.master.addBuildset.assert_called_with(builderNames=['bldr1'],
                                                           sourcestampsetid=101,
                                                           reason = 'unit test', 
                                                           properties = {})
@@ -803,7 +808,7 @@ class TestRebuild(unittest.TestCase):
     def test_rebuild_with_multiple_sourcestamp(self):
         yield self.do_test_rebuild(101, 3)
         self.assertEqual(self.sslist, {1:101, 2:101, 3:101})
-        self.master.master.addBuildset.assert_called_with(builderNames=['bldr1'],
+        self.master.addBuildset.assert_called_with(builderNames=['bldr1'],
                                                           sourcestampsetid=101,
                                                           reason = 'unit test',
                                                           properties = {})

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -81,7 +81,8 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
         # should be fixed!
 
         # set up a buildmaster that knows about two fake schedulers, a and b
-        self.build.builder.botmaster.parent = m = fakemaster.make_master()
+        m = fakemaster.make_master()
+        self.build.builder.botmaster = m.botmaster
         m.db = fakedb.FakeDBConnector(self)
         m.status = master.Status(m)
         m.config.buildbotURL = "baseurl/"


### PR DESCRIPTION
This is a compromise between adding the required methods (and other
classes) to fakemaster.py, and mocking out the required methods/class in
the tests, or using a real method/class where appropriate.  Fixes #2302

Many yaks were shaved..
