### PR TITLE
Remove 'name' argument from pollers

### DIFF
--- a/master/buildbot/changes/bonsaipoller.py
+++ b/master/buildbot/changes/bonsaipoller.py
@@ -207,9 +207,9 @@ class BonsaiPoller(base.PollingChangeSource):
                      "module", "branch", "cvsroot"]
 
     def __init__(self, bonsaiURL, module, branch, tree="default",
-                 cvsroot="/cvsroot", pollInterval=30, project='', name=None):
+                 cvsroot="/cvsroot", pollInterval=30, project=''):
 
-        base.PollingChangeSource.__init__(self, name=name, pollInterval=pollInterval)
+        base.PollingChangeSource.__init__(self, name=bonsaiURL, pollInterval=pollInterval)
 
         self.bonsaiURL = bonsaiURL
         self.module = module

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -37,12 +37,12 @@ class HgPoller(base.PollingChangeSource):
                  workdir=None, pollInterval=10*60,
                  hgbin='hg', usetimestamps=True,
                  category=None, project='',
-                 encoding='utf-8', name=None):
+                 encoding='utf-8'):
 
         self.repourl = repourl
         self.branch = branch
         base.PollingChangeSource.__init__(
-            self, name=name, pollInterval=pollInterval)
+            self, name=repourl, pollInterval=pollInterval)
         self.encoding = encoding
         self.lastChange = time.time()
         self.lastPoll = time.time()

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -70,13 +70,13 @@ class SVNPoller(base.PollingChangeSource, util.ComparableMixin):
                  pollInterval=10*60, histmax=100,
                  svnbin='svn', revlinktmpl='', category=None, 
                  project='', cachepath=None, pollinterval=-2,
-                 extra_args=None, name=None):
+                 extra_args=None):
 
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
             pollInterval = pollinterval
 
-        base.PollingChangeSource.__init__(self, name=name, pollInterval=pollInterval)
+        base.PollingChangeSource.__init__(self, name=svnurl, pollInterval=pollInterval)
 
         if svnurl.endswith("/"):
             svnurl = svnurl[:-1] # strip the trailing slash

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -765,7 +765,6 @@ hook to get fast notification of new changes.
 Suppose you have a poller configured like this::
 
     c['change_source'] = SVNPoller(
-        name="amanda",
         svnurl="https://amanda.svn.sourceforge.net/svnroot/amanda/amanda",
         split_file=split_file_branches)
 
@@ -779,7 +778,7 @@ And you configure your WebStatus to enable this hook::
 Then you will be able to trigger a poll of the SVN repository by poking the
 ``/change_hook/poller`` URL from a commit hook like this::
 
-    curl http://yourbuildbot/change_hook/poller?poller=amanda
+    curl http://yourbuildbot/change_hook/poller?poller=https%3A%2F%2Famanda.svn.sourceforge.net%2Fsvnroot%2Famanda%2Famanda
 
 If no ``poller`` argument is provided then the hook will trigger polling of all
 polling change sources.
@@ -789,7 +788,7 @@ option::
 
     c['status'].append(html.WebStatus(
         …,
-        change_hook_dialects={'poller': {'allowed': ['amanda']}}
+        change_hook_dialects={'poller': {'allowed': ['https://amanda.svn.sourceforge.net/svnroot/amanda/amanda']}}
     ))
 
 


### PR DESCRIPTION
Recently @tomprince rewrote GitPolller and removed the name argument. This was added during the 0.8.7 cycle for my `/change_hook/pollers?poller=POLLERNAME` patch. Instead the repourl is used for the name.

Here is a patch which does the same change for SVN, hg and bonsai. However it doesn't for P4 - any ideas on what to do there would be appreciated.
