### PR TITLE
Shouldn't fetch against a specific branch

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -361,7 +361,7 @@ class Git(Source):
         return d
 
     def _fetch(self, _):
-        command = ['fetch', '-t', self.repourl, self.branch]
+        command = ['fetch', '-t', self.repourl]
         # If the 'progress' option is set, tell git fetch to output
         # progress information to the log. This can solve issues with
         # long fetches killed due to lack of output, but only works


### PR DESCRIPTION
When my scheduler doesn't specify a branch, `branch` here will default to `HEAD`. This is an issue when the commit SHA1 I want to build is not in whichever branch `HEAD` is looking at, as `git fetch` respects the branch specified (by this code, not by me).
