### PR TITLE
put README.rst in MANIFEST.in

### DIFF
--- a/master/MANIFEST.in
+++ b/master/MANIFEST.in
@@ -1,4 +1,4 @@
-include MANIFEST.in README CREDITS COPYING UPGRADING
+include MANIFEST.in README.rst CREDITS COPYING UPGRADING
 
 include docs/examples/*.cfg
 include docs/conf.py


### PR DESCRIPTION
the source tarballs are broken.

---
```
# pip install -r requirements.txt
Downloading/unpacking http://ftp.buildbot.net/pub/latest/buildbot-1latest.tar.gz (from -r requirements.txt (line 1))
  Downloading buildbot-1latest.tar.gz (4.9MB): 4.9MB downloaded
  Running setup.py (path:/tmp/pip-L_vU6r-build/setup.py) egg_info for package from http://ftp.buildbot.net/pub/latest/buildbot-1latest.tar.gz
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip-L_vU6r-build/setup.py", line 115, in <module>
        with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as long_d_f:
    IOError: [Errno 2] No such file or directory: '/tmp/pip-L_vU6r-build/README.rst'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip-L_vU6r-build/setup.py", line 115, in <module>

    with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as long_d_f:

IOError: [Errno 2] No such file or directory: '/tmp/pip-L_vU6r-build/README.rst'
```