### PR TITLE
Check that all steps have a non-None name

### DIFF
--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -158,6 +158,9 @@ class BuildStepMixin(object):
         self.exp_logfiles = {}
         self.exp_hidden = False
 
+        # check that the step's name is not None
+        self.assertNotEqual(step.name, None)
+
         return step
 
     def expectCommands(self, *exp):


### PR DESCRIPTION
This fixes #2501
