### PR TITLE
rename startCommands to remoteStartCommand

### DIFF
--- a/master/buildbot/buildslave/protocols/base.py
+++ b/master/buildbot/buildslave/protocols/base.py
@@ -55,7 +55,7 @@ class Connection(object):
     def remoteSetBuilderList(self, builders):
         raise NotImplementedError
 
-    def startCommands(self, remoteCommand, builderName, commandId, commandName, args):
+    def remoteStartCommand(self, remoteCommand, builderName, commandId, commandName, args):
         raise NotImplementedError
 
     def remoteShutdown(self):

--- a/master/buildbot/buildslave/protocols/pb.py
+++ b/master/buildbot/buildslave/protocols/pb.py
@@ -154,7 +154,7 @@ class Connection(base.Connection, pb.Avatar):
         d.addCallback(cache_builders)
         return d
 
-    def startCommands(self, remoteCommand, builderName, commandId, commandName, args):
+    def remoteStartCommand(self, remoteCommand, builderName, commandId, commandName, args):
         slavebuilder = self.builders.get(builderName)
         return slavebuilder.callRemote('startCommand',
             remoteCommand, commandId, commandName, args

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -103,7 +103,7 @@ class RemoteCommand(pb.Referenceable):
         # We will receive remote_update messages as the command runs.
         # We will get a single remote_complete when it finishes.
         # We should fire self.deferred when the command is done.
-        d = self.conn.startCommands(self, self.builder_name, self.commandID,
+        d = self.conn.remoteStartCommand(self, self.builder_name, self.commandID,
             self.remote_command, self.args)
         return d
 

--- a/master/buildbot/test/fake/fakeprotocol.py
+++ b/master/buildbot/test/fake/fakeprotocol.py
@@ -40,8 +40,8 @@ class FakeConnection(base.Connection):
         self.builders = dict((b, False) for b in builders)
         return defer.succeed(None)
 
-    def startCommands(self, remoteCommand, builderName, commandId, commandName, args):
-        self.remoteCalls.append(('startCommands', remoteCommand, builderName,
+    def remoteStartCommand(self, remoteCommand, builderName, commandId, commandName, args):
+        self.remoteCalls.append(('remoteStartCommand', remoteCommand, builderName,
             commandId, commandName, args))
         return defer.succeed(None)
 

--- a/master/buildbot/test/unit/test_buildslave_protocols_pb.py
+++ b/master/buildbot/test/unit/test_buildslave_protocols_pb.py
@@ -168,7 +168,7 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(conn.builders, builders)
         self.mind.callRemote.assert_called_with('setBuilderList', builders)
 
-    def test_startCommands(self):
+    def test_remoteStartCommand(self):
         builders = ['builder']
         ret_val = {'builder': mock.Mock()}
         self.mind.callRemote.return_value = defer.succeed(ret_val)
@@ -178,7 +178,7 @@ class TestConnection(unittest.TestCase):
         RCInstance, builder_name, commandID = None, "builder", None
         remote_command, args = "command", "args"
 
-        conn.startCommands(RCInstance, builder_name, commandID, remote_command, args)
+        conn.remoteStartCommand(RCInstance, builder_name, commandID, remote_command, args)
 
         ret_val['builder'].callRemote.assert_called_with('startCommand',
             RCInstance, commandID, remote_command, args)

--- a/master/buildbot/test/util/protocols.py
+++ b/master/buildbot/test/util/protocols.py
@@ -46,9 +46,9 @@ class ConnectionInterfaceTest(interfaces.InterfaceTests):
         def remoteSetBuilderList(self, builders):
             pass
 
-    def test_sig_startCommands(self):
-        @self.assertArgSpecMatches(self.conn.startCommands)
-        def startCommands(self, remoteCommand, builderName, commandId,
+    def test_sig_remoteStartCommand(self):
+        @self.assertArgSpecMatches(self.conn.remoteStartCommand)
+        def remoteStartCommand(self, remoteCommand, builderName, commandId,
                                 commandName, args):
             pass
 

--- a/master/docs/developer/cls-protocols.rst
+++ b/master/docs/developer/cls-protocols.rst
@@ -55,7 +55,7 @@ to know about protocol calls or handle protocol specific exceptions.
         Take list with wanted builders and send them to slave, return list with
         created builders
 
-    .. py:method:: startCommands(remoteCommand, builderName, commandId, commandName, args)
+    .. py:method:: remoteStartCommand(remoteCommand, builderName, commandId, commandName, args)
 
         :param remoteCommand: :py:class:`~buildbot.process.remotecommand.RemoteCommand` instance
         :param builderName: self explanatory


### PR DESCRIPTION
This just renames the method to be somewhat less confusing, and indicate that it makes a remote call.  It doesn't address the fact that its first argument is a `pb.Referencable`, nor that its args may contain `pb.Referencable` objects.

@MichaelMayorov
