### PR TITLE
www: Set a sensible default for the allowed_origins

### DIFF
--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -361,9 +361,12 @@ class V2RootResource(resource.Resource):
                 request.write(data)
 
     def reconfigResource(self, new_config):
+        # www['url'] will always ends with a '/', not the Origin header.
+        origin_self = new_config.www['url'].rstrip('/')
         # pre-translate the origin entries in the config
         self.origins = [re.compile(fnmatch.translate(o.lower()))
-                        for o in new_config.www.get('allowed_origins', [])]
+                        for o in new_config.www.get('allowed_origins',
+                                                    [origin_self])]
 
         # and copy some other flags
         self.debug = new_config.www.get('debug')


### PR DESCRIPTION
Allowing ourself shouldn't be a security issue, and is needed for the Forced builds (for instance).
