### PR TITLE
Make user name in GerritChangeSource optional.

### DIFF
--- a/master/buildbot/status/status_gerrit.py
+++ b/master/buildbot/status/status_gerrit.py
@@ -132,7 +132,7 @@ class GerritStatusPush(StatusReceiverMultiService, buildset.BuildSetSummaryNotif
 
     """Event streamer to a gerrit ssh server."""
 
-    def __init__(self, server, username, reviewCB=DEFAULT_REVIEW,
+    def __init__(self, server, username=None, reviewCB=DEFAULT_REVIEW,
                  startCB=None, port=29418, reviewArg=None,
                  startArg=None, summaryCB=DEFAULT_SUMMARY, summaryArg=None,
                  identity_file=None, **kwargs):
@@ -172,11 +172,13 @@ class GerritStatusPush(StatusReceiverMultiService, buildset.BuildSetSummaryNotif
             options = ['-i', self.gerrit_identity_file]
         else:
             options = []
-        return ['ssh'] + options + [
-            '@'.join((self.gerrit_username, self.gerrit_server)),
-            '-p', str(self.gerrit_port),
-            'gerrit'
-        ] + list(args)
+        result = ['ssh'] + options
+        if self.gerrit_username:
+            result.append('@'.join((self.gerrit_username, self.gerrit_server)))
+        else:
+            result.append(self.gerrit_server)
+        result += ['-p', str(self.gerrit_port), 'gerrit'] + list(args)
+        return result
 
     class VersionPP(ProcessProtocol):
 

--- a/master/buildbot/test/unit/test_status_gerrit.py
+++ b/master/buildbot/test/unit/test_status_gerrit.py
@@ -224,6 +224,10 @@ class TestGerritStatusPush(unittest.TestCase):
         ]
         self.assertEqual(expected2, with_identity._gerritCmd('foo'))
 
+        without_username = GerritStatusPush(kwargs["server"])
+        expected3 = ['ssh', 'example.com', '-p', '29418', 'gerrit', 'foo']
+        self.assertEqual(expected3, without_username._gerritCmd('foo'))
+
     def test_buildsetComplete_success_sends_summary_review(self):
         d = self.check_summary_build(buildResults=[SUCCESS, SUCCESS],
                                      finalResult=SUCCESS,

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -971,7 +971,7 @@ The :bb:chsrc:`GerritChangeSource` accepts the following arguments:
    the port of the gerrit ssh server
 
 ``username``
-   the username to use to connect to gerrit
+   the username to use to connect to gerrit (optional, defaults to username specified in .ssh/config or the current login if the previous is empty).
 
 ``identity_file``
    ssh identity file to for authentication (optional).

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -86,6 +86,9 @@ Features
 
 * :class:`~buildbot.status.status_gerrit.GerritStatusPush` supports specifying an SSH identity file explicitly.
 
+* :class:`~buildbot.changes.gerritchangesource.GerritChangeSource`
+  and :class:`~buildbot.status.status_gerrit.GerritStatusPush` constructors don't require username parameter anymore.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
The user name is not required and defaults to the .ssh/config
file content.