### PR TITLE
#2486: Property() is not rendered in {halt,flunk}OnFailure build step arguments

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -68,7 +68,8 @@ class ShellCommand(buildstep.LoggingBuildStep):
     name = "shell"
     renderables = buildstep.LoggingBuildStep.renderables + [
                    'slaveEnvironment', 'remote_kwargs', 'command',
-                   'description', 'descriptionDone', 'descriptionSuffix']
+                   'description', 'descriptionDone', 'descriptionSuffix',
+                   'haltOnFailure', 'flunkOnFailure']
 
     description = None # set this to a list of short strings to override
     descriptionDone = None # alternate description when the step is complete


### PR DESCRIPTION
I am new contributor and I am learning to work with the codebase so I am trying to resolve some simple tickets. 

I have understood when I read the ticket that the only thing necessary to resolve it is extend the attribute renderables with 'haltOnFailture' and 'flunkOnFailture' in the constructor of Configure class.

In theory it fixes ticket #2486. (http://trac.buildbot.net/ticket/2486)
