### PR TITLE
Bootstrap latest does not work with buildbot-www.

### DIFF
--- a/www/setup.py
+++ b/www/setup.py
@@ -99,7 +99,7 @@ package_json.update(base_json)
 # in a crazy CI fashion
 bower_json = {
     "dependencies": {
-    "bootstrap": "latest",
+    "bootstrap": "~2.3.2",
     "font-awesome": "latest",
     "angular": "latest",
     "angular-resource": "latest",


### PR DESCRIPTION
As suggested by Dustin, I am trying to have a go at the nine branch, and when trying to setup the buildbot-www, it seems like the current bootstrap version (3.0.0) is not compatible with buildbot. Version 2.3.2 seems to be ok.

This patch makes sure that setup.py ask for 2.3.2 instead of latest.
