### PR TITLE
samp inside a pre is overkill, beside, it's killing the formatting.

### DIFF
--- a/www/base/src/app/builders/log/logviewer/logviewer.directive.coffee
+++ b/www/base/src/app/builders/log/logviewer/logviewer.directive.coffee
@@ -20,7 +20,7 @@ class Logviewer extends Directive
                 if num_lines > self.num_lines
                     for i in [self.num_lines..num_lines - 1]
                         self.lines.push
-                            content: ".\n"
+                            content: "."
                             class: "log_o"
                     self.num_lines = num_lines
                     if self.auto_scroll

--- a/www/base/src/app/builders/log/logviewer/logviewer.less
+++ b/www/base/src/app/builders/log/logviewer/logviewer.less
@@ -4,8 +4,8 @@
 pre.log {
     // It is much more difficult to do autoscroll if line wrap is enabled.
     // For now we just disable it. There is space for some smarter algorithm
-    samp {
-        white-space: nowrap;
+    .no-wrap {
+        white-space: pre;
     }
   overflow: auto;
 }

--- a/www/base/src/app/builders/log/logviewer/logviewer.tpl.jade
+++ b/www/base/src/app/builders/log/logviewer/logviewer.tpl.jade
@@ -6,9 +6,8 @@
         i.fa.fa-search
   pre.row.log(ng-show="log.type!='h'")
     span(ng-if="log.type=='t'", ng-bind="content")
-    span(ng-repeat="line in lines | filter:searchText", class="{{line.class}}",  ng-if="log.type=='s'")
-        | {{line.content}}
-        br
+    span.no-wrap(ng-repeat="line in lines | filter:searchText", class="{{line.class}}",  ng-if="log.type=='s'")
+        | {{line.content + '\n'}}
   div.panel(ng-if="log.type=='h'", ng-class="log.name=='err.html' && 'panel-danger' || 'panel-default'")
     div.panel-heading
         h4.panel-title {{log.name}}


### PR DESCRIPTION
I add all my warning logs (from a Compile Step) on one line because all in the first 'samp' (now span)
