### PR TITLE
Add better support for modularized master.cfg

### DIFF
--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -480,7 +480,11 @@ class BuilderStatus(styles.Versioned):
         self.status._builder_subscribe(self.name, receiver)
 
     def unsubscribe(self, receiver):
-        self.watchers.remove(receiver)
+        try:
+            self.watchers.remove(receiver)
+        except ValueError:
+            # Receiver may not be in the list if modules are unloaded on reconfig
+            pass
         self.status._builder_unsubscribe(self.name, receiver)
 
     # Builder interface (methods called by the Builder which feeds us)

--- a/master/buildbot/status/mail.py
+++ b/master/buildbot/status/mail.py
@@ -483,7 +483,8 @@ class MailNotifier(base.StatusReceiverMultiService, buildset.BuildSetSummaryNoti
         return base.StatusReceiverMultiService.stopService(self)
 
     def disownServiceParent(self):
-        self.master_status.unsubscribe(self)
+        if self.master_status is not None:
+            self.master_status.unsubscribe(self)
         self.master_status = None
         for w in self.watched:
             w.unsubscribe(self)


### PR DESCRIPTION
master.cfg might unload all modules on reconfig.
Unclear if this is all the spots or the best fix, but it's what I
encountered and seems to fix the issue.