### PR TITLE
Show parent relationship for builds

### DIFF
--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -38,7 +38,7 @@ class Trigger(BuildStep):
     def __init__(self, schedulerNames=[], sourceStamp=None, sourceStamps=None,
                  updateSourceStamp=None, alwaysUseLatest=False,
                  waitForFinish=False, set_properties={},
-                 copy_properties=[], parent_relationship="triggered from", **kwargs):
+                 copy_properties=[], parent_relationship="Triggered from", **kwargs):
         if not schedulerNames:
             config.error(
                 "You must specify a scheduler to trigger")

--- a/www/base/src/app/builders/build/build.controller.coffee
+++ b/www/base/src/app/builders/build/build.controller.coffee
@@ -41,6 +41,7 @@ class Build extends Controller
             buildbotService.one("builds", build.id).all("properties").bind($scope)
             buildbotService.one("buildrequests", build.buildrequestid)
             .bind($scope).then (buildrequest) ->
+                buildbotService.one("buildsets", buildrequest.buildsetid).bind($scope)
                 recentStorage.addBuild
                     link: "#/builders/#{$scope.builder.builderid}/build/#{$scope.build.number}"
                     caption: "#{$scope.builder.name} / #{$scope.build.number}"

--- a/www/base/src/app/builders/build/build.tpl.jade
+++ b/www/base/src/app/builders/build/build.tpl.jade
@@ -4,7 +4,7 @@
       li.previous(ng-class="{'disabled': build.number == 1}")
         a(ng-if="build.number > 1 ", ui-sref="build({build:build.number - 1})") &larr; Previous
         span(ng-if="build.number == 1") &larr; Previous
-      span(ng-if="build.complete" title="{{ build.complete_at | dateformat:'LLL' }}") Finished {{ build.complete_at | timeago }}
+      li(ng-if="build.complete" title="{{ build.complete_at | dateformat:'LLL' }}") Finished {{ build.complete_at | timeago }}
       li.next(ng-class="{'disabled': last_build}")
         a(ng-if="!last_build", ui-sref="build({build:build.number + 1})") Next &rarr;
         span(ng-if="last_build") Next &rarr;
@@ -12,6 +12,8 @@
     .col-sm-5
       buildsummary(ng-if="build", buildid="build.buildid")
     .col-sm-7
+      .row(ng-if="buildset.parent_buildid")
+          buildsummary(buildid="buildset.parent_buildid", condensed="1", prefix="{{buildset.parent_relationship}}:")
       tabset
           tab(heading="Build Properties")
             table.table.table-hover.table-striped.table-condensed

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
@@ -3,7 +3,7 @@ class Buildsummary extends Directive('common')
         return {
             replace: true
             restrict: 'E'
-            scope: {buildid: '=', condensed: '='}
+            scope: {buildid: '=', condensed: '=', prefix: "@"}
             templateUrl: 'views/buildsummary.html'
             compile: RecursionHelper.compile
             controller: '_buildsummaryController'

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -1,5 +1,6 @@
 .panel.panel-default(ng-class="results2class(build)")
   .panel-heading.no-select(ng-click="toggleDetails()")
+    span(ng-if="prefix") {{prefix}}&nbsp;
     a(href="#/builders/{{builder.builderid}}/build/{{build.number}}")
       | {{builder.name}}/{{build.number}}
     .pull-right


### PR DESCRIPTION
It should be easy to go back to a parent build, when you are in a child build.
This changes implements link, and build summary of the parent build in a child build

After trying various options, I went to modifying the buildsummary to add a prefix. The prefix being in this case the parent_relationship that is configured in trigger step

![image](https://cloud.githubusercontent.com/assets/109859/5747072/70e20fcc-9c35-11e4-9365-9bb1effa9ba7.png)
