### PR TITLE
Add a leading 0 to the duration subparts

### DIFF
--- a/www/base/src/app/common/filters/moment/moment.filter.coffee
+++ b/www/base/src/app/common/filters/moment/moment.filter.coffee
@@ -12,10 +12,16 @@ class Durationformat extends Filter('common')
     constructor: (MOMENT) ->
         return (time) ->
             d = MOMENT.duration(time * 1000)
+            mins = d.minutes()
+            if mins < 10
+                mins = '0' + mins
+            secs = d.seconds()
+            if secs < 10
+                secs = '0' + secs
             if d.hours()
-                return "#{d.hours()}:#{d.minutes()}:#{d.seconds()}"
+                return "#{d.hours()}:#{mins}:#{secs}"
             else if d.minutes()
-                return "#{d.minutes()}:#{d.seconds()}"
+                return "#{d.minutes()}:#{secs}"
             else
                 return "#{d.seconds()}s"
 


### PR DESCRIPTION
This way, 1:05 is displayed as 1:05 instead of 1:5
