### PR TITLE
Display the build number instead of the buildid in the waterfall.

### DIFF
--- a/www/waterfall_view/src/module/main.module.coffee
+++ b/www/waterfall_view/src/module/main.module.coffee
@@ -370,7 +370,7 @@ class Waterfall extends Controller
             .attr('class', 'id')
             .attr('x', x.rangeBand() / 2)
             .attr('y', -3)
-            .text((build) -> build.buildid)
+            .text((build) -> build.number)
 
         # Add event listeners
         builds


### PR DESCRIPTION
This is more consistent with eight. Beside, the buildid is an internal reference that doesn't need to be communicated to the user.
