### PR TITLE
Make previous build chioce configurable

### DIFF
--- a/master/buildbot/status/mail.py
+++ b/master/buildbot/status/mail.py
@@ -153,6 +153,9 @@ def defaultMessage(mode, name, build, results, master_status):
     text += "\n"
     return { 'body' : text, 'type' : 'plain' }
 
+def defaultGetPreviousBuild(current_build):
+        return current_build.getPreviousBuild()
+
 class MailNotifier(base.StatusReceiverMultiService):
     """This is a status notifier which sends email to a list of recipients
     upon the completion of each build. It can be configured to only send out
@@ -188,8 +191,9 @@ class MailNotifier(base.StatusReceiverMultiService):
                  lookup=None, extraRecipients=[],
                  sendToInterestedUsers=True, customMesg=None,
                  messageFormatter=defaultMessage, extraHeaders=None,
-                 addPatch=True, useTls=False, 
-                 smtpUser=None, smtpPassword=None, smtpPort=25):
+                 addPatch=True, useTls=False,
+                 smtpUser=None, smtpPassword=None, smtpPort=25,
+                 previousBuildGetter=defaultGetPreviousBuild):
         """
         @type  fromaddr: string
         @param fromaddr: the email address to be used in the 'From' header.
@@ -305,6 +309,14 @@ class MailNotifier(base.StatusReceiverMultiService):
         @type smtpPort: int
         @param smtpPort: The port that will be used when connecting to the
                          relayhost. Defaults to 25.
+
+        @type previousBuildGetter: func
+        @param previousBuildGetter: function taking a BuildStatus instance
+                                    returning a BuildStatus of the build
+                                    previous to the one passed in. This allows
+                                    to implement a relative ordering between
+                                    builds other than the default one, which is
+                                    chronological.
         """
         base.StatusReceiverMultiService.__init__(self)
 
@@ -356,6 +368,7 @@ class MailNotifier(base.StatusReceiverMultiService):
         self.smtpPort = smtpPort
         self.buildSetSummary = buildSetSummary
         self.buildSetSubscription = None
+        self.getPreviousBuild = previousBuildGetter
         self.watched = []
         self.master_status = None
 
@@ -425,7 +438,7 @@ class MailNotifier(base.StatusReceiverMultiService):
                builder.category not in self.categories:
             return False # ignore this build
 
-        prev = build.getPreviousBuild()
+        prev = self.getPreviousBuild(build)
         if "change" in self.mode:
             if prev and prev.getResults() != results:
                 return True

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -1127,6 +1127,20 @@ MailNotifier arguments
     (dictionary) A dictionary containing key/value pairs of extra headers to add
     to sent e-mails. Both the keys and the values may be a `WithProperties` instance.
 
+``previousBuildGetter``
+    An optional function to calculate the previous build to the one at hand. A
+    :func:`previousBuildGetter` takes a :class:`BuildStatus` and returns a
+    :class:`BuildStatus`. This function is useful when builders don't process
+    their requests in order of arrival (chronologically) and therefore the order
+    of completion of builds does not reflect the order in which changes (and
+    their respective requests) arrived into the system. In such scenarios,
+    status transitions in the chronological sequence of builds within a builder
+    might not reflect the actual status transition in the topological sequence
+    of changes in the tree. What's more, the latest build (the build at hand)
+    might not always be for the most recent request so it might not make sense
+    to send a "change" or "problem" email about it. Returning None from this
+    function will prevent such emails from going out.
+
 As a help to those writing :func:`messageFormatter` functions, the following
 table describes how to get some useful pieces of information from the various
 status objects:


### PR DESCRIPTION
When prioritizing build requests in an order other than arrival time,
builds' relative order might not always reflect the topological order of
the changes. This change makes the build order to be configurable such
that status transition modes are only sent out when a more recent
_change_ affects the status of a less recent one, as opposed to relying
on the default chronological ordering of the builds.
