### PR TITLE
Fix perforce patch generation

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -237,7 +237,7 @@ class PerforceExtractor(SourceStampExtractor):
         self.patch = (patchlevel, mpatch)
 
     def getPatch(self, res):
-        d = self.dovc(["diff", "-du"])
+        d = self.dovc(["diff"])
         d.addCallback(self.readPatch, self.patchlevel)
         return d
 


### PR DESCRIPTION
The initial command to generate patch "p4 diff -du" doesn't work as the produced output is in this format:

--- //depot/v3.1.build/CMakeLists.txt   2012-11-30 17:44:14.000000000 0100
+++ d:\v3.1.build\CMakeLists.txt        2012-11-30 17:44:14.000000000 0100
@@ -170,3 +170,5 @@

+
+"Test patch"

where as the "readPatch" for perforce client is waiting for output in this format:

> p4 diff

==== //depot/v3.1.build/CMakeLists.txt#25 - d:\v3.1.build\CMakeLists.txt ====
172a173,174

> "Test patch"
