### PR TITLE
Fix none check in Interpolate

### DIFF
--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -444,10 +444,10 @@ class Interpolate(util.ComparableMixin, object):
             except ValueError:
                 config.error("Must specify both codebase and attribute for src Interpolation '%s'" % arg)
                 codebase = attr = repl = None
-        if not Interpolate.identifier_re.match(codebase):
+        if codebase and not Interpolate.identifier_re.match(codebase):
             config.error("Codebase must be alphanumeric for src Interpolation '%s'" % arg)
             codebase = attr = repl = None
-        if not Interpolate.identifier_re.match(attr):
+        if attr and not Interpolate.identifier_re.match(attr):
             config.error("Attribute must be alphanumeric for src Interpolation '%s'" % arg)
             codebase = attr = repl = None
         return _SourceStampDict(codebase), attr, repl


### PR DESCRIPTION
I had a bug in my script where I was missing one of the pieces of an Interpolate call. 

The try-except above this sets the local vars to None in the error case, and prints a config error, but then the regex match fails to match on None and creates a traceback.

This removes the traceback so that the "buildbot reconfig" fails gracefully.

There really is no way to test this. We are already checking that a failure is triggered in this case, but there's not really a way for us to check that it "fails better".
