### PR TITLE
Fix bug with getConfigFileFromTac() and relocatable buildmasters.

### DIFF
--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -43,8 +43,8 @@ def getConfigFileFromTac(basedir):
     # execute the .tac file to see if its configfile location exists
     tacFile = os.path.join(basedir, 'buildbot.tac')
     if os.path.exists(tacFile):
-        # don't mess with the global namespace
-        tacGlobals = {}
+        # don't mess with the global namespace, but set __file__ for relocatable buildmasters
+        tacGlobals = {'__file__' : tacFile}
         execfile(tacFile, tacGlobals)
         return tacGlobals.get("configfile", "master.cfg")
     else:


### PR DESCRIPTION
On lines 47 - 48 in base.py:getConfigFileFromTac(), tacGlobals is initialized as an empty dict and passed to execfile as an argument when loading the *.tac file from a buildmaster. However, relocatable buildmasters rely on the **file** attribute to be set, which does not happen and causes an exception. This patch sets **file** in tacGlobals before calling execfile.
