### PR TITLE
Fix small typo in docs (s/smpt/smtp/).

### DIFF
--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -852,7 +852,7 @@ This form does not send mail to individual developers (and thus does not need th
                       sendToInterestedUsers=False,
                       extraRecipients=['listaddr@example.org'])
 
-If your SMTP host requires authentication before it allows you to send emails, this can also be done by specifying ``smtpUser`` and ``smptPassword``::
+If your SMTP host requires authentication before it allows you to send emails, this can also be done by specifying ``smtpUser`` and ``smtpPassword``::
 
     mn = MailNotifier(fromaddr="myuser@gmail.com",
                       sendToInterestedUsers=False,


### PR DESCRIPTION
Backport of #1428