### PR TITLE
Filter bulider's slavenames when reconfiguring

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -102,6 +102,12 @@ class Builder(config.ReconfigurableServiceMixin,
         self.builder_status.setSlavenames(self.config.slavenames)
         self.builder_status.setCacheSize(new_config.caches['Builds'])
 
+        # if we have any slavebuilders attached which are no longer configured,
+        # drop them.
+        new_slavenames = set(builder_config.slavenames)
+        self.slaves = [ s for s in self.slaves
+                        if s.slave.slavename in new_slavenames ]
+
         return defer.succeed(None)
 
     def stopService(self):


### PR DESCRIPTION
Fixes #2507.  Note that a build which has its builder/slave pair removed
whlie it is executing will still hang indefinitely, but that's a much
larger problem.

@tomprince, I assume you'll want this in 0.8.8, so I've based in there.  Please merge if you like.
