### PR TITLE
add missing `buildbot.plugins` to `setup.py`

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -167,6 +167,7 @@ setup_args = {
         "buildbot.db.types",
         "buildbot.monkeypatches",
         "buildbot.mq",
+        "buildbot.plugins",
         "buildbot.process",
         "buildbot.process.users",
         "buildbot.schedulers",


### PR DESCRIPTION
I wonder if there's a way to automatically check this.
