### PR TITLE
Fix minor issue with the pylint Step:

### DIFF
--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -230,8 +230,8 @@ class PyLint(ShellCommand):
             if mo:
                 msgtype = mo.group(self._re_groupname)
                 assert msgtype in self.MESSAGES
-            self.summaries[msgtype].append(line)
-            self.counts[msgtype] += 1
+                self.summaries[msgtype].append(line)
+                self.counts[msgtype] += 1
 
     def createSummary(self, log):
         counts, summaries = self.counts, self.summaries
@@ -239,7 +239,7 @@ class PyLint(ShellCommand):
         for msg, fullmsg in self.MESSAGES.items():
             if counts[msg]:
                 self.descriptionDone.append("%s=%d" % (fullmsg, counts[msg]))
-                self.addCompleteLog(fullmsg, "".join(summaries[msg]))
+                self.addCompleteLog(fullmsg, "\n".join(summaries[msg]))
             self.setProperty("pylint-%s" % fullmsg, counts[msg])
         self.setProperty("pylint-total", sum(counts.values()))
 


### PR DESCRIPTION
- indentation issue
- don't write pylint additional log on a single line

Note: 
I had to overide this class in order to set:

```
 _parseable_line_re = re.compile(
        r'[^:]+:\d+: \[%s(\d{4})?\(.+\), .*\] .+' % _msgtypes_re_str)
```

by default, the pylint step fails to parse the output generated with pylint 1.1.0 configured with:

```
msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
```

I think this is equivalent to --output parseable (but I 'm not sure).
