### PR TITLE
git: force submodule update so local changes/files are overwritten

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -530,7 +530,7 @@ class Git(Source):
     def _updateSubmodule(self, _=None):
         if self.submodules:
             return self._dovccmd(['submodule', 'update',
-                                  '--init', '--recursive'])
+                                  '--init', '--recursive', '--force'])
         else:
             return defer.succeed(0)
 

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -931,7 +931,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'submodule', 'update', '--init', '--recursive'])
+                        command=['git', 'submodule', 'update', '--init', '--recursive', '--force'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'submodule', 'foreach', 'git', 'clean',

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -66,6 +66,10 @@ Fixes
 
 * The :bb:step:`HTTPStep` step's requeset parameters are now renderable.
 
+* With Git(), force the updating submodules to ensure local changes by the
+  build are overwitten. This both ensures more consistent builds and avoids
+  errors when updating submodules.
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Without this, we sometimes get "Your local changes to the following
files would be overwritten by checkout" when submodules are updates.

On the non-submodule side, we're already using reset instead of
checkout to avoid this.

Signed-off-by: Cody P Schafer dev@codyps.com
