### PR TITLE
Remove duplicate in doc for 'all' email status mode.

### DIFF
--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -1182,7 +1182,7 @@ MailNotifier arguments
 
     ``all``
         Always send mail about builds. Equivalent to (``change``, ``failing``,
-        ``passing``, ``passing``, ``problem``, ``warnings``, ``exception``).
+        ``passing``, ``problem``, ``warnings``, ``exception``).
 
     ``warnings``
         Equivalent to (``warnings``, ``failing``).


### PR DESCRIPTION
Trivial, so no release notes...

This really is just a retro-commit-comment.
