### PR TITLE
Collapse the buildsummaries on the home page.

### DIFF
--- a/www/base/src/app/home/home.tpl.jade
+++ b/www/base/src/app/home/home.tpl.jade
@@ -21,4 +21,4 @@
         h4 {{ builds_running.length }} Build{{ builds_running.length > 1 ? 's' : '' }} running currently
         ul
           li(ng-repeat="build in builds_running")
-            buildsummary(buildid="build.buildid")
+            buildsummary(buildid="build.buildid", condensed="true")


### PR DESCRIPTION
Side note: 'condensed' has another meaning in bootstrap. This should probably be renamed 'collapsed'
