### PR TITLE
Fixing popup in Console view in IE (verified against IE8)

### DIFF
--- a/master/buildbot/status/web/templates/console.html
+++ b/master/buildbot/status/web/templates/console.html
@@ -255,7 +255,7 @@ function checkMouseLeave(element, event) {
 </div>
 
 
-<iframe id="frameBox" style="display: none;"></iframe>
+<iframe id="frameBox" style="display: none;" onload="updateDiv(undefined);"></iframe>
   
 <script type="text/javascript">
 // replace 'onload="updateDiv(event);" with this, as iframe doesn't have onload event in xhtml


### PR DESCRIPTION
I've discovered that popup with detailed build information didn't show up in IE (at least in IE8).
I won't say IE is my browser of choice (personally I'm biased towards Opera), but this IE8 stuff is still popular, say, in corporate networks, so having this console view work in it as well is good I think, especially given the fix is simple :)
