### PR TITLE
SVN: Add option to use 'Last Changed Rev' instead of global 'Revision'

### DIFF
--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -37,7 +37,7 @@ class SVN(Source):
     def __init__(self, repourl=None, mode='incremental',
                  method=None, username=None,
                  password=None, extra_args=None, keep_on_purge=None,
-                 depth=None, **kwargs):
+                 depth=None, preferLastChangedRev=False, **kwargs):
 
         self.repourl = repourl
         self.username = username
@@ -47,6 +47,7 @@ class SVN(Source):
         self.depth = depth
         self.method = method
         self.mode = mode
+        self.preferLastChangedRev = preferLastChangedRev
         Source.__init__(self, **kwargs)
         errors = []
         if self.mode not in self.possible_modes:
@@ -250,6 +251,7 @@ class SVN(Source):
         defer.returnValue(mo and mo.group(1) == self.repourl)
         return
 
+    @defer.inlineCallbacks
     def parseGotRevision(self, _):
         # if this was a full/export, then we need to check svnversion in the
         # *source* directory, not the build directory
@@ -262,23 +264,41 @@ class SVN(Source):
                                            timeout=self.timeout,
                                            collectStdout=True)
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
-        def _setrev(_):
-            stdout = cmd.stdout
-            try:
-                stdout_xml = xml.dom.minidom.parseString(stdout)
-                match = stdout_xml.getElementsByTagName('entry')[0].attributes['revision'].value
-            except xml.parsers.expat.ExpatError:
-                msg = "Corrupted xml, aborting step"
-                self.stdio_log.addHeader(msg)
-                raise buildstep.BuildStepFailed()
-            revision = match
-            msg = "Got SVN revision %s" % (revision, )
+        yield self.runCommand(cmd)
+
+        stdout = cmd.stdout
+        try:
+            stdout_xml = xml.dom.minidom.parseString(stdout)
+        except xml.parsers.expat.ExpatError:
+            msg = "Corrupted xml, aborting step"
             self.stdio_log.addHeader(msg)
-            self.updateSourceProperty('got_revision', revision)
-            return 0
-        d.addCallback(lambda _: _setrev(cmd.rc))
-        return d
+            raise buildstep.BuildStepFailed()
+
+        revision = None
+        if self.preferLastChangedRev:
+            try:
+                revision = stdout_xml.getElementsByTagName('commit')[0].attributes['revision'].value
+            except (KeyError, IndexError):
+                msg =("SVN.parseGotRevision unable to detect Last Changed Rev in"
+                      " output of svn info")
+                log.msg(msg)
+                # fall through and try to get 'Revision' instead
+
+        if revision is None:
+            try:
+                revision = stdout_xml.getElementsByTagName('entry')[0].attributes['revision'].value
+            except (KeyError, IndexError):
+                msg =("SVN.parseGotRevision unable to detect revision in"
+                      " output of svn info")
+                log.msg(msg)
+                raise buildstep.BuildStepFailed()
+
+        msg = "Got SVN revision %s" % (revision, )
+        self.stdio_log.addHeader(msg)
+        self.updateSourceProperty('got_revision', revision)
+
+        defer.returnValue(cmd.rc)
+
 
     def purge(self, ignore_ignores):
         """Delete everything that shown up on status."""

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -519,6 +519,11 @@ Alternatively, the ``repourl`` argument can be used to create the :bb:step:`SVN`
    have depth-infinity. Infinity is equivalent to SVN default update
    behavior, without specifying any depth argument. 
 
+``preferLastChangedRev``
+   (optional): By default, the ``got_revision`` property is set to the
+   repository's global revision ("Revision" in the `svn info` output). Set this
+   parameter to ``True`` to have it set to the "Last Changed Rev" instead.
+
 ``mode``
 ``method``
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -33,6 +33,8 @@ Features
 
 * The latent buildslave support is less buggy, thanks to :bb:pull:`646`.
 
+* :bb:step:`SVN` has a new option `preferLastChangedRev=True` to use the last changed revision for ``got_revision``
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
A simple patch to capture the last-changed revision in SVN rather than the repository revision.
