### PR TITLE
Handle both json and simplejson in unit tests

### DIFF
--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -104,8 +104,9 @@ class V2RootResource(www.WwwTestMixin, unittest.TestCase):
         @d.addCallback
         def check(_):
             self.assertRequest(
-                # note whitespace here:
-                content='{\n  "count": 50, \n  "path": [\n    "some", \n    "path"\n  ]\n}',
+                content=json.dumps(
+                    {"count": 50, "path": ["some", "path"]},
+                    sort_keys=True, indent=2),
                 contentType='text/plain',
                 responseCode=200,
                 contentDisposition=None)


### PR DESCRIPTION
The simplejson and the json modules differ in the way they handle
trailing whitespace when indent is set.

```
>>> json.dumps({"foo":[1,2]}, indent=2)
'{\n  "foo": [\n    1, \n    2\n  ]\n}'

>>> simplejson.dumps({"foo":[1,2]}, indent=2)
'{\n  "foo": [\n    1,\n    2\n  ]\n}'
```

With this change, the unit tests use the same json implementation as the
tested code instead of hardcoding the expected json string in this
situation.
