### PR TITLE
Console: support for multiple codebases

### DIFF
--- a/master/buildbot/status/web/files/default.css
+++ b/master/buildbot/status/web/files/default.css
@@ -136,6 +136,10 @@ td.idle,td.waiting,td.offline,td.building {
 }
 
 /* Console view styles */
+td.DevStatus > table {
+	table-layout: fixed;
+}
+
 td.DevRev {
 	padding: 4px 8px 4px 8px;
 	color: #333333;
@@ -264,6 +268,10 @@ td.Alt {
 	line-height: 20px;
 	margin-left: auto;
 	margin-right: auto;
+}
+
+.DevStatusBox a.notinbuilder {
+	border-style: none;
 }
 
 .DevSlaveBox {


### PR DESCRIPTION
This request is for fixing showing multiple codebases in console view.

The main changes/effects are:

1) Only the changes in a build is used to compare with the changeset revision.
The revision id from got_revision is not used.

2) If there are multiple builds with the matching changeset the first one
found is used. So if a slave is lost the build is marked as exception. Then
when the build is restarted that will be used instead.

3) In the current code when multiple codebases is used the default view, buildbot:8010/console, loads all builds!!. As a side effect this is fixed.

4) If a builder does not have the codebase that the change is in, no box is shown. This makes it easier to see what builders a change affects.

There are no unit test for console view, so I don't know where to start.

I had this running for 3 months on a setup with 28 builders each with 50 to 60 codebases.
Console view is by far the most useful and it was just missing support for multiple codebases.
