### PR TITLE
[Fixes] For ticket #2605

### DIFF
--- a/master/buildbot/status/web/baseweb.py
+++ b/master/buildbot/status/web/baseweb.py
@@ -337,7 +337,7 @@ class WebStatus(service.MultiService):
         if change_hook_auth is not None:
             self.change_hook_auth = []
             for checker in change_hook_auth:
-                if isinstance(checker, str) or isinstance(checker, unicode):
+                if isinstance(checker, basestring):
                     try:
                         checker = strcred.makeChecker(checker)
                     except Exception, error:


### PR DESCRIPTION
#2605: Change Hooks Auth fails when checker is a unicode string
