### PR TITLE
Expose twisted.cred for change hook auth.

### DIFF
--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -730,10 +730,14 @@ useful in cases where you cannot expose the WebStatus for public consumption.
     Anyone who can access the web status can "fake" a request from
     GitHub, potentially causing the buildmaster to run arbitrary code.
 
-To protect URL against unauthorized access you should use ``change_hook_auth`` option. ::
+To protect URL against unauthorized access you should use ``change_hook_auth`` option ::
 
     c['status'].append(html.WebStatus(..
-                                      change_hook_auth=('user', 'password')))
+                                      change_hook_auth=["file:changehook.passwd"]))
+
+And create a file ``changehook.passwd`` ::
+
+    user:password
 
 Then, create a GitHub service hook (see https://help.github.com/articles/post-receive-hooks) with a WebHook URL like ``http://user:password@builds.mycompany.com/bbot/change_hook/github``.
 


### PR DESCRIPTION
Twisted provides a rich interface for defining authentication. Use it
for defining change hook authorization, rather than just one specific
bit of it.
