### PR TITLE
fixing broken link for systemd unit files in 0.8.9 release notes

### DIFF
--- a/master/docs/relnotes/0.8.9.rst
+++ b/master/docs/relnotes/0.8.9.rst
@@ -180,7 +180,7 @@ Features
 
 * An example of a declarative configuration is included in :bb:src:`master/contrib/SimpleConfig.py`, with copious comments.
 
-* Systemd unit files for Buildbot are available in the :bb:src:`contrib/` directory.
+* Systemd unit files for Buildbot are available in the :bb:src:`master/contrib/` directory.
 
 * We've added some extra checking to make sure that you have a valid locale before starting buildbot (#2608).
 


### PR DESCRIPTION
Simple fix for broken link in the 0.8.9 release notes for systemd unit files. I kept the link as close as possible to what it was instead of directly linking to the systemd dir in master/contrib.

Built docs locally, link to github source works.
