### PR TITLE
Add the list of BuildRequest's ID to BuildStatus

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -384,7 +384,7 @@ class Builder(config.ReconfigurableServiceMixin,
             return
 
         # create the BuildStatus object that goes with the Build
-        bs = self.builder_status.newBuild()
+        bs = self.builder_status.newBuild([req.id for req in build.requests])
 
         # record the build in the db - one row per buildrequest
         try:

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -62,7 +62,7 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
     finishedWatchers = []
     testResults = {}
 
-    def __init__(self, parent, master, number):
+    def __init__(self, parent, master, number, brids):
         """
         @type  parent: L{BuilderStatus}
         @type  number: int
@@ -77,6 +77,7 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
         self.steps = []
         self.testResults = {}
         self.properties = properties.Properties()
+        self.brids = brids
 
     def __repr__(self):
         return "<%s #%s>" % (self.__class__.__name__, self.number)
@@ -471,6 +472,7 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
         result['sourceStamps'] = [ss.asDict() for ss in self.getSourceStamps()]
         result['reason'] = self.getReason()
         result['blame'] = self.getResponsibleUsers()
+        result['brids'] = self.brids
 
         # Transient
         result['properties'] = self.getProperties().asList()

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -507,7 +507,7 @@ class BuilderStatus(styles.Versioned):
                 log.msg("Exception caught publishing state to %r" % w)
                 log.err()
 
-    def newBuild(self):
+    def newBuild(self, brids):
         """The Builder has decided to start a build, but the Build object is
         not yet ready to report status (it has not finished creating the
         Steps). Create a BuildStatus object that it can use."""
@@ -517,7 +517,7 @@ class BuilderStatus(styles.Versioned):
         # build number we've just allocated. This is not quite as important
         # as it was before we switch to determineNextBuildNumber, but I think
         # it may still be useful to have the new build save itself.
-        s = BuildStatus(self, self.master, number)
+        s = BuildStatus(self, self.master, number, brids)
         s.waitUntilFinished().addCallback(self._buildFinished)
         return s
 


### PR DESCRIPTION
I use HttpStatusPush (a custom version) to create a frontend for BuildBot.
My custom version of HttpStatusPush differs in a way that, for the events requestSubmitted, and requestCancelled the BuildRequest's ID are sent. The idea is to be able to represent in the Frontent the list of the Pending BuildRequest.

In order to be able to remove the BuildRequest from the queue (in real time with nodejs), the event buildStarted must contains the list of the related BuildRequest.
