### PR TITLE
Remove trailing / from setup.py

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -164,7 +164,7 @@ setup_args = {
             "buildbot/status/web/files/templates_readme.txt",
             "buildbot/status/web/files/favicon.ico",
         ]),
-        include("buildbot/status/web/files/", '*.png'),
+        include("buildbot/status/web/files", '*.png'),
         include("buildbot/status/web/templates", '*.html'),
         include("buildbot/status/web/templates", '*.xml'),
         ("buildbot/scripts", [


### PR DESCRIPTION
Fixes ValueError: path 'buildbot/status/web/files/' cannot end with '/'
