### PR TITLE
Build steps should retry if the slave is lost

### DIFF
--- a/master/buildbot/steps/source/bzr.py
+++ b/master/buildbot/steps/source/bzr.py
@@ -216,7 +216,7 @@ class Bzr(Source):
                     (self.cmd))
             return results
         d.addCallback(_gotResults)
-        d.addCallbacks(self.finished, self.checkDisconnect)
+        d.addCallback(self.finished)
         return d
 
     def _sourcedirIsUpdatable(self):

--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -243,7 +243,7 @@ class CVS(Source):
             self.setStatus(self.cmd, results)
             return results
         d.addCallback(_gotResults)
-        d.addCallbacks(self.finished, self.checkDisconnect)
+        d.addCallback(self.finished)
         return d
 
     def checkLogin(self, _):

--- a/master/buildbot/steps/source/darcs.py
+++ b/master/buildbot/steps/source/darcs.py
@@ -215,7 +215,7 @@ class Darcs(Source):
                     (self.cmd))
             return results
         d.addCallback(_gotResults)
-        d.addCallbacks(self.finished, self.checkDisconnect)
+        d.addCallback(self.finished)
         return d
 
     @defer.inlineCallbacks

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -288,7 +288,7 @@ class Git(Source):
                     (self.cmd))
             return results
         d.addCallback(_gotResults)
-        d.addCallbacks(self.finished, self.checkDisconnect)
+        d.addCallback(self.finished)
         return d
 
     @defer.inlineCallbacks

--- a/master/buildbot/steps/source/mercurial.py
+++ b/master/buildbot/steps/source/mercurial.py
@@ -192,7 +192,7 @@ class Mercurial(Source):
             self.setStatus(self.cmd, results)
             return results
         d.addCallback(_gotResults)
-        d.addCallbacks(self.finished, self.checkDisconnect)
+        d.addCallback(self.finished)
         return d
 
     def parseGotRevision(self, _):

--- a/master/buildbot/steps/source/mtn.py
+++ b/master/buildbot/steps/source/mtn.py
@@ -361,5 +361,5 @@ class Monotone(Source):
                     (self.cmd))
             return results
         d.addCallback(_gotResults)
-        d.addCallbacks(self.finished, self.checkDisconnect)
+        d.addCallback(self.finished)
         return d

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -180,7 +180,7 @@ class P4(Source):
             self.setStatus(self.cmd, results)
             return results
         d.addCallback(_gotResults)
-        d.addCallbacks(self.finished, self.checkDisconnect)
+        d.addCallback(self.finished)
         return d
 
     def _getP4BaseForLog(self):

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -203,7 +203,7 @@ class SVN(Source):
             self.setStatus(self.cmd, results)
             return results
         d.addCallback(_gotResults)
-        d.addCallbacks(self.finished, self.checkDisconnect)
+        d.addCallback(self.finished)
         return d
 
     def _dovccmd(self, command, collectStdout=False, abandonOnFailure=True):

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -21,6 +21,7 @@ from buildbot.process import properties
 from buildbot.process.buildstep import regex_log_evaluator
 from buildbot.status.results import EXCEPTION
 from buildbot.status.results import FAILURE
+from buildbot.status.results import RETRY
 from buildbot.status.results import SUCCESS
 from buildbot.status.results import WARNINGS
 from buildbot.test.fake import fakebuild
@@ -30,7 +31,7 @@ from buildbot.test.util import compat
 from buildbot.test.util import config
 from buildbot.test.util import steps
 from buildbot.util.eventual import eventually
-from twisted.internet import defer
+from twisted.internet import defer, error
 from twisted.python import log
 from twisted.trial import unittest
 
@@ -331,6 +332,11 @@ class TestCustomStepExecution(steps.BuildStepMixin, unittest.TestCase):
         def cb(_):
             self.assertEqual(len(self.flushLoggedErrors(ValueError)), 1)
         return d
+
+    def test_step_raising_connectionlost_in_start(self):
+        self.setupStep(FailingCustomStep(exception=error.ConnectionLost))
+        self.expectOutcome(result=RETRY, status_text=["generic", "exception", "slave", "lost"])
+        return self.runStep()
 
 
 class TestRemoteShellCommand(unittest.TestCase):

--- a/master/buildbot/test/unit/test_steps_source_p4.py
+++ b/master/buildbot/test/unit/test_steps_source_p4.py
@@ -19,12 +19,14 @@ import platform
 import textwrap
 
 from buildbot import config
+from buildbot.status.results import RETRY
 from buildbot.status.results import SUCCESS
 from buildbot.steps.source.p4 import P4
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import sourcesteps
 from buildbot.test.util.properties import ConstantRenderable
+from twisted.internet import error
 from twisted.trial import unittest
 
 _is_windows = (platform.system() == 'Windows')
@@ -725,3 +727,39 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
         self._full(client_stdin=client_spec, extra_args=['-Zproxyload'])
+
+    def test_slave_connection_lost(self):
+        self.setupStep(P4(p4port='localhost:12000', mode='incremental',
+                          p4base='//depot', p4branch='trunk',
+                          p4user='user', p4client='p4_client1', p4passwd='pass'),
+                       dict(revision='100',))
+
+        root_dir = '/home/user/workspace/wkdir'
+        if _is_windows:
+            root_dir = r'C:\Users\username\Workspace\wkdir'
+        client_spec = textwrap.dedent('''\
+        Client: p4_client1
+
+        Owner: user
+
+        Description:
+        \tCreated by user
+
+        Root:\t%s
+
+        Options:\tallwrite rmdir
+
+        LineEnd:\tlocal
+
+        View:
+        \t//depot/trunk/... //p4_client1/...
+        ''' % root_dir)
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['p4', '-V'])
+            + ('err', error.ConnectionLost()),
+        )
+        self.expectOutcome(result=RETRY,
+                           status_text=["update", "exception", "slave", "lost"])
+        return self.runStep()

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -16,6 +16,7 @@
 from buildbot import config
 from buildbot.process import buildstep
 from buildbot.status.results import FAILURE
+from buildbot.status.results import RETRY
 from buildbot.status.results import SUCCESS
 from buildbot.steps.source import svn
 from buildbot.steps.transfer import _FileReader
@@ -24,6 +25,7 @@ from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import sourcesteps
 from buildbot.test.util.properties import ConstantRenderable
+from twisted.internet import error
 from twisted.python.reflect import namedModule
 from twisted.trial import unittest
 
@@ -1733,6 +1735,20 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
         )
         self.expectOutcome(result=FAILURE, status_text=["updating"])
+        return self.runStep()
+
+    def test_slave_connection_lost(self):
+        self.setupStep(
+            svn.SVN(repourl='http://svn.local/app/trunk',
+                    mode='incremental', username='user',
+                    password='pass', extra_args=['--random']))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['svn', '--version'])
+            + ('err', error.ConnectionLost()),
+        )
+        self.expectOutcome(result=RETRY,
+                           status_text=["update", "exception", "slave", "lost"])
         return self.runStep()
 
 


### PR DESCRIPTION
If the slave is lost, it's not a failure of buildbot or the build
running, so we should just retry the job.  A bunch of the source
control steps already did this as well as `LoggingBuildstep`, but
this change centralizes all that logic into `Buildslave`.  All a
consumer has to do is add `Buildstep.failed` as an error handler and
everything will just work.

Since this is fixed in master, but broken on 0.8.8 for source control,
this change adds explicit tests to ensure that this isn't broken in the
future as well (since these tests were not added when the fix was added
originally).
