### PR TITLE
#2608 validate that locale is valid before starting

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -48,6 +48,7 @@ from buildbot.status.master import Status
 from buildbot.status.results import FAILURE
 from buildbot.status.results import SUCCESS
 from buildbot.status.results import WARNINGS
+from buildbot.util import check_functional_environment
 from buildbot.util import epoch2datetime
 from buildbot.util import subscription
 from buildbot.util.eventual import eventually
@@ -118,6 +119,9 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
         # local cache for this master's object ID
         self._object_id = None
+
+        # Check environment is sensible
+        check_functional_environment(self.config)
 
     def create_child_services(self):
         # note that these are order-dependent.  If you get the order wrong,

--- a/master/buildbot/test/unit/test_util.py
+++ b/master/buildbot/test/unit/test_util.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 
 import datetime
+import mock
+import os
 
 from twisted.internet import reactor
 from twisted.internet import task
@@ -214,3 +216,20 @@ class AsyncSleep(unittest.TestCase):
         self.assertFalse(d.called)
         clock.advance(1)
         self.assertTrue(d.called)
+
+
+class FunctionalEnvironment(unittest.TestCase):
+
+    def test_working_locale(self):
+        environ = {'LANG': 'en_GB.UTF-8'}
+        self.patch(os, 'environ', environ)
+        config = mock.Mock()
+        util.check_functional_environment(config)
+        self.assertEqual(config.error.called, False)
+
+    def test_broken_locale(self):
+        environ = {'LANG': 'NINE.UTF-8'}
+        self.patch(os, 'environ', environ)
+        config = mock.Mock()
+        util.check_functional_environment(config)
+        config.error.assert_called()

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -16,6 +16,7 @@
 
 import calendar
 import datetime
+import locale
 import re
 import string
 import time
@@ -243,8 +244,18 @@ def asyncSleep(delay):
     return d
 
 
+def check_functional_environment(config):
+    try:
+        locale.getdefaultlocale()
+    except KeyError:
+        config.error("\n".join([
+            "Your environment has incorrect locale settings. This means python cannot handle strings safely.",
+            "Please check 'LANG', 'LC_CTYPE', 'LC_ALL' and 'LANGUAGE' are either unset or set to a valid locale.",
+            ]))
+
+
 __all__ = [
     'naturalSort', 'now', 'formatInterval', 'ComparableMixin', 'json',
     'safeTranslate', 'none_or_str',
     'NotABranch', 'deferredLocked', 'SerializedInvocation', 'UTC',
-    'diffSets', 'makeList', 'in_reactor']
+    'diffSets', 'makeList', 'in_reactor', 'check_functional_environment']

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -181,6 +181,8 @@ Features
 
 * Systemd unit files for Buildbot are available in the :bb:src:`contrib/` directory.
 
+* We've added some extra checking to make sure that you have a valid locale before starting buildbot (#2608).
+
 
 Forward Compatibility
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This branch is against the buildbot 0.8.9 branch.

Buildbot will now fail to start with a helpful message if a stray environment variable has broken `locale.getdefaultlocale`.
