### PR TITLE
Fixing revlink in bitbucket-hook.

### DIFF
--- a/master/buildbot/status/web/hooks/bitbucket.py
+++ b/master/buildbot/status/web/hooks/bitbucket.py
@@ -52,7 +52,7 @@ def getChanges(request, options=None):
             'revision': commit['raw_node'],
             'when_timestamp': dateparse(commit['utctimestamp']),
             'branch': commit['branch'],
-            'revlink': '%s%s' % (repo_url, commit['raw_node']),
+            'revlink': '%scommits/%s' % (repo_url, commit['raw_node']),
             'repository': repo_url,
             'project': project
         })

--- a/master/buildbot/test/unit/test_status_web_hooks_bitbucket.py
+++ b/master/buildbot/test/unit/test_status_web_hooks_bitbucket.py
@@ -174,7 +174,7 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
         self.assertEqual(commit['branch'], 'master')
         self.assertEqual(
             commit['revlink'],
-            'https://bitbucket.org/marcus/project-x/'
+            'https://bitbucket.org/marcus/project-x/commits/'
             '620ade18607ac42d872b568bb92acaa9a28620e9'
         )
 
@@ -220,7 +220,7 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
         self.assertEqual(commit['branch'], 'master')
         self.assertEqual(
             commit['revlink'],
-            'https://bitbucket.org/marcus/project-x/'
+            'https://bitbucket.org/marcus/project-x/commits/'
             '620ade18607ac42d872b568bb92acaa9a28620e9'
         )
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -112,6 +112,8 @@ Fixes
 
 * :bb:chsrc:`P4Source`'s ``server_tz`` parameter now works correctly.
 
+* Fixing revlink in bitbucket-hook.
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Same as pull-request #1181 but fixed tests (i hope) and added release-note.
