### PR TITLE
add a master reference to www plugins

### DIFF
--- a/master/buildbot/www/plugin.py
+++ b/master/buildbot/www/plugin.py
@@ -26,6 +26,9 @@ class Application(object):
         self.static_dir = pkg_resources.resource_filename(modulename, "/static")
         self.resource = static.File(self.static_dir)
 
+    def setMaster(self, master):
+        self.master = master
+
     def __repr__(self):
         return ("www.plugin.Application(version=%(version)s, "
                 "description=%(description)s, "

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -125,6 +125,7 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             log.msg("initializing www plugin %r" % (key,))
             if key not in self.apps:
                 raise RuntimeError("could not find plugin %s; is it installed?" % (key,))
+            self.apps.get(key).setMaster(self.master)
             root.putChild(key, self.apps.get(key).resource)
         known_plugins = set(new_config.www.get('plugins', {})) | set(['base'])
         for plugin_name in set(self.apps.names) - known_plugins:

--- a/master/docs/developer/www.rst
+++ b/master/docs/developer/www.rst
@@ -428,7 +428,8 @@ The entrypoint must contain a twisted.web Resource, that is populated in the web
 The front-end part of the plugin system automatically loads `/<pluginname>/scripts.js` and `/<pluginname>/styles.css` into the angular.js application.
 The scripts.js files can register itself as a dependency to the main "app" module, register some new states to $stateProvider, or new menu items via glMenuProvider.
 
-The entrypoint being a Resource, nothing forbids plugin writers to add more REST apis in `/<pluginname>/api`.
+The entrypoint containing a Resource, nothing forbids plugin writers to add more REST apis in `/<pluginname>/api`.
+For that, a reference to the master singleton is provided in ``master`` attribute of the Application entrypoint. 
 You are even not restricted to twisted, and could even `load a wsgi application using flask, django, etc <http://twistedmatrix.com/documents/13.1.0/web/howto/web-in-60/wsgi.html>`_.
 
 .. _Routing:


### PR DESCRIPTION
That way, they can really implement new REST apis.

ex:
https://github.com/tardyp/buildbot_travis/blob/master/buildbot_travis/__init__.py
