### PR TITLE
Dockerfile: Fixes unmet dependencies

### DIFF
--- a/master/contrib/Dockerfile
+++ b/master/contrib/Dockerfile
@@ -62,7 +62,10 @@ from ubuntu:12.04
 #run ln -s /bin/true /sbin/initctl
 
 # Install buildbot and its dependencies
-run echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > \
+
+run /bin/echo -e "\
+    deb http://archive.ubuntu.com/ubuntu precise main universe\n\
+    deb http://archive.ubuntu.com/ubuntu precise-updates main universe" > \
     /etc/apt/sources.list
 run apt-get update
 run DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip python-dev \


### PR DESCRIPTION
Following http://docs.buildbot.net/current/tutorial/docker.html up until 
`$ sudo ./docker build -t buildbot - < Dockerfile`
which then errored out:

```
(...)
The following packages have unmet dependencies:
 python-dev : Depends: python (= 2.7.3-0ubuntu2) but it is not going to be installed
 python-pip : Depends: python (>= 2.7.1-0ubuntu2) but it is not going to be installed
              Depends: python (< 2.8) but it is not going to be installed
              Depends: python-pkg-resources but it is not going to be installed
              Depends: python-setuptools (>= 0.6c1) but it is not going to be installed
 supervisor : Depends: python (>= 2.3) but it is not going to be installed
              Depends: python-medusa (>= 0.5.4) but it is not going to be installed
              Depends: python-meld3 but it is not going to be installed
              Depends: python-pkg-resources (>= 0.6c7) but it is not going to be installed
              Depends: python-support (>= 0.90.0) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
2014/08/28 13:18:20 The command [/bin/sh -c DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip python-dev     supervisor git sudo ssh] returned a non-zero code: 100
```

This should fix the dependency problem.
