### PR TITLE
tryclient: Fix off-by-one error when finding current git branch

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -330,7 +330,7 @@ class GitExtractor(SourceStampExtractor):
         remote = self.config.get("branch." + self.branch + ".remote")
         ref = self.config.get("branch." + self.branch + ".merge")
         if remote and ref:
-            remote_branch = ref.split("/", 3)[-1]
+            remote_branch = ref.split("/", 2)[-1]
             d = self.dovc(["rev-parse", remote + "/" + remote_branch])
             d.addCallback(self.override_baserev)
             return d


### PR DESCRIPTION
Git branches' complete names follow the form "refs/heads/<branchname>".
Branchnames may contain additional slashes. Therefore, we need to split
up to two times (three pieces) if the last piece is to contain the
complete branch name.

Without this patch, when the branch "dev/newstuff"
("refs/heads/dev/newstuff", to be exact) has the remote "origin", it
would get mangled into "origin/newstuff" - as that's not the same
branch, the try job would fail.
