### PR TITLE
add branch name to hgpoller default name. Fixes #2469

### DIFF
--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -48,7 +48,7 @@ class HgPoller(base.PollingChangeSource):
             pollInterval = pollinterval
 
         if name is None:
-            name = repourl
+            name = "%s[%s]" % (repourl, branch)
 
         self.repourl = repourl
         self.branch = branch

--- a/master/buildbot/test/unit/test_changes_hgpoller.py
+++ b/master/buildbot/test/unit/test_changes_hgpoller.py
@@ -35,6 +35,7 @@ class TestHgPoller(gpo.GetProcessOutputMixin,
         self.setUpGetProcessOutput()
         d = self.setUpChangeSource()
         self.remote_repo = 'ssh://example.com/foo/baz'
+        self.branch = 'default'
         self.repo_ready = True
 
         def _isRepositoryReady():
@@ -71,7 +72,7 @@ class TestHgPoller(gpo.GetProcessOutputMixin,
         self.assertSubstring("HgPoller", self.poller.describe())
 
     def test_name(self):
-        self.assertEqual(self.remote_repo, self.poller.name)
+        self.assertEqual("%s[%s]" % (self.remote_repo, self.branch), self.poller.name)
 
         # and one with explicit name...
         other = hgpoller.HgPoller(self.remote_repo, name="MyName", workdir='/some/dir')


### PR DESCRIPTION
this allows multiple hgpoller for different branches of the same repo
