### PR TITLE
Makefile: Allow to use another pip than the system one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 .PHONY: docs apidocs pylint
 
+PIP?=pip
+
 docs:
 	$(MAKE) -C master/docs
 
@@ -20,13 +22,13 @@ pep8:
 	pep8 --config=common/pep8rc master/buildbot slave/buildslave www/*/buildbot_*/ www/*/setup.py
 
 frontend:
-	pip install -e pkg
-	pip install mock
-	for i in www/*/; do pip install -e $$i ; done
+	$(PIP) install -e pkg
+	$(PIP) install mock
+	for i in www/*/; do $(PIP) install -e $$i ; done
 
 frontend_install_tests:
-	pip install -e pkg
-	pip install mock wheel
+	$(PIP) install -e pkg
+	$(PIP) install mock wheel
 	trial pkg/test_buildbot_pkg.py
 
 rmpyc:


### PR DESCRIPTION
When installing buildbot in a not-activated virtualenv, it comes handy to define PIP before calling make frontend.
