### PR TITLE
HgPoller breaks with invalid UTF-8 hg output

### DIFF
--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -93,7 +93,7 @@ class HgPoller(base.PollingChangeSource):
                                    env=os.environ, errortoo=False )
         def process(output):
             # fortunately, Mercurial issues all filenames one one line
-            date, author, files, comments = output.decode(self.encoding).split(
+            date, author, files, comments = output.decode(self.encoding, errors="replace").split(
                 os.linesep, 3)
 
             if not self.usetimestamps:


### PR DESCRIPTION
If there are invalid UTF-8 characters in Mercurial's output, HgPoller
will raise an error. Invalid characters can most likely come from
commit messages.

It should use errors="replace" when decoding the output so
it handles things gracefully.
