### PR TITLE
scheduler: Improve logging to say which scheduler refuses the codebase.

### DIFF
--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -20,6 +20,7 @@ from twisted.internet import defer
 from buildbot.process.properties import Properties
 from buildbot.util import ComparableMixin
 from buildbot import config, interfaces
+import logging
 
 class BaseScheduler(service.MultiService, ComparableMixin):
     """
@@ -213,7 +214,9 @@ class BaseScheduler(service.MultiService, ComparableMixin):
             if change_filter and not change_filter.filter_change(change):
                 return
             if change.codebase not in self.codebases:
-                log.msg('change contains codebase %s that is not processed by scheduler %s' % (change.codebase, self.name))
+                log.msg('change contains codebase %s that is not processed by'
+                    ' scheduler %s' % (change.codebase, self.name),
+                    logLevel=logging.DEBUG)
                 return
             if fileIsImportant:
                 try:


### PR DESCRIPTION
This change was made on the web interface so there might be some failing test cases, handle with care. Although I don't remember us testing on the logging of the schedulers.
