### PR TITLE
httpStatusPush error without maxDiskItems parameter

### DIFF
--- a/master/buildbot/status/status_push.py
+++ b/master/buildbot/status/status_push.py
@@ -395,7 +395,7 @@ class HttpStatusPush(StatusPush):
         self.chunkSize = chunkSize
         self.lastPushWasSuccessful = True
         self.maxHttpRequestSize = maxHttpRequestSize
-        if maxDiskItems and maxDiskItems != 0:
+        if maxDiskItems:
             # The queue directory is determined by the server url.
             path = ('events_' +
                     urlparse.urlparse(self.serverUrl)[1].split(':')[0])


### PR DESCRIPTION
I ran into the following when migrating a config to buildbot latest:

``` python
sp = buildbot.status.status_push.HttpStatusPush(serverUrl="http://webserver/pushservice/")
...
<[Errno 13] Permission denied:>
```

Looking through the code, I see that at some point the maxDiskItems parameter was added and is defaulted to None

``` python
class HttpStatusPush(StatusPush):
    """Event streamer to a HTTP server."""
    def __init__(self, serverUrl, debug=None, maxMemoryItems=None,
                        maxDiskItems=None, chunkSize=200, maxHttpRequestSize=2 ** 20,
                        extra_post_params=None, **kwargs):
    """
    @serverUrl: Base URL to be used to push events notifications.
    @maxMemoryItems: Maximum number of items to keep queued in memory.
    @maxDiskItems: Maximum number of items to buffer to disk, if 0, doesn't
        use disk at all.
    @debug: Save the json with nice formatting.
    @chunkSize: maximum number of items to send in each at each HTTP POST.
    @maxHttpRequestSize: limits the size of encoded data for AE, the default
        is 1MB.
"""
```

Within the code, there is an if statement that will pass if maxDiskItems is set to a None value.  This code is at line 398, near the top of the HttpStatusPush `__init__` function:

``` python
if maxDiskItems != 0:
    # The queue directory is determined by the server url.
    path = ('events_' +
    urlparse.urlparse(self.serverUrl)[1].split(':')[0])
    queue = PersistentQueue(
    primaryQueue=MemoryQueue(maxItems=maxMemoryItems),
    secondaryQueue=DiskQueue(path, maxItems=maxDiskItems))
```

I simply requalified the if statement in order to avoid forcing end users to provide a maxDiskItems parameter.

``` python
 if maxDiskItems and maxDiskItems != 0:
```

There are a few ways to handle it.  (changing the parameter default to 0, chaning the qualification to `if maxDiskItems and maxDiskItems > 0`, etc.)  I picked the one that I felt was least intrusive and went with the original intent of the code.

The workaround to this problem for the time being is to simply provide a `0` parameter for maxDiskItems:

`````` python
```python
sp = buildbot.status.status_push.HttpStatusPush(serverUrl="http://webserver/pushservice/",
                                                                              maxDiskItems=0)
<no errors>
``````
