### PR TITLE
Don't specify a revision to pull from a mercurial repository

### DIFF
--- a/master/buildbot/steps/source/mercurial.py
+++ b/master/buildbot/steps/source/mercurial.py
@@ -219,8 +219,6 @@ class Mercurial(Source):
 
     def _pullUpdate(self, res):
         command = ['pull' , self.repourl]
-        if self.revision:
-            command.extend(['--rev', self.revision])
         d = self._dovccmd(command)
         d.addCallback(self._checkBranchChange)
         return d


### PR DESCRIPTION
Buildbot trac ticket 438.  Pulling a tag does not guarantee
that mercurial can update to that tag.
