### PR TITLE
make Mock.assert_not_called do what it sounds like

### DIFF
--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -139,6 +139,12 @@ def patch_decorators():
 
 
 @onlyOnce
+def patch_mock_asserts():
+    from buildbot.monkeypatches import mock_asserts
+    mock_asserts.patch()
+
+
+@onlyOnce
 def patch_LoopingCall_reset():
     if twisted.version.major == 11 and twisted.version.minor == 0:
         from buildbot.monkeypatches import loopingcall_reset
@@ -152,6 +158,7 @@ def patch_all(for_tests=False):
         patch_testcase_synctest()
         patch_testcase_assert_raises_regexp()
         patch_decorators()
+        patch_mock_asserts()
 
     patch_bug4881()
     patch_bug4520()

--- a/master/buildbot/monkeypatches/mock_asserts.py
+++ b/master/buildbot/monkeypatches/mock_asserts.py
@@ -1,0 +1,33 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import mock
+
+
+def patch():
+    # mock doesn't ordinarily have this method, but we keep calling it by
+    # mistake.  It unhelpfully returns without error, regardless of whether
+    # the mock has been called!
+    mock.Mock.assert_not_called = lambda self: self.assert_has_calls([])
+
+    # similarly, let's make every other 'assert_' method on a mock
+    # automatically fail.
+    orig = mock.NonCallableMock.__getattr__
+
+    def new__getattr__(self, name):
+        if name.startswith('assert_'):
+            raise AttributeError(name)
+        return orig(self, name)
+    mock.NonCallableMock.__getattr__ = new__getattr__


### PR DESCRIPTION
This also makes any undefined `assert_` methods on a mock fail.
