### PR TITLE
ec2buildslave: Fix import error with EC2LatentBuildSlave

### DIFF
--- a/master/buildbot/ec2buildslave.py
+++ b/master/buildbot/ec2buildslave.py
@@ -16,7 +16,7 @@
 from twisted.python.deprecate import deprecatedModuleAttribute
 from twisted.python.versions import Version
 
-from buildbot.buildslave.libvirt import (
+from buildbot.buildslave.ec2 import (
     EC2LatentBuildSlave)
 
 deprecatedModuleAttribute(Version("Buildbot", 0, 8, 8),


### PR DESCRIPTION
The migration module buildbot.ec2buildslave tried to import
EC2LatentBuildSlave from buildbot.buildslave.libvirt, but that class
lives in buildbot.buildslave.ec2, causing a import error when loading
the module.

Or perhaps I'm just missing something, sorry for the noise in that case. @tomprince, do you mind take a look? (Should this be rebased to the 0.8.8 branch?)

(This was discovered thanks to @elmirjagudin's work on enabling pylint.)
