### PR TITLE
Added the 'shell' config parameter

### DIFF
--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -625,6 +625,14 @@ life, it is considered as safe to disable the signal restriction in
 the Apache setting like that ``WSGIRestrictSignal Off``. Refer to the
 documentation of your web server for other way to do the same.
 
+You may also take advantage of the ``shell`` parameter.  Like ``fork``,
+this is also a predicate value, and when enabled, invokes the Buildbot
+``sendchange`` command directly via a shell process, bypassing any
+inconsistencies that may arise by running the hook within the same
+process space as Mercurial.  You may also find that the ``shell``
+parameter may be somewhat more efficient for your situation in terms
+system resource usage compared to the ``fork`` option.
+
 Resulting Changes
 #################
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -36,6 +36,8 @@ Features
 
 * The Console view now supports codebases.
 
+* The ``shell`` predicate parameter has been added as an alternative to the ``fork`` parameter to enable direct invocation of the Buildbot ``sendchange`` command.
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I have added a 'shell' predicate parameter to the [hgbuildbot] section as an alternative to the 'fork' parameter.  This is to enable direct invocation of the Buildbot 'sendchange' command, bypassing any potential conflicts or inconsistencies that might arise by running the hook 'in-process'.

I have submitted this patch at Dustin's request.
