### PR TITLE
contrib/github_buildbot.py Update

### DIFF
--- a/master/contrib/github_buildbot.py
+++ b/master/contrib/github_buildbot.py
@@ -236,7 +236,7 @@ def setup_options():
                       help="The username and password, separated by a colon, "
                            "to use when connecting to buildbot over the "
                            "perspective broker.",
-                      default=None, dest="auth")
+                      default="change:changepw", dest="auth")
 
     parser.add_option("--secret",
                       help="If provided then use the X-Hub-Signature header "


### PR DESCRIPTION
So I was playing around with github_buildbot.py to try and get it to work with my own project and after spending some time with it decided to open this pull request.  Here's a quick summary of the differences:
- Reject POSTs that are not a push event type
- Added support for the `X-Hub-Signature` header so messages can be signed by github and then verified on the receiving end
- Added responses to the incoming request so views don't return an empty body and so the request does not appear to timeout to github
- Added support for custom credentials to the perspective broker
- Better default for the --master flag
- Cleaned up logging and syntax in a few places
