### PR TITLE
properties: add adapter for callables

### DIFF
--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -17,6 +17,7 @@ import collections
 import re
 import warnings
 import weakref
+from types import FunctionType
 from buildbot import config, util
 from buildbot.util import json
 from buildbot.interfaces import IRenderable, IProperties
@@ -679,3 +680,18 @@ class _DictRenderer(object):
         return d
 
 registerAdapter(_DictRenderer, dict, IRenderable)
+
+class _CallableRenderer(object):
+    """
+    Callable IRenderable adaptor. call the function with property in argument
+    """
+
+    implements(IRenderable)
+
+    def __init__(self, value):
+        self.value = value
+
+    def getRenderingFor(self, props):
+        return defer.maybeDeferred(self.value, props)
+
+registerAdapter(_CallableRenderer, FunctionType, IRenderable)

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -1263,7 +1263,7 @@ class TestProperty(unittest.TestCase):
         return d
 
 
-class TestRenderalbeAdapters(unittest.TestCase):
+class TestRenderableAdapters(unittest.TestCase):
     """
     Tests for list, tuple and dict renderers.
     """
@@ -1307,4 +1307,16 @@ class TestRenderalbeAdapters(unittest.TestCase):
         r1.callback("load")
         k2.callback("dict")
         r2.callback("lookup")
+        return d
+
+    def test_callable(self):
+        def a(b):
+            return b.getProperty("inexistant","OK")
+        d = self.build.render(a)
+        d.addCallback(self.failUnlessEqual, "OK")
+        return d
+
+    def test_callable_lambda(self):
+        d = self.build.render(lambda p:"OK")
+        d.addCallback(self.failUnlessEqual, "OK")
         return d


### PR DESCRIPTION
it is a very common need for users just to want to create a
function to do the property interpolation.

one can now say:

Shell(command=lambda p:"echo next build is"+(p.getProperty("buildnumber")+1))
