### PR TITLE
Fix Git failures when master-side Gerrit step used

### DIFF
--- a/master/buildbot/steps/source/gerrit.py
+++ b/master/buildbot/steps/source/gerrit.py
@@ -36,4 +36,4 @@ class Gerrit(Git):
                 pass
 
         branch = gerrit_branch or branch
-        super(Gerrit, self).startVC(gerrit_branch, revision, patch)
+        super(Gerrit, self).startVC(branch, revision, patch)


### PR DESCRIPTION
The Git step fetches from the wrong branch when being notified by
Gerrit 'ref-updated' events. In that case, branch=None is passed to
Git.startVC(...), hence the resulting git-fetch call tries to fetch HEAD
instead of the desired branch.

This was likely a typo from the original author.
