### PR TITLE
Byte-compiled files spotted in sdist tarball

### DIFF
--- a/master/MANIFEST.in
+++ b/master/MANIFEST.in
@@ -16,7 +16,7 @@ include docs/manual/_images/*.txt
 include docs/manual/_images/*.ai
 include docs/manual/_images/icon.blend
 include docs/manual/_images/Makefile
-include docs/bbdocs/*
+include docs/bbdocs/*.py
 include docs/developer/*
 
 include buildbot/scripts/sample.cfg


### PR DESCRIPTION
Last released (0.8.7) buildbot master tarball included *.pyc files in docs/bbdocs directory. This commit allows to exclude all unnecessary files out of this folder.
