### PR TITLE
flatten all renderables by default

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -593,6 +593,9 @@ class BuildStep(object, properties.PropertiesMixin):
         accumulateClassList(self.__class__, 'renderables', renderables)
 
         def setRenderable(res, attr):
+            #only flatten renderables which are not list
+            if not isinstance(getattr(self.__class__, attr, None), (list, tuple)):
+                res = self._flatten(res)
             setattr(self, attr, res)
 
         dl = [ doStep ]
@@ -604,6 +607,20 @@ class BuildStep(object, properties.PropertiesMixin):
 
         dl.addCallback(self._startStep_3)
         return dl
+
+    def _flatten(self, val):
+        if not isinstance(val, (list, tuple)):
+            return val
+        return self._flattenList([], val)
+
+    def _flattenList(self, mainlist, val):
+        for x in val:
+            if isinstance(x, (list, tuple)):
+                if x != []:
+                    self._flattenList(mainlist, x)
+            else:
+                mainlist.append(x)
+        return mainlist
 
     @defer.inlineCallbacks
     def _startStep_3(self, doStep):

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -157,14 +157,6 @@ class ShellCommand(buildstep.LoggingBuildStep):
     def setCommand(self, command):
         self.command = command
 
-    def _flattenList(self, mainlist, commands):
-        for x in commands:
-            if isinstance(x, (list, tuple)):
-                if x != []:
-                    self._flattenList(mainlist, x)
-            else:
-                mainlist.append(x)
-
     def describe(self, done=False):
         desc = self._describe(done)
         if self.descriptionSuffix:
@@ -211,9 +203,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
                 return ["???"]
 
             # flatten any nested lists
-            tmp = []
-            self._flattenList(tmp, words)
-            words = tmp
+            words = self._flattenList([], words)
 
             # strip instances and other detritus (which can happen if a
             # description is requested before rendering)
@@ -251,13 +241,8 @@ class ShellCommand(buildstep.LoggingBuildStep):
     def buildCommandKwargs(self, warnings):
         kwargs = buildstep.LoggingBuildStep.buildCommandKwargs(self)
         kwargs.update(self.remote_kwargs)
-        tmp = []
-        if isinstance(self.command, list):
-           self._flattenList(tmp, self.command) 
-        else:
-           tmp = self.command
 
-        kwargs['command'] = tmp 
+        kwargs['command'] = self.command
 
         # check for the usePTY flag
         if kwargs.has_key('usePTY') and kwargs['usePTY'] != 'slave-config':

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -46,6 +46,8 @@ class P4(Source):
 
     name = 'p4'
 
+    # mark p4viewspec as a list so it won't be flattened by BuildStep
+    p4viewspec = []
     renderables = ['p4base', 'p4client', 'p4viewspec', 'p4branch']
     possible_modes = ('incremental', 'full')
 

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -287,7 +287,7 @@ class ExpectShell(Expect):
                  want_stdout=1, want_stderr=1, initialStdin=None,
                  timeout=20*60, maxTime=None, logfiles={},
                  usePTY="slave-config", logEnviron=True,
-                 user=None):
+                 user=None, description=None):
         args = dict(workdir=workdir, command=command, env=env,
                 want_stdout=want_stdout, want_stderr=want_stderr,
                 initial_stdin=initialStdin,

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -199,6 +199,21 @@ class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase, configm
                 status_text=["'trial", "-b", "...'"])
         return self.runStep()
 
+    def test_run_nested_description(self):
+        self.setupStep(
+                shell.ShellCommand(workdir='build',
+                         command=['trial', ['-b', '-B'], 'buildbot.test'],
+                         description=['test', ['done']]))
+        self.expectCommands(
+            ExpectShell(workdir='build',
+                         command=['trial', '-b', '-B', 'buildbot.test'],
+                         usePTY="slave-config")
+            + 0
+        )
+        self.expectOutcome(result=SUCCESS, 
+           status_text=['test', 'done'])
+        return self.runStep()
+
     def test_run_nested_command(self):
         self.setupStep(
                 shell.ShellCommand(workdir='build',


### PR DESCRIPTION
unless a renderable default value is a list, the renderable will be
flattened

this is useful so that if a property is a list, the property could be used in description/descriptionDone
