### PR TITLE
pin the version of astroid to one that supports py2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,8 @@ install:
     fi;
 
   # Run additional tests only in latest configuration
+  # Astroid 1.3.0 dropped Python-2.6 spuport
+  - "[ $IS_LATEST = false ] || pip install 'astroid<1.3.0'"
   # Note pylint version is pinned because newer versions can't import zope.interface - http://www.logilab.org/92792
   - "[ $IS_LATEST = false ] || pip install pylint==1.1.0"
   - "[ $IS_LATEST = false ] || pip install pyflakes"


### PR DESCRIPTION
This should fix the Travis failures