### PR TITLE
buildbot.status.mail: improve email address regexp

### DIFF
--- a/master/buildbot/status/mail.py
+++ b/master/buildbot/status/mail.py
@@ -51,7 +51,19 @@ from buildbot.process.users import users
 from buildbot.status import base
 from buildbot.status.results import FAILURE, SUCCESS, WARNINGS, EXCEPTION, Results
 
-VALID_EMAIL = re.compile("[a-zA-Z0-9\.\_\%\-\+]+@[a-zA-Z0-9\.\_\%\-]+.[a-zA-Z]{2,6}")
+# Email parsing can be complex. We try to take a very liberal
+# approach. The local part of an email address matches ANY non
+# whitespace character. Rather allow a malformed email address than
+# croaking on a valid (the matching of domains should be correct
+# though; requiring the domain to not be a top level domain). With
+# these regular expressions, we can match the following:
+#
+#    full.name@example.net
+#    Full Name <full.name@example.net>
+#    <full.name@example.net>
+VALID_EMAIL_ADDR = r"(?:\S+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+\.?)"
+VALID_EMAIL = re.compile(r"^(?:%s|(.+\s+)?<%s>\s*)$" % ((VALID_EMAIL_ADDR,)*2))
+VALID_EMAIL_ADDR = re.compile(VALID_EMAIL_ADDR)
 
 ENCODING = 'utf8'
 LOG_ENCODING = 'utf-8'


### PR DESCRIPTION
The previous email regexp contained some flaws; the intentions of the regexp and the implemention had some gaps that would make it hard to rely on.

This rewrite should match any valid email address, but it does not give any guarantees that what it matches is a valid address. An increased level of complexity is (hopefully) compensated by a comment explaining the reasoning behind the regexp. This is accompanied by unit tests; you are encouraged to add any corner case addresses in either the test for valid or invalid addresses.

---

Using regular expressions for parsing email addresses can be tricky, http://www.ex-parrot.com/~pdw/Mail-RFC822-Address.html. :-) From the original regexp, it wasn't completely clear what it would match and what it wouldn't match. Some surprising addresses were accepted! But, as I write in the comment, it's more important to not reject a valid address than it is to reject an invalid address (that would be handled by the MTA later anyways).

The main purpose of this change is to make it clear what kind of strings the regexp is expected to be applied on, the actual regexp is very much up for debate.
