### PR TITLE
Add the running builds to the home page

### DIFF
--- a/www/base/src/app/home/home.controller.coffee
+++ b/www/base/src/app/home/home.controller.coffee
@@ -1,5 +1,5 @@
 class Home extends Controller
-    constructor: ($scope, recentStorage) ->
+    constructor: ($scope, recentStorage, buildbotService) ->
         $scope.recent = {}
         recentStorage.getAll().then (e) ->
             $scope.recent.recent_builders = e.recent_builders
@@ -9,3 +9,6 @@ class Home extends Controller
                 recentStorage.getAll().then (e) ->
                     $scope.recent.recent_builders = e.recent_builders
                     $scope.recent.recent_builds = e.recent_builds
+
+
+        buildbotService.some('builds', order: '-started_at', complete: false).bind($scope, dest_key:'builds_running')

--- a/www/base/src/app/home/home.tpl.jade
+++ b/www/base/src/app/home/home.tpl.jade
@@ -18,4 +18,7 @@
     .col-sm-8
       .well
         h2 Welcome to buildbot
-        | Probably we should display information about what's going on currently
+        h4 {{ builds_running.length }} Build{{ builds_running.length > 1 ? 's' : '' }} running currently
+        ul
+          li(ng-repeat="build in builds_running")
+            buildsummary(buildid="build.buildid")


### PR DESCRIPTION
This is WIP ...

@tardyp This one is mostly for you.

Lots of question remaining:
- How do we get that page automatically update itself ?
- Can we get the slave status ?
- About the build info, do I need to perform a request for each filed I need ? (builder name, slave name)

Do we want a list of recently finished builds, or is currently running enough ?
