### PR TITLE
Tags: backport #928 to eight

### DIFF
--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -157,7 +157,7 @@ class IStatus(Interface):
         """Return a list of ISchedulerStatus objects for all
         currently-registered Schedulers."""
 
-    def getBuilderNames(categories=None):
+    def getBuilderNames(categories=None, tags=None):
         """Return a list of the names of all current Builders."""
     def getBuilder(name):
         """Return the IBuilderStatus object for a given named Builder. Raises
@@ -333,6 +333,9 @@ class IBuilderStatus(Interface):
 
     def getName():
         """Return the name of this Builder (a string)."""
+
+    def getTags():
+        """Return the tags of this builder (a list of strings)"""
 
     def getCategory():
         """Return the category of this builder (a string)."""

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -97,15 +97,15 @@ class Builder(config.ReconfigurableServiceMixin,
         # set up a builder status object on the first reconfig
         if not self.builder_status:
             self.builder_status = self.master.status.builderAdded(
-                builder_config.name,
-                builder_config.builddir,
-                builder_config.category,
-                builder_config.description)
+                name=builder_config.name,
+                basedir=builder_config.builddir,
+                tags=builder_config.tags,
+                description=builder_config.description)
 
         self.config = builder_config
 
         self.builder_status.setDescription(builder_config.description)
-        self.builder_status.setCategory(builder_config.category)
+        self.builder_status.setTags(builder_config.tags)
         self.builder_status.setSlavenames(self.config.slavenames)
         self.builder_status.setCacheSize(new_config.caches['Builds'])
 

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -336,10 +336,12 @@ class BuilderStatus(styles.Versioned):
         self.tags = tags
 
     def matchesAnyTag(self, tags):
-        return self.tags and any((tag in self.tags) for tag in tags)
+        # Need to guard against None with the "or []".
+        return set(self.tags or []).isdisjoint(tags)
 
     def matchesAllTags(self, tags):
-        return self.tags and all((tag in self.tags) for tag in tags)
+        # Need to guard against None with the "or []".
+        return set(self.tags or []).issuperset(tags)
 
     def setCategory(self, category):
         return self.setTags([category])

--- a/master/buildbot/status/mail.py
+++ b/master/buildbot/status/mail.py
@@ -242,14 +242,14 @@ class MailNotifier(base.StatusReceiverMultiService, buildset.BuildSetSummaryNoti
     implements(interfaces.IEmailSender)
 
     compare_attrs = ["extraRecipients", "lookup", "fromaddr", "mode",
-                     "categories", "builders", "addLogs", "relayhost",
+                     "tags", "builders", "addLogs", "relayhost",
                      "subject", "sendToInterestedUsers", "customMesg",
                      "messageFormatter", "extraHeaders"]
 
     possible_modes = ("change", "failing", "passing", "problem", "warnings", "exception")
 
     def __init__(self, fromaddr, mode=("failing", "passing", "warnings"),
-                 categories=None, builders=None, addLogs=False,
+                 tags=None, builders=None, addLogs=False,
                  relayhost="localhost", buildSetSummary=False,
                  subject="buildbot %(result)s in %(title)s on %(builder)s",
                  lookup=None, extraRecipients=[],
@@ -257,7 +257,9 @@ class MailNotifier(base.StatusReceiverMultiService, buildset.BuildSetSummaryNoti
                  messageFormatter=defaultMessage, extraHeaders=None,
                  addPatch=True, useTls=False,
                  smtpUser=None, smtpPassword=None, smtpPort=25,
-                 previousBuildGetter=defaultGetPreviousBuild):
+                 previousBuildGetter=defaultGetPreviousBuild,
+                 categories=None  # deprecated, use tags
+                 ):
         """
         @type  fromaddr: string
         @param fromaddr: the email address to be used in the 'From' header.
@@ -299,11 +301,14 @@ class MailNotifier(base.StatusReceiverMultiService, buildset.BuildSetSummaryNoti
                          sent. Defaults to None (send mail for all builds).
                          Use either builders or categories, but not both.
 
-        @type  categories: list of strings
-        @param categories: a list of category names to serve status
+        @type  tags: list of strings
+        @param tags: a list of tag names to serve status
                            information for. Defaults to None (all
-                           categories). Use either builders or categories,
+                           categories). Use either builders or tags,
                            but not both.
+
+        @type  categories: list of strings
+        @param categories: (this attribute is deprecated; use 'tags' instead)
 
         @type  addLogs: boolean
         @param addLogs: if True, include all build logs as attachments to the
@@ -410,7 +415,7 @@ class MailNotifier(base.StatusReceiverMultiService, buildset.BuildSetSummaryNoti
                     config.error(
                         "mode %s is not a valid mode" % (m,))
         self.mode = mode
-        self.categories = categories
+        self.tags = tags or categories
         self.builders = builders
         self.addLogs = addLogs
         self.relayhost = relayhost
@@ -440,10 +445,10 @@ class MailNotifier(base.StatusReceiverMultiService, buildset.BuildSetSummaryNoti
         self.watched = []
         self.master_status = None
 
-        # you should either limit on builders or categories, not both
-        if self.builders is not None and self.categories is not None:
+        # you should either limit on builders or tags, not both
+        if self.builders is not None and self.tags is not None:
             config.error(
-                "Please specify only builders or categories to include - " +
+                "Please specify only builders or tags to include - " +
                 "not both.")
 
         if customMesg:
@@ -479,7 +484,7 @@ class MailNotifier(base.StatusReceiverMultiService, buildset.BuildSetSummaryNoti
 
     def builderAdded(self, name, builder):
         # only subscribe to builders we are interested in
-        if self.categories is not None and builder.category not in self.categories:
+        if self.tags is not None and not builder.matchesAnyTag(self.tags):
             return None
 
         self.watched.append(builder)
@@ -499,8 +504,8 @@ class MailNotifier(base.StatusReceiverMultiService, buildset.BuildSetSummaryNoti
         builder = build.getBuilder()
         if self.builders is not None and builder.name not in self.builders:
             return False  # ignore this build
-        if self.categories is not None and \
-                builder.category not in self.categories:
+        if self.tags is not None and \
+                not builder.matchesAnyTag(self.tags):
             return False  # ignore this build
 
         prev = self.getPreviousBuild(build)

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -229,15 +229,19 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
     def getSchedulers(self):
         return self.master.allSchedulers()
 
-    def getBuilderNames(self, categories=None):
-        if categories is None:
+    def getBuilderNames(self, tags=None, categories=None):
+        if categories is not None:
+            # Categories is deprecated; pretend they said "tags".
+            tags = categories
+
+        if tags is None:
             return util.naturalSort(self.botmaster.builderNames)  # don't let them break it
 
         l = []
         # respect addition order
         for name in self.botmaster.builderNames:
             bldr = self.botmaster.builders[name]
-            if bldr.config.category in categories:
+            if bldr.matchesAnyTag(tags):
                 l.append(name)
         return util.naturalSort(l)
 
@@ -336,7 +340,7 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
         if t:
             builder_status.subscribe(t)
 
-    def builderAdded(self, name, basedir, category=None, description=None):
+    def builderAdded(self, name, basedir, tags=None, description=None):
         """
         @rtype: L{BuilderStatus}
         """
@@ -366,13 +370,13 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
             log.msg("error follows:")
             log.err()
         if not builder_status:
-            builder_status = builder.BuilderStatus(name, category, self.master,
+            builder_status = builder.BuilderStatus(name, tags, self.master,
                                                    description)
             builder_status.addPointEvent(["builder", "created"])
-        log.msg("added builder %s in category %s" % (name, category))
-        # an unpickled object might not have category set from before,
+        log.msg("added builder %s with tags %r" % (name, tags))
+        # an unpickled object might not have tags set from before,
         # so set it here to make sure
-        builder_status.category = category
+        builder_status.setTags(tags)
         builder_status.description = description
         builder_status.master = self.master
         builder_status.basedir = os.path.join(self.basedir, basedir)

--- a/master/buildbot/status/tinderbox.py
+++ b/master/buildbot/status/tinderbox.py
@@ -66,7 +66,7 @@ class TinderboxMailNotifier(mail.MailNotifier):
                  subject="buildbot %(result)s in %(builder)s", binaryURL="",
                  logCompression="", errorparser="unix", columnName=None,
                  useChangeTime=False,
-                 categories=None # deprecated, use tags instead
+                 categories=None  # deprecated, use tags instead
                  ):
         """
         @type  fromaddr: string

--- a/master/buildbot/status/tinderbox.py
+++ b/master/buildbot/status/tinderbox.py
@@ -56,16 +56,18 @@ class TinderboxMailNotifier(mail.MailNotifier):
     """
     implements(interfaces.IEmailSender)
 
-    compare_attrs = ["extraRecipients", "fromaddr", "categories", "builders",
+    compare_attrs = ["extraRecipients", "fromaddr", "tags", "builders",
                      "addLogs", "relayhost", "subject", "binaryURL", "tree",
                      "logCompression", "errorparser", "columnName",
                      "useChangeTime"]
 
     def __init__(self, fromaddr, tree, extraRecipients,
-                 categories=None, builders=None, relayhost="localhost",
+                 tags=None, builders=None, relayhost="localhost",
                  subject="buildbot %(result)s in %(builder)s", binaryURL="",
                  logCompression="", errorparser="unix", columnName=None,
-                 useChangeTime=False):
+                 useChangeTime=False,
+                 categories=None # deprecated, use tags instead
+                 ):
         """
         @type  fromaddr: string
         @param fromaddr: the email address to be used in the 'From' header.
@@ -79,16 +81,18 @@ class TinderboxMailNotifier(mail.MailNotifier):
         @param extraRecipients: E-mail addresses of recipients. This should at
                                 least include the tinderbox daemon.
 
-        @type  categories: list of strings
-        @param categories: a list of category names to serve status
+        @type  tags: list of strings
+        @param tags: a list of tag names to serve status
                            information for. Defaults to None (all
-                           categories). Use either builders or categories,
+                           tags). Use either builders or tags,
                            but not both.
+
+        @type  categories: list of strings; DEPRECATED: use tags instead.
 
         @type  builders: list of strings
         @param builders: a list of builder names for which mail should be
                          sent. Defaults to None (send mail for all builds).
-                         Use either builders or categories, but not both.
+                         Use either builders or tags, but not both.
 
         @type  relayhost: string
         @param relayhost: the host to which the outbound SMTP connection
@@ -131,7 +135,7 @@ class TinderboxMailNotifier(mail.MailNotifier):
                               the current time is used as the builddate.
         """
 
-        mail.MailNotifier.__init__(self, fromaddr, categories=categories,
+        mail.MailNotifier.__init__(self, fromaddr, tags=tags,
                                    builders=builders, relayhost=relayhost,
                                    subject=subject,
                                    extraRecipients=extraRecipients,
@@ -153,8 +157,8 @@ class TinderboxMailNotifier(mail.MailNotifier):
         builder = build.getBuilder()
         if self.builders is not None and name not in self.builders:
             return  # ignore this Build
-        if self.categories is not None and \
-                builder.category not in self.categories:
+        if self.tags is not None and \
+                not builder.matchesAnyTag(self.tags):
             return  # ignore this build
         self.buildMessage(name, build, "building")
 

--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -602,10 +602,13 @@ class BuildersResource(HtmlResource):
         status = self.getStatus(req)
         encoding = getRequestCharset(req)
 
-        showCategories = req.args.get("category", [])
-        if showCategories == []:
-            showCategories = None
-        builders = req.args.get("builder", status.getBuilderNames(categories=showCategories))
+        showTags = req.args.get("tag", [])
+        if not showTags:
+            showTags = req.args.get("category", [])
+            if not showTags:
+                showTags = None
+
+        builders = req.args.get("builder", status.getBuilderNames(tags=showTags))
         branches = [b.decode(encoding)
                     for b in req.args.get("branch", [])
                     if b]

--- a/master/buildbot/status/web/buildstatus.py
+++ b/master/buildbot/status/web/buildstatus.py
@@ -19,7 +19,7 @@ from buildbot.status.web.base import IBox
 
 class BuildStatusStatusResource(HtmlResource):
 
-    def __init__(self, categories=None):
+    def __init__(self, tags=None):
         HtmlResource.__init__(self)
 
     def content(self, request, ctx):

--- a/master/buildbot/status/web/console.py
+++ b/master/buildbot/status/web/console.py
@@ -291,15 +291,6 @@ class ConsoleStatusResource(HtmlResource):
 
             # We want to display this builder.
             tags = builder.getTags() or ["default"]
-            
-            # Strip the category to keep only the text before the first |.
-            # This is a hack to support the chromium usecase where they have
-            # multiple tags for each slave. We use only the first one.
-            # TODO(nsylvain): Create another way to specify "display category"
-            #     in master.cfg.
-            if len(tags)==1:
-                tags = tags[0].split('|')
-
             for tag in tags:
                 # Append this builder to the dictionary of builders.
                 builderList.setdefault(tag, []).append(builderName)

--- a/master/buildbot/status/web/console.py
+++ b/master/buildbot/status/web/console.py
@@ -258,7 +258,7 @@ class ConsoleStatusResource(HtmlResource):
         return builds
 
     def getAllBuildsForRevision(self, status, request, codebase, lastRevision,
-                                numBuilds, categories, builders, debugInfo):
+                                numBuilds, tags, builders, debugInfo):
         """Returns a dictionary of builds we need to inspect to be able to
         display the console page. The key is the builder name, and the value is
         an array of build we care about. We also returns a dictionary of
@@ -266,7 +266,7 @@ class ConsoleStatusResource(HtmlResource):
 
         codebase is the codebase to get revisions from
         lastRevision is the last revision we want to display in the page.
-        categories is a list of categories to display. It is coming from the
+        tags is a list of tags to display. It is coming from the
             HTTP GET parameters.
         builders is a list of builders to display. It is coming from the HTTP
             GET parameters.
@@ -284,24 +284,26 @@ class ConsoleStatusResource(HtmlResource):
             builder = status.getBuilder(builderName)
 
             # Make sure we are interested in this builder.
-            if categories and builder.category not in categories:
+            if tags and not builder.matchesAnyTag(tags):
                 continue
             if builders and builderName not in builders:
                 continue
 
             # We want to display this builder.
-            category = builder.category or "default"
+            tags = builder.getTags() or ["default"]
+            
             # Strip the category to keep only the text before the first |.
             # This is a hack to support the chromium usecase where they have
-            # multiple categories for each slave. We use only the first one.
+            # multiple tags for each slave. We use only the first one.
             # TODO(nsylvain): Create another way to specify "display category"
             #     in master.cfg.
-            category = category.split('|')[0]
-            if not builderList.get(category):
-                builderList[category] = []
+            if len(tags)==1:
+                tags = tags[0].split('|')
 
-            # Append this builder to the dictionary of builders.
-            builderList[category].append(builderName)
+            for tag in tags:
+                # Append this builder to the dictionary of builders.
+                builderList.setdefault(tag, []).append(builderName)
+
             # Set the list of builds for this builder.
             allBuilds[builderName] = self.getBuildsForRevision(request,
                                                                builder,
@@ -316,26 +318,26 @@ class ConsoleStatusResource(HtmlResource):
     #
     # Display functions
     #
-    def displayCategories(self, builderList, debugInfo):
-        """Display the top category line."""
+    def displayTags(self, builderList, debugInfo):
+        """Display the top tags line."""
 
         count = 0
-        for category in builderList:
-            count += len(builderList[category])
+        for tag in builderList:
+            count += len(builderList[tag])
 
-        categories = sorted(builderList.keys())
+        tags = sorted(builderList.keys())
 
         cs = []
 
-        for category in categories:
+        for tag in tags:
             c = {}
 
-            c["name"] = category
+            c["name"] = tag
 
             # To be able to align the table correctly, we need to know
-            # what percentage of space this category will be taking. This is
-            # (#Builders in Category) / (#Builders Total) * 100.
-            c["size"] = (len(builderList[category]) * 100) / count
+            # what percentage of space this tag will be taking. This is
+            # (#Builders in tag) / (#Builders Total) * 100.
+            c["size"] = (len(builderList[tag]) * 100) / count
             cs.append(c)
 
         return cs
@@ -347,20 +349,20 @@ class ConsoleStatusResource(HtmlResource):
         nbSlaves = 0
 
         # Get the number of builders.
-        for category in builderList:
-            nbSlaves += len(builderList[category])
+        for tag in builderList:
+            nbSlaves += len(builderList[tag])
 
-        # Get the categories, and order them alphabetically.
-        categories = sorted(builderList.keys())
+        # Get the tags, and order them alphabetically.
+        tags = sorted(builderList.keys())
 
         slaves = {}
 
-        # For each category, we display each builder.
-        for category in categories:
-            slaves[category] = []
-            # For each builder in this category, we set the build info and we
+        # For each tag, we display each builder.
+        for tag in tags:
+            slaves[tag] = []
+            # For each builder in this tag, we set the build info and we
             # display the box.
-            for bldr in builderList[category]:
+            for bldr in builderList[tag]:
                 s = {}
                 s["color"] = "notstarted"
                 s["pageTitle"] = bldr
@@ -380,7 +382,7 @@ class ConsoleStatusResource(HtmlResource):
                         s["color"] = getResultsClass(build.getResults(), None,
                                                      False, True)
 
-                slaves[category].append(s)
+                slaves[tag].append(s)
 
         return slaves
 
@@ -404,21 +406,21 @@ class ConsoleStatusResource(HtmlResource):
 
         details = []
         nbSlaves = 0
-        for category in builderList:
-            nbSlaves += len(builderList[category])
+        for tag in builderList:
+            nbSlaves += len(builderList[tag])
 
-        # Sort the categories.
-        categories = sorted(builderList.keys())
+        # Sort the tags.
+        tags = sorted(builderList.keys())
 
         builds = {}
 
-        # Display the boxes by category group.
-        for category in categories:
+        # Display the boxes by tag group.
+        for tag in tags:
 
-            builds[category] = []
+            builds[tag] = []
 
-            # Display the boxes for each builder in this category.
-            for bldr in builderList[category]:
+            # Display the boxes for each builder in this tag.
+            for bldr in builderList[tag]:
                 introducedIn = None
                 firstNotIn = None
                 # If there is no builds default to True
@@ -475,7 +477,7 @@ class ConsoleStatusResource(HtmlResource):
                 b["color"] = resultsClass
                 b["tag"] = tag
 
-                builds[category].append(b)
+                builds[tag].append(b)
 
                 # If the box is red, we add the explaination in the details
                 # section.
@@ -516,7 +518,7 @@ class ConsoleStatusResource(HtmlResource):
                     pass
 
     def displayPage(self, request, status, builderList, allBuilds, codebase,
-                    revisions, categories, repository, project, branch,
+                    revisions, tags, repository, project, branch,
                     debugInfo):
         """Display the console page."""
         # Build the main template directory with all the informations we have.
@@ -525,18 +527,18 @@ class ConsoleStatusResource(HtmlResource):
         subs["repository"] = repository
         subs["project"] = project
         subs["codebase"] = codebase
-        if categories:
-            subs["categories"] = ' '.join(categories)
+        if tags:
+            subs["tags"] = ' '.join(tags)
         subs["time"] = time.strftime("%a %d %b %Y %H:%M:%S",
                                      time.localtime(util.now()))
         subs["debugInfo"] = debugInfo
         subs["ANYBRANCH"] = ANYBRANCH
 
         if builderList:
-            subs["categories"] = self.displayCategories(builderList, debugInfo)
+            subs["tags"] = self.displayTags(builderList, debugInfo)
             subs['slaves'] = self.displaySlaveLine(status, builderList, debugInfo)
         else:
-            subs["categories"] = []
+            subs["tags"] = []
 
         subs['revisions'] = []
 
@@ -601,8 +603,10 @@ class ConsoleStatusResource(HtmlResource):
         debugInfo["load_time"] = time.time()
 
         # get url parameters
-        # Categories to show information for.
-        categories = request.args.get("category", [])
+        # tags to show information for.
+        tags = request.args.get("tag", [])
+        if not tags:
+            tags = request.args.get("category", [])
         # List of all builders to show on the page.
         builders = request.args.get("builder", [])
         # Repo used to filter the changes shown.
@@ -658,7 +662,7 @@ class ConsoleStatusResource(HtmlResource):
                                                                         codebase,
                                                                         lastRevision,
                                                                         numRevs,
-                                                                        categories,
+                                                                        tags,
                                                                         builders,
                                                                         debugInfo)
 
@@ -666,7 +670,7 @@ class ConsoleStatusResource(HtmlResource):
 
             cxt.update(self.displayPage(request, status, builderList,
                                         allBuilds, codebase, revisions,
-                                        categories, repository, project,
+                                        tags, repository, project,
                                         branch, debugInfo))
 
             templates = request.site.buildbot_service.templates

--- a/master/buildbot/status/web/templates/grid.html
+++ b/master/buildbot/status/web/templates/grid.html
@@ -9,7 +9,7 @@
 
 <tr>
  <td class="title"><a href="{{ title_url }}">{{ title }}</a>
-  {{ grid.category_title() }}
+  {{ grid.tag_title() }}
  </td>
 
  {% for s in stamps %}

--- a/master/buildbot/status/web/templates/grid_macros.html
+++ b/master/buildbot/status/web/templates/grid_macros.html
@@ -1,12 +1,12 @@
-{% macro category_title() -%}
- {% if categories %}
+{% macro tag_title() -%}
+ {% if tags %}
   <br>
-  {% trans categories=categories %}
-   <b>Category:</b></br>
-  {% pluralize categories %}
-   <b>Categories:</b><br/>
+  {% trans tags=tags %}
+   <b>Tag:</b></br>
+  {% pluralize tags %}
+   <b>Tags:</b><br/>
   {% endtrans %}
-  {% for c in categories %}
+  {% for c in tags %}
     {{ c|e }}<br/>
   {% endfor %}
  {% endif %}

--- a/master/buildbot/status/web/templates/grid_transposed.html
+++ b/master/buildbot/status/web/templates/grid_transposed.html
@@ -9,7 +9,7 @@
 
 <tr>
  <td class="title"><a href="{{ title_url }}">{{ title }}</a>
-  {{ grid.category_title() }}
+  {{ grid.tag_title() }}
  </td>
  {% for builder in builders %}
   {{ grid.builder_td(builder) }}

--- a/master/buildbot/status/web/templates/waterfall.html
+++ b/master/buildbot/status/web/templates/waterfall.html
@@ -8,10 +8,10 @@
   <a style="float: right;" href="{{ help_url }}">waterfall help</a>
 </div>
 
-{% if categories|length > 1 %}
- <p><b>Categories:</b>
- {% for c in categories %}
-  <a href="?category={{ c }}">{{ c }}</a> &nbsp;
+{% if tags|length > 1 %}
+ <p><b>Tags:</b>
+ {% for t in tags %}
+  <a href="?tag={{ t }}">{{ t }}</a> &nbsp;
  {% endfor -%}
  </p>
 {% endif %}

--- a/master/buildbot/status/web/templates/waterfallhelp.html
+++ b/master/buildbot/status/web/templates/waterfallhelp.html
@@ -83,21 +83,21 @@ the Builders you are interested in here.</p>
 {% endfor %}
 </table>
 
-<h2>Limiting the Categories that are displayed</h2>
+<h2>Limiting the Tags that are displayed</h2>
 
-<p>By adding one or more <tt>category=</tt> arguments, the display will be
-limited to showing builds that ran on the builders with those categories. 
+<p>By adding one or more <tt>tag=</tt> arguments, the display will be
+limited to showing builds that ran on the builders with those tags. 
 This serves to limit the display to the specific named columns. 
-If no <tt>category=</tt> arguments are provided, all Categories will be displayed.</p>
+If no <tt>tag=</tt> arguments are provided, all tags will be displayed.</p>
 
-<p>To view a Waterfall page with only a subset of Categories displayed, select
-the Categories you are interested in here.</p>
+<p>To view a Waterfall page with only a subset of tags displayed, select
+the tags you are interested in here.</p>
        
 <table>
-{% for cat in all_categories %}
- <tr><td><input type="checkbox" name="category" value="{{ cat }}"
-  {% if cat in show_categories %}checked="checked"{% endif %} />
- </td><td>{{cat}}</td></tr>
+{% for tag in all_tags %}
+ <tr><td><input type="checkbox" name="tag" value="{{ tag }}"
+  {% if tag in show_tags %}checked="checked"{% endif %} />
+ </td><td>{{tag}}</td></tr>
 {% endfor %}
 </table>
 

--- a/master/buildbot/status/web/waterfall.py
+++ b/master/buildbot/status/web/waterfall.py
@@ -294,9 +294,9 @@ def insertGaps(g, showEvents, lastEventTime, idleGap=2):
 class WaterfallHelp(HtmlResource):
     pageTitle = "Waterfall Help"
 
-    def __init__(self, categories=None):
+    def __init__(self, tags=None):
         HtmlResource.__init__(self)
-        self.categories = categories
+        self.tags = tags
 
     def content(self, request, cxt):
         status = self.getStatus(request)
@@ -312,16 +312,21 @@ class WaterfallHelp(HtmlResource):
         show_builders = request.args.get("show", [])
         show_builders.extend(request.args.get("builder", []))
         cxt['show_builders'] = show_builders
-        cxt['all_builders'] = status.getBuilderNames(categories=self.categories)
+        cxt['all_builders'] = status.getBuilderNames(tags=self.tags)
 
         # this has a set of toggle-buttons to let the user choose the
-        # categories
-        show_categories = request.args.get("category", [])
+        # tags
+        show_tags = request.args.get("tag", [])
+        if not show_tags:
+            show_tags = request.args.get("category", [])
         allBuilderNames = status.getBuilderNames()
         builders = [status.getBuilder(name) for name in allBuilderNames]
-        allCategories = [builder.getCategory() for builder in builders]
-        cxt['show_categories'] = show_categories
-        cxt['all_categories'] = allCategories
+        allTags = set()
+        for builder in builders:
+            tags = builder.getTags()
+            allTags.update(tags or [])
+        cxt['show_tags'] = show_tags
+        cxt['all_tags'] = allTags
 
         # a couple of radio-button selectors for refresh time will appear
         # just after that text
@@ -372,12 +377,12 @@ class WaterfallStatusResource(HtmlResource):
     """This builds the main status page, with the waterfall display, and
     all child pages."""
 
-    def __init__(self, categories=None, num_events=200, num_events_max=None):
+    def __init__(self, tags=None, num_events=200, num_events_max=None):
         HtmlResource.__init__(self)
-        self.categories = categories
+        self.tags = tags
         self.num_events = num_events
         self.num_events_max = num_events_max
-        self.putChild("help", WaterfallHelp(categories))
+        self.putChild("help", WaterfallHelp(tags))
 
     def getPageTitle(self, request):
         status = self.getStatus(request)
@@ -452,7 +457,7 @@ class WaterfallStatusResource(HtmlResource):
         changes_d.addCallback(keep_changes)
 
         # build request counts for each builder
-        allBuilderNames = status.getBuilderNames(categories=self.categories)
+        allBuilderNames = status.getBuilderNames(tags=self.tags)
         brstatus_ds = []
         brcounts = {}
 
@@ -478,15 +483,15 @@ class WaterfallStatusResource(HtmlResource):
         ctx['refresh'] = self.get_reload_time(request)
 
         # we start with all Builders available to this Waterfall: this is
-        # limited by the config-file -time categories= argument, and defaults
+        # limited by the config-file -time tags= argument, and defaults
         # to all defined Builders.
-        allBuilderNames = status.getBuilderNames(categories=self.categories)
+        allBuilderNames = status.getBuilderNames(tags=self.tags)
         builders = [status.getBuilder(name) for name in allBuilderNames]
 
         # but if the URL has one or more builder= arguments (or the old show=
         # argument, which is still accepted for backwards compatibility), we
         # use that set of builders instead. We still don't show anything
-        # outside the config-file time set limited by categories=.
+        # outside the config-file time set limited by tags=.
         showBuilders = request.args.get("show", [])
         showBuilders.extend(request.args.get("builder", []))
         if showBuilders:
@@ -494,10 +499,12 @@ class WaterfallStatusResource(HtmlResource):
 
         # now, if the URL has one or category= arguments, use them as a
         # filter: only show those builders which belong to one of the given
-        # categories.
-        showCategories = request.args.get("category", [])
-        if showCategories:
-            builders = [b for b in builders if b.category in showCategories]
+        # tags.
+        showTags = request.args.get("tag", [])
+        if not showTags:
+            showTags = request.args.get("category", [])
+        if showTags:
+            builders = [b for b in builders if b.matchesAnyTag(showTags)]
 
         # If the URL has the failures_only=true argument, we remove all the
         # builders that are not currently red or won't be turning red at the end
@@ -572,15 +579,14 @@ class WaterfallStatusResource(HtmlResource):
         if self.get_reload_time(request) is not None:
             ctx['no_reload_page'] = with_args(request, remove_args=["reload"])
 
-        # get alphabetically sorted list of all categories
-        categories = set()
+        # get alphabetically sorted list of all tags
+        tags = set()
         builderNames = status.getBuilderNames()
         for builderName in builderNames:
             builder = status.getBuilder(builderName)
-            categories.add(builder.category)
-        categories = list(categories)
-        categories.sort()
-        ctx['categories'] = categories
+            tags.update(builder.getTags() or [])
+        tags = sorted(tags)
+        ctx['tags'] = tags
 
         template = request.site.buildbot_service.templates.get_template("waterfall.html")
         data = template.render(**ctx)

--- a/master/buildbot/status/web/waterfall.py
+++ b/master/buildbot/status/web/waterfall.py
@@ -322,8 +322,8 @@ class WaterfallHelp(HtmlResource):
         allBuilderNames = status.getBuilderNames()
         builders = [status.getBuilder(name) for name in allBuilderNames]
         allTags = set()
-        for builder in builders:
-            tags = builder.getTags()
+        for bldr in builders:
+            tags = bldr.getTags()
             allTags.update(tags or [])
         cxt['show_tags'] = show_tags
         cxt['all_tags'] = allTags

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -20,6 +20,7 @@ from buildbot import config
 from buildbot import interfaces
 from buildbot.process import factory
 from buildbot.process import properties
+from buildbot.test.fake import fakemaster
 from twisted.python import components
 
 
@@ -39,9 +40,9 @@ components.registerAdapter(
 
 class FakeBuild(properties.PropertiesMixin):
 
-    def __init__(self, props=None):
+    def __init__(self, props=None, master=None):
         self.build_status = FakeBuildStatus()
-        self.builder = mock.Mock(name='build.builder')
+        self.builder = fakemaster.FakeBuilderStatus(master)
         self.builder.config = config.BuilderConfig(
             name='bldr',
             slavenames=['a'],
@@ -59,6 +60,9 @@ class FakeBuild(properties.PropertiesMixin):
         if codebase in self.sources:
             return self.sources[codebase]
         return None
+
+    def getBuilder(self):
+        return self.builder
 
 
 components.registerAdapter(

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -62,7 +62,7 @@ class FakeStatus(object):
         self.master = master
         self.lastBuilderStatus = None
 
-    def builderAdded(self, name, basedir, category=None, description=None):
+    def builderAdded(self, name, basedir, tags=None, description=None):
         bs = FakeBuilderStatus(self.master)
         self.lastBuilderStatus = bs
         return bs
@@ -78,10 +78,13 @@ class FakeBuilderStatus(object):
 
     implements(interfaces.IBuilderStatus)
 
-    def __init__(self, master):
-        self.master = master
-        self.basedir = os.path.join(master.basedir, 'bldr')
+    def __init__(self, master=None, buildername="Builder"):
+        if master:
+            self.master = master
+            self.basedir = os.path.join(master.basedir, 'bldr')
         self.lastBuildStatus = None
+        self._tags = None
+        self.name = buildername
 
     def setDescription(self, description):
         self._description = description
@@ -89,11 +92,14 @@ class FakeBuilderStatus(object):
     def getDescription(self):
         return self._description
 
-    def setCategory(self, category):
-        self._category = category
+    def setTags(self, tags):
+        self._tags = tags
 
-    def getCategory(self):
-        return self._category
+    def getTags(self):
+        return self._tags
+
+    def matchesAnyTag(self, tags):
+        return set(self._tags) & set(tags)
 
     def setSlavenames(self, names):
         pass

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1067,6 +1067,25 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
             lambda: config.BuilderConfig(category=13,
                                          name='a', slavenames=['a'], factory=self.factory))
 
+    def test_tags_must_be_list(self):
+        self.assertRaisesConfigError(
+            "tags must be a list",
+            lambda: config.BuilderConfig(tags='abc',
+                                         name='a', slavenames=['a'], factory=self.factory))
+
+    def test_tags_must_be_list_of_str(self):
+        self.assertRaisesConfigError(
+            "tags list contains something that is not a string",
+            lambda: config.BuilderConfig(tags=['abc', 13],
+                                         name='a', slavenames=['a'], factory=self.factory))
+
+    def test_tags_no_categories_too(self):
+        self.assertRaisesConfigError(
+            "category is being replaced by tags; you should only specify tags",
+            lambda: config.BuilderConfig(tags=['abc'],
+                                         category='def',
+                                         name='a', slavenames=['a'], factory=self.factory))
+
     def test_inv_nextSlave(self):
         self.assertRaisesConfigError(
             "nextSlave must be a callable",
@@ -1100,7 +1119,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
                               slavenames=['a'],
                               builddir='a_b_c',
                               slavebuilddir='a_b_c',
-                              category='',
+                              tags=None,
                               nextSlave=None,
                               locks=[],
                               env={},
@@ -1111,7 +1130,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
     def test_args(self):
         cfg = config.BuilderConfig(
             name='b', slavename='s1', slavenames='s2', builddir='bd',
-            slavebuilddir='sbd', factory=self.factory, category='c',
+            slavebuilddir='sbd', factory=self.factory, tags=['c'],
             nextSlave=lambda: 'ns', nextBuild=lambda: 'nb', locks=['l'],
             env=dict(x=10), properties=dict(y=20), mergeRequests='mr',
             description='buzz')
@@ -1121,7 +1140,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
                               slavenames=['s2', 's1'],
                               builddir='bd',
                               slavebuilddir='sbd',
-                              category='c',
+                              tags=['c'],
                               locks=['l'],
                               env={'x': 10},
                               properties={'y': 20},
@@ -1133,12 +1152,12 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
         nb = lambda: 'nb'
         cfg = config.BuilderConfig(
             name='b', slavename='s1', slavenames='s2', builddir='bd',
-            slavebuilddir='sbd', factory=self.factory, category='c',
+            slavebuilddir='sbd', factory=self.factory, tags=['c'],
             nextSlave=ns, nextBuild=nb, locks=['l'],
             env=dict(x=10), properties=dict(y=20), mergeRequests='mr',
             description='buzz')
         self.assertEqual(cfg.getConfigDict(), {'builddir': 'bd',
-                                               'category': 'c',
+                                               'tags': ['c'],
                                                'description': 'buzz',
                                                'env': {'x': 10},
                                                'factory': self.factory,

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -425,15 +425,15 @@ class TestReconfig(BuilderMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_reconfig(self):
-        yield self.makeBuilder(description="Old", category="OldCat")
+        yield self.makeBuilder(description="Old", tags=["OldTag"])
         self.builder_config.description = "New"
-        self.builder_config.category = "NewCat"
+        self.builder_config.tags = ["NewTag"]
 
         mastercfg = config.MasterConfig()
         mastercfg.builders = [self.builder_config]
         yield self.bldr.reconfigService(mastercfg)
         self.assertEqual(
             dict(description=self.bldr.builder_status.getDescription(),
-                 category=self.bldr.builder_status.getCategory()),
+                 tags=self.bldr.builder_status.getTags()),
             dict(description="New",
-                 category="NewCat"))
+                 tags=["NewTag"]))

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -86,7 +86,7 @@ class TestPropertyMap(unittest.TestCase):
             prop_true=True,
             prop_empty='',
         )
-        self.build = FakeBuild(self.props)
+        self.build = FakeBuild(props=self.props)
 
     def doTestSimpleWithProperties(self, fmtstring, expect, **kwargs):
         d = self.build.render(WithProperties(fmtstring, **kwargs))
@@ -336,7 +336,7 @@ class TestInterpolatePositional(unittest.TestCase):
 
     def setUp(self):
         self.props = Properties()
-        self.build = FakeBuild(self.props)
+        self.build = FakeBuild(props=self.props)
 
     def test_string(self):
         command = Interpolate("test %s", "one fish")
@@ -372,7 +372,7 @@ class TestInterpolateProperties(unittest.TestCase):
 
     def setUp(self):
         self.props = Properties()
-        self.build = FakeBuild(self.props)
+        self.build = FakeBuild(props=self.props)
 
     def test_properties(self):
         self.props.setProperty("buildername", "winbld", "test")
@@ -518,7 +518,7 @@ class TestInterpolateSrc(unittest.TestCase):
 
     def setUp(self):
         self.props = Properties()
-        self.build = FakeBuild(self.props)
+        self.build = FakeBuild(props=self.props)
         sa = FakeSource()
         sb = FakeSource()
         sc = FakeSource()
@@ -641,7 +641,7 @@ class TestInterpolateKwargs(unittest.TestCase):
 
     def setUp(self):
         self.props = Properties()
-        self.build = FakeBuild(self.props)
+        self.build = FakeBuild(props=self.props)
         sa = FakeSource()
 
         sa.repository = 'cvs://A..'
@@ -774,7 +774,7 @@ class TestInterpolateSlaveInfo(unittest.TestCase):
 
     def setUp(self):
         self.props = Properties()
-        self.build = FakeBuild(self.props)
+        self.build = FakeBuild(props=self.props)
 
         # this is a bit ugly... but we dont really have fakes for all this yet:
         self.build.slavebuilder = mock.Mock()
@@ -806,7 +806,7 @@ class TestWithProperties(unittest.TestCase):
 
     def setUp(self):
         self.props = Properties()
-        self.build = FakeBuild(self.props)
+        self.build = FakeBuild(props=self.props)
 
     def testInvalidParams(self):
         self.assertRaises(ValueError, lambda:
@@ -1142,7 +1142,7 @@ class TestProperty(unittest.TestCase):
 
     def setUp(self):
         self.props = Properties()
-        self.build = FakeBuild(self.props)
+        self.build = FakeBuild(props=self.props)
 
     def testIntProperty(self):
         self.props.setProperty("do-tests", 1, "scheduler")
@@ -1247,7 +1247,7 @@ class TestRenderalbeAdapters(unittest.TestCase):
 
     def setUp(self):
         self.props = Properties()
-        self.build = FakeBuild(self.props)
+        self.build = FakeBuild(props=self.props)
 
     def test_list_deferred(self):
         r1 = DeferredRenderable()
@@ -1288,7 +1288,7 @@ class Renderer(unittest.TestCase):
 
     def setUp(self):
         self.props = Properties()
-        self.build = FakeBuild(self.props)
+        self.build = FakeBuild(props=self.props)
 
     def test_renderer(self):
         self.props.setProperty("x", "X", "test")

--- a/master/buildbot/test/unit/test_status_builder_cache.py
+++ b/master/buildbot/test/unit/test_status_builder_cache.py
@@ -27,9 +27,9 @@ class TestBuildStatus(unittest.TestCase):
     # that buildstep.BuildStepStatus is never instantiated here should tell you
     # that these classes are not well isolated!
 
-    def setupBuilder(self, buildername, category=None, description=None):
+    def setupBuilder(self, buildername, description=None):
         m = fakemaster.make_master()
-        b = builder.BuilderStatus(buildername=buildername, category=category,
+        b = builder.BuilderStatus(buildername=buildername, tags=None,
                                   master=m, description=description)
         # Awkwardly, Status sets this member variable.
         b.basedir = os.path.abspath(self.mktemp())

--- a/master/buildbot/test/unit/test_status_buildstep.py
+++ b/master/buildbot/test/unit/test_status_buildstep.py
@@ -26,11 +26,11 @@ class TestBuildStepStatus(unittest.TestCase):
     # that buildstep.BuildStepStatus is never instantiated here should tell you
     # that these classes are not well isolated!
 
-    def setupBuilder(self, buildername, category=None, description=None):
+    def setupBuilder(self, buildername, tags=None, description=None):
         self.master = fakemaster.make_master()
         self.master.basedir = '/basedir'
 
-        b = builder.BuilderStatus(buildername, self.master, category, description)
+        b = builder.BuilderStatus(buildername, tags, self.master, description)
         b.master = self.master
         # Ackwardly, Status sets this member variable.
         b.basedir = os.path.abspath(self.mktemp())

--- a/master/buildbot/test/unit/test_status_mail.py
+++ b/master/buildbot/test/unit/test_status_mail.py
@@ -185,7 +185,6 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
                           MailNotifier, 'from@example.org',
                           tags=['fast', 'slow'], builders=['a', 'b'])
 
-
     def test_init_enforces_categories_and_builders_are_mutually_exclusive(self):
         # categories are deprecated, but allow them until they're removed.
         self.assertRaises(config.ConfigErrors,

--- a/master/buildbot/test/unit/test_status_mail.py
+++ b/master/buildbot/test/unit/test_status_mail.py
@@ -26,6 +26,7 @@ from buildbot.status.results import FAILURE
 from buildbot.status.results import SUCCESS
 from buildbot.status.results import WARNINGS
 from buildbot.test.fake import fakedb
+from buildbot.test.fake import fakemaster
 from buildbot.test.fake.fakebuild import FakeBuildStatus
 from buildbot.test.util.config import ConfigErrorsMixin
 from mock import Mock
@@ -70,6 +71,9 @@ class FakeSource:
 
 
 class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.master = fakemaster.make_master(testcase=self)
 
     def do_test_createEmail_cte(self, funnyChars, expEncoding):
         builds = [FakeBuildStatus(name='build')]
@@ -176,7 +180,14 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
             self.assertIn('application/octet-stream', txt)
         return d
 
+    def test_init_enforces_tags_and_builders_are_mutually_exclusive(self):
+        self.assertRaises(config.ConfigErrors,
+                          MailNotifier, 'from@example.org',
+                          tags=['fast', 'slow'], builders=['a', 'b'])
+
+
     def test_init_enforces_categories_and_builders_are_mutually_exclusive(self):
+        # categories are deprecated, but allow them until they're removed.
         self.assertRaises(config.ConfigErrors,
                           MailNotifier, 'from@example.org',
                           categories=['fast', 'slow'], builders=['a', 'b'])
@@ -185,11 +196,21 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         self.assertRaisesConfigError("mode 'all' is not valid in an iterator and must be passed in as a separate string",
                                      lambda: MailNotifier('from@example.org', mode=['all']))
 
+    def test_builderAdded_ignores_unspecified_tags(self):
+        mn = MailNotifier('from@example.org', tags=['fast'])
+
+        builder = fakemaster.FakeBuilderStatus(self.master)
+        builder.setTags(['slow'])
+
+        self.assertEqual(None, mn.builderAdded('dummyBuilder', builder))
+        self.assert_(builder not in mn.watched)
+
     def test_builderAdded_ignores_unspecified_categories(self):
+        # categories are deprecated, but leave a test for it until we remove it
         mn = MailNotifier('from@example.org', categories=['fast'])
 
-        builder = Mock()
-        builder.category = 'slow'
+        builder = fakemaster.FakeBuilderStatus(self.master)
+        builder.setTags(['slow'])
 
         self.assertEqual(None, mn.builderAdded('dummyBuilder', builder))
         self.assert_(builder not in mn.watched)
@@ -197,10 +218,11 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
     def test_builderAdded_subscribes_to_all_builders_by_default(self):
         mn = MailNotifier('from@example.org')
 
-        builder = Mock()
-        builder.category = 'slow'
-        builder2 = Mock()
-        builder2.category = None
+        builder = fakemaster.FakeBuilderStatus(self.master)
+        builder.setTags(['slow'])
+
+        builder2 = fakemaster.FakeBuilderStatus(self.master)
+        # No tags set.
 
         self.assertEqual(mn, mn.builderAdded('dummyBuilder', builder))
         self.assertEqual(mn, mn.builderAdded('dummyBuilder2', builder2))
@@ -463,12 +485,24 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         self.assertTrue(isinstance(self.passedAttrs['revision'], str))
         self.assertEqual(self.passedAttrs['revision'], '111222')
 
+    def test_buildFinished_ignores_unspecified_tags(self):
+        mn = MailNotifier('from@example.org', tags=['fast'])
+
+        build = FakeBuildStatus(name="build")
+        build.builder = fakemaster.FakeBuilderStatus(self.master)
+        build.builder.setTags(['slow'])
+        build.getBuilder = lambda: build.builder
+
+        self.assertEqual(None, mn.buildFinished('dummyBuilder', build, SUCCESS))
+
     def test_buildFinished_ignores_unspecified_categories(self):
+        # categories are deprecated, but test them until they're removed
         mn = MailNotifier('from@example.org', categories=['fast'])
 
         build = FakeBuildStatus(name="build")
-        build.builder = Mock()
-        build.builder.category = 'slow'
+        build.builder = fakemaster.FakeBuilderStatus(self.master)
+        build.builder.setTags(['slow'])
+        build.getBuilder = lambda: build.builder
 
         self.assertEqual(None, mn.buildFinished('dummyBuilder', build, SUCCESS))
 

--- a/master/buildbot/test/unit/test_status_words.py
+++ b/master/buildbot/test/unit/test_status_words.py
@@ -391,13 +391,12 @@ class TestIrcContactChannel(unittest.TestCase):
         build = mock.Mock()
         build.getNumber = lambda: 42
         build.getName = get_name
-        build.category = lambda: ""
 
         builder = mock.Mock()
         builder.getName = get_name
         build.getBuilder = lambda: builder
 
-        self.bot.categories = None
+        self.bot.tags = None
         self.contact.notify_for = lambda _: True
         self.contact.useRevisions = False
 
@@ -643,7 +642,7 @@ class TestIRC(config.ConfigErrorsMixin, unittest.TestCase):
             pm_to_nicks=['pm', 'to', 'nicks'],
             port=1234,
             allowForce=True,
-            categories=['categories'],
+            tags=['tags'],
             password='pass',
             notify_events={'successToFailure': 1, },
             noticeOnChannel=True,
@@ -665,7 +664,7 @@ class TestIRC(config.ConfigErrorsMixin, unittest.TestCase):
         self.assertIdentical(p, proto_obj)
         factory.protocol.assert_called_with(
             'nick', 'pass', ['channels'], ['pm', 'to', 'nicks'],
-            factory.status, ['categories'], {'successToFailure': 1},
+            factory.status, ['tags'], {'successToFailure': 1},
             noticeOnChannel=True,
             useColors=False,
             useRevisions=True,

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -94,7 +94,7 @@ class BuildStepMixin(object):
 
         # step.build
 
-        b = self.build = fakebuild.FakeBuild()
+        b = self.build = fakebuild.FakeBuild(master=self.master)
         b.master = self.master
 
         def getSlaveVersion(cmd, oldversion):

--- a/master/docs/manual/cfg-builders.rst
+++ b/master/docs/manual/cfg-builders.rst
@@ -54,12 +54,12 @@ Other optional keys may be set on each ``BuilderConfig``:
     If not set, defaults to ``builddir``.
     If a slave is connected to multiple builders that share the same ``slavebuilddir``, make sure the slave is set to run one build at a time or ensure this is fine to run multiple builds from the same directory simultaneously.
 
-``category``
-    If provided, this is a string that identifies a category for the builder to be a part of.
-    Status clients can limit themselves to a subset of the available categories.
+``tags``
+    If provided, this is a list of strings that identifies tags for the builder.
+    Status clients can limit themselves to a subset of the available tags.
     A common use for this is to add new builders to your setup (for a new module, or for a new buildslave) that do not work correctly yet and allow you to integrate them with the active builders.
-    You can put these new builders in a test category, make your main status clients ignore them, and have only private status clients pick them up.
-    As soon as they work, you can move them over to the active category.
+    You can tag these new builders with a ``test`` tag, make your main status clients ignore them, and have only private status clients pick them up.
+    As soon as they work, you can move them over to the active tag.
 
 ``nextSlave``
     If provided, this is a function that controls which slave will be assigned future jobs.

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -29,7 +29,7 @@ To add status targets, you just append more objects to this list::
                                             {"channel": "#example2",
                                              "password": "somesecretpassword"}]))
 
-Most status delivery objects take a ``categories=`` argument, which can contain a list of `category` names: in this case, it will only show status for Builders that are in one of the named categories.
+Most status delivery objects take a ``tags=`` argument, which can contain a list of `tag` names: in this case, it will only show status for Builders that have one of the named tags.
 
 .. note:: Implementation Note
 
@@ -138,7 +138,7 @@ The table below lists all of the internal pages and the URLs that can be used to
 
     By adding one or more ``builder=`` query arguments, the Waterfall is restricted to only showing information about the given Builders.
     By adding one or more ``branch=`` query arguments, the display is restricted to showing information about the given branches.
-    In addition, adding one or more ``category=`` query arguments to the URL will limit the display to Builders that were defined with one of the given categories.
+    In addition, adding one or more ``tag=`` query arguments to the URL will limit the display to Builders that were defined with one of the given tags.
 
     A ``show_events=true`` query argument causes the display to include non-:class:`Build` events, like slaves attaching and detaching, as well as reconfiguration events.
     ``show_events=false`` hides these events.
@@ -157,7 +157,7 @@ The table below lists all of the internal pages and the URLs that can be used to
     This provides a chronologically oriented display of builders, by revision.
     The builders are listed down the left side of the page, and the revisions are listed across the top.
 
-    By adding one or more ``category=`` arguments the grid will be restricted to revisions in those categories.
+    By adding one or more ``tag=`` arguments the grid will be restricted to builders with those tags.
 
     A :samp:`width={N}` argument will limit the number of revisions shown to *N*, defaulting to 5.
 
@@ -183,7 +183,7 @@ The table below lists all of the internal pages and the URLs that can be used to
     By adding one or more ``builder=`` query arguments, the Console view is restricted to only showing information about the given Builders.
     Adding a ``repository=`` argument will limit display to a given repository.
     By adding one or more ``branch=`` query arguments, the display is restricted to showing information about the given branches.
-    In addition, adding one or more ``category=`` query arguments to the URL will limit the display to Builders that were defined with one of the given categories.
+    In addition, adding one or more ``tag=`` query arguments to the URL will limit the display to Builders that were defined with one of the given tags.
     With the ``project=`` query argument, it's possible to restrict the view to changes from the given project.
     With the ``codebase=`` query argument, it's possible to restrict the view to changes for the given codebase.
 
@@ -1094,12 +1094,12 @@ MailNotifier arguments
 ``builders`` (list of strings)
     A list of builder names for which mail should be sent.
     Defaults to ``None`` (send mail for all builds).
-    Use either builders or categories, but not both.
+    Use either builders or tags, but not both.
 
-``categories`` (list of strings)
-    A list of category names to serve status information for.
-    Defaults to ``None`` (all categories).
-    Use either builders or categories, but not both.
+``tags`` (list of strings)
+    A list of tag names to serve status information for.
+    Defaults to ``None`` (all tags).
+    Use either builders or tags, but not both.
 
 ``addLogs`` (boolean)
     If ``True``, include all build logs as attachments to the messages.
@@ -1391,7 +1391,7 @@ If the ``allowForce=True`` option was used, some additional commands will be ava
     *REASON* will be added to the build status to explain why it was stopped.
     You might use this if you committed a bug, corrected it right away, and don't want to wait for the first build (which is destined to fail) to complete before starting the second (hopefully fixed) build.
 
-If the `categories` is set to a category of builders (see the categories option in :ref:`Builder-Configuration`) changes related to only that category of builders will be sent to the channel.
+If the `tags` is set (see the tags option in :ref:`Builder-Configuration`) changes related to only builders belonging to those tags of builders will be sent to the channel.
 
 If the `useRevisions` option is set to `True`, the IRC bot will send status messages that replace the build number with a list of revisions that are contained in that build.
 So instead of seeing `build #253 of ...`, you would see something like `build containing revisions [a87b2c4]`.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -79,6 +79,8 @@ Features
 
 * GitHub change hook now supports payload validation using shared secret, see :ref:`GitHub-hook` for details.
 
+* Builders can now have multiple "tags" associated with them. Tags can be used in various status classes as filters (eg, on the waterfall page).
+
 Fixes
 ~~~~~
 
@@ -88,6 +90,8 @@ Fixes
 
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* The builder parameter "category" is deprecated and is replaced by a parameter called "tags".
 
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is a backport to eight of the following change:
> commit 0d222614c5996b0b3bc3ca0dc30629c4199f50a4
> Author: Jared Grubb <jaredgrubb@gmail.com>
> Date:   Mon Feb 10 12:53:43 2014 -0800
> 
>     Fix #928: Allow builder to be associated with multiple tags

For the most part, this patch is identical to the one I contributed to nine. However, the Status parts of the patch (eg, waterfall) are all brand new, since Status does not exist in this form in Nine. 

I'm sure there's going to be some issues, as I had some questions on parts of this patch (I'll write them inline below). 
Also, docs arent ported and notes are not updated. I'll do that next, but wanted to get this up for comment.