### PR TITLE
make the category param of gitpoller callable.

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -64,7 +64,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
         self.lastChange = time.time()
         self.lastPoll = time.time()
         self.useTimestamps = useTimestamps
-        self.category = category
+        self.category = category if callable(category) else ascii2unicode(category)
         self.project = ascii2unicode(project)
         self.initLock = defer.DeferredLock()
 

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -71,10 +71,7 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         self.gitbin = gitbin
         self.workdir = workdir
         self.usetimestamps = usetimestamps
-        if not callable(category):
-            self.category = lambda _: ascii2unicode(category)
-        else:
-            self.category = category
+        self.category = category if callable(category) else ascii2unicode(category)
         self.project = ascii2unicode(project)
         self.changeCount = 0
         self.lastRev = {}
@@ -288,21 +285,13 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                 raise failures[0]
 
             timestamp, author, files, comments = [r[1] for r in results]
-            pre_change = self.master.config.preChangeGenerator(author=author,
-                                                               revision=unicode(rev),
-                                                               files=files,
-                                                               comments=comments,
-                                                               when_timestamp=timestamp,
-                                                               branch=ascii2unicode(self._removeHeads(branch)),
-                                                               project=self.project,
-                                                               repository=ascii2unicode(self.repourl))
 
             yield self.master.data.updates.addChange(
-                author=author, revision=unicode(rev), files=files,
+                author=author, revision=ascii2unicode(rev), files=files,
                 comments=comments, when_timestamp=timestamp,
                 branch=ascii2unicode(self._removeHeads(branch)),
                 project=self.project, repository=ascii2unicode(self.repourl),
-                category=self.category(pre_change), src=u'git')
+                category=self.category, src=u'git')
 
     def _dovccmd(self, command, args, path=None):
         def encodeArg(arg):

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -288,18 +288,15 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                 raise failures[0]
 
             timestamp, author, files, comments = [r[1] for r in results]
-                
+            preChange = dict(author=author, revision=unicode(rev), files=files,
+                             comments=comments, when_timestamp=timestamp,
+                             branch=ascii2unicode(self._removeHeads(branch)),
+                             project=self.project,
+                             repository=ascii2unicode(self.repourl))
             yield self.master.data.updates.addChange(
-                author=author,
-                revision=unicode(rev),
-                files=files,
-                comments=comments,
-                when_timestamp=timestamp,
-                branch=ascii2unicode(self._removeHeads(branch)),
-                category=self.category(self._removeHeads(branch)),
-                project=self.project,
-                repository=ascii2unicode(self.repourl),
-                src=u'git')
+                category=self.category(preChange),
+                src=u'git',
+                **preChange)
 
     def _dovccmd(self, command, args, path=None):
         def encodeArg(arg):

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -288,15 +288,21 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                 raise failures[0]
 
             timestamp, author, files, comments = [r[1] for r in results]
-            preChange = dict(author=author, revision=unicode(rev), files=files,
-                             comments=comments, when_timestamp=timestamp,
-                             branch=ascii2unicode(self._removeHeads(branch)),
-                             project=self.project,
-                             repository=ascii2unicode(self.repourl))
+            pre_change = self.master.config.preChangeGenerator(author=author,
+                                                               revision=unicode(rev),
+                                                               files=files,
+                                                               comments=comments,
+                                                               when_timestamp=timestamp,
+                                                               branch=ascii2unicode(self._removeHeads(branch)),
+                                                               project=self.project,
+                                                               repository=ascii2unicode(self.repourl))
+
             yield self.master.data.updates.addChange(
-                category=self.category(preChange),
-                src=u'git',
-                **preChange)
+                author=author, revision=unicode(rev), files=files,
+                comments=comments, when_timestamp=timestamp,
+                branch=ascii2unicode(self._removeHeads(branch)),
+                project=self.project, repository=ascii2unicode(self.repourl),
+                category=self.category(pre_change), src=u'git')
 
     def _dovccmd(self, command, args, path=None):
         def encodeArg(arg):

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -71,7 +71,10 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         self.gitbin = gitbin
         self.workdir = workdir
         self.usetimestamps = usetimestamps
-        self.category = ascii2unicode(category)
+        if not callable(category):
+            self.category = lambda _: ascii2unicode(category)
+        else:
+            self.category = category
         self.project = ascii2unicode(project)
         self.changeCount = 0
         self.lastRev = {}
@@ -285,6 +288,7 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                 raise failures[0]
 
             timestamp, author, files, comments = [r[1] for r in results]
+                
             yield self.master.data.updates.addChange(
                 author=author,
                 revision=unicode(rev),
@@ -292,7 +296,7 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                 comments=comments,
                 when_timestamp=timestamp,
                 branch=ascii2unicode(self._removeHeads(branch)),
-                category=self.category,
+                category=self.category(self._removeHeads(branch)),
                 project=self.project,
                 repository=ascii2unicode(self.repourl),
                 src=u'git')

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -60,7 +60,7 @@ class HgPoller(base.PollingChangeSource):
         self.hgbin = hgbin
         self.workdir = workdir
         self.usetimestamps = usetimestamps
-        self.category = category
+        self.category = category if callable(category) else ascii2unicode(category)
         self.project = project
         self.commitInfo = {}
         self.initLock = defer.DeferredLock()

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -120,7 +120,7 @@ class SVNPoller(base.PollingChangeSource, util.ComparableMixin):
         self.svnbin = svnbin
         self.histmax = histmax
         self._prefix = None
-        self.category = util.ascii2unicode(category)
+        self.category = category if callable(category) else util.ascii2unicode(category)
         self.project = util.ascii2unicode(project)
 
         self.cachepath = cachepath

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -136,6 +136,22 @@ class MasterConfig(util.ComparableMixin):
     ])
     compare_attrs = list(_known_config_keys)
 
+    def preChangeGenerator(self, **kwargs):
+        return {
+            'author': kwargs.get('author', None),
+            'files': kwargs.get('files', None),
+            'comments': kwargs.get('comments', None),
+            'revision': kwargs.get('revision', None),
+            'when_timestamp': kwargs.get('when_timestamp', None),
+            'branch': kwargs.get('branch', None),
+            'category': kwargs.get('category', None),
+            'revlink': kwargs.get('revlink', u''),
+            'properties': kwargs.get('properties', {}),
+            'repository': kwargs.get('repository', u''),
+            'project': kwargs.get('project', u''),
+            'codebase': kwargs.get('codebase', None)
+        }
+
     @classmethod
     def loadConfig(cls, basedir, filename):
         if not os.path.isdir(basedir):

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -130,21 +130,17 @@ class Change(base.ResourceType):
         # set the codebase, either the default, supplied, or generated
         if codebase is None \
                 and self.master.config.codebaseGenerator is not None:
-            pre_change = {
-                'author': author,
-                'files': files,
-                'comments': comments,
-                'revision': revision,
-                'when_timestamp': when_timestamp,
-                'branch': branch,
-                'category': category,
-                'revlink': revlink,
-                'properties': properties,
-                'repository': repository,
-                'project': project,
-                'codebase': None,
-                # 'uid': uid, -- not in data API yet?
-            }
+            pre_change = self.master.config.preChangeGenerator(author=author,
+                                                               files=files,
+                                                               comments=comments,
+                                                               revision=revision,
+                                                               when_timestamp=when_timestamp,
+                                                               branch=branch,
+                                                               category=category,
+                                                               revlink=revlink,
+                                                               properties=properties,
+                                                               repository=repository,
+                                                               project=project)
             codebase = self.master.config.codebaseGenerator(pre_change)
             codebase = unicode(codebase)
         else:

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -127,6 +127,19 @@ class Change(base.ResourceType):
         else:
             uid = None
 
+        if callable(category):
+            pre_change = self.master.config.preChangeGenerator(author=author,
+                                                               files=files,
+                                                               comments=comments,
+                                                               revision=revision,
+                                                               when_timestamp=when_timestamp,
+                                                               branch=branch,
+                                                               revlink=revlink,
+                                                               properties=properties,
+                                                               repository=repository,
+                                                               project=project)
+            category = category(pre_change)
+
         # set the codebase, either the default, supplied, or generated
         if codebase is None \
                 and self.master.config.codebaseGenerator is not None:

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -85,6 +85,20 @@ class FakeUpdates(object):
         self.testcase.assertIsInstance(revision, (types.NoneType, unicode))
         self.testcase.assertIsInstance(when_timestamp, (types.NoneType, int))
         self.testcase.assertIsInstance(branch, (types.NoneType, unicode))
+
+        if callable(category):
+            pre_change = self.master.config.preChangeGenerator(author=author,
+                                                               files=files,
+                                                               comments=comments,
+                                                               revision=revision,
+                                                               when_timestamp=when_timestamp,
+                                                               branch=branch,
+                                                               revlink=revlink,
+                                                               properties=properties,
+                                                               repository=repository,
+                                                               project=project)
+            category = category(pre_change)
+
         self.testcase.assertIsInstance(category, (types.NoneType, unicode))
         self.testcase.assertIsInstance(revlink, (types.NoneType, unicode))
         self.assertProperties(sourced=False, properties=properties)

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -335,6 +335,23 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
             self.basedir, self.filename)
         self.assertIsInstance(rv, config.MasterConfig)
 
+    def test_preChangeGenerator(self):
+        cfg = config.MasterConfig()
+        self.assertEqual({
+            'author': None,
+            'files': None,
+            'comments': None,
+            'revision': None,
+            'when_timestamp': None,
+            'branch': None,
+            'category': None,
+            'revlink': u'',
+            'properties': {},
+            'repository': u'',
+            'project': u'',
+            'codebase': None},
+            cfg.preChangeGenerator())
+
 
 class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
 

--- a/master/buildbot/test/unit/test_data_changes.py
+++ b/master/buildbot/test/unit/test_data_changes.py
@@ -255,7 +255,10 @@ class Change(interfaces.InterfaceTests, unittest.TestCase):
         return d
 
     def test_addChange_src_codebaseGenerator(self):
+        def preChangeGenerator(**kwargs):
+            return kwargs
         self.master.config = mock.Mock(name='master.config')
+        self.master.config.preChangeGenerator = preChangeGenerator
         self.master.config.codebaseGenerator = \
             lambda change: 'cb-%s' % change['category']
         kwargs = dict(author=u'warner', branch=u'warnerdb',


### PR DESCRIPTION
This PR is for review.
It makes the param category of gitpoller callable. the function takes only 1 arg: the branch.