### PR TITLE
Fix libvirt module load after internal module rename. Thanks Jc2k.

### DIFF
--- a/master/buildbot/buildslave/libvirt.py
+++ b/master/buildbot/buildslave/libvirt.py
@@ -14,6 +14,7 @@
 # Portions Copyright Buildbot Team Members
 # Portions Copyright 2010 Isotoma Limited
 
+from __future__ import absolute_import
 import os
 
 from twisted.internet import defer, utils, threads


### PR DESCRIPTION
See #2538.
If you already planned to fix it in a better way, it will be a reminder
