### PR TITLE
Fix typos

### DIFF
--- a/master/buildbot/buildslave/__init__.py
+++ b/master/buildbot/buildslave/__init__.py
@@ -476,7 +476,7 @@ class AbstractBuildSlave(config.ReconfigurableServiceMixin, pb.Avatar,
             if self.slave_system == "nt":
                 self.path_module = namedModule("ntpath")
             else:
-                # most eveything accepts / as separator, so posix should be a
+                # most everything accepts / as separator, so posix should be a
                 # reasonable fallback
                 self.path_module = namedModule("posixpath")
             log.msg("bot attached")

--- a/master/buildbot/status/web/authz.py
+++ b/master/buildbot/status/web/authz.py
@@ -91,7 +91,7 @@ class Authz(object):
         return request.args.get("username", ["<unknown>"])[0]
 
     def getUsernameHTML(self, request):
-        """Get the user formatated in html (with possible link to email)"""
+        """Get the user formatted in html (with possible link to email)"""
         if self.useHttpHeader:
             return request.getUser()
         s = self.session(request)

--- a/master/buildbot/test/unit/test_changes_mail_CVSMaildirSource.py
+++ b/master/buildbot/test/unit/test_changes_mail_CVSMaildirSource.py
@@ -128,7 +128,7 @@ class TestCVSMaildirSource(unittest.TestCase):
             self.fail('Expect ValueError.')
 
     def test_CVSMaildirSource_create_change_with_bad_cvsmode(self):
-        # Branch is indicated afer 'Tag:' in modified file list
+        # Branch is indicated after 'Tag:' in modified file list
         msg = cvs1_11_msg.replace('Cvsmode: 1.11', 'Cvsmode: 9.99')
         m = message_from_string(msg)
         src = CVSMaildirSource('/dev/null')
@@ -140,7 +140,7 @@ class TestCVSMaildirSource(unittest.TestCase):
             self.fail('Expected ValueError')
 
     def test_CVSMaildirSource_create_change_with_branch(self):
-        # Branch is indicated afer 'Tag:' in modified file list
+        # Branch is indicated after 'Tag:' in modified file list
         msg = cvs1_11_msg.replace('        GNUmakefile',
                                   '      Tag: Test_Branch\n      GNUmakefile')
         m = message_from_string(msg)

--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -58,7 +58,7 @@ else:
 # The full version, including alpha/beta/rc tags.
 release = version
 
-# add a loud note for anyone loking at the latest docs
+# add a loud note for anyone looking at the latest docs
 if release == 'latest':
     rst_prolog = textwrap.dedent("""\
     .. caution:: This page documents the latest, unreleased version of

--- a/master/docs/developer/tests.rst
+++ b/master/docs/developer/tests.rst
@@ -30,7 +30,7 @@ Tests are divided into a few suites:
   and execute a lot of code.  As such, use of integration tests is limited to a
   few, broad tests to act as a failsafe for the unit and interface tests.
 
-* Regression tests (``buildbot.test.regrssions``) - these test to prevent
+* Regression tests (``buildbot.test.regressions``) - these test to prevent
   re-occurrence of historical bugs.  In most cases, a regression is better
   tested by a test in the other suites, or unlike to recur, so this suite tends
   to be small.

--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -178,4 +178,4 @@ touching the configuration.
 
 You've got a taste now, but you're probably curious for more.  Let's step it
 up a little in the second tutorial by changing the configuration and doing
-an actual build. Continue on to :ref:`quick-tour-label`
+an actual build. Continue on to :ref:`quick-tour-label`.

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -413,7 +413,7 @@ class BotFactory(ReconnectingPBClientFactory):
             # was already dropped, so just log and ignore.
             log.msg("sending app-level keepalive")
             d = self.perspective.callRemote("keepalive")
-            d.addErrback(log.err, "eror sending keepalive")
+            d.addErrback(log.err, "error sending keepalive")
         self.keepaliveTimer = self._reactor.callLater(self.keepaliveInterval,
                                                       doKeepalive)
 

--- a/slave/buildslave/runprocess.py
+++ b/slave/buildslave/runprocess.py
@@ -593,7 +593,7 @@ class RunProcess:
     def _collapseMsg(self, msg):
         """
         Take msg, which is a dictionary of lists of output chunks, and
-        concatentate all the chunks into a single string
+        concatenate all the chunks into a single string
         """
         retval = {}
         for log in msg:


### PR DESCRIPTION
Typos: "eveything", "formatated", "afer", "loking",
"buildbot.test.regrssions", "eror", "concatentate".
Plus missing dot.
