### PR TITLE
Update docs referring to the old getProjectName()

### DIFF
--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -1161,8 +1161,8 @@ status objects:
 Name of the builder that generated this event
     ``name``
 
-Name of the project
-    :meth:`master_status.getProjectName()`
+Title of the buildmaster
+    :meth:`master_status.getTitle()`
 
 MailNotifier mode
     ``mode`` (a combination of ``change``, ``failing``, ``passing``, ``problem``, ``warnings``,


### PR DESCRIPTION
Minor documentation fix: The buildbot.status.master.getProjectName() was renamed to getTitle() in cce5dd1710.
