### PR TITLE
set up test requirements with extras_require

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -395,7 +395,6 @@ else:
 
     if os.getenv('NO_INSTALL_REQS'):
         setup_args['install_requires'] = None
-        setup_args['tests_require'] = None
         setup_args['extras_require'] = None
 
 setup(**setup_args)

--- a/slave/setup.py
+++ b/slave/setup.py
@@ -145,5 +145,6 @@ else:
 
     if os.getenv('NO_INSTALL_REQS'):
         setup_args['install_requires'] = None
+        setup_args['extras_require'] = None
 
 setup(**setup_args)


### PR DESCRIPTION
This means you can just use `pip install -e .[test]` to install the test requirements.

I'll update the wiki, too.
