### PR TITLE
Support specifying an identity file with GerritStatusPush

### DIFF
--- a/master/buildbot/status/status_gerrit.py
+++ b/master/buildbot/status/status_gerrit.py
@@ -134,7 +134,8 @@ class GerritStatusPush(StatusReceiverMultiService, buildset.BuildSetSummaryNotif
 
     def __init__(self, server, username, reviewCB=DEFAULT_REVIEW,
                  startCB=None, port=29418, reviewArg=None,
-                 startArg=None, summaryCB=DEFAULT_SUMMARY, summaryArg=None, **kwargs):
+                 startArg=None, summaryCB=DEFAULT_SUMMARY, summaryArg=None,
+                 identity_file=None, **kwargs):
         StatusReceiverMultiService.__init__(self)
 
         # If neither reviewCB nor summaryCB were specified, default to sending
@@ -155,6 +156,7 @@ class GerritStatusPush(StatusReceiverMultiService, buildset.BuildSetSummaryNotif
         self.gerrit_port = port
         self.gerrit_version = None
         self.gerrit_version_time = 0
+        self.gerrit_identity_file = identity_file
         self.reviewCB = reviewCB
         self.reviewArg = reviewArg
         self.startCB = startCB
@@ -163,7 +165,18 @@ class GerritStatusPush(StatusReceiverMultiService, buildset.BuildSetSummaryNotif
         self.summaryArg = summaryArg
 
     def _gerritCmd(self, *args):
-        return ["ssh", self.gerrit_username + "@" + self.gerrit_server, "-p %d" % self.gerrit_port, "gerrit"] + list(args)
+        '''Construct a command as a list of strings suitable for
+        :func:`subprocess.call`.
+        '''
+        if self.gerrit_identity_file is not None:
+            options = ['-i', self.gerrit_identity_file]
+        else:
+            options = []
+        return ['ssh'] + options + [
+                '@'.join((self.gerrit_username, self.gerrit_server)),
+                '-p', str(self.gerrit_port),
+                'gerrit'
+        ] + list(args)
 
     class VersionPP(ProcessProtocol):
 

--- a/master/buildbot/test/unit/test_status_gerrit.py
+++ b/master/buildbot/test/unit/test_status_gerrit.py
@@ -206,6 +206,24 @@ class TestGerritStatusPush(unittest.TestCase):
                                                        result)
         return d
 
+    def test_gerrit_ssh_cmd(self):
+        kwargs = {
+            'server': 'example.com',
+            'username': 'buildbot',
+        }
+        without_identity = GerritStatusPush(**kwargs)
+
+        expected1 = ['ssh', 'buildbot@example.com', '-p', '29418', 'gerrit', 'foo']
+        self.assertEqual(expected1, without_identity._gerritCmd('foo'))
+
+        with_identity = GerritStatusPush(
+                identity_file='/path/to/id_rsa', **kwargs)
+        expected2 = [
+            'ssh', '-i', '/path/to/id_rsa', 'buildbot@example.com', '-p', '29418',
+            'gerrit', 'foo',
+        ]
+        self.assertEqual(expected2, with_identity._gerritCmd('foo'))
+
     def test_buildsetComplete_success_sends_summary_review(self):
         d = self.check_summary_build(buildResults=[SUCCESS, SUCCESS],
                                      finalResult=SUCCESS,

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -657,10 +657,11 @@ GerritStatusPush
 :class:`GerritStatusPush` sends review of the :class:`Change` back to the Gerrit server, optionally also sending a message when a build is started.
 GerritStatusPush can send a separate review for each build that completes, or a single review summarizing the results for all of the builds.
 
-.. py:class:: GerritStatusPush(server, username, reviewCB, startCB, port, reviewArg, startArg, summaryCB, summaryArg, ...)
+.. py:class:: GerritStatusPush(server, username, reviewCB, startCB, port, reviewArg, startArg, summaryCB, summaryArg, identity_file, ...)
 
    :param string server: Gerrit SSH server's address to use for push event notifications.
    :param string username: Gerrit SSH server's username.
+   :param identity_file: (optional) Gerrit SSH identity file.
    :param int port: (optional) Gerrit SSH server's port (default: 29418)
    :param reviewCB: (optional) callback that is called each time a build is finished, and that is used to define the message and review approvals depending on the build result.
    :param reviewArg: (optional) argument passed to the review callback.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -84,6 +84,8 @@ Features
 
      While the components can be still directly imported as ``buildbot.kind.other.bits``, this might not be the case after Buildbot v1.0 is released.
 
+* :class:`~buildbot.status.status_gerrit.GerritStatusPush` supports specifying an SSH identity file explicitly.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
GerritChangeSource supports a knob for specifying a secret key to use
for connecting - make sure status push is symmetric.
