### PR TITLE
fix html_message_formatter example. removing reference to file['url']

### DIFF
--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -953,9 +953,9 @@ given below::
                     text.append(u'</table>')
                     files = cd['files']
                     if files:
-                        text.append(u'<table cellspacing="10"><tr><th align="left">Files</th><th>URL</th></tr>')
+                        text.append(u'<table cellspacing="10"><tr><th align="left">Files</th></tr>')
                         for file in files:
-                            text.append(u'<tr><td>%s:</td><td>%s</td></tr>' % (file['name'], file['url']))
+                            text.append(u'<tr><td>%s:</td></tr>' % file['name'] )
                         text.append(u'</table>')
             text.append(u'<br>')
             # get log for last step 


### PR DESCRIPTION
which nolonger exists and will actually throw an exception if used.

Left as table column because the whole output is a table so much simpler than making the file list as a list.
