### PR TITLE
Add a `BuildsetProperties` cache and seed from `addBuildset`

### DIFF
--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+import mock
 import datetime
 
 from buildbot.db import buildsets
@@ -455,3 +456,26 @@ class TestBuildsetsConnectorComponent(
             self.assertEqual(bsdictlist, [])
         d.addCallback(check)
         return d
+
+    @defer.inlineCallbacks
+    def test_addBuildset_properties_cache(self):
+        """
+        Test that `addChange` properly seeds the `getChange` cache.
+        """
+
+        # Patchup the buildset properties cache so we can verify that
+        # it got called form `addBuildset`.
+        mockedCachePut = mock.Mock()
+        self.patch(
+            self.db.buildsets.getBuildsetProperties.cache,
+            "put", mockedCachePut)
+
+        # Setup a dummy set of properties to insert with the buildset.
+        props = dict(prop=(['list'], 'test'))
+
+        # Now, call `addBuildset`, and verify that the above properties
+        # were seeed in the `getBuildsetProperties` cache.
+        bsid, _ = yield self.db.buildsets.addBuildset(
+            sourcestampsetid=234, reason='because',
+            properties=props, builderNames=['a', 'b'])
+        mockedCachePut.assert_called_once_with(bsid, props)


### PR DESCRIPTION
This diff adds a cache around the buildset properties table
accessed from `getBuildsetProperties` and seeds it from `addBuildset`,
to avoid extra DB accesses immediately after adding a buildset.
