### PR TITLE
clean up changes to try scheduler

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -495,43 +495,6 @@ class RemoteTryPP(protocol.ProcessProtocol):
         self.d.callback((sig, rc))
 
 
-class BuildSetStatusGrabber:
-    retryCount = 5  # how many times to we try to grab the BuildSetStatus?
-    retryDelay = 3  # seconds to wait between attempts
-
-    def __init__(self, status, bsid):
-        self.status = status
-        self.bsid = bsid
-
-    def grab(self):
-        # return a Deferred that either fires with the BuildSetStatus
-        # reference or errbacks because we were unable to grab it
-        self.d = defer.Deferred()
-        # wait a second before querying to give the master's maildir watcher
-        # a chance to see the job
-        reactor.callLater(0.01, self.go)
-        return self.d
-
-    def go(self, dummy=None):
-        if self.retryCount == 0:
-            output("couldn't find matching buildset")
-            sys.exit(1)
-        self.retryCount -= 1
-        d = self.status.callRemote("getBuildSets")
-        d.addCallback(self._gotSets)
-
-    def _gotSets(self, buildsets):
-        print "GOT", buildsets, self.bsid
-        for bs, bsid in buildsets:
-            if bsid == self.bsid:
-                # got it
-                self.d.callback(bs)
-                return
-        d = defer.Deferred()
-        d.addCallback(self.go)
-        reactor.callLater(self.retryDelay, d.callback, None)
-
-
 class Try(pb.Referenceable):
     buildsetStatus = None
     quiet = False
@@ -682,40 +645,14 @@ class Try(pb.Referenceable):
         # may emit status messages while we wait
         wait = bool(self.getopt("wait"))
         if not wait:
-            # TODO: emit the URL where they can follow the builds. This
-            # requires contacting the Status server over PB and doing
-            # getURLForThing() on the BuildSetStatus. To get URLs for
-            # individual builds would require we wait for the builds to
-            # start.
             output("not waiting for builds to finish")
-            return
-        if self.connect == "ssh":
+        elif self.connect == "ssh":
             output("waiting for builds with ssh is not supported")
-            return
-        d = self.running = defer.Deferred()
-        if self.buildsetStatus:
+        else:
+            self.running = defer.Deferred()
+            assert self.buildsetStatus
             self._getStatus_1()
             return self.running
-        # contact the status port
-        # we're probably using the ssh style
-        master = self.getopt("master")
-        host, port = master.split(":")
-        port = int(port)
-        self.announce("contacting the status port at %s:%d" % (host, port))
-        f = pb.PBClientFactory()
-        creds = credentials.UsernamePassword("statusClient", "clientpw")
-        d = f.login(creds)
-        reactor.connectTCP(host, port, f)
-        d.addCallback(self._getStatus_ssh_1)
-        return self.running
-
-    def _getStatus_ssh_1(self, remote):
-        # find a remotereference to the corresponding BuildSetStatus object
-        self.announce("waiting for job to be accepted")
-        g = BuildSetStatusGrabber(remote, self.bsid)
-        d = g.grab()
-        d.addCallback(self._getStatus_1)
-        return d
 
     def _getStatus_1(self, res=None):
         if res:

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -245,14 +245,6 @@ the path of the user given by :option:`--username`. The
 :option:`--buildbotbin` argument can be provided in
 :file:`.buildbot/options` as ``try_buildbotbin``
 
-Finally, the SSH approach needs to connect to a :class:`PBListener`
-status port, so it can retrieve and report the results of the build
-(the PB approach uses the existing connection to retrieve status
-information, so this step is not necessary). This requires a
-:option:`--masterstatus` argument, or a ``try_masterstatus`` entry in
-:file:`.buildbot/options`, in the form of a :samp:`{HOSTNAME}:{PORT}`
-string.
-
 The following command line arguments are deprecated, but retained for
 backward compatibility:
 
@@ -268,6 +260,18 @@ deprecated, but retained for backward compatibility:
 
  * ``try_dir`` is replaced by ``try_jobdir``
  * ``masterstatus`` is replaced by ``try_masterstatus``
+
+Waiting for results
+###################
+
+If you provide the :option:`--wait` option (or ``try_wait = True``
+in :file:`.buildbot/options`), the ``buildbot try`` command will
+wait until your changes have either been proven good or bad before
+exiting. Unless you use the :option:`--quiet` option (or
+``try_quiet=True``), it will emit a progress message every 60
+seconds until the builds have completed.
+
+The SSH connection method does not support waiting for results.
 
 Choosing the Builders
 #####################
@@ -459,16 +463,6 @@ work on version 0.8.3 or earlier masters.
 Similarly, :option:`--comment=COMMENT` will specify the comment for the patch,
 which is also displayed in the patch information.  The corresponding
 config-file option is ``try_comment``.
-
-Waiting for results
-###################
-
-If you provide the :option:`--wait` option (or ``try_wait = True``
-in :file:`.buildbot/options`), the ``buildbot try`` command will
-wait until your changes have either been proven good or bad before
-exiting. Unless you use the :option:`--quiet` option (or
-``try_quiet=True``), it will emit a progress message every 60
-seconds until the builds have completed.
 
 Sending properties
 ##################

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -156,6 +156,8 @@ Deprecations, Removals, and Non-Compatible Changes
   The runtimes for these two tools are incompatible, yet ``hgbuildbot`` attempts to run both in the same Python interpreter.
   Mayhem ensues.
 
+* The try scheduler's ``--connect=ssh`` method no longer supports waiting for results (``--wait``).
+
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This cleans up some now-dead code in the try client and updates the docs to reflect the fact that ssh+wait doesn't work.
