### PR TITLE
use buildbot.tac from the current directory as default for checkconfig

### DIFF
--- a/master/buildbot/scripts/checkconfig.py
+++ b/master/buildbot/scripts/checkconfig.py
@@ -38,7 +38,7 @@ def _loadConfig(basedir, configFile, quiet):
 
 def checkconfig(config):
     quiet = config.get('quiet')
-    configFile = config.get('configFile')
+    configFile = config.get('configFile', os.getcwd())
 
     if os.path.isdir(configFile):
         basedir = configFile

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -487,13 +487,12 @@ class CheckConfigOptions(base.SubcommandOptions):
 
     def getSynopsis(self):
         return "Usage:\t\tbuildbot checkconfig [configFile]\n" + \
-            "\t\tIf not specified, 'master.cfg' will be used as 'configFile'"
+            "\t\tIf not specified, the config file specified in " + \
+            "'buildbot.tac' from the current directory will be used"
 
     def parseArgs(self, *args):
         if len(args) >= 1:
             self['configFile'] = args[0]
-        else:
-            self['configFile'] = 'master.cfg'
 
 
 class UserOptions(base.SubcommandOptions):

--- a/master/buildbot/test/unit/test_scripts_checkconfig.py
+++ b/master/buildbot/test/unit/test_scripts_checkconfig.py
@@ -147,19 +147,27 @@ class TestCheckconfig(unittest.TestCase):
         self.loadConfig = mock.Mock(spec=checkconfig._loadConfig, return_value=3)
         self.patch(checkconfig, '_loadConfig', self.loadConfig)
 
+    def test_checkconfig_default(self):
+        self.assertEqual(checkconfig.checkconfig(dict()), 3)
+        self.loadConfig.assert_called_with(basedir=os.getcwd(),
+                                           configFile='master.cfg', quiet=None)
+
     def test_checkconfig_given_dir(self):
         self.assertEqual(checkconfig.checkconfig(dict(configFile='.')), 3)
-        self.loadConfig.assert_called_with(basedir='.', configFile='master.cfg', quiet=None)
+        self.loadConfig.assert_called_with(basedir='.', configFile='master.cfg',
+                                           quiet=None)
 
     def test_checkconfig_given_file(self):
         config = dict(configFile='master.cfg')
         self.assertEqual(checkconfig.checkconfig(config), 3)
-        self.loadConfig.assert_called_with(basedir=os.getcwd(), configFile='master.cfg', quiet=None)
+        self.loadConfig.assert_called_with(basedir=os.getcwd(),
+                                           configFile='master.cfg', quiet=None)
 
     def test_checkconfig_quiet(self):
         config = dict(configFile='master.cfg', quiet=True)
         self.assertEqual(checkconfig.checkconfig(config), 3)
-        self.loadConfig.assert_called_with(basedir=os.getcwd(), configFile='master.cfg', quiet=True)
+        self.loadConfig.assert_called_with(basedir=os.getcwd(),
+                                           configFile='master.cfg', quiet=True)
 
     def test_checkconfig_syntaxError_quiet(self):
         """

--- a/master/buildbot/test/unit/test_scripts_runner.py
+++ b/master/buildbot/test/unit/test_scripts_runner.py
@@ -595,7 +595,7 @@ class TestCheckConfigOptions(OptionsMixin, unittest.TestCase):
 
     def test_defaults(self):
         opts = self.parse()
-        exp = dict(quiet=False, configFile='master.cfg')
+        exp = dict(quiet=False)
         self.assertOptions(opts, exp)
 
     def test_configfile(self):
@@ -605,7 +605,7 @@ class TestCheckConfigOptions(OptionsMixin, unittest.TestCase):
 
     def test_quiet(self):
         opts = self.parse('-q')
-        exp = dict(quiet=True, configFile='master.cfg')
+        exp = dict(quiet=True)
         self.assertOptions(opts, exp)
 
 

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -129,6 +129,19 @@ sighup
 
 This sends a SIGHUP to the buildmaster running in the given directory, which causes it to re-read its :file:`master.cfg` file.
 
+.. bb:cmdline:: checkconfig
+
+checkconfig
++++++++++++
+
+.. code-block:: none
+
+    buildbot checkconfig {BASEDIR|CONFIG_FILE}
+
+This checks if the buildmaster configuration is well-formed and contains no deprecated or invalid elements.
+If no arguments are used or the base directory is passed as the argument the config file specified in :file:`buildbot.tac` is checked.
+If the argument is the path to a config file then it will be checked without using the :file:`buildbot.tac` file.
+
 Developer Tools
 ~~~~~~~~~~~~~~~
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -188,6 +188,8 @@ Fixes
 * GitHub change hook now correctly responds to ping events.
 * ``buildbot.steps.http`` steps now correctly have ``url`` parameter renderable
 
+* When no arguments are used ``buildbot checkconfig`` now uses :file:`buildbot.tac` to locate the master config file.
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
When `buildbot checkconfig` is used without an argument default to using buildbot.tac in the current directory to find the config file.

This makes checkconfig work like `buildbot start` where it defaults to the current directory.