### PR TITLE
ForceScheduler: make errors more helpful by telling which scheduler has the issue

### DIFF
--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -542,30 +542,30 @@ class ForceScheduler(base.BaseScheduler):
                          name)
 
         if not self.checkIfListOfType(builderNames, str):
-            config.error("ForceScheduler builderNames must be a list of strings: %r" %
-                         builderNames)
+            config.error("ForceScheduler '%s': builderNames must be a list of strings: %r" %
+                         (name, builderNames))
 
         if self.checkIfType(reason, BaseParameter):
             self.reason = reason
         else:
-            config.error("ForceScheduler reason must be a StringParameter: %r" %
-                         reason)
+            config.error("ForceScheduler '%s': reason must be a StringParameter: %r" %
+                         (name, reason))
 
         if not self.checkIfListOfType(properties, BaseParameter):
-            config.error("ForceScheduler properties must be a list of BaseParameters: %r" %
-                         properties)
+            config.error("ForceScheduler '%s': properties must be a list of BaseParameters: %r" %
+                         (name, properties))
 
         if self.checkIfType(username, BaseParameter):
             self.username = username
         else:
-            config.error("ForceScheduler username must be a StringParameter: %r" %
-                         username)
+            config.error("ForceScheduler '%s': username must be a StringParameter: %r" %
+                         (name, username))
 
         self.forcedProperties = []
 
         if any((branch, revision, repository, project)):
             if codebases:
-                config.error("ForceScheduler: Must either specify 'codebases' or the 'branch/revision/repository/project' parameters: %r " % (codebases,))
+                config.error("ForceScheduler '%s': Must either specify 'codebases' or the 'branch/revision/repository/project' parameters: %r " % (name, codebases))
 
             codebases = [
                 CodebaseParameter(codebase='',
@@ -580,14 +580,14 @@ class ForceScheduler(base.BaseScheduler):
         if codebases is None:
             codebases = [CodebaseParameter(codebase='')]
         elif not codebases:
-            config.error("ForceScheduler: 'codebases' cannot be empty; use CodebaseParameter(codebase='', hide=True) if needed: %r " % (codebases,))
+            config.error("ForceScheduler '%s': 'codebases' cannot be empty; use CodebaseParameter(codebase='', hide=True) if needed: %r " % (name, codebases))
 
         codebase_dict = {}
         for codebase in codebases:
             if isinstance(codebase, basestring):
                 codebase = CodebaseParameter(codebase=codebase)
             elif not isinstance(codebase, CodebaseParameter):
-                config.error("ForceScheduler: 'codebases' must be a list of strings or CodebaseParameter objects: %r" % (codebases,))
+                config.error("ForceScheduler '%s': 'codebases' must be a list of strings or CodebaseParameter objects: %r" % (name, codebases))
 
             self.forcedProperties.append(codebase)
             codebase_dict[codebase.codebase] = dict(branch='', repository='', revision='')

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -237,29 +237,29 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
 
     def test_bad_codebases(self):
         # cant specify both codebases and branch/revision/project/repository:
-        self.assertRaisesConfigError("ForceScheduler: Must either specify 'codebases' or the 'branch/revision/repository/project' parameters:",
+        self.assertRaisesConfigError("ForceScheduler 'foo': Must either specify 'codebases' or the 'branch/revision/repository/project' parameters:",
                                      lambda: ForceScheduler(name='foo', builderNames=['bar'],
                                                             codebases=['foo'], branch=StringParameter('name')))
-        self.assertRaisesConfigError("ForceScheduler: Must either specify 'codebases' or the 'branch/revision/repository/project' parameters:",
+        self.assertRaisesConfigError("ForceScheduler 'foo': Must either specify 'codebases' or the 'branch/revision/repository/project' parameters:",
                                      lambda: ForceScheduler(name='foo', builderNames=['bar'],
                                                             codebases=['foo'], revision=StringParameter('name')))
-        self.assertRaisesConfigError("ForceScheduler: Must either specify 'codebases' or the 'branch/revision/repository/project' parameters:",
+        self.assertRaisesConfigError("ForceScheduler 'foo': Must either specify 'codebases' or the 'branch/revision/repository/project' parameters:",
                                      lambda: ForceScheduler(name='foo', builderNames=['bar'],
                                                             codebases=['foo'], project=StringParameter('name')))
-        self.assertRaisesConfigError("ForceScheduler: Must either specify 'codebases' or the 'branch/revision/repository/project' parameters:",
+        self.assertRaisesConfigError("ForceScheduler 'foo': Must either specify 'codebases' or the 'branch/revision/repository/project' parameters:",
                                      lambda: ForceScheduler(name='foo', builderNames=['bar'],
                                                             codebases=['foo'], repository=StringParameter('name')))
 
         # codebases must be a list of either string or BaseParameter types
-        self.assertRaisesConfigError("ForceScheduler: 'codebases' must be a list of strings or CodebaseParameter objects:",
+        self.assertRaisesConfigError("ForceScheduler 'foo': 'codebases' must be a list of strings or CodebaseParameter objects:",
                                      lambda: ForceScheduler(name='foo', builderNames=['bar'],
                                                             codebases=[123],))
-        self.assertRaisesConfigError("ForceScheduler: 'codebases' must be a list of strings or CodebaseParameter objects:",
+        self.assertRaisesConfigError("ForceScheduler 'foo': 'codebases' must be a list of strings or CodebaseParameter objects:",
                                      lambda: ForceScheduler(name='foo', builderNames=['bar'],
                                                             codebases=[IntParameter('foo')],))
 
         # codebases cannot be empty
-        self.assertRaisesConfigError("ForceScheduler: 'codebases' cannot be empty; use CodebaseParameter(codebase='', hide=True) if needed:",
+        self.assertRaisesConfigError("ForceScheduler 'foo': 'codebases' cannot be empty; use CodebaseParameter(codebase='', hide=True) if needed:",
                                      lambda: ForceScheduler(name='foo',
                                                             builderNames=['bar'],
                                                             codebases=[]))
@@ -482,12 +482,12 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                               klass=NestedParameter, fields=fields, name='')
 
     def test_bad_reason(self):
-        self.assertRaisesConfigError("ForceScheduler reason must be a StringParameter",
+        self.assertRaisesConfigError("ForceScheduler 'testsched': reason must be a StringParameter",
                                      lambda: ForceScheduler(name='testsched', builderNames=[],
                                                             codebases=['bar'], reason="foo"))
 
     def test_bad_username(self):
-        self.assertRaisesConfigError("ForceScheduler username must be a StringParameter",
+        self.assertRaisesConfigError("ForceScheduler 'testsched': username must be a StringParameter",
                                      lambda: ForceScheduler(name='testsched', builderNames=[],
                                                             codebases=['bar'], username="foo"))
 
@@ -502,35 +502,35 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                                                             codebases=['bar'], username="foo"))
 
     def test_integer_builderNames(self):
-        self.assertRaisesConfigError("ForceScheduler builderNames must be a list of strings:",
+        self.assertRaisesConfigError("ForceScheduler 'testsched': builderNames must be a list of strings:",
                                      lambda: ForceScheduler(name='testsched', builderNames=1234,
                                                             codebases=['bar'], username="foo"))
 
     def test_listofints_builderNames(self):
-        self.assertRaisesConfigError("ForceScheduler builderNames must be a list of strings:",
+        self.assertRaisesConfigError("ForceScheduler 'testsched': builderNames must be a list of strings:",
                                      lambda: ForceScheduler(name='testsched', builderNames=[1234],
                                                             codebases=['bar'], username="foo"))
 
     def test_listofmixed_builderNames(self):
-        self.assertRaisesConfigError("ForceScheduler builderNames must be a list of strings:",
+        self.assertRaisesConfigError("ForceScheduler 'testsched': builderNames must be a list of strings:",
                                      lambda: ForceScheduler(name='testsched',
                                                             builderNames=['test', 1234],
                                                             codebases=['bar'], username="foo"))
 
     def test_integer_properties(self):
-        self.assertRaisesConfigError("ForceScheduler properties must be a list of BaseParameters:",
+        self.assertRaisesConfigError("ForceScheduler 'testsched': properties must be a list of BaseParameters:",
                                      lambda: ForceScheduler(name='testsched', builderNames=[],
                                                             codebases=['bar'], username="foo",
                                                             properties=1234))
 
     def test_listofints_properties(self):
-        self.assertRaisesConfigError("ForceScheduler properties must be a list of BaseParameters:",
+        self.assertRaisesConfigError("ForceScheduler 'testsched': properties must be a list of BaseParameters:",
                                      lambda: ForceScheduler(name='testsched', builderNames=[],
                                                             codebases=['bar'], username="foo",
                                                             properties=[1234, 2345]))
 
     def test_listofmixed_properties(self):
-        self.assertRaisesConfigError("ForceScheduler properties must be a list of BaseParameters:",
+        self.assertRaisesConfigError("ForceScheduler 'testsched': properties must be a list of BaseParameters:",
                                      lambda: ForceScheduler(name='testsched', builderNames=[],
                                                             codebases=['bar'], username="foo",
                                                             properties=[BaseParameter(name="test",),


### PR DESCRIPTION
I recently had a ForceScheduler that wasnt configured right, and the config error was not helpful becuase it didnt tell me which one I messed up. This simple patch adds the name to the error messages.