### PR TITLE
ArtifactStorage management design doc

### DIFF
--- a/master/docs/developer/cls-buildsteps.rst
+++ b/master/docs/developer/cls-buildsteps.rst
@@ -331,7 +331,7 @@ BuildStep
         :param slavepath: path of the artifact on the slave (can be a file or a directory),
             relative to workdir
         :param storepath: destination path of the artifact on the storage server, relative to
-            buildDir configured the Create*ArtifactStorage step of the same build.
+            buildDir configured the IArtifactStorage named ``storageName`` in global config.
         :param kw: optional StorageManager backend parameters
 
         can be used by composite steps for uploading artifacts, return deferred that is
@@ -342,7 +342,7 @@ BuildStep
         :param slavepath: path of the artifact on the slave (can be a file or a directory),
             relative to workdir
         :param storepath: path of the artifact on the storage server, relative to
-            buildDir configured the Create*ArtifactStorage step of the same build.
+            buildDir configured the IArtifactStorage named ``storageName`` in global config.
         :param kw: optional StorageManager backend parameters
 
         can be used by composite steps for downloading artifacts, return deferred that is
@@ -352,7 +352,7 @@ BuildStep
 
         :param blob: (string (or bytes??)) data to store
         :param storepath: destination path of the artifact on the storage server, relative to
-            buildDir configured the Create*ArtifactStorage step of the same build.
+            buildDir configured the IArtifactStorage named ``storageName`` in global config.
         :param kw: optional StorageManager backend parameters
 
         can be used by composite steps for uploading artifacts, return deferred that is
@@ -364,7 +364,7 @@ BuildStep
     .. py:method:: downloadArtifactBlob(storepath, storageName, **kw)
 
         :param storepath: path of the artifact on the storage server, relative to
-            buildDir configured the Create*ArtifactStorage step of the same build.
+            buildDir configured the IArtifactStorage named ``storageName`` in global config.
         :param kw: optional StorageManager backend parameters
 
         can be used by composite steps for downloading artifacts, return deferred that is

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -300,6 +300,23 @@ The available caches are:
 
     c['buildCacheSize'] = 15
 
+.. bb:cfg:: artifactStorage
+
+.. index:: artifact; storage
+
+Artifact Storage Global Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+You need to define the list of ArtifactStorage you want to use in your config in the
+config variable ``storage``. e.g.::
+
+    from buildbot.steps.artifacts import MasterArtifactStorage
+    c["storage"] = [ MasterArtifactStorage(storageName="default", storageDir="/data/buildbot-storage/") ]
+
+at least one ``"default"`` storage needs to be defined, and will be the default backend for upload steps, and
+exception logs.
+
+See the :ref:`Build_Artifact_Storage` documentation for ArtifactStorage backends choice.
+
 .. bb:cfg:: mergeRequests
 
 .. index:: Builds; merging


### PR DESCRIPTION
Buildbot lacks a framework for storing the build artifacts.
Here is my proposal for building such.

The overall goal is to be able to write backend plugins for
more complex artifact storage systems like artifactory, or apache's
archiva

I volunter for implementing it once we have an agreement on the API,
I plan to implement a simple dictionary of storageManager, in process.build.Build class that Create*ArtifactStorage will populate, and that the BuildStep artifact APIs will proxy.

Signed-off-by: Pierre Tardy pierre.tardy@intel.com
