### PR TITLE
Remove Python 2.5 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: python
 # Available Python versions:
 # http://about.travis-ci.org/docs/user/ci-environment/#Python-VM-images
 python:
+  # "2.5" -- not supported by Travis CI anymore
   - "2.6"
   - "2.7"
 


### PR DESCRIPTION
Looks like Travis CI dropped Python 2.5 support [recently](http://about.travis-ci.org/blog/2013-11-18-upcoming-build-environment-updates/). The supported versions can found here: http://about.travis-ci.org/docs/user/ci-environment/#Python-VM-images

The fact that we can't test Python 2.5 compatibility on Travis CI anymore is concerning though.
