### PR TITLE
GitPoller support for multiple branches per repo

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -42,9 +42,6 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         if pollinterval != -2:
             pollInterval = pollinterval
 
-        base.PollingChangeSource.__init__(self, name=repourl,
-                pollInterval=pollInterval)
-
         if project is None: project = ''
 
         if branch and branches:
@@ -53,6 +50,10 @@ class GitPoller(base.PollingChangeSource, StateMixin):
             branches = [branch]
         elif not branches:
             branches = ['master']
+
+        for br in branches:
+            base.PollingChangeSource.__init__(self, name=repourl+'-'+br,
+                    pollInterval=pollInterval)
 
         self.repourl = repourl
         self.branches = branches
@@ -195,8 +196,8 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         revList.reverse()
         self.changeCount = len(revList)
             
-        log.msg('gitpoller: processing %d changes: %s from "%s"'
-                % (self.changeCount, revList, self.repourl) )
+        log.msg('gitpoller: processing %d changes: %s from "%s" (branch %s)'
+                % (self.changeCount, revList, self.repourl, branch) )
 
         for rev in revList:
             dl = defer.DeferredList([

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -120,6 +120,7 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
                     unittest.TestCase):
 
     REPOURL = 'git@example.com:foo/baz.git'
+    BRANCH = 'master'
     REPOURL_QUOTED = 'git%40example.com%3Afoo%2Fbaz.git'
 
     def setUp(self):
@@ -157,7 +158,7 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
                 'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
                 })
             self.master.db.state.assertStateByClass(
-                    name=self.REPOURL, class_name='GitPoller',
+                    name=self.REPOURL+'-'+self.BRANCH, class_name='GitPoller',
                     lastRev={
                         'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
                         })
@@ -271,7 +272,7 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
         def cb(_):
             self.assertAllCommandsRan()
             self.master.db.state.assertStateByClass(
-                    name=self.REPOURL, class_name='GitPoller',
+                    name=self.REPOURL+'-'+self.BRANCH, class_name='GitPoller',
                     lastRev={
                         'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
                         })
@@ -507,7 +508,7 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
             self.assertAllCommandsRan()
 
             self.master.db.state.assertStateByClass(
-                    name=self.REPOURL, class_name='GitPoller',
+                    name=self.REPOURL+'-'+self.BRANCH, class_name='GitPoller',
                     lastRev={
                         'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
                         })
@@ -533,7 +534,7 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
         startService = mock.Mock()
         self.patch(base.PollingChangeSource, "startService", startService)
         self.master.db.state.fakeState(
-            name=self.REPOURL, class_name='GitPoller',
+            name=self.REPOURL+'-'+self.BRANCH, class_name='GitPoller',
             lastRev={"master": "fa3ae8ed68e664d4db24798611b352e3c6509930"},
         )
 


### PR DESCRIPTION
When trying to get two GitPoller's working with the same repourl but with different branches, master crashes with this error:

File "/home/buildbot/lib/python2.6/site-packages/twisted/application/service.py", line 303, in addService
            " '%s'" % service.name)
        exceptions.RuntimeError: cannot have two services with same name ...

The fix is to combine repourl and branch to get the name of the service.
