### PR TITLE
Fix minor typo in INVALID EMAIL log msg

### DIFF
--- a/master/buildbot/status/mail.py
+++ b/master/buildbot/status/mail.py
@@ -747,7 +747,7 @@ class MailNotifier(base.StatusReceiverMultiService):
             if VALID_EMAIL.search(r):
                 to_recipients.add(r)
             else:
-                twlog.msg("INVALID EMAIL: %r" + r)
+                twlog.msg("INVALID EMAIL: %r" % r)
 
         # If we're sending to interested users put the extras in the
         # CC list so they can tell if they are also interested in the


### PR DESCRIPTION
I just noticed this in my logs: 

2013-05-14 21:10:43+0000 [-] INVALID EMAIL: %r@10gen.com

And realized there was a "+ r" that should be "% r"
