### PR TITLE
Fix master-side SVN step.

### DIFF
--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -319,7 +319,7 @@ class SVN(Source):
             if len(files) == 0:
                 d = defer.succeed(0)
             else:
-                if not self.slaveVersionIsOlderThan('rmdir', '2.14'):
+                if self.slaveVersionIsOlderThan('rmdir', '2.14'):
                     d = self.removeFiles(files)
                 else:
                     cmd = buildstep.RemoteCommand('rmdir', {'dir': files,

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -420,7 +420,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                 stdout=self.svn_st_xml)
             + 0,
             Expect('rmdir', {'dir':
-                             'wkdir/svn_external_path/unversioned_file2',
+                             ['wkdir/svn_external_path/unversioned_file2'],
                              'logEnviron': True})
             + 0,
             ExpectShell(workdir='wkdir',
@@ -566,7 +566,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
         self.setupStep(
                 svn.SVN(repourl='http://svn.local/app/trunk',
                                     mode='full', method='clean'))
-        self.patch_slaveVersionIsOlderThan(False)
+        self.patch_slaveVersionIsOlderThan(True)
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
@@ -612,7 +612,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                 svn.SVN(repourl='http://svn.local/app/trunk',
                                     mode='full', method='clean'))
 
-        self.patch_slaveVersionIsOlderThan(True)
+        self.patch_slaveVersionIsOlderThan(False)
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['svn', '--version'])
@@ -1070,7 +1070,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                 stdout=self.svn_st_xml)
             + 0,
             Expect('rmdir', {'dir':
-                             'wkdir/svn_external_path/unversioned_file2',
+                             ['wkdir/svn_external_path/unversioned_file2'],
                              'logEnviron': True})
             + 1,
         )


### PR DESCRIPTION
New and old rmdir slave command was inverted accidentally where
it was used and in the unit tests too. It isn't problem for newer
slaves, they understand the old rmdir. But older slaves doesn't
understand the new rmdir and they throw exception.
