### PR TITLE
Allow customization of the Jinja2 loaders that are used

### DIFF
--- a/master/buildbot/status/web/base.py
+++ b/master/buildbot/status/web/base.py
@@ -481,7 +481,7 @@ def map_branches(branches):
 # jinja utilities
 
 def createJinjaEnv(revlink=None, changecommentlink=None,
-                     repositories=None, projects=None):
+                     repositories=None, projects=None, jinja_loaders=None):
     ''' Create a jinja environment changecommentlink is used to
         render HTML in the WebStatus and for mail changes
 
@@ -503,10 +503,12 @@ def createJinjaEnv(revlink=None, changecommentlink=None,
     # See http://buildbot.net/trac/ticket/658
     assert not hasattr(sys, "frozen"), 'Frozen config not supported with jinja (yet)'
 
-    default_loader = jinja2.PackageLoader('buildbot.status.web', 'templates')
-    root = os.path.join(os.getcwd(), 'templates')
-    loader = jinja2.ChoiceLoader([jinja2.FileSystemLoader(root),
-                                  default_loader])
+    all_loaders = [jinja2.FileSystemLoader(os.path.join(os.getcwd(), 'templates'))]
+    if jinja_loaders:
+        all_loaders.extend(jinja_loaders)
+    all_loaders.append(jinja2.PackageLoader('buildbot.status.web', 'templates'))
+    loader = jinja2.ChoiceLoader(all_loaders)
+
     env = jinja2.Environment(loader=loader,
                              extensions=['jinja2.ext.i18n'],
                              trim_blocks=True,

--- a/master/buildbot/status/web/baseweb.py
+++ b/master/buildbot/status/web/baseweb.py
@@ -148,7 +148,7 @@ class WebStatus(service.MultiService):
                  order_console_by_time=False, changecommentlink=None,
                  revlink=None, projects=None, repositories=None,
                  authz=None, logRotateLength=None, maxRotatedFiles=None,
-                 change_hook_dialects = {}, provide_feeds=None):
+                 change_hook_dialects = {}, provide_feeds=None, jinja_loaders=None):
         """Run a web server that provides Buildbot status.
 
         @type  http_port: int or L{twisted.application.strports} string
@@ -266,6 +266,10 @@ class WebStatus(service.MultiService):
                               Otherwise, a dictionary of strings of
                               the type of feeds provided.  Current
                               possibilities are "atom", "json", and "rss"
+
+        @type  jinja_loaders: None or list
+        @param jinja_loaders: If not empty, a list of additional Jinja2 loader
+                              objects to search for templates.
         """
 
         service.MultiService.__init__(self)
@@ -344,6 +348,8 @@ class WebStatus(service.MultiService):
         else:
             self.provide_feeds = provide_feeds
 
+        self.jinja_loaders = jinja_loaders
+
     def setupUsualPages(self, numbuilds, num_events, num_events_max):
         #self.putChild("", IndexOrWaterfallRedirection())
         self.putChild("waterfall", WaterfallStatusResource(num_events=num_events,
@@ -402,7 +408,7 @@ class WebStatus(service.MultiService):
         else:
             revlink = self.master.config.revlink
         self.templates = createJinjaEnv(revlink, self.changecommentlink,
-                                        self.repositories, self.projects)
+                                        self.repositories, self.projects, self.jinja_loaders)
 
         if not self.site:
             

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -57,11 +57,8 @@ server and retrieve information about every build the buildbot knows
 about, as well as find out what the buildbot is currently working on.
 
 The first page you will see is the *Welcome Page*, which contains
-links to all the other useful pages. By default, this page is served from
-the :file:`status/web/templates/root.html` file in buildbot's library area.
-If you'd like to override this page or the other templates found there,
-copy the files you're interested in into a :file:`templates/` directory in
-the buildmaster's base directory.
+links to all the other useful pages. By default, this page is served from the
+:file:`status/web/templates/root.html` file in buildbot's library area.
 
 One of the most complex resource provided by :class:`WebStatus` is the
 *Waterfall Display*, which shows a time-based chart of events. This
@@ -86,11 +83,28 @@ in great detail below.
 Configuration
 +++++++++++++
 
-Buildbot now uses a templating system for the web interface. The source
+The simplest possible configuration for WebStatus is::
+
+    from buildbot.status.html import WebStatus
+    c['status'].append(WebStatus(8080))
+
+Buildbot uses a templating system for the web interface. The source
 of these templates can be found in the :file:`status/web/templates/` directory
 in buildbot's library area. You can override these templates by creating
 alternate versions in a :file:`templates/` directory within the buildmaster's
 base directory.
+
+If that isn't enough you can also provide additional Jinja2 template loaders::
+
+    import jinja2
+    myloaders = [
+        jinja2.FileSystemLoader("/tmp/mypath"),
+        ]
+
+    c['status'].append(html.WebStatus(
+        …,
+        jinja_loaders = myloaders,
+    ))
 
 The first time a buildmaster is created, the :file:`public_html/`
 directory is populated with some sample files, which you will probably
@@ -98,13 +112,10 @@ want to customize for your own project. These files are all static:
 the buildbot does not modify them in any way as it serves them to HTTP
 clients.
 
-Note that templates in :file:`templates/` take precedence over static files in
-:file:`public_html/`. ::
+Templates in :file:`templates/` take precedence over static files in
+:file:`public_html/`.
 
-    from buildbot.status.html import WebStatus
-    c['status'].append(WebStatus(8080))
-
-Note that the initial :file:`robots.txt` file has Disallow lines for all of
+The initial :file:`robots.txt` file has Disallow lines for all of
 the dynamically-generated buildbot pages, to discourage web spiders
 and search engines from consuming a lot of CPU time as they crawl
 through the entire history of your buildbot. If you are running the
@@ -708,6 +719,7 @@ that periodically poll the Google Code commit feed for changes.
    ``'branch'`` option::
 
       change_hook_dialects={'googlecode': {'secret_key': 'FSP3p-Ghdn4T0oqX', 'branch': 'master'}}
+
 
 .. bb:status:: MailNotifier
 


### PR DESCRIPTION
Another patch I promised @djmitche moons ago.

I often package my reusable buildbot code as python eggs, and with the deployment process I have in place this works brilliantly for us. One sore point is that these eggs can't contribute easily to the template search path. Right now i end up monkey patching in my own createJinjaEnv which is a bit unfortunate.

This adds a loaders parameter to WebStatus that at least saves my from patching createJinjaEnv.
