### PR TITLE
Instead of hard-coding a list of modes in svn.startVC(), use getattr instead

### DIFF
--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -99,10 +99,7 @@ class SVN(Source):
                 return 0
         d.addCallback(checkPatched)
 
-        if self.mode == 'full':
-            d.addCallback(self.full)
-        elif self.mode == 'incremental':
-            d.addCallback(self.incremental)
+        d.addCallback(getattr(self, self.mode))
 
         if patch:
             d.addCallback(self.patch, patch)


### PR DESCRIPTION
This patch allows users of buildbot to subclass the SVN class and create a new
mode. The only way to do this currently is by copying the entire startVC() class
to ensure that the new mode callback is added in the proper place.