### PR TITLE
Make HgPoller break file paths correctly

### DIFF
--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -94,14 +94,14 @@ class HgPoller(base.PollingChangeSource):
         args = ['log', '-r', rev, os.linesep.join((
             '--template={date|hgdate}',
             '{author}',
-            '{files}',
+            "{files % '{file}" + os.pathsep + "'}",
             '{desc|strip}'))]
         # Mercurial fails with status 255 if rev is unknown
         d = utils.getProcessOutput(self.hgbin, args, path=self._absWorkdir(),
                                    env=os.environ, errortoo=False)
 
         def process(output):
-            # fortunately, Mercurial issues all filenames one one line
+            # all file names are on one line
             date, author, files, comments = output.decode(self.encoding, "replace").split(
                 os.linesep, 3)
 
@@ -114,7 +114,7 @@ class HgPoller(base.PollingChangeSource):
                     log.msg('hgpoller: caught exception converting output %r '
                             'to timestamp' % date)
                     raise
-            return stamp, author.strip(), files.split(), comments.strip()
+            return stamp, author.strip(), files.split(os.pathsep)[:-1], comments.strip()
 
         d.addCallback(process)
         return d

--- a/master/buildbot/test/unit/test_changes_hgpoller.py
+++ b/master/buildbot/test/unit/test_changes_hgpoller.py
@@ -93,11 +93,11 @@ class TestHgPoller(gpo.GetProcessOutputMixin,
                        '--template={rev}:{node}\\n')
             .path('/some/dir').stdout(os.linesep.join(['73591:4423cdb'])),
             gpo.Expect('hg', 'log', '-r', '4423cdb',
-                       '--template={date|hgdate}' + os.linesep + '{author}' + os.linesep + '{files}' + os.linesep + '{desc|strip}')
+                       '--template={date|hgdate}' + os.linesep + '{author}' + os.linesep + "{files % '{file}" + os.pathsep + "'}" + os.linesep + '{desc|strip}')
             .path('/some/dir').stdout(os.linesep.join([
                 '1273258100.0 -7200',
                 'Bob Test <bobtest@example.org>',
-                'file1 dir/file2',
+                'file1' + os.pathsep + 'dir/file2' + os.pathsep,
                 'This is rev 73591',
                 ''])),
         )
@@ -162,7 +162,7 @@ class TestHgPoller(gpo.GetProcessOutputMixin,
                        '--template={rev}:{node}\\n')
             .path('/some/dir').stdout('5:784bd' + os.linesep),
             gpo.Expect('hg', 'log', '-r', '784bd',
-                       '--template={date|hgdate}' + os.linesep + '{author}' + os.linesep + '{files}' + os.linesep + '{desc|strip}')
+                       '--template={date|hgdate}' + os.linesep + '{author}' + os.linesep + "{files % '{file}" + os.pathsep + "'}" + os.linesep + '{desc|strip}')
             .path('/some/dir').stdout(os.linesep.join([
                 '1273258009.0 -7200',
                 'Joe Test <joetest@example.org>',


### PR DESCRIPTION
The command to get revision info lists all files on one line and was
splitting on spaces to get file paths. Sometimes paths have spaces so
that doesn't work. Instead, insert a pathsep character between paths
and use that for splitting.

This fixes http://trac.buildbot.net/ticket/2595
