### PR TITLE
Buck nine fix sourcestamps with unknown codebase

### DIFF
--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -191,11 +191,11 @@ class BaseScheduler(ClusteredService, StateMixin):
         # Merge codebases with the passed list of sourcestamps
         # This results in a new sourcestamp for each codebase
         stampsWithDefaults = []
-        for codebase in self.codebases:
-            ss = self.codebases[codebase].copy()
+        for codebase in stampsByCodebase:
+            ss = self.codebases.get(codebase, {}).copy()
              # apply info from passed sourcestamps onto the configured default
              # sourcestamp attributes for this codebase.
-            ss.update(stampsByCodebase.get(codebase,{}))
+            ss.update(stampsByCodebase[codebase])
             stampsWithDefaults.append(ss)
 
         return self.addBuildsetForSourceStamps(sourcestamps=stampsWithDefaults,

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -275,6 +275,28 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
             })
 
     @defer.inlineCallbacks
+    def test_addBuildsetForSourceStamps_unknown(self):
+        sched = self.makeScheduler(name='n', builderNames=['b'])
+        bsid, brids = yield sched.addBuildsetForSourceStampsWithDefaults(
+                reason=u'power', sourcestamps=[
+                    {'codebase': 'cbA', 'branch': 'AA'},
+                    {'codebase': 'cbB', 'revision': 'BB'},
+                ])
+        self.assertEqual((bsid, brids), self.exp_bsid_brids)
+        self.master.data.updates.addBuildset.assert_called_with(
+            sourcestamps=[
+                {'revision': 'BB', 'codebase': 'cbB'},
+                {'branch': 'AA', 'codebase': 'cbA'},
+            ],
+            reason=u'power',
+            scheduler=u'n',
+            external_idstring=None,
+            builderNames=['b'],
+            properties={
+                u'scheduler': ('n', u'Scheduler'),
+            })
+
+    @defer.inlineCallbacks
     def test_addBuildsetForChanges_one_change(self):
         sched = self.makeScheduler(name='n', builderNames=['b'])
         self.db.insertTestData([


### PR DESCRIPTION
Fix a bug and add test-coverage for it.

I found it difficult to back-port this to master since the stampsByCodebase doesn't exist in that branch.
