### PR TITLE
Bugfix 2943: Fix cross-site scripting in status_json by specifying nosniff and app/js...

### DIFF
--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -175,10 +175,10 @@ class JsonResource(resource.Resource):
             if isinstance(data, unicode):
                 data = data.encode("utf-8")
             request.setHeader("Access-Control-Allow-Origin", "*")
+            request.setHeader("content-type", self.contentType)
             if RequestArgToBool(request, 'as_text', False):
-                request.setHeader("content-type", 'text/plain')
+                request.setHeader("X-Content-Type-Options", "nosniff")
             else:
-                request.setHeader("content-type", self.contentType)
                 request.setHeader("content-disposition",
                                   "attachment; filename=\"%s.json\"" % request.path)
             # Make sure we get fresh pages.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -25,6 +25,8 @@ Fixes
 
 * Fixed content spoofing vulnerabilities (#2589)
 
+* Fixed cross-site scripting in status_json (#2943)
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Guard against CSS in IE6 and IE8 by specifying X-Content-Type-Options: nosniff and not using plain text content type. 
