### PR TITLE
rewrite some steps to not use removed IStatusLog methods

### DIFF
--- a/master/buildbot/steps/package/deb/lintian.py
+++ b/master/buildbot/steps/package/deb/lintian.py
@@ -18,10 +18,22 @@ Steps and objects related to lintian
 """
 
 from buildbot import config
+from buildbot.process import logobserver
 from buildbot.status.results import FAILURE
 from buildbot.status.results import SUCCESS
 from buildbot.status.results import WARNINGS
 from buildbot.steps.shell import ShellCommand
+
+
+class MaxQObserver(logobserver.LogLineObserver):
+
+    def __init__(self):
+        logobserver.LogLineObserver.__init__(self)
+        self.failures = 0
+
+    def outLineReceived(self, line):
+        if line.startswith('TEST FAILURE:'):
+            self.failures += 1
 
 
 class DebLintian(ShellCommand):


### PR DESCRIPTION
This is in preparation for getText, readlines, etc. to be removed in
nine.  There are lots more steps to rewrite -- this is just a start.

Basically, I started working on rewriting all of the steps, but then found a way to avoid doing so immediately.  I didn't want to lose the work on these two steps.  So here it is.
