### PR TITLE
Add WebStatus authz "view" action.

### DIFF
--- a/master/buildbot/status/web/authz.py
+++ b/master/buildbot/status/web/authz.py
@@ -23,7 +23,8 @@ class Authz(object):
 
     knownActions = [
     # If you add a new action here, be sure to also update the documentation
-    # at docs/cfg-statustargets.texinfo
+    # at docs/manual/cfg-statustargets.rst.
+            'view',
             'gracefulShutdown',
             'forceBuild',
             'forceAllBuilds',

--- a/master/buildbot/status/web/templates/layout.html
+++ b/master/buildbot/status/web/templates/layout.html
@@ -22,6 +22,7 @@
     {% block header -%}
     <div class="header">    
         <a href="{{ path_to_root or '.' }}">Home</a>
+        {% if authz.advertiseAction('view', request) %}
         - <a href="{{ path_to_root }}waterfall">Waterfall</a>
         <a href="{{ path_to_root }}grid">Grid</a>
         <a href="{{ path_to_root }}tgrid">T-Grid</a>
@@ -35,6 +36,7 @@
         {% endif %}
         - <a href="{{ path_to_root }}json/help">JSON API</a>
         - <a href="{{ path_to_root }}about">About</a>
+        {% endif %}
     <div class="auth">    
     {% if authz.authenticated(request) %}
     {{ authz.getUsernameHTML(request) }}

--- a/master/buildbot/status/web/templates/root.html
+++ b/master/buildbot/status/web/templates/root.html
@@ -18,6 +18,7 @@
 
 <div class="column">
 
+{% if authz.advertiseAction('view', request) %}
 <ul>
   {% set item_class=cycler('alt', '') %}
   
@@ -53,6 +54,7 @@ Master is shutting down<br/>
 {{ forms.clean_shutdown(shutdown_url, authz) }}
 {%- endif -%}
 {%- endif -%}
+{% endif %}
 
 <p><i>This and other pages can be overridden and customized.</i></p>
 

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -442,6 +442,9 @@ buildmaster.  However, there are a number of supported activities that can
 be enabled, and Buildbot can also perform rudimentary username/password
 authentication.  The actions are:
 
+``view``
+    view buildbot web status
+
 ``forceBuild``
     force a particular builder to begin building, optionally with a specific revision, branch, etc.
 


### PR DESCRIPTION
This commit adds a new action to authz called "view". This action
represents the ability to view the Buildbot's WebStatus. If, for
example, you set `view='auth'` in authz, a user must be logged in to
view any meaningful status information.

The exception is that the root page and the login action are
whitelisted to always be viewable since these are necessary to log in.

Using this authz action it becomes possible to run a "private" Buildbot
instance for projects that don't wish to expose themselves to the
Internet at large.
