### PR TITLE
Fix failing libvirt test

### DIFF
--- a/master/buildbot/test/unit/test_buildslave_libvirt.py
+++ b/master/buildbot/test/unit/test_buildslave_libvirt.py
@@ -41,6 +41,7 @@ class TestLibVirtSlave(unittest.TestCase):
         self.assertRaises(config.ConfigErrors, self.ConcreteBuildSlave,
                           'bot', 'pass', None, 'path', 'path')
 
+    @defer.inlineCallbacks
     def test_constructor_minimal(self):
         bs = self.ConcreteBuildSlave('bot', 'pass', self.conn, 'path', 'otherpath')
         yield bs._find_existing_deferred


### PR DESCRIPTION
Buildbot 0.8.9 is failing its tests for me, it looks like a test casing is missing an inlineCallbacks.
