### PR TITLE
GitPoller: Allow polling all branches, or a filtered subset of branches.

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -101,23 +101,63 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         status = ""
         if not self.master:
             status = "[STOPPED - check log]"
+        if self.branches:
+            branches = ', '.join(self.branches)
+        else:
+            branches = 'ALL'
+
         str = ('GitPoller watching the remote git repository %s, branches: %s %s'
-               % (self.repourl, ', '.join(self.branches), status))
+               % (self.repourl, ', '.join(branches), status))
         return str
+
+    def _getBranches(self):
+        d = self._dovccmd('ls-remote', [self.repourl])
+        @d.addCallback
+        def parseRemote(rows):
+            branches = []
+            for row in rows.splitlines():
+                if not '\t' in row:
+                    # Not a useful line
+                    continue
+                sha, ref = row.split("\t")
+                branches.append(ref)
+            return branches
+        return d
+
+    def _headsFilter(self, branch):
+        """Filter out remote references that don't begin with 'refs/heads'."""
+        return branch.startswith("refs/heads/")
+
+    def _removeHeads(self, branch):
+        """Remove 'refs/heads/' prefix from remote references."""
+        if branch.startswith("refs/heads/"):
+            branch = branch[11:]
+        return branch
 
     @defer.inlineCallbacks
     def poll(self):
         yield self._dovccmd('init', ['--bare', self.workdir])
 
+        branches = self.branches
+        if branches is True or callable(branches):
+            branches = yield self._getBranches()
+            if callable(self.branches):
+                branches = filter(self.branches, branches)
+            else:
+                branches = filter(self._headsFilter, branches)
+            # We remove the refs/heads/ prefix here, so that
+            # poller state with bare branch names is respected
+            branches = map(self._removeHeads, branches)
+
         refspecs = [
             '+%s:%s' % (branch, self._localBranch(branch))
-            for branch in self.branches
+            for branch in branches
         ]
         yield self._dovccmd('fetch',
                             [self.repourl] + refspecs, path=self.workdir)
 
         revs = {}
-        for branch in self.branches:
+        for branch in branches:
             try:
                 revs[branch] = rev = yield self._dovccmd('rev-parse',
                                                          [self._localBranch(branch)], path=self.workdir)

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -875,7 +875,13 @@ arguments:
     (see the :command:`git fetch` help for more info on git-url formats)
 
 ``branches``
-    a list of the branches to fetch, will default to ``['master']``
+    One of the following:
+
+    * a list of the branches to fetch.
+    * ``True`` indicating that all branches should be fetched
+    * a callable which takes a single argument.
+      It should take a remote refspec (such as ``'refs/heads/master'``, and
+      return a boolean indicating whether that branch should be fetched.
 
 ``branch``
     accepts a single branch name to fetch.


### PR DESCRIPTION
The make the `branches` argument accept either `True` to poll all branches,
or a callable to filter the remote branches.

(Pull request based on @jhol's comment in #597)
