### PR TITLE
Enforce Property name and source as unicode or ascii string

### DIFF
--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -100,8 +100,7 @@ class Properties(util.ComparableMixin):
     def asDict(self):
         """Return the properties as a simple key:value dictionary,
         properly unicoded"""
-        return dict((util.ascii2unicode(k), (v, util.ascii2unicode(s)))
-                    for k, (v, s) in self.properties.iteritems())
+        return dict((k, (v, s)) for k, (v, s) in self.properties.iteritems())
 
     def __repr__(self):
         return ('Properties(**' +
@@ -136,6 +135,7 @@ class Properties(util.ComparableMixin):
     has_key = hasProperty
 
     def setProperty(self, name, value, source, runtime=False):
+        name = util.ascii2unicode(name)
         try:
             json.dumps(value)
         except TypeError:
@@ -143,6 +143,7 @@ class Properties(util.ComparableMixin):
                 "Non jsonable properties are not explicitly supported and" +
                 "will be explicitly disallowed in a future version.",
                 DeprecationWarning, stacklevel=2)
+        source = util.ascii2unicode(source)
 
         self.properties[name] = (value, source)
         if runtime:

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -257,6 +257,8 @@ Changes and Removals
 
 * The undocumented ``path`` parameter of the :bb:step:`MasterShellCommand` buildstep has been renamed ``workdir`` for better consistency with the other steps.
 
+* The name and source of a Property have to be unicode or ascii string.
+
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
See discussion there: https://github.com/buildbot/buildbot/pull/1380/files#r20767214
