### PR TITLE
Allow user to specify baseURL for GithubStatus

### DIFF
--- a/master/buildbot/status/github.py
+++ b/master/buildbot/status/github.py
@@ -38,7 +38,8 @@ class GitHubStatus(StatusReceiverMultiService):
     """
 
     def __init__(self, token, repoOwner, repoName, sha=None,
-                 startDescription=None, endDescription=None):
+                 startDescription=None, endDescription=None,
+                 baseURL=None):
         """
         Token for GitHub API.
         """
@@ -59,7 +60,7 @@ class GitHubStatus(StatusReceiverMultiService):
         self._sha = sha
         self._repoOwner = repoOwner
         self._repoName = repoName
-        self._github = GitHubAPI(oauth2_token=self._token)
+        self._github = GitHubAPI(oauth2_token=self._token, baseURL=baseURL)
 
     def startService(self):
         StatusReceiverMultiService.startService(self)


### PR DESCRIPTION
Looks like there was an issued open for this a few months ago. <http://trac.buildbot.net/ticket/2876>. The changes were made to txgithub (tomprince/txgithub#7), but never carried over to buildbot. 

I just added the parameter to ```__init__``` to take in a custom url and passed it to txgithub's GithubApi. Relevent code: https://github.com/tomprince/txgithub/blob/master/txgithub/api.py#L37-L47