### PR TITLE
Fix step None bug

### DIFF
--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -232,7 +232,7 @@ class StatusResourceBuild(HtmlResource):
 
             step['link'] = req.childLink("steps/%s" %
                                          urllib.quote(s.getName(), safe=''))
-            step['text'] = " ".join(s.getText())
+            step['text'] = " ".join([str(txt) for txt in s.getText()])
             step['urls'] = map(lambda x: dict(url=x[1], logname=x[0]), s.getURLs().items())
 
             step['logs'] = []


### PR DESCRIPTION
Step text might be None sometimes when the step is failed.
It broke the build detail page. Check the screenshot attached.
https://trello-attachments.s3.amazonaws.com/520e20a062ccc3b70d0029d0/52a1ca4124eaaa752a005976/21abdc7f2b56df6af1244653e3bbd0e1/build_detail_bug.png
