### PR TITLE
RemoteShellCommand: add parameters to override uid and gid

### DIFF
--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -81,12 +81,15 @@ class FakeRemoteShellCommand(FakeRemoteCommand):
                  timeout=20*60, maxTime=None, logfiles={},
                  usePTY="slave-config", logEnviron=True, collectStdout=False,
                  collectStderr=False,
-                 interruptSignal=None, initialStdin=None, decodeRC={0:SUCCESS}):
+                 interruptSignal=None, initialStdin=None, decodeRC={0:SUCCESS},
+                 user=None):
         args = dict(workdir=workdir, command=command, env=env or {},
                 want_stdout=want_stdout, want_stderr=want_stderr,
                 initial_stdin=initialStdin,
                 timeout=timeout, maxTime=maxTime, logfiles=logfiles,
                 usePTY=usePTY, logEnviron=logEnviron)
+        if user is not None:
+            args['user'] = user
         FakeRemoteCommand.__init__(self, "shell", args,
                                    collectStdout=collectStdout,
                                    collectStderr=collectStderr,
@@ -283,7 +286,8 @@ class ExpectShell(Expect):
     def __init__(self, workdir, command, env={},
                  want_stdout=1, want_stderr=1, initialStdin=None,
                  timeout=20*60, maxTime=None, logfiles={},
-                 usePTY="slave-config", logEnviron=True):
+                 usePTY="slave-config", logEnviron=True,
+                 user=None):
         args = dict(workdir=workdir, command=command, env=env,
                 want_stdout=want_stdout, want_stderr=want_stderr,
                 initial_stdin=initialStdin,

--- a/master/buildbot/test/interfaces/test_remotecommand.py
+++ b/master/buildbot/test/interfaces/test_remotecommand.py
@@ -44,7 +44,7 @@ class Tests(interfaces.InterfaceTests):
                 want_stderr=1, timeout=20*60, maxTime=None, logfiles={},
                 usePTY="slave-config", logEnviron=True, collectStdout=False,
                 collectStderr=False, interruptSignal=None, initialStdin=None,
-                decodeRC={0:SUCCESS}):
+                decodeRC={0:SUCCESS}, user=None):
             pass
 
     def test_signature_run(self):

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -270,3 +270,36 @@ class TestCustomStepExecution(steps.BuildStepMixin, unittest.TestCase):
             self.assertEqual(len(self.flushLoggedErrors(ValueError)), 1)
         return d
 
+
+class RemoteShellCommandTests(object):
+
+    def test_user_argument(self):
+        """
+        Test that the 'user' parameter is correctly threaded through
+        RemoteShellCommand to the 'args' member of the RemoteCommand
+        parent command, if and only if it is passed in as a non-None
+        value.
+        """
+
+        rc = self.makeRemoteShellCommand("build", ["echo", "hello"])
+        self.assertNotIn('user', rc.args)
+
+        rc = self.makeRemoteShellCommand("build", ["echo", "hello"], user=None)
+        self.assertNotIn('user', rc.args)
+
+        user = 'test'
+        rc = self.makeRemoteShellCommand("build", ["echo", "hello"], user=user)
+        self.assertIn('user', rc.args)
+        self.assertEqual(rc.args['user'], user)
+
+
+class TestRealRemoteShellCommand(unittest.TestCase, RemoteShellCommandTests):
+
+    def makeRemoteShellCommand(self, *args, **kwargs):
+        return buildstep.RemoteShellCommand(*args, **kwargs)
+
+
+class TestFakeRemoteShellCommand(unittest.TestCase, RemoteShellCommandTests):
+
+    def makeRemoteShellCommand(self, *args, **kwargs):
+        return remotecommand.FakeRemoteShellCommand(*args, **kwargs)

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -1609,6 +1609,12 @@ The :bb:step:`ShellCommand` arguments are:
     The default is to treat just 0 as successful. (``{0:SUCCESS}``)
     any exit code not present in the dictionary will be treated as ``FAILURE``
 
+``user``
+    When this is not None, runs the command as the given user by wrapping the
+    command with 'sudo', which typically requires root permissions to run
+    (and as discussed in the :ref:`System Architecture <System-Architecture>`
+    section, is generally not a good idea).
+
 .. bb:step:: Configure
 
 Configure

--- a/master/docs/manual/introduction.rst
+++ b/master/docs/manual/introduction.rst
@@ -112,6 +112,15 @@ admin*, who do not need to be quite as involved. Generally slaves are
 run by anyone who has an interest in seeing the project work well on
 their favorite platform.
 
+While not always the case, it is typically a good idea to run the
+buildslaves with reduced privileges (e.g. not as the 'root' user).
+This protects the system installed on the machine the buildslave
+is running on from the commands that are running on behalf of the
+buildmaster. There are some cases where running buildslaves with
+admin privileges is appropriate, one example of which is doing so
+on latent slaves that are reverted to a snapshot on each startup
+and contain no sensitive information.
+
 .. _BuildSlave-Connections:
 
 BuildSlave Connections

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -48,6 +48,9 @@ Features
 * The new :bb:step:`LogRenderable` step logs Python objects, which can contain renderables, to the logfile.
   This is helpful for debugging property values during a build.
 
+* The :bb:step:`ShellCommand` step has a new parameter ``user``.  When this is set, the slave will use 'sudo' to
+  run the command as the given user.
+
 
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/slave/buildslave/commands/base.py
+++ b/slave/buildslave/commands/base.py
@@ -32,7 +32,7 @@ from buildslave import util
 # this used to be a CVS $-style "Revision" auto-updated keyword, but since I
 # moved to Darcs as the primary repository, this is updated manually each
 # time this file is changed. The last cvs_ver that was here was 1.51 .
-command_version = "2.15"
+command_version = "2.16"
 
 # version history:
 #  >=1.17: commands are interruptable
@@ -64,6 +64,7 @@ command_version = "2.15"
 #  >= 2.13: SlaveFileUploadCommand supports option 'keepstamp'
 #  >= 2.14: RemoveDirectory can delete multiple directories
 #  >= 2.15: 'interruptSignal' option is added to SlaveShellCommand
+#  >= 2.16: 'user' option is added to SlaveShellCommand
 
 class Command:
     implements(ISlaveCommand)

--- a/slave/buildslave/commands/shell.py
+++ b/slave/buildslave/commands/shell.py
@@ -39,6 +39,7 @@ class SlaveShellCommand(base.Command):
                          logfiles=args.get('logfiles', {}),
                          usePTY=args.get('usePTY', "slave-config"),
                          logEnviron=args.get('logEnviron', True),
+                         user=args.get('user'),
                          )
         if args.get('interruptSignal'):
             c.interruptSignal = args['interruptSignal']

--- a/slave/buildslave/test/fake/runprocess.py
+++ b/slave/buildslave/test/fake/runprocess.py
@@ -103,7 +103,8 @@ class FakeRunProcess:
                  sendStdout=True, sendStderr=True, sendRC=True,
                  timeout=None, maxTime=None, initialStdin=None,
                  keepStdout=False, keepStderr=False,
-                 logEnviron=True, logfiles={}, usePTY="slave-config")
+                 logEnviron=True, logfiles={}, usePTY="slave-config",
+                 user=None)
 
         if not self._expectations:
             raise AssertionError("unexpected instantiation: %s" % (kwargs,))
@@ -132,6 +133,7 @@ class FakeRunProcess:
         self._builder = builder
         self.stdout = ''
         self.stderr = ''
+        self.user = kwargs.get('user')
 
     def start(self):
         # figure out the stdio-related parameters

--- a/slave/buildslave/test/unit/test_commands_shell.py
+++ b/slave/buildslave/test/unit/test_commands_shell.py
@@ -49,4 +49,33 @@ class TestSlaveShellCommand(CommandTestMixin, unittest.TestCase):
         d.addCallback(check)
         return d
 
+    def test_user_parameter(self):
+        """
+        Test that the 'user' parameter is threaded through into the
+        underlying RunProcess object.
+        """
+
+        user = 'test'
+        self.make_command(shell.SlaveShellCommand, dict(
+            command=[ 'true' ],
+            workdir='workdir',
+            user=user,
+        ))
+
+        self.patch_runprocess(
+            Expect([ 'true', ], self.basedir_workdir, user=user)
+            + { 'hdr' : 'headers' } + { 'rc' : 0 }
+            + 0,
+        )
+
+        d = self.run_command()
+
+        # Verify that the 'user' parameter is correctly passed into the
+        # RunProcess object.
+        def check(_):
+            self.assertTrue(hasattr(self.cmd.command, 'user'))
+            self.assertEqual(self.cmd.command.user, user)
+        d.addCallback(check)
+        return d
+
     # TODO: test all functionality that SlaveShellCommand adds atop RunProcess


### PR DESCRIPTION
This adds the ability to run remote shell commands as different user when the buildslave itself is running as root (which is the case when some build steps need to run with root privileges for things like mounting and chroot'ing).  Since twisted's spawnProcess API already supports setting a uid/gid, this change basically just threads a user and group through to that call.

I was experimenting with a few tests but the situation is a bit weird since this feature relies on root perms and its unlikely that these tests will ever be run as root.  One potential test could check for a invalid permissions errors when trying to use this feature, but this would assume that the tests would always run as non-root.  If this isn't acceptable without tests as-is, I can try put something together.
