### PR TITLE
Fix ternary replacements that contain :- :~ or :+

### DIFF
--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -197,9 +197,9 @@ class _PropertyMap(object):
     Privately-used mapping object to implement WithProperties' substitutions,
     including the rendering of None as ''.
     """
-    colon_minus_re = re.compile(r"(.*):-(.*)")
-    colon_tilde_re = re.compile(r"(.*):~(.*)")
-    colon_plus_re = re.compile(r"(.*):\+(.*)")
+    colon_minus_re = re.compile(r"([^:]*):-([^:]*)")
+    colon_tilde_re = re.compile(r"([^:]*):~([^:]*)")
+    colon_plus_re = re.compile(r"([^:]*):\+([^:]*)")
     
     colon_ternary_re = re.compile(r"""(?P<prop>.*) # the property to match
                                       :            # colon

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -249,6 +249,15 @@ class TestPropertyMap(unittest.TestCase):
     def testColonTernaryHashUnset(self):
         return self.doTestSimpleWithProperties('%(prop_nosuch:#?.truish.falsish)s', 'falsish')
 
+    def testColonTernaryHashSetMinus(self):
+        return self.doTestSimpleWithProperties('%(prop_str:#?:-truish:falsish)s', '-truish')
+        
+    def testColonTernaryHashSetTilde(self):
+        return self.doTestSimpleWithProperties('%(prop_str:#?:~truish:falsish)s', '~truish')
+        
+    def testColonTernaryHashSetPlus(self):
+        return self.doTestSimpleWithProperties('%(prop_str:#?:+truish:falsish)s', '+truish')
+        
 
     def testClearTempValues(self):
         d = self.doTestSimpleWithProperties('', '',


### PR DESCRIPTION
`<pepsiman> WithProperties("%(foo:#?:-bar:baz)s") doesn't behave as I expect.  Is my expectation wrong?
<djmitche> yes?
 how do you expect it to behave
 and how does it behave?
<pepsiman> I expect "-bar" when foo is True
 I get "bar:baz"
 colon_minus() is executed instead of colon_ternary()
<djmitche> yeah, looks like your expectation is correct`
