### PR TITLE
Rework locating config file for checkconfig and upgrade-master.

### DIFF
--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -38,19 +38,16 @@ def isBuildmasterDir(dir):
 
     return True
 
-def getConfigFileWithFallback(basedir, defaultName='master.cfg'):
-    configFile = os.path.abspath(os.path.join(basedir, defaultName))
-    if os.path.exists(configFile):
-        return configFile
+def getConfigFileFromTac(basedir):
     # execute the .tac file to see if its configfile location exists
     tacFile = os.path.join(basedir, 'buildbot.tac')
     if os.path.exists(tacFile):
         # don't mess with the global namespace
         tacGlobals = {}
         execfile(tacFile, tacGlobals)
-        return tacGlobals["configfile"]
-    # No config file found; return default location and fail elsewhere
-    return configFile
+        return tacGlobals.get("configfile", "master.cfg")
+    else:
+        return "master.cfg"
 
 class SubcommandOptions(usage.Options):
     # subclasses should set this to a list-of-lists in order to source the

--- a/master/buildbot/scripts/checkconfig.py
+++ b/master/buildbot/scripts/checkconfig.py
@@ -16,35 +16,35 @@
 import sys
 import os
 from buildbot import config
-from buildbot.scripts.base import getConfigFileWithFallback
+from buildbot.scripts.base import getConfigFileFromTac
 
-class ConfigLoader(object):
-    def __init__(self, basedir=os.getcwd(), configFileName='master.cfg'):
-        self.basedir = os.path.abspath(basedir)
-        self.configFileName = getConfigFileWithFallback(basedir, configFileName)
-
-    def load(self, quiet=False):
-        try:
-            config.MasterConfig.loadConfig(
-                    self.basedir, self.configFileName)
-        except config.ConfigErrors, e:
-            if not quiet:
-                print >> sys.stderr, "Configuration Errors:"
-                for e in e.errors:
-                    print >> sys.stderr, "  " + e
-            return 1
-
+def _loadConfig(basedir, configFile, quiet):
+    try:
+        config.MasterConfig.loadConfig(
+                basedir, configFile)
+    except config.ConfigErrors, e:
         if not quiet:
-            print "Config file is good!"
-        return 0
+            print >> sys.stderr, "Configuration Errors:"
+            for e in e.errors:
+                print >> sys.stderr, "  " + e
+        return 1
+
+    if not quiet:
+        print "Config file is good!"
+    return 0
+
 
 def checkconfig(config):
     quiet = config.get('quiet')
-    configFileName = config.get('configFile')
+    configFile = config.get('configFile')
 
-    if os.path.isdir(configFileName):
-        cl = ConfigLoader(basedir=configFileName)
+    if os.path.isdir(configFile):
+        basedir = configFile
+        configFile = getConfigFileFromTac(basedir)
     else:
-        cl = ConfigLoader(configFileName=configFileName)
+        basedir = os.getcwd()
 
-    return cl.load(quiet=quiet)
+    return _loadConfig(basedir=basedir, configFile=configFile, quiet=quiet)
+
+
+__all__ = ['checkconfig']

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -159,7 +159,7 @@ def upgradeMaster(config, _noMonkey=False):
 
     os.chdir(config['basedir'])
 
-    configFile = base.getConfigFileWithFallback(config['basedir'])
+    configFile = base.getConfigFileFromTac(config['basedir'])
     master_cfg = loadConfig(config, configFile)
     if not master_cfg:
         defer.returnValue(1)


### PR DESCRIPTION
This changes the logic of checkconfig so that,
1. If a file is passed, that file is used.
2. If a directory is passed containing `buildbot.tac`, that file is
   loaded and `configfile` is defined there, that file is used.
3. If `buildbot.tac` doesn't exist, or doesn't define `configfile`,
   `master.cfg` from that directory is used.

The logic for upgrade-master is similar, except only directories are
supported, so (1) is skipped.
