### PR TITLE
Issue 3019.5

### DIFF
--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -17,6 +17,7 @@ import os.path
 import signal
 import socket
 import sys
+import multiprocessing
 
 from twisted.application import internet
 from twisted.application import service
@@ -322,9 +323,12 @@ class Bot(pb.Referenceable, service.MultiService):
                 filename = os.path.join(basedir, f)
                 if os.path.isfile(filename):
                     files[f] = open(filename, "r").read()
+        if not self.maxcpus:
+            self.maxcpus = multiprocessing.cpu_count()
         files['environ'] = os.environ.copy()
         files['system'] = os.name
         files['basedir'] = self.basedir
+        files['maxcpus'] = self.maxcpus
         return files
 
     def remote_getVersion(self):
@@ -443,7 +447,8 @@ class BuildSlave(service.MultiService):
 
     def __init__(self, buildmaster_host, port, name, passwd, basedir,
                  keepalive, usePTY, keepaliveTimeout=None, umask=None,
-                 maxdelay=300, unicode_encoding=None, allow_shutdown=None):
+                 maxdelay=300, maxcpus=None, unicode_encoding=None,
+                 allow_shutdown=None):
 
         # note: keepaliveTimeout is ignored, but preserved here for
         # backward-compatibility
@@ -456,7 +461,7 @@ class BuildSlave(service.MultiService):
             keepalive = None
         self.umask = umask
         self.basedir = basedir
-
+        self.maxcpus = maxcpus
         self.shutdown_loop = None
 
         if allow_shutdown == 'signal':

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -13,11 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+import multiprocessing
 import os.path
 import signal
 import socket
 import sys
-import multiprocessing
 
 from twisted.application import internet
 from twisted.application import service

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -245,6 +245,7 @@ class Bot(pb.Referenceable, service.MultiService):
     def __init__(self, basedir, usePTY, unicode_encoding=None):
         service.MultiService.__init__(self)
         self.basedir = basedir
+        self.maxcpus = None
         self.usePTY = usePTY
         self.unicode_encoding = unicode_encoding or sys.getfilesystemencoding() or 'ascii'
         self.builders = {}

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -245,7 +245,7 @@ class Bot(pb.Referenceable, service.MultiService):
     def __init__(self, basedir, usePTY, unicode_encoding=None):
         service.MultiService.__init__(self)
         self.basedir = basedir
-        self.maxcpus = None
+        self.numcpus = None
         self.usePTY = usePTY
         self.unicode_encoding = unicode_encoding or sys.getfilesystemencoding() or 'ascii'
         self.builders = {}
@@ -324,12 +324,12 @@ class Bot(pb.Referenceable, service.MultiService):
                 filename = os.path.join(basedir, f)
                 if os.path.isfile(filename):
                     files[f] = open(filename, "r").read()
-        if not self.maxcpus:
-            self.maxcpus = multiprocessing.cpu_count()
+        if not self.numcpus:
+            self.numcpus = multiprocessing.cpu_count()
         files['environ'] = os.environ.copy()
         files['system'] = os.name
         files['basedir'] = self.basedir
-        files['maxcpus'] = self.maxcpus
+        files['numcpus'] = self.numcpus
         return files
 
     def remote_getVersion(self):
@@ -448,7 +448,7 @@ class BuildSlave(service.MultiService):
 
     def __init__(self, buildmaster_host, port, name, passwd, basedir,
                  keepalive, usePTY, keepaliveTimeout=None, umask=None,
-                 maxdelay=300, maxcpus=None, unicode_encoding=None,
+                 maxdelay=300, numcpus=None, unicode_encoding=None,
                  allow_shutdown=None):
 
         # note: keepaliveTimeout is ignored, but preserved here for
@@ -462,7 +462,7 @@ class BuildSlave(service.MultiService):
             keepalive = None
         self.umask = umask
         self.basedir = basedir
-        self.maxcpus = maxcpus
+        self.numcpus = numcpus
         self.shutdown_loop = None
 
         if allow_shutdown == 'signal':

--- a/slave/buildslave/scripts/create_slave.py
+++ b/slave/buildslave/scripts/create_slave.py
@@ -60,7 +60,7 @@ allow_shutdown = %(allow-shutdown)s
 
 s = BuildSlave(buildmaster_host, port, slavename, passwd, basedir,
                keepalive, usepty, umask=umask, maxdelay=maxdelay,
-               allow_shutdown=allow_shutdown)
+               maxcpus=None, allow_shutdown=allow_shutdown)
 s.setServiceParent(application)
 
 """]

--- a/slave/buildslave/scripts/create_slave.py
+++ b/slave/buildslave/scripts/create_slave.py
@@ -55,6 +55,7 @@ keepalive = %(keepalive)d
 usepty = %(usepty)d
 umask = %(umask)s
 maxdelay = %(maxdelay)d
+maxcpus = %(maxcpus)s
 allow_shutdown = %(allow-shutdown)s
 
 s = BuildSlave(buildmaster_host, port, slavename, passwd, basedir,

--- a/slave/buildslave/scripts/create_slave.py
+++ b/slave/buildslave/scripts/create_slave.py
@@ -60,7 +60,7 @@ allow_shutdown = %(allow-shutdown)s
 
 s = BuildSlave(buildmaster_host, port, slavename, passwd, basedir,
                keepalive, usepty, umask=umask, maxdelay=maxdelay,
-               maxcpus=None, allow_shutdown=allow_shutdown)
+               maxcpus=maxcpus, allow_shutdown=allow_shutdown)
 s.setServiceParent(application)
 
 """]

--- a/slave/buildslave/scripts/create_slave.py
+++ b/slave/buildslave/scripts/create_slave.py
@@ -55,12 +55,12 @@ keepalive = %(keepalive)d
 usepty = %(usepty)d
 umask = %(umask)s
 maxdelay = %(maxdelay)d
-maxcpus = %(maxcpus)s
+numcpus = %(numcpus)s
 allow_shutdown = %(allow-shutdown)s
 
 s = BuildSlave(buildmaster_host, port, slavename, passwd, basedir,
                keepalive, usepty, umask=umask, maxdelay=maxdelay,
-               maxcpus=maxcpus, allow_shutdown=allow_shutdown)
+               numcpus=numcpus, allow_shutdown=allow_shutdown)
 s.setServiceParent(application)
 
 """]

--- a/slave/buildslave/scripts/runner.py
+++ b/slave/buildslave/scripts/runner.py
@@ -126,7 +126,7 @@ class CreateSlaveOptions(MakerBase):
          "Use --umask=022 to be world-readable"],
         ["maxdelay", None, 300,
          "Maximum time between connection attempts"],
-        ["maxcpus", None, None,
+        ["maxcpus", None, "None",
          "Maximum number of cpus to use on a build. "],
         ["log-size", "s", "10000000",
          "size at which to rotate twisted log files"],
@@ -216,7 +216,7 @@ class CreateSlaveOptions(MakerBase):
 
         if not re.match(r'^\d+$', self['maxcpus']) and \
                 self['maxcpus'] != 'None':
-            raise usage.UsageError("maxcpus parameter needs to be a number"
+            raise usage.UsageError("maxcpus parameter needs to be an number"
                                    " or None")
 
         if self['allow-shutdown'] not in [None, 'signal', 'file']:

--- a/slave/buildslave/scripts/runner.py
+++ b/slave/buildslave/scripts/runner.py
@@ -126,8 +126,8 @@ class CreateSlaveOptions(MakerBase):
          "Use --umask=022 to be world-readable"],
         ["maxdelay", None, 300,
          "Maximum time between connection attempts"],
-        ["maxcpus", None, "None",
-         "Maximum number of cpus to use on a build. "],
+        ["numcpus", None, "None",
+         "Number of available cpus to use on a build. "],
         ["log-size", "s", "10000000",
          "size at which to rotate twisted log files"],
         ["log-count", "l", "10",
@@ -214,9 +214,9 @@ class CreateSlaveOptions(MakerBase):
             raise usage.UsageError("umask parameter needs to be an number"
                                    " or None")
 
-        if not re.match(r'^\d+$', self['maxcpus']) and \
-                self['maxcpus'] != 'None':
-            raise usage.UsageError("maxcpus parameter needs to be an number"
+        if not re.match(r'^\d+$', self['numcpus']) and \
+                self['numcpus'] != 'None':
+            raise usage.UsageError("numcpus parameter needs to be an number"
                                    " or None")
 
         if self['allow-shutdown'] not in [None, 'signal', 'file']:

--- a/slave/buildslave/scripts/runner.py
+++ b/slave/buildslave/scripts/runner.py
@@ -126,6 +126,8 @@ class CreateSlaveOptions(MakerBase):
          "Use --umask=022 to be world-readable"],
         ["maxdelay", None, 300,
          "Maximum time between connection attempts"],
+        ["maxcpus", None, 1,
+         "Maximum number of cpus to use on a build. "],
         ["log-size", "s", "10000000",
          "size at which to rotate twisted log files"],
         ["log-count", "l", "10",
@@ -210,6 +212,11 @@ class CreateSlaveOptions(MakerBase):
         if not re.match(r'^\d+$', self['umask']) and \
                 self['umask'] != 'None':
             raise usage.UsageError("umask parameter needs to be an number"
+                                   " or None")
+
+        if not re.match(r'^\d+$', self['maxcpus']) and \
+                self['maxcpus'] != 'None':
+            raise usage.UsageError("maxcpus parameter needs to be a number"
                                    " or None")
 
         if self['allow-shutdown'] not in [None, 'signal', 'file']:

--- a/slave/buildslave/scripts/runner.py
+++ b/slave/buildslave/scripts/runner.py
@@ -126,7 +126,7 @@ class CreateSlaveOptions(MakerBase):
          "Use --umask=022 to be world-readable"],
         ["maxdelay", None, 300,
          "Maximum time between connection attempts"],
-        ["maxcpus", None, 1,
+        ["maxcpus", None, None,
          "Maximum number of cpus to use on a build. "],
         ["log-size", "s", "10000000",
          "size at which to rotate twisted log files"],

--- a/slave/buildslave/test/unit/test_bot.py
+++ b/slave/buildslave/test/unit/test_bot.py
@@ -85,7 +85,7 @@ class TestBot(unittest.TestCase):
             self.assertEqual(info, dict(admin='testy!', foo='bar',
                                         environ=os.environ, system=os.name,
                                         basedir=self.basedir,
-                                        maxcpus=multiprocessing.cpu_count()))
+                                        numcpus=multiprocessing.cpu_count()))
         d.addCallback(check)
         return d
 
@@ -93,7 +93,7 @@ class TestBot(unittest.TestCase):
         d = self.bot.callRemote("getSlaveInfo")
 
         def check(info):
-            self.assertEqual(set(info.keys()), set(['environ', 'system', 'maxcpus', 'basedir']))
+            self.assertEqual(set(info.keys()), set(['environ', 'system', 'numcpus', 'basedir']))
         d.addCallback(check)
         return d
 

--- a/slave/buildslave/test/unit/test_bot.py
+++ b/slave/buildslave/test/unit/test_bot.py
@@ -93,7 +93,7 @@ class TestBot(unittest.TestCase):
         d = self.bot.callRemote("getSlaveInfo")
 
         def check(info):
-            self.assertEqual(set(info.keys()), set(['environ', 'system', 'basedir']))
+            self.assertEqual(set(info.keys()), set(['environ', 'system', 'maxcpus', 'basedir']))
         d.addCallback(check)
         return d
 

--- a/slave/buildslave/test/unit/test_bot.py
+++ b/slave/buildslave/test/unit/test_bot.py
@@ -16,6 +16,7 @@
 import mock
 import os
 import shutil
+import multiprocessing
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -81,7 +82,10 @@ class TestBot(unittest.TestCase):
         d = self.bot.callRemote("getSlaveInfo")
 
         def check(info):
-            self.assertEqual(info, dict(admin='testy!', foo='bar', environ=os.environ, system=os.name, basedir=self.basedir))
+            self.assertEqual(info, dict(admin='testy!', foo='bar',
+                                        environ=os.environ, system=os.name,
+                                        basedir=self.basedir,
+                                        maxcpus=multiprocessing.cpu_count()))
         d.addCallback(check)
         return d
 

--- a/slave/buildslave/test/unit/test_scripts_create_slave.py
+++ b/slave/buildslave/test/unit/test_scripts_create_slave.py
@@ -488,6 +488,7 @@ class TestCreateSlave(misc.StdoutAssertionsMixin, unittest.TestCase):
         "log-count": 8,
         "keepalive": 4,
         "maxdelay": 2,
+        "maxcpus": 4,
 
         # arguments
         "host": "masterhost",

--- a/slave/buildslave/test/unit/test_scripts_create_slave.py
+++ b/slave/buildslave/test/unit/test_scripts_create_slave.py
@@ -488,7 +488,7 @@ class TestCreateSlave(misc.StdoutAssertionsMixin, unittest.TestCase):
         "log-count": 8,
         "keepalive": 4,
         "maxdelay": 2,
-        "maxcpus": 4,
+        "maxcpus": None,
 
         # arguments
         "host": "masterhost",
@@ -617,6 +617,7 @@ class TestCreateSlave(misc.StdoutAssertionsMixin, unittest.TestCase):
             options["keepalive"],
             options["usepty"],
             umask=options["umask"],
+            maxcpus=options["maxcpus"],
             maxdelay=options["maxdelay"],
             allow_shutdown=options["allow-shutdown"])
 

--- a/slave/buildslave/test/unit/test_scripts_create_slave.py
+++ b/slave/buildslave/test/unit/test_scripts_create_slave.py
@@ -488,7 +488,7 @@ class TestCreateSlave(misc.StdoutAssertionsMixin, unittest.TestCase):
         "log-count": 8,
         "keepalive": 4,
         "maxdelay": 2,
-        "maxcpus": None,
+        "numcpus": None,
 
         # arguments
         "host": "masterhost",
@@ -617,7 +617,7 @@ class TestCreateSlave(misc.StdoutAssertionsMixin, unittest.TestCase):
             options["keepalive"],
             options["usepty"],
             umask=options["umask"],
-            maxcpus=options["maxcpus"],
+            numcpus=options["numcpus"],
             maxdelay=options["maxdelay"],
             allow_shutdown=options["allow-shutdown"])
 

--- a/slave/buildslave/test/unit/test_scripts_runner.py
+++ b/slave/buildslave/test/unit/test_scripts_runner.py
@@ -225,6 +225,7 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
         self.assertRaisesRegexp(usage.UsageError,
                                 "maxdelay parameter needs to be an number",
                                 self.parse, "--maxdelay=X", *self.req_args)
+
     def test_inv_maxcpus(self):
         self.assertRaisesRegexp(usage.UsageError,
                                 "maxcpus parameter needs to be an number",

--- a/slave/buildslave/test/unit/test_scripts_runner.py
+++ b/slave/buildslave/test/unit/test_scripts_runner.py
@@ -226,11 +226,6 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
                                 "maxdelay parameter needs to be an number",
                                 self.parse, "--maxdelay=X", *self.req_args)
 
-    def test_inv_maxcpus(self):
-        self.assertRaisesRegexp(usage.UsageError,
-                                "maxcpus parameter needs to be an number",
-                                self.parse, "--maxcpus=X", *self.req_args)
-
     def test_inv_log_size(self):
         self.assertRaisesRegexp(usage.UsageError,
                                 "log-size parameter needs to be an number",
@@ -240,6 +235,11 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
         self.assertRaisesRegexp(usage.UsageError,
                                 "log-count parameter needs to be an number or None",
                                 self.parse, "--log-count=X", *self.req_args)
+
+    def test_inv_maxcpus(self):
+        self.assertRaisesRegexp(usage.UsageError,
+                                "maxcpus parameter needs to be an number or None",
+                                self.parse, "--maxcpus=X", *self.req_args)
 
     def test_inv_umask(self):
         self.assertRaisesRegexp(usage.UsageError,

--- a/slave/buildslave/test/unit/test_scripts_runner.py
+++ b/slave/buildslave/test/unit/test_scripts_runner.py
@@ -187,7 +187,7 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
 
         opts = self.parse("--force", "--relocatable", "--no-logrotate",
                           "--keepalive=4", "--usepty=0", "--umask=022",
-                          "--maxdelay=3", "--maxcpus=4", "--log-size=2", "--log-count=1",
+                          "--maxdelay=3", "--numcpus=4", "--log-size=2", "--log-count=1",
                           "--allow-shutdown=file", *self.req_args)
         self.assertOptions(opts,
                            {"force": True,
@@ -196,7 +196,7 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
                             "usepty": 0,
                             "umask": "022",
                             "maxdelay": 3,
-                            "maxcpus":"4",
+                            "numcpus": "4",
                             "log-size": 2,
                             "log-count": "1",
                             "allow-shutdown": "file",
@@ -236,10 +236,10 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
                                 "log-count parameter needs to be an number or None",
                                 self.parse, "--log-count=X", *self.req_args)
 
-    def test_inv_maxcpus(self):
+    def test_inv_numcpus(self):
         self.assertRaisesRegexp(usage.UsageError,
-                                "maxcpus parameter needs to be an number or None",
-                                self.parse, "--maxcpus=X", *self.req_args)
+                                "numcpus parameter needs to be an number or None",
+                                self.parse, "--numcpus=X", *self.req_args)
 
     def test_inv_umask(self):
         self.assertRaisesRegexp(usage.UsageError,

--- a/slave/buildslave/test/unit/test_scripts_runner.py
+++ b/slave/buildslave/test/unit/test_scripts_runner.py
@@ -187,7 +187,7 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
 
         opts = self.parse("--force", "--relocatable", "--no-logrotate",
                           "--keepalive=4", "--usepty=0", "--umask=022",
-                          "--maxdelay=3","--maxcpus=4", "--log-size=2", "--log-count=1",
+                          "--maxdelay=3", "--maxcpus=4", "--log-size=2", "--log-count=1",
                           "--allow-shutdown=file", *self.req_args)
         self.assertOptions(opts,
                            {"force": True,

--- a/slave/buildslave/test/unit/test_scripts_runner.py
+++ b/slave/buildslave/test/unit/test_scripts_runner.py
@@ -187,7 +187,7 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
 
         opts = self.parse("--force", "--relocatable", "--no-logrotate",
                           "--keepalive=4", "--usepty=0", "--umask=022",
-                          "--maxdelay=3", "--log-size=2", "--log-count=1",
+                          "--maxdelay=3","--maxcpus=4", "--log-size=2", "--log-count=1",
                           "--allow-shutdown=file", *self.req_args)
         self.assertOptions(opts,
                            {"force": True,
@@ -196,6 +196,7 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
                             "usepty": 0,
                             "umask": "022",
                             "maxdelay": 3,
+                            "maxcpus": 4,
                             "log-size": 2,
                             "log-count": "1",
                             "allow-shutdown": "file",
@@ -224,6 +225,10 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
         self.assertRaisesRegexp(usage.UsageError,
                                 "maxdelay parameter needs to be an number",
                                 self.parse, "--maxdelay=X", *self.req_args)
+    def test_inv_maxcpus(self):
+        self.assertRaisesRegexp(usage.UsageError,
+                                "maxcpus parameter needs to be an number",
+                                self.parse, "--maxcpus=X", *self.req_args)
 
     def test_inv_log_size(self):
         self.assertRaisesRegexp(usage.UsageError,

--- a/slave/buildslave/test/unit/test_scripts_runner.py
+++ b/slave/buildslave/test/unit/test_scripts_runner.py
@@ -196,7 +196,7 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
                             "usepty": 0,
                             "umask": "022",
                             "maxdelay": 3,
-                            "maxcpus": 4,
+                            "maxcpus":"4",
                             "log-size": 2,
                             "log-count": "1",
                             "allow-shutdown": "file",


### PR DESCRIPTION
This should add the property 'maxcpus' to a buildslaves configuration. If 'maxcpus' is not specified it defaults to 'None' which uses 'multiprocessing.cpu_count()' to receive the max amount of CPUs.