### PR TITLE
Wrong error messages for a failed rebuild

### DIFF
--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -91,9 +91,9 @@ class ForceBuildActionResource(ActionResource):
             extraProperties = getAndCheckProperties(req)
             if not bc or not b.isFinished() or extraProperties is None:
                 msg = "could not rebuild: "
-                if b.isFinished():
+                if not b.isFinished():
                     msg += "build still not finished "
-                if bc:
+                if not bc:
                     msg += "could not get builder control"
             else:
                 tup = yield bc.rebuildBuild(b,


### PR DESCRIPTION
A colleague was trying to rebuild a build and got "could not get build control" and asked me what it meant. Looking in the source, looks like it's the wrong error message. His problem was that he was trying to rebuild something still in progress, and I think these error messages got inverted.
