### PR TITLE
Change CVS to SVN in doc (code snippet uses svn)

### DIFF
--- a/master/docs/manual/cfg-buildfactories.rst
+++ b/master/docs/manual/cfg-buildfactories.rst
@@ -22,7 +22,7 @@ Defining a Build Factory
 ------------------------
 
 A :class:`BuildFactory` defines the steps that every build will follow.  Think of it as
-a glorified script.  For example, a build factory which consists of a CVS checkout
+a glorified script.  For example, a build factory which consists of an SVN checkout
 followed by a ``make build`` would be configured as follows::
 
     from buildbot.steps import svn, shell


### PR DESCRIPTION
This is a tiny documentation fix; the code snippet described by the paragraph uses SVN, but the text refers to this a "CVS checkout". I guess this has been updated, and somebody just missed this.
