### PR TITLE
rewrite BuildStep.startStep to use inlineCallbacks

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -418,7 +418,7 @@ class Build(properties.PropertiesMixin):
         text = None
         if isinstance(result, types.TupleType):
             result, text = result
-        assert isinstance(result, type(SUCCESS))
+        assert isinstance(result, type(SUCCESS)), "got %r" % (result,)
         log.msg(" step '%s' complete: %s" % (step.name, Results[result]))
         self.results.append(result)
         if text:

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -159,6 +159,8 @@ class Trigger(LoggingBuildStep):
 
         if self.waitForFinish:
             rclist = yield defer.DeferredList(dl, consumeErrors=1)
+            if self.ended:
+                return
         else:
             # do something to handle errors
             for d in dl:

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -225,8 +225,6 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
         d = self.runStep()
         d.addErrback(log.err)
         d.addCallback(lambda _:
-                      self.assertEqual(len(self.flushLoggedErrors(defer.FirstError)), 1))
-        d.addCallback(lambda _:
                       self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1))
         d.addCallback(lambda _: self.assertTrue(called[0]))
         return d

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -132,13 +132,12 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
     def runStep(self, expect_waitForFinish=False):
         d = steps.BuildStepMixin.runStep(self)
 
+        # the build doesn't finish until after a callLater, so this has the
+        # effect of checking whether the deferred has been fired already;
         if expect_waitForFinish:
-            # the build doesn't finish until after a callLater, so this has the
-            # effect of checking whether the deferred has been fired already;
-            # it should not have been!
-            early = []
-            d.addCallback(early.append)
-            self.assertEqual(early, [])
+            self.assertFalse(d.called)
+        else:
+            self.assertTrue(d.called)
 
         def check(_):
             self.assertEqual(self.scheduler_a.triggered_with,


### PR DESCRIPTION
A cleanup backported from nine
