### PR TITLE
fix urls in json help pages

### DIFF
--- a/master/buildbot/status/web/templates/jsonhelp.html
+++ b/master/buildbot/status/web/templates/jsonhelp.html
@@ -12,8 +12,8 @@
 <p>Child Nodes</p>
 <ul>
 {% for child in children %}
-    <li><a href="{{path_to_root}}json/{{ child|e }}">{{ child|e }}</a>
-        (<a href="{{path_to_root}}json/{{ child|e }}/help">{{ child|e }}/help</a>)
+    <li><a href="{{ child|e }}">{{ child|e }}</a>
+        (<a href="{{ child|e }}/help">{{ child|e }}/help</a>)
     </li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
Hello,

Url generated in json help pages are broken :

```
{{path_to_root}}json/{{ child|e }}
{{path_to_root}}json/{{ child|e }}/help
```

This generates invalid urls in children, for exemple in json/builders, the url for child nodes are
http://localdomain/json/my_builder1
http://localdomain/json/my_builder2

instead of:
http://localdomain/json/builders/my_builder1
http://localdomain/json/builders/my_builder2

Fix is to make child nodes url relatives.
