### PR TITLE
fixing sphinx errors

### DIFF
--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -969,8 +969,6 @@ for example::
 
 .. _Step-Gerrit:
 
-.. bb:step:: Gerrit
-
 Gerrit
 ++++++
 
@@ -989,8 +987,6 @@ in Gerrit, and can only be described by humans.
 .. bb:step:: Darcs
 
 .. _Step-Darcs:
-
-.. bb:step:: Darcs
 
 Darcs
 +++++


### PR DESCRIPTION
fixing sphinx warnings/errors.

```
% make docs                                                                                       -I-
make -C master/docs
make[1]: Entering directory `/home/bak1an/workspaces/buildbot/buildbot/master/docs'
rm -rf _build/*
sphinx-build -b html -d _build/doctrees  -q -W . _build/html
Making output directory...

Warning, treated as error:
/home/bak1an/workspaces/buildbot/buildbot/master/docs/manual/cfg-buildsteps.rst:4: SEVERE: Duplicate ID: "step-Darcs".

make[1]: *** [html] Error 1
make[1]: Leaving directory `/home/bak1an/workspaces/buildbot/buildbot/master/docs'
make: *** [docs] Error 2
```
