### PR TITLE
Modify WebStatus auth to allow for external authenticators.

### DIFF
--- a/master/buildbot/status/web/templates/layout.html
+++ b/master/buildbot/status/web/templates/layout.html
@@ -39,7 +39,7 @@
     {% if authz.authenticated(request) %}
     {{ authz.getUsernameHTML(request) }}
     |<a href="{{ path_to_root }}logout">Logout</a>
-    {% elif authz.useHttpHeader and authz.httpLoginUrl %}
+    {% elif authz.httpLoginUrl %}
     <a href="{{ authz.httpLoginUrl }}">Login</a>
     {% elif authz.auth %}
     <form method="post" name="login" action="{{ path_to_root }}login">

--- a/master/buildbot/test/unit/test_status_web_auth_HTPasswdAprAuth.py
+++ b/master/buildbot/test/unit/test_status_web_auth_HTPasswdAprAuth.py
@@ -25,11 +25,10 @@ shabuildslave:{SHA}sNA10GbdONwGJ+a8VGRNtEyWd9I=
 shabuildbot:{SHA}TwEDa5Q31ZhI4GLmIbE1VrrAkpk=
 """
 
-
 from twisted.trial import unittest
-
 from buildbot.status.web.auth import HTPasswdAprAuth
 from buildbot.test.util import compat
+from buildbot.test.unit.test_status_web_authz_Authz import StubRequest
 
 class TestHTPasswdAprAuth(unittest.TestCase):
 
@@ -37,39 +36,43 @@ class TestHTPasswdAprAuth(unittest.TestCase):
 
     @compat.skipUnlessPlatformIs('posix') # crypt module
     def test_authenticate_des(self):
-        for key in ('buildmaster','buildslave','buildbot'):                
-            if self.htpasswd.authenticate('des'+key, key) == False:
-                self.fail("authenticate failed for '%s'" % ('des'+key))
+        for key in ('buildmaster','buildslave','buildbot'):
+            user = "des" + key
+            if self.htpasswd.authenticate(StubRequest(user, key)) == None:
+                self.fail("authenticate failed for '%s'" % (user))
 
     def test_authenticate_md5(self):
         if not self.htpasswd.apr:
             raise unittest.SkipTest("libaprutil-1 not found")
         for key in ('buildmaster','buildslave','buildbot'):                
-            if self.htpasswd.authenticate('md5'+key, key) == False:
-                self.fail("authenticate failed for '%s'" % ('md5'+key))
+            user = "md5" + key
+            if self.htpasswd.authenticate(StubRequest(user, key)) == None:
+                self.fail("authenticate failed for '%s'" % (user))
 
     def test_authenticate_sha(self):
         if not self.htpasswd.apr:
             raise unittest.SkipTest("libaprutil-1 not found")
         for key in ('buildmaster','buildslave','buildbot'):                
-            if self.htpasswd.authenticate('sha'+key, key) == False:
-                self.fail("authenticate failed for '%s'" % ('sha'+key))
+            user = "sha" + key
+            if self.htpasswd.authenticate(StubRequest(user, key)) == None:
+                self.fail("authenticate failed for '%s'" % (user))
 
     def test_authenticate_unknown(self):
-        if self.htpasswd.authenticate('foo', 'bar') == True:
+        if self.htpasswd.authenticate(StubRequest('foo', 'bar')) == "foo":
             self.fail("authenticate succeed for 'foo:bar'")
 
     @compat.skipUnlessPlatformIs('posix') # crypt module
     def test_authenticate_wopassword(self):
         for algo in ('des','md5','sha'):
-            if self.htpasswd.authenticate(algo+'buildmaster', '') == True:
-                self.fail("authenticate succeed for %s w/o password"
-                                        % (algo+'buildmaster'))
+            user = algo + "buildmaster"
+            if self.htpasswd.authenticate(StubRequest(user, '')) == user:
+                self.fail("authenticate succeed for %s w/o password" % (user))
 
     @compat.skipUnlessPlatformIs('posix') # crypt module
     def test_authenticate_wrongpassword(self):
         for algo in ('des','md5','sha'):
-            if self.htpasswd.authenticate(algo+'buildmaster', algo) == True:
+            user = algo + "buildmaster"
+            if self.htpasswd.authenticate(StubRequest(user, algo)) == user:
                 self.fail("authenticate succeed for %s w/ wrong password"
-                                        % (algo+'buildmaster'))
+                                        % (user))
 

--- a/master/buildbot/test/unit/test_status_web_auth_HTPasswdAuth.py
+++ b/master/buildbot/test/unit/test_status_web_auth_HTPasswdAuth.py
@@ -19,11 +19,10 @@ desbuildslave:W8SPURMnCs7Tc
 desbuildbot:IzclhyfHAq6Oc
 """
 
-
 from twisted.trial import unittest
-
 from buildbot.status.web.auth import HTPasswdAuth
 from buildbot.test.util import compat
+from buildbot.test.unit.test_status_web_authz_Authz import StubRequest
 
 class TestHTPasswdAuth(unittest.TestCase):
 
@@ -32,24 +31,25 @@ class TestHTPasswdAuth(unittest.TestCase):
     @compat.skipUnlessPlatformIs('posix') # crypt module
     def test_authenticate_des(self):
         for key in ('buildmaster','buildslave','buildbot'):                
-            if self.htpasswd.authenticate('des'+key, key) == False:
+            if self.htpasswd.authenticate(StubRequest('des'+key, key)) is None:
                 self.fail("authenticate failed for '%s'" % ('des'+key))
 
     def test_authenticate_unknown(self):
-        if self.htpasswd.authenticate('foo', 'bar') == True:
+        if self.htpasswd.authenticate(StubRequest('foo', 'bar')) == "foo":
             self.fail("authenticate succeed for 'foo:bar'")
 
     @compat.skipUnlessPlatformIs('posix') # crypt module
     def test_authenticate_wopassword(self):
         for algo in ('des','md5','sha'):
-            if self.htpasswd.authenticate(algo+'buildmaster', '') == True:
-                self.fail("authenticate succeed for %s w/o password"
-                                        % (algo+'buildmaster'))
+            user = algo + "buildmaster"
+            if self.htpasswd.authenticate(StubRequest(user, '')) == user:
+                self.fail("authenticate succeed for %s w/o password" % (user))
 
     @compat.skipUnlessPlatformIs('posix') # crypt module
     def test_authenticate_wrongpassword(self):
         for algo in ('des','md5','sha'):
-            if self.htpasswd.authenticate(algo+'buildmaster', algo) == True:
-                self.fail("authenticate succeed for %s w/ wrong password"
-                                        % (algo+'buildmaster'))
+            user = algo + "buildmaster"
+            if self.htpasswd.authenticate(StubRequest(user, algo)) == user:
+                self.fail(
+                    "authenticate succeed for %s w/ wrong password" % (user))
 

--- a/master/buildbot/test/unit/test_status_web_authz_Authz.py
+++ b/master/buildbot/test/unit/test_status_web_authz_Authz.py
@@ -55,8 +55,9 @@ class StubAuth(AuthBase):
     def __init__(self, user):
         self.user = user
 
-    def authenticate(self, user, pw):
-        return user == self.user
+    def authenticate(self, request):
+        return self.user if self.parseUsername(request) == self.user else None
+
 class TestAuthz(unittest.TestCase):
 
     def test_actionAllowed_Defaults(self):


### PR DESCRIPTION
This commit modifies auth/authz such that implementations of IAuth can
specify custom login URLs. It also attempts to work around auth's
current assumption that all users will have a visible username and
password.

The intent is to make IAuth extensible enough that authentication could
be delegated to a third party identity provider (e.g. Google OAuth2).
In that case the custom login URL would point to the external service's
authentication endpoint and the IAuth.authenticate call would implement
whatever callback logic is necessary to verify and complete the authentication.

Users authenticated in this mode would have a unique identifier
("username"), but would not have a password. While they may have some
password-like access token, we leave it up to the IAuth implementer to
handle these in whatever way he sees fit.
