### PR TITLE
Docs: update some index references

### DIFF
--- a/master/docs/developer/cls-iproperties.rst
+++ b/master/docs/developer/cls-iproperties.rst
@@ -1,4 +1,4 @@
-.. index:: single; Properties; IProperties
+.. index:: single: Properties; IProperties
 
 IProperties
 ===========

--- a/master/docs/developer/cls-irenderable.rst
+++ b/master/docs/developer/cls-irenderable.rst
@@ -1,4 +1,4 @@
-.. index:: single; Properties; IRenderable
+.. index:: single: Properties; IRenderable
 
 IRenderable
 ===========

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -830,7 +830,7 @@ This Source step integrates with :bb:chsrc:`GerritChangeSource`, and will
 automatically use the :command:`repo download` command of repo to
 download the additionnal changes introduced by a pending changeset.
 
-.. index:: Properties; Gerrit integration
+.. index:: double: Gerrit integration; Repo Build Step
 
 Gerrit integration can be also triggered using forced build with following properties:
 ``repo_d``, ``repo_d[0-9]``, ``repo_download``, ``repo_download[0-9]``
@@ -1340,7 +1340,7 @@ This Source step integrates with :bb:chsrc:`GerritChangeSource`, and will automa
 Gerrit's "virtual branch" (``refs/changes/*``) to download the additionnal changes
 introduced by a pending changeset.
 
-.. index:: Properties; Gerrit integration
+.. index:: double: Gerrit integration; Git (Slave-Side) Build Step
 
 Gerrit integration can be also triggered using forced build with ``gerrit_change``
 property with value in format: ``change_number/patchset_number``.
@@ -1406,7 +1406,7 @@ This Source step integrates with :bb:chsrc:`GerritChangeSource`, and will
 automatically use the :command:`repo download` command of repo to
 download the additionnal changes introduced by a pending changeset.
 
-.. index:: Properties; Gerrit integration
+.. index:: double: Gerrit integration; Repo (Slave-Side) Build Step
 
 Gerrit integration can be also triggered using forced build with following properties:
 ``repo_d``, ``repo_d[0-9]``, ``repo_download``, ``repo_download[0-9]``

--- a/master/docs/manual/cfg-properties.rst
+++ b/master/docs/manual/cfg-properties.rst
@@ -181,7 +181,7 @@ The default value can reference other properties, e.g., ::
 
     command=Property('command', default=Property('default-command'))
 
-.. Index:: single; Properties; Interpolate
+.. index:: single: Properties; Interpolate
 
 .. _Interpolate:
 
@@ -266,7 +266,7 @@ Here, ``%s`` is used as a placeholder, and the substitutions (which may themselv
   dictionary-style interpolation, not both.  Thus you cannot use a string
   like ``Interpolate("foo-%(src::revision)s-%s", "branch")``.
 
-.. index:: single; Properties; Renderer
+.. index:: single: Properties; Renderer
 
 .. _Renderer:
 
@@ -291,7 +291,7 @@ The function receives an :class:`~buildbot.interfaces.IProperties` object, which
 
 You can think of ``renderer`` as saying "call this function when the step starts".
 
-.. index:: single; Properties; WithProperties
+.. index:: single: Properties; WithProperties
 
 .. _WithProperties:
 


### PR DESCRIPTION
As I was updating some stuff for the clustered service, I saw some weirdness in the 'index' page.

Fixes:
- change a semi-colon to colon for the "single" index
- 'gerrit integration' shows up under Properties, and that doesnt seem like the right place. Although I'm not sure if the place I did put them is right either... up for comment :)
