### PR TITLE
Fix: unsubscribe StatusPush

### DIFF
--- a/master/buildbot/status/status_push.py
+++ b/master/buildbot/status/status_push.py
@@ -217,6 +217,7 @@ class StatusPush(StatusReceiverMultiService):
         """Unsubscribe from watched builders"""
         for w in self.watched:
             w.unsubscribe(self)
+        self.status.unsubscribe(self)
         return StatusReceiverMultiService.disownServiceParent(self)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
StatusPush doesn't unsubscribe. As a consequence, if buildbot is reconfigured, then you will receive several time the same event, because several instance of StatusPush are active.

Here's a copy/paste of the IRC discussion: 

```
<xavierd> Hi, 
<xavierd> I notice a weird behaviour when I reconfigure buildbot.
<xavierd> status instance (like words.IRC, status_push.HttpStatusPush) never unsubscribe ... As a consequence, once I reconfigure buildbot, I receive the same event several times
<xavierd> because there's several instance of status_push.HttpStatusPush
<xavierd> I activate the Telnet Manhole, and here's what I see: 
<xavierd> When I start buildbot: 
<xavierd> master.status.watchers
<xavierd> [<cmgwbotcfg.status.CTAFFrontendPush instance at 0x4c1b368>, <buildbot.status.words.IRCContact instance at 0x7fc47c037680>]
<xavierd> that's exactly what I'm expected.
<xavierd> If I reconfigure buildbot 1 time: 
<xavierd> [<cmgwbotcfg.status.CTAFFrontendPush instance at 0x4c1b368>, <buildbot.status.words.IRCContact instance at 0x7fc47c037680>, <cmgwbotcfg.status.CTAFFrontendPush instance at 0x4e5b6c8>, <buildbot.status.words.IRCContact instance at 0x4e606c8>]
<xavierd> old instance aren't remove from master.status.watchers
<xavierd> IMO, in the stopService function (of IRC.words and status_push.HttpStatusPush) we should have this: 
<xavierd> self.status.unsubscribe(self)
<xavierd> (in the startService function, the status instance subscribe ... so I'm expected that the status instance must unsubscribe in the stopService function)
<xavierd> Am I right ? or did I miss something ?
<djmitche> xavierd: yeah, that's been fixed recently in the IRC daemon, but I didn't know it existed in HttpStatusPush
<xavierd> djmitche, ok
<xavierd> djmitche, my fix is to add this line: self.status.unsubscribe(self)
```
