### PR TITLE
Show buildstep statistics at corresponding WebStatus page

### DIFF
--- a/master/buildbot/status/buildstep.py
+++ b/master/buildbot/status/buildstep.py
@@ -175,6 +175,9 @@ class BuildStepStatus(styles.Versioned):
         """
         return self.statistics.get(name, default)
 
+    def getStatistics(self):
+        return self.statistics.copy()
+
     # subscription interface
 
     def subscribe(self, receiver, updateInterval=10):

--- a/master/buildbot/status/web/step.py
+++ b/master/buildbot/status/web/step.py
@@ -46,6 +46,11 @@ class StatusResourceBuildStep(HtmlResource):
                          'name': l.getName(),
                          'link': req.childLink("logs/%s" % urllib.quote(l.getName())) })
 
+        stepStatistics = s.getStatistics()
+        statistics = cxt['statistics'] = []
+        for stat in stepStatistics:
+            statistics.append({'name': stat, 'value': stepStatistics[stat]})
+
         start, end = s.getTimes()
         
         if start:

--- a/master/buildbot/status/web/templates/buildstep.html
+++ b/master/buildbot/status/web/templates/buildstep.html
@@ -58,6 +58,16 @@
 {% endfor %}
 </ul>
 
+{% if statistics %}
+<h2>Statistics</h2>
+<table class="info">
+  <tr><th>Name</th><th>Value</th></tr>
+  {% for stat in statistics %}
+    <tr class="{{ loop.cycle('alt', '') }}"><td>{{ stat.name|e }}</td><td>{{ stat.value|e }}</td></tr>
+  {% endfor %}
+</table>
+{% endif %}
+
 </div>
 
 {% endblock %}


### PR DESCRIPTION
If a buildstep has statistic values add a table with name
and value of them to the rendered page for the buildstep.
