### PR TITLE
Add a to-do list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,10 @@ The outstanding resource types are:
  * scheduler
  * builder
  * buildrequest
+ * build
+ * step
+ * logfile
+ * buildslave
 
 Other Tasks
 -----------
@@ -100,6 +104,11 @@ Later
 =====
 
 This section can hold tasks that don't need to be done by 0.9.0, but shouldn't be forgotten, and might be implemented sooner if convenient.
+
+Infrastructure
+--------------
+
+* Use some fancy algorithms to delay message transmission until the data is known-good in the database, for cases where the underlying database is asynchronously replicated.
 
 Documentation
 -------------


### PR DESCRIPTION
@jaredgrubb asked in IRC if there's a to-do list for nine.  There wasn't, but it's a good idea.

This adds a todo list in `README.rst`.  I chose that filename since Github helpfully displays it on the repository-view page.

The idea is that when nine is merged, this will be removed (or moved to another filename, at least, if there's still a lot on it).

I've dumped my TODO ideas into it; others are welcome to do so.  I think that we can use this in two ways:
- commit new items directly to the 'nine' branch, as appropriate
- modify it in topic branches that finish existing items, deleting the relevant items.
