### PR TITLE
Test that RemoteShellCommand's constructor can run with trivial arguments.

### DIFF
--- a/master/buildbot/test/interfaces/test_remotecommand.py
+++ b/master/buildbot/test/interfaces/test_remotecommand.py
@@ -83,6 +83,9 @@ class Tests(interfaces.InterfaceTests):
         cmd = self.makeRemoteCommand()
         self.assertIsInstance(cmd.active, bool)
 
+    def test_RemoteShellCommand_constructor(self):
+        self.remoteShellCommandClass('wkdir', 'some-command')
+
 
 class TestRunCommand(unittest.TestCase, Tests):
 


### PR DESCRIPTION
This catches the error fixed in ab47f56fe1e441a761098234adfac9a27077a1f9.
