### PR TITLE
Various Fix

### DIFF
--- a/master/buildbot/buildslave/manager.py
+++ b/master/buildbot/buildslave/manager.py
@@ -31,7 +31,7 @@ class BuildslaveRegistration(object):
         self.buildslave = buildslave
 
     def __repr__(self):
-        return "<%s for %r>" % (self.__class__.__name__, self.slavename)
+        return "<%s for %r>" % (self.__class__.__name__, self.buildslave.slavename)
 
     @defer.inlineCallbacks
     def unregister(self):

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -157,6 +157,8 @@ class Buildset(base.ResourceType):
                                    'builder', str(builderid),
                                    'buildrequest', str(brid),
                                    'new'), msg)
+            # TODO
+            #~ self.master.mq.produce(('buildrequest', None, None, None, 'new'), dict(buildername=bn))
 
         # and the buildset itself
         msg = dict(
@@ -173,7 +175,7 @@ class Buildset(base.ResourceType):
         self.master.mq.produce(("buildset", str(bsid), "new"), msg)
 
         log.msg("added buildset %d to database" % bsid)
-
+    
         # if there are no builderNames, then this is done already, so send the
         # appropriate messages for that
         if not builderNames:

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -147,9 +147,16 @@ class BotMaster(config.ReconfigurableServiceMixin, service.AsyncMultiService):
         def buildRequestAdded(key, msg):
             self.maybeStartBuildsForBuilder(msg['buildername'])
         # consume both 'new' and 'unclaimed' build requests
+
+        # TODO: Support for BuildRequest doesn't exist yet
+        # It's a temporary fix in order to wake up the BuildRequestDistributor
+        #
+        # self.buildrequest_consumer_new = self.master.mq.startConsuming(
+        #     buildRequestAdded,
+        #     ('buildrequest', None, None, None, 'new'))
         self.buildrequest_consumer_new = self.master.mq.startConsuming(
             buildRequestAdded,
-            ('buildrequest', None, None, None, 'new'))
+            ('buildset', None, 'builder', None, 'buildrequest', None, 'new'))
         self.buildrequest_consumer_unclaimed = self.master.mq.startConsuming(
             buildRequestAdded,
             ('buildrequest', None, None, None, 'unclaimed'))

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -139,7 +139,7 @@ class BuildRequest(object):
                 ss.patch = (patch['level'], patch['body'], patch['subdir'])
                 ss.patch_info = (patch['author'], patch['comment'])
             else:
-                ss.patch = (None, None, None)
+                ss.patch = None
                 ss.patch_info = (None, None)
             ss.changes = []
             # XXX: sourcestamps don't have changes anymore; this affects merging!!

--- a/master/buildbot/status/buildstep.py
+++ b/master/buildbot/status/buildstep.py
@@ -301,6 +301,11 @@ class BuildStepStatus(styles.Versioned):
         del d['finishedWatchers']
         del d['updates']
         del d['master']
+
+        for attr in ("getStatistic", "hasStatistic", "setStatistic"):
+            if attr in d:
+                del d[attr]
+
         return d
 
     def __setstate__(self, d):


### PR DESCRIPTION
- Fix: master/buildbot/buildslave/manager.py
  - **repr** method of BuildslaveRegistration
- Fix: master/buildbot/process/buildrequest.py
  - set ss.patch to None instead of (None, None, None)
- Fix: master/buildbot/status/buildstep.py
  - Make BuildStepStatus picklable
- New BuildRequest are processed:
  - Change the filter of BotMaster::buildrequest_consumer_new from ('buildrequest', None, None, None, 'new')
    to ('buildset', None, 'builder', None, 'buildrequest', None, 'new'), otherwise the BuildRequestDistributor activity_loop is never wakeup
    on a new buildRequest.
  - Note: This is certainly a temporary fix.
