### PR TITLE
start testing the buildrequest fakes

### DIFF
--- a/master/buildbot/test/unit/test_db_buildrequests.py
+++ b/master/buildbot/test/unit/test_db_buildrequests.py
@@ -14,18 +14,15 @@
 # Copyright Buildbot Team Members
 
 import datetime
-import sqlalchemy as sa
 from twisted.trial import unittest
-from twisted.internet import task, defer
+from twisted.internet import task
 from buildbot.db import buildrequests
-from buildbot.test.util import connector_component, db
-from buildbot.test.fake import fakedb
+from buildbot.test.util import interfaces, connector_component, db
+from buildbot.test.fake import fakedb, fakemaster
 from buildbot.util import UTC, epoch2datetime
 
-class TestBuildsetsConnectorComponent(
-            connector_component.ConnectorComponentMixin,
-            unittest.TestCase):
 
+class Tests(interfaces.InterfaceTests):
     # test that the datetime translations are done correctly by specifying
     # the epoch timestamp and datetime objects explicitly.  These should
     # pass regardless of the local timezone used while running tests!
@@ -37,42 +34,25 @@ class TestBuildsetsConnectorComponent(
     COMPLETE_AT_EPOCH = 329920275
     BSID = 567
     BSID2 = 5670
-    MASTER_ID = "set in setUp"
-    OTHER_MASTER_ID = "set in setUp"
-
+    MASTER_ID = "set in setUpTests"
+    OTHER_MASTER_ID = "set in setUpTests"
     MASTER_NAME = "testmaster"
     MASTER_INCARN = "pid123-boot456789"
 
-    def setUp(self):
+    def setUpTests(self):
+        # set up a sourcestamp and buildset for use below
         self.MASTER_ID = fakedb.FakeBuildRequestsComponent.MASTER_ID
         self.OTHER_MASTER_ID = self.MASTER_ID + 1111
-        d = self.setUpConnectorComponent(
-            table_names=[ 'patches', 'changes', 'sourcestamp_changes',
-                'buildsets', 'buildset_properties', 'buildrequests',
-                'objects', 'buildrequest_claims', 'sourcestamps', 'sourcestampsets' ])
 
-        def finish_setup(_):
-            self.db.buildrequests = \
-                    buildrequests.BuildRequestsConnectorComponent(self.db)
-            self.db.master.getObjectId = lambda : defer.succeed(self.MASTER_ID)
-        d.addCallback(finish_setup)
-
-        # set up a sourcestamp and buildset for use below
-        d.addCallback(lambda _ :
-            self.insertTestData([
-                fakedb.SourceStampSet(id=234),
-                fakedb.SourceStamp(id=234, sourcestampsetid=234),
-                fakedb.Object(id=self.MASTER_ID, name="fake master",
-                                         class_name="BuildMaster"),
-                fakedb.Object(id=self.OTHER_MASTER_ID, name="other master",
-                                         class_name="BuildMaster"),
-                fakedb.Buildset(id=self.BSID, sourcestampsetid=234),
-            ]))
-
-        return d
-
-    def tearDown(self):
-        return self.tearDownConnectorComponent()
+        return self.insertTestData([
+			fakedb.SourceStampSet(id=234),
+			fakedb.SourceStamp(id=234, sourcestampsetid=234),
+			fakedb.Object(id=self.MASTER_ID, name="fake master",
+										class_name="BuildMaster"),
+			fakedb.Object(id=self.OTHER_MASTER_ID, name="other master",
+										class_name="BuildMaster"),
+			fakedb.Buildset(id=self.BSID, sourcestampsetid=234),
+        ])
 
     # tests
 
@@ -357,20 +337,15 @@ class TestBuildsetsConnectorComponent(
         d.addCallback(lambda _ :
             self.db.buildrequests.claimBuildRequests(brids=brids,
                         claimed_at=claimed_at, _reactor=clock))
-        def check(brlist):
+        d.addCallback(lambda _ :
+                self.db.buildrequests.getBuildRequests())
+        def check(results):
             self.assertNotEqual(expected, None,
                     "unexpected success from claimBuildRequests")
-            def thd(conn):
-                reqs_tbl = self.db.model.buildrequests
-                claims_tbl = self.db.model.buildrequest_claims
-                q = sa.select([ reqs_tbl.outerjoin(claims_tbl,
-                                        reqs_tbl.c.id == claims_tbl.c.brid) ])
-                results = conn.execute(q).fetchall()
-                self.assertEqual(
-                    sorted([ (r.id, r.claimed_at, r.objectid)
-                             for r in results ]),
-                    sorted(expected))
-            return self.db.pool.do(thd)
+            self.assertEqual(
+                sorted([ (r['brid'], r['claimed_at'], r['mine'])
+                            for r in results ]),
+                sorted(expected))
         d.addCallback(check)
         def fail(f):
             if not expfailure:
@@ -383,13 +358,13 @@ class TestBuildsetsConnectorComponent(
         return self.do_test_claimBuildRequests([
             fakedb.BuildRequest(id=44, buildsetid=self.BSID),
             ], 1300305712, [ 44 ],
-            [ (44, 1300305712, self.MASTER_ID) ])
+            [ (44, epoch2datetime(1300305712), True) ])
 
     def test_claimBuildRequests_single_explicit_claimed_at(self):
         return self.do_test_claimBuildRequests([
             fakedb.BuildRequest(id=44, buildsetid=self.BSID),
             ], 1300305712, [ 44 ],
-            [ (44, 14000000, self.MASTER_ID) ],
+            [ (44, epoch2datetime(14000000), True) ],
             claimed_at=epoch2datetime(14000000))
 
     def test_claimBuildRequests_multiple(self):
@@ -399,9 +374,9 @@ class TestBuildsetsConnectorComponent(
                 fakedb.BuildRequest(id=46, buildsetid=self.BSID),
             ], 1300305712, [ 44, 46 ],
             [
-                (44, 1300305712, self.MASTER_ID),
-                (45, None, None),
-                (46, 1300305712, self.MASTER_ID),
+                (44, epoch2datetime(1300305712), True),
+                (45, None, False),
+                (46, epoch2datetime(1300305712), True),
             ])
 
     def test_claimBuildRequests_stress(self):
@@ -410,7 +385,7 @@ class TestBuildsetsConnectorComponent(
                 for id in xrange(1, 1000)
             ], 1300305713, range(1, 1000),
             [
-                (id, 1300305713, self.MASTER_ID)
+                (id, epoch2datetime(1300305713), True)
                 for id in xrange(1, 1000)
             ])
 
@@ -435,16 +410,16 @@ class TestBuildsetsConnectorComponent(
                     objectid=self.OTHER_MASTER_ID, claimed_at=1300103810),
             ], 1300305712, range(1, 1001),
             expfailure=buildrequests.AlreadyClaimedError)
-        def check(_):
+        d.addCallback(lambda _ :
+                self.db.buildrequests.getBuildRequests(claimed=True))
+        def check(results):
             # check that [1,1000) were not claimed, and 1000 is still claimed
-            def thd(conn):
-                tbl = self.db.model.buildrequest_claims
-                q = tbl.select()
-                results = conn.execute(q).fetchall()
-                self.assertEqual([ (r.brid, r.objectid, r.claimed_at)
-                    for r in results ][:10],
-                        [ (1000, self.OTHER_MASTER_ID, 1300103810) ])
-            return self.db.pool.do(thd)
+            self.assertEqual([
+                (r['brid'], r['mine'], r['claimed_at'])
+                for r in results
+            ][:10], [
+                (1000, False, epoch2datetime(1300103810))
+            ])
         d.addCallback(check)
         return d
 
@@ -463,16 +438,10 @@ class TestBuildsetsConnectorComponent(
         d.addCallback(lambda _ :
             self.db.buildrequests.claimBuildRequests(brids=[45],
                         _reactor=clock))
-        def check(brlist):
-            def thd(conn):
-                reqs_tbl = self.db.model.buildrequests
-                claims_tbl = self.db.model.buildrequest_claims
-                join = reqs_tbl.outerjoin(claims_tbl,
-                        reqs_tbl.c.id == claims_tbl.c.brid)
-                q = join.select(claims_tbl.c.claimed_at == None)
-                results = conn.execute(q).fetchall()
-                self.assertEqual(results, [])
-            return self.db.pool.do(thd)
+        d.addCallback(lambda _ :
+            self.db.buildrequests.getBuildRequests(claimed=False))
+        def check(results):
+            self.assertEqual(results, [])
         d.addCallback(check)
         return d
 
@@ -485,20 +454,18 @@ class TestBuildsetsConnectorComponent(
         d.addCallback(lambda _ :
             self.db.buildrequests.reclaimBuildRequests(brids=brids,
                         _reactor=clock))
-        def check(brlist):
+        d.addCallback(lambda _ :
+                self.db.buildrequests.getBuildRequests())
+        def check(results):
             self.assertNotEqual(expected, None,
                     "unexpected success from claimBuildRequests")
-            def thd(conn):
-                reqs_tbl = self.db.model.buildrequests
-                claims_tbl = self.db.model.buildrequest_claims
-                q = sa.select([ reqs_tbl.outerjoin(claims_tbl,
-                                        reqs_tbl.c.id == claims_tbl.c.brid) ])
-                results = conn.execute(q).fetchall()
-                self.assertEqual(
-                    sorted([ (r.id, r.claimed_at, r.objectid)
-                             for r in results ]),
-                    sorted(expected))
-            return self.db.pool.do(thd)
+            self.assertEqual(
+                sorted([
+                    (r['brid'], r['claimed_at'], r['mine'])
+                    for r in results
+                ]),
+                sorted(expected)
+            )
         d.addCallback(check)
         def fail(f):
             if not expfailure:
@@ -514,7 +481,7 @@ class TestBuildsetsConnectorComponent(
                     claimed_at=1300103810),
             ], 1300305712, [ 44 ],
             # note that the time is updated
-            [ (44, 1300305712, self.MASTER_ID) ])
+            [ (44, epoch2datetime(1300305712), True) ])
 
     def test_reclaimBuildRequests_fail(self):
         d = self.do_test_reclaimBuildRequests([
@@ -526,21 +493,22 @@ class TestBuildsetsConnectorComponent(
                     claimed_at=1300103810),
             ], 1300305712, [ 44, 45 ],
             expfailure=buildrequests.AlreadyClaimedError)
-        def check(_):
-            # check that the time wasn't updated on 44, noting that MySQL does
-            # not support this.
-            if self.db_engine.dialect.name == 'mysql':
-                return
-            def thd(conn):
-                tbl = self.db.model.buildrequest_claims
-                q = tbl.select(order_by=tbl.c.brid)
-                results = conn.execute(q).fetchall()
-                self.assertEqual([ (r.brid, r.claimed_at, r.objectid)
-                                    for r in results ], [
-                        (44, 1300103810, self.MASTER_ID),
-                        (45, 1300103810, self.OTHER_MASTER_ID),
-                    ])
-            return self.db.pool.do(thd)
+
+        # check that the time wasn't updated on 44, noting that MySQL does
+        # not support this.
+        if self.db_engine.dialect.name == 'mysql':
+            return d
+
+        d.addCallback(lambda _ :
+                self.db.buildrequests.getBuildRequests())
+        def check(results):
+            self.assertEqual(sorted(
+                (r['brid'], r['claimed_at'], r['mine'])
+                for r in results
+            ), [
+                (44, epoch2datetime(1300103810), True),
+                (45, epoch2datetime(1300103810), False),
+            ])
         d.addCallback(check)
         return d
 
@@ -555,16 +523,15 @@ class TestBuildsetsConnectorComponent(
             self.db.buildrequests.completeBuildRequests(brids=brids,
                                             results=7, complete_at=complete_at,
                                             _reactor=clock))
-        def check(brlist):
+        d.addCallback(lambda _ :
+                self.db.buildrequests.getBuildRequests())
+        def check(results):
             self.assertNotEqual(expected, None,
                     "unexpected success from completeBuildRequests")
-            def thd(conn):
-                tbl = self.db.model.buildrequests
-                q = sa.select([ tbl.c.id, tbl.c.complete,
-                                 tbl.c.results, tbl.c.complete_at ])
-                results = conn.execute(q).fetchall()
-                self.assertEqual(sorted(map(tuple, results)), sorted(expected))
-            return self.db.pool.do(thd)
+            self.assertEqual(sorted(
+                    (r['brid'], r['complete'], r['results'], r['complete_at'])
+                    for r in results
+                ), sorted(expected))
         d.addCallback(check)
         def fail(f):
             if not expfailure:
@@ -579,7 +546,7 @@ class TestBuildsetsConnectorComponent(
             fakedb.BuildRequestClaim(brid=44, objectid=self.MASTER_ID,
                     claimed_at=1300103810),
             ], 1300305712,
-            [ (44, 1, 7, 1300305712) ])
+            [ (44, True, 7, epoch2datetime(1300305712)) ])
 
     def test_completeBuildRequests_explicit_time(self):
         return self.do_test_completeBuildRequests([
@@ -587,7 +554,7 @@ class TestBuildsetsConnectorComponent(
             fakedb.BuildRequestClaim(brid=44, objectid=self.MASTER_ID,
                     claimed_at=1300103810),
             ], 1300305712,
-            [ (44, 1, 7, 999999) ],
+            [ (44, True, 7, epoch2datetime(999999)) ],
             complete_at=epoch2datetime(999999))
 
     def test_completeBuildRequests_multiple(self):
@@ -602,9 +569,9 @@ class TestBuildsetsConnectorComponent(
             fakedb.BuildRequestClaim(brid=46, objectid=self.MASTER_ID,
                     claimed_at=1300103812),
             ], 1300305712,
-            [ (44, 1, 7, 1300305712),
-              (45, 0, -1, 0),
-              (46, 1, 7, 1300305712),
+            [ (44, True, 7, epoch2datetime(1300305712)),
+              (45, False, -1, None),
+              (46, True, 7, epoch2datetime(1300305712)),
             ], brids=[44, 46])
 
     def test_completeBuildRequests_stress(self):
@@ -616,7 +583,7 @@ class TestBuildsetsConnectorComponent(
                         claimed_at=1300103810)
                 for id in range(1, 280)
             ], 1300305712,
-            [ (id, 1, 7, 1300305712)
+            [ (id, True, 7, epoch2datetime(1300305712))
                 for id in range(1, 280)
             ], brids=range(1, 280))
 
@@ -631,9 +598,9 @@ class TestBuildsetsConnectorComponent(
             fakedb.BuildRequestClaim(brid=46, objectid=self.OTHER_MASTER_ID,
                     claimed_at=1300103812),
             ], 1300305712,
-            [ (44, 1, 7, 1300305712),
-              (45, 1, 7, 1300305712),
-              (46, 1, 7, 1300305712), ],
+            [ (44, True, 7, epoch2datetime(1300305712)),
+              (45, True, 7, epoch2datetime(1300305712)),
+              (46, True, 7, epoch2datetime(1300305712)), ],
             brids=[44, 45, 46])
 
     def test_completeBuildRequests_already_completed(self):
@@ -687,20 +654,12 @@ class TestBuildsetsConnectorComponent(
                 claimed_at=self.CLAIMED_AT_EPOCH - 1000),
         ])
         d.addCallback(lambda _ : method())
-        def check(brlist):
-            def thd(conn):
-                # just select the unclaimed requests
-                reqs_tbl = self.db.model.buildrequests
-                claims_tbl = self.db.model.buildrequest_claims
-                join = reqs_tbl.outerjoin(claims_tbl,
-                        reqs_tbl.c.id == claims_tbl.c.brid)
-                q = sa.select([ reqs_tbl.c.id ],
-                        from_obj=[ join ],
-                        whereclause=claims_tbl.c.claimed_at == None)
-                results = conn.execute(q).fetchall()
-                self.assertEqual(sorted([ r.id for r in results ]),
-                                 sorted(expected))
-            return self.db.pool.do(thd)
+        # just select the unclaimed requests
+        d.addCallback(lambda _ :
+            self.db.buildrequests.getBuildRequests(claimed=False))
+        def check(results):
+            self.assertEqual(sorted([ r['brid'] for r in results ]),
+                                sorted(expected))
         d.addCallback(check)
         return d
 
@@ -715,7 +674,7 @@ class TestBuildsetsConnectorComponent(
 
     def test_unclaimBuildRequests(self):
         to_unclaim = [
-            44, # completed -> unclaimed anyway
+            44, # completed -> should not be unclaimed
             45, # incomplete -> unclaimed
             46, # from another master -> not unclaimed
             47, # unclaimed -> still unclaimed
@@ -725,5 +684,37 @@ class TestBuildsetsConnectorComponent(
         ]
         return self.do_test_unclaimMethod(
             lambda : self.db.buildrequests.unclaimBuildRequests(to_unclaim),
-            [44, 45, 47, 48])
+            [45, 47, 48])
 
+class TestFakeDB(unittest.TestCase, Tests):
+    # Compatiblity with some checks in the "real" tests.
+    class db_engine:
+        class dialect:
+            name = 'buildbot_fake'
+
+    def setUp(self):
+        self.master = fakemaster.make_master(wantDb=True, testcase=self)
+        self.db = self.master.db
+        self.insertTestData = self.db.insertTestData
+        return self.setUpTests()
+
+
+class TestRealDB(unittest.TestCase,
+        connector_component.ConnectorComponentMixin,
+        Tests):
+
+    def setUp(self):
+        d = self.setUpConnectorComponent(
+            table_names=[ 'patches', 'changes', 'sourcestamp_changes',
+                'buildsets', 'buildset_properties', 'buildrequests',
+                'objects', 'buildrequest_claims', 'sourcestamps', 'sourcestampsets' ])
+
+        @d.addCallback
+        def finish_setup(_):
+            self.db.buildrequests = \
+                    buildrequests.BuildRequestsConnectorComponent(self.db)
+        d.addCallback(lambda _ : self.setUpTests())
+        return d
+
+    def tearDown(self):
+        return self.tearDownConnectorComponent()


### PR DESCRIPTION
The buildrequest test were in a bad state in the sense that they only tested the "real" database implementation, and left the fakes untested.

I've rectified this, and fixed the various deficiencies in the fakes that were revealed.
