### PR TITLE
JSONP: Accept anything as a 'callback'

### DIFF
--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -251,10 +251,7 @@ class JsonResource(resource.Resource):
         else:
             data = json.dumps(data, sort_keys=True, indent=2)
         if callback:
-            # Only accept things that look like identifiers for now
-            callback = callback[0]
-            if re.match(r'^[a-zA-Z$][a-zA-Z$0-9.]*$', callback):
-                data = '%s(%s);' % (callback, data)
+            data = '%s(%s);' % (callback[0], data)
         defer.returnValue(data)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
As discussed there: https://github.com/buildbot/buildbot/commit/4985d3f7c5b9c7be1968804cade7b62fd8db45d8.

The previous regular expression was too strict, and from multiple sources on the web, it seems that we can accept any arbitrary text over there ...

http://bob.ippoli.to/archives/2005/12/05/remote-json-jsonp/
http://www.json-p.org/
