### PR TITLE
Make EC2 slaves take a subnet_id

### DIFF
--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -312,7 +312,10 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
 
     def _stop_instance(self, instance, fast):
         if self.elastic_ip is not None:
-            self.conn.disassociate_address(self.elastic_ip.public_ip)
+            # Refresh the address data to get the associationId, required
+            # for disassociation
+            self.elastic_ip = self.conn.get_all_addresses([self.elastic_ip.public_ip])[0]
+            self.elastic_ip.disassociate()
         instance.update()
         if instance.state not in (SHUTTINGDOWN, TERMINATED):
             instance.terminate()


### PR DESCRIPTION
The Rust project has been carrying this critical patch for a long time. This makes it possible to launch an EC2 slave into VPC by specifying the subnet_id.
