### PR TITLE
Don't display a leading zero for the first element of the duration.

### DIFF
--- a/www/base/src/app/common/filters/moment/moment.filter.coffee
+++ b/www/base/src/app/common/filters/moment/moment.filter.coffee
@@ -18,11 +18,11 @@ class Durationformat extends Filter('common')
                 plural = ""
                 if days > 1
                     plural = "s"
-                return "#{days} day#{plural} " + m.format('HH:mm:ss')
+                return "#{days} day#{plural} " + m.format('H:mm:ss')
             if d.hours()
-                return m.format('HH:mm:ss')
+                return m.format('H:mm:ss')
             if d.minutes()
-                return m.format('mm:ss')
+                return m.format('m:ss')
             else
                 return m.format('s') + " s"
 


### PR DESCRIPTION
5 minutes 8 seconds is 5:08, not 05:08
