### PR TITLE
Fix documentation about update Gerrit Status

### DIFF
--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -1662,10 +1662,6 @@ GerritStatusPush
         message = "Buildbot started compiling your patchset\n"
         message += "on configuration: %s\n" % builderName
 
-        if arg:
-            message += "\nFor more details visit:\n"
-            message += status.getURLForThing(build) + "\n"
-
         return message
 
     c['buildbotURL'] = 'http://buildbot.example.com/'


### PR DESCRIPTION
There is no status variable in gerritStartCB

message += status.getURLForThing(build) + "\n"
exceptions.NameError: global name 'status' is not defined
