### PR TITLE
Do not catch GeneratorExit exception

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -74,7 +74,7 @@ class _BuildStepFactory(util.ComparableMixin):
     def buildStep(self):
         try:
             return self.factory(*self.args, **self.kwargs)
-        except:
+        except Exception:
             log.msg("error while creating step, factory=%s, args=%s, kwargs=%s"
                     % (self.factory, self.args, self.kwargs))
             raise
@@ -266,7 +266,7 @@ class BuildStep(object, properties.PropertiesMixin):
                     result = yield defer.maybeDeferred(self.start)
                     if result == SKIPPED:
                         doStep = False
-            except:
+            except Exception:
                 log.msg("BuildStep.startStep exception in .start")
                 self.failed(Failure())
 


### PR DESCRIPTION
On buildbot 0.8.8 in rare conditions, we hit:

File "/data/buildbot/twisted/internet/threads.py", line 49, in deferToThreadPool
      threadpool.callInThreadWithCallback(onResult, f, _args, *_kwargs)
    File "/data/buildbot/twisted/python/threadpool.py", line 148, in callInThreadWithCallb
ack
      self.q.put(o)
    File "//usr/lib/python2.7/Queue.py", line 138, in put
      self.not_empty.notify()
    File "//usr/lib/python2.7/threading.py", line 392, in notify
      for waiter in waiters:
  --- <exception caught here> ---
    File "/data/buildbot/buildbot/process/buildstep.py", line 605, in _startStep_3
      result = yield defer.maybeDeferred(self.start)
  exceptions.GeneratorExit:

this applies the fix from http://trac.buildbot.net/ticket/2395#comment:10 to master/buildbot/process/buildstep.py
