### PR TITLE
Propagate interrupts to remote commands

### DIFF
--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -179,6 +179,10 @@ class Source(LoggingBuildStep, CompositeStepMixin):
         self.checkoutDelay value."""
         return None
 
+    def runCommand(self, cmd):
+        self.cmd = cmd
+        return LoggingBuildStep.runCommand(self, cmd)
+
     def start(self):
         if self.notReally:
             log.msg("faking %s checkout/update" % self.name)

--- a/master/buildbot/steps/source/repo.py
+++ b/master/buildbot/steps/source/repo.py
@@ -193,10 +193,10 @@ class Repo(Source):
     def _Cmd(self, command, abandonOnFailure=True, workdir=None, **kwargs):
         if workdir is None:
             workdir = self.workdir
-        self.cmd = cmd = buildstep.RemoteShellCommand(workdir, command,
-                                                      env=self.env,
-                                                      logEnviron=self.logEnviron,
-                                                      timeout=self.timeout,  **kwargs)
+        cmd = buildstep.RemoteShellCommand(workdir, command,
+                                           env=self.env,
+                                           logEnviron=self.logEnviron,
+                                           timeout=self.timeout,  **kwargs)
         # does not make sense to logEnviron for each command (just for first)
         self.logEnviron = False
         cmd.useLog(self.stdio_log, False)


### PR DESCRIPTION
Propagate interrupts to remote commands

This appears to be already fixed in master (`Buildstep.runCommand` has this same fix).  I opted to only patch `Source` instead of `LoggingBuildstep` or `Buildstep` on the off chance that this fix might break someone.  I'm happy to make that change to, if that is deemed to be the better fix.

`trial buildbot.test` is how I ensured I didn't break anything with this change.
