### PR TITLE
tryclient: support commas in property CLI

### DIFF
--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -401,6 +401,9 @@ class TryOptions(base.SubcommandOptions):
          "A set of properties made available in the build environment, "
          "format is --properties=prop1=value1,prop2=value2,.. "
          "option can be specified multiple times."],
+        ["property", None, None,
+         "A property made available in the build environment, "
+         "format:prop=value. Can be used multiple times."],
 
         ["topfile", None, None,
          "Name of a file at the top of the tree, used to find the top. "
@@ -461,6 +464,10 @@ class TryOptions(base.SubcommandOptions):
         for i in range(0,len(propertylist)):
             splitproperty = propertylist[i].split("=", 1)
             self['properties'][splitproperty[0]] = splitproperty[1]
+
+    def opt_property(self, option):
+        name, _, value = option.partition("=")
+        self['properties'][name] = value
 
     def opt_patchlevel(self, option):
         self['patchlevel'] = int(option)

--- a/master/buildbot/test/unit/test_scripts_runner.py
+++ b/master/buildbot/test/unit/test_scripts_runner.py
@@ -448,6 +448,31 @@ class TestTryOptions(OptionsMixin, unittest.TestCase):
         exp = self.defaults_and(properties=dict(a='b', c='d'))
         self.assertOptions(opts, exp)
 
+    def test_property(self):
+        opts = self.parse('--property=a=b')
+        exp = self.defaults_and(properties=dict(a='b'))
+        self.assertOptions(opts, exp)
+
+    def test_property_multiple_opts(self):
+        opts = self.parse('--property=X=1', '--property=Y=2')
+        exp = self.defaults_and(properties=dict(X='1', Y='2'))
+        self.assertOptions(opts, exp)
+
+    def test_property_equals(self):
+        opts = self.parse('--property=X=2+2=4')
+        exp = self.defaults_and(properties=dict(X='2+2=4'))
+        self.assertOptions(opts, exp)
+
+    def test_property_commas(self):
+        opts = self.parse('--property=a=b,c=d')
+        exp = self.defaults_and(properties=dict(a='b,c=d'))
+        self.assertOptions(opts, exp)
+
+    def test_property_and_properties(self):
+        opts = self.parse('--property=X=1', '--properties=Y=2')
+        exp = self.defaults_and(properties=dict(X='1', Y='2'))
+        self.assertOptions(opts, exp)
+
     def test_properties_builders_multiple(self):
         opts = self.parse('--builder=aa', '--builder=bb')
         exp = self.defaults_and(builders=['aa', 'bb'])

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -470,6 +470,18 @@ exiting. Unless you use the :option:`--quiet` option (or
 ``try_quiet=True``), it will emit a progress message every 60
 seconds until the builds have completed.
 
+Sending properties
+##################
+
+You can set properties to send with your change using either the
+:option:`--property=key=value` option, which sets a single property,
+or the :option:`--properties=key1=value1,key2=value2...` option,
+which sets multiple comma-separated properties.
+Either of these can be sepcified multiple times.
+Note that the :option:`--properties` option uses commas to split on
+properties, so if your property value itself contains a comma,
+you'll need to use the :option:`--property` option to set it.
+
 .. _try--diff:
 
 try --diff

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -48,6 +48,11 @@ Features
 * The new :bb:step:`LogRenderable` step logs Python objects, which can contain renderables, to the logfile.
   This is helpful for debugging property values during a build.
 
+* 'buildbot try' now has an additional :option:`--property` option to set properties.
+  Unlike the existing :option:`--properties` option, this new option supports setting
+  only a single property and therefore allows commas to be included in the property
+  name and value.
+
 
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This removes the '--properties' flag which accepted multiple
property settings, separated by commas, and replaces it with
a '--property' flag which contains a single property setting
and can be set multiple times.  This allows strings containing
commas as property values.
