### PR TITLE
Fixed grep command for IRC in log

### DIFF
--- a/master/docs/tutorial/tour.rst
+++ b/master/docs/tutorial/tour.rst
@@ -176,7 +176,7 @@ below the WebStatus line in master.cfg::
 
 Reconfigure the build master then do::
 
-  cat master/twistd.log | grep IRC
+  grep -i irc master/twistd.log
 
 The log output should contain a line like this::
 


### PR DESCRIPTION
With `grep IRC` there is not output from `cat` on the log file but with `grep -i irc` there is, see e.g.

```
$ cat master/twistd.log | grep IRC
$ cat master/twistd.log | grep -i irc
2013-04-15 13:26:44+0200 [-] Starting factory <buildbot.status.words.IrcStatusFactory instance at 0x26ab638>
2013-04-15 13:26:58+0200 [IrcStatusBot,client] <buildbot.status.words.IrcStatusBot instance at 0x23ea4d0>: I have joined #buildbot-test
2013-04-15 13:27:29+0200 [-] Starting factory <buildbot.status.words.IrcStatusFactory instance at 0x26b8170>
2013-04-15 13:27:29+0200 [IrcStatusBot,client] not scheduling reconnection attempt
2013-04-15 13:27:29+0200 [IrcStatusBot,client] Stopping factory <buildbot.status.words.IrcStatusFactory instance at 0x26ab638>
2013-04-15 13:27:42+0200 [IrcStatusBot,client] <buildbot.status.words.IrcStatusBot instance at 0x25a10e0>: I have joined #buildbot-test
```

Thus, maybe the example line from the log should be changed too as they do not seem to reflect what you get with a later version?

I use
Buildbot version: 0.8.6p1
Twisted version: 12.2.0

I have also removed the unnecessary `cat`.
