### PR TITLE
Add a default for request.args.get

### DIFF
--- a/master/buildbot/status/web/slaves.py
+++ b/master/buildbot/status/web/slaves.py
@@ -114,8 +114,8 @@ class OneBuildSlaveResource(HtmlResource, BuildLineMixin):
                     current_builds.append(self.get_line_values(request, cb))
 
         try:
-            max_builds = int(request.args.get('numbuilds')[0])
-        except ValueError:
+            max_builds = int(request.args.get('numbuilds', ['10'])[0])
+        except (TypeError, ValueError):
             max_builds = 10
 
         recent_builds = []


### PR DESCRIPTION
And, just for the heck of it, catch TypeError anyway.  Fixes #[3107](http://trac.buildbot.net/ticket/3107).

I always take the easy ones, don't I?  At least this one passed `validate.sh`.
