### PR TITLE
Buildbot UI: fixes related to config.url not existing anymore

### DIFF
--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -144,7 +144,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
     def getURLForBuild(self, builderid, build_number):
         prefix = self.getBuildbotURL()
-        return prefix + "#builders/%d/build/%d" % (
+        return prefix + "#builders/%d/builds/%d" % (
             builderid,
             build_number)
 
@@ -152,7 +152,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         # dont use this API. this URL is not supported
         # its here waiting for getURLForThing removal or switch to deferred
         prefix = self.getBuildbotURL()
-        return prefix + "#builders/%s/build/%d" % (
+        return prefix + "#builders/%s/builds/%d" % (
             urllib.quote(builder_name, safe=''),
             build_number)
 

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -144,7 +144,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
     def getURLForBuild(self, builderid, build_number):
         prefix = self.getBuildbotURL()
-        return prefix + "#builders/%d/builds/%d" % (
+        return prefix + "#builders/%d/build/%d" % (
             builderid,
             build_number)
 
@@ -152,7 +152,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         # dont use this API. this URL is not supported
         # its here waiting for getURLForThing removal or switch to deferred
         prefix = self.getBuildbotURL()
-        return prefix + "#builders/%s/builds/%d" % (
+        return prefix + "#builders/%s/build/%d" % (
             urllib.quote(builder_name, safe=''),
             build_number)
 

--- a/www/base/src/app/builders/build/build.controller.coffee
+++ b/www/base/src/app/builders/build/build.controller.coffee
@@ -43,5 +43,5 @@ class Build extends Controller
             .bind($scope).then (buildrequest) ->
                 buildbotService.one("buildsets", buildrequest.buildsetid).bind($scope)
                 recentStorage.addBuild
-                    link: "#/builders/#{$scope.builder.builderid}/build/#{$scope.build.number}"
+                    link: "#/builders/#{$scope.builder.builderid}/builds/#{$scope.build.number}"
                     caption: "#{$scope.builder.name} / #{$scope.build.number}"

--- a/www/base/src/app/builders/build/build.controller.coffee
+++ b/www/base/src/app/builders/build/build.controller.coffee
@@ -41,6 +41,7 @@ class Build extends Controller
             buildbotService.one("builds", build.id).all("properties").bind($scope)
             buildbotService.one("buildrequests", build.buildrequestid)
             .bind($scope).then (buildrequest) ->
+                buildbotService.one("buildsets", buildrequest.buildsetid).bind($scope)
                 recentStorage.addBuild
                     link: "#/builders/#{$scope.builder.builderid}/build/#{$scope.build.number}"
                     caption: "#{$scope.builder.name} / #{$scope.build.number}"

--- a/www/base/src/app/builders/build/build.route.coffee
+++ b/www/base/src/app/builders/build/build.route.coffee
@@ -9,7 +9,7 @@ class State extends Config
             controller: "#{name}Controller"
             templateUrl: "views/#{name}.html"
             name: name
-            url: '/builders/:builder/build/:build'
+            url: '/builders/:builder/builds/:build'
             data: {}
 
         $stateProvider.state(state)

--- a/www/base/src/app/builders/build/build.tpl.jade
+++ b/www/base/src/app/builders/build/build.tpl.jade
@@ -4,7 +4,7 @@
       li.previous(ng-class="{'disabled': build.number == 1}")
         a(ng-if="build.number > 1 ", ui-sref="build({build:build.number - 1})") &larr; Previous
         span(ng-if="build.number == 1") &larr; Previous
-      span(ng-if="build.complete" title="{{ build.complete_at | dateformat:'LLL' }}") Finished {{ build.complete_at | timeago }}
+      li(ng-if="build.complete" title="{{ build.complete_at | dateformat:'LLL' }}") Finished {{ build.complete_at | timeago }}
       li.next(ng-class="{'disabled': last_build}")
         a(ng-if="!last_build", ui-sref="build({build:build.number + 1})") Next &rarr;
         span(ng-if="last_build") Next &rarr;
@@ -12,6 +12,8 @@
     .col-sm-5
       buildsummary(ng-if="build", buildid="build.buildid")
     .col-sm-7
+      .row(ng-if="buildset.parent_buildid")
+          buildsummary(buildid="buildset.parent_buildid", condensed="1", prefix="{{buildset.parent_relationship}}:")
       tabset
           tab(heading="Build Properties")
             table.table.table-hover.table-striped.table-condensed

--- a/www/base/src/app/builders/buildrequest/buildrequest.controller.coffee
+++ b/www/base/src/app/builders/buildrequest/buildrequest.controller.coffee
@@ -1,5 +1,5 @@
 class Buildrequest extends Controller
-    constructor: ($scope, buildbotService, $stateParams, findBuilds) ->
+    constructor: ($scope, buildbotService, $stateParams, findBuilds, glBreadcrumbService) ->
         $scope.$watch "buildrequest.claimed", (n, o) ->
             if n  # if it is unclaimed, then claimed, we need to try again
                 findBuilds $scope,
@@ -8,5 +8,17 @@ class Buildrequest extends Controller
 
         buildbotService.bindHierarchy($scope, $stateParams, ['buildrequests'])
         .then ([buildrequest]) ->
-            buildbotService.one("buildsets", buildrequest.buildsetid)
-            .bind($scope)
+            buildbotService.one("builders", buildrequest.builderid).bind($scope).then (builder) ->
+                breadcrumb = [
+                        caption: "buildrequests"
+                        sref: "buildrequests"
+                    ,
+                        caption: builder.name
+                        sref: "builder({builder:#{buildrequest.builderid}})"
+                    ,
+                        caption: buildrequest.id
+                        sref: "buildrequest({buildrequest:#{buildrequest.id}})"
+                ]
+
+                glBreadcrumbService.setBreadcrumb(breadcrumb)
+            buildbotService.one("buildsets", buildrequest.buildsetid).bind($scope)

--- a/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.coffee
+++ b/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.coffee
@@ -31,14 +31,15 @@ describe 'buildrequest controller', ->
         createController = ->
             return $controller 'buildrequestController',
                 $scope: $scope
+        $httpBackend.expectDataGET('buildrequests/1')
+        $httpBackend.expectDataGET('builders/1')
+        $httpBackend.expectDataGET('buildsets/1')
     beforeEach(inject(injected))
 
     afterEach ->
         $httpBackend.verifyNoOutstandingExpectation()
         $httpBackend.verifyNoOutstandingRequest()
     it 'should query for buildrequest', ->
-        $httpBackend.expectDataGET('buildrequests/1')
-        $httpBackend.expectDataGET('buildsets/1')
         controller = createController()
         $httpBackend.flush()
         $scope.buildrequest.claimed = true
@@ -49,8 +50,6 @@ describe 'buildrequest controller', ->
         $httpBackend.verifyNoOutstandingRequest()
 
     it 'should query for builds again if first query returns 0', ->
-        $httpBackend.expectDataGET('buildrequests/1')
-        $httpBackend.expectDataGET('buildsets/1')
         controller = createController()
         $httpBackend.flush()
         $scope.buildrequest.claimed = true
@@ -73,8 +72,6 @@ describe 'buildrequest controller', ->
 
     it 'should go to build page if build started', ->
         $stateParams.redirect_to_build = 1
-        $httpBackend.expectDataGET('buildrequests/1')
-        $httpBackend.expectDataGET('buildsets/1')
         controller = createController()
         $httpBackend.flush()
         $scope.buildrequest.claimed = true
@@ -89,4 +86,4 @@ describe 'buildrequest controller', ->
         expect($scope.builds[0].buildid).toBeDefined()
         $timeout.flush()
         $httpBackend.verifyNoOutstandingRequest()
-        expect(goneto).toEqual([ 'build', { builder : 2, build : 1 } ])
+        expect(goneto).toEqual([ 'build', { builder : 3, build : 1 } ])

--- a/www/base/src/app/builders/buildrequest/buildrequest.tpl.jade
+++ b/www/base/src/app/builders/buildrequest/buildrequest.tpl.jade
@@ -1,24 +1,16 @@
 .container
-  .row(ng-repeat="build in builds")
-    .col-sm-4
-      ul.breadcrumb
-        li
-          a(href="#/builders")
-            | Builders
-        li
-          a(href="#/builders/{{build.builderid}}")
-            | {{buildrequest.buildername}}
-        li
-          a(href="#/builders/{{build.builderid}}/build/{{build.number}}")
-            | {{build.number}}
   .row
-    .col-sm-8
-      tabset(justified="true")
-          tab(heading="build {{build.number}}", ng-repeat="build in builds")
-              rawdata(data="build")
-          tab(heading="buildrequest")
-              rawdata(data="buildrequest")
-          tab(heading="properties")
-              rawdata(data="buildset.properties")
-          tab(heading="buildset")
-              rawdata(data="buildset")
+      .col-sm-5
+          h3 Associated builds:
+          .row(ng-repeat="build in builds")
+              buildsummary(buildid="build.buildid", condensed='1')
+      .col-sm-7
+          tabset(justified="true")
+              tab(heading="build {{build.number}}", ng-repeat="build in builds")
+                  rawdata(data="build")
+              tab(heading="buildrequest")
+                  rawdata(data="buildrequest")
+              tab(heading="properties")
+                  rawdata(data="buildset.properties")
+              tab(heading="buildset")
+                  rawdata(data="buildset")

--- a/www/base/src/app/builders/log/log.route.coffee
+++ b/www/base/src/app/builders/log/log.route.coffee
@@ -13,7 +13,7 @@ class State extends Config
             controller: "#{name}Controller"
             templateUrl: "views/#{name}.html"
             name: name
-            url: '/builders/:builder/build/:build/step/:step/log/:log'
+            url: '/builders/:builder/builds/:build/steps/:step/logs/:log'
             data: cfg
 
         $stateProvider.state(state)

--- a/www/base/src/app/builders/step/step.route.coffee
+++ b/www/base/src/app/builders/step/step.route.coffee
@@ -13,5 +13,5 @@ class State extends Config
             controller: "#{name}Controller"
             templateUrl: "views/#{name}.html"
             name: name
-            url: '/builders/:builder/build/:build/step/:step'
+            url: '/builders/:builder/builds/:build/steps/:step'
             data: cfg

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
@@ -3,7 +3,7 @@ class Buildsummary extends Directive('common')
         return {
             replace: true
             restrict: 'E'
-            scope: {buildid: '=', condensed: '='}
+            scope: {buildid: '=', condensed: '=', prefix: "@"}
             templateUrl: 'views/buildsummary.html'
             compile: RecursionHelper.compile
             controller: '_buildsummaryController'

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
@@ -10,12 +10,12 @@ class Buildsummary extends Directive('common')
         }
 
 class _buildsummary extends Controller('common')
-    constructor: ($scope, buildbotService, config, resultsService, $urlMatcherFactory) ->
-
+    constructor: ($scope, buildbotService, resultsService, $urlMatcherFactory, $location) ->
+        baseurl = $location.absUrl().split("#")[0]
         buildrequestURLMatcher = $urlMatcherFactory.compile(
-            "#{config.url}#buildrequests/{buildrequestid:[0-9]+}")
+            "#{baseurl}#buildrequests/{buildrequestid:[0-9]+}")
         buildURLMatcher = $urlMatcherFactory.compile(
-            "#{config.url}#builders/{builderid:[0-9]+}/builds/{buildid:[0-9]+}")
+            "#{baseurl}#builders/{builderid:[0-9]+}/builds/{buildid:[0-9]+}")
 
         NONE = 0
         ONLY_NOT_SUCCESS = 1

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.coffee
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.coffee
@@ -92,7 +92,7 @@ describe 'buildsummary controller', ->
         .toBe(true)
         expect($scope.isBuildRequestURL("http://otherdomain:5000/#buildrequests/123"))
         .toBe(false)
-        expect($scope.isBuildRequestURL("#{baseurl}#build/123"))
+        expect($scope.isBuildRequestURL("#{baseurl}#builds/123"))
         .toBe(false)
         expect($scope.isBuildRequestURL("#{baseurl}#buildrequests/bla"))
         .toBe(false)

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.coffee
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.coffee
@@ -2,12 +2,12 @@ beforeEach module 'app'
 
 describe 'buildsummary controller', ->
     buildbotService = mqService = $scope = $httpBackend = $rootScope = null
-    $timeout = createController = $stateParams = results = config = null
+    $timeout = createController = $stateParams = results = baseurl = null
     goneto  = null
 
     injected = ($injector) ->
         $httpBackend = $injector.get('$httpBackend')
-        config = $injector.get('config')
+        $location = $injector.get('$location')
         decorateHttpBackend($httpBackend)
         results = $injector.get('RESULTS')
         $rootScope = $injector.get('$rootScope')
@@ -25,6 +25,8 @@ describe 'buildsummary controller', ->
         $stateParams = $injector.get('$stateParams')
         $controller = $injector.get('$controller')
         $q = $injector.get('$q')
+        baseurl = $location.absUrl().split("#")[0]
+
         # stub out the actual backend of mqservice
         spyOn(mqService,"setBaseUrl").and.returnValue(null)
         spyOn(mqService,"startConsuming").and.returnValue($q.when( -> ))
@@ -78,30 +80,27 @@ describe 'buildsummary controller', ->
         $scope.toggleDetails()
 
     it 'should provide correct getBuildRequestIDFromURL', ->
-        config.url = 'http://localhost:5000/'
         controller = createController()
         $httpBackend.flush()
-        expect($scope.getBuildRequestIDFromURL("http://localhost:5000/#buildrequests/123"))
+        expect($scope.getBuildRequestIDFromURL("#{baseurl}#buildrequests/123"))
         .toBe(123)
 
     it 'should provide correct isBuildRequestURL', ->
-        config.url = 'http://localhost:5000/'
         controller = createController()
         $httpBackend.flush()
-        expect($scope.isBuildRequestURL("http://localhost:5000/#buildrequests/123"))
+        expect($scope.isBuildRequestURL("#{baseurl}#buildrequests/123"))
         .toBe(true)
         expect($scope.isBuildRequestURL("http://otherdomain:5000/#buildrequests/123"))
         .toBe(false)
-        expect($scope.isBuildRequestURL("http://localhost:5000/#build/123"))
+        expect($scope.isBuildRequestURL("#{baseurl}#build/123"))
         .toBe(false)
-        expect($scope.isBuildRequestURL("http://localhost:5000/#buildrequests/bla"))
+        expect($scope.isBuildRequestURL("#{baseurl}#buildrequests/bla"))
         .toBe(false)
 
     it 'should provide correct isBuildURL', ->
-        config.url = 'http://localhost:5000/'
         controller = createController()
         $httpBackend.flush()
-        expect($scope.isBuildURL("http://localhost:5000/#builders/123/builds/123"))
+        expect($scope.isBuildURL("#{baseurl}#builders/123/builds/123"))
         .toBe(true)
-        expect($scope.isBuildURL("http://localhost:5000/#builders/sdf/builds/123"))
+        expect($scope.isBuildURL("#{baseurl}#builders/sdf/builds/123"))
         .toBe(false)

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -1,5 +1,6 @@
 .panel.panel-default(ng-class="results2class(build)")
   .panel-heading.no-select(ng-click="toggleDetails()")
+    span(ng-if="prefix") {{prefix}}&nbsp;
     a(href="#/builders/{{builder.builderid}}/build/{{build.number}}")
       | {{builder.name}}/{{build.number}}
     .pull-right

--- a/www/base/src/app/common/directives/loginbar/loginbar.directive.coffee
+++ b/www/base/src/app/common/directives/loginbar/loginbar.directive.coffee
@@ -9,7 +9,8 @@ class Loginbar extends Directive('common')
         }
 
 class _loginbar extends Controller('common')
-    constructor: ($scope, config, $http) ->
+    constructor: ($scope, config, $http, $location) ->
+        baseurl = $location.absUrl().split("#")[0]
         $scope.username = ""
         $scope.password = ""
         $scope.loginCollapsed = 1
@@ -22,7 +23,7 @@ class _loginbar extends Controller('common')
             $http.defaults.headers.common['Authorization'] = auth
             $http
                 method: "GET"
-                url: "#{config.url}auth/login"
+                url: "#{baseurl}auth/login"
             .success (data, status) ->
                 window.location.reload()
 
@@ -30,13 +31,13 @@ class _loginbar extends Controller('common')
             $http.defaults.headers.common = {}
             $http
                 method: "GET"
-                url: "#{config.url}auth/logout"
+                url: "#{baseurl}auth/logout"
             .success (data, status) ->
                 window.location.reload()
         $scope.loginoauth2 = ->
             $http
                 method: "GET"
-                url: "#{config.url}auth/login"
+                url: "#{baseurl}auth/login"
             .success (data, status) ->
                 document.location = data
         if config.auth.autologin and config.user.anonymous and config.auth.oauth2

--- a/www/codeparameter/src/module/codefield.directive.coffee
+++ b/www/codeparameter/src/module/codefield.directive.coffee
@@ -7,8 +7,9 @@ class Codeparameter extends App
 
 # setup ace to fetch its module from the plugin baseURL
 class AceConfig extends Run
-    constructor: (config) ->
-        window.ace.config.set("basePath", config.url + "codeparameter")
+    constructor: ($location) ->
+        baseurl = $location.absUrl().split("#")[0]
+        window.ace.config.set("basePath", "#{baseurl}codeparameter")
 
 # defines custom field directives which only have templates
 class Codefield extends Directive


### PR DESCRIPTION
- Replace config.url logic by use of $location
- modernize the buildrequest page to use breadcrumb, and buildsummary. This page is purely for debug, as there is nothing that points there, but we can still have something nice enough. 

![image](https://cloud.githubusercontent.com/assets/109859/5745356/672aa1ae-9c28-11e4-8d9d-d7ea3147d1a9.png)
