### PR TITLE
Ignore std error on version discovery

### DIFF
--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -30,14 +30,14 @@ try:
         version = f.read().strip()
 
 except IOError:
-    from subprocess import Popen, PIPE, STDOUT
+    from subprocess import Popen, PIPE
     import re
 
     VERSION_MATCH = re.compile(r'\d+\.\d+\.\d+(\w|-)*')
 
     try:
         dir  = os.path.dirname(os.path.abspath(__file__))
-        p = Popen(['git', 'describe', '--tags', '--always'], cwd=dir, stdout=PIPE, stderr=STDOUT)
+        p = Popen(['git', 'describe', '--tags', '--always'], cwd=dir, stdout=PIPE, stderr=PIPE)
         out = p.communicate()[0]
 
         if (not p.returncode) and out:


### PR DESCRIPTION
git may print warnings out that can confuse the parsing, and std error
could never provide a trustworthy errorn number anyway. (In my case, it
was providing a tag name which provided a valid but undesirable match,
so I was ending up with the wrong version number)
