### PR TITLE
On Python 2.6 and 2.7 install txrequests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ install:
   # mock is preinstalled on Travis
   # txgithub requires Twisted >= 12.3.0, which doesn't work on Python 2.5.
   - "[ $TRAVIS_PYTHON_VERSION = '2.5' ] || pip install txgithub"
+  # txrequests support only Python 2.6 and 2.7.
+  - "[ $TRAVIS_PYTHON_VERSION = '2.5' ] || pip install txrequests"
 
   # Determine is current configuration is latest
   - |


### PR DESCRIPTION
Required for several tests:

buildbot.test.unit.test_steps_http.TestHTTPStep.test_404
buildbot.test.unit.test_steps_http.TestHTTPStep.test_POST
buildbot.test.unit.test_steps_http.TestHTTPStep.test_basic
buildbot.test.unit.test_steps_http.TestHTTPStep.test_header
