### PR TITLE
Add createAbsoluteSourceStamps argument to Nightly

### DIFF
--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -121,6 +121,8 @@ class Change(Row):
         repository = 'repo',
         codebase =  '',
         project = 'proj',
+        properties = dict(),
+        files = []
     )
 
     lists = ('files',)
@@ -464,7 +466,7 @@ class FakeChangesComponent(FakeDBComponent):
             changeid = change.number
 
         # make a row from the change
-        row = dict(
+        row = Change(
             changeid=changeid,
             author=change.who,
             files=change.files,
@@ -520,25 +522,25 @@ class FakeSchedulersComponent(FakeDBComponent):
             # filter out the classifications for the requested branch
             classifications = dict(
                     (k,v) for (k,v) in classifications.iteritems()
-                    if self.db.changes.changes.get(k, sentinel)['branch'] == branch )
+                    if self.db.changes.changes.get(k, sentinel).branch == branch )
 
         if repository != -1:
             # filter out the classifications for the requested branch
             classifications = dict(
                     (k,v) for (k,v) in classifications.iteritems()
-                    if self.db.changes.changes.get(k, sentinel)['repository'] == repository )
+                    if self.db.changes.changes.get(k, sentinel).repository == repository )
 
         if project != -1:
             # filter out the classifications for the requested branch
             classifications = dict(
                     (k,v) for (k,v) in classifications.iteritems()
-                    if self.db.changes.changes.get(k, sentinel)['project'] == project )
+                    if self.db.changes.changes.get(k, sentinel).project == project )
 
         if codebase != -1:
             # filter out the classifications for the requested branch
             classifications = dict(
                     (k,v) for (k,v) in classifications.iteritems()
-                    if self.db.changes.changes.get(k, sentinel)['codebase'] == codebase )
+                    if self.db.changes.changes.get(k, sentinel).codebase == codebase )
 
         return defer.succeed(classifications)
 

--- a/master/docs/manual/cfg-schedulers.rst
+++ b/master/docs/manual/cfg-schedulers.rst
@@ -109,6 +109,12 @@ available with all schedulers.
 ``reason``
     A string that will be used as the reason for the triggered build.
 
+``createAbsoluteSourceStamps``
+    This option only has effect when using multiple codebases. When ``True``, it
+    uses the last seen revision for each codebase that does not have a change.
+    When ``False``, the default value, codebases without changes will use the
+    revision from the ``codebases`` argument.
+
 The remaining subsections represent a catalog of the available Scheduler types.
 All these Schedulers are defined in modules under :mod:`buildbot.schedulers`,
 and the docstrings there are the best source of documentation on the arguments
@@ -264,12 +270,6 @@ The arguments to this scheduler are:
 
     .. note:: ``None`` is a keyword, not a string, so write ``None``
        and not ``"None"``.
-
-``createAbsoluteSourceStamps``
-    This option only has effect when using multiple codebases. When ``True``, it
-    uses the last seen revision for each codebase that does not have a change.
-    When ``False``, the default value, codebases without changes will use the
-    revision from the ``codebases`` argument.
 
 
 Example::
@@ -482,9 +482,11 @@ The full list of parameters is:
 ``reason``
 
 ``codebases``
-    See :ref:`Configuring-Schedulers`.  Note that ``fileIsImportant`` and
-    ``change_filter`` are only relevant if ``onlyIfChanged`` is
-    ``True``.
+
+``createAbsoluteSourceStamps``
+    See :ref:`Configuring-Schedulers`.  Note that ``fileIsImportant``,
+    ``change_filter`` and ``createAbsoluteSourceStamps`` are only relevant
+    if ``onlyIfChanged`` is ``True``.
 
 ``onlyIfChanged``
     If this is true, then builds will not be scheduled at the designated time

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -117,6 +117,8 @@ Features
   
 * :bb:step:`CVS` source step now checks for "sticky dates" from a previous checkout before updating an existing source directory.
 
+* A new argument ``createAbsoluteSourceStamps`` has been added to ``Nightly`` for use with multiple codebases.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
This is based on pull request #758.

When multiple codebases are used and createAbsoluteSourceStamps is
enabled, it uses the last revision seen for each codebase without
changes when creating the buildset. This stops any changes from the time
the buildset it created and source step is run from being included in
the build.
