### PR TITLE
Install buildbot.buildslave master module

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -120,6 +120,7 @@ setup_args = {
     'packages': ["buildbot",
               "buildbot.status", "buildbot.status.web","buildbot.status.web.hooks",
               "buildbot.changes",
+              "buildbot.buildslave",
               "buildbot.steps",
               "buildbot.steps.package",
               "buildbot.steps.package.deb",


### PR DESCRIPTION
Since the change introduced in 868b5888e39941676db7e3d30568b611d39a5217, the buildslave module stopped getting installed since it was moved in to a new subpackage. This commit adds the new buildbot.buildslave package to setup.py.
