### PR TITLE
Do not ignore default choices for ForceScheduler list parameters

### DIFF
--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -214,8 +214,6 @@ def buildForceContextForField(req, default_props, sch, field, master, buildernam
 
     if "list" in field.type:
         choices = field.getChoices(master, sch, buildername)
-        if choices:
-            default = choices[0]
         default_props[pname+".choices"] = choices
             
     default = req.args.get(pname, [default])[0]


### PR DESCRIPTION
The default choices for `ForceScheduler`s list type parameters are ignored in 0.8.8. Right now the default selection is hardcoded to the first element of `choices` and `default` is totally ignored for parameters of type `"list"`.

This commit restores the behavior of buildbot <=0.8.7.
