### PR TITLE
Avoid extra DB lookups in BuildRequest

### DIFF
--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -308,7 +308,7 @@ class BuilderStatus(styles.Versioned):
 
         def make_statuses(brdicts):
             return [BuildRequestStatus(self.name, brdict['brid'],
-                                       self.status)
+                                       self.status, brdict=brdict)
                     for brdict in brdicts]
         d.addCallback(make_statuses)
         return d


### PR DESCRIPTION
When returning the list of pending build requests,
BuilderStatus.getPendingBuildRequests loads on brdicts
just to grab the brid to pass into the BuildRequest
constructor.  This brdict is then reloaded from the DB
if virtually any of the BuildRequest methods are called.
To avoid this extra lookup, this diff adds an extra
constructor parameter to thread the brdict into the
BuildRequest object.
