### PR TITLE
logs: implement on the fly parsing of ansi code

### DIFF
--- a/master/buildbot/status/web/files/default.css
+++ b/master/buildbot/status/web/files/default.css
@@ -564,6 +564,30 @@ span.stderr {
 span.header {
 	color: blue;
 }
+span.ansi30 {
+	color: black;
+}
+span.ansi31 {
+	color: red;
+}
+span.ansi32 {
+	color: green;
+}
+span.ansi33 {
+	color: orange;
+}
+span.ansi34 {
+	color: yellow;
+}
+span.ansi35 {
+	color: purple;
+}
+span.ansi36 {
+	color: blue;
+}
+span.ansi37 {
+	color: white;
+}
 
 /* revision & email */
 .revision .full {


### PR DESCRIPTION
Some times ago, we got email or irc asking for support for ansi codes inside log files.

It happens that while integrating some coffeelint into buildbot, I also got the ugly "]30m" in the log.

I did find a simple way to implement the parsing. We are not supposed to accept more contrib to the webstatus code, but this one is quite useful and simple given the raise of popularity of grunt and family
