### PR TITLE
Remove potentially misleading message about rebuilding builds.

### DIFF
--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -247,12 +247,9 @@ class StatusResourceBuild(HtmlResource):
             now = util.now()
             cxt['elapsed'] = util.formatInterval(now - start)
             
-        exactly = True
         has_changes = False
         for ss in sourcestamps:
-            exactly = exactly and (ss.revision is not None)
             has_changes = has_changes or ss.changes
-        cxt['exactly'] = (exactly) or b.getChanges()
         cxt['has_changes'] = has_changes
         cxt['build_url'] = path_to_build(req, b)
         cxt['authz'] = self.getAuthz(req)

--- a/master/buildbot/status/web/templates/build.html
+++ b/master/buildbot/status/web/templates/build.html
@@ -215,7 +215,7 @@ SourceStamps:
 
   {% if authz.advertiseAction('forceBuild', request) %}
     <h3>Resubmit Build:</h3>
-    {{ forms.rebuild_build(build_url+"/rebuild", authz, exactly, sourcestamps[0]) }}
+    {{ forms.rebuild_build(build_url+"/rebuild", authz, sourcestamps[0]) }}
   {% endif %}
 
 </div>

--- a/master/buildbot/status/web/templates/forms.html
+++ b/master/buildbot/status/web/templates/forms.html
@@ -185,23 +185,8 @@
   </form>
 {% endmacro %}
 
-{% macro rebuild_build(rebuild_url, authz, exactly, ss) %}
+{% macro rebuild_build(rebuild_url, authz, ss) %}
  <form method="post" action="{{ rebuild_url }}" class="command rebuild">
-
-    {% if exactly %}
-      <p>This tree was built from a specific set of
-          source files, and can be rebuilt exactly</p>
-    {% else %}
-      <p>This tree was built from the most recent revision
-      {% if ss.branch %}
-        (along branch {{ ss.branch }})
-      {% endif %}
-      and thus it might not be possible to rebuild it
-      exactly. <br/>Any changes that have been committed
-      after this build was started <b>will</b> be
-      included in a rebuild.</p>
-    {% endif %}
-
 
   {% if on_all %}
      <p>To force a build on <strong>all Builders</strong>, fill out the following fields

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -34,6 +34,9 @@ Deprecations, Removals, and Non-Compatible Changes
 * StatusReceivers' checkConfig method should no longer take an `errors`
   parameter. It should indicate errors by calling :py:function:`~buildbot.config.error`.
 
+* The web status no longer displays a potentially misleading message, indicating whether the build
+  can be rebuilt exactly.
+
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
It isn't possible to reliably detect when a build can be rebuilt exactly,
so don't try.

Fixes #2377.
