### PR TITLE
Fix bug in parameter validation, empty arg should be remove from args li...

### DIFF
--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -88,6 +88,12 @@ class BaseParameter(object):
            the optional regex field and calls 'parse_from_args' for the final conversion.
         """
         args = kwargs.get(self.fullName, [])
+
+        # delete white space for args
+        for arg in args:
+            if not arg.strip():
+                args.remove(arg)
+                
         if len(args) == 0:
             if self.required:
                 raise ValidationError("'%s' needs to be specified" % (self.label))


### PR DESCRIPTION
When using a forcescheduler Stringparameter the option "required" option is not taken account as the args  length is always bigger than 0.
