### PR TITLE
Use pytz to handle P4Poller's `server_tz`.

### DIFF
--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -18,7 +18,7 @@
 # Many thanks to Dave Peticolas for contributing this module
 
 import datetime
-import dateutil
+import dateutil.tz
 import exceptions
 import os
 import os.path
@@ -148,7 +148,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
         self.project = util.ascii2unicode(project)
         self.use_tickets = use_tickets
         self.ticket_login_interval = ticket_login_interval
-        self.server_tz = server_tz
+        self.server_tz = dateutil.tz.gettz(server_tz) if server_tz else None
 
         self._ticket_passwd = None
         self._ticket_login_counter = 0
@@ -272,7 +272,6 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
             if self.server_tz:
                 # Convert from the server's timezone to the local timezone.
                 when = when.replace(tzinfo=self.server_tz)
-                when = when.astimezone(dateutil.tz.tzlocal())
             when = util.datetime2epoch(when)
             comments = ''
             while not lines[0].startswith('Affected files'):

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -22,18 +22,10 @@ from buildbot.interfaces import ITriggerableScheduler
 from buildbot.process import buildstep
 from buildbot.process import properties
 from buildbot.schedulers import base
+from buildbot.util import croniter
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log
-# Import croniter if available.
-# This is only required for Nightly schedulers,
-# so fail gracefully if it isn't present.
-try:
-    from buildbot.util import croniter
-except ImportError:
-    # Pyflakes doesn't like a redefinition here
-    # Instead, we check if croniter is defined when we need it
-    pass
 
 
 class Timed(base.BaseScheduler):

--- a/master/buildbot/test/unit/test_util.py
+++ b/master/buildbot/test/unit/test_util.py
@@ -124,7 +124,7 @@ class TimeFunctions(unittest.TestCase):
                          datetime.timedelta(0))
         self.assertEqual(util.UTC.dst(datetime.datetime.now()),
                          datetime.timedelta(0))
-        self.assertEqual(util.UTC.tzname(), "UTC")
+        self.assertEqual(util.UTC.tzname(datetime.datetime.utcnow()), "UTC")
 
     def test_epoch2datetime(self):
         self.assertEqual(util.epoch2datetime(0),

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -16,6 +16,7 @@
 
 import calendar
 import datetime
+import dateutil.tz
 import locale
 import re
 import string
@@ -88,7 +89,8 @@ class ComparableMixin(object):
 
     def __hash__(self):
         compare_attrs = []
-        reflect.accumulateClassList(self.__class__, 'compare_attrs', compare_attrs)
+        reflect.accumulateClassList(
+            self.__class__, 'compare_attrs', compare_attrs)
 
         alist = [self.__class__] + \
                 [getattr(self, name, self._None) for name in compare_attrs]
@@ -104,7 +106,8 @@ class ComparableMixin(object):
             return result
 
         compare_attrs = []
-        reflect.accumulateClassList(self.__class__, 'compare_attrs', compare_attrs)
+        reflect.accumulateClassList(
+            self.__class__, 'compare_attrs', compare_attrs)
 
         self_list = [getattr(self, name, self._None)
                      for name in compare_attrs]
@@ -114,7 +117,8 @@ class ComparableMixin(object):
 
     def getConfigDict(self):
         compare_attrs = []
-        reflect.accumulateClassList(self.__class__, 'compare_attrs', compare_attrs)
+        reflect.accumulateClassList(
+            self.__class__, 'compare_attrs', compare_attrs)
         return dict([(k, getattr(self, k)) for k in compare_attrs
                      if hasattr(self, k) and k not in ("passwd", "password")])
 
@@ -182,20 +186,8 @@ NotABranch = NotABranch()
 
 # time-handling methods
 
-
-class UTC(datetime.tzinfo):
-
-    """Simple definition of UTC timezone"""
-
-    def utcoffset(self, dt):
-        return datetime.timedelta(0)
-
-    def dst(self, dt):
-        return datetime.timedelta(0)
-
-    def tzname(self):
-        return "UTC"
-UTC = UTC()
+# this used to be a custom class; now it's just an instance of dateutil's class
+UTC = dateutil.tz.tzutc()
 
 
 def epoch2datetime(epoch):

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -618,8 +618,7 @@ depot for changes. It accepts the following arguments:
 
 ``server_tz``
     The timezone of the Perforce server, using the usual timezone format
-    (e.g: ``Europe/Stockholm``) in case it's in a different timezone than the
-    buildbot master.
+    (e.g: ``"Europe/Stockholm"``) in case it's not in UTC.
 
 ``use_tickets``
     Set to ``True`` to use ticket-based authentication, instead of passwords (but

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -51,6 +51,11 @@ But the devil is in the details:
  * If you want multiple masters, you'll need an external message broker of some sort.
    Messaging is based on `Kombu <http://kombu.readthedocs.org/>`_, and supports the backends that Kombu supports.
 
+Minor Python Packages
+.....................
+
+* Buildbot requires at least Twisted-11.0.0.
+
 Features
 ~~~~~~~~
 
@@ -104,6 +109,8 @@ Fixes
 
   More detailed information is available in :bb:status:`GerritStatusPush`
   section.
+
+* :bb:chsrc:`P4Poller`'s ``server_tz`` parameter now works correctly.
 
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This introduces a new requirement for Buildbot, but it's just a pure-python requirement.  I'd like some feedback from other maintainers and users on whether that's OK.
