### PR TITLE
Add the StashStatusPush handler

### DIFF
--- a/master/buildbot/status/status_stash.py
+++ b/master/buildbot/status/status_stash.py
@@ -1,0 +1,151 @@
+"""
+Send build results of builds to Atlassian Stash.
+
+https://developer.atlassian.com/stash/docs/latest/how-tos/updating-build-status-for-commits.html
+"""
+
+from base64 import b64encode
+from buildbot.interfaces import IStatusReceiver
+from buildbot.process.properties import Interpolate
+from buildbot.status.base import StatusReceiverMultiService
+from buildbot.status.builder import SUCCESS
+from buildbot.status.buildset import BuildSetSummaryNotifierMixin
+from json import dumps
+from twisted.web.client import Agent
+from twisted.web.http_headers import Headers
+from twisted.web.iweb import IBodyProducer
+from twisted.internet import reactor, defer
+from twisted.python import log
+from zope.interface import implements
+
+try:
+    from twisted.web.client import readBody
+except ImportError:
+    def readBody(*args, **kwargs):
+        return defer.succeed('StatusStashPush requires twisted.web.client.readBody() '
+                             'to report the body of Stash API errors. '
+                             'Please upgrade to Twisted 13.1.0 or newer if you need more verbose error messages.')
+
+# Magic words understood by Stash REST API
+INPROGRESS = 'INPROGRESS'
+SUCCESSFUL = 'SUCCESSFUL'
+FAILED = 'FAILED'
+
+
+def logIfNot2XX(response):
+    """
+    If we get a response other than 200, 204, or other success,
+    log it.
+    """
+    if 200 < response.code <= 300:
+        return
+
+    def cbBody(body):
+        error_message = 'StashStatusPush received %s with body: %s'
+        log.err(error_message % (response.code, body))
+
+    d = readBody(response)
+    d.addCallback(cbBody)
+    return d
+
+
+class StringProducer(object):
+    implements(IBodyProducer)
+
+    def __init__(self, body):
+        self.body = body
+        self.length = len(body)
+
+    def startProducing(self, consumer):
+        consumer.write(self.body)
+        return defer.succeed(None)
+
+    def pauseProducing(self):
+        pass
+
+    def stopProducing(self):
+        pass
+
+
+class StashStatusPush(StatusReceiverMultiService,
+                      BuildSetSummaryNotifierMixin):
+    implements(IStatusReceiver)
+
+    def __init__(self, base_url, user, password):
+        """
+        :param base_url: The base url of the stash host, up to the path.
+        For example, https://stash.example.com/
+        :param user: The stash user to log in as using http basic auth.
+        :param password: The password to use with the stash user.
+        :return:
+        """
+        StatusReceiverMultiService.__init__(self)
+        if not base_url.endswith('/'):
+            base_url += '/'
+        self.base_url = '%srest/build-status/1.0/commits/' % (base_url, )
+        self.auth = b64encode('%s:%s' % (user, password))
+        self._sha = Interpolate('%(src::revision)s')
+        self.master_status = None
+
+    @defer.inlineCallbacks
+    def send(self, builderName, build, status):
+        (sha, ) = yield defer.gatherResults([build.render(self._sha), ])
+        build_url = build.builder.status.getURLForThing(build)
+        body = dumps({'state': status, 'key': builderName, 'url': build_url})
+        stash_uri = self.base_url + sha
+        agent = Agent(reactor)
+        d = agent.request(
+            method='POST',
+            uri=bytes(stash_uri),
+            headers=Headers({
+                'Content-Type': ['application/json; charset=utf-8', ],
+                'Authorization': ['Basic %s' % (self.auth, ), ],
+                'Accept': ['*/*', ],
+                'Accept-Language': ['en-US, en;q=0.8', ],
+            }),
+            bodyProducer=StringProducer(body)
+        )
+        d.addCallback(logIfNot2XX)
+        d.addErrback(log.err,
+                     'StashStatusPush failed while POSTing status message '
+                     'for commit %s built by builder %s to %s with body %s'
+                     '' % (sha, builderName, stash_uri, body))
+
+    def setServiceParent(self, parent):
+        """
+        @type  parent: L{buildbot.master.BuildMaster}
+        """
+        StatusReceiverMultiService.setServiceParent(self, parent)
+        self.master_status = self.parent
+        self.master_status.subscribe(self)
+        self.master = self.master_status.master
+
+    def startService(self):
+        print """Starting up StashStatusPush"""
+        self.summarySubscribe()
+        StatusReceiverMultiService.startService(self)
+
+    def stopService(self):
+        self.summaryUnsubscribe()
+
+    def builderAdded(self, name, builder):
+        return self
+
+    def buildStarted(self, builderName, build):
+        self.send(builderName, build, INPROGRESS)
+        return self
+
+    def buildFinished(self, builderName, build, results):
+        self.send(builderName, build,
+                  SUCCESSFUL if results == SUCCESS else FAILED)
+        return self
+
+    # necessary methods to satisfy implements()
+    def sendBuildSetSummary(self, buildset, builds):
+        pass
+
+    def sendCodeReviews(self, build, result):
+        pass
+
+    def sendCodeReview(self, project, revision, result):
+        pass

--- a/master/buildbot/test/unit/test_status_stash.py
+++ b/master/buildbot/test/unit/test_status_stash.py
@@ -1,0 +1,59 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.status.results import FAILURE
+from buildbot.status.results import SUCCESS
+from buildbot.status.status_stash import StashStatusPush, INPROGRESS, SUCCESSFUL, FAILED
+from buildbot.test.fake.fakebuild import FakeBuild
+from buildbot.test.util import logging
+from mock import Mock
+from twisted.trial import unittest
+
+
+class TestStashStatusPush(unittest.TestCase, logging.LoggingMixin):
+
+    def setUp(self):
+        super(TestStashStatusPush, self).setUp()
+
+        self.setUpLogging()
+        self.build = FakeBuild()
+        self.status = StashStatusPush('fake host', 'fake user', 'fake password')
+
+    def tearDown(self):
+        pass
+
+    def test_buildStarted_sends_inprogress(self):
+        """
+        buildStarted should send INPROGRESS
+        """
+        self.status.send = Mock()
+        self.status.buildStarted('fakeBuilderName', self.build)
+        self.status.send.assert_called_with('fakeBuilderName', self.build, INPROGRESS)
+
+    def test_buildFinished_sends_successful_on_success(self):
+        """
+        buildFinished should send SUCCESSFUL if called with SUCCESS
+        """
+        self.status.send = Mock()
+        self.status.buildFinished('fakeBuilderName', self.build, SUCCESS)
+        self.status.send.assert_called_with('fakeBuilderName', self.build, SUCCESSFUL)
+
+    def test_buildFinished_sends_failed_on_failure(self):
+        """
+        buildFinished should send FAILED if called with anything other than SUCCESS
+        """
+        self.status.send = Mock()
+        self.status.buildFinished('fakeBuilderName', self.build, FAILURE)
+        self.status.send.assert_called_with('fakeBuilderName', self.build, FAILED)

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -1517,7 +1517,7 @@ GerritStatusPush can send a separate review for each build that completes, or a 
 
    :param summaryCB: (optional) callback that is called each time a buildset finishes, and that is used to define a message and review approvals depending on the build result.
    :param summaryArg: (optional) argument passed to the summary callback.
- 
+
                       If :py:func:`summaryCB` callback is specified, determines the message and score to give when sending a single review summarizing all of the builds.
                       It should return a dictionary:
 
@@ -1600,6 +1600,39 @@ You can define custom start and end build messages using the `startDescription` 
 Starting with Buildbot version 0.8.11, :class:`GitHubStatus` supports additional parameter -- ``baseURL`` -- that allows to specify a different API base endpoint.
 This is required if you work with GitHub Enterprise installation.
 This feature requires ``txgithub`` of version 0.2.0 or better.
+
+StashStatusPush
+~~~~~~~~~~~~~~~
+
+.. @cindex StashStatusPush
+.. py:class:: buildbot.status.status_stash.StashStatusPush
+
+::
+
+    from buildbot.status.status_stash import StashStatusPush
+
+    ss = StashStatusPush('https://stash.example.com:8080/',
+                         'stash_username',
+                         'secret_password')
+
+    c['status'].append(ss)
+
+
+:class:`StashStatusPush` publishes build status using `Stash Build Integration REST API <https://developer.atlassian.com/static/rest/stash/3.6.0/stash-build-integration-rest.html>`_.
+The build status is published to a specific commit SHA in Stash.
+It tracks the last build for each builderName for each commit built.
+
+Specifically, it follows the `Updating build status for commits <https://developer.atlassian.com/stash/docs/latest/how-tos/updating-build-status-for-commits.html>`_ document.
+
+It uses the standard Python Twisted Agent to make REST requests to the stash server.
+It uses HTTP Basic AUTH.
+As a result, we recommend you use https in your base_url rather than http.
+If you use https, it requires `pyOpenSSL`.
+
+Configuration requires exactly 3 parameters:
+`base_url` is the base url of the stash host, up to and optionally including the first / of the path.
+`user` is the stash user to post as
+`password` is the stash user's password
 
 .. [#] Apparently this is the same way http://buildd.debian.org displays build status
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -79,6 +79,8 @@ Features
 
 * GitHub change hook now supports payload validation using shared secret, see :ref:`GitHub-hook` for details.
 
+* Added StashStatusPush status hook for Atlassian Stash
+
 * Builders can now have multiple "tags" associated with them. Tags can be used in various status classes as filters (eg, on the waterfall page).
 
 Fixes


### PR DESCRIPTION
This adds a StashStatusPush handler that works with Atlassian Stash to update commits with build status.