### PR TITLE
Improve api for trigger step

### DIFF
--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -2327,13 +2327,13 @@ Dynamic Trigger
 +++++++++++++++
 
 Sometimes it is desirable to select which scheduler to trigger, and which properties to set dynamically, at the time of the build.
-For this purpose, Trigger step support a method that you can customize in order to override statically defined ``schedulernames``, and ``set_properties``.
+For this purpose, Trigger step supports a method that you can customize in order to override statically defined ``schedulernames``, and ``set_properties``.
 
 .. py:method:: getSchedulersAndProperties()
 
     :returns: list of tuples (schedulerName, propertiesDict) optionally via deferred
 
-    This methods returns a list of tuples describing what scheduler to trigger, with which properties.
+    This method returns a list of tuples describing what scheduler to trigger, with which properties.
     With this method, you can trigger several time the same scheduler with different set of properties.
     The sourcestamp configuration is however the same for each triggered build request.
 

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -2272,6 +2272,11 @@ For previous versions, no environment variables are available (the slave environ
 Triggering Schedulers
 ---------------------
 
+.. py:class:: Trigger(schedulerNames=[], sourceStamp=None, sourceStamps=None,
+                 updateSourceStamp=None, alwaysUseLatest=False,
+                 waitForFinish=False, set_properties={},
+                 copy_properties=[], parent_relationship="triggered from")
+
 The counterpart to the :bb:Sched:`Triggerable` scheduler is the :bb:step:`Trigger` build step::
 
     from buildbot.plugins import steps
@@ -2280,31 +2285,58 @@ The counterpart to the :bb:Sched:`Triggerable` scheduler is the :bb:step:`Trigge
                             updateSourceStamp=True,
                             set_properties={ 'quick' : False }))
 
-The ``schedulerNames=`` argument lists the :bb:sched:`Triggerable` schedulers that should be triggered when this step is executed.
-Note that it is possible, but not advisable, to create a cycle where a build continually triggers itself, because the schedulers are specified by name.
-
-If ``waitForFinish`` is ``True``, then the step will not finish until all of the builds from the triggered schedulers have finished.
-Hyperlinks are added to the waterfall and the build detail web pages for each triggered build.
-If this argument is ``False`` (the default) or not given, then the buildstep succeeds immediately after triggering the schedulers.
-
 The SourceStamps to use for the triggered build are controlled by the arguments ``updateSourceStamp``, ``alwaysUseLatest``, and ``sourceStamps``.
-If ``updateSourceStamp`` is ``True`` (the default), then step updates the source stamps given to the :bb:sched:`Triggerable` schedulers to include ``got_revision`` (the revision actually used in this build) as ``revision`` (the revision to use in the triggered builds).
-This is useful to ensure that all of the builds use exactly the same source stamps, even if other :class:`Change`\s have occurred while the build was running.
-If ``updateSourceStamp`` is False (and neither of the other arguments are specified), then the exact same SourceStamps are used.
-If ``alwaysUseLatest`` is True, then no SourceStamps are given, corresponding to using the latest revisions of the repositories specified in the Source steps.
-This is useful if the triggered builds use to a different source repository.
-The argument ``sourceStamps`` accepts a list of dictionaries containing the keys ``branch``, ``revision``, ``repository``, ``project``, and optionally ``patch_level``, ``patch_body``, ``patch_subdir``, ``patch_author`` and ``patch_comment`` and creates the corresponding SourceStamps.
-If only one sourceStamp has to be specified then the argument ``sourceStamp`` can be used for a dictionary containing the keys mentioned above.
-The arguments ``updateSourceStamp``, ``alwaysUseLatest``, and ``sourceStamp`` can be specified using properties.
 
-The ``set_properties`` parameter allows control of the properties that are passed to the triggered scheduler.
-The parameter takes a dictionary mapping property names to values.
-You may use :ref:`Interpolate` here to dynamically construct new property values.
-For the simple case of copying a property, this might look like::
+Hyperlinks are added to the build detail web pages for each triggered build.
 
-    set_properties={"my_prop1" : Property("my_prop1")}
+:param schedulerNames:
+    lists the :bb:sched:`Triggerable` schedulers that should be triggered when this step is executed.
+
+    .. note::
+
+        It is possible, but not advisable, to create a cycle where a build continually triggers itself, because the schedulers are specified by name.
+:param waitForFinish:
+    * If ``True``, the step will not finish until all of the builds from the triggered schedulers have finished.
+    * If ``False`` (the default) or not given, then the buildstep succeeds immediately after triggering the schedulers.
+
+:param updateSourceStamp:
+    * If ``True`` (the default), then step updates the source stamps given to the :bb:sched:`Triggerable` schedulers to include ``got_revision`` (the revision actually used in this build) as ``revision`` (the revision to use in the triggered builds).
+        This is useful to ensure that all of the builds use exactly the same source stamps, even if other :class:`Change`\s have occurred while the build was running.
+    * If ``False`` (and neither of the other arguments are specified), then the exact same SourceStamps are used.
+
+:param alwaysUseLatest:
+    If ``True``, then no SourceStamps are given, corresponding to using the latest revisions of the repositories specified in the Source steps.
+    This is useful if the triggered builds use to a different source repository.
+
+:param sourceStamps:
+    Accepts a list of dictionaries containing the keys ``branch``, ``revision``, ``repository``, ``project``, and optionally ``patch_level``, ``patch_body``, ``patch_subdir``, ``patch_author`` and ``patch_comment`` and creates the corresponding SourceStamps.
+    If only one sourceStamp has to be specified then the argument ``sourceStamp`` can be used for a dictionary containing the keys mentioned above.
+    The arguments ``updateSourceStamp``, ``alwaysUseLatest``, and ``sourceStamp`` can be specified using properties.
+
+:param set_properties:
+    allows control of the properties that are passed to the triggered scheduler.
+    The parameter takes a dictionary mapping property names to values.
+    You may use :ref:`Interpolate` here to dynamically construct new property values.
+    For the simple case of copying a property, this might look like::
+
+        set_properties={"my_prop1" : Property("my_prop1")}
 
 The ``copy_properties`` parameter, given a list of properties to copy into the new build request, has been deprecated in favor of explicit use of ``set_properties``.
+
+Dynamic Trigger
++++++++++++++++
+
+Sometimes it is desirable to select which scheduler to trigger, and which properties to set dynamically, at the time of the build.
+For this purpose, Trigger step support a method that you can customize in order to override statically defined ``schedulernames``, and ``set_properties``.
+
+.. py:method:: getSchedulersAndProperties()
+
+    :returns: list of tuples (schedulerName, propertiesDict) optionally via deferred
+
+    This methods returns a list of tuples describing what scheduler to trigger, with which properties.
+    With this method, you can trigger several time the same scheduler with different set of properties.
+    The sourcestamp configuration is however the same for each triggered build request.
+
 
 RPM-Related Steps
 -----------------

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -290,7 +290,7 @@ Changes and Removals
 
     - setDefaultWorkdir() has been deprecated, but is now behaving the same for all the steps: Setting self.workdir if not already set
 
-* :bb:step:`Trigger` now has a ``getSchedulersAndProperties`` overriding entry point, for dynamic triggering.
+* :bb:step:`Trigger` now has a ``getSchedulersAndProperties`` method that can ve overriden to support dynamic triggering.
 
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -290,6 +290,8 @@ Changes and Removals
 
     - setDefaultWorkdir() has been deprecated, but is now behaving the same for all the steps: Setting self.workdir if not already set
 
+* :bb:step:`Trigger` now has a ``getSchedulersAndProperties`` overriding entry point, for dynamic triggering.
+
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Trigger step was still difficult to subclass in order to add dynamic scheduler and property choosing.
Now it is much easier

While documenting this new API, it also improves a lot the doc for this step.

With this, you don't need to copy paste the entire step in order to implement travis.yml controlled parallel builds:
https://github.com/tardyp/buildbot_travis/blob/master/buildbot_travis/steps/spawner.py
