### PR TITLE
Fixed an issue when stop() was raising an exception incorrectly

### DIFF
--- a/master/docs/relnotes/0.8.8.rst
+++ b/master/docs/relnotes/0.8.8.rst
@@ -123,6 +123,10 @@ Features
 
 * The ``--nodaemon`` option to ``buildslave start`` now correctly prevents the slave from forking before running.
 
+* Fixed an issue when buildstep stop() was raising an exception incorrectly if timeout for 
+  buildstep wasn't set or was None (see :bb:pull:`753`) thus keeping watched logfiles open
+  (this prevented their removal on Windows in subsequent builds).
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixed an issue when stop() was raising an exception incorrectly if timeout for buildstep was None because self.timer was re-used for entirely different purpose but stop() code was unaware of such use.

This for example stopped log watcher from correctly closing file handles.

I've introduced fourth timer (independent of self.timer) and refactored timer cancelling copy-pasted code into one function.
