### PR TITLE
buildbot.util.deferredpool

### DIFF
--- a/master/buildbot/test/unit/test_util_deferredpool.py
+++ b/master/buildbot/test/unit/test_util_deferredpool.py
@@ -18,6 +18,193 @@ from twisted.internet import defer
 
 from buildbot.util.deferredpool import DeferredPool
 
+
+class TestPool(unittest.TestCase):
+    """
+    Test the L{DeferredPool} class used by L{ResizableDispatchQueue}.
+    """
+
+    def testEmptyPoolStatus(self):
+        """
+        A newly created (empty) pool should have no deferreds in progress
+        and no deferreds waiting for the pool to drain.
+        """
+        pool = DeferredPool()
+        self.assertEqual(pool.status(), (0, 0))
+
+    def testPoolDeferredCount(self):
+        """
+        The pool must correctly report how many deferreds it has underway.
+        """
+        pool = DeferredPool()
+        pool.add(defer.Deferred())
+        pool.add(defer.Deferred())
+        self.assertEqual(pool.status(), (2, 0))
+
+    def testPoolWaitingCount(self):
+        """
+        The pool must correctly report how many deferreds are waiting
+        for it to drain.
+        """
+        pool = DeferredPool()
+        pool.notifyWhenEmpty(testImmediately=False)
+        pool.notifyWhenEmpty(testImmediately=False)
+        self.assertEqual(pool.status(), (0, 2))
+
+    def testPoolStatus(self):
+        """
+        The pool must correctly report how many deferreds are underway
+        and how many are waiting for it to drain.
+        """
+        pool = DeferredPool()
+        pool.add(defer.Deferred())
+        pool.add(defer.Deferred())
+        pool.notifyWhenEmpty(testImmediately=False)
+        self.assertEqual(pool.status(), (2, 1))
+
+    def testPoolStatusAfterDeferredIsCallbacked(self):
+        """
+        The pool must correctly report how many deferreds are underway
+        and how many are waiting for it to drain after one of its underway
+        deferreds is callbacked.
+        """
+        pool = DeferredPool()
+        d = defer.Deferred()
+        pool.add(d)
+        pool.add(defer.Deferred())
+        self.assertEqual(pool.status(), (2, 0))
+        d.callback(None)
+        self.assertEqual(pool.status(), (1, 0))
+
+    def testPoolStatusAfterDeferredIsErrbacked(self):
+        """
+        The pool must correctly report how many deferreds are underway
+        and how many are waiting for it to drain after one of its underway
+        deferreds is errbacked.
+        """
+        pool = DeferredPool()
+        d = defer.Deferred()
+        d.addErrback(lambda _: True)
+        pool.add(d)
+        pool.add(defer.Deferred())
+        self.assertEqual(pool.status(), (2, 0))
+        d.errback(Exception())
+        self.assertEqual(pool.status(), (1, 0))
+
+    def testCallbackedDeferredFiresWithTheRightResult(self):
+        """
+        The pool must correctly pass the original deferred callback result
+        through any callbacks it might have added.
+        """
+        pool = DeferredPool()
+        d = defer.Deferred()
+        pool.add(d)
+        pool.notifyWhenEmpty()
+        expectedValue = object()
+        d.callback(expectedValue)
+        self.assertIdentical(d.result, expectedValue)
+
+    def testErrbackedDeferredFiresWithTheRightResult(self):
+        """
+        The pool must correctly pass the original deferred errback result
+        through any callbacks it might have added.
+        """
+        expectedValue = Exception()
+        pool = DeferredPool()
+        d = defer.Deferred()
+        pool.add(d)
+        pool.notifyWhenEmpty()
+        d.errback(expectedValue)
+        self.assertIdentical(d.result.value, expectedValue)
+        return self.assertFailure(d, Exception)
+
+    def testEmptyPoolWithTestImmediatelyTrue(self):
+        """
+        If the pool is empty and C{testImmediately} is C{True} when
+        calling L{notifyWhenEmpty}, an already fired (with C{None} result)
+        deferred must be returned and the pool should be empty.
+        """
+        pool = DeferredPool()
+        d = pool.notifyWhenEmpty(testImmediately=True)
+        self.assertEqual(d.called, True)
+        self.assertEqual(d.result, None)
+        self.assertEqual(pool.status(), (0, 0))
+
+    def testEmptyPoolWithTestImmediatelyFalse(self):
+        """
+        If the pool is empty and C{testImmediately} is C{False} when
+        calling L{notifyWhenEmpty}, the returned deferred must not have
+        already fired and the pool should contain one waiting deferred.
+        """
+        pool = DeferredPool()
+        d = pool.notifyWhenEmpty(testImmediately=False)
+        self.assertEqual(d.called, False)
+        self.assertEqual(pool.status(), (0, 1))
+
+    def testNonEmptyPoolWithTestImmediatelyTrue(self):
+        """
+        If the pool is not empty and C{testImmediately} is C{True} when
+        calling L{notifyWhenEmpty}, the returned deferred must not have
+        already fired and the pool should contain one underway deferred
+        and one waiting.
+        """
+        pool = DeferredPool()
+        pool.add(defer.Deferred())
+        d = pool.notifyWhenEmpty(testImmediately=True)
+        self.assertEqual(d.called, False)
+        self.assertEqual(pool.status(), (1, 1))
+
+    def testPoolEmpties(self):
+        """
+        If all the deferreds in a pool fire, its underway list should be empty.
+        """
+        pool = DeferredPool()
+        d1 = defer.Deferred()
+        d2 = defer.Deferred()
+        d3 = defer.Deferred()
+        pool.add(d1)
+        pool.add(d2)
+        pool.add(d3)
+        self.assertEqual(pool.status(), (3, 0))
+        d1.callback(None)
+        d2.callback(None)
+        d3.callback(None)
+        self.assertEqual(pool.status(), (0, 0))
+
+    def testNotifyWhenPoolEmpties(self):
+        """
+        After all the deferreds in a pool fire, it should call all notify
+        callbacks.
+        """
+        pool = DeferredPool()
+        d1 = defer.Deferred()
+        d2 = defer.Deferred()
+        d3 = defer.Deferred()
+        pool.add(d1)
+        pool.add(d2)
+        pool.add(d3)
+        # There must be 3 deferreds underway.
+        self.assertEqual(pool.status(), (3, 0))
+        wait1 = pool.notifyWhenEmpty()
+        wait2 = pool.notifyWhenEmpty()
+        # There must be 3 deferreds underway and 2 waiting.
+        self.assertEqual(pool.status(), (3, 2))
+        d1.callback(None)
+        d2.callback(None)
+        # There must be 1 deferreds underway and 2 waiting.
+        self.assertEqual(pool.status(), (1, 2))
+        # The waiters must not have fired yet.
+        self.assertEqual(wait1.called, False)
+        self.assertEqual(wait2.called, False)
+        d3.callback(None)
+        # Both waiters must have fired (with None) & the pool must be empty.
+        self.assertEqual(wait1.called, True)
+        self.assertEqual(wait2.called, True)
+        self.assertEqual(pool.status(), (0, 0))
+        self.assertEqual(wait1.result, None)
+        self.assertEqual(wait2.result, None)
+
+
 class TestDeferredPool(unittest.TestCase):
     
     def test_trivial(self):

--- a/master/buildbot/util/deferredpool.py
+++ b/master/buildbot/util/deferredpool.py
@@ -1,28 +1,17 @@
-# Copyright 2013 Terry Jones (terry@jon.es). All Rights Reserved.
-# 
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-# 
-# 1. Redistributions of source code must retain the above copyright notice, this
-#    list of conditions and the following disclaimer.
-# 
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
-# 
-# 3. The name of the author may not be used to endorse or promote products
-#    derived from this software without specific prior written permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY [LICENSOR] "AS IS" AND ANY EXPRESS OR IMPLIED
-# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
-# EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-# OF SUCH DAMAGE.
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
 
 from twisted.internet import defer
 
@@ -70,3 +59,11 @@ class DeferredPool(object):
             d = defer.Deferred()
             self._waiting.append(d)
             return d
+
+    def status(self):
+        """
+        Return a tuple containing the number of deferreds that are
+        outstanding and the number of deferreds that are waiting for the
+        pool to empty.
+        """
+        return len(self._pool), len(self._waiting)


### PR DESCRIPTION
This DeferredPool is similar to a DeferredList, but can have additional deferreds added to it after creation.

Buildbot doesn't currently use this, but I plan to.
If you want me to hold these commits till then, that's cool, but wanted to let you have a look in either case.
