### PR TITLE
Make url to d3.min.js relative.

### DIFF
--- a/www/base/src/app/d3/d3.service.coffee
+++ b/www/base/src/app/d3/d3.service.coffee
@@ -6,7 +6,7 @@ class D3 extends Service
         d = $q.defer()
 
         # Resolve function
-        $.getScript config.url + 'd3.min.js', ->
+        $.getScript 'd3.min.js', ->
             $rootScope.$apply ->
                 d.resolve(window.d3)
 


### PR DESCRIPTION
This allow us to mis-configure www['url'], and still have it working. Beside, we don't need to access it absolutely actually.
