### PR TITLE
add support for pathPatterns - multiple patterns for one endpoint class

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -39,6 +39,7 @@ class ResourceType(object):
 
 class Endpoint(object):
     pathPattern = None
+    pathPatterns = []
     rootLinkName = None
 
     def __init__(self, master):

--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -63,11 +63,16 @@ class DataConnector(service.Service):
                 # load its endpoints
                 for ep in rtype.getEndpoints():
                     # don't use inherited values for these parameters
-                    pathPattern = ep.__class__.__dict__.get('pathPattern')
-                    rootLinkName = ep.__class__.__dict__.get('rootLinkName')
-                    self.matcher[pathPattern] = ep
+                    clsdict = ep.__class__.__dict__
+                    pathPattern = clsdict.get('pathPattern')
+                    pathPatterns = clsdict.get('pathPatterns', [])
+                    patterns = [ pathPattern ] + pathPatterns
+                    rootLinkName = clsdict.get('rootLinkName')
+                    for pp in patterns:
+                        if pp is not None:
+                            self.matcher[pp] = ep
                     if rootLinkName:
-                        link = base.Link(pathPattern)
+                        link = base.Link(patterns[0])
                         self.rootLinks[rootLinkName] = link
 
     def _setup(self):

--- a/master/buildbot/test/unit/test_data_connector.py
+++ b/master/buildbot/test/unit/test_data_connector.py
@@ -118,6 +118,10 @@ class DataConnector(unittest.TestCase):
         match = self.data.matcher[('test', '10')]
         self.assertIsInstance(match[0], TestEndpoint)
         self.assertEqual(match[1], dict(testid=10))
+        match = self.data.matcher[('test', '10', 'p1')]
+        self.assertIsInstance(match[0], TestEndpoint)
+        match = self.data.matcher[('test', '10', 'p2')]
+        self.assertIsInstance(match[0], TestEndpoint)
         match = self.data.matcher[('test',)]
         self.assertIsInstance(match[0], TestsEndpoint)
         self.assertEqual(match[1], dict())
@@ -186,6 +190,7 @@ class TestsEndpointSubclass(TestsEndpointParentClass):
 
 class TestEndpoint(base.Endpoint):
     pathPattern = ('test', 'i:testid')
+    pathPatterns = [ ('test', 'i:testid', 'p1'), ('test', 'i:testid', 'p2') ]
 
 class TestResourceType(base.ResourceType):
     name = 'tests'

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import mock
+import types
 from twisted.internet import defer
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import interfaces
@@ -33,11 +34,14 @@ class EndpointMixin(interfaces.InterfaceTests):
 
         # this usually fails when a single-element pathPattern does not have a
         # trailing comma
-        self.assertIsInstance(self.ep.pathPattern, tuple)
+        patterns = [ self.ep.pathPattern ] + self.ep.pathPatterns
+        for pp in patterns:
+            if pp is not None:
+                self.assertIsInstance(pp, tuple)
 
-        self.path_args = set([
-            arg.split(':', 1)[1] for arg in self.ep.pathPattern
-            if ':' in arg ])
+        self.pathArgs = [
+            set([ arg.split(':', 1)[1] for arg in pp if ':' in arg ])
+            for pp in patterns if pp is not None ]
 
     def tearDownEndpoint(self):
         pass
@@ -45,13 +49,13 @@ class EndpointMixin(interfaces.InterfaceTests):
     # call methods, with extra checks
 
     def callGet(self, options, kwargs):
-        self.assertEqual(set(kwargs), self.path_args)
+        self.assertIn(set(kwargs), self.pathArgs)
         d = self.ep.get(options, kwargs)
         self.assertIsInstance(d, defer.Deferred)
         return d
 
     def callStartConsuming(self, options, kwargs, expected_filter=None):
-        self.assertEqual(set(kwargs), self.path_args)
+        self.assertIn(set(kwargs), self.pathArgs)
         cb = mock.Mock()
         qref = self.ep.startConsuming(cb, options, kwargs)
         self.assertTrue(hasattr(qref, 'stopConsuming'))

--- a/master/docs/developer/data.rst
+++ b/master/docs/developer/data.rst
@@ -364,11 +364,19 @@ See that module's description for details.
 
         The path pattern which incoming paths must match to select this endpoint.
 
+    .. py:attribute:: pathPatterns
+
+        :type: list of tuples
+
+        List of path patterns which incoming paths must match to select this endpoint.
+        This is useful where the same endpoint class services multiple paths.
+        If specified, ``pathPattern`` is prepended to this list.
+
     .. py:attribute:: rootLinkName
 
         :type: string
 
-        If set, then the path for this endpoint will be included as a link in the root of the API.
+        If set, then the first path pattern for this endpoint will be included as a link in the root of the API.
         This should be set for any endpoints that begin an explorable tree.
 
     .. py:method:: get(options, kwargs)


### PR DESCRIPTION
When we have roughly the same data at e.g.,
- /masters/:masterid/builders/:builderid
- /builders/:builderid/masters/:masterid

it makes sense to use the same Endpoint class with both
