### PR TITLE
fix assertArgSpecMatches

### DIFF
--- a/master/buildbot/test/unit/test_util_interfaces.py
+++ b/master/buildbot/test/unit/test_util_interfaces.py
@@ -74,7 +74,7 @@ class TestAssertArgSpecMatches(interfaces.InterfaceTests, unittest.TestCase):
             error = None
 
         self.assertIdentical(type(error), unittest.FailTest)
-        self.assertEqual(error.args, ('Expected: (xx, yy); got: (x, y)',))
+        self.assertEqual(error.args, ('Expected: (x, y); got: (x, yy)',))
 
     def test_function_style(self):
         def myfunc(x, y=2, *args):
@@ -93,6 +93,5 @@ class TestAssertArgSpecMatches(interfaces.InterfaceTests, unittest.TestCase):
         else:
             error = None
 
-        # TODO: instate these commented assertions
-        self.assertIdentical(type(error), type(None)) #unittest.FailTest)
-        #self.assertEqual(error.args, ('Expected: (x, y=3, *args); got: (x, y=2, *args)',))
+        self.assertIdentical(type(error), unittest.FailTest)
+        self.assertEqual(error.args, ('Expected: (x, y=2, *args); got: (x, y=3, *args)',))


### PR DESCRIPTION
I've fixed the testing issue which allowed the recent regression.
In short, the below line didn't do what its writer intended, but it now does:

./test/util/scheduler.py:                self.assertArgSpecMatches(actual, fake)
