### PR TITLE
Various Fix

### DIFF
--- a/master/buildbot/buildslave/manager.py
+++ b/master/buildbot/buildslave/manager.py
@@ -31,7 +31,7 @@ class BuildslaveRegistration(object):
         self.buildslave = buildslave
 
     def __repr__(self):
-        return "<%s for %r>" % (self.__class__.__name__, self.slavename)
+        return "<%s for %r>" % (self.__class__.__name__, self.buildslave.slavename)
 
     @defer.inlineCallbacks
     def unregister(self):

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -157,6 +157,7 @@ class Buildset(base.ResourceType):
                                    'builder', str(builderid),
                                    'buildrequest', str(brid),
                                    'new'), msg)
+            self.master.mq.produce(('buildrequest', None, None, None, 'new'), dict(buildername=bn))
 
         # and the buildset itself
         msg = dict(

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -139,7 +139,11 @@ class BuildRequest(object):
                 ss.patch = (patch['level'], patch['body'], patch['subdir'])
                 ss.patch_info = (patch['author'], patch['comment'])
             else:
-                ss.patch = (None, None, None)
+                # Set ss.patch to None instead of (None, None, None)
+                # As in buildbot/steps/source/base.py line 293 we do this:
+                # patch = s.patch
+                #     if patch:
+                ss.patch = None # (None, None, None)
                 ss.patch_info = (None, None)
             ss.changes = []
             # XXX: sourcestamps don't have changes anymore; this affects merging!!

--- a/master/buildbot/status/buildstep.py
+++ b/master/buildbot/status/buildstep.py
@@ -301,6 +301,11 @@ class BuildStepStatus(styles.Versioned):
         del d['finishedWatchers']
         del d['updates']
         del d['master']
+
+        for attr in ("getStatistic", "hasStatistic", "setStatistic"):
+            if attr in d:
+                del d[attr]
+
         return d
 
     def __setstate__(self, d):


### PR DESCRIPTION
- Fix: master/buildbot/buildslave/manager.py
  - **repr** method of BuildslaveRegistration
- Fix: master/buildbot/process/buildrequest.py
  - new BuildRequest are now processed:
    - add self.master.mq.produce(('buildrequest', None, None, None, 'new'), dict(buildername=bn))
      (in order to wake up the BuildRequestDistributor activity_loop)
- Fix: master/buildbot/process/buildrequest.py
  - set ss.patch to None instead of (None, None, None)
- Fix: master/buildbot/status/buildstep.py
  - Make BuildStepStatus picklable
