### PR TITLE
status_json: Allow double escaping for resources in select

### DIFF
--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -19,6 +19,7 @@
 import datetime
 import os
 import re
+import urllib
 
 from twisted.internet import defer
 from twisted.web import html
@@ -229,7 +230,11 @@ class JsonResource(resource.Resource):
                 postpath = request.postpath[:]
                 request.postpath = filter(None, item.split('/'))
                 while request.postpath and not child.isLeaf:
-                    pathElement = request.postpath.pop(0)
+                    # Twisted unquotes the querystring once. We unquote once more
+                    # to allow for "doubly escaped" elements, which makes it possible
+                    # to select on resource names with slashes in them without them being
+                    # split into separate (invalid) elements.
+                    pathElement = urllib.unquote(request.postpath.pop(0))
                     node[pathElement] = {}
                     node = node[pathElement]
                     request.prepath.append(pathElement)


### PR DESCRIPTION
This patch provides a workaround for an issue that would cause queries
of the form

"select=builders/my%20slashed%2Fbuilder"

to be interpreted as a hierarchy of separate resources:

builders
- my slashed
  - builder

Instead of the intended:

builders
- my slashed/builder

This way, we can double escape resources with specially treated
characters in them (such as slashes), and still retrieve them properly.

For instance, the query above becomes:

"select=builders/my%2520slashed%252Fbuilder"

instead, and renders the desired result.

Signed-off-by: Anton Lofgren alofgren@op5.com
