### PR TITLE
Fix build start time retrieving

### DIFF
--- a/master/buildbot/status/web/grid.py
+++ b/master/buildbot/status/web/grid.py
@@ -152,7 +152,7 @@ class GridStatusMixin(object):
             for build in self.getRecentBuilds(builder, numBuilds, branch):
                 ss = build.getSourceStamps(absolute=True)
                 key = self.getSourceStampKey(ss)
-                start = min(build.getTimes())
+                start = build.getTimes()[0]
                 if key not in sourcestamps or sourcestamps[key][1] > start:
                     sourcestamps[key] = (ss, start)
 


### PR DESCRIPTION
When build is not finished getTimes() returns tuple (start_time, None),
and min((start_time, None)) == None.  This lead to incorrect sorting of
builds in grid view --- not finished builds were displayed first and if
there were more build revisions than grid width builds (five by default)
not finished builds doesn't displayed at all.

Sorry, my fault :(
