### PR TITLE
Codebase support in PBChangeSource

### DIFF
--- a/master/buildbot/test/unit/test_changes_pb.py
+++ b/master/buildbot/test/unit/test_changes_pb.py
@@ -152,6 +152,15 @@ class TestChangePerspective(unittest.TestCase):
         d.addCallback(check)
         return d
 
+    def test_addChange_codebase(self):
+        cp = pb.ChangePerspective(self.master, None)
+        d = cp.perspective_addChange(dict(who="bar", files=[], codebase='cb'))
+        def check(_):
+            self.assertEqual(self.added_changes,
+                    [ dict(author="bar", files=[], codebase='cb') ])
+        d.addCallback(check)
+        return d
+
     def test_addChange_prefix(self):
         cp = pb.ChangePerspective(self.master, 'xx/')
         d = cp.perspective_addChange(

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -445,19 +445,19 @@ execution on buildslaves.
 
 The :bb:chsrc:`PBChangeSource` is created with the following arguments.
 
-`port`
+``port``
     which port to listen on. If ``None`` (which is the default), it
     shares the port used for buildslave connections.
 
-`user`
+``user``
     The user account that the client program must use to connect. Defaults to
     ``change``
 
-`passwd`
+``passwd``
     The password for the connection - defaults to ``changepw``.  Do not use
     this default on a publicly exposed port!
 
-`prefix`
+``prefix``
     The prefix to be found and stripped from filenames delivered over the
     connection, defaulting to ``None``. Any filenames which do not start with
     this prefix will be removed. If all the filenames in a given Change are


### PR DESCRIPTION
Codebase was already supported by PBChangeSource, but this verifies that
and adds forcedCodebase.  Refs #2358.
