### PR TITLE
Supporting "all branches" in describe

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -93,8 +93,12 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         status = ""
         if not self.master:
             status = "[STOPPED - check log]"
-        str = ('GitPoller watching the remote git repository %s, branches: %s %s'
-                % (self.repourl, ', '.join(self.branches), status))
+        if self.branches is True:
+            branches = 'all branches'
+        else:
+            branches = 'branches: %s' % ', '.join(self.branches)
+        str = ('GitPoller watching the remote git repository %s, %s %s'
+                % (self.repourl, branches, status))
         return str
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Currently, passing `branches=True` causes an error on the web interface Changesources page, as it assumes `self.branches` is a list, and joins it.
