### PR TITLE
add build.buildid, sl.buildslaveid, and st.stepid

### DIFF
--- a/master/buildbot/buildslave/base.py
+++ b/master/buildbot/buildslave/base.py
@@ -316,10 +316,8 @@ class AbstractBuildSlave(config.ReconfigurableServiceMixin,
             return defer.succeed(None)
 
     def updateSlaveStatus(self, buildStarted=None, buildFinished=None):
-        if buildStarted:
-            self.slave_status.buildStarted(buildStarted)
-        if buildFinished:
-            self.slave_status.buildFinished(buildFinished)
+        # TODO
+        pass
 
     @defer.inlineCallbacks
     def attached(self, conn):

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -86,6 +86,8 @@ class Build(properties.PropertiesMixin):
         self.progress = None
         self.currentStep = None
         self.slaveEnvironment = {}
+        self.buildid = None
+        self.number = None
 
         self.terminate = False
 
@@ -109,9 +111,6 @@ class Build(properties.PropertiesMixin):
     def setSlaveEnvironment(self, env):
         self.slaveEnvironment = env
 
-    def setBuilDBId(self, dbid):
-        self._dbid = dbid
-
     def getSourceStamp(self, codebase=''):
         for source in self.sources:
             if source.codebase == codebase:
@@ -120,11 +119,6 @@ class Build(properties.PropertiesMixin):
 
     def getAllSourceStamps(self):
         return list(self.sources)
-
-    def getBuilDBId(self):
-        # TODO:
-        # Maybe is needed to implement a function in the DATA API to retreive the id
-        return self._dbid
 
     def allChanges(self):
         for s in self.sources:
@@ -198,7 +192,7 @@ class Build(properties.PropertiesMixin):
 
         # now set some properties of our own, corresponding to the
         # build itself
-        props.setProperty("buildnumber", self.build_status.number, "Build")
+        props.setProperty("buildnumber", self.number, "Build")
 
         if self.sources and len(self.sources) == 1:
             # old interface for backwards compatibility
@@ -230,10 +224,12 @@ class Build(properties.PropertiesMixin):
         self.slavename = slavebuilder.slave.slavename
         self.build_status.setSlavename(self.slavename)
 
+    @defer.inlineCallbacks
     def startBuild(self, build_status, expectations, slavebuilder):
         """This method sets up the build, then starts it by invoking the
         first Step. It returns a Deferred which will fire when the build
         finishes. This Deferred is guaranteed to never errback."""
+        slave = slavebuilder.slave
 
         # we are taking responsibility for watching the connection to the
         # remote. This responsibility was held by the Builder until our
@@ -242,10 +238,19 @@ class Build(properties.PropertiesMixin):
 
         log.msg("%s.startBuild" % self)
         self.build_status = build_status
+        # TODO: this will go away when build collapsing is implemented; until
+        # then we just assign the bulid to the first buildrequest
+        brid = self.requests[0].id
+        self.buildid, self.number = \
+            yield self.master.data.updates.newBuild(
+                builderid=(yield self.builder.getBuilderId()),
+                buildrequestid=brid,
+                buildslaveid=slave.buildslaveid)
+
         # now that we have a build_status, we can set properties
         self.setupProperties()
         self.setupSlaveBuilder(slavebuilder)
-        slavebuilder.slave.updateSlaveStatus(buildStarted=build_status)
+        slave.updateSlaveStatus(buildStarted=self)
 
         # then narrow SlaveLocks down to the right slave
         self.locks = [(l.getLock(self.slavebuilder.slave), a)
@@ -255,18 +260,7 @@ class Build(properties.PropertiesMixin):
 
         metrics.MetricCountEvent.log('active_builds', 1)
 
-        d = self.deferred = defer.Deferred()
-
-        def _uncount_build(res):
-            metrics.MetricCountEvent.log('active_builds', -1)
-            return res
-        d.addBoth(_uncount_build)
-
-        def _release_slave(res, slave, bs):
-            self.slavebuilder.buildFinished()
-            slave.updateSlaveStatus(buildFinished=bs)
-            return res
-        d.addCallback(_release_slave, self.slavebuilder.slave, build_status)
+        self.deferred = defer.Deferred()
 
         try:
             self.setupBuild(expectations)  # create .steps
@@ -279,19 +273,27 @@ class Build(properties.PropertiesMixin):
             # handler
             log.msg("Build.setupBuild failed")
             log.err(Failure())
-            self.builder.builder_status.addPointEvent(["setupBuild",
-                                                       "exception"])
             self.finished = True
             self.results = EXCEPTION
             self.deferred = None
-            d.callback(self)
-            return d
+            return
 
-        self.master.data.updates.setBuildStateStrings(self.getBuilDBId(), [u'starting'])
+        self.master.data.updates.setBuildStateStrings(self.buildid, [u'starting'])
         self.build_status.buildStarted(self)
+        yield self.acquireLocks()
 
-        self.acquireLocks().addCallback(self._startBuild_2)
-        return d
+        try:
+            # start the sequence of steps and wait until it's finished
+            self.startNextStep()
+            yield self.deferred
+        finally:
+            metrics.MetricCountEvent.log('active_builds', -1)
+
+        yield self.master.db.builds.finishBuild(self.buildid, self.results)
+
+        # mark the build as finished
+        self.slavebuilder.buildFinished()
+        slave.updateSlaveStatus(buildFinished=self)
 
     @staticmethod
     def canStartWithSlavebuilder(lockList, slavebuilder):
@@ -319,9 +321,6 @@ class Build(properties.PropertiesMixin):
         for lock, access in self.locks:
             lock.claim(self, access)
         return defer.succeed(None)
-
-    def _startBuild_2(self, res):
-        self.startNextStep()
 
     def setupBuild(self, expectations):
         # create the actual BuildSteps. If there are any name collisions, we
@@ -509,7 +508,6 @@ class Build(properties.PropertiesMixin):
         if self.finished:
             return
         # TODO: include 'reason' in this point event
-        self.builder.builder_status.addPointEvent(['interrupt'])
         self.stopped = True
         if self.currentStep:
             self.currentStep.interrupt(reason)

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -307,10 +307,6 @@ class Builder(config.ReconfigurableServiceMixin,
 
     @defer.inlineCallbacks
     def _startBuildFor(self, slavebuilder, buildrequests):
-        # get some ID's for use later
-        buildslaveid = slavebuilder.slave.buildslaveid
-        builderid = yield self.getBuilderId()
-
         # Build a stack of cleanup functions so that, at any point, we can
         # abort this operation and unwind the commitments made so far.
         cleanups = []
@@ -326,8 +322,6 @@ class Builder(config.ReconfigurableServiceMixin,
         # the last cleanup we want to perform is to update the big
         # status based on any other cleanup
         cleanups.append(lambda: self.updateBigStatus())
-
-        builderid = yield self.getBuilderId()
 
         build = self.config.factory.newBuild(buildrequests)
         build.setBuilder(self)
@@ -402,24 +396,6 @@ class Builder(config.ReconfigurableServiceMixin,
         # create the BuildStatus object that goes with the Build
         bs = self.builder_status.newBuild()
 
-        # record the build in the db, but only for the last buildrequest
-        # (NOTE: this is a behavior change that will cause unexpected results
-        #  in the nine branch!)
-        # (NOTE: the build number the db assigns may not be the same that the
-        #  builder status assigns!)
-        try:
-            bids = []
-            req = build.requests[-1]
-            bid, number = yield self.master.data.updates.newBuild(builderid=builderid,
-                                                                  buildrequestid=req.id, buildslaveid=buildslaveid)
-            bids.append(bid)
-            build.setBuilDBId(bid)
-        except:
-            log.err(failure.Failure(), 'while adding rows to build table:')
-            run_cleanups()
-            defer.returnValue(False)
-            return
-
         # IMPORTANT: no yielding is allowed from here to the startBuild call!
 
         # it's possible that we lost the slave remote between the ping above
@@ -432,9 +408,6 @@ class Builder(config.ReconfigurableServiceMixin,
             defer.returnValue(False)
             return
 
-        # let status know
-        self.master.status.build_started(req.id, self.name, bs)
-
         # start the build. This will first set up the steps, then tell the
         # BuildStatus that it has started, which will announce it to the world
         # (through our BuilderStatus object, which is its parent).  Finally it
@@ -445,7 +418,7 @@ class Builder(config.ReconfigurableServiceMixin,
         # http://trac.buildbot.net/ticket/2428).
         d = defer.maybeDeferred(build.startBuild,
                                 bs, self.expectations, slavebuilder)
-        d.addCallback(self.buildFinished, slavebuilder, bids)
+        d.addCallback(lambda _: self.buildFinished(build, slavebuilder))
         # this shouldn't happen. if it does, the slave will be wedged
         d.addErrback(log.err, 'from a running build; this is a '
                      'serious error - please file a bug at http://buildbot.net')
@@ -463,7 +436,7 @@ class Builder(config.ReconfigurableServiceMixin,
                                   self.config.properties[propertyname],
                                   "Builder")
 
-    def buildFinished(self, build, sb, bids):
+    def buildFinished(self, build, sb):
         """This is called when the Build has finished (either success or
         failure). Any exceptions during the build are reported with
         results=FAILURE, not with an errback."""
@@ -473,15 +446,6 @@ class Builder(config.ReconfigurableServiceMixin,
         # (maybeStartBuilds)
 
         results = build.build_status.getResults()
-
-        # mark the builds as finished, although since nothing ever reads this
-        # table, it's not too important that it complete successfully
-        # TODO: The www service use this table
-        #       So, I think it's important that it complete successfully.
-        #       tardyp, djmitche do you confirm ?
-        d = self.master.data.updates.finishBuild(bids[0], results)
-        d.addCallback(lambda _: self.master.data.updates.setBuildStateStrings(bids[0], [u'finished']))
-        d.addErrback(log.err, 'while marking builds as finished (ignored)')
 
         self.building.remove(build)
         if results == RETRY:

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from buildbot import interfaces
 from buildbot import util
 from buildbot.process import metrics
 from buildbot.status.results import FAILURE

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -105,7 +105,7 @@ class Source(LoggingBuildStep, CompositeStepMixin):
 
         self.codebase = codebase
         if self.codebase:
-            self.name = ' '.join((self.name, self.codebase))
+            self.name = '-'.join((self.name, self.codebase))
 
         self.alwaysUseLatest = alwaysUseLatest
 

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -41,6 +41,8 @@ class FakeBuild(properties.PropertiesMixin):
         self.build_status = FakeBuildStatus()
         self.builder = mock.Mock(name='build.builder')
         self.path_module = posixpath
+        self.buildid = 92
+        self.number = 13
 
         self.sources = {}
         if props is None:

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -252,7 +252,12 @@ class FakeUpdates(object):
                               validation.IntValidator())
         validation.verifyType(self.testcase, 'name', name,
                               validation.IdentifierValidator(50))
-        return defer.succeed((10, 1))
+        return defer.succeed((10, 1, name))
+
+    def startStep(self, stepid):
+        validation.verifyType(self.testcase, 'stepid', stepid,
+                              validation.IntValidator())
+        return defer.succeed(None)
 
     def setStepStateStrings(self, stepid, state_strings):
         validation.verifyType(self.testcase, 'stepid', stepid,
@@ -319,10 +324,6 @@ class FakeUpdates(object):
         return self.master.db.buildslaves.buildslaveDisconnected(
             buildslaveid=buildslaveid,
             masterid=masterid)
-
-    def __getattr__(self, name):
-        import traceback
-        traceback.print_stack()
 
 
 class FakeDataConnector(object):

--- a/master/buildbot/test/fake/slave.py
+++ b/master/buildbot/test/fake/slave.py
@@ -27,6 +27,10 @@ class FakeSlave(object):
         self.master = master
         self.conn = fakeprotocol.FakeConnection(master, self)
         self.properties = properties.Properties()
+        self.buildslaveid = 383
+
+    def updateSlaveStatus(self, buildStarted=None, buildFinished=None):
+        pass
 
     def acquireLocks(self):
         pass

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -146,8 +146,8 @@ class RunSteps(unittest.TestCase):
         bfd = defer.Deferred()
         old_buildFinished = self.builder.buildFinished
 
-        def buildFinished(build, sb, bids):
-            old_buildFinished(build, sb, bids)
+        def buildFinished(*args):
+            old_buildFinished(*args)
             bfd.callback(None)
         self.builder.buildFinished = buildFinished
 

--- a/master/buildbot/test/unit/test_data_steps.py
+++ b/master/buildbot/test/unit/test_data_steps.py
@@ -170,11 +170,24 @@ class Step(interfaces.InterfaceTests, unittest.TestCase):
         def newStep(self, buildid, name):
             pass
 
+    def test_signature_startStep(self):
+        @self.assertArgSpecMatches(
+            self.master.data.updates.startStep,  # fake
+            self.rtype.startStep)  # real
+        def newStep(self, stepid):
+            pass
+
     def test_newStep(self):
         self.do_test_callthrough('addStep', self.rtype.newStep,
                                  buildid=10, name=u'name',
                                  exp_kwargs=dict(buildid=10, name=u'name',
                                                  state_strings=['pending']))
+
+    @defer.inlineCallbacks
+    def test_fake_newStep(self):
+        self.assertEqual(
+            len((yield self.master.data.updates.newStep(10, u'ten'))),
+            3)
 
     def test_startStep(self):
         self.do_test_callthrough('startStep', self.rtype.startStep,

--- a/master/buildbot/test/unit/test_steps_source_base_Source.py
+++ b/master/buildbot/test/unit/test_steps_source_base_Source.py
@@ -92,7 +92,7 @@ class TestSource(sourcesteps.SourceStepMixin, unittest.TestCase):
         step.build.getSourceStamp.return_value = None
 
         self.assertEqual(step.describe(), ['updating', 'codebase'])
-        self.assertEqual(step.name, Source.name + " codebase")
+        self.assertEqual(step.name, Source.name + "-codebase")
 
         step.startStep(mock.Mock())
         self.assertEqual(step.build.getSourceStamp.call_args[0], ('codebase',))
@@ -108,7 +108,7 @@ class TestSource(sourcesteps.SourceStepMixin, unittest.TestCase):
         step.build.getSourceStamp.return_value = None
 
         self.assertEqual(step.describe(), ['updating', 'suffix'])
-        self.assertEqual(step.name, Source.name + " my-code")
+        self.assertEqual(step.name, Source.name + "-my-code")
 
         step.startStep(mock.Mock())
         self.assertEqual(step.build.getSourceStamp.call_args[0], ('my-code',))

--- a/master/buildbot/test/unit/test_steps_source_repo.py
+++ b/master/buildbot/test/unit/test_steps_source_repo.py
@@ -93,9 +93,10 @@ class TestRepo(sourcesteps.SourceStepMixin, unittest.TestCase):
         d = self.runStep()
 
         def printlogs(res):
-            text = self.step.stdio_log.getTextWithHeaders()
-            if "Failure instance" in text and not self.shouldRetry:
-                print text
+            if hasattr(self.step, 'stdio_log'):
+                text = self.step.stdio_log.getTextWithHeaders()
+                if "Failure instance" in text and not self.shouldRetry:
+                    print text
             return res
         d.addBoth(printlogs)
         return d

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -82,7 +82,7 @@ class BuildStepMixin(object):
         """
         factory = interfaces.IBuildStepFactory(step)
         step = self.step = factory.buildStep()
-        self.master = fakemaster.make_master(testcase=self)
+        self.master = fakemaster.make_master(wantData=True, testcase=self)
 
         # step.build
 
@@ -108,7 +108,6 @@ class BuildStepMixin(object):
 
         # step.buildslave
 
-        self.master = fakemaster.make_master(testcase=self)
         self.buildslave = step.buildslave = slave.FakeSlave(self.master)
 
         # step.step_status

--- a/master/docs/developer/classes.rst
+++ b/master/docs/developer/classes.rst
@@ -12,6 +12,7 @@ The sections contained here document classes that can be used or subclassed.
     :maxdepth: 1
 
     cls-build
+    cls-buildslave
     cls-buildfactory
     cls-remotecommands
     cls-buildsteps

--- a/master/docs/developer/cls-build.rst
+++ b/master/docs/developer/cls-build.rst
@@ -10,6 +10,10 @@ Build
 
 .. py:class:: Build
 
+    .. py:attribute:: buildid
+
+        The ID of this build in the database.
+
     .. py:method:: getSummaryStatistic(name, summary_fn, initial_value=None)
 
         :param name: statistic name to summarize

--- a/master/docs/developer/cls-buildslave.rst
+++ b/master/docs/developer/cls-buildslave.rst
@@ -1,0 +1,16 @@
+Build Slaves
+============
+
+.. py:module:: buildbot.buildslave.base
+
+The :py:class:`BuildSlave` class represents a buildslave, which may or may not be connected to the master.
+Instances of this class are created directly in the Buildbot configuration file.
+
+BuildSlave
+----------
+
+.. py:class:: BuildSlave
+
+    .. py:attribute:: bulidslaveid
+
+        The ID of this buildslave in the database.

--- a/master/docs/developer/cls-buildsteps.rst
+++ b/master/docs/developer/cls-buildsteps.rst
@@ -20,6 +20,12 @@ BuildStep
     .. py:attribute:: name
 
         The name of the step.
+        Note that this value may change when the step is started, if the existing name was not unique.
+
+    .. py:attribute:: stepid
+
+        The ID of this step in the database.
+        This attribute is not set until the step starts.
 
     .. py:attribute:: description
 


### PR DESCRIPTION
This required a lot of refactoring of old tests.  It also required
changing the automatic generation of source step names to generate
proper identifiers.
