### PR TITLE
Added a default for view in the web.authz module.

### DIFF
--- a/master/buildbot/status/web/authz.py
+++ b/master/buildbot/status/web/authz.py
@@ -43,6 +43,7 @@ class Authz(object):
             auth=None,
             useHttpHeader=False,
             httpLoginUrl=False,
+            view=True,
             **kwargs):
         self.auth = auth
         if auth:
@@ -52,6 +53,7 @@ class Authz(object):
         self.httpLoginUrl = httpLoginUrl
 
         self.config = dict( (a, default_action) for a in self.knownActions )
+        self.config['view'] = view
         for act in self.knownActions:
             if act in kwargs:
                 self.config[act] = kwargs[act]


### PR DESCRIPTION
I added a default to true for the view in the master.status.web.authz
module. If there is no view specified in the master config then the
master will behave the same as it did before view was added. If view is
explicitly set in the master.cfg that argument will be used.
