### PR TITLE
Call a method that actually exists from the timed schedulers.

### DIFF
--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -62,6 +62,10 @@ class SchedulerMixin(interfaces.InterfaceTests):
         C{addSourceStamp} and C{addSourceStampSet}, and uses that information
         to generate C{addBuildsetForSourceStamp} results.
 
+        To add additional functionality to any of the addBuildsetForXxx
+        methods, just override fake_addBuildsetForXxx.  The signature of this
+        method will be checked at runtime.
+
         @returns: scheduler
         """
         scheduler.objectid = objectid
@@ -176,27 +180,29 @@ class SchedulerMixin(interfaces.InterfaceTests):
         brids = dict(zip(builderNames, self._bridGenerator))
         return defer.succeed((bsid, brids))
 
+    def _addBuildsetCall(self, name, **args):
+        self.addBuildsetCalls.append((name, args))
+
     def fake_addBuildsetForSourceStampsWithDefaults(self, reason, sourcestamps,
                                                     waited_for=False, properties=None,
                                                     builderNames=None, **kw):
-        properties = properties.asDict()
+        properties = properties.asDict() if properties is not None else None
         self.assertIsInstance(sourcestamps, list)
         sourcestamps.sort()
-        self.addBuildsetCalls.append(('addBuildsetForSourceStampsWithDefaults',
-                                      dict(reason=reason, sourcestamps=sourcestamps,
-                                           waited_for=waited_for, properties=properties,
-                                           builderNames=builderNames)))
+        self._addBuildsetCall('addBuildsetForSourceStampsWithDefaults',
+                              reason=reason, sourcestamps=sourcestamps,
+                              waited_for=waited_for, properties=properties,
+                              builderNames=builderNames)
         return self._addBuildsetReturnValue(builderNames)
 
     def fake_addBuildsetForChanges(self, waited_for=False, reason='', external_idstring=None,
                                    changeids=[], builderNames=None, properties=None, **kw):
         properties = properties.asDict() if properties is not None else None
-        self.addBuildsetCalls.append(('addBuildsetForChanges',
-                                      dict(waited_for=waited_for, reason=reason,
-                                           external_idstring=external_idstring,
-                                           changeids=changeids,
-                                           properties=properties, builderNames=builderNames,
-                                           )))
+        self._addBuildsetCall('addBuildsetForChanges',
+                              waited_for=waited_for, reason=reason,
+                              external_idstring=external_idstring,
+                              changeids=changeids, properties=properties,
+                              builderNames=builderNames)
         return self._addBuildsetReturnValue(builderNames)
 
     def fake_addBuildsetForSourceStamps(self, waited_for=False, sourcestamps=[],
@@ -205,9 +211,10 @@ class SchedulerMixin(interfaces.InterfaceTests):
         properties = properties.asDict() if properties is not None else None
         self.assertIsInstance(sourcestamps, list)
         sourcestamps.sort()
-        self.addBuildsetCalls.append(('addBuildsetForSourceStamp',
-                                      dict(reason=reason, external_idstring=external_idstring,
-                                           properties=properties, builderNames=builderNames,
-                                           sourcestamps=sourcestamps)))
+        self._addBuildsetCall('addBuildsetForSourceStamp',
+                              reason=reason,
+                              external_idstring=external_idstring,
+                              properties=properties, builderNames=builderNames,
+                              sourcestamps=sourcestamps)
 
         return self._addBuildsetReturnValue(builderNames)

--- a/master/docs/manual/cfg-schedulers.rst
+++ b/master/docs/manual/cfg-schedulers.rst
@@ -450,11 +450,14 @@ The full list of parameters is:
     Note that ``fileIsImportant``, ``change_filter`` and ``createAbsoluteSourceStamps`` are only relevant if ``onlyIfChanged`` is ``True``.
 
 ``onlyIfChanged``
-    If this is true, then builds will not be scheduled at the designated time *unless* the specified branch has seen an important change since the previous build.
+    If this is true, then builds will not be scheduled at the designated time *unless* the scheduler seen an important change (matching the change filter) since the previous build.
 
-``branch``
-    (required) The branch to build when the time comes.
-    Remember that a value of ``None`` here means the default branch, and will not match other branches!
+``branch`` (deprecated; use ``codebases`` and ``change_filter``)
+    Specifying ``branch="prod"`` is equivalent to specifying ``codebases={'': {'branch': 'prod'}}``
+    Branch and codebases cannot both be specified.
+
+    If ``onlyIfChanged`` is given, then only changes on that branch are considered.
+    Specify the branch in the ``change_filter`` instead.
 
 ``minute``
     The minute of the hour on which to start the build.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -266,6 +266,11 @@ Changes for Developers
 
 * The triggerable schedulers` ``trigger`` method now requires a list of sourcestamps, rather than a dictionary.
 
+* The :bb:sched:`Periodic` scheduler no longer accepts a ``branch`` parameter; the behavior of this parameter was never documented, anyway.
+
+* The :bb:sched:`Nightly` scheduler's ``branch`` parameter is deprecated, and should be replaced with an equivalent codebase.
+  See the scheduler documentation.
+
 * The :py:class:`~buildbot.sourcestamp.SourceStamp` class is no longer used.
   It remains in the codebase to support loading data from pickles on upgrade, but should not be used in running code.
 


### PR DESCRIPTION
Fixes #2897.  This also addresses the issue that allowed the tests to
miss this error.
