### PR TITLE
(port from eight) recover from the SVN operation being interrupted

### DIFF
--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -164,6 +164,9 @@ Fixes
 
 * The :bb:step:`PyLint` step has been updated to understand newer output.
 
+* Fixed SVN master-side source step: if a SVN operation fails, the repository end up in a situation when a manual intervention is required.
+  Now if SVN reports such a situation during initial check, the checkout will be clobbered.
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
- in case 'svn info' returns 'E155037' (run 'cleanup' if it was
  interrupted), clobber the checkout

See ticket:3053

Conflicts:
    master/buildbot/steps/source/svn.py
    master/docs/relnotes/index.rst
