### PR TITLE
Add a BufferLogObserver and use it in SetPropertyFromCommand (0.8.x)

### DIFF
--- a/master/buildbot/process/logobserver.py
+++ b/master/buildbot/process/logobserver.py
@@ -96,3 +96,32 @@ class OutputProgressObserver(LogObserver):
     def logChunk(self, build, step, log, channel, text):
         self.length += len(text)
         self.step.setProgress(self.name, self.length)
+
+class BufferLogObserver(LogObserver):
+
+    def __init__(self, wantStdout=True, wantStderr=False):
+        self.stdout = [] if wantStdout else None
+        self.stderr = [] if wantStderr else None
+
+    def outReceived(self, data):
+        if self.stdout is not None:
+            self.stdout.append(data)
+
+    def errReceived(self, data):
+        if self.stderr is not None:
+            self.stderr.append(data)
+
+    def _get(self, chunks):
+        if chunks is None:
+            return [u'']
+        if len(chunks) > 1:
+            chunks = [''.join(chunks)]
+        elif not chunks:
+            chunks = [u'']
+        return chunks
+
+    def getStdout(self):
+        return self._get(self.stdout)[0]
+
+    def getStderr(self):
+        return self._get(self.stderr)[0]

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -19,8 +19,7 @@ import re
 
 from buildbot import config
 from buildbot.process import buildstep
-from buildbot.status.logfile import STDERR
-from buildbot.status.logfile import STDOUT
+from buildbot.process import logobserver
 from buildbot.status.results import FAILURE
 from buildbot.status.results import SUCCESS
 from buildbot.status.results import WARNINGS
@@ -316,6 +315,11 @@ class SetPropertyFromCommand(ShellCommand):
 
         ShellCommand.__init__(self, **kwargs)
 
+        if self.extract_fn:
+            self.observer = logobserver.BufferLogObserver(wantStdout=True,
+                                                          wantStderr=True)
+            self.addLogObserver('stdio', self.observer)
+
         self.property_changes = {}
 
     def commandComplete(self, cmd):
@@ -331,8 +335,8 @@ class SetPropertyFromCommand(ShellCommand):
         else:
             log = cmd.logs['stdio']
             new_props = self.extract_fn(cmd.rc,
-                                        ''.join(log.getChunks([STDOUT], onlyText=True)),
-                                        ''.join(log.getChunks([STDERR], onlyText=True)))
+                                        self.observer.getStdout(),
+                                        self.observer.getStderr())
             for k, v in new_props.items():
                 self.setProperty(k, v, "SetProperty Step")
             self.property_changes = new_props

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -3055,6 +3055,8 @@ stderr is lost.  For example, given ::
 Then ``my_extract`` will see ``stdout="output1\noutput2\n"``
 and ``stderr="error\n"``.
 
+Avoid using the ``extract_fn`` form of this step with commands that produce a great deal of output, as the output is buffered in memory until complete.
+
 .. bb:step:: SetPropertiesFromEnv
 
 .. py:class:: buildbot.steps.slave.SetPropertiesFromEnv


### PR DESCRIPTION
This is a quick and dirty way to replace users of log.getText, etc.
