### PR TITLE
Pass tryclient properties to getAvailableBuilderNames call

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -844,7 +844,13 @@ class Try(pb.Referenceable):
             "unknown connecttype '%s', should be 'pb'" % self.connect)
 
     def _getBuilderNames(self, remote, output):
-        d = remote.callRemote("getAvailableBuilderNames")
+        # Older schedulers won't support the properties argument, so only
+        # attempt to send them when necessary.
+        properties = self.config.get('properties', {})
+        if properties:
+            d = remote.callRemote("getAvailableBuilderNames", properties)
+        else:
+            d = remote.callRemote("getAvailableBuilderNames")
         d.addCallback(self._getBuilderNames2)
         return d
 

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -264,7 +264,7 @@ class Try_Userpass_Perspective(pbutil.NewCredPerspective):
         from buildbot.status.client import makeRemote
         defer.returnValue(makeRemote(bss))
 
-    def perspective_getAvailableBuilderNames(self):
+    def perspective_getAvailableBuilderNames(self, properties={}):
         # Return a list of builder names that are configured
         # for the try service
         # This is mostly intended for integrating try services

--- a/master/buildbot/test/unit/test_clients_sendchange.py
+++ b/master/buildbot/test/unit/test_clients_sendchange.py
@@ -16,52 +16,23 @@
 
 import mock
 from twisted.trial import unittest
-from twisted.spread import pb
-from twisted.internet import defer, reactor
+from twisted.internet import defer
 from buildbot.clients import sendchange
+from buildbot.test.util import pbclient
 
-class Sender(unittest.TestCase):
+class Sender(unittest.TestCase, pbclient.PBClientMixin):
 
     def setUp(self):
-        # patch out some PB components and make up some mocks
-        self.patch(pb, 'PBClientFactory', self._fake_PBClientFactory)
-        self.patch(reactor, 'connectTCP', self._fake_connectTCP)
-
-        self.factory = mock.Mock(name='PBClientFactory')
-        self.factory.login = self._fake_login
-        self.factory.login_d = defer.Deferred()
-
-        self.remote = mock.Mock(name='PB Remote')
-        self.remote.callRemote = self._fake_callRemote
-        self.remote.broker.transport.loseConnection = self._fake_loseConnection
+        self.setUpPBClient()
 
         # results
-        self.creds = None
-        self.conn_host = self.conn_port = None
-        self.lostConnection = False
         self.added_changes = []
         self.vc_used = None
-
-    def _fake_PBClientFactory(self):
-        return self.factory
-
-    def _fake_login(self, creds):
-        self.creds = creds
-        return self.factory.login_d
-
-    def _fake_connectTCP(self, host, port, factory):
-        self.conn_host = host
-        self.conn_port = port
-        self.assertIdentical(factory, self.factory)
-        self.factory.login_d.callback(self.remote)
 
     def _fake_callRemote(self, method, change):
         self.assertEqual(method, 'addChange')
         self.added_changes.append(change)
         return defer.succeed(None)
-
-    def _fake_loseConnection(self):
-        self.lostConnection = True
 
     def assertProcess(self, host, port, username, password, changes):
         self.assertEqual([host, port, username, password, changes],

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -685,6 +685,14 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, unittest.TestCase):
         def check(buildernames):
             self.assertEqual(buildernames, ['a', 'b'])
         d.addCallback(check)
+
+        # Test that getAvailabelBuilderNames also accepts the properties
+        # argument.
+        d.addCallback(
+            lambda _: persp.perspective_getAvailableBuilderNames(
+                properties={'foo': 'bar'}))
+        d.addCallback(check)
+
         return d
 
 

--- a/master/buildbot/test/util/pbclient.py
+++ b/master/buildbot/test/util/pbclient.py
@@ -1,0 +1,57 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import mock
+from twisted.internet import defer, reactor
+from twisted.spread import pb
+
+class PBClientMixin(object):
+
+    def setUpPBClient(self):
+        # patch out some PB components and make up some mocks
+        self.patch(pb, 'PBClientFactory', self._fake_PBClientFactory)
+        self.patch(reactor, 'connectTCP', self._fake_connectTCP)
+
+        self.factory = mock.Mock(name='PBClientFactory')
+        self.factory.login = self._fake_login
+        self.factory.login_d = defer.Deferred()
+
+        self.remote = mock.Mock(name='PB Remote')
+        self.remote.callRemote = self._fake_callRemote
+        self.remote.broker.transport.loseConnection = self._fake_loseConnection
+
+        # results
+        self.creds = None
+        self.conn_host = self.conn_port = None
+        self.lostConnection = False
+
+    def _fake_PBClientFactory(self):
+        return self.factory
+
+    def _fake_login(self, creds):
+        self.creds = creds
+        return self.factory.login_d
+
+    def _fake_connectTCP(self, host, port, factory):
+        self.conn_host = host
+        self.conn_port = port
+        self.assertIdentical(factory, self.factory)
+        self.factory.login_d.callback(self.remote)
+
+    def _fake_callRemote(self, method, change):
+        raise NotImplementedError()
+
+    def _fake_loseConnection(self):
+        self.lostConnection = True

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -53,6 +53,10 @@ Features
   only a single property and therefore allows commas to be included in the property
   name and value.
 
+* The ``TryScheduler`` now accepts an additional ``properties`` argument to its
+  ``getAvailableBuilderNames`` method, which 'buildbot try' uses to send the properties
+  it was passed (and are normally sent when starting a build).
+
 
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is useful to pass extra information into user-defined sub-classes of the TryScheduler.
