### PR TITLE
Update docker tutorial

### DIFF
--- a/master/docs/tutorial/docker.rst
+++ b/master/docs/tutorial/docker.rst
@@ -4,7 +4,7 @@
 First Buildbot run with Docker
 ==============================
 
-Docker_ is an tool that makes building and deploying custom environments a breeze.
+Docker_ is a tool that makes building and deploying custom environments a breeze.
 It uses lightweight linux containers (LXC) and performs quickly, making it a great instrument for the testing community.
 The next section includes a Docker pre-flight check.
 If it takes more that 3 minutes to get the 'Success' message for you, try the Buildbot pip-based :ref:`first run <getting-code-label>` instead.
@@ -16,17 +16,18 @@ Current Docker dependencies
 
 * Linux system, with at least kernel 3.8 and AUFS support.
   For example, Standard Ubuntu, Debian and Arch systems.
-* Packages: lxc, iptables, ca-certificates, and bzip2 packages
-* Local clock on time or slightly in the future for proper SSL communication
-* Download, launch and test docker is happy in your linux enviroment:
+* Packages: lxc, iptables, ca-certificates, and bzip2 packages.
+* Local clock on time or slightly in the future for proper SSL communication.
 
-.. code-block:: bash
+Installation
+------------
 
-  mkdir tmp; cd tmp
-  wget -O docker http://get.docker.io/builds/Linux/x86_64/docker-latest
-  chmod 755 docker; sudo ./docker -d &
-  sudo ./docker run -i busybox /bin/echo Success
+* Use the `Docker installation instructions <https://docs.docker.com/installation/>`_ for your operating system.
+* Test docker is happy in your environment:
 
+  .. code-block:: bash
+
+          sudo docker run -i busybox /bin/echo Success
 
 Building and running Buildbot
 -----------------------------
@@ -37,21 +38,18 @@ Building and running Buildbot
   wget https://raw.github.com/buildbot/buildbot/master/master/contrib/Dockerfile
 
   # Build the Buildbot container (it will take a few minutes to download packages)
-  sudo ./docker build -t buildbot - < Dockerfile
+  sudo docker build -t buildbot - < Dockerfile
 
   # Run buildbot
-  CONTAINER_ID=$(sudo ./docker run -d buildbot)
+  CONTAINER_ID=$(sudo docker run -d -p 127.0.0.1:8010:8010 buildbot)
 
 
-You should now be able to go to http://localhost:8010 and see a web page
-similar to:
+You should now be able to go to http://localhost:8010 and see a web page similar to:
 
 .. image:: _images/index.png
    :alt: index page
 
-Click on the
-`Waterfall Display link <http://localhost:8010/waterfall>`_
-and you get this:
+Click on the `Waterfall Display link <http://localhost:8010/waterfall>`_ and you get this:
 
 .. image:: _images/waterfall-empty.png
    :alt: empty waterfall.
@@ -61,13 +59,13 @@ Playing with your Buildbot container
 ------------------------------------
 
 If you've come this far, you have a Buildbot environment that you can freely experiment with.
-You can access your container using ssh  (username: admin, password: admin):
+You can access your container using ssh (username: admin, password: admin):
 
 .. code-block:: bash
 
-  ssh -p $(sudo ./docker port $CONTAINER_ID 22) admin@localhost
+  ssh -p $(sudo docker port $CONTAINER_ID 22) admin@localhost
 
 
 You've got a taste now, but you're probably curious for more.
 Let's step it up a little in the second tutorial by changing the configuration and doing an actual build.
-Continue on to :ref:`quick-tour-label`
+Continue on to :ref:`quick-tour-label`.


### PR DESCRIPTION
- Use the standard installation instruction instead of the master
  version: 0.7 has been out for some time now.
- As a result, switch to `sudo docker` instead of `sudo ./docker`.
- Publish ports when running buildbot to be able to log into ssh and
  see the buildbot frontend.
- Reformat the text
