### PR TITLE
fix ticket 2320. 

### DIFF
--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -49,7 +49,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
                      "p4bin", "pollInterval"]
 
     env_vars = ["P4CLIENT", "P4PORT", "P4PASSWD", "P4USER",
-                "P4CHARSET"]
+                "P4CHARSET" , "PATH"]
 
     changes_line_re = re.compile(
             r"Change (?P<num>\d+) on \S+ by \S+@\S+ '.*'$")


### PR DESCRIPTION
P4Poller was not propagating the PATH from the user who starts the buildbot master. PATH has been added to the short list of environment variables propagated when calling p4 to get changes
