### PR TITLE
Skip unit tests when buildbot-www isn't available

### DIFF
--- a/master/buildbot/test/unit/test_scripts_create_master.py
+++ b/master/buildbot/test/unit/test_scripts_create_master.py
@@ -21,7 +21,7 @@ from twisted.trial import unittest
 from twisted.internet import defer
 from buildbot.scripts import create_master
 from buildbot.db import connector, model
-from buildbot.test.util import dirs, misc
+from buildbot.test.util import dirs, misc, www
 
 def mkconfig(**kwargs):
     config = dict(force=False, relocatable=False, config='master.cfg',
@@ -78,8 +78,8 @@ class TestCreateMaster(misc.StdoutAssertionsMixin, unittest.TestCase):
             self.assertInStdout('buildmaster configured in')
         return d
 
-class TestCreateMasterFunctions(dirs.DirsMixin, misc.StdoutAssertionsMixin,
-                                unittest.TestCase):
+class TestCreateMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
+                                misc.StdoutAssertionsMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpDirs('test')

--- a/master/buildbot/test/unit/test_scripts_upgrade_master.py
+++ b/master/buildbot/test/unit/test_scripts_upgrade_master.py
@@ -22,7 +22,7 @@ from twisted.internet import defer
 from buildbot.scripts import upgrade_master
 from buildbot import config as config_module
 from buildbot.db import connector, model
-from buildbot.test.util import dirs, misc, compat
+from buildbot.test.util import dirs, misc, compat, www
 
 def mkconfig(**kwargs):
     config = dict(quiet=False, replace=False, basedir='test')
@@ -98,8 +98,8 @@ class TestUpgradeMaster(dirs.DirsMixin, misc.StdoutAssertionsMixin,
             self.assertEqual(rv, 1)
         return d
 
-class TestUpgradeMasterFunctions(dirs.DirsMixin, misc.StdoutAssertionsMixin,
-                                unittest.TestCase):
+class TestUpgradeMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
+                                 misc.StdoutAssertionsMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpDirs('test')

--- a/master/buildbot/test/unit/test_util_namespace.py
+++ b/master/buildbot/test/unit/test_util_namespace.py
@@ -17,8 +17,9 @@ from twisted.trial import unittest
 from buildbot.util import namespace
 import pickle
 from buildbot.util import json
+from buildbot.test.util import www
 
-class Namespace(unittest.TestCase):
+class Namespace(www.WwwTestMixin, unittest.TestCase):
 
     def test_basic(self):
         n = namespace.Namespace({'a':{'b':{'c':1}}})


### PR DESCRIPTION
Hi,

I noticed that running the nine unit tests without having buildbot.www installed caused multiple failures for this reason, while a lot of other cases were skipped. I added WwwTestMixin inheritance to the test classes in question (even though nothing is used but the skip condition. Alternatively, the skip condition could be moved to the classes instead).
