### PR TITLE
buildslave: don't fork when '--nodaemon' flag is passed

### DIFF
--- a/slave/buildslave/scripts/startup.py
+++ b/slave/buildslave/scripts/startup.py
@@ -83,7 +83,7 @@ def start(config):
         sys.exit(1)
 
     os.chdir(config['basedir'])
-    if config['quiet']:
+    if config['quiet'] or config['nodaemon']:
         return launch(config)
 
     # we probably can't do this os.fork under windows


### PR DESCRIPTION
The '--nodaemon' flag was added in 2ae0ecb6347c2fd7b9301fe4dc3aaeebea235280
and efc3b6853ab7b03ba35de5820292a8bd7de96596 later fixed the
build master to not fork when this flag was used.  This commit
applies roughly the same fix to the buildslave.
