### PR TITLE
Report missing python-dateutil at config time, rather than later.

### DIFF
--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -23,6 +23,15 @@ from twisted.internet import defer, reactor
 from twisted.python import log
 from buildbot import config
 from buildbot.changes import filter
+# Import croniter if available.
+# This is only required for Nightly schedulers,
+# so fail gracefully if it isn't present.
+try:
+    from buildbot.util import croniter
+except ImportError:
+    # Pyflakes doesn't like a redefinition here
+    # Instead, we check if croniter is defined when we need it
+    pass
 
 class Timed(base.BaseScheduler):
     """
@@ -240,6 +249,12 @@ class NightlyBase(Timed):
         self.month = month
         self.dayOfWeek = dayOfWeek
 
+        try:
+            croniter
+        except NameError:
+            config.error("python-dateutil required for scheduler %s '%s'." %
+                (self.__class__.__name__, self.name))
+
     def _timeToCron(self, time, isDayOfWeek = False):
         if isinstance(time, int):
             if isDayOfWeek:
@@ -255,9 +270,6 @@ class NightlyBase(Timed):
         return ','.join([ str(s) for s in time ]) # Convert the list to a string
 
     def getNextBuildTime(self, lastActuated):
-        # deferred import in case python-dateutil is not present
-        from buildbot.util import croniter
-
         dateTime = lastActuated or self.now()
         sched =  '%s %s %s %s %s' % (self._timeToCron(self.minute),
                                      self._timeToCron(self.hour),


### PR DESCRIPTION
The test is somewhat fragile.
