### PR TITLE
status/web/feeds.py: fix pubDate format

### DIFF
--- a/master/buildbot/status/web/feeds.py
+++ b/master/buildbot/status/web/feeds.py
@@ -66,7 +66,7 @@ _abbr_mon = ['', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
 def rfc822_time(tstamp):
     res = time.strftime("%%s, %d %%s %Y %H:%M:%S GMT",
                                        tstamp)
-    res = res % (tstamp.tm_wday, tstamp.tm_mon)
+    res = res % (_abbr_day[tstamp.tm_wday], _abbr_mon[tstamp.tm_mon])
     return res
 
 class FeedResource(XmlResource):


### PR DESCRIPTION
A prior localization fix caused RFC822-style dates to be rendered as follows:

1, 23 7 2013 13:04:18 GMT

This implements the fix proposed in http://trac.buildbot.net/ticket/2530

Patch applied and tested on 0.8.8rc1. Dates now render properly with Vienna.app, and http://feedvalidator.org only has an unrelated recommendation.
