### PR TITLE
Fix documentation: Shell Sequence

### DIFF
--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -1165,10 +1165,10 @@ A list of :class:`~buildbot.steps.shellsequence.ShellArg` objects or a renderabl
 
     from buildbot.plugins import steps, util
     f.addStep(steps.ShellSequence(commands=[
-                                    util.ShellArg(cmd='configure'),
-                                    util.ShellArg(cmd='make', log='make'),
-                                    util.ShellArg(cmd='make check_warning', log='warning', warnOnFailure=True),
-                                    util.ShellArg(cmd='make install', log='make install')
+                                    util.ShellArg(command=['configure']),
+                                    util.ShellArg(command=['make'], log='make'),
+                                    util.ShellArg(command=['make', 'check_warning'], log='warning', warnOnFailure=True),
+                                    util.ShellArg(command=['make', 'install'], log='make install')
                                   ]))
 
 All these commands share the same configuration of ``environment``, ``workdir`` and ``pty`` usage that can be setup the same way as in :bb:step:`ShellCommand`.


### PR DESCRIPTION
The doc says:  util.ShellArg(cmd='configure'), which is not correct.

It should be: util.ShellArg(command='configure'),
