### PR TITLE
 svnpoller: Don't fail when revisions contain changes outside our prefix.

### DIFF
--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -213,7 +213,7 @@ class SVNPoller(base.PollingChangeSource, util.ComparableMixin):
             if not self.svnurl.startswith(root):
                 log.msg(format="svnurl='%(svnurl)s' doesn't start with <root>='%(root)s'",
                         svnurl=self.svnurl, root=root)
-                raise RuntimeError("Can't handle redirected svn connections!?"
+                raise RuntimeError("Can't handle redirected svn connections!? "
                         "This shouldn't happen.")
             prefix = self.svnurl[len(root):]
             if prefix.startswith("/"):


### PR DESCRIPTION
When getting the logs, revisions that don't affect the SVNPoller.svnurl path
are already being filtered out by svn.  Since the poller doesn't even consider
them, I would expect it not to consider unrelated paths that come with the logs
and just filter them out.

Fixes #385.
