### PR TITLE
Set Cache-Controll header for log files in WebStatus. (Fix #2292)

### DIFF
--- a/master/buildbot/status/web/logs.py
+++ b/master/buildbot/status/web/logs.py
@@ -103,6 +103,11 @@ class TextLog(Resource):
         self._setContentType(req)
         self.req = req
 
+        if (self.original.isFinished()):
+            req.setHeader("Cache-Control", "max-age=604800")
+        else:
+            req.setHeader("Cache-Control", "no-cache")
+
         if not self.asText:
             self.template = req.site.buildbot_service.templates.get_template("logs.html")                
             


### PR DESCRIPTION
Set the Cache-Controll http header either to no-cache for unfinished log files or 1week for finished log files.
