### PR TITLE
Spell check and correct of documentation

### DIFF
--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -223,7 +223,7 @@ class StartupAndReconfig(dirs.DirsMixin, unittest.TestCase):
             self.patch(master.BuildMaster, 'create_child_services',
                     lambda self : None)
 
-            # patch out a few other annoying things the msater likes to do
+            # patch out a few other annoying things the master likes to do
             self.patch(monkeypatches, 'patch_all', lambda : None)
             self.patch(signal, 'signal', lambda sig, hdlr : None)
             self.patch(master, 'Status', lambda master : mock.Mock()) # XXX temporary

--- a/master/docs/developer/cls-buildsteps.rst
+++ b/master/docs/developer/cls-buildsteps.rst
@@ -123,7 +123,7 @@ BuildStep
 
         If the step is tracking progress, this is a :class:`~buildbot.status.progress.StepProgress` instance performing that task.
 
-    Exeuction of the step itself is governed by the following methods and attributes.
+    Execution of the step itself is governed by the following methods and attributes.
 
     .. py:method:: startStep(remote)
 
@@ -402,7 +402,7 @@ LoggingBuildStep
         This hook should decide what result the step should have.
         The default implementation invokes ``log_eval_func`` if it exists, and looks at :attr:`~buildbot.process.buildstep.RemoteCommand.rc` to distinguish :data:`~buildbot.status.results.SUCCESS` from :data:`~buildbot.status.results.FAILURE`.
 
-    The remaining methods provide an embarassment of ways to set the summary of the step that appears in the various status interfaces.
+    The remaining methods provide an embarrassment of ways to set the summary of the step that appears in the various status interfaces.
     The easiest way to affect this output is to override :meth:`~BuildStep.describe`.
     If that is not flexible enough, override :meth:`getText` and/or :meth:`getText2`.
 
@@ -413,7 +413,7 @@ LoggingBuildStep
         :returns: a list of short strings
 
         This method is the primary means of describing the step.
-        The default implementation calls :meth:`~BuildStep.describe`, which is usally the easiest method to override, and then appends a string describing the step status if it was not successful.
+        The default implementation calls :meth:`~BuildStep.describe`, which is usually the easiest method to override, and then appends a string describing the step status if it was not successful.
 
     .. py:method:: getText2(command, results)
 

--- a/master/docs/developer/cls-irenderable.rst
+++ b/master/docs/developer/cls-irenderable.rst
@@ -11,4 +11,4 @@ IRenderable
 
         :param iprops: the :class:`~buildbot.interfaces.IProperties` provider supplying the properties of the build.
 
-        Reeturns the interpretation of the given properties, optionally in a Deferred.
+        Returns the interpretation of the given properties, optionally in a Deferred.

--- a/master/docs/developer/config.rst
+++ b/master/docs/developer/config.rst
@@ -96,7 +96,7 @@ described in :ref:`developer-Reconfiguration`.
 
     .. py:attribute:: codebaseGenerator
     
-        A callable, or None, used to determine the codebase from an incomming 
+        A callable, or None, used to determine the codebase from an incoming 
         :py:class:`~buildbot.changes.changes.Change`,
         from :bb:cfg:`codebaseGenerator`
         
@@ -117,7 +117,7 @@ described in :ref:`developer-Reconfiguration`.
 
     .. py:attribute:: manhole
 
-        The manhole instance to ues, or None; from :bb:cfg:`manhole`.
+        The manhole instance to use, or None; from :bb:cfg:`manhole`.
 
     The remaining attributes contain compound configuration structures, usually
     dictionaries:
@@ -264,9 +264,9 @@ configuration - change sources, slaves, schedulers, build steps, and so on.
     :raises: :py:exc:`ConfigErrors` if called at build-time
 
     This function reports a configuration error. If a config file is being loaded,
-    then the function merely records ther error, and allows he rest of the configuration
+    then the function merely records the error, and allows the rest of the configuration
     to be loaded. At any other time, it raises :py:exc:`ConfigErrors`.  This is done
-    so all config erros can be reported, rather than just the first.
+    so all config errors can be reported, rather than just the first.
 
 .. py:exception:: ConfigErrors([errors])
 
@@ -292,7 +292,7 @@ configuration - change sources, slaves, schedulers, build steps, and so on.
 Reconfiguration
 ===============
 
-When the buildmaster receives a signal to beging a reconfig, it re-reads the
+When the buildmaster receives a signal to begin a reconfig, it re-reads the
 configuration file, generating a new :py:class:`MasterConfig` instance, and
 then notifies all of its child services via the reconfig mechanism described
 below.  The master ensures that at most one reconfiguration is taking place at

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -6,7 +6,7 @@ Database
 As of version 0.8.0, Buildbot has used a database as part of its storage
 backend.  This section describes the database connector classes, which allow
 other parts of Buildbot to access the database.  It also describes how to
-modify the database schema and the connector classes themsleves.
+modify the database schema and the connector classes themselves.
 
 .. note::
 
@@ -162,7 +162,7 @@ buildrequests
         :raises: :py:exc:`AlreadyClaimedError`
 
         Re-claim the given build requests, updating the timestamp, but checking
-        that the requsts are owned by this master.  The resulting deferred will
+        that the requests are owned by this master.  The resulting deferred will
         fire normally on success, or fail with :py:exc:`AlreadyClaimedError` if
         *any* of the build requests are already claimed by another master
         instance, or don't exist.  In this case, none of the reclaims will take
@@ -967,7 +967,7 @@ Database Schema
 .. py:module:: buildbot.db.model
 
 Database connector methods access the database through SQLAlchemy, which
-requires access to Python objects represenging the database tables.  That is
+requires access to Python objects representing the database tables.  That is
 handled through the model.
 
 .. py:class:: Model
@@ -1057,7 +1057,7 @@ Tests
 It goes without saying that any new connector methods must be fully tested!
 
 You will also want to add an in-memory implementation of the methods to the
-fake classes in ``master/budilbot/test/fake/fakedb.py``.  Non-DB Buildbot code
+fake classes in ``master/buildbot/test/fake/fakedb.py``.  Non-DB Buildbot code
 is tested using these fake implementations in order to isolate that code from
 the database code.
 
@@ -1082,7 +1082,7 @@ be complex and require caution so as not to lose information.
 
 Create a new script in :bb:src:`master/buildbot/db/migrate/versions`, following
 the numbering scheme already present.  The script should have an ``update``
-method, which takes an engine as a parameter, and ugprades the database, both
+method, which takes an engine as a parameter, and upgrades the database, both
 changing the schema and performing any required data migrations.  The engine
 passed to this parameter is "enhanced" by SQLAlchemy-Migrate, with methods to
 handle adding, altering, and dropping columns.  See the SQLAlchemy-Migrate
@@ -1172,5 +1172,5 @@ query specifying id's that are IN a subquery will not work.  The workaround is
 to run the subquery directly, and then execute a DELETE query for each returned
 id.
 
-If this weakness has a significant peformance impact, it would be acceptable to
+If this weakness has a significant performance impact, it would be acceptable to
 conditionalize use of the subquery on the database dialect.

--- a/master/docs/developer/master-overview.rst
+++ b/master/docs/developer/master-overview.rst
@@ -23,7 +23,7 @@ The master has several child services:
     A :py:class:`buildbot.process.metrics.MetricLogObserver` instance that
     handles tracking and reporting on master metrics.
 
-``msater.caches``
+``master.caches``
     A :py:class:`buildbot.process.caches.CacheManager` instance that provides
     access to object caches.
 

--- a/master/docs/developer/master-slave.rst
+++ b/master/docs/developer/master-slave.rst
@@ -379,7 +379,7 @@ following arguments:
 
 ``mode``
 
-    Acess mode for the new file.
+    Access mode for the new file.
 
 The reader object's ``read(maxsize)`` method will be called with a maximum
 size, which will return no more than that number of bytes as a bytestring.  At
@@ -393,7 +393,7 @@ mkdir
 .....
 
 This command will create a directory on the slave.  It will also create any
-intervening directories required.  It takes the following arugment:
+intervening directories required.  It takes the following argument:
 
 ``dir``
 

--- a/master/docs/developer/metrics.rst
+++ b/master/docs/developer/metrics.rst
@@ -57,7 +57,7 @@ monitor. There are three sub-classes implemented:
 Metric Handlers
 ---------------
 
-:class:`MetricsHandler` objects are responsble for collecting
+:class:`MetricsHandler` objects are responsible for collecting
 :class:`MetricEvent`\s of a specific type and keeping track of their
 values for future reporting. There are :class:`MetricsHandler` classes
 corresponding to each of the :class:`MetricEvent` types. 

--- a/master/docs/developer/tests.rst
+++ b/master/docs/developer/tests.rst
@@ -201,7 +201,7 @@ For testing things that themselves depend on time, consider using
 :class:`twisted.internet.tasks.Clock`.  This may mean passing a clock instance to
 the code under test, and propagating that instance as necessary to ensure that
 all of the code using :meth:`callLater` uses it.  Refactoring code for
-testability is difficult, but wortwhile.
+testability is difficult, but worthwhile.
 
 For testing things that do not depend on time, but for which you cannot detect
 the "end" of an operation: add a way to detect the end of the operation!

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -467,7 +467,7 @@ apply that to a non-network situation.
         :param data: a portion of netstring-formatted data
         :raises: :py:exc:`twisted.protocols.basic.NetstringParseError`
 
-        Add arbitrariliy-sized ``data`` to the incoming-data buffer.  Any
+        Add arbitrarily-sized ``data`` to the incoming-data buffer.  Any
         complete netstrings will trigger a call to the
         :py:meth:`stringReceived` method.
 
@@ -523,7 +523,7 @@ buildbot.util.croniter
 ~~~~~~~~~~~~~~~~~~~~~~
 
 This module is a copy of https://github.com/taichino/croniter, and provides
-suport for converting cron-like time specifications into actual times.
+support for converting cron-like time specifications into actual times.
 
 buildbot.util.state
 ~~~~~~~~~~~~~~~~~~~
@@ -537,7 +537,7 @@ The classes in the :py:mod:`buildbot.util.subscription` module are used for deal
 
     .. py:attribute:: name
 
-         This must be set to the name to be used to identifiy this object in the database.
+         This must be set to the name to be used to identify this object in the database.
 
     .. py:attribute:: master
 

--- a/master/docs/manual/cfg-builders.rst
+++ b/master/docs/manual/cfg-builders.rst
@@ -29,7 +29,7 @@ configuration file, its use looks like::
 ``slavenames``
     These arguments specify the buildslave or buildslaves that will be used by
     this Builder.  All slaves names must appear in the :bb:cfg:`slaves`
-    configuration parameter. Each buildslave can accomodate multiple
+    configuration parameter. Each buildslave can accommodate multiple
     builders.  The ``slavenames`` parameter can be a list of names,
     while ``slavename`` can specify only one slave.
 

--- a/master/docs/manual/cfg-buildslaves.rst
+++ b/master/docs/manual/cfg-buildslaves.rst
@@ -177,7 +177,7 @@ Amazon Web Services Elastic Compute Cloud ("AWS EC2")
 
 `EC2 <http://aws.amazon.com/ec2/>`_ is a web service that allows you to
 start virtual machines in an Amazon data center. Please see their website for
-details, incuding costs. Using the AWS EC2 latent buildslaves involves getting
+details, including costs. Using the AWS EC2 latent buildslaves involves getting
 an EC2 account with AWS and setting up payment; customizing one or more EC2
 machine images ("AMIs") on your desired operating system(s) and publishing
 them (privately if needed); and configuring the buildbot master to know how to

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -98,7 +98,7 @@ Arguments common to all :class:`BuildStep` subclasses:
     A step can be configured to only run under certain conditions.  To do this, set
     the step's ``doStepIf`` to a boolean value, or to a function that returns a
     boolean value or Deferred.  If the value or function result is false, then the step will
-    return ``SKIPPED`` without doing anything.  Oherwise, the step will be executed
+    return ``SKIPPED`` without doing anything.  Otherwise, the step will be executed
     normally.  If you set ``doStepIf`` to a function, that function should
     accept one parameter, which will be the :class:`Step` object itself.
 
@@ -722,7 +722,7 @@ The Repo step takes the following arguments:
     the last repo sync was on all branches
     Returns: max age of tarball in seconds, or -1, if we
     want to skip tarball update
-    The default value should be good tradeof on size of the tarball,
+    The default value should be good trade off on size of the tarball,
     and update frequency compared to cost of tarball creation
 
 This Source step integrates with :bb:chsrc:`GerritChangeSource`, and will
@@ -830,15 +830,15 @@ sources are coming from.
     The name of this parameter might varies depending on the Source step you
     are running. The concept explained here is common to all steps and
     applies to ``repourl`` as well as for ``baseURL`` (when
-    aplicable). Buildbot, now being aware of the repository name via the
+    applicable). Buildbot, now being aware of the repository name via the
     change source, might in some cases not need the repository url. There
     are multiple way to pass it through to this step, those correspond to
     the type of the parameter given to this step:
 
     ``None``
-        In the case where no paraneter is specified, the repository url will be
+        In the case where no parameter is specified, the repository url will be
         taken exactly from the Change attribute. You are looking for that one if
-        your ChangeSource step has all informations about how to reach the
+        your ChangeSource step has all information about how to reach the
         Change.
 
     string
@@ -849,7 +849,7 @@ sources are coming from.
     format string
         If the parameter is a string containing ``%s``, then this the
         repository attribute from the :class:`Change` will be place in place of the
-        ``%s``. This is usefull when the change source knows where the
+        ``%s``. This is useful when the change source knows where the
         repository resides locally, but don't know the scheme used to access
         it. For instance ``ssh://server/%s`` makes sense if the the
         repository attribute is the local path of the repository.
@@ -1018,7 +1018,7 @@ should preferentially create the ``SVN`` step with the
 
     If set to "empty" updates will not pull in any files or subdirectories not
     already present. If set to "files", updates will pull in any files not already
-    present, but not directories. If set to "immediates", updates willl pull in any
+    present, but not directories. If set to "immediates", updates will pull in any
     files or subdirectories not already present, the new subdirectories will have
     depth: empty. If set to "infinity", updates will pull in any files or
     subdirectories not already present; the new subdirectories will have
@@ -1342,7 +1342,7 @@ The Monotone step takes the following arguments:
 ShellCommand
 ------------
 
-Most interesting steps involve exectuing a process of some sort on the
+Most interesting steps involve executing a process of some sort on the
 buildslave.  The :bb:step:`ShellCommand` class handles this activity.
 
 Several subclasses of :bb:step:`ShellCommand` are provided as starting points for
@@ -1678,7 +1678,7 @@ only one number is given it matches only on that line.
 
 The default warningPattern regexp only matches the warning text, so line
 numbers and file names are ignored. To enable line number and file name
-matching, privide a different regexp and provide a function (callable) as the
+matching, provide a different regexp and provide a function (callable) as the
 argument of ``warningExtractor=``. The function is called with three
 arguments: the :class:`BuildStep` object, the line in the log file with the warning,
 and the ``SRE_Match`` object of the regexp search for ``warningPattern``. It
@@ -1795,11 +1795,11 @@ The available constructor arguments are
     for building cmake generate projects.
 
 ``platform``
-    This is a madatory argument for MsBuild specifying the target platform
+    This is a mandatory argument for MsBuild specifying the target platform
     such as 'Win32', 'x64' or 'Vista Debug'. The last one is an example of
     driver targets that appear once Windows Driver Kit 8 is installed.
 
-Here is an example on how to drive compilatin with Visual Studio 2010::
+Here is an example on how to drive compilation with Visual Studio 2010::
 
     from buildbot.steps.VisualStudio import VS2010
 
@@ -2049,7 +2049,7 @@ This step requires slave version 0.8.5 or later.
 Python BuildSteps
 -----------------
 
-Here are some :class:`BuildStep`\s that are specifcally useful for projects
+Here are some :class:`BuildStep`\s that are specifically useful for projects
 implemented in Python.
 
 .. bb:step:: BuildEPYDoc
@@ -2125,7 +2125,7 @@ Sphinx
 
 .. py:class:: buildbot.steps.python.Sphinx
 
-`Shinx <http://sphinx.pocoo.org/>`_ is  the Python Documentation
+`Sphinx <http://sphinx.pocoo.org/>`_ is  the Python Documentation
 Generator. It uses `RestructuredText <http://docutils.sourceforge.net/rst.html>`_
 as input format.
 
@@ -2150,14 +2150,14 @@ This step takes the following arguments:
    (optional) Indicates the builder to use.
 
 ``sphinx``
-   (optional, defaulting to :program:`shinx-build`) Indicates the
+   (optional, defaulting to :program:`sphinx-build`) Indicates the
    executable to run.
 
 ``tags``
    (optional) List of ``tags`` to pass to :program:`sphinx-build`
 
 ``defines``
-   (optional) Dictionnary of defines to overwrite values of the
+   (optional) Dictionary of defines to overwrite values of the
    :file:`conf.py` file.
 
 ``mode``
@@ -2360,7 +2360,7 @@ on the buildmaster.
 
 The ``url=`` argument allows you to specify an url that will be
 displayed in the HTML status. The title of the url will be the name of
-the item transfered (directory for :class:`DirectoryUpload` or file
+the item transferred (directory for :class:`DirectoryUpload` or file
 for :class:`FileUpload`). This allows the user to add a link to the
 uploaded item if that one is uploaded to an accessible place.
 
@@ -2401,7 +2401,7 @@ The optional ``compress`` argument can be given as ``'gz'`` or
 ``'bz2'`` to compress the datastream.
 
 .. note:: The permissions on the copied files will be the same on the
-          master as originately on the slave, see :option:`buildslave
+          master as originally on the slave, see :option:`buildslave
           create-slave --umask` to change the default one.
 
 .. bb:step:: StringDownload
@@ -2723,7 +2723,7 @@ MockBuildSRPM Step
 ++++++++++++++++++
 
 The :bb:step:`MockBuildSRPM` step builds a SourceRPM based on a spec file and
-optionaly a source directory::
+optionally a source directory::
 
     from buildbot.steps.package.rpm import MockBuildSRPM
     f.addStep(MockBuildSRPM(root='default', spec='mypkg.spec'))
@@ -2775,7 +2775,7 @@ The :bb:step:`DebPbuilder` step builds Debian packages within a chroot built
 by pbuilder. It populates the changeroot with a basic system and the packages
 listed as build requirement. The type of chroot to build is specified with the
 ``distribution``, ``distribution`` and ``mirror`` parameter. To use pbuilder
-your buildbot must have the right to run pbuilder as root throug sudo. ::
+your buildbot must have the right to run pbuilder as root through sudo. ::
 
     from buildbot.steps.package.deb.pbuilder import DepPbuilder
     f.addStep(DepPbuilder())
@@ -2786,7 +2786,7 @@ The step takes the following parameters
     Architecture to build chroot for.
 
 ``distribution``
-    Name, or nickname, of the dirstribution. Defaults to 'stable'.
+    Name, or nickname, of the distribution. Defaults to 'stable'.
 
 ``basetgz``
     Path of the basetgz to use for building.
@@ -2799,7 +2799,7 @@ The step takes the following parameters
 
 ``keyring``
     Path to a gpg keyring to verify the downloaded packages. This is necessary
-    if you build for a forain distribution.
+    if you build for a foreign distribution.
 
 ``components``
     Repos to activate for chroot building.

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -3,7 +3,7 @@
 Change Sources
 --------------
 
-A Version Control System mantains a source tree, and tells the
+A Version Control System maintains a source tree, and tells the
 buildmaster when it changes. The first step of each :class:`Build` is typically
 to acquire a copy of some version of this tree.
 
@@ -118,7 +118,7 @@ Configuring Change Sources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :bb:cfg:`change_source` configuration key holds all active
-change sources for the confguration.
+change sources for the configuration.
 
 Most configurations have a single :class:`ChangeSource`, watching only a single
 tree, e.g., ::
@@ -1040,7 +1040,7 @@ arguments:
 
 ``branch``
     accepts a single branch name to fetch.
-    Exists for backwards compatability with old configurations.
+    Exists for backwards compatibility with old configurations.
 
 ``pollinterval``
     interval in seconds between polls, default is 10 minutes
@@ -1130,7 +1130,7 @@ The :bb:chsrc:`HgPoller` accepts the following arguments:
 
     Several :bb:chsrc:`HgPoller` instances may share the same ``workdir`` for
     mutualisation of the common history between two different branches, thus
-    easing on local and remote system resources and bandwith.
+    easing on local and remote system resources and bandwidth.
 
     If relative, the ``workdir`` will be interpreted from the master directory.
 

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -30,7 +30,7 @@ The format of this parameter is completely documented at http://www.sqlalchemy.o
      driver://[username:password@]host:port/database[?args]
 
 The optional ``db_poll_interval`` specifies the interval, in seconds, between checks for pending tasks in the database.
-This parameter is generally only usful in multi-master mode. See :ref:`Multi-master-mode`.
+This parameter is generally only useful in multi-master mode. See :ref:`Multi-master-mode`.
 
 These parameters can be specified directly in the configuration dictionary, as ``c['db_url']`` and ``c['db_poll_interval']``, although this method is deprecated.
 
@@ -225,7 +225,7 @@ The :bb:cfg:`changeHorizon` key determines how many changes the master will keep
 This parameter defaults to 0, which means keep all changes indefinitely.
 
 The :bb:cfg:`buildHorizon` specifies the minimum number of builds for each builder which should be kept on disk.
-The :bb:cfg:`eventHorizon` specifies the minumum number of events to keep--events mostly describe connections and disconnections of slaves, and are seldom helpful to developers.
+The :bb:cfg:`eventHorizon` specifies the minimum number of events to keep--events mostly describe connections and disconnections of slaves, and are seldom helpful to developers.
 The :bb:cfg:`logHorizon` gives the minimum number of builds for which logs should be maintained; this parameter must be less than or equal to :bb:cfg:`buildHorizon`.
 Builds older than :bb:cfg:`logHorizon` but not older than :bb:cfg:`buildHorizon` will maintain their overall status and the status of each step, but the logfiles will be deleted.
 
@@ -391,7 +391,7 @@ Debug Options
 ~~~~~~~~~~~~~
 
 If you set :bb:cfg:`debugPassword`, then you can connect to the buildmaster with the diagnostic tool launched by :samp:`buildbot debugclient {MASTER}:{PORT}`.
-From this tool, you can reload the config file, manually force builds, and inject changes, which may be useful for testing your buildmaster without actually commiting changes to your repository (or before you have the Change Sources configured.)
+From this tool, you can reload the config file, manually force builds, and inject changes, which may be useful for testing your buildmaster without actually committing changes to your repository (or before you have the Change Sources configured.)
 
 The debug tool uses the same port number as the slaves, :bb:cfg:`slavePortnum`, and you may configure its authentication credentials as follows::
 
@@ -585,7 +585,7 @@ The callable takes the revision id and repository argument, and should return an
 Note that the revision id may not always be in the form you expect, so code defensively.
 In particular, a revision of "??" may be supplied when no other information is available.
 
-Note that :class:`SourceStamp`\s that are not created from version-control changes (e.g., those created by a Nightly or Periodic scheduler) may have an empty repository string, if the respository is not known to the scheduler.
+Note that :class:`SourceStamp`\s that are not created from version-control changes (e.g., those created by a Nightly or Periodic scheduler) may have an empty repository string, if the repository is not known to the scheduler.
 
 Revision Link Helpers
 +++++++++++++++++++++

--- a/master/docs/manual/cfg-intro.rst
+++ b/master/docs/manual/cfg-intro.rst
@@ -193,7 +193,7 @@ which get queued after the reconfig) will use the new process.
 
     * Any modules imported by the configuration file are not automatically reloaded.
       Python modules such as http://pypi.python.org/pypi/lazy-reload may help
-      here, but reloading modules is fraught with subtlties and difficult-to-decipher
+      here, but reloading modules is fraught with subtleties and difficult-to-decipher
       failure cases.
 
     * During the reconfiguration, active internal objects are divorced from the service
@@ -206,7 +206,7 @@ which get queued after the reconfig) will use the new process.
       occurs, it is best to restart the master.
 
     * For more advanced configurations, it is impossible for Buildbot to tell if the
-      configuration for a :class:`Builder` or :class:`Scheduler` has chanaged, and thus the :class:`Builder` or
+      configuration for a :class:`Builder` or :class:`Scheduler` has changed, and thus the :class:`Builder` or
       :class:`Scheduler` will always be reloaded.  This occurs most commonly when a callable
       is passed as a configuration parameter.
 

--- a/master/docs/manual/cfg-properties.rst
+++ b/master/docs/manual/cfg-properties.rst
@@ -146,7 +146,7 @@ placeholders will be replaced using the current values of the build properties.
     the ``if`` statement is executed.  However, Python will not detect this as
     an error - you will just never see the step added to the factory.
 
-You can use build properties in most step paramaters.  Please file bugs for any
+You can use build properties in most step parameters.  Please file bugs for any
 parameters which do not accept properties.
 
 .. index:: single: Properties; Property
@@ -215,7 +215,7 @@ The following selectors are supported.
     The key is the name of a property.
 
 ``src``
-    The key is a codebase and source stamp attribute, seperated by a colon.
+    The key is a codebase and source stamp attribute, separated by a colon.
 
 ``kw``
     The key refers to a keyword argument passed to ``Interpolate``.
@@ -244,7 +244,7 @@ The following ways of interpreting the value are available.
     ``?``, similar to ``+``) or being ``True`` (with ``#?``, like ``~``).
     Notice that there is a pipe immediately following the question mark *and*
     between the two substitution alternatives. The character that follows the
-    question mark is used as the delimeter between the two alternatives. In the
+    question mark is used as the delimiter between the two alternatives. In the
     above examples, it is a pipe, but any character other than ``(`` can be used.
 
 
@@ -301,7 +301,7 @@ WithProperties
 .. warning::
 
     This placeholder is deprecated. It is an older version of :ref:`Interpolate`.
-    It exists for compatability with older configs.
+    It exists for compatibility with older configs.
 
 The simplest use of this class is with positional string interpolation.  Here,
 ``%s`` is used as a placeholder, and property names are given as subsequent
@@ -365,7 +365,7 @@ dictionary-style interpolation, not both. Thus you cannot use a string like
 Custom Renderables
 ++++++++++++++++++
 
-If the options described above are not sufficient, more complex substitutions can be achieved by writting custom renderables.
+If the options described above are not sufficient, more complex substitutions can be achieved by writing custom renderables.
 
 Renderables are objects providing the :class:`~buildbot.interfaces.IRenderable` interface.
 That interface is simple - objects must provide a `getRenderingFor` method.

--- a/master/docs/manual/cfg-schedulers.rst
+++ b/master/docs/manual/cfg-schedulers.rst
@@ -657,7 +657,7 @@ with it.
 To use the username/password form of authentication, create a
 :class:`Try_Userpass` instance instead. It takes the same
 ``builderNames`` argument as the :class:`Try_Jobdir` form, but
-accepts an addtional ``port`` argument (to specify the TCP port to
+accepts an additional ``port`` argument (to specify the TCP port to
 listen on) and a ``userpass`` list of username/password pairs to
 accept. Remember to use good passwords for this: the security of the
 buildslave accounts depends upon it::
@@ -810,7 +810,7 @@ Here is a fully-worked example::
     checkin_factory.addStep(shell.Test())
     checkin_factory.addStep(trigger.Trigger(schedulerNames=['nightly'])
 
-    # and every night, package the latest succesful build
+    # and every night, package the latest successful build
     nightly_factory = factory.BuildFactory()
     nightly_factory.addStep(shell.ShellCommand(command=['make', 'package']))
 

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -271,7 +271,7 @@ be used to access them.
     default the view sorts revisions lexically, which can lead to odd
     behavior with non-integer revisions (e.g., Git), or with integer
     revisions of different length (e.g., 999 and 1000). It also has
-    some issues with displaying multiple braches at the same time. If
+    some issues with displaying multiple branches at the same time. If
     you do have multiple branches, you should use the ``branch=``
     query argument.  The ``order_console_by_time`` option may help
     sorting revisions, although it depends on the date being set
@@ -291,7 +291,7 @@ be used to access them.
 
 ``/json``
     This view provides quick access to Buildbot status information in a form that
-    is easiliy digested from other programs, including JavaScript.  See
+    is easily digested from other programs, including JavaScript.  See
     ``/json/help`` for detailed interactive documentation of the output formats
     for this view.
 
@@ -480,7 +480,7 @@ specify ``False`` (the default) to prohibit that action or ``True`` to enable
 it.  Or you can specify a callable.  Each such callable will take a username as
 its first argument.  The remaining arguments vary depending on the type of
 authorization request.  For ``forceBuild``, the second argument is the builder
-stsatus.
+status.
 
 Authentication
 ##############
@@ -509,7 +509,7 @@ keyword argument to :class:`Authz`, and specify the action as ``"auth"``. ::
 The class :class:`BasicAuth` implements a basic authentication mechanism using a
 list of user/password tuples provided from the configuration file.  The class
 `HTPasswdAuth` implements an authentication against an :file:`.htpasswd`
-file. The `HTPasswdAprAuth` a subcalss of `HTPasswdAuth` use libaprutil for
+file. The `HTPasswdAprAuth` a subclass of `HTPasswdAuth` use libaprutil for
 authenticating. This adds support for apr1/md5 and sha1 password hashes but
 requires libaprutil at runtime. The :class:`UsersAuth` works with
 :ref:`User-Objects` to check for valid user credentials.
@@ -1215,7 +1215,7 @@ Source information (only valid if ss is not ``None``)
 
     The ``Change`` methods :meth:`asText` and :meth:`asDict` can be used to format the
     information above.  :meth:`asText` returns a list of strings and :meth:`asDict` returns
-    a dictonary suitable for html/mail rendering.
+    a dictionary suitable for html/mail rendering.
     
 Log information ::
     
@@ -1357,7 +1357,7 @@ Some of the commands currently available:
 Additionally, the config file may specify default notification options
 as shown in the example earlier.
 
-If the ``allowForce=True`` option was used, some addtional commands
+If the ``allowForce=True`` option was used, some additional commands
 will be available:
 
 .. index:: Properties; from forced build
@@ -1442,7 +1442,7 @@ StatusPush
 :class:`StatusPush` batches events normally processed and sends it to the
 :func:`serverPushCb` callback every ``bufferDelay`` seconds. The callback
 should pop items from the queue and then queue the next callback.
-If no items were poped from ``self.queue``, ``retryDelay`` seconds will be
+If no items were popped from ``self.queue``, ``retryDelay`` seconds will be
 waited instead.
 
 .. bb:status:: HttpStatusPush

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -401,9 +401,9 @@ Mercurial
 
 Perforce
     :command:`try` does a ``p4 changes -m1 ...`` to determine the latest
-    changelist and implicitly assumes that the local tree is synched to this
+    changelist and implicitly assumes that the local tree is synced to this
     revision. This is followed by a ``p4 diff -du`` to obtain the patch.
-    A p4 patch differs sligtly from a normal diff. It contains full depot
+    A p4 patch differs slightly from a normal diff. It contains full depot
     paths and must be converted to paths relative to the branch top. To convert
     the following restriction is imposed. The p4base (see :bb:chsrc:`P4Source`)
     is assumed to be ``//depot``
@@ -853,7 +853,7 @@ the command-line option name.
     system being used.
 
 ``try_branch``
-    Equivlanent to :option:`--branch`, this indicates that the current tree is on a
+    Equivalent to :option:`--branch`, this indicates that the current tree is on a
     non-trunk branch.
 
 ``try_topdir``

--- a/master/docs/manual/concepts.rst
+++ b/master/docs/manual/concepts.rst
@@ -17,10 +17,10 @@ configure it properly.
 Source Stamps
 -------------
 
-Source code comes from *respositories*, provided by version control systems.
+Source code comes from *repositories*, provided by version control systems.
 Repositories are generally identified by URLs, e.g., ``git://github.com/buildbot/buildbot.git``.
 
-In these days of distribtued version control systems, the same *codebase* may appear in mutiple repositories.
+In these days of distributed version control systems, the same *codebase* may appear in multiple repositories.
 For example, ``https://github.com/mozilla/mozilla-central`` and ``http://hg.mozilla.org/mozilla-release`` both contain the Firefox codebase, although not exactly the same code.
 
 Many *projects* are built from multiple codebases.
@@ -235,9 +235,9 @@ In such cases, it can be used to control which builds are scheduled for a given 
 Repository
 ~~~~~~~~~~
 
-This attibute specifies the repository in which this change occurred.
+This attribute specifies the repository in which this change occurred.
 In the case of DVCS's, this information may be required to check out the committed source code.
-However, using the repository from a change has security risks: if Buildbot is configured to blidly trust this information, then it may easily be tricked into building arbitrary source code, potentially compromising the buildslaves and the integrity of subsequent builds.
+However, using the repository from a change has security risks: if Buildbot is configured to blindly trust this information, then it may easily be tricked into building arbitrary source code, potentially compromising the buildslaves and the integrity of subsequent builds.
 
 .. _Attr-Codebase:
 
@@ -559,7 +559,7 @@ pages and in each :class:`Build`\'s *blamelist*.
 To do more with the User than just refer to them, this username needs to be
 mapped into an address of some sort. The responsibility for this mapping is
 left up to the status module which needs the address.  In the future, the
-responsbility for managing users will be transferred to User Objects.
+responsibility for managing users will be transferred to User Objects.
 
 The ``who`` fields in ``git`` Changes are used to create :ref:`User-Objects`,
 which allows for more control and flexibility in how Buildbot manages users.
@@ -756,12 +756,12 @@ of functionality.  Here are some examples:
 Most Source steps record the revision that they checked out in
 the ``got_revision`` property.  A later step could use this
 property to specify the name of a fully-built tarball, dropped in an
-easily-acessible directory for later testing.
+easily-accessible directory for later testing.
 
 .. note:: 
     In builds with more than one codebase, the ``got_revision`` property is a dictionary, keyed by codebase.
 
-Some projects want to perform nightly builds as well as bulding in response to
+Some projects want to perform nightly builds as well as building in response to
 committed changes.  Such a project would run two schedulers, both pointing to
 the same set of builders, but could provide an ``is_nightly`` property so
 that steps can distinguish the nightly builds, perhaps to run more
@@ -781,9 +781,9 @@ What if an end-product is composed of code from several codebases?
 Changes may arrive from different repositories within the tree-stable-timer period.
 Buildbot will not only use the source-trees that contain changes but also needs the remaining source-trees to build the complete product.
 
-For this reason a :ref:`Scheduler<Scheduling-Builds>` can be configured to base a build on a set of several source-trees that can (partly) be overidden by the information from incoming :class:`Change`\s.
+For this reason a :ref:`Scheduler<Scheduling-Builds>` can be configured to base a build on a set of several source-trees that can (partly) be overridden by the information from incoming :class:`Change`\s.
 
-As descibed :ref:`above <Source-Stamps>`, the source for each codebase is identified by a source stamp, containing its repository, branch and revision.
+As described :ref:`above <Source-Stamps>`, the source for each codebase is identified by a source stamp, containing its repository, branch and revision.
 A full build set will specify a source stamp set describing the source to use for each codebase.
 
 Configuring all of this takes a coordinated approach.  A complete multiple repository configuration consists of:

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -343,7 +343,7 @@ The following definition for :meth:`my_file_splitter` will do the job::
         projectname = pieces.pop(0)
         if projectname != 'Nevow':
             return None # wrong project
-        return dict(branc=branch, path='/'.join(pieces))
+        return dict(branch=branch, path='/'.join(pieces))
 
 If you later decide you want to get changes for Quotient as well you could
 replace the last 3 lines with simply::
@@ -356,7 +356,7 @@ replace the last 3 lines with simply::
 Writing Change Sources
 ----------------------
 
-For some version-control systems, making Bulidbot aware of new changes can be a
+For some version-control systems, making Buildbot aware of new changes can be a
 challenge.  If the pre-supplied classes in :ref:`Change-Sources` are not
 sufficient, then you will need to write your own.
 
@@ -475,12 +475,12 @@ with the :class:`SourceStamp` for the build, and should return the appropriate
 workdir.  Note that the value must be returned immediately - Deferreds are not
 supported.
 
-This can be useful, for exmaple, in scenarios with multiple repositories
+This can be useful, for example, in scenarios with multiple repositories
 submitting changes to BuildBot. In this case you likely will want to have a
 dedicated workdir per repository, since otherwise a sourcing step with mode =
 "update" will fail as a workdir with a working copy of repository A can't be
 "updated" for changes from a repository B. Here is an example how you can
-achive workdir-per-repo::
+achieve workdir-per-repo::
 
         def workdir(source_stamp):
             return hashlib.md5 (source_stamp.repository).hexdigest()[:8]
@@ -536,7 +536,7 @@ Consider the use of a :class:`BuildStep` in :file:`master.cfg`::
 
 This creates a single instance of class ``MyStep``.
 However, Buildbot needs a new object each time the step is executed.
-An instance of :class:`~buildbot.process.buildstep.BuildStep` rembers how it was constructed, and can create copies of itself.
+An instance of :class:`~buildbot.process.buildstep.BuildStep` remembers how it was constructed, and can create copies of itself.
 When writing a new step class, then, keep in mind are that you cannot do anything "interesting" in the constructor -- limit yourself to checking and storing arguments.
 
 It is customary to call the parent class's constructor with all otherwise-unspecified keyword arguments.
@@ -833,7 +833,7 @@ arbitrary object. For example::
 
 Remember that properties set in a step may not be available until the next step
 begins.  In particular, any :class:`Property` or :class:`Interpolate`
-instances for the current step are interpoloated before the ``start`` method
+instances for the current step are interpolated before the ``start`` method
 begins.
 
 .. index:: links, BuildStep URLs, addURL

--- a/master/docs/manual/installation.rst
+++ b/master/docs/manual/installation.rst
@@ -172,7 +172,7 @@ To test this, shift to a different directory (like :file:`/tmp`), and run:
 
 If it shows you the versions of Buildbot and Twisted, the install went
 ok. If it says "no such command" or it gets an ``ImportError``
-when it tries to load the libaries, then something went wrong.
+when it tries to load the libraries, then something went wrong.
 ``pydoc buildbot`` is another useful diagnostic tool.
 
 Windows users will find these files in other places. You will need to

--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -48,7 +48,7 @@ easy_install will need to download other projects from the Internet.
 .. note::
 
     Buildbot does not require root access.  Run the commands in this tutorial
-    as a normal, unpriviledged user.
+    as a normal, unprivileged user.
 
 Let's dive in by typing at the terminal::
 

--- a/master/docs/tutorial/tour.rst
+++ b/master/docs/tutorial/tour.rst
@@ -81,7 +81,7 @@ is complete.
 Now, if you go back to
 `the waterfall page <http://localhost:8010/waterfall>`_,
 you will see that the project's name is whatever you may have changed it to and when you click on the 
-the URL of the project name at the bottom of the page it should take you to the link you put in the configuration.
+URL of the project name at the bottom of the page it should take you to the link you put in the configuration.
 
 Configuration Errors
 --------------------


### PR DESCRIPTION
Also changed a comment in buildbot/test/unit/test_master.py with a minor typo
## Things that have not been corrected

Note this list is not 100% complete (I only started keeping track of words I decided not to fix part way through).

un-hyphenated or possibly incorrectly hyphenated words where meaning
was clear. An example is reimplement or subdirectories.

mutualisation in cfg-changesources.rst
queriers in cfg-global.rst
uncollectable in cfg-global.rst
syntaxes in cfg-properties.rst
proven in cmdline.rst

release notes
## Possibly incorrect code example

Example code change on line 346 in customization.rst - I think my
change is correct, but am insufficiently experienced to be 100% sure.

As I am fairly sure the original is incorrect, I have made the
correction.
