### PR TITLE
GitPoller: Allow polling all branches, or a filtered subset of branches.

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -93,23 +93,63 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         status = ""
         if not self.master:
             status = "[STOPPED - check log]"
+        if self.branches:
+            branches = ', '.join(self.branches)
+        else:
+            branches = 'ALL'
+
         str = ('GitPoller watching the remote git repository %s, branches: %s %s'
-                % (self.repourl, ', '.join(self.branches), status))
+                % (self.repourl, ', '.join(branches), status))
         return str
+
+    def _getBranches(self):
+        d = self._dovccmd('ls-remote', [self.repourl])
+        @d.addCallback
+        def parseRemote(rows):
+            branches = []
+            for row in rows.splitlines():
+                if not '\t' in row:
+                    # Not a useful line
+                    continue
+                sha, ref = row.split("\t")
+                branches.append(ref)
+            return branches
+        return d
+
+    def _headsFilter(self, branch):
+        """Filter out remote references that don't begin with 'refs/heads'."""
+        return branch.startswith("refs/heads/")
+
+    def _removeHeads(self, branch):
+        """Remove 'refs/heads/' prefix from remote references."""
+        if branch.startswith("refs/heads/"):
+            branch = branch[11:]
+        return branch
 
     @defer.inlineCallbacks
     def poll(self):
         yield self._dovccmd('init', ['--bare', self.workdir])
 
+        branches = self.branches
+        if branches is True or callable(branches):
+            branches = yield self._getBranches()
+            if callable(self.branches):
+                branches = filter(self.branches, branches)
+            else:
+                branches = filter(self._headsFilter, branches)
+            # We remove the refs/heads/ prefix here, so that
+            # poller state with bare branch names is respected
+            branches = map(self._removeHeads, branches)
+
         refspecs = [
                 '+%s:%s'% (branch, self._localBranch(branch))
-                for branch in self.branches
+                for branch in branches
                 ]
         yield self._dovccmd('fetch',
                 [self.repourl] + refspecs, path=self.workdir)
 
         revs = {}
-        for branch in self.branches:
+        for branch in branches:
             try:
                 revs[branch] = rev = yield self._dovccmd('rev-parse',
                         [self._localBranch(branch)], path=self.workdir)

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -15,6 +15,7 @@
 
 import os
 import mock
+import re
 from twisted.trial import unittest
 from twisted.internet import defer
 from buildbot.changes import base, gitpoller
@@ -393,6 +394,74 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
 
         return d
 
+    def test_poll_allBranches_single(self):
+        self.expectCommands(
+                gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
+                gpo.Expect('git', 'ls-remote', self.REPOURL)
+                    .stdout('4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master\n'),
+                gpo.Expect('git', 'fetch', self.REPOURL,
+                    '+master:refs/buildbot/%s/master' % self.REPOURL_QUOTED)
+                    .path('gitpoller-work'),
+                gpo.Expect('git', 'rev-parse',
+                    'refs/buildbot/%s/master' % self.REPOURL_QUOTED)
+                    .path('gitpoller-work')
+                    .stdout('4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
+                gpo.Expect('git', 'log',
+                    'fa3ae8ed68e664d4db24798611b352e3c6509930..4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                    '--format=%H')
+                    .path('gitpoller-work')
+                    .stdout('\n'.join([
+                        '64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
+                        '4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
+                )
+
+        # and patch out the _get_commit_foo methods which were already tested
+        # above
+        def timestamp(rev):
+            return defer.succeed(1273258009.0)
+        self.patch(self.poller, '_get_commit_timestamp', timestamp)
+        def author(rev):
+            return defer.succeed('by:' + rev[:8])
+        self.patch(self.poller, '_get_commit_author', author)
+        def files(rev):
+            return defer.succeed(['/etc/' + rev[:3]])
+        self.patch(self.poller, '_get_commit_files', files)
+        def comments(rev):
+            return defer.succeed('hello!')
+        self.patch(self.poller, '_get_commit_comments', comments)
+
+        # do the poll
+        self.poller.branches = True
+        self.poller.lastRev = {
+                'master': 'fa3ae8ed68e664d4db24798611b352e3c6509930',
+                }
+        d = self.poller.poll()
+        @d.addCallback
+        def cb(_):
+            self.assertAllCommandsRan()
+            self.assertEqual(self.poller.lastRev, {
+                'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                })
+
+            self.assertEqual(len(self.changes_added), 2)
+
+            self.assertEqual(self.changes_added[0]['author'], 'by:4423cdbc')
+            self.assertEqual(self.changes_added[0]['when_timestamp'],
+                                        epoch2datetime(1273258009))
+            self.assertEqual(self.changes_added[0]['comments'], 'hello!')
+            self.assertEqual(self.changes_added[0]['branch'], 'master')
+            self.assertEqual(self.changes_added[0]['files'], [ '/etc/442' ])
+            self.assertEqual(self.changes_added[0]['src'], 'git')
+
+            self.assertEqual(self.changes_added[1]['author'], 'by:64a5dc2a')
+            self.assertEqual(self.changes_added[1]['when_timestamp'],
+                                        epoch2datetime(1273258009))
+            self.assertEqual(self.changes_added[1]['comments'], 'hello!')
+            self.assertEqual(self.changes_added[1]['files'], [ '/etc/64a' ])
+            self.assertEqual(self.changes_added[1]['src'], 'git')
+
+        return d
+
 
     def test_poll_noChanges(self):
         # Test that environment variables get propagated to subprocesses
@@ -428,6 +497,170 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
             self.assertEqual(self.poller.lastRev, {
                 'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
                 })
+        return d
+
+    def test_poll_allBranches_multiple(self):
+        self.expectCommands(
+                gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
+                gpo.Expect('git', 'ls-remote', self.REPOURL)
+                    .stdout('\n'.join([
+                        '4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
+                        '9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
+                        ])),
+                gpo.Expect('git', 'fetch', self.REPOURL,
+                    '+master:refs/buildbot/%s/master' % self.REPOURL_QUOTED,
+                    '+release:refs/buildbot/%s/release' % self.REPOURL_QUOTED)
+                    .path('gitpoller-work'),
+                gpo.Expect('git', 'rev-parse',
+                    'refs/buildbot/%s/master' % self.REPOURL_QUOTED)
+                    .path('gitpoller-work')
+                    .stdout('4423cdbcbb89c14e50dd5f4152415afd686c5241\n'),
+                gpo.Expect('git', 'log',
+                    'fa3ae8ed68e664d4db24798611b352e3c6509930..4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                    '--format=%H')
+                    .path('gitpoller-work')
+                    .stdout('\n'.join([
+                        '64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
+                        '4423cdbcbb89c14e50dd5f4152415afd686c5241'])),
+                gpo.Expect('git', 'rev-parse',
+                    'refs/buildbot/%s/release' % self.REPOURL_QUOTED)
+                    .path('gitpoller-work')
+                    .stdout('9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
+                gpo.Expect('git', 'log',
+                    'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5..9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+                    '--format=%H')
+                    .path('gitpoller-work')
+                    .stdout( '\n'.join([
+                        '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
+                        ])),
+                )
+
+        # and patch out the _get_commit_foo methods which were already tested
+        # above
+        def timestamp(rev):
+            return defer.succeed(1273258009.0)
+        self.patch(self.poller, '_get_commit_timestamp', timestamp)
+        def author(rev):
+            return defer.succeed('by:' + rev[:8])
+        self.patch(self.poller, '_get_commit_author', author)
+        def files(rev):
+            return defer.succeed(['/etc/' + rev[:3]])
+        self.patch(self.poller, '_get_commit_files', files)
+        def comments(rev):
+            return defer.succeed('hello!')
+        self.patch(self.poller, '_get_commit_comments', comments)
+
+        # do the poll
+        self.poller.branches = True
+        self.poller.lastRev = {
+                'master': 'fa3ae8ed68e664d4db24798611b352e3c6509930',
+                'release': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
+                }
+        d = self.poller.poll()
+        @d.addCallback
+        def cb(_):
+            self.assertAllCommandsRan()
+            self.assertEqual(self.poller.lastRev, {
+                'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
+                'release': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
+                })
+
+            self.assertEqual(len(self.changes_added), 3)
+
+            self.assertEqual(self.changes_added[0]['author'], 'by:4423cdbc')
+            self.assertEqual(self.changes_added[0]['when_timestamp'],
+                                        epoch2datetime(1273258009))
+            self.assertEqual(self.changes_added[0]['comments'], 'hello!')
+            self.assertEqual(self.changes_added[0]['branch'], 'master')
+            self.assertEqual(self.changes_added[0]['files'], [ '/etc/442' ])
+            self.assertEqual(self.changes_added[0]['src'], 'git')
+
+            self.assertEqual(self.changes_added[1]['author'], 'by:64a5dc2a')
+            self.assertEqual(self.changes_added[1]['when_timestamp'],
+                                        epoch2datetime(1273258009))
+            self.assertEqual(self.changes_added[1]['comments'], 'hello!')
+            self.assertEqual(self.changes_added[1]['files'], [ '/etc/64a' ])
+            self.assertEqual(self.changes_added[1]['src'], 'git')
+
+            self.assertEqual(self.changes_added[2]['author'], 'by:9118f4ab')
+            self.assertEqual(self.changes_added[2]['when_timestamp'],
+                                        epoch2datetime(1273258009))
+            self.assertEqual(self.changes_added[2]['comments'], 'hello!')
+            self.assertEqual(self.changes_added[2]['files'], [ '/etc/911' ])
+            self.assertEqual(self.changes_added[2]['src'], 'git')
+
+        return d
+
+    def test_poll_branchFilter(self):
+        self.expectCommands(
+                gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
+                gpo.Expect('git', 'ls-remote', self.REPOURL)
+                    .stdout('\n'.join([
+                        '4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/pull/410/merge',
+                        '9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/pull/410/head',
+                        ])),
+                gpo.Expect('git', 'fetch', self.REPOURL,
+                    '+refs/pull/410/head:refs/buildbot/%s/refs/pull/410/head' % self.REPOURL_QUOTED)
+                    .path('gitpoller-work'),
+                gpo.Expect('git', 'rev-parse',
+                    'refs/buildbot/%s/refs/pull/410/head' % self.REPOURL_QUOTED)
+                    .path('gitpoller-work')
+                    .stdout('9118f4ab71963d23d02d4bdc54876ac8bf05acf2'),
+                gpo.Expect('git', 'log',
+                    'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5..9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
+                    '--format=%H')
+                    .path('gitpoller-work')
+                    .stdout( '\n'.join([
+                        '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
+                        ])),
+                )
+
+        # and patch out the _get_commit_foo methods which were already tested
+        # above
+        def timestamp(rev):
+            return defer.succeed(1273258009.0)
+        self.patch(self.poller, '_get_commit_timestamp', timestamp)
+        def author(rev):
+            return defer.succeed('by:' + rev[:8])
+        self.patch(self.poller, '_get_commit_author', author)
+        def files(rev):
+            return defer.succeed(['/etc/' + rev[:3]])
+        self.patch(self.poller, '_get_commit_files', files)
+        def comments(rev):
+            return defer.succeed('hello!')
+        self.patch(self.poller, '_get_commit_comments', comments)
+
+        def pullFilter(branch):
+            """
+            Note that this isn't useful in practice, because it will only
+            pick up *changes* to pull requests, not the original request.
+            """
+            return re.match('^refs/pull/[0-9]*/head$', branch)
+
+        # do the poll
+        self.poller.branches = pullFilter
+        self.poller.lastRev = {
+                'master': 'fa3ae8ed68e664d4db24798611b352e3c6509930',
+                'refs/pull/410/head': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
+                }
+        d = self.poller.poll()
+        @d.addCallback
+        def cb(_):
+            self.assertAllCommandsRan()
+            self.assertEqual(self.poller.lastRev, {
+                'master': 'fa3ae8ed68e664d4db24798611b352e3c6509930',
+                'refs/pull/410/head': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2'
+                })
+
+            self.assertEqual(len(self.changes_added), 1)
+
+            self.assertEqual(self.changes_added[0]['author'], 'by:9118f4ab')
+            self.assertEqual(self.changes_added[0]['when_timestamp'],
+                                        epoch2datetime(1273258009))
+            self.assertEqual(self.changes_added[0]['comments'], 'hello!')
+            self.assertEqual(self.changes_added[0]['files'], [ '/etc/911' ])
+            self.assertEqual(self.changes_added[0]['src'], 'git')
+
         return d
 
     def test_poll_old(self):
@@ -553,7 +786,7 @@ class TestGitPollerConstructor(unittest.TestCase, config.ConfigErrorsMixin):
 
     def test_branches_default(self):
         poller = gitpoller.GitPoller("/tmp/git.git")
-        self.assertEqual(poller.branches, ["master"])
+        self.assertEqual(poller.branches, ['master'])
 
     def test_branches_oldBranch(self):
         poller = gitpoller.GitPoller("/tmp/git.git", branch='magic')
@@ -563,6 +796,10 @@ class TestGitPollerConstructor(unittest.TestCase, config.ConfigErrorsMixin):
         poller = gitpoller.GitPoller("/tmp/git.git",
                 branches=['magic', 'marker'])
         self.assertEqual(poller.branches, ["magic", "marker"])
+
+    def test_branches_True(self):
+        poller = gitpoller.GitPoller("/tmp/git.git", branches=True)
+        self.assertEqual(poller.branches, True)
 
     def test_branches_andBranch(self):
         self.assertRaisesConfigError("can't specify both branch and branches",

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -1036,7 +1036,12 @@ arguments:
     (see the :command:`git fetch` help for more info on git-url formats)
 
 ``branches``
-    a list of the branches to fetch, will default to ``['master']``
+    One of the following:
+
+    * a list of the branches to fetch.
+    * ``True`` indicating that all branches should be fetched
+    * a callable which takes a single argument.
+      It should take a remote refspec (such as ``'refs/heads/master'``, and return a boolean indicating whether that branch should be fetched.
 
 ``branch``
     accepts a single branch name to fetch.


### PR DESCRIPTION
The make the `branches` argument accept either `True` to poll all branches,
or a callable to filter the remote branches.

Supersedes #490.
