### PR TITLE
WIP extend IRC bot

### DIFF
--- a/master/buildbot/test/unit/test_status_words.py
+++ b/master/buildbot/test/unit/test_status_words.py
@@ -13,7 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
-import mock
+import mock, os, signal
 from twisted.trial import unittest
 from twisted.application import internet
 from twisted.internet import task, reactor
@@ -36,6 +36,17 @@ class TestIrcContactChannel(unittest.TestCase):
             self.subscribed = False
         self.bot.status.unsubscribe = unsubscribe
 
+        # fake out clean shutdown
+        self.bot.master = mock.Mock(name='IRCStatusBot-instance.master')
+        self.bot.master.botmaster = mock.Mock(name='IRCStatusBot-instance.master.botmaster')
+        self.bot.master.botmaster.shuttingDown = False
+        def cleanShutdown():
+            self.bot.master.botmaster.shuttingDown = True
+        self.bot.master.botmaster.cleanShutdown = cleanShutdown
+        def cancelCleanShutdown():
+            self.bot.master.botmaster.shuttingDown = False
+        self.bot.master.botmaster.cancelCleanShutdown = cancelCleanShutdown
+
         self.contact = words.IRCContact(self.bot, '#buildbot')
 
     def patch_send(self):
@@ -51,7 +62,8 @@ class TestIrcContactChannel(unittest.TestCase):
         self.contact.act = act
 
     def do_test_command(self, command, args='', who='me', clock_ticks=None,
-            exp_usage=True, exp_UsageError=False):
+            exp_usage=True, exp_UsageError=False, allowShutdown=False,
+            shuttingDown=False):
         cmd = getattr(self.contact, 'command_' + command.upper())
 
         if exp_usage:
@@ -61,6 +73,8 @@ class TestIrcContactChannel(unittest.TestCase):
         self.patch(reactor, 'callLater', clock.callLater)
         self.patch_send()
         self.patch_act()
+        self.bot.factory.allowShutdown = allowShutdown
+        self.bot.master.botmaster.shuttingDown = shuttingDown
 
         if exp_UsageError:
             try:
@@ -171,6 +185,48 @@ class TestIrcContactChannel(unittest.TestCase):
 
     def test_command_help_nosuch(self):
         self.do_test_command('help', args='foo', exp_UsageError=True)
+
+    def test_command_shutdown(self):
+        self.do_test_command('shutdown', exp_UsageError=True)
+        self.assertEqual(self.bot.factory.allowShutdown, False)
+        self.assertEqual(self.bot.master.botmaster.shuttingDown, False)
+
+    def test_command_shutdown_dissalowed(self):
+        self.do_test_command('shutdown', args='check', exp_UsageError=True)
+        self.assertEqual(self.bot.factory.allowShutdown, False)
+        self.assertEqual(self.bot.master.botmaster.shuttingDown, False)
+
+    def test_command_shutdown_check_running(self):
+        self.do_test_command('shutdown', args='check', allowShutdown=True, shuttingDown=False)
+        self.assertEqual(self.bot.factory.allowShutdown, True)
+        self.assertEqual(self.bot.master.botmaster.shuttingDown, False)
+        self.assertIn('buildbot is running', self.sent[0])
+
+    def test_command_shutdown_check_shutting_down(self):
+        self.do_test_command('shutdown', args='check', allowShutdown=True, shuttingDown=True)
+        self.assertEqual(self.bot.factory.allowShutdown, True)
+        self.assertEqual(self.bot.master.botmaster.shuttingDown, True)
+        self.assertIn('buildbot is shutting down', self.sent[0])
+
+    def test_command_shutdown_start(self):
+        self.do_test_command('shutdown', args='start', allowShutdown=True, shuttingDown=False)
+        self.assertEqual(self.bot.factory.allowShutdown, True)
+        self.assertEqual(self.bot.master.botmaster.shuttingDown, True)
+
+    def test_command_shutdown_stop(self):
+        self.do_test_command('shutdown', args='stop', allowShutdown=True, shuttingDown=True)
+        self.assertEqual(self.bot.factory.allowShutdown, True)
+        self.assertEqual(self.bot.master.botmaster.shuttingDown, False)
+
+    def test_command_shutdown_now(self):
+        self.killargs = None
+        def kill(*args):
+            self.killargs = args
+        self.patch(os, 'kill', kill)
+        self.do_test_command('shutdown', args='now', allowShutdown=True)
+        self.assertEqual(self.bot.factory.allowShutdown, True)
+        self.assertEqual(self.bot.master.botmaster.shuttingDown, False)
+        self.assertEqual(self.killargs, (os.getpid(), signal.SIGTERM))
 
     def test_command_source(self):
         self.do_test_command('source')

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -1330,6 +1330,22 @@ Some of the commands currently available:
 :samp:`help {COMMAND}`
     Describe a command. Use :command:`help commands` to get a list of known
     commands.
+
+:samp:`shutdown {ARG}`
+    Control the shutdown process of the buildbot master.
+    Available arguments are:
+
+    ``check``
+        Check if the buildbot master is running or shutting down
+
+    ``start``
+        Start clean shutdown
+
+    ``stop``
+        Stop clean shutdown
+
+    ``now``
+        Shutdown immediately without waiting for the builders to finish
     
 ``source``
     Announce the URL of the Buildbot's home page.

--- a/master/docs/release-notes.rst
+++ b/master/docs/release-notes.rst
@@ -20,6 +20,9 @@ Features
 * The :bb:status:`MailNotifier` now takes a callable to calculate the "previous" build for purposes of determining status changes.
   See :bb:pull:`489`.
 
+* The :bb:status:`IRC` bot now supports clean shutdown and immediate shutdown by using the command 'shutdown'.
+  To allow the command to function, you must provide `allowShutdown=True`.
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Planned changes to the IRC bot:
- clean shutdown - DONE
- force polls - TODO
- use ForceScheduler - POSTPONED until irc users support is done

I'm making the pull request now because I want some feedback regarding the implementation of the shutdown command:
- It's already inside the target process, so i'm not sure if sending a signal is the best option for an immediate shutdown...
- Should I propagate allowShutdown up to IrcStatusBot/IRCContact or is propagating it to IrcStatusFactory good enough?
