### PR TITLE
Install buildbot-www on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,11 @@ before_install:
   # command prompt.
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 
+  # Install fresh Node.js from PPA
+  - sudo add-apt-repository -y ppa:chris-lea/node.js
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq nodejs
+
 # Dependencies installation commands
 install:
   # Fetch objects and tags from upstream git repository.


### PR DESCRIPTION
Required for running buildbot-www tests.

With this change test run time in single configuration on Travis increases up to 3-4 minutes (was 1-2 minutes).
