### PR TITLE
Check slave before trying to access it - fixes race condition in slave shutdown

### DIFF
--- a/master/buildbot/process/slavebuilder.py
+++ b/master/buildbot/process/slavebuilder.py
@@ -119,7 +119,7 @@ class AbstractSlaveBuilder(pb.Referenceable):
         return d
 
     def prepare(self, builder_status, build):
-        if not self.slave or if not self.slave.acquireLocks():
+        if not self.slave or not self.slave.acquireLocks():
             return defer.succeed(False)
         return defer.succeed(True)
 


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=923155#c11 and #c12:
some more digging into this today and we _think_ there's a race condition in normal (that is, non-graceful) shutdown. We correlated two instances of this happening with slaves in shutdown. Specifically:

From buildbot-master51:
71952 2013-10-18 07:42:08-0700 [Broker,38873,10.134.57.229] BuildSlave.detached(tst-linux64-ec2-016)
71953 2013-10-18 07:42:09-0700 [-] starting build <Build Ubuntu VM 12.04 x64 mozilla-aurora debug test mochitest-3> using slave <SlaveBuilder builder='Ubuntu VM 12.04 x64 mozilla-aurora debug test mochitest-3'>
71954 2013-10-18 07:42:09-0700 [-] Unhandled Error

And from tst-linux64-ec2-016:
5926 2013-10-18 07:42:08-0700 [Broker,client] lost remote
5927 2013-10-18 07:42:08-0700 [Broker,client] Lost connection to buildbot-master51.srv.releng.use1.mozilla.com:9201
5928 2013-10-18 07:42:08-0700 [Broker,client] Stopping factory <buildslave.bot.BotFactory instance at 0x1d91b00>
5929 2013-10-18 07:42:08-0700 [-] Main loop terminated.
5930 2013-10-18 07:42:08-0700 [-] Server Shut Down.

From buildbot-master52:
18063 2013-10-18 09:01:41-0700 [Broker,38810,10.134.56.83] BuildSlave.detached(tst-linux32-ec2-096)
18064 2013-10-18 09:01:43-0700 [Broker,38812,10.134.57.241] BuildSlave.detached(tst-linux32-ec2-029)
18065 2013-10-18 09:01:44-0700 [-] starting build <Build Ubuntu VM 12.04 mozilla-aurora pgo test reftest-no-accel> using slave <SlaveBuilder builder='Ubuntu VM 12.04 mozilla-aurora pgo test reftest-no-accel'>
18066 2013-10-18 09:01:44-0700 [-] Unhandled Error

And from tst-linux32-ec2-029:
435 2013-10-18 09:01:41-0700 [Broker,client] lost remote
436 2013-10-18 09:01:41-0700 [Broker,client] Lost connection to buildbot-master52.srv.releng.use1.mozilla.com:9201
437 2013-10-18 09:01:41-0700 [Broker,client] Stopping factory <buildslave.bot.BotFactory instance at 0x8adbb2c>
438 2013-10-18 09:01:41-0700 [-] Main loop terminated.
439 2013-10-18 09:01:41-0700 [-] Server Shut Down.

The times on the second instance don't correlate _quite_ as well as the first, but that could be due to clock differences between the master and the slave. It's certainly clear that in both cases there are slaves shutting down directly before the master tries to start the job. So the master may be trying to start the job with that slave - which looks okay when it calls startBuild() - but then the slave shuts down before startBuild() can finish initiating the job.

Assuming the assessment in comment #11 is correct, I think this patch should fix us up...by making sure we don't throw in prepare() and return False instead, the "if not ready" block from _prepared should run, and reset the claim: https://hg.mozilla.org/build/buildbot/file/b22c537e9f18/master/buildbot/process/builder.py#l837.
