### PR TITLE
add 'writefile' and 'readfile' commands on the slave

### DIFF
--- a/slave/buildslave/commands/registry.py
+++ b/slave/buildslave/commands/registry.py
@@ -36,6 +36,8 @@ commandRegistry = {
     "rmdir" : "buildslave.commands.fs.RemoveDirectory",
     "cpdir" : "buildslave.commands.fs.CopyDirectory",
     "stat" : "buildslave.commands.fs.StatFile",
+    "writefile" : "buildslave.commands.transfer.WriteFileCommand",
+    "readfile" : "buildslave.commands.transfer.ReadFileCommand",
 }
 
 def getFactory(command):


### PR DESCRIPTION
I found this while cleaning out my branches. Is there any good reason not to add these commands?

(accidentally misfiled at https://github.com/djmitche/buildbot/pull/13 initially)
