### PR TITLE
make DirectoryLister use HtmlResource to honor 'view' authorization property

### DIFF
--- a/master/buildbot/status/web/base.py
+++ b/master/buildbot/status/web/base.py
@@ -433,16 +433,16 @@ class StaticHTML(HtmlResource):
         return template.render(**cxt)
 
 
-class DirectoryLister(static.DirectoryLister, ContextMixin):
+class DirectoryLister(static.DirectoryLister, HtmlResource):
 
     """This variant of the static.DirectoryLister uses a template
     for rendering."""
 
-    pageTitle = 'BuildBot'
+    def __init__(self, pathname, dirs, contentTypes, contentEncodings, defaultType):
+        static.DirectoryLister.__init__(self, pathname, dirs, contentTypes, contentEncodings, defaultType)
+        HtmlResource.__init__(self)
 
-    def render(self, request):
-        cxt = self.getContext(request)
-
+    def content(self, request, cxt):
         if self.dirs is None:
             directory = sorted(os.listdir(self.path))
         else:
@@ -458,6 +458,9 @@ class DirectoryLister(static.DirectoryLister, ContextMixin):
         if isinstance(data, unicode):
             data = data.encode("utf-8")
         return data
+
+    def render(self, request):
+        return HtmlResource.render(self, request)
 
 
 class StaticFile(static.File):


### PR DESCRIPTION
I've never before used buildbot, but in my initial setup today I made it such that slaves upload their build artifacts to the master's `public_html/builds` directory.

Our buildbot instance is on a public server, so we wanted to have this directory behind some sort of an authentication layer. After updating to the dev build, I noticed the 'view' property, and it _seemed_ to make sense that the directory listings would also honor this.
