### PR TITLE
Set .master for buildsteps

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -512,6 +512,7 @@ class BuildStep(object, properties.PropertiesMixin):
 
         self._acquiringLock = None
         self.stopped = False
+        self.master = None
 
     def __new__(klass, *args, **kwargs):
         self = object.__new__(klass)
@@ -533,6 +534,7 @@ class BuildStep(object, properties.PropertiesMixin):
 
     def setBuild(self, build):
         self.build = build
+        self.master = self.build.master
 
     def setBuildSlave(self, buildslave):
         self.buildslave = buildslave

--- a/master/buildbot/test/regressions/test_shell_command_properties.py
+++ b/master/buildbot/test/regressions/test_shell_command_properties.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+import mock
 from twisted.trial import unittest
 
 from buildbot.steps.shell import ShellCommand, SetPropertyFromCommand
@@ -84,6 +85,7 @@ class TestShellCommandProperties(unittest.TestCase):
         req = FakeBuildRequest("Testing", {ss.repository:ss}, None)
 
         b = f.newBuild([req])
+        b.master = mock.Mock(name='master')
         b.build_status = FakeBuildStatus()
         b.slavebuilder = FakeSlaveBuilder()
 
@@ -101,6 +103,7 @@ class TestSetProperty(unittest.TestCase):
         req = FakeBuildRequest("Testing", {ss.repository:ss}, None)
 
         b = f.newBuild([req])
+        b.master = mock.Mock(name='master')
         b.build_status = FakeBuildStatus()
         b.slavebuilder = FakeSlaveBuilder()
 

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -111,6 +111,7 @@ class TestBuild(unittest.TestCase):
 
         self.builder = self.createBuilder()
         self.build = Build([r])
+        self.build.master = self.master
         self.build.setBuilder(self.builder)
 
     def createBuilder(self):

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -16,7 +16,7 @@
 import mock
 from buildbot import interfaces
 from buildbot.process import buildstep
-from buildbot.test.fake import remotecommand, fakebuild, slave
+from buildbot.test.fake import remotecommand, fakebuild, slave, fakemaster
 
 
 class BuildStepMixin(object):
@@ -73,10 +73,12 @@ class BuildStepMixin(object):
         """
         factory = interfaces.IBuildStepFactory(step)
         step = self.step = factory.buildStep()
+        self.master = fakemaster.make_master(testcase=self)
 
         # step.build
 
         b = self.build = fakebuild.FakeBuild()
+        b.master = self.master
         def getSlaveVersion(cmd, oldversion):
             if cmd in slave_version:
                 return slave_version[cmd]


### PR DESCRIPTION
This actually passes the tests, unlike the first version I learned.

@tomprince pointed out that there may be steps using a similarly-named attribute.  If those are widespread, I'd like to see an example; otherwise, I think a release note ("don't use this attribute") should be sufficient.
