### PR TITLE
make the default warning pattern case insensitive

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -400,7 +400,7 @@ class WarningCountingShellCommand(ShellCommand):
     renderables = ['suppressionFile']
 
     warnCount = 0
-    warningPattern = '.*warning[: ].*'
+    warningPattern = '(?i).*warning[: ].*'
     # The defaults work for GNU Make.
     directoryEnterPattern = (u"make.*: Entering directory "
                              u"[\u2019\"`'](.*)[\u2019'`\"]")

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -703,12 +703,14 @@ class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase):
             ExpectShell(workdir='wkdir', usePTY='slave-config',
                         command=["make"])
             + ExpectShell.log('stdio',
-                              stdout='normal: foo\nwarning: blarg!\nalso normal')
+                              stdout='normal: foo\nwarning: blarg!\n'
+                                     'also normal\nWARNING: blarg!\n')
             + 0
         )
         self.expectOutcome(result=WARNINGS, status_text=["'make'", "warnings"])
-        self.expectProperty("warnings-count", 1)
-        self.expectLogfile("warnings (1)", "warning: blarg!\n")
+        self.expectProperty("warnings-count", 2)
+        self.expectLogfile("warnings (2)",
+                           "warning: blarg!\nWARNING: blarg!\n")
         return self.runStep()
 
     def test_custom_pattern(self):


### PR DESCRIPTION
WarningCountingShellCommand is a generic class so it seems reasonable to catch as many warnings as possible
