### PR TITLE
Fix bug in master/buildbot/db/sourcestamps.py

### DIFF
--- a/master/buildbot/db/sourcestamps.py
+++ b/master/buildbot/db/sourcestamps.py
@@ -64,7 +64,7 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
             return patchid
         patchid = yield self.db.pool.do(thd)
 
-        ss_hash = self.hashColumns(branch, revision, repository, project,
+        ss_hash = self.hashColumns(branch, repository, project,
                                    codebase, patchid)
         sourcestampid = yield self.findSomethingId(
             tbl=tbl,


### PR DESCRIPTION
Dustin says:

```
<djmitche> you only get multiple changes attached to a sourcestamp if you have a long enough treeStableTimer that the schedule deals with both changes at the same time
<djmitche> asking "which changes led to this sourcestamp", translated to, say, git terms means "which commits led to this revision"
<djmitche> to which the only logical answer is "all of them"
<djmitche> what we really want is "what are the commits *between* this sourcestamp and that sourcestsamp"
<djmitche> so a sourcestamp will have a single change (the commit that generated it)
<djmitche> and we'll do some tree traversal to answer theq uesetion
<djmitche> but until that happens, it's this kind of crappy "it depends what the scheduler sees" answer :(
```

But with the current implementation, a sourcestamp is created for each change, because "revision" (GIT SHA1 in case of the gitpoller) is used to calculate the ss_hash.
As a consequence, buildbot creates a new sourcestamp for each new changes.
