### PR TITLE
 - Fix PeriodicScheduler when a build is triggered with no changes

### DIFF
--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -203,8 +203,9 @@ class BaseScheduler(ClusteredService, StateMixin):
             # apply info from passed sourcestamps onto the configured default
             # sourcestamp attributes for this codebase.
             ss.update(stampsByCodebase[codebase])
+            if ss.get('project') is None:
+                ss['project'] = ''
             stampsWithDefaults.append(ss)
-
         return self.addBuildsetForSourceStamps(sourcestamps=stampsWithDefaults,
                                                reason=reason, waited_for=waited_for, properties=properties,
                                                builderNames=builderNames,

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -286,8 +286,8 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
             waited_for=False,
             sourcestamps=[
                 {'repository': 'svn://B..', 'branch': 'stable',
-                    'revision': 'BB', 'codebase': 'cbB'},
-                {'repository': 'svn://A..', 'branch': 'AA',
+                    'revision': 'BB', 'codebase': 'cbB', 'project': ''},
+                {'repository': 'svn://A..', 'branch': 'AA', 'project': '',
                     'revision': '13579', 'codebase': 'cbA'},
             ],
             reason=u'power',
@@ -310,8 +310,8 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
         self.master.data.updates.addBuildset.assert_called_with(
             waited_for=True,
             sourcestamps=[
-                {'revision': 'BB', 'codebase': 'cbB'},
-                {'branch': 'AA', 'codebase': 'cbA'},
+                {'revision': 'BB', 'codebase': 'cbB', 'project': ''},
+                {'branch': 'AA', 'codebase': 'cbA', 'project': ''},
             ],
             reason=u'power',
             scheduler=u'n',


### PR DESCRIPTION
when the PeriodicScheduler trigger a build with no changes, we have this traceback: 

```
    Traceback (most recent call last):
    Failure: twisted.internet.defer.FirstError: FirstError[#0, [Failure instance: Traceback: <type 'exceptions.AssertionError'>: project cannot be None
    /home/xavierd/Projects/myGitHub/buildbot-work/sandbox/local/lib/python2.7/site-packages/twisted/internet/defer.py:1099:_inlineCallbacks
    /home/xavierd/Projects/myGitHub/buildbot-work/src/master/buildbot/db/buildsets.py:60:addBuildset
    /home/xavierd/Projects/myGitHub/buildbot-work/src/master/buildbot/db/buildsets.py:58:toSsid
    /home/xavierd/Projects/myGitHub/buildbot-work/sandbox/local/lib/python2.7/site-packages/twisted/internet/defer.py:1237:unwindGenerator
    --- <exception caught here> ---
    /home/xavierd/Projects/myGitHub/buildbot-work/sandbox/local/lib/python2.7/site-packages/twisted/internet/defer.py:1099:_inlineCallbacks
    /home/xavierd/Projects/myGitHub/buildbot-work/src/master/buildbot/db/sourcestamps.py:45:findSourceStampId
    ]]
```
