### PR TITLE
IRC: implement deprecation at the right spot

### DIFF
--- a/master/buildbot/status/irc.py
+++ b/master/buildbot/status/irc.py
@@ -159,7 +159,6 @@ class IrcStatusFactory(ThrottledClientFactory):
         self.useColors = useColors
         self.allowShutdown = allowShutdown
 
-
     def __getstate__(self):
         d = self.__dict__.copy()
         del d['p']


### PR DESCRIPTION
Move it one level higher, in the class that is actually instantiated fro the config.
