### PR TITLE
recover from the SVN operation being interrupted

### DIFF
--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -214,7 +214,7 @@ class SVN(Source):
         d.addCallback(self.finished)
         return d
 
-    def _dovccmd(self, command, collectStdout=False, abandonOnFailure=True):
+    def _dovccmd(self, command, collectStdout=False, collectStderr=False, abandonOnFailure=True):
         assert command, "No command specified"
         command.extend(['--non-interactive', '--no-auth-cache'])
         if self.username:
@@ -230,7 +230,8 @@ class SVN(Source):
                                            env=self.env,
                                            logEnviron=self.logEnviron,
                                            timeout=self.timeout,
-                                           collectStdout=collectStdout)
+                                           collectStdout=collectStdout,
+                                           collectStderr=collectStderr)
         cmd.useLog(self.stdio_log, False)
         d = self.runCommand(cmd)
 
@@ -238,8 +239,12 @@ class SVN(Source):
             if cmd.didFail() and abandonOnFailure:
                 log.msg("Source step failed while running command %s" % cmd)
                 raise buildstep.BuildStepFailed()
-            if collectStdout:
+            if collectStdout and collectStderr:
+                return (cmd.stdout, cmd.stderr)
+            elif collectStdout:
                 return cmd.stdout
+            elif collectStderr:
+                return cmd.stderr
             else:
                 return cmd.rc
         d.addCallback(lambda _: evaluateCommand(cmd))
@@ -262,7 +267,12 @@ class SVN(Source):
             return
 
         # then run 'svn info --xml' to check that the URL matches our repourl
-        stdout = yield self._dovccmd(['info', '--xml'], collectStdout=True)
+        stdout, stderr = yield self._dovccmd(['info', '--xml'], collectStdout=True, collectStderr=True, abandonOnFailure=False)
+
+        # svn: E155037: Previous operation has not finished; run 'cleanup' if it was interrupted
+        if 'E155037:' in stderr:
+            defer.returnValue(False)
+            return
 
         try:
             stdout_xml = xml.dom.minidom.parseString(stdout)

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -34,6 +34,9 @@ Fixes
 * Fixed bug which made it impossible to specify the project when using the
   BitBucket dialect.
 
+* Fixed SVN master-side source step: if a SVN operation fails, the repository end up in a situation when a manual intervention is required.
+  Now if SVN reports such a situation during initial check, the checkout will be clobbered.
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
- in case 'svn info' returns 'E155037' (run 'cleanup' if it was interrupted), clobber the checkout

Fixes ticket:3053
