### PR TITLE
Fix issue raised by benallard

### DIFF
--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -205,12 +205,12 @@ class PyLint(ShellCommand):
 
     def __init__(self, **kwargs):
         ShellCommand.__init__(self, **kwargs)
+        self.counts = {}
+        self.summaries = {}
         self.addLogObserver(
             'stdio', logobserver.LineConsumerLogObserver(self.logConsumer))
 
     def logConsumer(self):
-        self.counts = {}
-        self.summaries = {}
         for m in self.MESSAGES:
             self.counts[m] = 0
             self.summaries[m] = []


### PR DESCRIPTION
```
 1 Traceback (most recent call last):
 2   File "/home/benoit/buildbot/openvas/venv/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 577, in _runCallbacks
 3     current.result = callback(current.result, *args, **kw)
 4   File "/home/benoit/buildbot/openvas/venv/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1155, in gotResult
 5     _inlineCallbacks(r, g, deferred)
 6   File "/home/benoit/buildbot/openvas/venv/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1097, in _inlineCallbacks
 7     result = result.throwExceptionIntoGenerator(g)
 8   File "/home/benoit/buildbot/openvas/venv/local/lib/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
 9     return g.throw(self.type, self.value, self.tb)
10 --- <exception caught here> ---
11   File "/home/benoit/buildbot/buildbot/master/buildbot/process/buildstep.py", line 461, in startStep
12     results = yield self.run()
13   File "/home/benoit/buildbot/openvas/venv/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1099, in _inlineCallbacks
14     result = g.send(result)
15   File "/home/benoit/buildbot/buildbot/master/buildbot/process/buildstep.py", line 576, in run
16     results = yield self._start_deferred
17   File "/home/benoit/buildbot/openvas/venv/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 577, in _runCallbacks
18     current.result = callback(current.result, *args, **kw)
19   File "/home/benoit/buildbot/buildbot/master/buildbot/process/buildstep.py", line 852, in <lambda>
20     d.addCallback(lambda res: self.createSummary(cmd.logs['stdio']))
21   File "/home/benoit/buildbot/buildbot/master/buildbot/steps/python.py", line 237, in createSummary
22     counts, summaries = self.counts, self.summaries
23 exceptions.AttributeError: 'PyLint' object has no attribute 'counts'
```
