### PR TITLE
When use GerritChangeSource, the first test never work on step addStep(G...

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -414,7 +414,7 @@ class Git(Source):
         """Retry if clone failed"""
 
         args = []
-        if self.supportsBranch and self.branch != 'HEAD':
+        if self.supportsBranch and self.branch != 'HEAD' and self.branch.startswith("refs/changes") == 0:
             args += ['--branch', self.branch]
         if shallowClone:
             args += ['--depth', '1']


### PR DESCRIPTION
...errit(repourl=repo, mode="full",retry=[60,60],timeout=3600))...

The step launch a cloning of git repo

The build always fails with fatal: Remote branch refs/changes/xx/yy/zz not found in upstream origin...

Add check when clone to no add branch if the branch start with refs/changes/

Only this issue with > Git 1.8
See also http://trac.buildbot.net/ticket/2485#comment:8
