### PR TITLE
Handle `\r\n` and `\r` in LineBoundaryFinder

### DIFF
--- a/master/buildbot/util/lineboundaries.py
+++ b/master/buildbot/util/lineboundaries.py
@@ -13,12 +13,18 @@
 #
 # Copyright Buildbot Team Members
 
+import re
+
 from twisted.internet import defer
 
 
 class LineBoundaryFinder(object):
 
     __slots__ = ['partialLine', 'callback']
+
+    # the lookahead here (`(?=.)`) ensures that `\r` doesn't match at the end
+    # of the buffer
+    newline_re = re.compile(r'(\r\n|\r(?=.)|\n)')
 
     def __init__(self, callback):
         self.partialLine = None
@@ -28,6 +34,7 @@ class LineBoundaryFinder(object):
         if self.partialLine:
             text = self.partialLine + text
             self.partialLine = None
+        text = self.newline_re.sub('\n', text)
         if text:
             if text[-1] != '\n':
                 i = text.rfind('\n')

--- a/master/docs/developer/rtype-log.rst
+++ b/master/docs/developer/rtype-log.rst
@@ -137,6 +137,7 @@ All update methods are available as attributes of ``master.data.updates``.
 
         Append the given content to the given log.
         The content must end with a newline.
+        All newlines in the content should be UNIX-style (``\n``).
 
     .. py:method:: finishLog(logid)
 

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -822,6 +822,8 @@ buildbot.util.lineboundaries
 
     This class accepts a sequence of arbitrary strings and invokes a callback only with complete (newline-terminated) substrings.
     It buffers any partial lines until a subsequent newline is seen.
+    It considers any of ``\r``, ``\n``, and ``\r\n`` to be newlines.
+    Because of the ambiguity of an append operation ending in the character ``\r`` (it may be a bare ``\r`` or half of ``\r\n``), the last line of such an append operation will be buffered until the next append or flush.
 
     :param callback: asynchronous function to call with newline-terminated strings
 


### PR DESCRIPTION
Including careful handling of the case where `\r\n` is split along a
buffer boundary.  Fixes #3144.