### PR TITLE
Don't log the password in the DB URL

### DIFF
--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -16,6 +16,7 @@
 import textwrap
 
 from buildbot import config
+from buildbot import util
 from buildbot.db import builders
 from buildbot.db import buildrequests
 from buildbot.db import builds
@@ -99,7 +100,8 @@ class DBConnector(config.ReconfigurableServiceMixin, service.AsyncMultiService):
     def setup(self, check_version=True, verbose=True):
         db_url = self.configured_url = self.master.config.db['db_url']
 
-        log.msg("Setting up database with URL %r" % (db_url,))
+        log.msg("Setting up database with URL %r"
+                % util.stripUrlPassword(db_url))
 
         # set up the engine and pool
         self._engine = enginestrategy.create_engine(db_url,

--- a/master/buildbot/test/unit/test_util.py
+++ b/master/buildbot/test/unit/test_util.py
@@ -287,3 +287,27 @@ class FunctionalEnvironment(unittest.TestCase):
         config = mock.Mock()
         util.check_functional_environment(config)
         config.error.assert_called_with(mock.ANY)
+
+
+class StripUrlPassword(unittest.TestCase):
+
+    def test_simple_url(self):
+        self.assertEqual(util.stripUrlPassword('http://foo.com/bar'),
+                         'http://foo.com/bar')
+
+    def test_username(self):
+        self.assertEqual(util.stripUrlPassword('http://d@foo.com/bar'),
+                         'http://d@foo.com/bar')
+
+    def test_username_with_at(self):
+        self.assertEqual(util.stripUrlPassword('http://d@bb.net@foo.com/bar'),
+                         'http://d@bb.net@foo.com/bar')
+
+    def test_username_pass(self):
+        self.assertEqual(util.stripUrlPassword('http://d:secret@foo.com/bar'),
+                         'http://d:xxxx@foo.com/bar')
+
+    def test_username_pass_with_at(self):
+        self.assertEqual(
+            util.stripUrlPassword('http://d@bb.net:scrt@foo.com/bar'),
+            'http://d@bb.net:xxxx@foo.com/bar')

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -22,6 +22,7 @@ import re
 import string
 import time
 import types
+import urlparse
 
 from twisted.python import reflect
 
@@ -265,6 +266,15 @@ def check_functional_environment(config):
             "Your environment has incorrect locale settings. This means python cannot handle strings safely.",
             "Please check 'LANG', 'LC_CTYPE', 'LC_ALL' and 'LANGUAGE' are either unset or set to a valid locale.",
         ]))
+
+
+_netloc_url_re = re.compile(r':[^@]*@')
+
+
+def stripUrlPassword(url):
+    parts = list(urlparse.urlsplit(url))
+    parts[1] = _netloc_url_re.sub(':xxxx@', parts[1])
+    return urlparse.urlunsplit(parts)
 
 
 __all__ = [

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -179,6 +179,13 @@ package.
     Yield a deferred that will fire with no result after ``secs`` seconds.
     This is the asynchronous equivalent to ``time.sleep``, and can be useful in tests.
 
+.. py:function:: stripUrlPassword(url)
+
+    :param url: a URL
+    :returns: URL with any password component replaced with ``xxxx``
+
+    Sanitize a URL; use this before logging or displaying a DB URL.
+
 buildbot.util.lru
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Passwords in logs make security teams twitchy.  Fixes #2896.
