### PR TITLE
fix more AssertionError's for new-style steps in web status ui

### DIFF
--- a/master/buildbot/status/web/logs.py
+++ b/master/buildbot/status/web/logs.py
@@ -191,7 +191,7 @@ class LogsResource(HtmlResource):
     def getChild(self, path, req):
         for log in self.step_status.getLogs():
             if path == log.getName():
-                if log.hasContents():
+                if log.old_hasContents():
                     return IHTMLLog(interfaces.IStatusLog(log))
                 return NoResource("Empty Log '%s'" % path)
         return HtmlResource.getChild(self, path, req)

--- a/master/buildbot/status/web/step.py
+++ b/master/buildbot/status/web/step.py
@@ -47,7 +47,7 @@ class StatusResourceBuildStep(HtmlResource):
             # it chops up the step name.  If we quote it and '/'s
             # are not safe, it escapes the / that separates the
             # step name from the log number.
-            logs.append({'has_contents': l.hasContents(),
+            logs.append({'has_contents': l.old_hasContents(),
                          'name': l.getName(),
                          'link': req.childLink("logs/%s" % urllib.quote(l.getName()))})
 

--- a/master/buildbot/status/web/waterfall.py
+++ b/master/buildbot/status/web/waterfall.py
@@ -194,7 +194,7 @@ class StepBox(components.Adapter):
 
         for num in range(len(logs)):
             name = logs[num].getName()
-            if logs[num].hasContents():
+            if logs[num].old_hasContents():
                 url = urlbase + "/logs/%s" % urllib.quote(name)
             else:
                 url = None


### PR DESCRIPTION
This fixes the following urls:
  http://localhost:8010/builders/<builder name>/builds/<build no>/steps/<step name>/logs/<log name>
  http://localhost:8010/builders/<builder name>/builds/<build no>/steps/<step name>
  http://localhost:8010/waterfall
