### PR TITLE
Revert p4 change log tabs

### DIFF
--- a/master/buildbot/test/unit/test_changes_p4poller.py
+++ b/master/buildbot/test/unit/test_changes_p4poller.py
@@ -35,20 +35,20 @@ third_p4changes = \
 change_4_log = \
 """Change 4 by mpatel@testclient on 2006/04/13 21:55:39
 
-	short desc truncated because this is a long description.
+\tshort desc truncated because this is a long description.
 """
 
 change_3_log = \
 u"""Change 3 by bob@testclient on 2006/04/13 21:51:39
 
-	short desc truncated because this is a long description.
+\tshort desc truncated because this is a long description.
     ASDF-GUI-P3-\u2018Upgrade Icon\u2019 disappears sometimes.
 """
 
 change_2_log = \
 """Change 2 by slamb@testclient on 2006/04/13 21:46:23
 
-	creation
+\tcreation
 """
 
 p4change = {


### PR DESCRIPTION
@jaredgrubb pertinently remarked in https://github.com/buildbot/buildbot/pull/923 that in some emulated output from Perforce tabs was replaced with spaces (in 9a233a and 9507d3) and that this change can break Perforce emulation.

I'm not familiar with P4 output format and tests in master/buildbot/test/unit/test_changes_p4poller.py module, so I prefer to revert to using tabs (but in a way that doesn't break pep8).
