### PR TITLE
IRCContact use the DATA API

### DIFF
--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -40,7 +40,8 @@ class BuilderEndpoint(base.Endpoint):
         defer.returnValue(
             dict(builderid=builderid,
                  name=bdict['name'],
-                 description=bdict['description']))
+                 description=bdict['description'],
+                 tags=bdict['tags']))
 
 
 class BuildersEndpoint(base.Endpoint):
@@ -59,7 +60,8 @@ class BuildersEndpoint(base.Endpoint):
         defer.returnValue([
             dict(builderid=bd['id'],
                  name=bd['name'],
-                 description=bd['description'])
+                 description=bd['description'],
+                 tags=bd['tags'])
             for bd in bdicts])
 
     def startConsuming(self, callback, options, kwargs):
@@ -78,6 +80,7 @@ class Builder(base.ResourceType):
         builderid = types.Integer()
         name = types.Identifier(20)
         description = types.NoneOk(types.String())
+        tags = types.NoneOk(types.List(of=types.String()))
     entityType = EntityType(name)
 
     def __init__(self, master):
@@ -88,8 +91,8 @@ class Builder(base.ResourceType):
         return self.master.db.builders.findBuilderId(name)
 
     @base.updateMethod
-    def updateBuilderDescription(self, builderid, description):
-        return self.master.db.builders.updateBuilderDescription(builderid, description)
+    def updateBuilderInfo(self, builderid, description, tags):
+        return self.master.db.builders.updateBuilderInfo(builderid, description, tags)
 
     @base.updateMethod
     @defer.inlineCallbacks

--- a/master/buildbot/db/migrate/versions/040_add_builder_tags.py
+++ b/master/buildbot/db/migrate/versions/040_add_builder_tags.py
@@ -1,0 +1,24 @@
+# This file is part of Buildbot. Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+    builders_table = sa.Table('builders', metadata, autoload=True)
+    tags = sa.Column('tags', sa.Text, nullable=True)
+    tags.create(builders_table)

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -447,6 +447,8 @@ class Model(base.DBConnectorComponent):
                         sa.Column('name', sa.Text, nullable=False),
                         # builder's description
                         sa.Column('description', sa.Text, nullable=True),
+                        # builder's tags
+                        sa.Column('tags', sa.Text, nullable=True),
                         # sha1 of name; used for a unique index
                         sa.Column('name_hash', sa.String(40), nullable=False),
                         )

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -113,7 +113,9 @@ class Builder(config.ReconfigurableServiceMixin,
         # build.
         builderid = yield self.getBuilderId()
 
-        self.master.data.updates.updateBuilderDescription(builderid, builder_config.description)
+        self.master.data.updates.updateBuilderInfo(builderid,
+                                                   builder_config.description,
+                                                   builder_config.tags)
 
         self.builder_status.setDescription(builder_config.description)
         self.builder_status.setTags(builder_config.tags)

--- a/master/buildbot/status/words.py
+++ b/master/buildbot/status/words.py
@@ -44,6 +44,7 @@ from buildbot.status.results import RETRY
 from buildbot.status.results import SUCCESS
 from buildbot.status.results import WARNINGS
 
+
 # twisted.internet.ssl requires PyOpenSSL, so be resilient if it's missing
 try:
     from twisted.internet import ssl
@@ -184,6 +185,9 @@ class IRCContact(base.StatusReceiver):
             reactor.callLater(when, self.send, r)
             when += 2.5
 
+    def builderMatchesAnyTag(self, builder, tags):
+        return builder['tags'] and any(tag for tag in builder['tags'] if tag in self.bot.tags)
+
     @defer.inlineCallbacks
     def getBuilder(self, buildername=None, builderid=None):
         if buildername:
@@ -205,6 +209,9 @@ class IRCContact(base.StatusReceiver):
                 which = 'number %s' % builderid
             raise UsageError("no such builder '%s'" % which)
         defer.returnValue(bdict)
+
+    def getPreviousBuild(self, build):
+        return self.master.data.get(('builders', build['builderid'], 'builds', build['number'] - 1))
 
     def getControl(self, which):
         # TODO in nine: there's going to be a better way to do all this.
@@ -332,17 +339,20 @@ class IRCContact(base.StatusReceiver):
                 return True
         return False
 
+    @defer.inlineCallbacks
     def subscribe_to_build_events(self):
+        startConsuming = self.master.mq.startConsuming
 
-        # FIXME:
-        #  -- builderAdded
-        #  -- builderRemoved
-        #  -- builderStarted
-        #  -- buildFinished
+        def buildStarted(key, msg):
+            return self.buildStarted(msg)
 
-        handle = True  # self.master.data.startConsuming(watchForCompleteEvent, {},
-        #                               (build['link'].path))
-        self.subscribed.append(handle)
+        def buildFinished(key, msg):
+            return self.buildFinished(msg)
+
+        for e, f in (("new", buildStarted),             # BuilderStarted
+                     ("finished", buildFinished)):      # BuilderFinished
+            handle = yield startConsuming(f, ('builders', None, 'builds', None, e))
+            self.subscribed.append(handle)
 
     def unsubscribe_from_build_events(self):
         # Cancel all the subscriptions we have
@@ -462,32 +472,16 @@ class IRCContact(base.StatusReceiver):
             self.send(r)
     command_WATCH.usage = "watch <which> - announce the completion of an active build"
 
-    # OLD_STYLE
-    def builderAdded(self, builderName, builder):
-        # FIXME: NEED TO THINK ABOUT!
-        if (self.bot.tags is not None and
-                not builder.matchesAnyTag(tags=self.bot.tags)):
-            return
-
-        log.msg('[Contact] Builder %s added' % (builderName))
-        builder.subscribe(self)
-
-    # OLD_STYLE
-    def builderRemoved(self, builderName):
-        # FIXME: NEED TO THINK ABOUT!
-        log.msg('[Contact] Builder %s removed' % (builderName))
-
-    # OLD_STYLE
     @defer.inlineCallbacks
-    def buildStarted(self, builderName, build):
-        # FIXME: NEED TO THINK ABOUT!
-        builder = build.getBuilder()
-        log.msg('[Contact] Builder %r started' % (builder,))
+    def buildStarted(self, build):
+        builder = yield self.getBuilder(builderid=build['builderid'])
+        builderName = builder['name']
+        buildNumber = build['number']
+        log.msg('[Contact] Builder %s started' % (builder['name'],))
 
         # only notify about builders we are interested in
-
         if (self.bot.tags is not None and
-                not builder.matchesAnyTag(tags=self.bot.tags)):
+                not self.builderMatchesAnyTag(builder, self.bot.tags)):
             log.msg('Not notifying for a build that does not match any tags')
             return
 
@@ -497,28 +491,59 @@ class IRCContact(base.StatusReceiver):
         if self.useRevisions:
             revisions = yield self.getRevisionsForBuild(build)
             r = "build containing revision(s) [%s] on %s started" % \
-                (','.join(revisions), builder.getName())
+                (','.join(revisions), builderName)
         else:
             # Abbreviate long lists of changes to simply two
             # revisions, and the number of additional changes.
-            changes = [str(c.revision) for c in build.getChanges()][:2]
+            # TODO: We can't get the list of the changes related to a build in nine
             changes_str = ""
 
-            if len(build.getChanges()) > 0:
-                changes_str = "including [%s]" % ', '.join(changes)
-
-                if len(build.getChanges()) > 2:
-                    # Append number of truncated changes
-                    changes_str += " and %d more" % (len(build.getChanges()) - 2)
-
-            r = "build #%d of %s started" % (
-                build.getNumber(),
-                builder.getName())
-
+            r = "build #%d of %s started" % (buildNumber, builderName)
             if changes_str:
                 r += " (%s)" % changes_str
 
         self.send(r)
+
+    @defer.inlineCallbacks
+    def buildFinished(self, build):
+        builder = yield self.getBuilder(builderid=build['builderid'])
+        builderName = builder['name']
+        buildNumber = build['number']
+        buildResult = build['results']
+
+        # only notify about builders we are interested in
+        if (self.bot.tags is not None and
+                not self.builderMatchesAnyTag(builder, self.bot.tags)):
+            log.msg('Not notifying for a build that does not match any tags')
+            return
+
+        if not self.notify_for_finished(build):
+            return
+
+        if not self.shouldReportBuild(builderName, buildNumber):
+            return
+
+        results = self.getResultsDescriptionAndColor(buildResult)
+
+        if self.useRevisions:
+            revisions = yield self.getRevisionsForBuild(build)
+            r = "Hey! build %s containing revision(s) [%s] is complete: %s" % \
+                (builderName, ','.join(revisions), results[0])
+        else:
+            r = "Hey! build %s #%d is complete: %s" % \
+                (builderName, buildNumber, results[0])
+
+        r += ' [%s]' % maybeColorize(build['state_string'], results[1], self.useColors)
+        self.send(r)
+
+        # FIXME: where do we get the list of changes for a build ?
+        # if self.bot.showBlameList and buildResult != SUCCESS and len(build.changes) != 0:
+        #    r += '  blamelist: ' + ', '.join(list(set([c.who for c in build.changes])))
+
+        # FIXME: where do we get the base_url? Then do we use the build Link to make the URL?
+        buildurl = None  # self.bot.status.getBuildbotURL() + build
+        if buildurl:
+            self.send("Build details are at %s" % buildurl)
 
     results_descriptions = {
         SUCCESS: ("Success", 'GREEN'),
@@ -532,61 +557,20 @@ class IRCContact(base.StatusReceiver):
     def getResultsDescriptionAndColor(self, results):
         return self.results_descriptions.get(results, ("??", 'RED'))
 
-    # OLD_STYLE
-    def buildFinished(self, builderName, build, results):
-        # FIXME: NEED TO THINK ABOUT!
-        builder = build.getBuilder()
-
-        if (self.bot.tags is not None and
-                not builder.matchesAnyTag(tags=self.bot.tags)):
-            return
-
-        if not self.notify_for_finished(build):
-            return
-
-        builder_name = builder.getName()
-        buildnum = build.getNumber()
-
-        results = self.getResultsDescriptionAndColor(build.getResults())
-        if not self.shouldReportBuild(builder_name, buildnum):
-            return
-
-        bdict = None  # ???
-        if self.useRevisions:
-            revisions = yield self.getRevisionsForBuild(bdict)
-            r = "build containing revision(s) [%s] on %s is complete: %s" % \
-                (','.join(revisions), builder_name, results[0])
-        else:
-            r = "build #%d of %s is complete: %s" % \
-                (buildnum, builder_name, results[0])
-
-        r += ' [%s]' % maybeColorize(" ".join(build.getText()), results[1], self.useColors)
-        buildurl = self.bot.status.getURLForThing(build)
-        if buildurl:
-            r += "  Build details are at %s" % buildurl
-
-        if self.bot.showBlameList and build.getResults() != SUCCESS and len(build.changes) != 0:
-            r += '  blamelist: ' + ', '.join(list(set([c.who for c in build.changes])))
-
-        self.send(r)
-
     def notify_for_finished(self, build):
-        # FIXME: NEED TO THINK ABOUT!
-        results = build.getResults()
-
         if self.notify_for('finished'):
             return True
 
-        if self.notify_for(lower(self.results_descriptions.get(results)[0])):
+        if self.notify_for(lower(self.results_descriptions.get(build['results'])[0])):
             return True
 
-        prevBuild = build.getPreviousBuild()
+        prevBuild = self.getPreviousBuild(build)
         if prevBuild:
-            prevResult = prevBuild.getResults()
+            prevResult = prevBuild['results']
 
             required_notification_control_string = join((lower(self.results_descriptions.get(prevResult)[0]),
                                                          'To',
-                                                         capitalize(self.results_descriptions.get(results)[0])),
+                                                         capitalize(self.results_descriptions.get(build['results'])[0])),
                                                         '')
 
             if (self.notify_for(required_notification_control_string)):
@@ -598,11 +582,11 @@ class IRCContact(base.StatusReceiver):
     def watchedBuildFinished(self, build):
         builder = yield self.getBuilder(builderid=build['builderid'])
 
-        # FIXME: NEED TO THINK ABOUT!
         # only notify about builders we are interested in
-        # if (self.bot.tags is not None and
-        #         not builder.matchesAnyTag(tags=self.bot.tags)):
-        #     return
+        if (self.bot.tags is not None and
+                not self.builderMatchesAnyTag(builder, self.bot.tags)):
+            log.msg('Not notifying for a build that does not match any tags')
+            return
 
         builder_name = builder['name']
         buildnum = build['number']
@@ -1157,6 +1141,9 @@ class IrcStatusFactory(ThrottledClientFactory):
         self.showBlameList = showBlameList
         self.useColors = useColors
         self.allowShutdown = allowShutdown
+
+        if categories:
+            log.msg("WARNING: categories are deprecated and should be replaced with 'tags=[cat]'")
 
     def __getstate__(self):
         d = self.__dict__.copy()

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -210,8 +210,8 @@ class FakeUpdates(object):
         self.builderNames = builderNames
         return defer.succeed(None)
 
-    def updateBuilderDescription(self, builderid, description):
-        yield self.master.db.builders.updateBuilderDescription(builderid, description)
+    def updateBuilderInfo(self, builderid, description, tags):
+        yield self.master.db.builders.updateBuilderInfo(builderid, description, tags)
 
     def masterDeactivated(self, masterid):
         return defer.succeed(None)

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -533,6 +533,7 @@ class Builder(Row):
         name='some:builder',
         name_hash=None,
         description=None,
+        tags=None,
     )
 
     id_column = 'id'
@@ -2135,7 +2136,8 @@ class FakeBuildersComponent(FakeDBComponent):
                 self.builders[row.id] = dict(
                     id=row.id,
                     name=row.name,
-                    description=row.description)
+                    description=row.description,
+                    tags=row.tags if row.tags else [])
             if isinstance(row, BuilderMaster):
                 self.builder_masters[row.id] = \
                     (row.builderid, row.masterid)
@@ -2148,7 +2150,8 @@ class FakeBuildersComponent(FakeDBComponent):
         self.builders[id] = dict(
             id=id,
             name=name,
-            description=None)
+            description=None,
+            tags=[])
         return defer.succeed(id)
 
     def addBuilderMaster(self, builderid=None, masterid=None):
@@ -2194,9 +2197,10 @@ class FakeBuildersComponent(FakeDBComponent):
             Builder(id=builderid, name=name),
         ])
 
-    def updateBuilderDescription(self, builderid, description):
+    def updateBuilderInfo(self, builderid, description, tags):
         if builderid in self.builders:
             self.builders[builderid]['description'] = description
+            self.builders[builderid]['tags'] = tags if tags else []
 
 
 class FakeDBConnector(object):

--- a/master/buildbot/test/unit/test_data_builders.py
+++ b/master/buildbot/test/unit/test_data_builders.py
@@ -159,9 +159,9 @@ class Builder(interfaces.InterfaceTests, unittest.TestCase):
         self.master.db.builders.findBuilderId = mock.Mock(return_value=rv)
         self.assertIdentical(self.rtype.findBuilderId('foo'), rv)
 
-    def test_signature_updateBuilderDescription(self):
-        @self.assertArgSpecMatches(self.master.data.updates.updateBuilderDescription)
-        def updateBuilderDescription(self, builderid, description):
+    def test_signature_updateBuilderInfo(self):
+        @self.assertArgSpecMatches(self.master.data.updates.updateBuilderInfo)
+        def updateBuilderInfo(self, builderid, description, tags):
             pass
 
     def test_signature_updateBuilderList(self):
@@ -178,7 +178,7 @@ class Builder(interfaces.InterfaceTests, unittest.TestCase):
         self.assertEqual(sorted((yield self.master.db.builders.getBuilders())),
                          sorted([
                              dict(id=1, masterids=[13],
-                                  name='somebuilder', description=None),
+                                  name='somebuilder', description=None, tags=[]),
                          ]))
         self.master.mq.assertProductions([(('builders', '1', 'started'),
                                            {'builderid': 1, 'masterid': 13, 'name': u'somebuilder'})])
@@ -188,9 +188,9 @@ class Builder(interfaces.InterfaceTests, unittest.TestCase):
         self.assertEqual(sorted((yield self.master.db.builders.getBuilders())),
                          sorted([
                              dict(id=1, masterids=[13],
-                                  name='somebuilder', description=None),
+                                  name='somebuilder', description=None, tags=[]),
                              dict(id=2, masterids=[13],
-                                  name='another', description=None),
+                                  name='another', description=None, tags=[]),
                          ]))
         self.master.mq.assertProductions([(('builders', '2', 'started'),
                                            {'builderid': 2, 'masterid': 13, 'name': u'another'})])
@@ -200,9 +200,9 @@ class Builder(interfaces.InterfaceTests, unittest.TestCase):
         self.assertEqual(sorted((yield self.master.db.builders.getBuilders())),
                          sorted([
                              dict(id=1, masterids=[13],
-                                  name='somebuilder', description=None),
+                                  name='somebuilder', description=None, tags=[]),
                              dict(id=2, masterids=[13, 14],
-                                  name='another', description=None),
+                                  name='another', description=None, tags=[]),
                          ]))
         self.master.mq.assertProductions([(('builders', '2', 'started'),
                                            {'builderid': 2, 'masterid': 14, 'name': u'another'})])
@@ -211,8 +211,8 @@ class Builder(interfaces.InterfaceTests, unittest.TestCase):
         yield self.rtype.updateBuilderList(13, [])
         self.assertEqual(sorted((yield self.master.db.builders.getBuilders())),
                          sorted([
-                             dict(id=1, masterids=[], name='somebuilder', description=None),
-                             dict(id=2, masterids=[14], name='another', description=None),
+                             dict(id=1, masterids=[], name='somebuilder', description=None, tags=[]),
+                             dict(id=2, masterids=[14], name='another', description=None, tags=[]),
                          ]))
         self.master.mq.assertProductions([
             (('builders', '1', 'stopped'),

--- a/master/buildbot/test/unit/test_db_builders.py
+++ b/master/buildbot/test/unit/test_db_builders.py
@@ -58,22 +58,29 @@ class Tests(interfaces.InterfaceTests):
         def getBuilders(self, masterid=None):
             pass
 
-    def test_signature_updateBuilderDescription(self):
-        @self.assertArgSpecMatches(self.db.builders.updateBuilderDescription)
-        def updateBuilderDescription(self, builderid, description):
+    def test_signature_updateBuilderInfo(self):
+        @self.assertArgSpecMatches(self.db.builders.updateBuilderInfo)
+        def updateBuilderInfo(self, builderid, description, tags):
             pass
 
     @defer.inlineCallbacks
-    def test_updateBuilderDescription(self):
+    def test_updateBuilderInfo(self):
         yield self.insertTestData([
-            fakedb.Builder(id=7, name='some:builder'),
+            fakedb.Builder(id=7, name='some:builder7'),
+            fakedb.Builder(id=8, name='some:builder8'),
         ])
 
-        yield self.db.builders.updateBuilderDescription(7, u'a string which describe the builder')
-        builderdict = yield self.db.builders.getBuilder(7)
-        validation.verifyDbDict(self, 'builderdict', builderdict)
-        self.assertEqual(builderdict,
-                         dict(id=7, name='some:builder',
+        yield self.db.builders.updateBuilderInfo(7, u'a string which describe the builder', [u'cat1', u'cat2'])
+        yield self.db.builders.updateBuilderInfo(8, u'a string which describe the builder', None)
+        builderdict7 = yield self.db.builders.getBuilder(7)
+        validation.verifyDbDict(self, 'builderdict', builderdict7)
+        self.assertEqual(builderdict7,
+                         dict(id=7, name='some:builder7', tags=['cat1', 'cat2'],
+                              masterids=[], description='a string which describe the builder'))
+        builderdict8 = yield self.db.builders.getBuilder(8)
+        validation.verifyDbDict(self, 'builderdict', builderdict8)
+        self.assertEqual(builderdict8,
+                         dict(id=8, name='some:builder8', tags=[],
                               masterids=[], description='a string which describe the builder'))
 
     @defer.inlineCallbacks
@@ -81,7 +88,7 @@ class Tests(interfaces.InterfaceTests):
         id = yield self.db.builders.findBuilderId('some:builder')
         builderdict = yield self.db.builders.getBuilder(id)
         self.assertEqual(builderdict,
-                         dict(id=id, name='some:builder',
+                         dict(id=id, name='some:builder', tags=[],
                               masterids=[], description=None))
 
     @defer.inlineCallbacks
@@ -104,7 +111,7 @@ class Tests(interfaces.InterfaceTests):
         builderdict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(builderdict,
-                         dict(id=7, name='some:builder',
+                         dict(id=7, name='some:builder', tags=[],
                               masterids=[9, 10], description=None))
 
     @defer.inlineCallbacks
@@ -119,7 +126,7 @@ class Tests(interfaces.InterfaceTests):
         builderdict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(builderdict,
-                         dict(id=7, name='some:builder',
+                         dict(id=7, name='some:builder', tags=[],
                               masterids=[9], description=None))
 
     @defer.inlineCallbacks
@@ -135,7 +142,7 @@ class Tests(interfaces.InterfaceTests):
         builderdict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(builderdict,
-                         dict(id=7, name='some:builder',
+                         dict(id=7, name='some:builder', tags=[],
                               masterids=[10], description=None))
 
     @defer.inlineCallbacks
@@ -146,7 +153,7 @@ class Tests(interfaces.InterfaceTests):
         builderdict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(builderdict,
-                         dict(id=7, name='some:builder',
+                         dict(id=7, name='some:builder', tags=[],
                               masterids=[], description=None))
 
     @defer.inlineCallbacks
@@ -161,7 +168,7 @@ class Tests(interfaces.InterfaceTests):
         builderdict = yield self.db.builders.getBuilder(7)
         validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(builderdict,
-                         dict(id=7, name='some:builder',
+                         dict(id=7, name='some:builder', tags=[],
                               masterids=[3, 4], description=None))
 
     @defer.inlineCallbacks
@@ -185,9 +192,9 @@ class Tests(interfaces.InterfaceTests):
         for builderdict in builderlist:
             validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(sorted(builderlist), sorted([
-            dict(id=7, name='some:builder', masterids=[3], description=None),
-            dict(id=8, name='other:builder', masterids=[3, 4], description=None),
-            dict(id=9, name='third:builder', masterids=[], description=None),
+            dict(id=7, name='some:builder', masterids=[3], tags=[], description=None),
+            dict(id=8, name='other:builder', masterids=[3, 4], tags=[], description=None),
+            dict(id=9, name='third:builder', masterids=[], tags=[], description=None),
         ]))
 
     @defer.inlineCallbacks
@@ -206,8 +213,8 @@ class Tests(interfaces.InterfaceTests):
         for builderdict in builderlist:
             validation.verifyDbDict(self, 'builderdict', builderdict)
         self.assertEqual(sorted(builderlist), sorted([
-            dict(id=7, name='some:builder', masterids=[3], description=None),
-            dict(id=8, name='other:builder', masterids=[3, 4], description=None),
+            dict(id=7, name='some:builder', masterids=[3], tags=[], description=None),
+            dict(id=8, name='other:builder', masterids=[3, 4], tags=[], description=None),
         ]))
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_db_migrate_versions_040_add_builder_tags.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_040_add_builder_tags.py
@@ -1,0 +1,65 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+
+from buildbot.test.util import migration
+from twisted.trial import unittest
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_thd(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        builders = sa.Table('builders', metadata,
+                            sa.Column('id', sa.Integer, primary_key=True),
+                            # builder's name
+                            sa.Column('name', sa.Text, nullable=False),
+                            sa.Column('description', sa.Text, nullable=True),
+                            # sha1 of name; used for a unique index
+                            sa.Column('name_hash', sa.String(40), nullable=False),)
+        builders.create()
+
+        conn.execute(builders.insert(), [
+            dict(name='bname', name_hash='dontcare')])
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            builders = sa.Table('builders', metadata, autoload=True)
+            self.assertIsInstance(builders.c.tags.type, sa.Text)
+
+            q = sa.select([builders.c.name, builders.c.tags])
+            num_rows = 0
+            for row in conn.execute(q):
+                # verify that the default value was set correctly
+                self.assertEqual(row.tags, None)
+                num_rows += 1
+            self.assertEqual(num_rows, 1)
+
+        return self.do_test_migration(39, 40, setup_thd, verify_thd)

--- a/master/buildbot/test/unit/test_status_words.py
+++ b/master/buildbot/test/unit/test_status_words.py
@@ -442,6 +442,7 @@ class TestIrcContactChannel(unittest.TestCase):
     @defer.inlineCallbacks
     def test_command_watch_builder0_get_notifications(self):
         # (continue from the prior test)
+        self.bot.tags = None
         yield self.test_command_watch_builder0()
         del self.sent[:]
 
@@ -639,58 +640,20 @@ class TestIrcContactChannel(unittest.TestCase):
         yield self.do_test_command('last', args='args\'', exp_UsageError=True)
         yield self.do_test_command('help', args='args\'', exp_UsageError=True)
 
+    @defer.inlineCallbacks
     def test_buildStarted(self):
-        class MockChange(object):
-
-            def __init__(self, revision):
-                self.revision = revision
-
-        def get_name():
-            return "dummy"
-
+        self.setupSomeBuilds()
         self.patch_send()
-
-        build = mock.Mock()
-        build.getNumber = lambda: 42
-        build.getName = get_name
-
-        builder = mock.Mock()
-        builder.getName = get_name
-        build.getBuilder = lambda: builder
+        build = yield self.master.db.builds.getBuild(13)
 
         self.bot.tags = None
         self.contact.notify_for = lambda _: True
         self.contact.useRevisions = False
 
-        # we have no information on included changes
-        build.getChanges = lambda: []
-        self.contact.buildStarted("dummy", build)
+        self.contact.buildStarted(build)
         self.assertEqual(
             self.sent.pop(),
-            "build #42 of dummy started")
-
-        # we have one change included
-        build.getChanges = lambda: [MockChange("1")]
-        self.contact.buildStarted("dummy", build)
-        self.assertEqual(
-            self.sent.pop(),
-            "build #42 of dummy started (including [1])")
-
-        # we have two changes included (all revisions are printed)
-        build.getChanges = lambda: [MockChange("1"), MockChange("2")]
-        self.contact.buildStarted("dummy", build)
-        self.assertEqual(
-            self.sent.pop(),
-            "build #42 of dummy started (including [1, 2])")
-
-        # we have three changes included (not all revisions are printed)
-        build.getChanges = lambda: [
-            MockChange("1"), MockChange("2"), MockChange("3")
-        ]
-        self.contact.buildStarted("dummy", build)
-        self.assertEqual(
-            self.sent.pop(),
-            "build #42 of dummy started (including [1, 2] and 1 more)")
+            "build #3 of builder1 started")
 
 
 class FakeContact(object):

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -382,6 +382,7 @@ dbdict['builderdict'] = DictValidator(
     masterids=ListValidator(IntValidator()),
     name=StringValidator(),
     description=NoneOk(StringValidator()),
+    tags=NoneOk(ListValidator(StringValidator())),
 )
 
 # slave


### PR DESCRIPTION
IRCContact consume 2 events: 
- ('builders', None, 'builds', None, 'new') => A build is started
- ('builders', None, 'builds', None, 'finished') => A build is finished

When we will be able to get the list of changes for a build, the IRCContact must be updated.
