### PR TITLE
Tweak default status email formatting

### DIFF
--- a/master/buildbot/status/mail.py
+++ b/master/buildbot/status/mail.py
@@ -123,10 +123,10 @@ def defaultMessage(mode, name, build, results, master_status):
                 projects.append(ss.project)
     if not projects:
         projects = [master_status.getTitle()]
-    text += " on builder %s while building %s.\n" % (name, ', '.join(projects))
+    text += " on builder %s while building %s." % (name, ', '.join(projects))
 
     if master_status.getURLForThing(build):
-        text += "Full details are available at:\n %s\n" % master_status.getURLForThing(build)
+        text += " Full details are available at:\n    %s\n" % master_status.getURLForThing(build)
     text += "\n"
 
     if master_status.getBuildbotURL():
@@ -169,7 +169,7 @@ def defaultMessage(mode, name, build, results, master_status):
         text += "BUILD FAILED%s\n" % t
 
     text += "\n"
-    text += "sincerely,\n"
+    text += "Sincerely,\n"
     text += " -The Buildbot\n"
     text += "\n"
     return {'body': text, 'type': 'plain'}


### PR DESCRIPTION
Use a space instead of line break before "Full details" sentence.

Extra spaces before details URL.

Capitalize "Sincerely"
