### PR TITLE
Fix pngstatus if the build is currently in progress

### DIFF
--- a/master/buildbot/status/web/pngstatus.py
+++ b/master/buildbot/status/web/pngstatus.py
@@ -85,12 +85,13 @@ class PngStatusResource(resource.Resource):
             build = self.status.getBuilder(builder).getBuild(b)
             if build is not None:
                 result = build.getResults()
-                data['filename'] = (
-                    results.Results[result] + '_' + size + '.png')
+                if result is not None:
+                    data['filename'] = (
+                        results.Results[result] + '_' + size + '.png')
 
-                # read the png file from the disc
-                png_file = (os.path.dirname(os.path.abspath(__file__)) +
-                            '/files/' + data['filename'])
+                    # read the png file from the disc
+                    png_file = (os.path.dirname(os.path.abspath(__file__)) +
+                                '/files/' + data['filename'])
 
         # load the png file from the file system
         png = open(png_file, 'rb')


### PR DESCRIPTION
If the builder is currently building `getResults` returns None for the latest build which is not a valid dict key.
