### PR TITLE
trigger: deprecate copy_property

### DIFF
--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -493,8 +493,8 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
         self.properties.setProperty('c', 'C', 'CC')
         self.expectOutcome(result=SUCCESS, status_text=['triggered', 'a'])
         self.expectTriggeredWith(a=({},
-                            dict(a=('A', 'AA (in triggering build)'),
-                                 b=('B', 'BB (in triggering build)'))))
+                            dict(a=('A', 'Trigger'),
+                                 b=('B', 'Trigger'))))
         return self.runStep()
 
     def test_interrupt(self):


### PR DESCRIPTION
Same functionality can be implemented with renderable set_property

We change the implementation to rather use set_property

This has the slight side effect of loosing the source inheritance
information.

I think this is worth the simplification of API.

The doc is not updated becuse it will clash with tom's interpolate doc
