### PR TITLE
Add option to 'Rebuild' button to build updated sources

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -558,7 +558,7 @@ class BuilderControl:
         return d
 
     @defer.inlineCallbacks
-    def rebuildBuild(self, bs, reason="<rebuild, no reason given>", extraProperties=None):
+    def rebuildBuild(self, bs, reason="<rebuild, no reason given>", extraProperties=None, absolute=True):
         if not bs.isFinished():
             return
 
@@ -570,7 +570,7 @@ class BuilderControl:
             properties.updateFromProperties(extraProperties)
 
         properties_dict = dict((k,(v,s)) for (k,v,s) in properties.asList())
-        ssList = bs.getSourceStamps(absolute=True)
+        ssList = bs.getSourceStamps(absolute=absolute)
         
         if ssList:
             sourcestampsetid = yield  ssList[0].getSourceStampSetId(self.control.master)

--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -57,6 +57,13 @@ class ForceBuildActionResource(ActionResource):
             comments.decode(getRequestCharset(req))
             reason = ("The web-page 'rebuild' button was pressed by "
                       "'%s': %s\n" % (name, comments))
+
+            useSourcestamp = req.args.get("useSourcestamp", None)
+            if useSourcestamp and useSourcestamp==['updated']:
+                absolute=False
+            else:
+                absolute=True
+
             msg = ""
             extraProperties = getAndCheckProperties(req)
             if not bc or not b.isFinished() or extraProperties is None:
@@ -66,7 +73,10 @@ class ForceBuildActionResource(ActionResource):
                 if bc:
                     msg += "could not get builder control"
             else:
-                tup = yield bc.rebuildBuild(b, reason, extraProperties)
+                tup = yield bc.rebuildBuild(b, 
+                    reason=reason, 
+                    extraProperties=extraProperties,
+                    absolute=absolute)
                 # rebuildBuild returns None on error (?!)
                 if not tup:
                     msg = "rebuilding a build failed "+ str(tup)

--- a/master/buildbot/status/web/templates/forms.html
+++ b/master/buildbot/status/web/templates/forms.html
@@ -218,6 +218,13 @@
      <span class="label">Reason for re-running build:</span>
      <input type='text' name='comments' />
    </div>
+   <div class="row">
+     Rebuild using:
+     <select name="useSourcestamp">
+        <option value='exact' selected>Exact same revisions</option>
+        <option value='updated'>Same sourcestamps (ignoring 'got revision')</option>
+     </select>
+   </div>
    <input type="submit" value="Rebuild" />
  </form>
 {% endmacro %}

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -21,6 +21,9 @@ Features
 * Buildbot now support a new PNG Status Resource that can be accessed publicly from for example README.md files or wikis or whatever other resource.
   This view produces an image in PNG format with information about the last build for the given builder name or whatever other build number if is passed as an argument to the view.
 
+* The 'Rebuild' button on the web pages for builds features a dropdown to choose whether to 
+  rebuild from exact revisions or from the same sourcestamps (ie, update branch references)
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Right now the Rebuild button builds the exact same checkout as another build. This makes it difficult for the following workflow:
- run a build on a branch
- it fails, so add a commit on the branch to fix the failure
- hit "rebuild" -> it builds the original revision
