### PR TITLE
Remove assert from subscribeConsumer

### DIFF
--- a/master/buildbot/status/logfile.py
+++ b/master/buildbot/status/logfile.py
@@ -431,7 +431,8 @@ class LogFile:
             self.watchers.remove(receiver)
 
     def subscribeConsumer(self, consumer):
-        assert not self._isNewStyle, "not available in new-style steps"
+        # NOTE: this method is called by WebStatus, so it must remain available
+        # even for new-style steps
         p = LogFileProducer(self, consumer)
         p.resumeProducing()
 


### PR DESCRIPTION
This method is used by the WebStatus, and thus necessary (even for new-style steps) in eight.  Without this fix, new-style steps do not work -- at all -- on 0.8.9.

This fix is not necessary in nine, but should it be merged to the buidlbot-0.8.9 branch?
