### PR TITLE
Add a "show more builds" link on the builder page

### DIFF
--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -288,7 +288,7 @@ class StatusResourceBuilder(HtmlResource, BuildLineMixin):
                 'properties' : properties,
                 })
 
-        numbuilds = int(req.args.get('numbuilds', [self.numbuilds])[0])
+        numbuilds = cxt['numbuilds'] = int(req.args.get('numbuilds', [self.numbuilds])[0])
         recent = cxt['recent'] = []
         for build in b.generateFinishedBuilds(num_builds=int(numbuilds)):
             recent.append(self.get_line_values(req, build, False))

--- a/master/buildbot/status/web/templates/builder.html
+++ b/master/buildbot/status/web/templates/builder.html
@@ -74,6 +74,8 @@
 
 {{ build_table(recent) }}
 
+<a href="?numbuilds={{numbuilds + 5}}">Show more</a>
+
 </div>
 <div class="column">
 


### PR DESCRIPTION
This way the ?numbuilds parameter becomes discoverable.
