### PR TITLE
Modify GerritStatusPush to use the "Verify" label with gerrit review.

### DIFF
--- a/master/buildbot/status/status_gerrit.py
+++ b/master/buildbot/status/status_gerrit.py
@@ -139,7 +139,7 @@ class GerritStatusPush(StatusReceiverMultiService):
         if message:
             command.append("--message '%s'" % message.replace("'","\""))
         if verified:
-            command.extend(["--verified %d" % int(verified)])
+            command.extend(["--label Verified=%d" % int(verified)])
         if reviewed:
             command.extend(["--code-review %d" % int(reviewed)])
         command.append(str(revision))

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -66,6 +66,8 @@ Features
 
 * Gerrit integration with Git Source step on master side.
 
+* GerritStatusPush now uses the "Verify" label with gerrit review.
+
 * A new :bb:step:`Robocopy` step is available for Windows builders.
 
 * The :bb:chsrc:`P4Source` changesource now supports Perforce servers in a different timezone than the buildbot master.


### PR DESCRIPTION
Using "--verified" is not a valid option as of Gerrit 2.6.

Closes http://trac.buildbot.net/ticket/2550
