### PR TITLE
status/words: don't print revisions if useRevisions is false

### DIFF
--- a/master/buildbot/status/words.py
+++ b/master/buildbot/status/words.py
@@ -398,11 +398,24 @@ class IRCContact(base.StatusReceiver):
             r = "build containing revision(s) [%s] on %s started" % \
                 (build.getRevisions(), builder.getName())
         else:
-            r = "build #%d of %s started, including [%s]" % \
-                (build.getNumber(),
-                 builder.getName(),
-                 ", ".join([str(c.revision) for c in build.getChanges()])
-                 )
+            # Abbreviate long lists of changes to simply two
+            # revisions, and the number of additional changes.
+            changes = [str(c.revision) for c in build.getChanges()][:2]
+            changes_str = ""
+
+            if len(build.getChanges()) > 0:
+                changes_str = "including [%s]" % ', '.join(changes)
+
+                if len(build.getChanges()) > 2:
+                    # Append number of truncated changes
+                    changes_str += " and %d more" % (len(build.getChanges())-2)
+
+            r = "build #%d of %s started" % (
+                build.getNumber(),
+                builder.getName())
+
+            if changes_str:
+                r += " (%s)" % changes_str
 
         self.send(r)
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -117,6 +117,10 @@ Features
   
 * :bb:step:`CVS` source step now checks for "sticky dates" from a previous checkout before updating an existing source directory.
 
+* The IRC bot of :bb:status:`words` will, unless useRevisions is set, shorten
+  long lists of revisions printed when a build starts; it will only show two,
+  and the number of additional revisions included in the build.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
Having useRevisions set to false, and still having a (potentially very long) list of revisions when a build starts printed in the IRC channel can be confusing. This change removes the "including [list of revisions]" part of the message.
