### PR TITLE
builddir and workdir properties should be strings, not tuples

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -199,7 +199,7 @@ class Build(properties.PropertiesMixin):
         if slavebuilder.slave.slave_basedir:
             builddir = self.path_module.join(
                             slavebuilder.slave.slave_basedir,
-                            self.builder.config.slavebuilddir),
+                            self.builder.config.slavebuilddir)
             self.setProperty("builddir", builddir, "slave")
             self.setProperty("workdir", builddir, "slave (deprecated)")
 


### PR DESCRIPTION
With eb8526ce0, the builddir and workdir properties became tuples, not strings, caused by a trailing comma.

The change to fix this bug should be unproblematic (remove said comma), but the unit test i wrote for this introduces a dependency on mock 0.8.0. If this isn't acceptable (I suspect it isn't), could somebody give me a pointer on alternative approaches?

The mock 0.8.0 specific features I use are assert_has_calls and the call() object.
