### PR TITLE
Use master branch by default

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -58,7 +58,7 @@ class Git(Source):
     name='git'
     renderables = [ "repourl"]
 
-    def __init__(self, repourl=None, branch='HEAD', mode='incremental',
+    def __init__(self, repourl=None, branch='master', mode='incremental',
                  method=None, submodules=False, shallow=False, progress=False,
                  retryFetch=False, clobberOnFailure=False, getDescription=False,
                  **kwargs):
@@ -118,7 +118,7 @@ class Git(Source):
         assert isinstance(self.getDescription, (bool, dict))
 
     def startVC(self, branch, revision, patch):
-        self.branch = branch or 'HEAD'
+        self.branch = branch or 'master'
         self.revision = revision
         self.method = self._getMethod()
         self.stdio_log = self.addLog("stdio")
@@ -183,7 +183,7 @@ class Git(Source):
         if rc == 0:
             yield self._dovccmd(['reset', '--hard', self.revision])
 
-            if self.branch != 'HEAD':
+            if self.branch != 'master':
                 yield self._dovccmd(['branch', '-M', self.branch],
                         abandonOnFailure=False)
         else:
@@ -338,7 +338,7 @@ class Git(Source):
             d.addCallback(lambda _: res)
             return d
 
-        if self.branch != 'HEAD':
+        if self.branch != 'master':
             d.addCallback(renameBranch)
         return d
 


### PR DESCRIPTION
it seems the new style Git source step do not use master by default (which is the documented behavior)

Please note I changed all occurrences that made sense to me, leaving a couple "HEAD" around on functions that retrieve data about the last commit; I'm not 100% sure about that so please take it into account during review.
