### PR TITLE
Add gitlab webhook based on existing github webhook.

### DIFF
--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 from mock import Mock
+from StringIO import StringIO
 
 from twisted.internet import defer
 from twisted.web import server
@@ -30,10 +31,11 @@ class FakeRequest(Mock):
     redirected_to = None
     failure = None
 
-    def __init__(self, args={}):
+    def __init__(self, args={}, content=''):
         Mock.__init__(self)
 
         self.args = args
+        self.content = StringIO(content)
         self.site = Mock()
         self.site.buildbot_service = Mock()
         master = self.site.buildbot_service.master = Mock()

--- a/master/buildbot/test/unit/test_status_web_change_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_status_web_change_hooks_gitlab.py
@@ -1,0 +1,121 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import calendar
+
+import buildbot.status.web.change_hook as change_hook
+from buildbot.test.fake.web import FakeRequest
+
+from twisted.trial import unittest
+
+# Sample GITHUB commit payload from http://help.github.com/post-receive-hooks/
+# Added "modfied" and "removed", and change email
+
+gitJsonPayload = """
+{
+  "before": "95790bf891e76fee5e1747ab589903a6a1f80f22",
+  "after": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+  "ref": "refs/heads/master",
+  "user_id": 4,
+  "user_name": "John Smith",
+  "repository": {
+    "name": "Diaspora",
+    "url": "git@localhost:diaspora.git",
+    "description": "",
+    "homepage": "http://localhost/diaspora"
+  },
+  "commits": [
+    {
+      "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "message": "Update Catalan translation to e38cb41.",
+      "timestamp": "2011-12-12T14:27:31+02:00",
+      "url": "http://localhost/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "author": {
+        "name": "Jordi Mallach",
+        "email": "jordi@softcatala.org"
+      }
+    },
+    {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "message": "fixed readme",
+      "timestamp": "2012-01-03T23:36:29+02:00",
+      "url": "http://localhost/diaspora/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "author": {
+        "name": "GitLab dev user",
+        "email": "gitlabdev@dv6700.(none)"
+      }
+    }
+  ],
+  "total_commits_count": 2
+}
+"""
+
+class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
+    def setUp(self):
+        self.changeHook = change_hook.ChangeHookResource(dialects={'gitlab': True})
+
+    # Test 'base' hook with attributes. We should get a json string representing
+    # a Change object as a dictionary. All values show be set.
+    def testGitWithChange(self):
+        self.request = FakeRequest(content=gitJsonPayload)
+        self.request.uri = "/change_hook/gitlab"
+        self.request.method = "POST"
+        d = self.request.test_render(self.changeHook)
+
+        def check_changes(r):
+            self.assertEquals(len(self.request.addedChanges), 2)
+            change = self.request.addedChanges[0]
+
+            self.assertEquals(change["repository"], "git@localhost:diaspora.git")
+            self.assertEquals(
+                calendar.timegm(change["when_timestamp"].utctimetuple()),
+                1323692851
+            )
+            self.assertEquals(change["author"], "Jordi Mallach <jordi@softcatala.org>")
+            self.assertEquals(change["revision"], 'b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327')
+            self.assertEquals(change["comments"], "Update Catalan translation to e38cb41.")
+            self.assertEquals(change["branch"], "master")
+            self.assertEquals(change["revlink"], "http://localhost/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327")
+
+            change = self.request.addedChanges[1]
+            self.assertEquals(change["repository"], "git@localhost:diaspora.git")
+            self.assertEquals(
+                calendar.timegm(change["when_timestamp"].utctimetuple()),
+                1325626589
+            )
+            self.assertEquals(change["author"], "GitLab dev user <gitlabdev@dv6700.(none)>")
+            self.assertEquals(change["src"], "git")
+            self.assertEquals(change["revision"], 'da1560886d4f094c3e6c9ef40349f7d38b5d27d7')
+            self.assertEquals(change["comments"], "fixed readme")
+            self.assertEquals(change["branch"], "master")
+            self.assertEquals(change["revlink"], "http://localhost/diaspora/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7")
+
+        d.addCallback(check_changes)
+        return d
+
+    def testGitWithNoJson(self):
+        self.request = FakeRequest()
+        self.request.uri = "/change_hook/gitlab"
+        self.request.method = "POST"
+        d = self.request.test_render(self.changeHook)
+
+        def check_changes(r):
+            expected = "No JSON object could be decoded"
+            self.assertEquals(len(self.request.addedChanges), 0)
+            self.assertEqual(self.request.written, expected)
+            self.request.setResponseCode.assert_called_with(400, expected)
+
+        d.addCallback(check_changes)
+        return d

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -851,6 +851,35 @@ option::
         change_hook_dialects={'poller': {'allowed': ['https://amanda.svn.sourceforge.net/svnroot/amanda/amanda']}}
     ))
 
+GitLab hook
+###########
+
+The GitLab hook is as simple as GitHub one and it also takes no options. ::
+
+    c['status'].append(html.WebStatus(..
+                       change_hook_dialects={ 'gitlab' : True }))
+
+When this is setup you should add a `POST` service pointing to ``/change_hook/gitlab``
+relative to the root of the web status. For example, it the grid URL is
+``http://builds.mycompany.com/bbot/grid``, then point GitLab to
+``http://builds.mycompany.com/change_hook/gitlab``. To specify a project associated
+to the repository, append ``?project=name`` to the URL.
+
+.. warning::
+
+    As in the previous case, the incoming HTTP requests for this hook are not
+    authenticated bu default. Anyone who can access the web status can "fake"
+    a request from your GitLab server, potentially causing the buildmaster to run
+    arbitrary code.
+
+To protect URL against unauthorized access you should use ``change_hook_auth`` option. ::
+
+  c['status'].append(html.WebStatus(..
+                                    change_hook_auth=('user', 'password')))
+
+Then, create a GitLab service hook (see https://your.gitlab.server/help/web_hooks) with a WebHook URL like ``http://user:password@builds.mycompany.com/bbot/change_hook/bitbucket``.
+
+Note that as before, not using ``change_hook_auth`` can expose you to security risks.
 
 .. bb:status:: MailNotifier
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -23,6 +23,8 @@ Features
 
 * The web hooks now include support for Bitbucket.
 
+* The web hooks now include support for GitLab.
+
 * The 'Rebuild' button on the web pages for builds features a dropdown to choose whether to 
   rebuild from exact revisions or from the same sourcestamps (ie, update branch references)
 


### PR DESCRIPTION
I'm currently using this webhook in my buildbot environment with my gitlab (http://www.gitlab.org/) server. It works pretty well.

The change I made is pretty simple. Since gitlab send out webhook in simillar format to github, I just have to make few changes to comfort the gitlab format. Changed files detection is not working because gitlab doesn't send this information.

There is no test at the moment. But I'll be more than happy to contribute some tests if we're planning to merge this PR in.
