### PR TITLE
web/builder: add category filtering to builders page.

### DIFF
--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -599,7 +599,10 @@ class BuildersResource(HtmlResource):
         status = self.getStatus(req)
         encoding = getRequestCharset(req)
 
-        builders = req.args.get("builder", status.getBuilderNames())
+        showCategories = req.args.get("category", [])
+        if showCategories == []:
+            showCategories = None
+        builders = req.args.get("builder", status.getBuilderNames(categories=showCategories))
         branches = [b.decode(encoding)
                     for b in req.args.get("branch", [])
                     if b]


### PR DESCRIPTION
With this patch you can filter on category on the builders page.
example:
http://ci-master:8010/builders?category=maint

Change-Id: I3aba9ad9fce95e94b13971750403bec86dcc564b
Signed-off-by: Mattias Ryrlén mattiasr@op5.com
