### PR TITLE
Use guanlecoja-ui contextual actions for forceschedulers

### DIFF
--- a/www/base/guanlecoja/config.coffee
+++ b/www/base/guanlecoja/config.coffee
@@ -30,7 +30,7 @@ config =
         # JavaScript libraries (order matters)
         deps:
             "guanlecoja-ui":
-                version: '~1.3.0'
+                version: '~1.4.0'
                 files: ['vendors.js', 'scripts.js']
             moment:
                 version: "~2.6.0"

--- a/www/base/src/app/builders/build/build.controller.coffee
+++ b/www/base/src/app/builders/build/build.controller.coffee
@@ -1,5 +1,7 @@
 class Build extends Controller
-    constructor: ($rootScope, $scope, $location, buildbotService, $stateParams, recentStorage, glBreadcrumbService, $state) ->
+    constructor: ($rootScope, $scope, $location, buildbotService, $stateParams, recentStorage, glBreadcrumbService,
+                $state) ->
+
         builderid = _.parseInt($stateParams.builder)
         buildnumber = _.parseInt($stateParams.build)
 

--- a/www/base/src/app/builders/build/build.tpl.jade
+++ b/www/base/src/app/builders/build/build.tpl.jade
@@ -8,25 +8,11 @@
         a(ng-if="!last_build", ui-sref="build({build:build.number + 1})") Next &rarr;
         span(ng-if="last_build") Next &rarr;
   .row
-    ul.breadcrumb
-      li.pull-right
-        button.btn.btn-default(ng-show="build.complete") Rebuild
-      li.pull-right
-        button.btn.btn-default(ng-show="build.complete") Promote
-  .row
     .col-sm-5
       buildsummary(ng-if="build", buildid="build.buildid")
     .col-sm-7
       tabset
-          tab(heading="properties")
+          tab(heading="buildrequest properties")
               rawdata(data="properties")
           tab(heading="{{buildslave.name}}")
               rawdata(data="buildslave")
-          tab(heading="builder")
-              rawdata(data="builder")
-          tab(heading="build")
-              rawdata(data="build")
-          tab(heading="buildrequest")
-              rawdata(data="buildrequest")
-          tab(heading="buildset")
-              rawdata(data="buildset")

--- a/www/base/src/app/builders/builder/builder.controller.coffee
+++ b/www/base/src/app/builders/builder/builder.controller.coffee
@@ -1,10 +1,11 @@
 class Builder extends Controller
-    constructor: ($rootScope, $scope, buildbotService, $stateParams, resultsService, recentStorage, glBreadcrumbService) ->
+    constructor: ($rootScope, $scope, buildbotService, $stateParams, resultsService, recentStorage,
+        glBreadcrumbService, $state, glTopbarContextualActionsService) ->
         # make resultsService utilities available in the template
         _.mixin($scope, resultsService)
         builder = buildbotService.one('builders', $stateParams.builder)
-        builder.bind($scope).then (builder)->
-            glBreadcrumbService.setBreadcrumb [
+        builder.bind($scope).then (builder) ->
+            breadcrumb = [
                     caption: "Builders"
                     sref: "builders"
                 ,
@@ -14,6 +15,23 @@ class Builder extends Controller
             recentStorage.addBuilder
                 link: "#/builders/#{$scope.builder.builderid}"
                 caption: $scope.builder.name
-        builder.all('forceschedulers').bind($scope)
+
+            # reinstall breadcrumb when coming back from forcesched
+            $scope.$on '$stateChangeSuccess', ->
+                glBreadcrumbService.setBreadcrumb(breadcrumb)
+            glBreadcrumbService.setBreadcrumb(breadcrumb)
+
+        builder.all('forceschedulers').bind($scope).then (forceschedulers) ->
+            actions = []
+            _.forEach forceschedulers, (sch) ->
+                actions.push
+                    caption: sch.name
+                    action: -> $state.go("builder.forcebuilder", scheduler:sch.name)
+
+            # reinstall contextual actions when coming back from forcesched
+            glTopbarContextualActionsService.setContextualActions(actions)
+            $scope.$on '$stateChangeSuccess', ->
+                glTopbarContextualActionsService.setContextualActions(actions)
+
         builder.some('builds', {limit:20, order:"-number"}).bind($scope)
         builder.some('buildrequests', {claimed:0}).bind($scope)

--- a/www/base/src/app/builders/builder/builder.tpl.jade
+++ b/www/base/src/app/builders/builder/builder.tpl.jade
@@ -1,8 +1,4 @@
 .container
-  .row
-    ul.breadcrumb
-      li.pull-right(ng-repeat='sch in forceschedulers')
-        a.btn.btn-default(href="#/builders/{{builder.id}}/force/{{sch.name}}", ng-init="sch.toggle=false") {{sch.name}}
   .row(ng-show='builder.description')
     h4 Description:
     | {{ builder.description }}

--- a/www/base/src/app/index.jade
+++ b/www/base/src/app/index.jade
@@ -2,6 +2,6 @@ extends layout
 block content
     gl-page-with-sidebar
         gl-topbar
-            gl-notification
+            gl-topbar-contextual-actions
             loginbar
         ui-view


### PR DESCRIPTION
- remove previous unwired contextual actions (promote/rebuild)
- remove useless rawdata in build page

partially solve #2995:
Get rid of all the broken / unwired elements from the web UI.
