### PR TITLE
Remove the todo: document nine

### DIFF
--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -59,9 +59,6 @@ Minor Python Packages
 Features
 ~~~~~~~~
 
-..
-    TODO: talk about big new Nine features
-
 * Both the P4 source step and P4 change source support ticket-based authentication.
 * Buildbot now supports plugins.
   They allow Buildbot to be extended by using components distributed independently from the main code.


### PR DESCRIPTION
Not that nine is documented (yet), but that todo gives the wrong impression that someone will document the master's state once for all. That is wrong as it should be documented as it happens.

See TRAC-3067
