### PR TITLE
For timeouts include the command being run in the failure string

### DIFF
--- a/slave/buildslave/runprocess.py
+++ b/slave/buildslave/runprocess.py
@@ -768,12 +768,12 @@ class RunProcess:
 
     def doTimeout(self):
         self.ioTimeoutTimer = None
-        msg = "command timed out: %d seconds without output" % self.timeout
+        msg = "command timed out: %d seconds without output running %s" % (self.timeout, self.fake_command)
         self.kill(msg)
 
     def doMaxTimeout(self):
         self.maxTimeoutTimer = None
-        msg = "command timed out: %d seconds elapsed" % self.maxTime
+        msg = "command timed out: %d seconds elapsed running %s" % (self.maxTime, self.fake_command)
         self.kill(msg)
 
     def isDead(self):


### PR DESCRIPTION
This makes it easier to identify failures in the log after parsing (eg https://bugzilla.mozilla.org/show_bug.cgi?id=961075) as well as save having to scroll up to see what command was being run at the start of the build step.
