### PR TITLE
Update recent storage service

### DIFF
--- a/master/docs/developer/www.rst
+++ b/master/docs/developer/www.rst
@@ -452,6 +452,64 @@ Several methods are added to each "restangularized" objects, aside from get(), p
 
         Call the control data api. This builds up a POST with jsonapi encoded parameters
 
+RecentStorage
+.............
+The service provides methods for adding, retrieving and clearing recently viewed builders and builds.
+It uses IndexedDB to store data inside the user’s browser. You can see the list of supported browsers here: http://caniuse.com/indexeddb.
+
+builder and build object properties:
+    * ``link`` - string: this specifies the builder’s or build’s link
+
+    * ``caption`` - string: this specifies the builder’s or build’s shown caption
+
+Sample:
+
+.. code-block:: coffeescript
+
+    {
+        link: '#/builders/1'
+        caption: 'Mac'
+    }
+
+Methods:
+
+    * ``.addBuild(build)``: stores the build passed as argument
+
+    * ``.addBuild(builder)``: stores the builder passed as argument
+
+    * ``.getBuilds()``: returns a promise, the result will be an array of builds when the promise is resolved
+        example:
+
+        .. code-block:: coffeescript
+
+            recentStorage.getBuilds().then (e) ->
+                $scope.builds = e
+
+    * ``.getBuilders()``: returns a promise, the result will be an array of builders when the promise is resolved
+        example:
+
+        .. code-block:: coffeescript
+
+            recentStorage.getBuilders().then (e) ->
+                $scope.builders = e
+
+    * ``.getAll()``: returns a promise, the result will be an object with two fields, recent_builds and recent_builders
+        example:
+
+        .. code-block:: coffeescript
+
+            recentStorage.getAll().then (e) ->
+                $scope.builds = e.recent_builds
+                $scope.builders = e.recent_builders
+
+    * ``.clearAll()``: removes the stored builds and builders
+        example:
+
+        .. code-block:: coffeescript
+
+            recentStorage.clearAll()
+
+
 Mocks and testing utils
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/www/src/scripts/controllers/buildController.coffee
+++ b/www/src/scripts/controllers/buildController.coffee
@@ -1,6 +1,6 @@
 angular.module('app').controller 'buildController',
-['$log', '$scope', '$location', 'buildbotService', '$stateParams'
-    ($log, $scope, $location, buildbotService, $stateParams) ->
+['$log', '$scope', '$location', 'buildbotService', '$stateParams', 'recentStorage'
+    ($log, $scope, $location, buildbotService, $stateParams, recentStorage) ->
 
         buildbotService.bindHierarchy($scope, $stateParams, ['builders', 'builds'])
         .then ([builder, build]) ->
@@ -10,5 +10,8 @@ angular.module('app').controller 'buildController',
                 buildset = buildbotService.one("buildsets", buildrequest.buildsetid)
                 buildset.bind($scope)
                 buildset.one("properties").bind($scope, dest_key:'properties')
+                recentStorage.addBuild
+                    link: '#/builders/' + $scope.builder.builderid + '/build/' + $scope.build.buildid
+                    caption: $scope.builder.name + ' / ' + $scope.build.buildid
 
 ]

--- a/www/src/scripts/controllers/builderController.coffee
+++ b/www/src/scripts/controllers/builderController.coffee
@@ -1,10 +1,13 @@
 angular.module('app').controller 'builderController',
-['$log', '$scope', '$location', 'buildbotService', '$stateParams', 'resultsService',
-    ($log, $scope, $location, buildbotService, $stateParams, resultsService) ->
+['$log', '$scope', '$location', 'buildbotService', '$stateParams', 'resultsService', 'recentStorage'
+    ($log, $scope, $location, buildbotService, $stateParams, resultsService, recentStorage) ->
         # make resultsService utilities available in the template
         _.mixin($scope, resultsService)
         builder = buildbotService.one('builders', $stateParams.builder)
-        builder.bind($scope)
+        builder.bind($scope).then ->
+            recentStorage.addBuilder
+                link: '#/builders/' + $scope.builder.builderid
+                caption: $scope.builder.name
         builder.all('forceschedulers').bind($scope)
         builder.some('builds', {limit:20, order:"-number"}).bind($scope)
         builder.some('buildrequests', {claimed:0}).bind($scope)

--- a/www/src/scripts/controllers/homeController.coffee
+++ b/www/src/scripts/controllers/homeController.coffee
@@ -1,5 +1,13 @@
 angular.module('app').controller 'homeController',
 ['$log', '$scope', '$location', 'recentStorage'
     ($log, $scope, $location, recentStorage) ->
-        $scope.recent = recentStorage.get()
+        $scope.recent = {}
+        recentStorage.getAll().then (e) ->
+            $scope.recent.recent_builders = e.recent_builders
+            $scope.recent.recent_builds = e.recent_builds
+        $scope.clear = ->
+            recentStorage.clearAll().then ->
+                recentStorage.getAll().then (e) ->
+                    $scope.recent.recent_builders = e.recent_builders
+                    $scope.recent.recent_builds = e.recent_builds
 ]

--- a/www/src/scripts/services/recentStorage.coffee
+++ b/www/src/scripts/services/recentStorage.coffee
@@ -1,14 +1,115 @@
 ###
-Services that persists and retrieves recents from localStorage. (from todomvc
-example)
+    Recent storage service
 ###
 
 angular.module('app').factory 'recentStorage',
-['$log', ($log) ->
-    STORAGE_ID = "buildbot-angularjs"
-    get: ->
-        JSON.parse localStorage.getItem(STORAGE_ID) or "[]"
+    ['$q', '$window', '$rootScope', ($q, $window, $rootScope) ->
+        self = this
 
-    put: (recent) ->
-        localStorage.setItem(STORAGE_ID, JSON.stringify(recent))
-]
+        db = null
+        setUp = false
+        self =
+            open: ->
+                if not $window.indexedDB?
+                    return $q.reject('IndexedDB is not supported')
+
+                if setUp
+                    return $q.when(true)
+
+                deferred = $q.defer()
+                indexedDB = $window.indexedDB
+
+                openRequest = indexedDB.open('Recent', 1)
+                openRequest.onupgradeneeded = (e) ->
+                    thisDB = e.target.result
+
+                    if not thisDB.objectStoreNames.contains('recent_builders')
+                        thisDB.createObjectStore 'recent_builders', { keyPath: 'link' }
+                    if not thisDB.objectStoreNames.contains('recent_builds')
+                        thisDB.createObjectStore 'recent_builds', { keyPath: 'link' }
+
+                openRequest.onsuccess = (e) ->
+                    db = e.target.result
+                    setUp = true
+                    $rootScope.$apply ->
+                        deferred.resolve(true)
+
+                openRequest.onerror = (e) ->
+                    $rootScope.$apply ->
+                        deferred.reject('Database error:' + e.toString())
+
+                return deferred.promise
+
+            addRecent: (link, recent) ->
+                return self.open().then ->
+                    transaction = db.transaction([link], 'readwrite')
+                    store = transaction.objectStore(link)
+                    store.add(recent)
+
+            getRecentLinks: (link) ->
+                return self.open().then ->
+                    deferred = $q.defer()
+
+                    transaction = db.transaction([link], 'readwrite')
+                    store = transaction.objectStore(link)
+                    cursorRequest = store.openCursor()
+
+                    cursorRequest.onerror = (e) ->
+                        $rootScope.$apply ->
+                            deferred.reject('Database error:' + e.toString())
+
+                    recents = []
+                    cursorRequest.onsuccess = (e) ->
+                        cursor = e.target.result
+                        if cursor?
+                            recents.push(cursor.value)
+                            cursor.continue()
+
+                    transaction.oncomplete = ->
+                        $rootScope.$apply ->
+                            deferred.resolve(recents)
+
+                    return deferred.promise
+
+            clear: (link) ->
+                return self.open().then ->
+                    deferred = $q.defer()
+                    transaction = db.transaction([link], 'readwrite')
+                    store = transaction.objectStore(link)
+                    req = store.clear()
+                    req.onerror = (e) ->
+                        $rootScope.$apply ->
+                            deferred.reject('Database error:' + e.toString())
+
+                    req.onsuccess = (e) ->
+                        $rootScope.$apply ->
+                            deferred.resolve(null)
+                    return deferred.promise
+
+        service =
+            addBuild: (build) ->
+                return self.addRecent('recent_builds', build)
+
+            addBuilder: (builder) ->
+                return self.addRecent('recent_builders', builder)
+
+            getBuilds: ->
+                return self.getRecentLinks('recent_builds')
+
+            getBuilders: ->
+                return self.getRecentLinks('recent_builders')
+
+            getAll: ->
+                return $q.all {
+                    recent_builds: service.getBuilds(),
+                    recent_builders: service.getBuilders()
+                }
+
+            clearAll: ->
+                return $q.all [
+                    self.clear('recent_builds')
+                    self.clear('recent_builders')
+                ]
+
+        return service
+    ]

--- a/www/src/views/home.jade
+++ b/www/src/views/home.jade
@@ -6,7 +6,7 @@
   .row
     .col-sm-3
       .well
-        button.btn-small.btn-default.btn.pull-right
+        button(ng-click='clear()').btn-small.btn-default.btn
           i.icon-trash
             |  Clear History
         ul.nav.nav-list

--- a/www/test/scripts/services/recentStorageSpec.coffee
+++ b/www/test/scripts/services/recentStorageSpec.coffee
@@ -1,0 +1,84 @@
+if window.__karma__?
+    beforeEach module 'app'
+
+    describe 'recent storage service', ->
+        recentStorage = $q = $window = $rootScope = null
+
+        injected = ($injector) ->
+            $q = $injector.get('$q')
+            $window = $injector.get('$window')
+            $rootScope = $injector.get('$rootScope')
+            recentStorage = $injector.get('recentStorage')
+
+        beforeEach (inject(injected))
+
+        it 'should store recent builds', (done) ->
+            testBuild1 = {link: '/test1', caption: 'test1'}
+            testBuild2 = {link: '/test2', caption: 'test2'}
+            testBuild3 = {link: '/test3', caption: 'test3'}
+
+            recentStorage.clearAll().then (e) ->
+                $q.all([
+                    recentStorage.addBuild(testBuild1),
+                    recentStorage.addBuild(testBuild3)
+                ])
+                .then ->
+                    recentStorage.getBuilds().then (e) ->
+                        resolved = e
+                        expect(resolved).not.toBeNull()
+                        expect(resolved).toContain(testBuild1)
+                        expect(resolved).toContain(testBuild3)
+                        expect(resolved).not.toContain(testBuild2)
+                        done()
+            , ->
+                expect($window.indexedDB).toBeUndefined()
+                done()
+            $rootScope.$digest()
+
+        it 'should store recent builders', (done) ->
+            testBuilder1 = {link: '/test1', caption: 'test1'}
+            testBuilder2 = {link: '/test2', caption: 'test2'}
+            testBuilder3 = {link: '/test3', caption: 'test3'}
+
+            recentStorage.clearAll().then (e) ->
+                $q.all([
+                    recentStorage.addBuilder(testBuilder1),
+                    recentStorage.addBuilder(testBuilder3)
+                ])
+                .then ->
+                    recentStorage.getBuilders().then (e) ->
+                        resolved = e
+                        expect(resolved).not.toBeNull()
+                        expect(resolved).toContain(testBuilder1)
+                        expect(resolved).toContain(testBuilder3)
+                        expect(resolved).not.toContain(testBuilder2)
+                        done()
+            , ->
+                expect($window.indexedDB).toBeUndefined()
+                done()
+            $rootScope.$digest()
+
+        it 'should clear all recent builds and builders', (done) ->
+            testBuild1 = {link: '/test1', caption: 'test1'}
+            testBuild2 = {link: '/test2', caption: 'test2'}
+            testBuilder1 = {link: '/test1', caption: 'test1'}
+            testBuilder2 = {link: '/test2', caption: 'test2'}
+
+            $q.all([
+                recentStorage.addBuild(testBuild1),
+                recentStorage.addBuild(testBuild2),
+                recentStorage.addBuilder(testBuilder1),
+                recentStorage.addBuilder(testBuilder2)
+            ])
+            .then ->
+                recentStorage.clearAll().then (e) ->
+                    recentStorage.getAll().then (e) ->
+                        resolved = e
+                        expect(resolved).toBeDefined()
+                        expect(resolved.recent_builds.length).toBe(0)
+                        expect(resolved.recent_builders.length).toBe(0)
+                        done()
+            , ->
+                expect($window.indexedDB).toBeUndefined()
+                done()
+            $rootScope.$digest()


### PR DESCRIPTION
The service provides methods for adding, retrieving and clearing recently viewed builders and builds.
It uses IndexedDB to store data inside the user’s browser.
