### PR TITLE
remotecommand: parameterize the name of the stdio logfile

### DIFF
--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -35,7 +35,8 @@ class RemoteCommand(pb.Referenceable):
     debug = False
 
     def __init__(self, remote_command, args, ignore_updates=False,
-                 collectStdout=False, collectStderr=False, decodeRC={0: SUCCESS}):
+                 collectStdout=False, collectStderr=False, decodeRC={0: SUCCESS},
+                 stdioLogName='stdio'):
         self.logs = {}
         self.delayedLogs = {}
         self._closeWhenFinished = {}
@@ -44,7 +45,7 @@ class RemoteCommand(pb.Referenceable):
         self.stdout = ''
         self.stderr = ''
         self.updates = {}
-
+        self.stdioLogName = stdioLogName
         self._startTime = None
         self._remoteElapsed = None
         self.remote_command = remote_command
@@ -193,20 +194,20 @@ class RemoteCommand(pb.Referenceable):
         return None
 
     def addStdout(self, data):
-        if 'stdio' in self.logs:
-            self.logs['stdio'].addStdout(data)
+        if self.stdioLogName is not None and self.stdioLogName in self.logs:
+            self.logs[self.stdioLogName].addStdout(data)
         if self.collectStdout:
             self.stdout += data
 
     def addStderr(self, data):
-        if 'stdio' in self.logs:
-            self.logs['stdio'].addStderr(data)
+        if self.stdioLogName is not None and self.stdioLogName in self.logs:
+            self.logs[self.stdioLogName].addStderr(data)
         if self.collectStderr:
             self.stderr += data
 
     def addHeader(self, data):
-        if 'stdio' in self.logs:
-            self.logs['stdio'].addHeader(data)
+        if self.stdioLogName is not None and self.stdioLogName in self.logs:
+            self.logs[self.stdioLogName].addHeader(data)
 
     def addToLog(self, logname, data):
         # Activate delayed logs on first data.
@@ -286,7 +287,8 @@ class RemoteShellCommand(RemoteCommand):
                  logfiles={}, usePTY="slave-config", logEnviron=True,
                  collectStdout=False, collectStderr=False,
                  interruptSignal=None,
-                 initialStdin=None, decodeRC={0: SUCCESS}):
+                 initialStdin=None, decodeRC={0: SUCCESS},
+                 stdioLogName='stdio'):
 
         self.command = command  # stash .command, set it later
         if isinstance(self.command, basestring):
@@ -322,7 +324,8 @@ class RemoteShellCommand(RemoteCommand):
             args['interruptSignal'] = interruptSignal
         RemoteCommand.__init__(self, "shell", args, collectStdout=collectStdout,
                                collectStderr=collectStderr,
-                               decodeRC=decodeRC)
+                               decodeRC=decodeRC,
+                               stdioLogName=stdioLogName)
 
     def _start(self):
         self.args['command'] = self.command

--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -99,10 +99,8 @@ class ShellSequence(buildstep.ShellMixin, buildstep.BuildStep):
             # stick the command in self.command so that describe can use it
             self.command = command
 
-            # TODO/XXX: logfile arg is ignored, because RemoteCommand will
-            # always log standard streams to the log named 'stdio'
-
-            cmd = yield self.makeRemoteShellCommand(command=command)
+            cmd = yield self.makeRemoteShellCommand(command=command,
+                                                    stdioLogName=arg.logfile)
             yield self.runCommand(cmd)
             overall_result, terminate = results.computeResultAndTermination(
                 arg, cmd.results(), overall_result)

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -29,7 +29,8 @@ class FakeRemoteCommand(object):
 
     def __init__(self, remote_command, args,
                  ignore_updates=False, collectStdout=False, collectStderr=False,
-                 decodeRC={0: SUCCESS}):
+                 decodeRC={0: SUCCESS},
+                 stdioLogName='stdio'):
         # copy the args and set a few defaults
         self.remote_command = remote_command
         self.args = args.copy()
@@ -40,6 +41,7 @@ class FakeRemoteCommand(object):
         self.collectStderr = collectStderr
         self.updates = {}
         self.decodeRC = decodeRC
+        self.stdioLogName = stdioLogName
         if collectStdout:
             self.stdout = ''
         if collectStderr:
@@ -84,7 +86,8 @@ class FakeRemoteShellCommand(FakeRemoteCommand):
                  timeout=20 * 60, maxTime=None, sigtermTime=None, logfiles={},
                  usePTY="slave-config", logEnviron=True, collectStdout=False,
                  collectStderr=False,
-                 interruptSignal=None, initialStdin=None, decodeRC={0: SUCCESS}):
+                 interruptSignal=None, initialStdin=None, decodeRC={0: SUCCESS},
+                 stdioLogName='stdio'):
         args = dict(workdir=workdir, command=command, env=env or {},
                     want_stdout=want_stdout, want_stderr=want_stderr,
                     initial_stdin=initialStdin,
@@ -93,7 +96,8 @@ class FakeRemoteShellCommand(FakeRemoteCommand):
         FakeRemoteCommand.__init__(self, "shell", args,
                                    collectStdout=collectStdout,
                                    collectStderr=collectStderr,
-                                   decodeRC=decodeRC)
+                                   decodeRC=decodeRC,
+                                   stdioLogName=stdioLogName)
 
 
 class ExpectRemoteRef(object):


### PR DESCRIPTION
this commits permits to record the name of the stdio used
by one remotecommand into a logfile different than 'stdio'.

Signed-off-by: Ion Alberdi ion.alberdi@intel.com
