### PR TITLE
db_poller isn't getting adjusted

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -82,7 +82,7 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
         # loop for polling the db
         self.db_loop = None
         # db configured values
-        self.configured_url = None
+        self.configured_db_url = None
         self.configured_poll_interval = None        
 
         # configuration / reconfiguration handling
@@ -172,7 +172,6 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
             try:
                 self.config = config.MasterConfig.loadConfig(self.basedir,
                                                         self.configFileName)
-                self.configured_url = self.config.db['db_url']
                 
             except config.ConfigErrors, e:
                 log.msg("Configuration Errors:")
@@ -299,7 +298,9 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
 
     def reconfigService(self, new_config):
-        if self.configured_url != new_config.db['db_url']:
+        if self.configured_db_url is None:
+            self.configured_db_url = new_config.db['db_url']
+        elif (self.configured_db_url != new_config.db['db_url']):
             config.error(
                 "Cannot change c['db']['db_url'] after the master has started",
             )

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -9,6 +9,7 @@ Release Notes for Buildbot |version|
 The following are the release notes for Buildbot |version|.
 
 * The ``MasterShellCommand`` step now correctly handles environment variables passed as list.
+* The master now poll the database for pending tasks when running buildbot in multi-master mode.
 
 Master
 ------


### PR DESCRIPTION
At the time we call def reconfigService(self, new_config):
self.config.db['db_poll_interval']  has the new value already assigned,
so this comparison is never true
https://github.com/buildbot/buildbot/blob/master/master/buildbot/master.py#L303
if (self.config.db['db_poll_interval']   !=
new_config.db['db_poll_interval'])

and the db_poller isn't getting adjusted, changed the reconfigService
implementations to store initial configuration in object attributes, and
compare those attributes to new_config.
