### PR TITLE
Handle multiple codebases in Grid and Transposed Grid views

### DIFF
--- a/master/buildbot/status/web/templates/grid_macros.html
+++ b/master/buildbot/status/web/templates/grid_macros.html
@@ -17,13 +17,17 @@
 {%- endmacro %}
 
 
-{% macro stamp_td(ss) -%}
+{% macro stamp_td(sourcestamps) -%}
   <td valign="bottom" class="sourcestamp">    
-    {%- if ss.revision -%}
-    {{ ss.revision|shortrev(ss.repository) }}
-    {%- else %}latest{% endif %}
-    {%- if ss.branch %} in {{ ss.branch|e }}{% endif %}
-    {%- if ss.hasPatch %} [patch]{% endif %}
+    {% for ss in sourcestamps %}
+      {%- if ss.codebase %}{{ ss.codebase|e }}: {% endif %}
+      {%- if ss.revision -%}
+      {{ ss.revision|shortrev(ss.repository) }}
+      {%- else %}latest{% endif %}
+      {%- if ss.branch %} in {{ ss.branch|e }}{% endif %}
+      {%- if ss.hasPatch %} [patch]{% endif -%}
+    <br/>
+    {%- endfor %}
   </td>
 {%- endmacro %}
 


### PR DESCRIPTION
Should fix http://trac.buildbot.net/ticket/2466.

In current implementation builds will be in the same row/column if they have same codebases and same revisions inside codebases.
