### PR TITLE
Fix documentation to avoid error when read doc...

### DIFF
--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -957,7 +957,7 @@ for example::
    from buildbot.steps.source.repo import RepoDownloadsFromProperties
    from buildbot.process.properties import FlattenList
 
-   factory.addStep(Repo(manifestUrl='git://mygerrit.org/manifest.git',
+   factory.addStep(Repo(manifestURL='git://mygerrit.org/manifest.git',
                         repoDownloads=FlattenList([RepoDownloadsFromChangeSource(),
                                                    RepoDownloadsFromProperties("repo_downloads")
                                                    ]


### PR DESCRIPTION
assert self.manifestURL is not None
exceptions.AssertionError:

<class 'buildbot.steps.source.repo.Repo'>.**init** got unexpected keyword argument(s) ['manifestUrl']
