### PR TITLE
Fix SQLAlchemy-Migrate version check

### DIFF
--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -720,7 +720,7 @@ class Model(base.DBConnectorComponent):
                         version = "0.6"
                 except Exception:
                     version = "0.0"
-            version_tup = tuple(map(int, version.split('.')))
+            version_tup = tuple(map(int, version.split('-', 1)[0].split('.')))
             log.msg("using SQLAlchemy-Migrate version %s" % (version,))
             if version_tup < (0, 6, 1):
                 raise RuntimeError("You are using SQLAlchemy-Migrate %s. "

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -93,6 +93,8 @@ Fixes
 
 * Buildbot is now compatible with SQLAlchemy 0.8 and higher, using the newly-released SQLAlchemy-Migrate.
 
+* The version check for SQLAlchemy-Migrate was fixed to accept more version string formats.
+
 * The :bb:step:`HTTPStep` step's requeset parameters are now renderable.
 
 * With Git(), force the updating submodules to ensure local changes by the


### PR DESCRIPTION
It failed for strings like `'0.9.1-r0'`.

```
$ buildbot create-master foobar
[...]
  File "/usr/lib/python2.7/site-packages/buildbot/db/model.py", line 547, in upgrade
    check_sqlalchemy_migrate_version()
  File "/usr/lib/python2.7/site-packages/buildbot/db/model.py", line 502, in check_sqlalchemy_migrate_version
    version_tup = tuple(map(int, version.split('.')))
exceptions.ValueError: invalid literal for int() with base 10: '1-r0'

$ python2 -c "import migrate; print(migrate.__version__)"
0.9.1-r0
```
