### PR TITLE
Fix exceptions.DeprecationWarning: Argument strings and environment keys...

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -298,8 +298,15 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                 src=u'git')
 
     def _dovccmd(self, command, args, path=None):
-        d = utils.getProcessOutputAndValue(self.gitbin,
-                                           [command] + args, path=path, env=os.environ)
+        def encodeArg(arg):
+            if isinstance(arg, list):
+                return [encodeArg(a) for a in arg]
+            elif isinstance(arg, unicode):
+                return arg.encode("ascii")
+            return arg
+        d = utils.getProcessOutputAndValue(encodeArg(self.gitbin),
+                                           encodeArg([command] + args),
+                                           path=encodeArg(path), env=os.environ)
 
         def _convert_nonzero_to_failure(res,
                                         command,


### PR DESCRIPTION
When I start buildbot I have more than 100 log lines like this in my twistd.log: 

```
 2014-12-09 16:39:23+0100 [-] /home/xavierd/Projects/myGitHub/buildbot-work/sandbox/local/lib/python2.7/site-packages/twisted/internet/utils.py:30: exceptions.DeprecationWarning: Argument strings and environment keys/values passed to reactor.spawnProcess should be str, not unicode.
```
