### PR TITLE
do not look at inherited class attributes for endpoint settings

### DIFF
--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -61,11 +61,14 @@ class DataConnector(service.Service):
                         setattr(self.updates, name, o)
 
                 # load its endpoints
-                for epoint in rtype.getEndpoints():
-                    self.matcher[epoint.pathPattern] = epoint
-                    if epoint.rootLinkName:
-                        link = base.Link(epoint.pathPattern)
-                        self.rootLinks[epoint.rootLinkName] = link
+                for ep in rtype.getEndpoints():
+                    # don't use inherited values for these parameters
+                    pathPattern = ep.__class__.__dict__.get('pathPattern')
+                    rootLinkName = ep.__class__.__dict__.get('rootLinkName')
+                    self.matcher[pathPattern] = ep
+                    if rootLinkName:
+                        link = base.Link(pathPattern)
+                        self.rootLinks[rootLinkName] = link
 
     def _setup(self):
         self.updates = Updates()

--- a/master/buildbot/test/unit/test_data_connector.py
+++ b/master/buildbot/test/unit/test_data_connector.py
@@ -121,6 +121,9 @@ class DataConnector(unittest.TestCase):
         match = self.data.matcher[('test',)]
         self.assertIsInstance(match[0], TestsEndpoint)
         self.assertEqual(match[1], dict())
+        match = self.data.matcher[('test','foo')]
+        self.assertIsInstance(match[0], TestsEndpointSubclass)
+        self.assertEqual(match[1], dict())
 
         # and that it found the update method
         self.assertEqual(self.data.updates.testUpdate(), "testUpdate return")
@@ -175,13 +178,19 @@ class TestsEndpoint(base.Endpoint):
     pathPattern = ('test',)
     rootLinkName = 'tests'
 
+class TestsEndpointParentClass(base.Endpoint):
+    rootLinkName = 'shouldnt-see-this'
+
+class TestsEndpointSubclass(TestsEndpointParentClass):
+    pathPattern = ('test', 'foo')
+
 class TestEndpoint(base.Endpoint):
     pathPattern = ('test', 'i:testid')
 
 class TestResourceType(base.ResourceType):
     name = 'tests'
     type = 'test'
-    endpoints = [ TestsEndpoint, TestEndpoint ]
+    endpoints = [ TestsEndpoint, TestEndpoint, TestsEndpointSubclass ]
     keyFields = ( 'testid', )
 
     @base.updateMethod


### PR DESCRIPTION
This makes it easier to put your endpoints in an inheritance hierarchy without having parent classes confuse the issue with child classes.
