### PR TITLE
Use repo forall instead of find to rm git locks

### DIFF
--- a/slave/buildslave/commands/repo.py
+++ b/slave/buildslave/commands/repo.py
@@ -140,7 +140,7 @@ class Repo(SourceBaseCommand):
                 ln -sf manifests/%(manifest_file)s manifest.xml
                 cd ..
              fi
-             find . -name .git/index.lock -exec rm -f {} \;
+             repo forall -c rm -f .git/index.lock
                repo forall -c git clean -f -d -x 2>/dev/null
                 repo forall -c git reset --hard HEAD 2>/dev/null
              """) % self.__dict__


### PR DESCRIPTION
For large repositories, performing a find operation can take quite a
long time. Instead, use repo to tell us where we might find index.lock
files, if they exist.
