### PR TITLE
irc: Use reactor.stop, instead of sending SIGTERM to ourself.

### DIFF
--- a/master/buildbot/status/words.py
+++ b/master/buildbot/status/words.py
@@ -13,7 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
-import re, shlex, random, os, signal
+import re, shlex, random
 from string import join, capitalize, lower
 
 from zope.interface import implements
@@ -754,8 +754,8 @@ class IRCContact(base.StatusReceiver):
                 self.send("Stopping clean shutdown")
                 botmaster.cancelCleanShutdown()
         elif args == 'now':
-            self.send("Sending signal SIGTERM")
-            os.kill(os.getpid(), signal.SIGTERM)
+            self.send("Stopping buildbot")
+            reactor.stop()
     command_SHUTDOWN.usage = {
         None: "shutdown check|start|stop|now - shutdown the buildbot master",
         "check": "shutdown check - check if the buildbot master is running or shutting down",

--- a/master/buildbot/test/unit/test_status_words.py
+++ b/master/buildbot/test/unit/test_status_words.py
@@ -13,7 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
-import mock, os, signal
+import mock
 from twisted.trial import unittest
 from twisted.application import internet
 from twisted.internet import task, reactor
@@ -219,14 +219,12 @@ class TestIrcContactChannel(unittest.TestCase):
         self.assertEqual(self.bot.master.botmaster.shuttingDown, False)
 
     def test_command_shutdown_now(self):
-        self.killargs = None
-        def kill(*args):
-            self.killargs = args
-        self.patch(os, 'kill', kill)
+        stop = mock.Mock()
+        self.patch(reactor, 'stop', stop)
         self.do_test_command('shutdown', args='now', allowShutdown=True)
         self.assertEqual(self.bot.factory.allowShutdown, True)
         self.assertEqual(self.bot.master.botmaster.shuttingDown, False)
-        self.assertEqual(self.killargs, (os.getpid(), signal.SIGTERM))
+        stop.assert_called_with()
 
     def test_command_source(self):
         self.do_test_command('source')


### PR DESCRIPTION
SIGTERM just causes reactor.stop, so just do it ourselves, rather than
involving the operating system.
