### PR TITLE
Add a timeout to stop command

### DIFF
--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -155,8 +155,21 @@ class StopOptions(base.BasedirMixin, base.SubcommandOptions):
         ["quiet", "q", "Do not emit the commands being run"],
         ["clean", "c", "Clean shutdown master"],
         ]
+    optParameters = [
+        ['timeout', 't', 10, "timeout in seconds"],
+        ]
     def getSynopsis(self):
         return "Usage:    buildbot stop [<basedir>]"
+
+    def postOptions(self):
+      try:
+        timeout = int(self['timeout'])
+      except ValueError:
+        raise usage.UsageError('timeout parameter has must be an integer. '
+                               'Received: ' + str(self['timeout']))
+      if timeout < 0:
+        raise usage.UsageError('timeout parameter must be a non-negative '
+                               'integer. Received: %d' % timeout)
 
 
 class RestartOptions(base.BasedirMixin, base.SubcommandOptions):

--- a/master/buildbot/scripts/stop.py
+++ b/master/buildbot/scripts/stop.py
@@ -21,7 +21,7 @@ import errno
 import signal
 from buildbot.scripts import base
 
-def stop(config, signame="TERM", wait=False):
+def stop(config, signame="TERM", wait=True):
     basedir = config['basedir']
     quiet = config['quiet']
 
@@ -65,7 +65,7 @@ def stop(config, signame="TERM", wait=False):
     # poll once per second until twistd.pid goes away, up to 10 seconds,
     # unless we're doing a clean stop, in which case wait forever
     count = 0
-    while count < 10 or config['clean']:
+    while count < int(config['timeout']) or config['clean']:
         try:
             os.kill(pid, 0)
         except OSError:


### PR DESCRIPTION
It should be able to wait for more than 10 seconds for the master to
tear shut itself down without having to wait for all current builds to
finish. Currently the shutdown wait is kind of all or nothing. This
change should allow for some flexibility.

Conflicts:
    master/buildbot/scripts/runner.py
