### PR TITLE
Sort changes chronologically for new SourceStamps

### DIFF
--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -139,6 +139,9 @@ class Change:
                 self.when, self.category, self.project, self.repository,
                 self.codebase)
 
+    def __cmp__(self, other):
+      return self.number - other.number
+
     def asText(self):
         data = ""
         data += self.getFileContents()

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -641,11 +641,10 @@ class Builder(config.ReconfigurableServiceMixin,
                 [ self._brdictToBuildRequest(brdict)
                   for brdict in unclaimed_requests ])
 
-        breq_object = unclaimed_request_objects.pop(
-                unclaimed_requests.index(breq))
+        breq_object = unclaimed_request_objects[unclaimed_requests.index(breq)]
 
         # gather the mergeable requests
-        merged_request_objects = [breq_object]
+        merged_request_objects = []
         for other_breq_object in unclaimed_request_objects:
             if (yield defer.maybeDeferred(
                         lambda : mergeRequests_fn(self, breq_object,

--- a/master/buildbot/sourcestamp.py
+++ b/master/buildbot/sourcestamp.py
@@ -14,8 +14,6 @@
 # Copyright Buildbot Team Members
 
 
-from operator import attrgetter
-
 from zope.interface import implements
 from twisted.persisted import styles
 from twisted.internet import defer
@@ -152,7 +150,7 @@ class SourceStamp(util.ComparableMixin, styles.Versioned):
         self.codebase = codebase or ''
         if changes:
             self.changes = changes = list(changes)
-            changes.sort(key=attrgetter('when'))
+            changes.sort()
             if not _ignoreChanges:
                 # set branch and revision to most recent change
                 self.branch = changes[-1].branch

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -548,6 +548,12 @@ class TestBuilderBuildCreation(unittest.TestCase):
                                 brdicts, mergeRequests_fn)
         self.assertEqual(evens, [ brdicts[1] ])
 
+        # check original relative order of requests within brdicts is maintained
+        merged = yield self.bldr._mergeRequests(brdicts[2],
+                                                brdicts, mergeRequests_fn)
+        self.assertEqual(merged, [brdicts[0], brdicts[2]],
+                         'relative order of merged requests was not maintained')
+
     @defer.inlineCallbacks
     def test_mergeRequest_no_other_request(self):
         """ Test if builder test for codebases in requests """
@@ -577,7 +583,7 @@ class TestBuilderBuildCreation(unittest.TestCase):
         res = yield self.bldr._mergeRequests(brdicts[0], brdicts,
                                             mergeRequests_fn)
         self.assertEqual(res, [ brdicts[0] ])
-        
+
     @defer.inlineCallbacks
     def test_mergeRequests_codebases_equal(self):
         """ Test if builder test for codebases in requests """
@@ -800,7 +806,7 @@ class TestRebuild(unittest.TestCase):
         self.assertEqual(self.sslist, {1:101})
         self.master.addBuildset.assert_called_with(builderNames=['bldr1'],
                                                           sourcestampsetid=101,
-                                                          reason = 'unit test', 
+                                                          reason = 'unit test',
                                                           properties = {})
 
 
@@ -812,5 +818,5 @@ class TestRebuild(unittest.TestCase):
                                                           sourcestampsetid=101,
                                                           reason = 'unit test',
                                                           properties = {})
-        
-        
+
+

--- a/master/buildbot/test/unit/test_sourcestamp.py
+++ b/master/buildbot/test/unit/test_sourcestamp.py
@@ -177,11 +177,13 @@ class TestBuilderBuildCreation(unittest.TestCase):
     def test_constructor_most_recent_change(self):
         chgs = [
             changes.Change('author', [], 'comments', branch='branch',
-                           revision='2', when=2),
+                           revision='2'),
             changes.Change('author', [], 'comments', branch='branch',
-                           revision='3', when=3),
+                           revision='3'),
             changes.Change('author', [], 'comments', branch='branch',
-                           revision='1', when=1),
+                           revision='1'),
             ]
+        for ch in chgs:  # mock the DB changeid (aka build number) to match rev
+          ch.number = int(ch.revision)
         ss = sourcestamp.SourceStamp(changes=chgs)
         self.assertEquals(ss.revision, '3')


### PR DESCRIPTION
When creating a new SourceStamp, comprising changes are not guaranteed
to come sorted chronologically. Sort them to ensure the most recent
Change's attributes are used for the new SourceStamp.

Conflicts:

```
master/buildbot/sourcestamp.py
master/buildbot/test/unit/test_sourcestamp.py
```

Change-Id: I682d0c48d1ce56a9cdc889db7325a61478bf8de9
