### PR TITLE
Fix: step.ShellSequence doesn't catch stdout/stderr even if the paramete...

### DIFF
--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -104,7 +104,9 @@ class ShellSequence(buildstep.ShellMixin, buildstep.BuildStep):
             self.last_command = command
 
             cmd = yield self.makeRemoteShellCommand(command=command,
-                                                    stdioLogName=arg.logfile)
+                                                    stdioLogName=arg.logfile,
+                                                    collectStdout=self.want_stdout,
+                                                    collectStderr=self.want_stderr)
             yield self.runCommand(cmd)
             overall_result, terminate = results.computeResultAndTermination(
                 arg, cmd.results(), overall_result)


### PR DESCRIPTION
step.ShellSequence doesn't catch stdout/stderr even if the parameters want_stdout/want_stderr are set to True.

Note:
- here's a example how to catch stderr/stdout with this patch applied

```
    factory.addStep(steps.ShellSequence(name="BuildSandBox",
                                        want_stdout=True,
                                        want_stderr=True,
                                        commands=[util.ShellArg(command=['rm', '-rf', 'sandbox'],
                                                                logfile="rm",),
                                                  util.ShellArg(command=['make', 'buildsandbox',  'args="sandbox"'],
                                                                logfile="sandbox",),]))
```
