### PR TITLE
when submitter or owner have no name value will cause exception,fix this...

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -119,8 +119,9 @@ class GerritChangeSource(base.ChangeSource):
         return d
     def eventReceived_patchset_created(self, properties, event):
         change = event["change"]
+        username = change["owner"].get("username","unknown")
         return self.addChange(dict(
-                author="%s <%s>" % (change["owner"]["name"], change["owner"]["email"]),
+                author="%s <%s>" % (change["owner"].get("name",username), change["owner"].get("email","unknown@example.com")),
                 project=change["project"],
                 repository="ssh://%s@%s:%s/%s" % (
                     self.username, self.gerritserver, self.gerritport, change["project"]),
@@ -136,7 +137,8 @@ class GerritChangeSource(base.ChangeSource):
         author = "gerrit"
 
         if "submitter" in event:
-            author="%s <%s>" % (event["submitter"]["name"], event["submitter"]["email"])
+            username = event["submitter"].get("username","unknown")
+            author="%s <%s>" % (event["submitter"].get("name",username), event["submitter"].get("email","unnkown@example.com"))
 
         return self.addChange(dict(
                 author=author,


### PR DESCRIPTION
... by give default value

In my gerrit with config with ldap,there are some accounts with no "name",for example some user just add for buildbot,it will cause exception because the data gerrit return have not "name" in dict.
This patch want to fix this by give default value of username.
