### PR TITLE
fix get all got revisions returning int

### DIFF
--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -90,7 +90,7 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
 
     def getAllGotRevisions(self):
         all_got_revisions = self.properties.getProperty('got_revision', {})
-        # For backwards compatibility all_got_revisions not a dict if codebases
+        # For backwards compatibility all_got_revisions is not a dict if codebases
         # are not used. Convert to the default internal type (dict)
         if not isinstance(all_got_revisions, dict):
             all_got_revisions = {'': all_got_revisions}


### PR DESCRIPTION
Hi,

First of all thanks for all the good work with buildbot. Loving it so far :)

When trying to render a builder web status builbot fails with:

```
        Traceback (most recent call last):
          File "~/buildbot-env/lib/python2.7/site-packages/twisted/internet/defer.py", line 368, in callback
            self._startRunCallbacks(result)
          File "~/buildbot-env/lib/python2.7/site-packages/twisted/internet/defer.py", line 464, in _startRunCallbacks
            self._runCallbacks()
          File "~/buildbot-env/lib/python2.7/site-packages/twisted/internet/defer.py", line 551, in _runCallbacks
            current.result = callback(current.result, *args, **kw)
          File "~/buildbot-env/lib/python2.7/site-packages/twisted/internet/defer.py", line 1101, in gotResult
            _inlineCallbacks(r, g, deferred)
        --- <exception caught here> ---
          File "~/buildbot-env/lib/python2.7/site-packages/twisted/internet/defer.py", line 1045, in _inlineCallbacks
            result = g.send(result)
          File "~/buildbot-env/buildbot-src/master/buildbot/status/web/builder.py", line 288, in content
            recent.append(self.get_line_values(req, build, False))
          File "~/buildbot-env/buildbot-src/master/buildbot/status/web/base.py", line 444, in get_line_values
            rev = all_got_revision.get(ss_list[0].codebase, "??")
        exceptions.AttributeError: 'int' object has no attribute 'get'
```

My buildbot configuration is copied from the sampe.cfg with a change in:

```
factory = BuildFactory()
# check out the source
factory.addStep(Bzr(repourl='/my/local/bzr/repo', mode='incremental'))
```

I am using Python 2.7.1 (r271:86832, May 23 2011, 13:26:56)

Hope this helps.
Cheers,
John
