### PR TITLE
rename reconfigService() to reconfigServiceWithBuildbotConfig

### DIFF
--- a/master/buildbot/buildslave/base.py
+++ b/master/buildbot/buildslave/base.py
@@ -210,7 +210,7 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         yield service.AsyncMultiService.startService(self)
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         # Given a new BuildSlave, configure this one identically.  Because
         # BuildSlave objects are remotely referenced, we can't replace them
         # without disconnecting the slave, yet there's no reason to do that.
@@ -250,8 +250,8 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         # which is why the reconfig_priority is set low in this class.
         yield self.updateSlave()
 
-        yield service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                 new_config)
+        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                   new_config)
 
     @defer.inlineCallbacks
     def stopService(self):

--- a/master/buildbot/buildslave/manager.py
+++ b/master/buildbot/buildslave/manager.py
@@ -85,13 +85,13 @@ class BuildslaveManager(service.ReconfigurableServiceMixin,
         self.slaves = {}  # maps slavename to BuildSlave
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
 
         yield self.reconfigServiceSlaves(new_config)
 
         # reconfig any newly-added change sources, as well as existing
-        yield service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                 new_config)
+        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                           new_config)
 
     @defer.inlineCallbacks
     def reconfigServiceSlaves(self, new_config):
@@ -186,8 +186,7 @@ class BuildslaveManager(service.ReconfigurableServiceMixin,
             log.msg("Got slaveinfo from '%s'" % buildslaveName)
         except Exception, e:
             log.msg("Failed to communicate with slave '%s'\n"
-                    "%s" % (buildslaveName, e)
-                    )
+                    "%s" % (buildslaveName, e))
             defer.returnValue(False)
 
         conn.info = info

--- a/master/buildbot/changes/manager.py
+++ b/master/buildbot/changes/manager.py
@@ -43,8 +43,8 @@ class ChangeManager(service.ReconfigurableServiceMixin, service.AsyncMultiServic
         self.master = master
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
-        timer = metrics.Timer("ChangeManager.reconfigService")
+    def reconfigServiceWithBuildbotConfig(self, new_config):
+        timer = metrics.Timer("ChangeManager.reconfigServiceWithBuildbotConfig")
         timer.start()
 
         removed, added = util.diffSets(
@@ -69,7 +69,7 @@ class ChangeManager(service.ReconfigurableServiceMixin, service.AsyncMultiServic
         metrics.MetricCountEvent.log("num_sources", num_sources, absolute=True)
 
         # reconfig any newly-added change sources, as well as existing
-        yield service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                 new_config)
+        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                   new_config)
 
         timer.stop()

--- a/master/buildbot/changes/pb.py
+++ b/master/buildbot/changes/pb.py
@@ -133,7 +133,7 @@ class PBChangeSource(service.ReconfigurableServiceMixin, base.ChangeSource):
         return port
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         port = self._calculatePort(new_config)
         if not port:
             config.error("No port specified for PBChangeSource, and no "
@@ -144,7 +144,7 @@ class PBChangeSource(service.ReconfigurableServiceMixin, base.ChangeSource):
             yield self._unregister()
             self._register(port)
 
-        yield service.ReconfigurableServiceMixin.reconfigService(
+        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(
             self, new_config)
 
     def activate(self):

--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -124,12 +124,12 @@ class DBConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
 
         return d
 
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         # double-check -- the master ensures this in config checks
         assert self.configured_url == new_config.db['db_url']
 
-        return service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                  new_config)
+        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                    new_config)
 
     def _doCleanup(self):
         """

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -260,7 +260,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService)
 
             # give all services a chance to load the new configuration, rather
             # than the base configuration
-            yield self.reconfigService(self.config)
+            yield self.reconfigServiceWithBuildbotConfig(self.config)
 
             # mark the master as active now that mq is running
             yield self.data.updates.masterActive(
@@ -356,7 +356,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService)
                 if name not in old_config.services:
                     yield new_config.services[name].setServiceParent(self)
 
-            yield self.reconfigService(new_config)
+            yield self.reconfigServiceWithBuildbotConfig(new_config)
 
         except config.ConfigErrors, e:
             for msg in e.errors:
@@ -376,7 +376,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         else:
             log.msg("configuration update complete")
 
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         if self.configured_db_url is None:
             self.configured_db_url = new_config.db['db_url']
         elif (self.configured_db_url != new_config.db['db_url']):
@@ -389,8 +389,8 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService)
                 "Cannot change c['mq']['type'] after the master has started",
             ])
 
-        return service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                  new_config)
+        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                    new_config)
 
     # informational methods
     def allSchedulers(self):

--- a/master/buildbot/mq/connector.py
+++ b/master/buildbot/mq/connector.py
@@ -48,18 +48,18 @@ class MQConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         self.impl.setServiceParent(self)
 
         # configure it (early)
-        self.impl.reconfigService(self.master.config)
+        self.impl.reconfigServiceWithBuildbotConfig(self.master.config)
 
         # copy the methods onto this object for ease of access
         self.produce = self.impl.produce
         self.startConsuming = self.impl.startConsuming
 
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         # double-check -- the master ensures this in config checks
         assert self.impl_type == new_config.mq['type']
 
-        return service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                  new_config)
+        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                    new_config)
 
     def produce(self, routing_key, data):
         # will be patched after configuration to point to the running

--- a/master/buildbot/mq/simple.py
+++ b/master/buildbot/mq/simple.py
@@ -30,10 +30,10 @@ class SimpleMQ(service.ReconfigurableServiceMixin, base.MQBase):
         self.persistent_qrefs = {}
         self.debug = False
 
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         self.debug = new_config.mq.get('debug', False)
-        return service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                  new_config)
+        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                    new_config)
 
     def produce(self, routingKey, data):
         if self.debug:

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -155,16 +155,16 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         yield service.AsyncMultiService.startService(self)
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
-        timer = metrics.Timer("BotMaster.reconfigService")
+    def reconfigServiceWithBuildbotConfig(self, new_config):
+        timer = metrics.Timer("BotMaster.reconfigServiceWithBuildbotConfig")
         timer.start()
 
         # reconfigure builders
         yield self.reconfigServiceBuilders(new_config)
 
         # call up
-        yield service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                 new_config)
+        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                   new_config)
 
         # try to start a build for every builder; this is necessary at master
         # startup, and a good idea in any other case

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -90,7 +90,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
             self.updateStatusService.setServiceParent(self)
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         # find this builder in the config
         for builder_config in new_config.builders:
             if builder_config.name == self.name:

--- a/master/buildbot/process/cache.py
+++ b/master/buildbot/process/cache.py
@@ -58,14 +58,14 @@ class CacheManager(service.ReconfigurableServiceMixin, service.AsyncService):
             c = self._caches[cache_name] = lru.AsyncLRUCache(miss_fn, max_size)
             return c
 
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         self.config = new_config.caches
         for name, cache in self._caches.iteritems():
             cache.set_max_size(new_config.caches.get(name,
                                                      self.DEFAULT_CACHE_SIZE))
 
-        return service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                  new_config)
+        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                    new_config)
 
     def get_metrics(self):
         return dict([

--- a/master/buildbot/process/debug.py
+++ b/master/buildbot/process/debug.py
@@ -30,7 +30,7 @@ class DebugServices(service.ReconfigurableServiceMixin, service.AsyncMultiServic
         self.manhole = None
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         if new_config.manhole != self.manhole:
             if self.manhole:
                 yield self.manhole.disownServiceParent()
@@ -43,8 +43,8 @@ class DebugServices(service.ReconfigurableServiceMixin, service.AsyncMultiServic
                 yield self.manhole.setServiceParent(self)
 
         # chain up
-        yield service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                 new_config)
+        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                   new_config)
 
     @defer.inlineCallbacks
     def stopService(self):

--- a/master/buildbot/process/metrics.py
+++ b/master/buildbot/process/metrics.py
@@ -395,7 +395,7 @@ class MetricLogObserver(util_service.ReconfigurableServiceMixin,
         self.getHandler(MetricCountEvent).addWatcher(
             AttachedSlavesWatcher(self))
 
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         # first, enable or disable
         if new_config.metrics is None:
             self.disable()
@@ -428,8 +428,8 @@ class MetricLogObserver(util_service.ReconfigurableServiceMixin,
                     self.periodic_task.start(periodic_interval)
 
         # upcall
-        return util_service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                       new_config)
+        return util_service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                         new_config)
 
     def stopService(self):
         self.disable()

--- a/master/buildbot/process/users/manager.py
+++ b/master/buildbot/process/users/manager.py
@@ -28,7 +28,7 @@ class UserManagerManager(util_service.ReconfigurableServiceMixin,
         self.master = master
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         # this is easy - kick out all of the old managers, and add the
         # new ones.
 
@@ -42,5 +42,5 @@ class UserManagerManager(util_service.ReconfigurableServiceMixin,
             yield mgr.setServiceParent(self)
 
         # reconfig any newly-added change sources, as well as existing
-        yield util_service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                      new_config)
+        yield util_service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                        new_config)

--- a/master/buildbot/schedulers/manager.py
+++ b/master/buildbot/schedulers/manager.py
@@ -31,8 +31,8 @@ class SchedulerManager(util_service.ReconfigurableServiceMixin,
         self.master = master
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
-        timer = metrics.Timer("SchedulerManager.reconfigService")
+    def reconfigServiceWithBuildbotConfig(self, new_config):
+        timer = metrics.Timer("SchedulerManager.reconfigServiceWithBuildbotConfig")
         timer.start()
 
         old_by_name = dict((sch.name, sch) for sch in self)
@@ -56,7 +56,7 @@ class SchedulerManager(util_service.ReconfigurableServiceMixin,
                 added_names.add(n)
 
             # compare using ComparableMixin if they don't support reconfig
-            elif not hasattr(old, 'reconfigService'):
+            elif not hasattr(old, 'reconfigServiceWithBuildbotConfig'):
                 if old != new:
                     removed_names.add(n)
                     added_names.add(n)
@@ -93,7 +93,7 @@ class SchedulerManager(util_service.ReconfigurableServiceMixin,
                                      absolute=True)
 
         # reconfig any newly-added schedulers, as well as existing
-        yield util_service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                      new_config)
+        yield util_service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                        new_config)
 
         timer.stop()

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -72,7 +72,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         yield service.AsyncMultiService.startService(self)
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         # remove the old listeners, then add the new
         for sr in list(self):
             yield defer.maybeDeferred(lambda:
@@ -92,8 +92,8 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             yield sr.setServiceParent(self)
 
         # reconfig any newly-added change sources, as well as existing
-        yield service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                 new_config)
+        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                   new_config)
 
     def stopService(self):
         if self._buildset_complete_consumer:

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -169,7 +169,7 @@ class RunSteps(unittest.TestCase):
         new_config.builders.append(
             config.BuilderConfig(name='test', slavename='testsl',
                                  factory=self.factory))
-        yield self.builder.reconfigService(new_config)
+        yield self.builder.reconfigServiceWithBuildbotConfig(new_config)
 
         self.slave = BuildSlave('bsl', 'pass')
         self.slave.sendBuilderList = lambda: defer.succeed(None)

--- a/master/buildbot/test/integration/test_customservices.py
+++ b/master/buildbot/test/integration/test_customservices.py
@@ -105,7 +105,7 @@ def masterConfig():
     class MyService(BuildbotService):
         name = "myService"
 
-        def reconfigServiceWithConstructorArgs(self, num_reconfig):
+        def reconfigService(self, num_reconfig):
             self.num_reconfig = num_reconfig
             return defer.succeed(None)
 

--- a/master/buildbot/test/integration/test_slave_comm.py
+++ b/master/buildbot/test/integration/test_slave_comm.py
@@ -205,8 +205,8 @@ class TestSlaveComm(unittest.TestCase):
         new_config.builders = [config.BuilderConfig(name='bldr',
                                                     slavename='testslave', factory=factory.BuildFactory())]
 
-        yield self.botmaster.reconfigService(new_config)
-        yield self.buildslaves.reconfigService(new_config)
+        yield self.botmaster.reconfigServiceWithBuildbotConfig(new_config)
+        yield self.buildslaves.reconfigServiceWithBuildbotConfig(new_config)
 
         # as part of the reconfig, the slave registered with the pbmanager, so
         # get the port it was assigned

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -81,14 +81,14 @@ class Www(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase):
             logfileName='http.log')
         master.www = wwwservice.WWWService(master)
         yield master.www.startService()
-        yield master.www.reconfigService(master.config)
+        yield master.www.reconfigServiceWithBuildbotConfig(master.config)
 
         # now that we have a port, construct the real URL and insert it into
         # the config.  The second reconfig isn't really required, but doesn't
         # hurt.
         self.url = 'http://127.0.0.1:%d/' % master.www.getPortnum()
         master.config.www['url'] = self.url
-        yield master.www.reconfigService(master.config)
+        yield master.www.reconfigServiceWithBuildbotConfig(master.config)
 
         self.master = master
 

--- a/master/buildbot/test/unit/test_buildslave_base.py
+++ b/master/buildbot/test/unit/test_buildslave_base.py
@@ -185,7 +185,7 @@ class TestAbstractBuildSlave(unittest.TestCase):
                                              notify_on_missing=['a@b.com', 13]))
 
     @defer.inlineCallbacks
-    def do_test_reconfigService(self, old, new, existingRegistration=True):
+    def do_test_reconfigServiceWithBuildbotConfig(self, old, new, existingRegistration=True):
         old.master = self.master
         if existingRegistration:
             old.registration = bslavemanager.FakeBuildslaveRegistration(old)
@@ -195,7 +195,7 @@ class TestAbstractBuildSlave(unittest.TestCase):
         new_config = mock.Mock()
         new_config.slaves = [new]
 
-        yield old.reconfigService(new_config)
+        yield old.reconfigServiceWithBuildbotConfig(new_config)
 
     @defer.inlineCallbacks
     def test_reconfigService_attrs(self):
@@ -212,7 +212,7 @@ class TestAbstractBuildSlave(unittest.TestCase):
 
         old.updateSlave = mock.Mock(side_effect=lambda: defer.succeed(None))
 
-        yield self.do_test_reconfigService(old, new)
+        yield self.do_test_reconfigServiceWithBuildbotConfig(old, new)
 
         self.assertEqual(old.max_builds, 3)
         self.assertEqual(old.notify_on_missing, ['her@me.com'])
@@ -225,14 +225,14 @@ class TestAbstractBuildSlave(unittest.TestCase):
     def test_reconfigService_has_properties(self):
         old = self.createBuildslave(name="bot", password="pass")
 
-        yield self.do_test_reconfigService(old, old)
+        yield self.do_test_reconfigServiceWithBuildbotConfig(old, old)
         self.assertTrue(old.properties.getProperty('slavename'), 'bot')
 
     @defer.inlineCallbacks
     def test_reconfigService_initial_registration(self):
         old = self.createBuildslave('bot', 'pass')
-        yield self.do_test_reconfigService(old, old,
-                                           existingRegistration=False)
+        yield self.do_test_reconfigServiceWithBuildbotConfig(old, old,
+                                                             existingRegistration=False)
         self.assertIn('bot', self.master.buildslaves.registrations)
         self.assertEqual(old.registration.updates, ['bot'])
 
@@ -245,7 +245,7 @@ class TestAbstractBuildSlave(unittest.TestCase):
         config.protocols = {'pb': {'port': 'tcp:1234'}}
         config.slaves = [slave]
 
-        yield slave.reconfigService(config)
+        yield slave.reconfigServiceWithBuildbotConfig(config)
 
         reg = slave.registration
 

--- a/master/buildbot/test/unit/test_buildslave_manager.py
+++ b/master/buildbot/test/unit/test_buildslave_manager.py
@@ -34,7 +34,7 @@ class FakeBuildSlave(service.ReconfigurableServiceMixin, service.AsyncService):
     def __init__(self, slavename):
         self.slavename = slavename
 
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         self.reconfig_count += 1
         return defer.succeed(None)
 
@@ -60,12 +60,12 @@ class TestBuildSlaveManager(unittest.TestCase):
     def tearDown(self):
         return self.buildslaves.stopService()
 
-    def test_reconfigService(self):
+    def test_reconfigServiceWithBuildbotConfig(self):
         self.patch(self.buildslaves, 'reconfigServiceSlaves',
                    mock.Mock(side_effect=lambda c: defer.succeed(None)))
 
         new_config = mock.Mock()
-        d = self.buildslaves.reconfigService(new_config)
+        d = self.buildslaves.reconfigServiceWithBuildbotConfig(new_config)
 
         @d.addCallback
         def check(_):

--- a/master/buildbot/test/unit/test_changes_manager.py
+++ b/master/buildbot/test/unit/test_changes_manager.py
@@ -42,7 +42,7 @@ class TestChangeManager(unittest.TestCase):
         src1.setServiceParent(self.cm)
         self.new_config.change_sources = [src1, src2]
 
-        d = self.cm.reconfigService(self.new_config)
+        d = self.cm.reconfigServiceWithBuildbotConfig(self.new_config)
 
         @d.addCallback
         def check(_):
@@ -55,7 +55,7 @@ class TestChangeManager(unittest.TestCase):
         src1.setServiceParent(self.cm)
         self.new_config.change_sources = []
 
-        d = self.cm.reconfigService(self.new_config)
+        d = self.cm.reconfigServiceWithBuildbotConfig(self.new_config)
 
         @d.addCallback
         def check(_):

--- a/master/buildbot/test/unit/test_changes_pb.py
+++ b/master/buildbot/test/unit/test_changes_pb.py
@@ -101,13 +101,13 @@ class TestPBChangeSource(
         if exp_ConfigErrors:
             # if it's not registered, it should raise a ConfigError.
             try:
-                yield self.changesource.reconfigService(cfg)
+                yield self.changesource.reconfigServiceWithBuildbotConfig(cfg)
             except config.ConfigErrors:
                 pass
             else:
                 self.fail("Expected ConfigErrors")
         else:
-            yield self.changesource.reconfigService(cfg)
+            yield self.changesource.reconfigServiceWithBuildbotConfig(cfg)
 
         if exp_registration:
             self.assertRegistered(*exp_registration)
@@ -153,7 +153,7 @@ class TestPBChangeSource(
         self.attachChangeSource(pb.PBChangeSource(port='9876'))
 
         self.startChangeSource()
-        yield self.changesource.reconfigService(config)
+        yield self.changesource.reconfigServiceWithBuildbotConfig(config)
 
         self.assertRegistered('9876', 'change', 'changepw')
 
@@ -168,13 +168,13 @@ class TestPBChangeSource(
         self.attachChangeSource(pb.PBChangeSource())
 
         self.startChangeSource()
-        yield self.changesource.reconfigService(config)
+        yield self.changesource.reconfigServiceWithBuildbotConfig(config)
 
         self.assertRegistered('9876', 'change', 'changepw')
 
         config.protocols = {'pb': {'port': '1234'}}
 
-        yield self.changesource.reconfigService(config)
+        yield self.changesource.reconfigServiceWithBuildbotConfig(config)
 
         self.assertUnregistered('9876', 'change', 'changepw')
         self.assertRegistered('1234', 'change', 'changepw')
@@ -192,13 +192,13 @@ class TestPBChangeSource(
         self.setChangeSourceToMaster(self.OTHER_MASTER_ID)
 
         self.startChangeSource()
-        yield self.changesource.reconfigService(config)
+        yield self.changesource.reconfigServiceWithBuildbotConfig(config)
 
         self.assertNotRegistered()
 
         config.slavePortnum = '1234'
 
-        yield self.changesource.reconfigService(config)
+        yield self.changesource.reconfigServiceWithBuildbotConfig(config)
 
         self.assertNotRegistered()
 

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -859,7 +859,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
 
         class MyService(service.BuildbotService):
 
-            def reconfigServiceWithConstructorArgs(foo=None):
+            def reconfigService(foo=None):
                 self.foo = foo
         myService = MyService(foo="bar", name="foo")
 
@@ -1297,10 +1297,10 @@ class FakeService(service.ReconfigurableServiceMixin,
     succeed = True
     call_index = 1
 
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         self.called = FakeService.call_index
         FakeService.call_index += 1
-        d = service.ReconfigurableServiceMixin.reconfigService(self, new_config)
+        d = service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self, new_config)
         if not self.succeed:
             @d.addCallback
             def fail(_):
@@ -1311,9 +1311,9 @@ class FakeService(service.ReconfigurableServiceMixin,
 class FakeMultiService(service.ReconfigurableServiceMixin,
                        service.AsyncMultiService):
 
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         self.called = True
-        d = service.ReconfigurableServiceMixin.reconfigService(self, new_config)
+        d = service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self, new_config)
         return d
 
 
@@ -1321,7 +1321,7 @@ class ReconfigurableServiceMixin(unittest.TestCase):
 
     def test_service(self):
         svc = FakeService()
-        d = svc.reconfigService(mock.Mock())
+        d = svc.reconfigServiceWithBuildbotConfig(mock.Mock())
 
         @d.addCallback
         def check(_):
@@ -1333,7 +1333,7 @@ class ReconfigurableServiceMixin(unittest.TestCase):
         svc = FakeService()
         svc.succeed = False
         try:
-            yield svc.reconfigService(mock.Mock())
+            yield svc.reconfigServiceWithBuildbotConfig(mock.Mock())
         except ValueError:
             pass
         else:
@@ -1347,7 +1347,7 @@ class ReconfigurableServiceMixin(unittest.TestCase):
         ch2.setServiceParent(svc)
         ch3 = FakeService()
         ch3.setServiceParent(ch2)
-        d = svc.reconfigService(mock.Mock())
+        d = svc.reconfigServiceWithBuildbotConfig(mock.Mock())
 
         @d.addCallback
         def check(_):
@@ -1369,7 +1369,7 @@ class ReconfigurableServiceMixin(unittest.TestCase):
             svc.setServiceParent(parent)
             services.append(svc)
 
-        d = parent.reconfigService(mock.Mock())
+        d = parent.reconfigServiceWithBuildbotConfig(mock.Mock())
 
         @d.addCallback
         def check(_):
@@ -1386,7 +1386,7 @@ class ReconfigurableServiceMixin(unittest.TestCase):
         ch1.setServiceParent(svc)
         ch1.succeed = False
         try:
-            yield svc.reconfigService(mock.Mock())
+            yield svc.reconfigServiceWithBuildbotConfig(mock.Mock())
         except ValueError:
             pass
         else:

--- a/master/buildbot/test/unit/test_db_connector.py
+++ b/master/buildbot/test/unit/test_db_connector.py
@@ -55,7 +55,7 @@ class DBConnector(db.RealDatabaseMixin, unittest.TestCase):
         self.master.config.db['db_url'] = self.db_url
         yield self.db.setup(check_version=check_version)
         self.db.startService()
-        yield self.db.reconfigService(self.master.config)
+        yield self.db.reconfigServiceWithBuildbotConfig(self.master.config)
 
     # tests
     def test_doCleanup_service(self):

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -223,7 +223,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
 
     def test_reconfig(self):
         reactor = self.make_reactor()
-        self.master.reconfigService = mock.Mock(
+        self.master.reconfigServiceWithBuildbotConfig = mock.Mock(
             side_effect=lambda n: defer.succeed(None))
 
         d = self.master.startService(_reactor=reactor)
@@ -232,7 +232,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
 
         @d.addCallback
         def check(_):
-            self.master.reconfigService.assert_called_with(mock.ANY)
+            self.master.reconfigServiceWithBuildbotConfig.assert_called_with(mock.ANY)
         return d
 
     @defer.inlineCallbacks
@@ -259,10 +259,10 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
     def test_reconfigService_db_url_changed(self):
         old = self.master.config = config.MasterConfig()
         old.db['db_url'] = 'aaaa'
-        yield self.master.reconfigService(old)
+        yield self.master.reconfigServiceWithBuildbotConfig(old)
 
         new = config.MasterConfig()
         new.db['db_url'] = 'bbbb'
 
         self.assertRaises(config.ConfigErrors, lambda:
-                          self.master.reconfigService(new))
+                          self.master.reconfigServiceWithBuildbotConfig(new))

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -26,7 +26,7 @@ class FakeMQ(service.ReconfigurableServiceMixin, base.MQBase):
 
     new_config = "not_called"
 
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         self.new_config = new_config
         return defer.succeed(None)
 
@@ -64,13 +64,13 @@ class MQConnector(unittest.TestCase):
         self.assertEqual(self.conn.impl.startConsuming,
                          self.conn.startConsuming)
 
-    def test_reconfigService(self):
+    def test_reconfigServiceWithBuildbotConfig(self):
         self.patchFakeMQ()
         self.mqconfig['type'] = 'fake'
         self.conn.setup()
         new_config = mock.Mock()
         new_config.mq = dict(type='fake')
-        d = self.conn.reconfigService(new_config)
+        d = self.conn.reconfigServiceWithBuildbotConfig(new_config)
 
         @d.addCallback
         def check(_):
@@ -85,7 +85,7 @@ class MQConnector(unittest.TestCase):
         new_config = mock.Mock()
         new_config.mq = dict(type='other')
         try:
-            yield self.conn.reconfigService(new_config)
+            yield self.conn.reconfigServiceWithBuildbotConfig(new_config)
         except AssertionError:
             pass  # expected
         else:

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -121,7 +121,7 @@ class TestBotMaster(unittest.TestCase):
     def tearDown(self):
         return self.botmaster.stopService()
 
-    def test_reconfigService(self):
+    def test_reconfigServiceWithBuildbotConfig(self):
         # check that reconfigServiceBuilders is called.
         self.patch(self.botmaster, 'reconfigServiceBuilders',
                    mock.Mock(side_effect=lambda c: defer.succeed(None)))
@@ -129,7 +129,7 @@ class TestBotMaster(unittest.TestCase):
                    mock.Mock())
 
         new_config = mock.Mock()
-        d = self.botmaster.reconfigService(new_config)
+        d = self.botmaster.reconfigServiceWithBuildbotConfig(new_config)
 
         @d.addCallback
         def check(_):

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -66,7 +66,7 @@ class BuilderMixin(object):
         mastercfg = config.MasterConfig()
         mastercfg.builders = [self.builder_config]
         if not noReconfig:
-            defer.returnValue((yield self.bldr.reconfigService(mastercfg)))
+            defer.returnValue((yield self.bldr.reconfigServiceWithBuildbotConfig(mastercfg)))
 
 
 class TestBuilder(BuilderMixin, unittest.TestCase):
@@ -417,7 +417,7 @@ class TestReconfig(BuilderMixin, unittest.TestCase):
 
         mastercfg = config.MasterConfig()
         mastercfg.builders = [new_builder_config]
-        yield self.bldr.reconfigService(mastercfg)
+        yield self.bldr.reconfigServiceWithBuildbotConfig(mastercfg)
         self.assertEqual(
             dict(description=self.bldr.builder_status.getDescription(),
                  tags=self.bldr.builder_status.getTags()),

--- a/master/buildbot/test/unit/test_process_cache.py
+++ b/master/buildbot/test/unit/test_process_cache.py
@@ -36,10 +36,10 @@ class CacheManager(unittest.TestCase):
         self.assertIdentical(foo_cache, foo_cache2)
         self.assertNotIdentical(foo_cache, bar_cache)
 
-    def test_reconfigService(self):
+    def test_reconfigServiceWithBuildbotConfig(self):
         # load config with one cache loaded and the other not
         foo_cache = self.caches.get_cache("foo", None)
-        d = self.caches.reconfigService(
+        d = self.caches.reconfigServiceWithBuildbotConfig(
             self.make_config(foo=5, bar=6, bing=11))
 
         @d.addCallback

--- a/master/buildbot/test/unit/test_process_debug.py
+++ b/master/buildbot/test/unit/test_process_debug.py
@@ -39,25 +39,25 @@ class TestDebugServices(unittest.TestCase):
         ds.startService()
 
         # start off with no manhole
-        yield ds.reconfigService(self.config)
+        yield ds.reconfigServiceWithBuildbotConfig(self.config)
 
         # set a manhole, fire it up
         self.config.manhole = manhole = FakeManhole()
-        yield ds.reconfigService(self.config)
+        yield ds.reconfigServiceWithBuildbotConfig(self.config)
 
         self.assertTrue(manhole.running)
         self.assertIdentical(manhole.master, master)
 
         # unset it, see it stop
         self.config.manhole = None
-        yield ds.reconfigService(self.config)
+        yield ds.reconfigServiceWithBuildbotConfig(self.config)
 
         self.assertFalse(manhole.running)
         self.assertIdentical(manhole.master, None)
 
         # re-start to test stopService
         self.config.manhole = manhole
-        yield ds.reconfigService(self.config)
+        yield ds.reconfigServiceWithBuildbotConfig(self.config)
 
         # stop the service, and see that it unregisters
         yield ds.stopService()

--- a/master/buildbot/test/unit/test_process_metrics.py
+++ b/master/buildbot/test/unit/test_process_metrics.py
@@ -31,7 +31,7 @@ class TestMetricBase(unittest.TestCase):
         self.master.config.metrics = dict(log_interval=0, periodic_interval=0)
         self.observer._reactor = self.clock
         self.observer.startService()
-        self.observer.reconfigService(self.master.config)
+        self.observer.reconfigServiceWithBuildbotConfig(self.master.config)
 
     def tearDown(self):
         if self.observer.running:
@@ -181,13 +181,13 @@ class TestReconfig(TestMetricBase):
 
         # enable log_interval
         new_config.metrics = dict(log_interval=10, periodic_interval=0)
-        observer.reconfigService(new_config)
+        observer.reconfigServiceWithBuildbotConfig(new_config)
         self.assert_(observer.log_task)
         self.assertEquals(observer.periodic_task, None)
 
         # disable that and enable periodic_interval
         new_config.metrics = dict(periodic_interval=10, log_interval=0)
-        observer.reconfigService(new_config)
+        observer.reconfigServiceWithBuildbotConfig(new_config)
         self.assert_(observer.periodic_task)
         self.assertEquals(observer.log_task, None)
 
@@ -196,20 +196,20 @@ class TestReconfig(TestMetricBase):
 
         # disable the whole listener
         new_config.metrics = None
-        observer.reconfigService(new_config)
+        observer.reconfigServiceWithBuildbotConfig(new_config)
         self.assertFalse(observer.enabled)
         self.assertEquals(observer.log_task, None)
         self.assertEquals(observer.periodic_task, None)
 
         # disable both
         new_config.metrics = dict(periodic_interval=0, log_interval=0)
-        observer.reconfigService(new_config)
+        observer.reconfigServiceWithBuildbotConfig(new_config)
         self.assertEquals(observer.log_task, None)
         self.assertEquals(observer.periodic_task, None)
 
         # enable both
         new_config.metrics = dict(periodic_interval=10, log_interval=10)
-        observer.reconfigService(new_config)
+        observer.reconfigServiceWithBuildbotConfig(new_config)
         self.assert_(observer.log_task)
         self.assert_(observer.periodic_task)
 

--- a/master/buildbot/test/unit/test_process_users_manager.py
+++ b/master/buildbot/test/unit/test_process_users_manager.py
@@ -39,18 +39,18 @@ class TestUserManager(unittest.TestCase):
         self.umm.stopService()
 
     @defer.inlineCallbacks
-    def test_reconfigService(self):
+    def test_reconfigServiceWithBuildbotConfig(self):
         # add a user manager
         um1 = FakeUserManager()
         self.config.user_managers = [um1]
 
-        yield self.umm.reconfigService(self.config)
+        yield self.umm.reconfigServiceWithBuildbotConfig(self.config)
 
         self.assertTrue(um1.running)
         self.assertIdentical(um1.master, self.master)
 
         # and back to nothing
         self.config.user_managers = []
-        yield self.umm.reconfigService(self.config)
+        yield self.umm.reconfigServiceWithBuildbotConfig(self.config)
 
         self.assertIdentical(um1.master, None)

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -74,12 +74,12 @@ class SchedulerManager(unittest.TestCase):
 
     class ReconfigSched(service.ReconfigurableServiceMixin, Sched):
 
-        def reconfigService(self, new_config):
+        def reconfigServiceWithBuildbotConfig(self, new_config):
             self.reconfig_count += 1
             new_sched = new_config.schedulers[self.name]
             self.attr = new_sched.attr
-            return service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                      new_config)
+            return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                        new_config)
 
     class ReconfigSched2(ReconfigSched):
         pass
@@ -96,7 +96,7 @@ class SchedulerManager(unittest.TestCase):
         sch1 = self.makeSched(self.ReconfigSched, 'sch1', attr='alpha')
         self.new_config.schedulers = dict(sch1=sch1)
 
-        yield self.sm.reconfigService(self.new_config)
+        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
 
         self.assertIdentical(sch1.parent, self.sm)
         self.assertIdentical(sch1.master, self.master)
@@ -106,7 +106,7 @@ class SchedulerManager(unittest.TestCase):
         sch2 = self.makeSched(self.ReconfigSched, 'sch2', attr='alpha')
         self.new_config.schedulers = dict(sch1=sch1_new, sch2=sch2)
 
-        yield self.sm.reconfigService(self.new_config)
+        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
 
         # sch1 is still the active scheduler, and has been reconfig'd,
         # and has the correct attribute
@@ -122,7 +122,7 @@ class SchedulerManager(unittest.TestCase):
 
         self.new_config.schedulers = {}
 
-        yield self.sm.reconfigService(self.new_config)
+        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
 
         self.assertIdentical(sch1.parent, None)
         self.assertIdentical(sch1.master, None)
@@ -132,7 +132,7 @@ class SchedulerManager(unittest.TestCase):
         sch1 = self.makeSched(self.ReconfigSched, 'sch1')
         self.new_config.schedulers = dict(sch1=sch1)
 
-        yield self.sm.reconfigService(self.new_config)
+        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
 
         self.assertIdentical(sch1.parent, self.sm)
         self.assertIdentical(sch1.master, self.master)
@@ -141,7 +141,7 @@ class SchedulerManager(unittest.TestCase):
         sch1_new = self.makeSched(self.ReconfigSched2, 'sch1')
         self.new_config.schedulers = dict(sch1=sch1_new)
 
-        yield self.sm.reconfigService(self.new_config)
+        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
 
         # sch1 had its class name change, so sch1_new is now the active
         # instance
@@ -153,7 +153,7 @@ class SchedulerManager(unittest.TestCase):
         sch1 = self.makeSched(self.Sched, 'sch1', attr='alpha')
         self.new_config.schedulers = dict(sch1=sch1)
 
-        yield self.sm.reconfigService(self.new_config)
+        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
 
         self.assertIdentical(sch1.parent, self.sm)
         self.assertIdentical(sch1.master, self.master)
@@ -162,7 +162,7 @@ class SchedulerManager(unittest.TestCase):
         sch2 = self.makeSched(self.Sched, 'sch2', attr='alpha')
         self.new_config.schedulers = dict(sch1=sch1_new, sch2=sch2)
 
-        yield self.sm.reconfigService(self.new_config)
+        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
 
         # sch1 is not longer active, and sch1_new is
         self.assertIdentical(sch1.parent, None)

--- a/master/buildbot/test/unit/test_status_master.py
+++ b/master/buildbot/test/unit/test_status_master.py
@@ -56,7 +56,7 @@ class TestStatus(unittest.TestCase):
         return d
 
     @defer.inlineCallbacks
-    def test_reconfigService(self):
+    def test_reconfigServiceWithBuildbotConfig(self):
         m = mock.Mock(name='master')
         status = master.Status(m)
         status.startService()
@@ -67,7 +67,7 @@ class TestStatus(unittest.TestCase):
         sr0 = FakeStatusReceiver()
         config.status = [sr0]
 
-        yield status.reconfigService(config)
+        yield status.reconfigServiceWithBuildbotConfig(config)
 
         self.assertTrue(sr0.running)
         self.assertIdentical(sr0.master, m)
@@ -77,7 +77,7 @@ class TestStatus(unittest.TestCase):
         sr2 = FakeStatusReceiver()
         config.status = [sr1, sr2]
 
-        yield status.reconfigService(config)
+        yield status.reconfigServiceWithBuildbotConfig(config)
 
         self.assertFalse(sr0.running)
         self.assertIdentical(sr0.master, None)
@@ -91,11 +91,11 @@ class TestStatus(unittest.TestCase):
         sr2 = FakeStatusReceiver()
         config.status = [sr1, sr2]
 
-        yield status.reconfigService(config)
+        yield status.reconfigServiceWithBuildbotConfig(config)
 
         # and back to nothing
         config.status = []
-        yield status.reconfigService(config)
+        yield status.reconfigServiceWithBuildbotConfig(config)
 
         self.assertIdentical(sr0.master, None)
         self.assertIdentical(sr1.master, None)

--- a/master/buildbot/test/unit/test_util_service.py
+++ b/master/buildbot/test/unit/test_util_service.py
@@ -543,7 +543,7 @@ class MyService(service.BuildbotService):
             config.error("a must be specified")
         return defer.succeed(True)
 
-    def reconfigServiceWithConstructorArgs(self, *argv, **kwargs):
+    def reconfigService(self, *argv, **kwargs):
         self.config = argv, kwargs
         return defer.succeed(None)
 
@@ -568,7 +568,7 @@ class BuildbotService(unittest.TestCase):
         self.master.config.services = {"basic": serv}
         yield serv.setServiceParent(self.master)
         yield self.master.startService()
-        yield self.master.reconfigService(self.master.config)
+        yield self.master.reconfigServiceWithBuildbotConfig(self.master.config)
         defer.returnValue(serv)
 
     @defer.inlineCallbacks
@@ -594,7 +594,7 @@ class BuildbotService(unittest.TestCase):
         self.master.config.services = {"basic": serv2}
 
         # reconfigure the master
-        yield self.master.reconfigService(self.master.config)
+        yield self.master.reconfigServiceWithBuildbotConfig(self.master.config)
         # the first service is still used
         self.assertIdentical(self.master.namedServices["basic"], serv)
         # the second service is not used
@@ -613,7 +613,7 @@ class BuildbotService(unittest.TestCase):
         self.master.config.services = {"basic": serv2}
 
         # reconfigure the master
-        yield self.master.reconfigService(self.master.config)
+        yield self.master.reconfigServiceWithBuildbotConfig(self.master.config)
         # the first service is still used
         self.assertIdentical(self.master.namedServices["basic"], serv)
         # the second service is not used

--- a/master/buildbot/test/unit/test_www_service.py
+++ b/master/buildbot/test/unit/test_www_service.py
@@ -52,7 +52,7 @@ class Test(www.WwwTestMixin, unittest.TestCase):
 
     def test_reconfigService_no_port(self):
         new_config = self.makeConfig()
-        d = self.svc.reconfigService(new_config)
+        d = self.svc.reconfigServiceWithBuildbotConfig(new_config)
 
         @d.addCallback
         def check(_):
@@ -66,16 +66,16 @@ class Test(www.WwwTestMixin, unittest.TestCase):
         NeedsReconfigResource.reconfigs = 0
 
         # first time, reconfigResource gets called along with setupSite
-        yield self.svc.reconfigService(new_config)
+        yield self.svc.reconfigServiceWithBuildbotConfig(new_config)
         self.assertEqual(NeedsReconfigResource.reconfigs, 1)
 
         # and the next time, setupSite isn't called, but reconfigResource is
-        yield self.svc.reconfigService(new_config)
+        yield self.svc.reconfigServiceWithBuildbotConfig(new_config)
         self.assertEqual(NeedsReconfigResource.reconfigs, 2)
 
     def test_reconfigService_port(self):
         new_config = self.makeConfig(port=20)
-        d = self.svc.reconfigService(new_config)
+        d = self.svc.reconfigServiceWithBuildbotConfig(new_config)
 
         @d.addCallback
         def check(_):
@@ -86,12 +86,12 @@ class Test(www.WwwTestMixin, unittest.TestCase):
 
     def test_reconfigService_port_changes(self):
         new_config = self.makeConfig(port=20)
-        d = self.svc.reconfigService(new_config)
+        d = self.svc.reconfigServiceWithBuildbotConfig(new_config)
 
         @d.addCallback
         def reconfig(_):
             newer_config = self.makeConfig(port=999)
-            return self.svc.reconfigService(newer_config)
+            return self.svc.reconfigServiceWithBuildbotConfig(newer_config)
 
         @d.addCallback
         def check(_):
@@ -102,12 +102,12 @@ class Test(www.WwwTestMixin, unittest.TestCase):
 
     def test_reconfigService_port_changes_to_none(self):
         new_config = self.makeConfig(port=20)
-        d = self.svc.reconfigService(new_config)
+        d = self.svc.reconfigServiceWithBuildbotConfig(new_config)
 
         @d.addCallback
         def reconfig(_):
             newer_config = self.makeConfig()
-            return self.svc.reconfigService(newer_config)
+            return self.svc.reconfigServiceWithBuildbotConfig(newer_config)
 
         @d.addCallback
         def check(_):

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -27,7 +27,7 @@ class ReconfigurableServiceMixin:
     reconfig_priority = 128
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         if not service.IServiceCollection.providedBy(self):
             return
 
@@ -40,7 +40,7 @@ class ReconfigurableServiceMixin:
         reconfigurable_services.sort(key=lambda svc: -svc.reconfig_priority)
 
         for svc in reconfigurable_services:
-            yield svc.reconfigService(new_config)
+            yield svc.reconfigServiceWithBuildbotConfig(new_config)
 
 
 class ClusteredService(service.Service, util.ComparableMixin):
@@ -251,7 +251,7 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin,
                 'args': self._config_args,
                 'kwargs': self._config_kwargs}
 
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         # get from the config object its sibling config
         config_sibling = getattr(new_config, self.config_attr)[self.name]
 
@@ -259,8 +259,8 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin,
         if self.configured and config_sibling == self:
             return defer.succeed(None)
         self.configured = True
-        return self.reconfigServiceWithConstructorArgs(*config_sibling._config_args,
-                                                       **config_sibling._config_kwargs)
+        return self.reconfigService(*config_sibling._config_args,
+                                    **config_sibling._config_kwargs)
 
     def setServiceParent(self, parent):
         self.master = parent
@@ -269,5 +269,5 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin,
     def checkConfig(self, *args, **kwargs):
         return defer.succeed(True)
 
-    def reconfigServiceWithConstructorArgs(self, *args, **kwargs):
+    def reconfigService(self, *args, **kwargs):
         return defer.succeed(None)

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -51,7 +51,7 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         return self.master.config.www['auth']
 
     @defer.inlineCallbacks
-    def reconfigService(self, new_config):
+    def reconfigServiceWithBuildbotConfig(self, new_config):
         www = new_config.www
 
         need_new_site = False
@@ -104,8 +104,8 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
                 yield self.port_service.setServiceParent(self)
 
-        yield service.ReconfigurableServiceMixin.reconfigService(self,
-                                                                 new_config)
+        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                   new_config)
 
     def getPortnum(self):
         # for tests, when the configured port is 0 and the kernel selects a

--- a/master/docs/developer/config.rst
+++ b/master/docs/developer/config.rst
@@ -381,11 +381,11 @@ Reconfigurable Services
 Instances which need to be notified of a change in configuration should be
 implemented as Twisted services, and mix in the
 :py:class:`ReconfigurableServiceMixin` class, overriding the
-:py:meth:`~ReconfigurableServiceMixin.reconfigService` method.
+:py:meth:`~ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig` method.
 
 .. py:class:: ReconfigurableServiceMixin
 
-    .. py:method:: reconfigService(new_config)
+    .. py:method:: reconfigServiceWithBuildbotConfig(new_config)
 
         :param new_config: new master configuration
         :type new_config: :py:class:`MasterConfig`


### PR DESCRIPTION
In the aim of simplifying the API for BuildbotService(),
we rename this method, so that the name is available for API of BuildbotService.

Next task is to convert more and more services of buildbot into BuildbotService, so that:
1) they can be abstracted from where they are configured
2) they can embed their checkConfig internally, and not in config.py

Signed-off-by: Pierre Tardy pierre.tardy@intel.com

sed was my friend for that patch, so nothing fancy. I'll make the interresting part in an easier to review followup
