### PR TITLE
relax requirement for python-dateutil

### DIFF
--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -56,6 +56,8 @@ Minor Python Packages
 
 * Buildbot requires at least Twisted-11.0.0.
 
+* Buildbot works python-dateutil >= 1.5
+
 Features
 ~~~~~~~~
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -369,7 +369,7 @@ else:
         # buildbot depends on sqlalchemy internals, and this is the tested
         # version.
         'sqlalchemy-migrate==0.7.2',
-        'python-dateutil==1.5',
+        'python-dateutil>=1.5',
     ]
 
     setup_args['extras_require'] = {


### PR DESCRIPTION
tests were run for python-dateutil 2.{0,1,2,3,4}