### PR TITLE
Use trial's less verbose "text" reporter on Travis (fixes http://trac.buildbot.net/ticket/2569)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,8 @@ install:
 
 # Tests running commands
 script:
-  - trial buildbot.test
-  - trial buildslave.test
+  - trial --reporter=text --rterrors buildbot.test
+  - trial --reporter=text --rterrors buildslave.test
 
   # Run additional tests only in latest configuration
   - "[ $IS_LATEST = false ] || make pylint"


### PR DESCRIPTION
Plus use "--rterrors" flag: "Print tracebacks to standard output as soon
as they occur".
