### PR TITLE
Seed the `getChange` cache from `addChange`.

### DIFF
--- a/master/buildbot/test/unit/test_db_changes.py
+++ b/master/buildbot/test/unit/test_db_changes.py
@@ -556,3 +556,23 @@ class TestChangesConnectorComponent(
                              {'notest': ('no', 'Change')})
         d.addCallback(check)
         return d
+
+    @defer.inlineCallbacks
+    def test_addChange_cache(self):
+        """
+        Test that `addChange` properly seeds the `getChange` cache.
+        """
+
+        mockedCachePut = mock.Mock()
+        self.patch(self.db.changes.getChange.cache, "put", mockedCachePut)
+
+        # Convert this chdict into a kwargs dict which can be passed to
+        # `addChange`, by removing the hard-coded `changeid`.
+        kwargs = dict(self.change14_dict)
+        del kwargs['changeid']
+
+        # Now, call `addChange`, and verify that an appropriate chdict was
+        # was put into the `getChange` cache.
+        changeid = yield self.db.changes.addChange(**kwargs)
+        kwargs['changeid'] = changeid
+        mockedCachePut.assert_called_once_with(changeid, kwargs)


### PR DESCRIPTION
A common flow is to add a change to database via `addChange`
then immediately read it back using `addChange`, which would
cause a DB access to insert it and another to read it back.
This change seeds the `getChange` cache directly from the
`addChange` call to avoid this second DB access.
