### PR TITLE
rewrite some steps to not use removed IStatusLog methods

### DIFF
--- a/master/buildbot/steps/maxq.py
+++ b/master/buildbot/steps/maxq.py
@@ -14,9 +14,21 @@
 # Copyright Buildbot Team Members
 
 from buildbot import config
+from buildbot.process import buildstep
 from buildbot.status.results import FAILURE
 from buildbot.status.results import SUCCESS
 from buildbot.steps.shell import ShellCommand
+
+
+class MaxQObserver(buildstep.LogLineObserver):
+
+    def __init__(self):
+        buildstep.LogLineObserver.__init__(self)
+        self.failures = 0
+
+    def outLineReceived(self, line):
+        if line.startswith('TEST FAILURE:'):
+            self.failures += 1
 
 
 class MaxQ(ShellCommand):
@@ -28,10 +40,11 @@ class MaxQ(ShellCommand):
             config.error("please pass testdir")
         kwargs['command'] = 'run_maxq.py %s' % (testdir,)
         ShellCommand.__init__(self, **kwargs)
+        self.observer = MaxQObserver()
+        self.addLogObserver('stdio', self.observer)
 
     def commandComplete(self, cmd):
-        output = cmd.logs['stdio'].getText()
-        self.failures = output.count('\nTEST FAILURE:')
+        self.failures = self.observer.failures
 
     def evaluateCommand(self, cmd):
         # treat a nonzero exit status as a failure, if no other failures are

--- a/master/buildbot/steps/package/deb/lintian.py
+++ b/master/buildbot/steps/package/deb/lintian.py
@@ -18,10 +18,22 @@ Steps and objects related to lintian
 """
 
 from buildbot import config
+from buildbot.process import buildstep
 from buildbot.status.results import FAILURE
 from buildbot.status.results import SUCCESS
 from buildbot.status.results import WARNINGS
 from buildbot.steps.shell import ShellCommand
+
+
+class MaxQObserver(buildstep.LogLineObserver):
+
+    def __init__(self):
+        buildstep.LogLineObserver.__init__(self)
+        self.failures = 0
+
+    def outLineReceived(self, line):
+        if line.startswith('TEST FAILURE:'):
+            self.failures += 1
 
 
 class DebLintian(ShellCommand):

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -155,6 +155,10 @@ class BuildStepMixin(object):
             observer.step = step
         step.addLogObserver = addLogObserver
 
+        # add any observers defined in the constructor, before this monkey-patch
+        for n, o in step._pendingLogObservers:
+            addLogObserver(n, o)
+
         # set defaults
 
         step.setDefaultWorkdir('wkdir')


### PR DESCRIPTION
This is in preparation for getText, readlines, etc. to be removed in
nine.  There are lots more steps to rewrite -- this is just a start.

Passes tests  with the addition in `steps.py`, and fixed to apply against master.

I'll carry forward @jaredgrubb's review from #983.
