### PR TITLE
Fixed try builds not being scheduled when more than one is pending

### DIFF
--- a/master/buildbot/sourcestamp.py
+++ b/master/buildbot/sourcestamp.py
@@ -179,7 +179,8 @@ class SourceStamp(util.ComparableMixin, styles.Versioned):
         if other.project != self.project:
             return False
         if self.patch or other.patch:
-            return False # you can't merge patched builds with anything
+            # you can't merge patched builds with anything else
+            return self is other
 
         if self.changes and other.changes:
             return True

--- a/master/buildbot/test/unit/test_sourcestamp.py
+++ b/master/buildbot/test/unit/test_sourcestamp.py
@@ -172,7 +172,13 @@ class TestBuilderBuildCreation(unittest.TestCase):
                 project='p', repository='r', codebase='cbA', changes=[])
         ss2 = sourcestamp.SourceStamp(branch='dev', revision='xyz',
                 project='p', repository='r', codebase='cbB', changes=[])
-        self.assertFalse(ss1.canBeMergedWith(ss2))        
+        self.assertFalse(ss1.canBeMergedWith(ss2))
+        
+    def test_canBeMergedWith_with_two_identical_patched_sourcestamps(self):
+        ss = sourcestamp.SourceStamp(branch='dev', revision='xyz',
+                project='p', repository='r', codebase='cbA', changes=[],
+                patch=(1, ''))
+        self.assertTrue(ss.canBeMergedWith(ss))        
 
     def test_constructor_most_recent_change(self):
         chgs = [


### PR DESCRIPTION
Probably the same issue as reported by kaie on #buildbot (builds pending and not scheduled despite idle slave available). I've managed to reproduce it and confirm it's fixed by additional functional testing.
