### PR TITLE
ShellComnmand: make description renderable

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -66,8 +66,9 @@ class ShellCommand(buildstep.LoggingBuildStep):
 
     name = "shell"
     renderables = buildstep.LoggingBuildStep.renderables + [
-                   'slaveEnvironment', 'remote_kwargs', 'command']
-    
+                   'slaveEnvironment', 'remote_kwargs', 'command',
+                   'description', 'descriptionDone', 'descriptionSuffix']
+
     description = None # set this to a list of short strings to override
     descriptionDone = None # alternate description when the step is complete
     descriptionSuffix = None # extra information to append to suffix


### PR DESCRIPTION
In commit 7ea9f954c77dbb9ae48ba49ed07d94c453f659c4:
    Fixes #2214: Add 'codebase' to Source base; add 'descriptionSuffix' to Source and Shell
'description' and 'descriptionDone' got removed from renderables array of the
ShellCommand step.
This patch makes using Properties in ShellCommand descriptions working again.

This fixes #2326
