### PR TITLE
Document poller hook POST request

### DIFF
--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -828,10 +828,10 @@ that periodically poll the Google Code commit feed for changes.
 Poller hook
 ###########
 
-The poller hook allows you to use GET requests to trigger polling. One
-advantage of this is your buildbot instance can (at start up) poll to get
-changes that happened while it was down, but then you can still use a commit
-hook to get fast notification of new changes.
+The poller hook allows you to use GET or POST requests to trigger
+polling. One advantage of this is your buildbot instance can (at start
+up) poll to get changes that happened while it was down, but then you
+can still use a commit hook to get fast notification of new changes.
 
 Suppose you have a poller configured like this::
 
@@ -851,7 +851,8 @@ Then you will be able to trigger a poll of the SVN repository by poking the
 
 .. code-block:: bash
 
-    curl http://yourbuildbot/change_hook/poller?poller=https%3A%2F%2Famanda.svn.sourceforge.net%2Fsvnroot%2Famanda%2Famanda
+    curl -s -F poller=https://amanda.svn.sourceforge.net/svnroot/amanda/amanda \
+        http://yourbuildbot/change_hook/poller
 
 If no ``poller`` argument is provided then the hook will trigger polling of all
 polling change sources.


### PR DESCRIPTION
The WebStatus Poller hook documentation did not mention POST requests.
POST allows use of cleaner curl -F option for poller parameter.
