### PR TITLE
BuildslaveChoiceParameter and EnforceChosenSlave

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -30,7 +30,7 @@ from buildbot.process import buildrequest, slavebuilder
 from buildbot.process.build import Build
 from buildbot.process.slavebuilder import BUILDING
 
-def EnforceChosenSlave(bldr, slavebuilder, breq):
+def enforceChosenSlave(bldr, slavebuilder, breq):
     if 'slavename' in breq.properties:
         slavename = breq.properties['slavename']
         if isinstance(slavename, basestring):

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -249,8 +249,8 @@ class InheritBuildParameter(ChoiceStringParameter):
 class BuildslaveChoiceParameter(ChoiceStringParameter):
     """A parameter that lets the buildslave name be explicitly chosen.
 
-    This parameter works in conjunction with 'builder.EnforceChosenSlave', which
-    should be added as the 'canStartBuild' parameter to the Builder.
+    This parameter works in conjunction with 'buildbot.process.builder.enforceChosenSlave', 
+    which should be added as the 'canStartBuild' parameter to the Builder.
 
     The "anySentinel" parameter represents the sentinel value to specify that 
     there is no buildslave preference.

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -89,7 +89,6 @@ class BuildRequest(Row):
         results = -1,
         submitted_at = 0,
         complete_at = 0,
-        properties = {}
     )
 
     id_column = 'id'

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -260,11 +260,11 @@ class TestBuilderBuildCreation(BuilderMixin, unittest.TestCase):
         self.assertEqual(record, [(self.bldr, 'slave', 100), (self.bldr, 'slave', 101)])
 
     @defer.inlineCallbacks
-    def test_EnforceChosenSlave(self):
-        """EnforceChosenSlave rejects and accepts builds"""
+    def test_enforceChosenSlave(self):
+        """enforceChosenSlave rejects and accepts builds"""
         yield self.makeBuilder()
 
-        self.bldr.config.canStartBuild = builder.EnforceChosenSlave
+        self.bldr.config.canStartBuild = builder.enforceChosenSlave
 
         slave = mock.Mock()
         slave.slave.slavename = 'slave5'

--- a/master/docs/manual/cfg-schedulers.rst
+++ b/master/docs/manual/cfg-schedulers.rst
@@ -1210,12 +1210,12 @@ BuildslaveChoiceParameter
 
 This parameter allows a scheduler to require that a build is assigned to the
 chosen buildslave. The choice is assigned to the `slavename` property for the build.
-The :py:class:`~buildbot.builder.EnforceChosenSlave` functor must be assigned to
+The :py:class:`~buildbot.builder.enforceChosenSlave` functor must be assigned to
 the ``canStartBuild`` parameter for the ``Builder``.
 
 Example::
 
-    from buildbot.process.builder import EnforceChosenSlave
+    from buildbot.process.builder import enforceChosenSlave
 
     # schedulers:
         ForceScheduler(
@@ -1228,7 +1228,7 @@ Example::
     # builders:
         BuilderConfig(
           # ...
-          canStartBuild=EnforceChosenSlave,
+          canStartBuild=enforceChosenSlave,
         )
 
 AnyPropertyParameter


### PR DESCRIPTION
This is a patch for a new ForceScheduler parameter to let the user select the buildslave to use. 

There are two parts:
- the parameter
- the functor to enforce it

So some questions about this patch:
- should EnforceChosenSlave be more built in? Or opt-in as I did it here?
- if opt-in, where should it be?

For this patch, I made it opt-in and next to Builder, but I'm not sure that's the right thing.
