### PR TITLE
Console view, remove 25 changeset limit

### DIFF
--- a/master/buildbot/status/web/console.py
+++ b/master/buildbot/status/web/console.py
@@ -637,12 +637,7 @@ class ConsoleStatusResource(HtmlResource):
 
         # Keep only the revisions we care about.
         # By default we process the last 40 revisions.
-        # If a dev name is passed, we look for the changes by this person in the
-        # last 80 revisions.
         numRevs = int(request.args.get("revs", [40])[0])
-        if devName:
-            numRevs *= 2
-        numBuilds = numRevs
 
         # Get all changes we can find.  This is a DB operation, so it must use
         # a deferred.
@@ -677,7 +672,7 @@ class ConsoleStatusResource(HtmlResource):
                                                     request,
                                                     codebase,
                                                     lastRevision,
-                                                    numBuilds,
+                                                    numRevs,
                                                     categories,
                                                     builders,
                                                     debugInfo)


### PR DESCRIPTION
With these changes the revs parameter to console view should work past 25 changes.
e.g. http://buildbot....:8010/console?revs=100

Also removed doubling of builds loaded as since the number of changes loaded is not increased then the same number of builds is required as if the devName is not set.
