### PR TITLE
make the trigger steps's fake scheduler behave like the real one

### DIFF
--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -148,10 +148,11 @@ class Trigger(LoggingBuildStep):
         dl = []
         triggered_names = []
         for sch in triggered_schedulers:
-            dl.append(sch.trigger(
+            idsDeferred, resultsDeferred = sch.trigger(
                 waited_for=self.waitForFinish, sourcestamps=ss_for_trigger,
                 set_props=props_to_set
-            ))
+            )
+            dl.append(resultsDeferred)
             triggered_names.append(sch.name)
         self.step_status.setText(['triggered'] + triggered_names)
 

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -32,6 +32,7 @@ class FakeTriggerable(object):
 
     triggered_with = None
     result = SUCCESS
+    bsid = 1
     brids = {}
     exception = False
 
@@ -40,12 +41,14 @@ class FakeTriggerable(object):
 
     def trigger(self, waited_for, sourcestamps = None, set_props=None):
         self.triggered_with = (waited_for, sourcestamps, set_props.properties)
-        d = defer.Deferred()
+        idsDeferred = defer.Deferred()
+        idsDeferred.callback((self.bsid, self.brids))
+        resultsDeferred = defer.Deferred()
         if self.exception:
-            reactor.callLater(0, d.errback, RuntimeError('oh noes'))
+            reactor.callLater(0, resultsDeferred.errback, RuntimeError('oh noes'))
         else:
-            reactor.callLater(0, d.callback, (self.result, self.brids))
-        return d
+            reactor.callLater(0, resultsDeferred.callback, (self.result, self.brids))
+        return (idsDeferred, resultsDeferred)
 
 class TriggerableInterfaceTest(unittest.TestCase, InterfaceTests):
 


### PR DESCRIPTION
The fake scheduler in the trigger step's test had drifted away from the real thing.
I had relied on the interface assertion to keep them in sync, but the interface doesn't capture cardinality of return values.

Not sure how to improve the test coverage, but it's fixed now.
