### PR TITLE
Pyflakes

### DIFF
--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -75,6 +75,13 @@ class PyFlakes(ShellCommand):
 
     MESSAGES = ("unused", "undefined", "redefs", "import*", "misc")
 
+    def __init__(self, *args, **kwargs):
+        # PyFlakes return 1 for both warnings and errors. We
+        # categorize this initially as WARNINGS so that
+        # evaluateCommand below can inspect the results more closely.
+        kwargs['decodeRC'] = {0: SUCCESS, 1: WARNINGS}
+        ShellCommand.__init__(self, *args, **kwargs)
+
     def createSummary(self, log):
         counts = {}
         summaries = {}

--- a/master/buildbot/test/unit/test_steps_python.py
+++ b/master/buildbot/test/unit/test_steps_python.py
@@ -276,6 +276,21 @@ class PyFlakes(steps.BuildStepMixin, unittest.TestCase):
         self.expectOutcome(result=SUCCESS, status_text=['pyflakes'])
         return self.runStep()
 
+    def test_unused(self):
+        self.setupStep(python.PyFlakes())
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['make', 'pyflakes'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                stdout="foo.py:1: 'bar' imported but unused\n")
+            + 1)
+        self.expectOutcome(result=WARNINGS,
+                           status_text=['pyflakes', 'unused=1', 'warnings'])
+        self.expectProperty('pyflakes-unused', 1)
+        self.expectProperty('pyflakes-total', 1)
+        return self.runStep()
+
     def test_undefined(self):
         self.setupStep(python.PyFlakes())
         self.expectCommands(
@@ -290,6 +305,52 @@ class PyFlakes(steps.BuildStepMixin, unittest.TestCase):
         self.expectProperty('pyflakes-undefined', 1)
         self.expectProperty('pyflakes-total', 1)
         return self.runStep()
+
+    def test_redefs(self):
+        self.setupStep(python.PyFlakes())
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['make', 'pyflakes'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                stdout="foo.py:2: redefinition of unused 'foo' from line 1\n")
+            + 1)
+        self.expectOutcome(result=WARNINGS,
+                           status_text=['pyflakes', 'redefs=1', 'warnings'])
+        self.expectProperty('pyflakes-redefs', 1)
+        self.expectProperty('pyflakes-total', 1)
+        return self.runStep()
+
+    def test_importstar(self):
+        self.setupStep(python.PyFlakes())
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['make', 'pyflakes'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                stdout="foo.py:1: 'from module import *' used; unable to detect undefined names\n")
+            + 1)
+        self.expectOutcome(result=WARNINGS,
+                           status_text=['pyflakes', 'import*=1', 'warnings'])
+        self.expectProperty('pyflakes-import*', 1)
+        self.expectProperty('pyflakes-total', 1)
+        return self.runStep()
+
+    def test_misc(self):
+        self.setupStep(python.PyFlakes())
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['make', 'pyflakes'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                stdout="foo.py:2: redefinition of function 'bar' from line 1\n")
+            + 1)
+        self.expectOutcome(result=WARNINGS,
+                           status_text=['pyflakes', 'misc=1', 'warnings'])
+        self.expectProperty('pyflakes-misc', 1)
+        self.expectProperty('pyflakes-total', 1)
+        return self.runStep()
+
 
 class TestSphinx(steps.BuildStepMixin, unittest.TestCase):
 


### PR DESCRIPTION
Hi,

I found that the PyFlakes buildstep didn't really work the way it was intended — non-flunking issues did not result in a WARNINGS result, but a FAILURE. The problem is simply that PyFlakes return 1 when it finds issues to warn about, not just when it finds errors.
