### PR TITLE
Override install_lib to actually install files

### DIFF
--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -19,6 +19,7 @@ from distutils.command.build import build
 from distutils.version import LooseVersion
 from setuptools import setup
 from setuptools.command.egg_info import egg_info
+from setuptools.command.install_lib import install_lib
 from textwrap import dedent
 
 import os
@@ -111,11 +112,6 @@ def build_js(cmd):
             recursive-include %(package)s/static *
             """ % dict(package=package)))
 
-    cmd.copy_tree(os.path.join(package, 'static'), os.path.join("build", "lib", package, "static"))
-
-    with open(os.path.join("build", "lib", package, "VERSION"), "w") as f:
-        f.write(cmd.distribution.metadata.version)
-
     with open(os.path.join(package, "VERSION"), "w") as f:
         f.write(cmd.distribution.metadata.version)
 
@@ -135,9 +131,33 @@ class my_egg_info(egg_info):
         build_js(self)
         return egg_info.run(self)
 
-cmdclassforjs = dict(build=my_build, egg_info=my_egg_info)
+
+class my_install_lib(install_lib):
+
+    def run(self):
+        # copy files to the install_lib directory
+        install_lib_dir = self.get_finalized_command('install').install_lib
+        package = self.distribution.packages[0]
+        self.copy_tree(os.path.join(package, 'static'),
+                       os.path.join(install_lib_dir, package, "static"))
+
+        with open(os.path.join(install_lib_dir, package, "VERSION"), "w") as f:
+            f.write(self.distribution.metadata.version)
+
+        # and then do the normal install stuff
+        return install_lib.run(self)
+
+cmdclassforjs = dict(
+    build=my_build,
+    egg_info=my_egg_info,
+    install_lib=my_install_lib)
 
 
-def setup_www_plugin(**kw):
-    package = kw['packages'][0]
-    setup(version=getVersion(os.path.join(package, "__init__.py")), cmdclass=cmdclassforjs, **kw)
+def setup_www_plugin(**kwargs):
+    package = kwargs['packages'][0]
+    setup(version=getVersion(os.path.join(package, "__init__.py")),
+          cmdclass=dict(
+              build=my_build,
+              egg_info=my_egg_info,
+              install_lib=my_install_lib),
+          **kwargs)


### PR DESCRIPTION
The destination directory isn't always just `lib`, and thus can't be
predicted in advance.  This fixes #2883 (I hope).

@tardyp if this looks decent, give it a merge and let's see how http://buildbot.buildbot.net/builders/builds handles it.  In my testing by hand, this was successful.
