### PR TITLE
Lock management: store LockAccess instances in class instances

### DIFF
--- a/master/buildbot/buildslave.py
+++ b/master/buildbot/buildslave.py
@@ -124,12 +124,8 @@ class AbstractBuildSlave(config.ReconfigurableServiceMixin, pb.Avatar,
             s.unsubscribe()
 
         # convert locks into their real form
-        locks = []
-        for access in self.access:
-            if not isinstance(access, LockAccess):
-                access = access.defaultAccess()
-            lock = self.botmaster.getLockByID(access.lockid)
-            locks.append((lock, access))
+        locks = [ (self.botmaster.getLockFromLockAccess(a), a)
+                    for a in self.access ]
         self.locks = [(l.getLock(self), la) for l, la in locks]
         self.lock_subscriptions = [ l.subscribeToReleases(self._lockReleased)
                                     for l, la in self.locks ]

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -292,6 +292,14 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
         # be hashable and that they should compare properly.
         return self.locks[lockid]
 
+    def getLockFromLockAccess(self, access):
+        # Convert a lock-access object into an actual Lock instance.
+        if not isinstance(access, locks.LockAccess):
+            # Buildbot 0.7.7 compability: user did not specify access
+            access = access.defaultAccess()
+        lock = self.getLockByID(access.lockid)
+        return lock
+
     def maybeStartBuildsForBuilder(self, buildername):
         """
         Call this when something suggests that a particular builder may now

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -522,17 +522,13 @@ class BuildStep(object, properties.PropertiesMixin):
         self.remote = remote
         self.deferred = defer.Deferred()
         # convert all locks into their real form
-        lock_list = []
-        for access in self.locks:
-            if not isinstance(access, locks.LockAccess):
-                # Buildbot 0.7.7 compability: user did not specify access
-                access = access.defaultAccess()
-            lock = self.build.builder.botmaster.getLockByID(access.lockid)
-            lock_list.append((lock, access))
-        self.locks = lock_list
+        self.locks = [(self.build.builder.botmaster.getLockByID(access.lockid), access) 
+                        for access in self.locks ]
         # then narrow SlaveLocks down to the slave that this build is being
         # run on
-        self.locks = [(l.getLock(self.build.slavebuilder.slave), la) for l, la in self.locks]
+        self.locks = [(l.getLock(self.build.slavebuilder.slave), la) 
+                        for l, la in self.locks ]
+
         for l, la in self.locks:
             if l in self.build.locks:
                 log.msg("Hey, lock %s is claimed by both a Step (%s) and the"

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -30,3 +30,6 @@ class FakeBotMaster(service.MultiService):
         # that this requires that MasterLock and SlaveLock (marker) instances
         # be hashable and that they should compare properly.
         return self.locks[lockid]
+
+    def getLockFromLockAccess(self, access):
+        return self.getLockByID(access.lockid)

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -17,6 +17,7 @@ import weakref
 from twisted.internet import defer
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import pbmanager
+from buildbot.test.fake.botmaster import FakeBotMaster
 from buildbot import config
 import mock
 
@@ -41,11 +42,6 @@ class FakeCaches(object):
 
     def get_cache(self, name, miss_fn):
         return FakeCache(name, miss_fn)
-
-
-class FakeBotMaster(object):
-
-    pass
 
 
 class FakeStatus(object):
@@ -92,7 +88,7 @@ class FakeMaster(object):
         self.caches = FakeCaches()
         self.pbmanager = pbmanager.FakePBManager()
         self.basedir = 'basedir'
-        self.botmaster = FakeBotMaster()
+        self.botmaster = FakeBotMaster(master=self)
         self.botmaster.parent = self
         self.status = FakeStatus()
         self.status.master = self

--- a/master/buildbot/test/unit/test_buildslave.py
+++ b/master/buildbot/test/unit/test_buildslave.py
@@ -212,7 +212,7 @@ class TestAbstractBuildSlave(unittest.TestCase):
         botmaster = FakeBotMaster(master)
         botmaster.startService()
         lock = locks.MasterLock('masterlock')
-        bs = self.ConcreteBuildSlave('bot', 'pass', locks = [lock])
+        bs = self.ConcreteBuildSlave('bot', 'pass', locks = [lock.access("counting")])
         bs.setServiceParent(botmaster)
 
     def test_setServiceParent_slaveLocks(self):
@@ -223,5 +223,5 @@ class TestAbstractBuildSlave(unittest.TestCase):
         botmaster = FakeBotMaster(master)
         botmaster.startService()
         lock = locks.SlaveLock('lock')
-        bs = self.ConcreteBuildSlave('bot', 'pass', locks = [lock])
+        bs = self.ConcreteBuildSlave('bot', 'pass', locks = [lock.access("counting")])
         bs.setServiceParent(botmaster)

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -22,6 +22,8 @@ from buildbot.process.properties import Properties
 from buildbot.status.results import FAILURE, SUCCESS, WARNINGS, RETRY, EXCEPTION
 from buildbot.locks import SlaveLock
 from buildbot.process.buildstep import LoggingBuildStep
+from buildbot.test.fake.fakemaster import FakeBotMaster
+from buildbot import config
 
 from mock import Mock
 
@@ -72,6 +74,7 @@ class FakeMaster:
     def __init__(self):
         self.locks = {}
         self.parent = Mock()
+        self.config = config.MasterConfig()
         
     def getLockByID(self, lockid):
         if not lockid in self.locks:
@@ -104,10 +107,16 @@ class TestBuild(unittest.TestCase):
         self.request = r
         self.master = FakeMaster()
 
+        self.master.botmaster = FakeBotMaster(master=self.master)
+
+        self.builder = self.createBuilder()
         self.build = Build([r])
-        self.builder = Mock()
-        self.builder.botmaster = self.master
         self.build.setBuilder(self.builder)
+
+    def createBuilder(self):
+        bldr = Mock()
+        bldr.botmaster = self.master.botmaster
+        return bldr
 
     def testRunSuccessfulBuild(self):
         b = self.build
@@ -204,7 +213,7 @@ class TestBuild(unittest.TestCase):
             return real_lock.old_claim(owner, access)
         real_lock.old_claim = real_lock.claim
         real_lock.claim = claim
-        b.setLocks([l])
+        b.setLocks([lock_access])
 
         step = Mock()
         step.return_value = step
@@ -223,9 +232,8 @@ class TestBuild(unittest.TestCase):
         counting locks cannot jump ahead of exclusive locks"""
         eBuild = self.build
 
+        cBuilder = self.createBuilder()
         cBuild = Build([self.request])
-        cBuilder = Mock()
-        cBuilder.botmaster = self.master
         cBuild.setBuilder(cBuilder)
 
         eSlavebuilder = Mock()
@@ -236,7 +244,7 @@ class TestBuild(unittest.TestCase):
 
         l = SlaveLock('lock', 2)
         claimLog = []
-        realLock = self.master.getLockByID(l).getLock(slave)
+        realLock = self.master.botmaster.getLockByID(l).getLock(slave)
         def claim(owner, access):
             claimLog.append(owner)
             return realLock.oldClaim(owner, access)
@@ -285,7 +293,7 @@ class TestBuild(unittest.TestCase):
             return real_lock.old_claim(owner, access)
         real_lock.old_claim = real_lock.claim
         real_lock.claim = claim
-        b.setLocks([l])
+        b.setLocks([lock_access])
 
         step = Mock()
         step.return_value = step
@@ -311,7 +319,7 @@ class TestBuild(unittest.TestCase):
         lock_access = l.access('counting')
         l.access = lambda mode: lock_access
         real_lock = b.builder.botmaster.getLockByID(l).getLock(slavebuilder)
-        b.setLocks([l])
+        b.setLocks([lock_access])
 
         step = Mock()
         step.return_value = step
@@ -344,7 +352,7 @@ class TestBuild(unittest.TestCase):
         lock_access = l.access('counting')
         l.access = lambda mode: lock_access
         real_lock = b.builder.botmaster.getLockByID(l).getLock(slavebuilder)
-        b.setLocks([l])
+        b.setLocks([lock_access])
 
         step = Mock()
         step.return_value = step


### PR DESCRIPTION
Moves some common code of converting between Lock and LockAccess to a common
place. 

Unit tests pass.
