### PR TITLE
Don't document categories any more, use tags

### DIFF
--- a/master/docs/manual/cfg-builders.rst
+++ b/master/docs/manual/cfg-builders.rst
@@ -53,12 +53,12 @@ Other optional keys may be set on each ``BuilderConfig``:
     If not set, defaults to ``builddir``.
     If a slave is connected to multiple builders that share the same ``slavebuilddir``, make sure the slave is set to run one build at a time or ensure this is fine to run multiple builds from the same directory simultaneously.
 
-``category``
-    If provided, this is a string that identifies a category for the builder to be a part of.
-    Status clients can limit themselves to a subset of the available categories.
+``tags``
+    If provided, this is a list of strings that identifies tags for the builder.
+    Status clients can limit themselves to a subset of the available tags.
     A common use for this is to add new builders to your setup (for a new module, or for a new buildslave) that do not work correctly yet and allow you to integrate them with the active builders.
-    You can put these new builders in a test category, make your main status clients ignore them, and have only private status clients pick them up.
-    As soon as they work, you can move them over to the active category.
+    You can tag these new builders with a ``test`` tag, make your main status clients ignore them, and have only private status clients pick them up.
+    As soon as they work, you can move them over to the active tag.
 
 ``nextSlave``
     If provided, this is a function that controls which slave will be assigned future jobs.

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -28,7 +28,7 @@ To add status targets, you just append more objects to this list::
                                             {"channel": "#example2",
                                              "password": "somesecretpassword"}]))
 
-Most status delivery objects take a ``categories=`` argument, which can contain a list of `category` names: in this case, it will only show status for Builders that are in one of the named categories.
+Most status delivery objects take a ``tags=`` argument, which can contain a list of tag names: in this case, it will only show status for Builders that contains the named tags.
 
 .. note:: Implementation Note
 
@@ -286,13 +286,13 @@ MailNotifier arguments
     (list of strings).
     A list of builder names for which mail should be sent.
     Defaults to ``None`` (send mail for all builds).
-    Use either builders or categories, but not both.
+    Use either builders or tags, but not both.
 
-``categories``
+``tags``
     (list of strings).
-    A list of category names to serve status information for.
-    Defaults to ``None`` (all categories).
-    Use either builders or categories, but not both.
+    A list of tag names to serve status information for.
+    Defaults to ``None`` (all tags).
+    Use either builders or tags, but not both.
 
 ``addLogs``
     (boolean).
@@ -597,7 +597,7 @@ If the ``allowForce=True`` option was used, some additional commands will be ava
     *REASON* will be added to the build status to explain why it was stopped.
     You might use this if you committed a bug, corrected it right away, and don't want to wait for the first build (which is destined to fail) to complete before starting the second (hopefully fixed) build.
 
-If the `categories` is set to a category of builders (see the categories option in :ref:`Builder-Configuration`) changes related to only that category of builders will be sent to the channel.
+If the `tags` is set (see the tags option in :ref:`Builder-Configuration`) changes related to only builders belonging to those tags of builders will be sent to the channel.
 
 If the `useRevisions` option is set to `True`, the IRC bot will send status messages that replace the build number with a list of revisions that are contained in that build.
 So instead of seeing `build #253 of ...`, you would see something like `build containing revisions [a87b2c4]`.


### PR DESCRIPTION
Builders switched for some time already, and the IRC status also accepts tags (isn't wired yet though).
