### PR TITLE
Slave proto: introduce proxies for RemoteCommand, FileWriter and FileReader

### DIFF
--- a/master/buildbot/buildslave/manager.py
+++ b/master/buildbot/buildslave/manager.py
@@ -48,9 +48,10 @@ class BuildslaveRegistration(object):
     def update(self, slave_config, global_config):
         # For most protocols, there's nothing to do, but for PB we must
         # update the registration in case the port or password has changed.
-        self.pbReg = yield self.master.buildslaves.pb.updateRegistration(
-            slave_config.slavename, slave_config.password,
-            global_config.protocols['pb']['port'])
+        if 'pb' in global_config.protocols:
+            self.pbReg = yield self.master.buildslaves.pb.updateRegistration(
+                slave_config.slavename, slave_config.password,
+                global_config.protocols['pb']['port'])
 
     def getPBPort(self):
         return self.pbReg.getPort()
@@ -91,7 +92,7 @@ class BuildslaveManager(service.ReconfigurableServiceMixin,
 
         # reconfig any newly-added change sources, as well as existing
         yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                           new_config)
+                                                                                   new_config)
 
     @defer.inlineCallbacks
     def reconfigServiceSlaves(self, new_config):

--- a/master/buildbot/buildslave/protocols/base.py
+++ b/master/buildbot/buildslave/protocols/base.py
@@ -68,6 +68,9 @@ class Connection(object):
         raise NotImplementedError
 
 
+# RemoteCommand base implementation and base proxy
+
+
 class RemoteCommandImpl(object):
 
     def remote_update(self, updates):
@@ -88,3 +91,63 @@ class RemoteCommandProxy(object):
 
     def remote_complete(self, failure=None):
         return self.impl.remote_complete(failure)
+
+
+# FileWriter base implementation and base proxy
+
+class FileWriterImpl(object):
+
+    def remote_write(self, data):
+        raise NotImplementedError
+
+    def remote_utime(self, accessed_modified):
+        raise NotImplementedError
+
+    def remote_unpack(self):
+        raise NotImplementedError
+
+    def remote_close(self):
+        raise NotImplementedError
+
+
+class FileWriterProxy(object):
+
+    def __init__(self, impl):
+        assert isinstance(impl, FileWriterImpl)
+        self.impl = impl
+
+    def remote_write(self, data):
+        return self.impl.remote_write(data)
+
+    def remote_utime(self, accessed_modified):
+        return self.impl.remote_utime(accessed_modified)
+
+    def remote_unpack(self):
+        return self.impl.remote_unpack()
+
+    def remote_close(self):
+        return self.impl.remote_close()
+
+# FileReader base implementation and base proxy
+
+
+class FileReaderImpl(object):
+
+    def remote_read(self, maxLength):
+        raise NotImplementedError
+
+    def remote_close(self):
+        raise NotImplementedError
+
+
+class FileReaderProxy(object):
+
+    def __init__(self, impl):
+        assert isinstance(impl, FileReaderImpl)
+        self.impl = impl
+
+    def remote_read(self, maxLength):
+        return self.impl.remote_read(maxLength)
+
+    def remote_close(self):
+        return self.impl.remote_close()

--- a/master/buildbot/buildslave/protocols/base.py
+++ b/master/buildbot/buildslave/protocols/base.py
@@ -79,8 +79,6 @@ class Connection(object):
 
 
 # RemoteCommand base implementation and base proxy
-
-
 class RemoteCommandImpl(object):
 
     def remote_update(self, updates):
@@ -90,21 +88,7 @@ class RemoteCommandImpl(object):
         raise NotImplementedError
 
 
-class RemoteCommandProxy(object):
-
-    def __init__(self, impl):
-        assert isinstance(impl, RemoteCommandImpl)
-        self.impl = impl
-
-    def remote_update(self, updates):
-        return self.impl.remote_update(updates)
-
-    def remote_complete(self, failure=None):
-        return self.impl.remote_complete(failure)
-
-
-# FileWriter base implementation and base proxy
-
+# FileWriter base implementation
 class FileWriterImpl(object):
 
     def remote_write(self, data):
@@ -120,27 +104,7 @@ class FileWriterImpl(object):
         raise NotImplementedError
 
 
-class FileWriterProxy(object):
-
-    def __init__(self, impl):
-        assert isinstance(impl, FileWriterImpl)
-        self.impl = impl
-
-    def remote_write(self, data):
-        return self.impl.remote_write(data)
-
-    def remote_utime(self, accessed_modified):
-        return self.impl.remote_utime(accessed_modified)
-
-    def remote_unpack(self):
-        return self.impl.remote_unpack()
-
-    def remote_close(self):
-        return self.impl.remote_close()
-
-# FileReader base implementation and base proxy
-
-
+# FileReader base implementation
 class FileReaderImpl(object):
 
     def remote_read(self, maxLength):
@@ -148,16 +112,3 @@ class FileReaderImpl(object):
 
     def remote_close(self):
         raise NotImplementedError
-
-
-class FileReaderProxy(object):
-
-    def __init__(self, impl):
-        assert isinstance(impl, FileReaderImpl)
-        self.impl = impl
-
-    def remote_read(self, maxLength):
-        return self.impl.remote_read(maxLength)
-
-    def remote_close(self):
-        return self.impl.remote_close()

--- a/master/buildbot/buildslave/protocols/base.py
+++ b/master/buildbot/buildslave/protocols/base.py
@@ -66,3 +66,25 @@ class Connection(object):
 
     def remoteInterruptCommand(self, commandId, why):
         raise NotImplementedError
+
+
+class RemoteCommandImpl(object):
+
+    def remote_update(self, updates):
+        raise NotImplementedError
+
+    def remote_complete(self, failure=None):
+        raise NotImplementedError
+
+
+class RemoteCommandProxy(object):
+
+    def __init__(self, impl):
+        assert isinstance(impl, RemoteCommandImpl)
+        self.impl = impl
+
+    def remote_update(self, updates):
+        return self.impl.remote_update(updates)
+
+    def remote_complete(self, failure=None):
+        return self.impl.remote_complete(failure)

--- a/master/buildbot/buildslave/protocols/base.py
+++ b/master/buildbot/buildslave/protocols/base.py
@@ -25,6 +25,7 @@ class Listener(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
 
 class Connection(object):
+    proxies = {}
 
     def __init__(self, master, buildslave):
         self.master = master
@@ -33,6 +34,15 @@ class Connection(object):
         self._disconnectSubs = subscription.SubscriptionPoint(
             "disconnections from %s" % name)
 
+    # This method replace all Impl args by their Proxy protocol implementation
+    def createArgsProxies(self, args):
+        newargs = {}
+        for k, v in args.iteritems():
+            for implclass, proxyclass in self.proxies.items():
+                if isinstance(v, implclass):
+                    v = proxyclass(v)
+            newargs[k] = v
+        return newargs
     # disconnection handling
 
     def notifyOnDisconnect(self, cb):

--- a/master/buildbot/buildslave/protocols/null.py
+++ b/master/buildbot/buildslave/protocols/null.py
@@ -26,6 +26,10 @@ class Listener(base.Listener):
 
 class ProxyMixin():
 
+    def __init__(self, impl):
+        assert isinstance(impl, self.ImplClass)
+        self.impl = impl
+
     def callRemote(self, message, *args, **kw):
         method = getattr(self.impl, "remote_%s" % message, None)
         if method is None:
@@ -43,20 +47,19 @@ class ProxyMixin():
     def dontNotifyOnDisconnect(self, cb):
         pass
 
+
 # just add ProxyMixin capability to the RemoteCommandProxy
 # so that callers of callRemote actually directly call the proper method
+class RemoteCommandProxy(ProxyMixin):
+    ImplClass = base.RemoteCommandImpl
 
 
-class RemoteCommandProxy(base.RemoteCommandProxy, ProxyMixin):
-    pass
+class FileReaderProxy(ProxyMixin):
+    ImplClass = base.FileReaderImpl
 
 
-class FileReaderProxy(base.FileReaderProxy, ProxyMixin):
-    pass
-
-
-class FileWriterProxy(base.FileWriterProxy, ProxyMixin):
-    pass
+class FileWriterProxy(ProxyMixin):
+    ImplClass = base.FileWriterImpl
 
 
 class Connection(base.Connection):

--- a/master/buildbot/buildslave/protocols/null.py
+++ b/master/buildbot/buildslave/protocols/null.py
@@ -1,0 +1,88 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+
+from buildbot.buildslave.protocols import base
+from twisted.internet import defer
+from twisted.python import log
+
+
+class Listener(base.Listener):
+    pass
+
+
+class ProxyMixin():
+
+    def callRemote(self, message, *args, **kw):
+        method = getattr(self.impl, "remote_%s" % message, None)
+        if method is None:
+            raise AttributeError("No such method: remote_%s" % (message,))
+        try:
+            state = method(*args, **kw)
+        except TypeError:
+            log.msg("%s didn't accept %s and %s" % (method, args, kw))
+            raise
+        return defer.maybeDeferred(lambda: state)
+
+    def notifyOnDisconnect(self, cb):
+        pass
+
+    def dontNotifyOnDisconnect(self, cb):
+        pass
+
+# just add ProxyMixin capability to the RemoteCommandProxy
+# so that callers of callRemote actually directly call the proper method
+
+
+class RemoteCommandProxy(base.RemoteCommandProxy, ProxyMixin):
+    pass
+
+
+class FileReaderProxy(base.FileReaderProxy, ProxyMixin):
+    pass
+
+
+class FileWriterProxy(base.FileWriterProxy, ProxyMixin):
+    pass
+
+
+class Connection(base.Connection):
+    proxies = {base.FileWriterImpl: FileWriterProxy, base.FileReaderImpl: FileReaderProxy}
+
+    def remotePrint(self, message):
+        return defer.maybeDeferred(self.buildslave.bot.remote_print, message)
+
+    def remoteGetSlaveInfo(self):
+        return defer.maybeDeferred(self.buildslave.bot.remote_getSlaveInfo)
+
+    def remoteSetBuilderList(self, builders):
+        return defer.maybeDeferred(self.buildslave.bot.remote_setBuilderList, builders)
+
+    def remoteStartCommand(self, remoteCommand, builderName, commandId, commandName, args):
+        remoteCommand = RemoteCommandProxy(remoteCommand)
+        args = self.createArgsProxies(args)
+        slavebuilder = self.buildslave.bot.builders[builderName]
+        return defer.maybeDeferred(slavebuilder.remote_startCommand, remoteCommand,
+                                   commandId, commandName, args)
+
+    def remoteShutdown(self):
+        return defer.maybeDeferred(self.buildslave.stopService)
+
+    def remoteStartBuild(self, builderName):
+        return defer.succeed(self.buildslave.bot.builders[builderName].remote_startBuild())
+
+    def remoteInterruptCommand(self, commandId, why):
+        return defer.maybeDeferred(self.buildslave.bot.remote_interruptCommand, commandId, why)

--- a/master/buildbot/buildslave/protocols/pb.py
+++ b/master/buildbot/buildslave/protocols/pb.py
@@ -76,6 +76,11 @@ class Listener(base.Listener):
             raise RuntimeError("rejecting duplicate slave")
 
 
+# just add pb.Referenceable capability to the RemoteCommandProxy
+class RemoteCommand(base.RemoteCommandProxy, pb.Referenceable):
+    pass
+
+
 class Connection(base.Connection, pb.Avatar):
 
     # TODO: configure keepalive_interval in c['protocols']['pb']['keepalive_interval']
@@ -175,6 +180,7 @@ class Connection(base.Connection, pb.Avatar):
 
     def remoteStartCommand(self, remoteCommand, builderName, commandId, commandName, args):
         slavebuilder = self.builders.get(builderName)
+        remoteCommand = RemoteCommand(remoteCommand)
         return slavebuilder.callRemote('startCommand',
                                        remoteCommand, commandId, commandName, args
                                        )

--- a/master/buildbot/buildslave/protocols/pb.py
+++ b/master/buildbot/buildslave/protocols/pb.py
@@ -166,6 +166,9 @@ class Connection(base.Connection, pb.Avatar):
         except pb.NoSuchMethod:
             log.msg("BuildSlave.getSlaveInfo is unavailable - ignoring")
 
+        # newer slaves send all info in one command
+        if "slave_commands" in info:
+            defer.returnValue(info)
         try:
             info["slave_commands"] = yield self.mind.callRemote('getCommands')
         except pb.NoSuchMethod:

--- a/master/buildbot/buildslave/protocols/pb.py
+++ b/master/buildbot/buildslave/protocols/pb.py
@@ -76,17 +76,27 @@ class Listener(base.Listener):
             raise RuntimeError("rejecting duplicate slave")
 
 
-# just add pb.Referenceable capability to the RemoteCommandProxy
-class RemoteCommand(base.RemoteCommandProxy, pb.Referenceable):
-    pass
+class ReferenceableProxy(pb.Referenceable):
+
+    def __init__(self, impl):
+        assert isinstance(impl, self.ImplClass)
+        self.impl = impl
+
+    def __getattr__(self, default=None):
+        return getattr(self.impl, default)
 
 
-class FileReaderProxy(base.FileReaderProxy, pb.Referenceable):
-    pass
+# Proxy are just ReferenceableProxy to the Impl classes
+class RemoteCommand(ReferenceableProxy):
+    ImplClass = base.RemoteCommandImpl
 
 
-class FileWriterProxy(base.FileWriterProxy, pb.Referenceable):
-    pass
+class FileReaderProxy(ReferenceableProxy):
+    ImplClass = base.FileReaderImpl
+
+
+class FileWriterProxy(ReferenceableProxy):
+    ImplClass = base.FileWriterImpl
 
 
 class Connection(base.Connection, pb.Avatar):

--- a/master/buildbot/buildslave/protocols/pb.py
+++ b/master/buildbot/buildslave/protocols/pb.py
@@ -81,8 +81,16 @@ class RemoteCommand(base.RemoteCommandProxy, pb.Referenceable):
     pass
 
 
-class Connection(base.Connection, pb.Avatar):
+class FileReaderProxy(base.FileReaderProxy, pb.Referenceable):
+    pass
 
+
+class FileWriterProxy(base.FileWriterProxy, pb.Referenceable):
+    pass
+
+
+class Connection(base.Connection, pb.Avatar):
+    proxies = {base.FileWriterImpl: FileWriterProxy, base.FileReaderImpl: FileReaderProxy}
     # TODO: configure keepalive_interval in c['protocols']['pb']['keepalive_interval']
     keepalive_timer = None
     keepalive_interval = 3600
@@ -181,6 +189,7 @@ class Connection(base.Connection, pb.Avatar):
     def remoteStartCommand(self, remoteCommand, builderName, commandId, commandName, args):
         slavebuilder = self.builders.get(builderName)
         remoteCommand = RemoteCommand(remoteCommand)
+        args = self.createArgsProxies(args)
         return slavebuilder.callRemote('startCommand',
                                        remoteCommand, commandId, commandName, args
                                        )

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -698,13 +698,16 @@ class MasterConfig(util.ComparableMixin):
         ports = set()
         if self.protocols:
             for proto, options in self.protocols.iteritems():
-                port = options.get("port")
+                if proto == 'null':
+                    port = -1
+                else:
+                    port = options.get("port")
                 if not port:
                     continue
                 if isinstance(port, int):
                     # Conversion needed to compare listenTCP and strports ports
                     port = "tcp:%d" % port
-                if port in ports:
+                if port != -1 and port in ports:
                     error("Some of ports in c['protocols'] duplicated")
                 ports.add(port)
 

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -496,9 +496,6 @@ class BuildStep(results.ResultComputingConfigMixin,
         except BuildStepFailed:
             self.results = FAILURE
 
-        except BuildSlaveTooOldError:
-            self.results = EXCEPTION
-
         except error.ConnectionLost:
             self.results = RETRY
 

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -117,7 +117,6 @@ class RemoteCommand(base.RemoteCommandImpl):
 
     def _start(self):
         self._startTime = util.now()
-
         # This method only initiates the remote command.
         # We will receive remote_update messages as the command runs.
         # We will get a single remote_complete when it finishes.

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 from buildbot import util
+from buildbot.buildslave.protocols import base
 from buildbot.process import metrics
 from buildbot.status.results import FAILURE
 from buildbot.status.results import SUCCESS
@@ -29,7 +30,7 @@ class RemoteException(Exception):
     pass
 
 
-class RemoteCommand(pb.Referenceable):
+class RemoteCommand(base.RemoteCommandImpl):
 
     # class-level unique identifier generator for command ids
     _commandCounter = 0

--- a/master/buildbot/process/remotetransfer.py
+++ b/master/buildbot/process/remotetransfer.py
@@ -1,0 +1,198 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import os
+import tarfile
+import tempfile
+try:
+    from cStringIO import StringIO
+    assert StringIO
+except ImportError:
+    from StringIO import StringIO
+
+
+from buildbot.buildslave.protocols import base
+
+"""
+module for regrouping all FileWriterImpl and FileReaderImpl away from steps
+"""
+
+
+class FileWriter(base.FileWriterImpl):
+
+    """
+    Helper class that acts as a file-object with write access
+    """
+
+    def __init__(self, destfile, maxsize, mode):
+        # Create missing directories.
+        destfile = os.path.abspath(destfile)
+        dirname = os.path.dirname(destfile)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+
+        self.destfile = destfile
+        self.mode = mode
+        fd, self.tmpname = tempfile.mkstemp(dir=dirname)
+        self.fp = os.fdopen(fd, 'wb')
+        self.remaining = maxsize
+
+    def remote_write(self, data):
+        """
+        Called from remote slave to write L{data} to L{fp} within boundaries
+        of L{maxsize}
+
+        @type  data: C{string}
+        @param data: String of data to write
+        """
+        if self.remaining is not None:
+            if len(data) > self.remaining:
+                data = data[:self.remaining]
+            self.fp.write(data)
+            self.remaining = self.remaining - len(data)
+        else:
+            self.fp.write(data)
+
+    def remote_utime(self, accessed_modified):
+        os.utime(self.destfile, accessed_modified)
+
+    def remote_close(self):
+        """
+        Called by remote slave to state that no more data will be transfered
+        """
+        self.fp.close()
+        self.fp = None
+        # on windows, os.rename does not automatically unlink, so do it manually
+        if os.path.exists(self.destfile):
+            os.unlink(self.destfile)
+        os.rename(self.tmpname, self.destfile)
+        self.tmpname = None
+        if self.mode is not None:
+            os.chmod(self.destfile, self.mode)
+
+    def cancel(self):
+        # unclean shutdown, the file is probably truncated, so delete it
+        # altogether rather than deliver a corrupted file
+        fp = getattr(self, "fp", None)
+        if fp:
+            fp.close()
+            if self.destfile and os.path.exists(self.destfile):
+                os.unlink(self.destfile)
+            if self.tmpname and os.path.exists(self.tmpname):
+                os.unlink(self.tmpname)
+
+
+class DirectoryWriter(FileWriter):
+
+    """
+    A DirectoryWriter is implemented as a FileWriter, with an added post-processing
+    step to unpack the archive, once the transfer has completed.
+    """
+
+    def __init__(self, destroot, maxsize, compress, mode):
+        self.destroot = destroot
+        self.compress = compress
+
+        self.fd, self.tarname = tempfile.mkstemp()
+        os.close(self.fd)
+
+        FileWriter.__init__(self, self.tarname, maxsize, mode)
+
+    def remote_unpack(self):
+        """
+        Called by remote slave to state that no more data will be transfered
+        """
+        # Make sure remote_close is called, otherwise atomic rename wont happen
+        self.remote_close()
+
+        # Map configured compression to a TarFile setting
+        if self.compress == 'bz2':
+            mode = 'r|bz2'
+        elif self.compress == 'gz':
+            mode = 'r|gz'
+        else:
+            mode = 'r'
+
+        # Unpack archive and clean up after self
+        archive = tarfile.open(name=self.tarname, mode=mode)
+        archive.extractall(path=self.destroot)
+        archive.close()
+        os.remove(self.tarname)
+
+
+class FileReader(base.FileReaderImpl):
+
+    """
+    Helper class that acts as a file-object with read access
+    """
+
+    def __init__(self, fp):
+        self.fp = fp
+
+    def remote_read(self, maxlength):
+        """
+        Called from remote slave to read at most L{maxlength} bytes of data
+
+        @type  maxlength: C{integer}
+        @param maxlength: Maximum number of data bytes that can be returned
+
+        @return: Data read from L{fp}
+        @rtype: C{string} of bytes read from file
+        """
+        if self.fp is None:
+            return ''
+
+        data = self.fp.read(maxlength)
+        return data
+
+    def remote_close(self):
+        """
+        Called by remote slave to state that no more data will be transfered
+        """
+        if self.fp is not None:
+            self.fp.close()
+            self.fp = None
+
+
+class StringFileWriter(base.FileWriterImpl):
+
+    """
+    FileWriter class that just puts received data into a buffer.
+
+    Used to upload a file from slave for inline processing rather than
+    writing into a file on master.
+    """
+
+    def __init__(self):
+        self.buffer = ""
+
+    def remote_write(self, data):
+        self.buffer += data
+
+    def remote_close(self):
+        pass
+
+
+class StringFileReader(FileReader):
+
+    """
+    FileWriter class that just buid send data from a string.
+
+    Used to download a file to slave from local string rather than first
+    writing into a file on master.
+    """
+
+    def __init__(self, s):
+        self.fp = StringIO(s)

--- a/master/buildbot/steps/slave.py
+++ b/master/buildbot/steps/slave.py
@@ -15,32 +15,12 @@
 
 import stat
 
-from twisted.spread import pb
-
 from buildbot.interfaces import BuildSlaveTooOldError
 from buildbot.process import buildstep
 from buildbot.process import remotecommand
+from buildbot.process import remotetransfer
 from buildbot.status.results import FAILURE
 from buildbot.status.results import SUCCESS
-
-
-class StringFileWriter(pb.Referenceable):
-
-    """
-    FileWriter class that just puts received data into a buffer.
-
-    Used to upload a file from slave for inline processing rather than
-    writing into a file on master.
-    """
-
-    def __init__(self):
-        self.buffer = ""
-
-    def remote_write(self, data):
-        self.buffer += data
-
-    def remote_close(self):
-        pass
 
 
 class SlaveBuildStep(buildstep.BuildStep):
@@ -322,7 +302,7 @@ class CompositeStepMixin():
 
     def getFileContentFromSlave(self, filename, abandonOnFailure=False):
         self.checkSlaveHasCommand("uploadFile")
-        fileWriter = StringFileWriter()
+        fileWriter = remotetransfer.StringFileWriter()
         # default arguments
         args = {
             'slavesrc': filename,

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -14,15 +14,13 @@
 # Copyright Buildbot Team Members
 
 
-import StringIO
-
 from buildbot.process import buildstep
 from buildbot.process import remotecommand
+from buildbot.process import remotetransfer
 from buildbot.process.buildstep import LoggingBuildStep
 from buildbot.status.builder import FAILURE
 from buildbot.status.builder import SKIPPED
 from buildbot.steps.slave import CompositeStepMixin
-from buildbot.steps.transfer import _FileReader
 from twisted.python import log
 
 
@@ -212,7 +210,7 @@ class Source(LoggingBuildStep, CompositeStepMixin):
             self.workdir = self.build.path_module.join(self.workdir, root)
 
         def _downloadFile(buf, filename):
-            filereader = _FileReader(StringIO.StringIO(buf))
+            filereader = remotetransfer.StringFileReader(buf)
             args = {
                 'slavedest': filename,
                 'maxsize': None,

--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -25,7 +25,7 @@ from twisted.python import log
 from buildbot.interfaces import BuildSlaveTooOldError
 from buildbot.process import buildstep
 from buildbot.process import remotecommand
-from buildbot.steps.slave import StringFileWriter
+from buildbot.process.remotetransfer import StringFileWriter
 from buildbot.steps.source.base import Source
 
 

--- a/master/buildbot/steps/source/darcs.py
+++ b/master/buildbot/steps/source/darcs.py
@@ -15,8 +15,6 @@
 
 # Source step code for darcs
 
-import StringIO
-
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log
@@ -25,9 +23,9 @@ from buildbot.config import ConfigErrors
 from buildbot.interfaces import BuildSlaveTooOldError
 from buildbot.process import buildstep
 from buildbot.process import remotecommand
+from buildbot.process import remotetransfer
 from buildbot.status.results import SUCCESS
 from buildbot.steps.source.base import Source
-from buildbot.steps.transfer import _FileReader
 
 
 class Darcs(Source):
@@ -255,7 +253,7 @@ class Darcs(Source):
         return self.pathExists(self.build.path_module.join(self.workdir, '_darcs'))
 
     def _downloadFile(self, buf, filename):
-        filereader = _FileReader(StringIO.StringIO(buf))
+        filereader = remotetransfer.StringFileReader(buf)
         args = {
             'slavedest': filename,
             'maxsize': None,

--- a/master/buildbot/test/integration/test_transfer.py
+++ b/master/buildbot/test/integration/test_transfer.py
@@ -27,7 +27,7 @@ from twisted.internet import defer
 
 
 class TransferStepsMasterPb(RunMasterBase):
-    slaveproto = "pb"
+    proto = "pb"
 
     def readMasterDirContents(self, top):
         contents = {}
@@ -53,6 +53,10 @@ class TransferStepsMasterPb(RunMasterBase):
         # cleanup our mess (slave is cleaned up by parent class)
         shutil.rmtree("dir")
         os.unlink("master.txt")
+
+
+class TransferStepsMasterNull(TransferStepsMasterPb):
+    proto = "null"
 
 
 # master configuration

--- a/master/buildbot/test/integration/test_transfer.py
+++ b/master/buildbot/test/integration/test_transfer.py
@@ -1,0 +1,82 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import os
+import shutil
+
+from buildbot.status.results import SUCCESS
+from buildbot.test.util.integration import RunMasterBase
+from twisted.internet import defer
+
+# This integration test creates a master and slave environment
+# and make sure the transfer steps are working
+
+# When new protocols are added, make sure you update this test to exercice your proto implementation
+
+
+class TransferStepsMasterPb(RunMasterBase):
+    slaveproto = "pb"
+
+    def readMasterDirContents(self, top):
+        contents = {}
+        for root, dirs, files in os.walk(top):
+            for name in files:
+                fn = os.path.join(root, name)
+                with open(fn) as f:
+                    contents[fn] = f.read()
+        return contents
+
+    @defer.inlineCallbacks
+    def test_transfer(self):
+
+        build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
+        self.assertEqual(build['results'], SUCCESS)
+        dirContents = self.readMasterDirContents("dir")
+        self.assertEqual(
+            dirContents,
+            {'dir/file1.txt': 'filecontent',
+             'dir/file2.txt': 'filecontent2',
+             'dir/file3.txt': 'filecontent2'})
+
+        # cleanup our mess (slave is cleaned up by parent class)
+        shutil.rmtree("dir")
+        os.unlink("master.txt")
+
+
+# master configuration
+def masterConfig():
+    c = {}
+    from buildbot.config import BuilderConfig
+    from buildbot.process.factory import BuildFactory
+    from buildbot.plugins import steps, schedulers
+
+    c['schedulers'] = [
+        schedulers.ForceScheduler(
+            name="force",
+            builderNames=["testy"])]
+
+    f = BuildFactory()
+    # do a bunch of transfer to exercise the protocol
+    f.addStep(steps.StringDownload("filecontent", slavedest="dir/file1.txt"))
+    f.addStep(steps.StringDownload("filecontent2", slavedest="dir/file2.txt"))
+    f.addStep(steps.FileUpload(slavesrc="dir/file2.txt", masterdest="master.txt"))
+    f.addStep(steps.FileDownload(mastersrc="master.txt", slavedest="dir/file3.txt"))
+    f.addStep(steps.DirectoryUpload(slavesrc="dir", masterdest="dir"))
+    c['builders'] = [
+        BuilderConfig(name="testy",
+                      slavenames=["local1"],
+                      factory=f)
+    ]
+    return c

--- a/master/buildbot/test/unit/test_buildslave_protocols_pb.py
+++ b/master/buildbot/test/unit/test_buildslave_protocols_pb.py
@@ -183,7 +183,7 @@ class TestConnection(unittest.TestCase):
         conn.remoteSetBuilderList(builders)
 
         RCInstance, builder_name, commandID = base.RemoteCommandImpl(), "builder", None
-        remote_command, args = "command", "args"
+        remote_command, args = "command", {"args": 'args'}
 
         conn.remoteStartCommand(RCInstance, builder_name, commandID, remote_command, args)
 

--- a/master/buildbot/test/unit/test_buildslave_protocols_pb.py
+++ b/master/buildbot/test/unit/test_buildslave_protocols_pb.py
@@ -15,6 +15,7 @@
 
 import mock
 
+from buildbot.buildslave.protocols import base
 from buildbot.buildslave.protocols import pb
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import protocols as util_protocols
@@ -181,13 +182,17 @@ class TestConnection(unittest.TestCase):
         conn = pb.Connection(self.master, self.buildslave, self.mind)
         conn.remoteSetBuilderList(builders)
 
-        RCInstance, builder_name, commandID = None, "builder", None
+        RCInstance, builder_name, commandID = base.RemoteCommandImpl(), "builder", None
         remote_command, args = "command", "args"
 
         conn.remoteStartCommand(RCInstance, builder_name, commandID, remote_command, args)
 
-        ret_val['builder'].callRemote.assert_called_with('startCommand',
-                                                         RCInstance, commandID, remote_command, args)
+        callargs = ret_val['builder'].callRemote.call_args_list[0][0]
+        callargs_without_rc = (callargs[0], callargs[2], callargs[3], callargs[4])
+        self.assertEqual(callargs_without_rc, ('startCommand',
+                                               commandID, remote_command, args))
+        self.assertIsInstance(callargs[1], pb.RemoteCommand)
+        self.assertEqual(callargs[1].impl, RCInstance)
 
     def test_doKeepalive(self):
         conn = pb.Connection(self.master, self.buildslave, self.mind)

--- a/master/buildbot/test/unit/test_process_remotetransfer.py
+++ b/master/buildbot/test/unit/test_process_remotetransfer.py
@@ -1,0 +1,49 @@
+import os
+import stat
+import tempfile
+
+from buildbot.process import remotetransfer
+from mock import Mock
+from twisted.trial import unittest
+
+
+# Test buildbot.steps.remotetransfer.FileWriter class.
+class TestFileWriter(unittest.TestCase):
+
+    # test FileWriter.__init__() method.
+
+    def testInit(self):
+        #
+        # patch functions called in constructor
+        #
+
+        # patch os.path.exists() to always return False
+        mockedExists = Mock(return_value=False)
+        self.patch(os.path, "exists", mockedExists)
+
+        # capture calls to os.makedirs()
+        mockedMakedirs = Mock()
+        self.patch(os, 'makedirs', mockedMakedirs)
+
+        # capture calls to tempfile.mkstemp()
+        mockedMkstemp = Mock(return_value=(7, "tmpname"))
+        self.patch(tempfile, "mkstemp", mockedMkstemp)
+
+        # capture calls to os.fdopen()
+        mockedFdopen = Mock()
+        self.patch(os, "fdopen", mockedFdopen)
+
+        #
+        # call _FileWriter constructor
+        #
+        destfile = os.path.join("dir", "file")
+        remotetransfer.FileWriter(destfile, 64, stat.S_IRUSR)
+
+        #
+        # validate captured calls
+        #
+        absdir = os.path.dirname(os.path.abspath(os.path.join("dir", "file")))
+        mockedExists.assert_called_once_with(absdir)
+        mockedMakedirs.assert_called_once_with(absdir)
+        mockedMkstemp.assert_called_once_with(dir=absdir)
+        mockedFdopen.assert_called_once_with(7, 'wb')

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -18,13 +18,13 @@ import textwrap
 
 from buildbot import config
 from buildbot.process import properties
+from buildbot.process import remotetransfer
 from buildbot.status.results import EXCEPTION
 from buildbot.status.results import FAILURE
 from buildbot.status.results import SKIPPED
 from buildbot.status.results import SUCCESS
 from buildbot.status.results import WARNINGS
 from buildbot.steps import shell
-from buildbot.steps import slave
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
@@ -732,7 +732,7 @@ class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase):
             # step will first get the remote suppressions file
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='supps', workdir='wkdir',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(upload_behavior),
 
             # and then run the command

--- a/master/buildbot/test/unit/test_steps_slave.py
+++ b/master/buildbot/test/unit/test_steps_slave.py
@@ -15,6 +15,7 @@
 
 import stat
 
+from buildbot.interfaces import BuildSlaveTooOldError
 from buildbot.process import buildstep
 from buildbot.process import properties
 from buildbot.status.results import EXCEPTION
@@ -121,12 +122,14 @@ class TestFileExists(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
     @compat.usesFlushLoggedErrors
+    @defer.inlineCallbacks
     def test_old_version(self):
         self.setupStep(slave.FileExists(file="x"),
                        slave_version=dict())
         self.expectOutcome(result=EXCEPTION,
                            state_string="finished (exception)")
-        return self.runStep()
+        yield self.runStep()
+        self.flushLoggedErrors(BuildSlaveTooOldError)
 
 
 class TestCopyDirectory(steps.BuildStepMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_steps_source_bzr.py
+++ b/master/buildbot/test/unit/test_steps_source_bzr.py
@@ -15,11 +15,11 @@
 
 import os.path
 
+from buildbot.process import remotetransfer
 from buildbot.status.results import FAILURE
 from buildbot.status.results import RETRY
 from buildbot.status.results import SUCCESS
 from buildbot.steps.source import bzr
-from buildbot.steps.transfer import _FileReader
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
@@ -248,12 +248,12 @@ class TestBzr(sourcesteps.SourceStepMixin, unittest.TestCase):
                         command=['bzr', 'update'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.FileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.FileReader),
                                         slavedest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,

--- a/master/buildbot/test/unit/test_steps_source_cvs.py
+++ b/master/buildbot/test/unit/test_steps_source_cvs.py
@@ -15,12 +15,11 @@
 
 import time
 
+from buildbot.process import remotetransfer
 from buildbot.status.results import FAILURE
 from buildbot.status.results import RETRY
 from buildbot.status.results import SUCCESS
-from buildbot.steps import slave
 from buildbot.steps.source import cvs
-from buildbot.steps.transfer import _FileReader
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
@@ -93,17 +92,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -135,17 +134,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -155,12 +154,12 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                         command=['cvs', '-z3', 'update', '-dP'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,
@@ -191,17 +190,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -232,17 +231,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -271,17 +270,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -310,17 +309,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -429,17 +428,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='source/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='source/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='source/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='source',
@@ -472,7 +471,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='source/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('the-end-of-the-universe'))
             + 0,
             Expect('rmdir', dict(dir='source',
@@ -508,17 +507,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -544,17 +543,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//D2013.10.08.11.20.33\nD'))
             + 0,
             Expect('rmdir', dict(dir='wkdir',
@@ -587,19 +586,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             # on Windows, this file does not contain the password, per
             # http://trac.buildbot.net/ticket/2355
             + Expect.behavior(uploadString(':pserver:dustin@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -624,17 +623,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -661,17 +660,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -698,17 +697,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -739,17 +738,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -775,7 +774,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
                                  logEnviron=True,
@@ -806,7 +805,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
                                  logEnviron=True,
@@ -847,7 +846,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('the-end-of-the-universe'))
             + 0,
             Expect('rmdir', dict(dir='wkdir',
@@ -879,12 +878,12 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('the-end-of-the-universe'))
             + 0,
             Expect('rmdir', dict(dir='wkdir',
@@ -916,7 +915,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + 1,
             ExpectShell(workdir='',
                         command=['cvs',
@@ -943,7 +942,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('the-end-of-the-universe'))
             + 0,
             ExpectShell(workdir='',
@@ -971,17 +970,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -1010,7 +1009,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
                                  logEnviron=True,
@@ -1042,17 +1041,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -1094,17 +1093,17 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Repository', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Entries', workdir='wkdir/CVS',
-                                      writer=ExpectRemoteRef(slave.StringFileWriter)))
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
             ExpectShell(workdir='wkdir',

--- a/master/buildbot/test/unit/test_steps_source_darcs.py
+++ b/master/buildbot/test/unit/test_steps_source_darcs.py
@@ -14,10 +14,10 @@
 # Copyright Buildbot Team Members
 
 from buildbot import config
+from buildbot.process import remotetransfer
 from buildbot.status.results import RETRY
 from buildbot.status.results import SUCCESS
 from buildbot.steps.source import darcs
-from buildbot.steps.transfer import _FileReader
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
@@ -234,12 +234,12 @@ class TestDarcs(sourcesteps.SourceStepMixin, unittest.TestCase):
                         command=['darcs', 'pull', '--all', '--verbose'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,
@@ -318,7 +318,7 @@ class TestDarcs(sourcesteps.SourceStepMixin, unittest.TestCase):
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.darcs-context', workdir='wkdir',
                                         mode=None))
             + 0,

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -13,11 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from buildbot.process import remotetransfer
 from buildbot.status.results import FAILURE
 from buildbot.status.results import RETRY
 from buildbot.status.results import SUCCESS
 from buildbot.steps.source import git
-from buildbot.steps.transfer import _FileReader
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
@@ -191,12 +191,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,
@@ -250,12 +250,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,

--- a/master/buildbot/test/unit/test_steps_source_mercurial.py
+++ b/master/buildbot/test/unit/test_steps_source_mercurial.py
@@ -14,11 +14,11 @@
 # Copyright Buildbot Team Members
 
 from buildbot import config
+from buildbot.process import remotetransfer
 from buildbot.status.results import FAILURE
 from buildbot.status.results import RETRY
 from buildbot.status.results import SUCCESS
 from buildbot.steps.source import mercurial
-from buildbot.steps.transfer import _FileReader
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
@@ -238,12 +238,12 @@ class TestMercurial(sourcesteps.SourceStepMixin, unittest.TestCase):
                                  '--clean', '--rev', 'default'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,
@@ -301,12 +301,12 @@ class TestMercurial(sourcesteps.SourceStepMixin, unittest.TestCase):
                                  '--clean', '--rev', 'default'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,

--- a/master/buildbot/test/unit/test_steps_source_mtn.py
+++ b/master/buildbot/test/unit/test_steps_source_mtn.py
@@ -15,11 +15,11 @@
 
 from twisted.trial import unittest
 
+from buildbot.process import remotetransfer
 from buildbot.status.results import FAILURE
 from buildbot.status.results import RETRY
 from buildbot.status.results import SUCCESS
 from buildbot.steps.source import mtn
-from buildbot.steps.transfer import _FileReader
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
@@ -128,12 +128,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
                         command=['mtn', 'update', '--db=../db.mtn', '-r', 'h:master', '-b', 'master'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,
@@ -196,12 +196,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
                         command=['mtn', 'update', '--db=../db.mtn', '-r', 'h:master', '-b', 'master'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -15,11 +15,11 @@
 
 from buildbot import config
 from buildbot.process import buildstep
+from buildbot.process import remotetransfer
 from buildbot.status.results import FAILURE
 from buildbot.status.results import RETRY
 from buildbot.status.results import SUCCESS
 from buildbot.steps.source import svn
-from buildbot.steps.transfer import _FileReader
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
@@ -1319,12 +1319,12 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                         command=['svn', 'export', 'source', 'wkdir'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(_FileReader),
+                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
                                         slavedest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,

--- a/master/docs/developer/cls-protocols.rst
+++ b/master/docs/developer/cls-protocols.rst
@@ -4,11 +4,14 @@ Protocols
 To exchange information over the network between master and slave we need to use
 protocol.
 
-:class:`Listener` and :class:`Connection` provide interfaces to implement
-wrappers around protocol specific calls, so other classes which use them no need
+:mod:`buildbot.buildslave.protocols.base` provide interfaces to implement
+wrappers around protocol specific calls, so other classes which use them do not need
 to know about protocol calls or handle protocol specific exceptions.
 
-.. py:class Listener(master)
+.. py:module:: buildbot.buildslave.protocols.base
+
+
+.. py:class:: Listener(master)
 
     :param master: :py:class:`buildbot.master.BuildMaster` instance
 
@@ -16,9 +19,20 @@ to know about protocol calls or handle protocol specific exceptions.
     Protocol-specific subclasses are instantiated with protocol-specific
     parameters by the buildmaster during startup.
 
-.. py:class Connection(master, buildslave, mind)
+.. py:class:: Connection(master, buildslave, mind)
 
     Represents connection to single slave
+
+    .. py:attribute:: proxies
+
+        Dictionary containing mapping between ``Impl`` classes and ``Proxy`` class for this protocol
+        This may be overridden by subclass to declare its proxy implementations
+
+    .. py:method:: createArgsProxies(args)
+
+        :returns: shallow copy of args dictionary with proxies instead of impls
+
+        Helper methods that will use :attr:`proxies`, and replace ``Impl`` objects by specific ``Proxy`` counterpart.
 
     .. py:method:: notifyOnDisconnect(cb)
 
@@ -57,7 +71,7 @@ to know about protocol calls or handle protocol specific exceptions.
 
     .. py:method:: remoteStartCommand(remoteCommand, builderName, commandId, commandName, args)
 
-        :param remoteCommand: :py:class:`~buildbot.process.remotecommand.RemoteCommand` instance
+        :param remoteCommand: :py:class:`~buildbot.buildslave.protocols.base.RemoteCommandImpl` instance
         :param builderName: self explanatory
         :type builderName: string
         :param commandId: command number
@@ -93,3 +107,131 @@ to know about protocol calls or handle protocol specific exceptions.
 
         Interrupt command with given CommandID on slave, print reason "why" to
         slave logs
+
+Following classes are describing the slave -> master part of the protocol.
+
+In order to support old slaves, we must make sure we do not change the current pb protocol.
+This is why we implement a ``Impl vs Proxy`` methods.
+All the objects that are referenced from the slaves for remote calls have an ``Impl`` and a ``Proxy`` base classes in this module.
+
+``Impl`` classes are subclassed by buildbot master, and implement the actual logic for the protocol api.
+``Proxy`` classes are subclassed by the slave/master protocols, and implements the demux and de-serialization of protocol calls.
+
+.. py:class:: RemoteCommandImpl()
+
+    Represents a RemoteCommand status controller
+
+    .. py:method:: remote_update(updates)
+
+        :param updates: dictionary of updates
+
+        Called when the slaves has updates to the current remote command
+
+        possible keys for updates are:
+
+        * ``stdout``: Some logs where captured in remote command's stdout. value: ``<data> as string``
+
+        * ``stderr``: Some logs where captured in remote command's stderr. value: ``<data> as string``
+
+        * ``header``: remote command's header text. value: ``<data> as  string``
+
+        * ``log``: one of the watched logs has received some text. value: ``(<logname> as string, <data> as string)``
+
+        * ``rc``: Remote command exited with a return code. value: ``<rc> as integer``
+
+        * ``elapsed``: Remote command has taken <elapsed> time. value: ``<elapsed seconds> as float``
+
+        * ``stat``: sent by the ``stat`` command with the result of the os.stat, converted to a tuple. value: ``<stat> as tuple``
+
+        * ``files``: sent by the ``glob`` command with the result of the glob.glob. value: ``<files> as list of string``
+
+        * ``got_revision``: sent by the source commands with the revision checked out. value: ``<revision> as string``
+
+        * ``repo_downloaded``: sent by the ``repo`` command with the list of patches downloaded by repo. value: ``<downloads> as list of string``
+
+
+    .. :py:method:: remote_complete(failure=None)
+
+        :param failure: copy of the failure if any
+
+            Called by the slave when the command is complete.
+
+
+.. py:class:: RemoteCommandProxy(impl):
+
+    .. :py:method:: remote_update(updates):
+
+        proxy ``update`` method to the impl
+
+    .. :py:method:: remote_complete(failure=None):
+
+        proxy ``complete`` method to the impl
+
+
+.. py:class:: FileWriterImpl()
+
+    Class used to implement data transfer between slave and master
+
+    .. :py:method:: remote_write(data)
+    
+        :param data: data to write
+
+        data needs to be written on master side
+
+    .. :py:method:: remote_utime(accessed_modified)
+
+        :param accessed_modified: modification times
+
+        called with value of the modification time to update on master side
+
+    .. :py:method:: remote_unpack()
+
+        Called when master should start to unpack the tarball sent via command ``uploadDirectory``
+
+    .. :py:method:: remote_close()
+
+        Called when master should close the file
+
+
+.. py:class:: FileWriterProxy(object)
+
+    .. py:method:: remote_write(data)
+
+        proxy ``write`` method to the impl
+
+    .. py:method:: remote_utime(accessed_modified)
+
+        proxy ``utime`` method to the impl
+
+    .. py:method:: remote_unpack()
+
+        proxy ``unpack`` method to the impl
+
+    .. py:method:: remote_close()
+
+        proxy ``close`` method to the impl
+
+
+.. py:class:: FileReaderImpl(object)
+
+    .. py:method:: remote_read(maxLength)
+
+        :param maxLength: maximum length of the data to send
+        :returns: data read
+
+        called when slave needs more data
+
+    .. py:method:: remote_close()
+
+        Called when master should close the file
+
+
+.. py:class:: FileReaderProxy(object)
+
+    .. py:method:: remote_read(maxLength)
+
+        proxy ``read`` method to the impl
+
+    .. py:method:: remote_close()
+
+        proxy ``close`` method to the impl

--- a/master/docs/developer/cls-protocols.rst
+++ b/master/docs/developer/cls-protocols.rst
@@ -115,7 +115,15 @@ This is why we implement a ``Impl vs Proxy`` methods.
 All the objects that are referenced from the slaves for remote calls have an ``Impl`` and a ``Proxy`` base classes in this module.
 
 ``Impl`` classes are subclassed by buildbot master, and implement the actual logic for the protocol api.
-``Proxy`` classes are subclassed by the slave/master protocols, and implements the demux and de-serialization of protocol calls.
+``Proxy`` classes are implemented by the slave/master protocols, and implements the demux and de-serialization of protocol calls.
+
+On slave sides, those proxy objects are replaced by a proxy object having a single method to call master side methodss:
+
+.. py:class:: SlaveProxyObject()
+
+    .. py:method:: callRemote(message, *args, **kw)
+
+        calls the method ``"remote_" + message`` on master side
 
 .. py:class:: RemoteCommandImpl()
 
@@ -157,17 +165,6 @@ All the objects that are referenced from the slaves for remote calls have an ``I
             Called by the slave when the command is complete.
 
 
-.. py:class:: RemoteCommandProxy(impl):
-
-    .. :py:method:: remote_update(updates):
-
-        proxy ``update`` method to the impl
-
-    .. :py:method:: remote_complete(failure=None):
-
-        proxy ``complete`` method to the impl
-
-
 .. py:class:: FileWriterImpl()
 
     Class used to implement data transfer between slave and master
@@ -193,25 +190,6 @@ All the objects that are referenced from the slaves for remote calls have an ``I
         Called when master should close the file
 
 
-.. py:class:: FileWriterProxy(object)
-
-    .. py:method:: remote_write(data)
-
-        proxy ``write`` method to the impl
-
-    .. py:method:: remote_utime(accessed_modified)
-
-        proxy ``utime`` method to the impl
-
-    .. py:method:: remote_unpack()
-
-        proxy ``unpack`` method to the impl
-
-    .. py:method:: remote_close()
-
-        proxy ``close`` method to the impl
-
-
 .. py:class:: FileReaderImpl(object)
 
     .. py:method:: remote_read(maxLength)
@@ -224,14 +202,3 @@ All the objects that are referenced from the slaves for remote calls have an ``I
     .. py:method:: remote_close()
 
         Called when master should close the file
-
-
-.. py:class:: FileReaderProxy(object)
-
-    .. py:method:: remote_read(maxLength)
-
-        proxy ``read`` method to the impl
-
-    .. py:method:: remote_close()
-
-        proxy ``close`` method to the impl

--- a/master/docs/developer/cls-protocols.rst
+++ b/master/docs/developer/cls-protocols.rst
@@ -32,7 +32,7 @@ to know about protocol calls or handle protocol specific exceptions.
 
         :returns: shallow copy of args dictionary with proxies instead of impls
 
-        Helper methods that will use :attr:`proxies`, and replace ``Impl`` objects by specific ``Proxy`` counterpart.
+        Helper method that will use :attr:`proxies`, and replace ``Impl`` objects by specific ``Proxy`` counterpart.
 
     .. py:method:: notifyOnDisconnect(cb)
 
@@ -173,7 +173,7 @@ All the objects that are referenced from the slaves for remote calls have an ``I
     Class used to implement data transfer between slave and master
 
     .. :py:method:: remote_write(data)
-    
+
         :param data: data to write
 
         data needs to be written on master side

--- a/slave/buildslave/base.py
+++ b/slave/buildslave/base.py
@@ -1,0 +1,386 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import os.path
+import socket
+import sys
+
+from twisted.application import service
+from twisted.internet import defer
+from twisted.internet import reactor
+from twisted.python import log
+from twisted.spread import pb
+
+import buildslave
+
+from buildslave import monkeypatches
+from buildslave.commands import base
+from buildslave.commands import registry
+
+
+class UnknownCommand(pb.Error):
+    pass
+
+
+class SlaveBuilderBase(service.Service):
+
+    """This is the local representation of a single Builder: it handles a
+    single kind of build (like an all-warnings build). It has a name and a
+    home directory. The rest of its behavior is determined by the master.
+    """
+
+    stopCommandOnShutdown = True
+
+    # remote is a ref to the Builder object on the master side, and is set
+    # when they attach. We use it to detect when the connection to the master
+    # is severed.
+    remote = None
+
+    # .command points to a SlaveCommand instance, and is set while the step
+    # is running. We use it to implement the stopBuild method.
+    command = None
+
+    # .remoteStep is a ref to the master-side BuildStep object, and is set
+    # when the step is started
+    remoteStep = None
+
+    bf = None
+
+    def __init__(self, name):
+        # service.Service.__init__(self) # Service has no __init__ method
+        self.setName(name)
+
+    def __repr__(self):
+        return "<SlaveBuilder '%s' at %d>" % (self.name, id(self))
+
+    def setServiceParent(self, parent):
+        service.Service.setServiceParent(self, parent)
+        self.bot = self.parent
+        # note that self.parent will go away when the buildmaster's config
+        # file changes and this Builder is removed (possibly because it has
+        # been changed, so the Builder will be re-added again in a moment).
+        # This may occur during a build, while a step is running.
+
+    def setBuilddir(self, builddir):
+        assert self.parent
+        self.builddir = builddir
+        self.basedir = os.path.join(self.bot.basedir, self.builddir)
+        if not os.path.isdir(self.basedir):
+            os.makedirs(self.basedir)
+
+    def stopService(self):
+        service.Service.stopService(self)
+        if self.stopCommandOnShutdown:
+            self.stopCommand()
+
+    def activity(self):
+        bot = self.parent
+        if bot:
+            bslave = bot.parent
+            if bslave and self.bf:
+                bf = bslave.bf
+                bf.activity()
+
+    def remote_setMaster(self, remote):
+        self.remote = remote
+        self.remote.notifyOnDisconnect(self.lostRemote)
+
+    def remote_print(self, message):
+        log.msg("SlaveBuilder.remote_print(%s): message from master: %s" %
+                (self.name, message))
+
+    def lostRemote(self, remote):
+        log.msg("lost remote")
+        self.remote = None
+
+    def lostRemoteStep(self, remotestep):
+        log.msg("lost remote step")
+        self.remoteStep = None
+        if self.stopCommandOnShutdown:
+            self.stopCommand()
+
+    # the following are Commands that can be invoked by the master-side
+    # Builder
+    def remote_startBuild(self):
+        """This is invoked before the first step of any new build is run.  It
+        doesn't do much, but masters call it so it's still here."""
+        pass
+
+    def remote_startCommand(self, stepref, stepId, command, args):
+        """
+        This gets invoked by L{buildbot.process.step.RemoteCommand.start}, as
+        part of various master-side BuildSteps, to start various commands
+        that actually do the build. I return nothing. Eventually I will call
+        .commandComplete() to notify the master-side RemoteCommand that I'm
+        done.
+        """
+
+        self.activity()
+
+        if self.command:
+            log.msg("leftover command, dropping it")
+            self.stopCommand()
+
+        try:
+            factory = registry.getFactory(command)
+        except KeyError:
+            raise UnknownCommand("unrecognized SlaveCommand '%s'" % command)
+        self.command = factory(self, stepId, args)
+
+        log.msg(" startCommand:%s [id %s]" % (command, stepId))
+        self.remoteStep = stepref
+        self.remoteStep.notifyOnDisconnect(self.lostRemoteStep)
+        d = self.command.doStart()
+        d.addCallback(lambda res: None)
+        d.addBoth(self.commandComplete)
+        return None
+
+    def remote_interruptCommand(self, stepId, why):
+        """Halt the current step."""
+        log.msg("asked to interrupt current command: %s" % why)
+        self.activity()
+        if not self.command:
+            # TODO: just log it, a race could result in their interrupting a
+            # command that wasn't actually running
+            log.msg(" .. but none was running")
+            return
+        self.command.doInterrupt()
+
+    def stopCommand(self):
+        """Make any currently-running command die, with no further status
+        output. This is used when the buildslave is shutting down or the
+        connection to the master has been lost. Interrupt the command,
+        silence it, and then forget about it."""
+        if not self.command:
+            return
+        log.msg("stopCommand: halting current command %s" % self.command)
+        self.command.doInterrupt()  # shut up! and die!
+        self.command = None  # forget you!
+
+    # sendUpdate is invoked by the Commands we spawn
+    def sendUpdate(self, data):
+        """This sends the status update to the master-side
+        L{buildbot.process.step.RemoteCommand} object, giving it a sequence
+        number in the process. It adds the update to a queue, and asks the
+        master to acknowledge the update so it can be removed from that
+        queue."""
+
+        if not self.running:
+            # .running comes from service.Service, and says whether the
+            # service is running or not. If we aren't running, don't send any
+            # status messages.
+            return
+        # the update[1]=0 comes from the leftover 'updateNum', which the
+        # master still expects to receive. Provide it to avoid significant
+        # interoperability issues between new slaves and old masters.
+        if self.remoteStep:
+            update = [data, 0]
+            updates = [update]
+            d = self.remoteStep.callRemote("update", updates)
+            d.addCallback(self.ackUpdate)
+            d.addErrback(self._ackFailed, "SlaveBuilder.sendUpdate")
+
+    def ackUpdate(self, acknum):
+        self.activity()  # update the "last activity" timer
+
+    def ackComplete(self, dummy):
+        self.activity()  # update the "last activity" timer
+
+    def _ackFailed(self, why, where):
+        log.msg("SlaveBuilder._ackFailed:", where)
+        log.err(why)  # we don't really care
+
+    # this is fired by the Deferred attached to each Command
+    def commandComplete(self, failure):
+        if failure:
+            log.msg("SlaveBuilder.commandFailed", self.command)
+            log.err(failure)
+            # failure, if present, is a failure.Failure. To send it across
+            # the wire, we must turn it into a pb.CopyableFailure.
+            failure = pb.CopyableFailure(failure)
+            failure.unsafeTracebacks = True
+        else:
+            # failure is None
+            log.msg("SlaveBuilder.commandComplete", self.command)
+        self.command = None
+        if not self.running:
+            log.msg(" but we weren't running, quitting silently")
+            return
+        if self.remoteStep:
+            self.remoteStep.dontNotifyOnDisconnect(self.lostRemoteStep)
+            d = self.remoteStep.callRemote("complete", failure)
+            d.addCallback(self.ackComplete)
+            d.addErrback(self._ackFailed, "sendComplete")
+            self.remoteStep = None
+
+    def remote_shutdown(self):
+        log.msg("slave shutting down on command from master")
+        log.msg("NOTE: master is using deprecated slavebuilder.shutdown method")
+        reactor.stop()
+
+
+class BotBase(service.MultiService):
+
+    """I represent the slave-side bot."""
+    usePTY = None
+    name = "bot"
+    SlaveBuilder = SlaveBuilderBase
+
+    def __init__(self, basedir, usePTY, unicode_encoding=None):
+        service.MultiService.__init__(self)
+        self.basedir = basedir
+        self.usePTY = usePTY
+        self.unicode_encoding = unicode_encoding or sys.getfilesystemencoding() or 'ascii'
+        self.builders = {}
+
+    def startService(self):
+        assert os.path.isdir(self.basedir)
+        service.MultiService.startService(self)
+
+    def remote_getCommands(self):
+        commands = dict([
+            (n, base.command_version)
+            for n in registry.getAllCommandNames()
+        ])
+        return commands
+
+    @defer.deferredGenerator
+    def remote_setBuilderList(self, wanted):
+        retval = {}
+        wanted_names = set([name for (name, builddir) in wanted])
+        wanted_dirs = set([builddir for (name, builddir) in wanted])
+        wanted_dirs.add('info')
+        for (name, builddir) in wanted:
+            b = self.builders.get(name, None)
+            if b:
+                if b.builddir != builddir:
+                    log.msg("changing builddir for builder %s from %s to %s"
+                            % (name, b.builddir, builddir))
+                    b.setBuilddir(builddir)
+            else:
+                b = self.SlaveBuilder(name)
+                b.usePTY = self.usePTY
+                b.unicode_encoding = self.unicode_encoding
+                b.setServiceParent(self)
+                b.setBuilddir(builddir)
+                self.builders[name] = b
+            retval[name] = b
+
+        # disown any builders no longer desired
+        to_remove = list(set(self.builders.keys()) - wanted_names)
+        dl = defer.DeferredList([
+            defer.maybeDeferred(self.builders[name].disownServiceParent)
+            for name in to_remove])
+        wfd = defer.waitForDeferred(dl)
+        yield wfd
+        wfd.getResult()
+
+        # and *then* remove them from the builder list
+        for name in to_remove:
+            del self.builders[name]
+
+        # finally warn about any leftover dirs
+        for dir in os.listdir(self.basedir):
+            if os.path.isdir(os.path.join(self.basedir, dir)):
+                if dir not in wanted_dirs:
+                    log.msg("I have a leftover directory '%s' that is not "
+                            "being used by the buildmaster: you can delete "
+                            "it now" % dir)
+
+        yield retval  # return value
+
+    def remote_print(self, message):
+        log.msg("message from master:", message)
+
+    def remote_getSlaveInfo(self):
+        """This command retrieves data from the files in SLAVEDIR/info/* and
+        sends the contents to the buildmaster. These are used to describe
+        the slave and its configuration, and should be created and
+        maintained by the slave administrator. They will be retrieved each
+        time the master-slave connection is established.
+        """
+
+        files = {}
+        basedir = os.path.join(self.basedir, "info")
+        if os.path.isdir(basedir):
+            for f in os.listdir(basedir):
+                filename = os.path.join(basedir, f)
+                if os.path.isfile(filename):
+                    files[f] = open(filename, "r").read()
+        files['environ'] = os.environ.copy()
+        files['system'] = os.name
+        files['basedir'] = self.basedir
+
+        files['version'] = self.remote_getVersion()
+        files['slave_commands'] = self.remote_getCommands()
+        return files
+
+    def remote_getVersion(self):
+        """Send our version back to the Master"""
+        return buildslave.version
+
+    def remote_shutdown(self):
+        log.msg("slave shutting down on command from master")
+        # there's no good way to learn that the PB response has been delivered,
+        # so we'll just wait a bit, in hopes the master hears back.  Masters are
+        # resilinet to slaves dropping their connections, so there is no harm
+        # if this timeout is too short.
+        reactor.callLater(0.2, reactor.stop)
+
+
+class BuildSlaveBase(service.MultiService):
+    Bot = BotBase
+
+    def __init__(self, name, basedir,
+                 usePTY, umask=None,
+                 unicode_encoding=None):
+
+        service.MultiService.__init__(self)
+        self.name = name
+        bot = self.Bot(basedir, usePTY, unicode_encoding=unicode_encoding)
+        bot.setServiceParent(self)
+        self.bot = bot
+        self.umask = umask
+        self.basedir = basedir
+
+    def startService(self):
+        # first, apply all monkeypatches
+        monkeypatches.patch_all()
+
+        log.msg("Starting BuildSlave -- version: %s" % buildslave.version)
+
+        if self.umask is not None:
+            os.umask(self.umask)
+
+        self.recordHostname(self.basedir)
+
+        service.MultiService.startService(self)
+
+    def recordHostname(self, basedir):
+        "Record my hostname in twistd.hostname, for user convenience"
+        log.msg("recording hostname in twistd.hostname")
+        filename = os.path.join(basedir, "twistd.hostname")
+
+        try:
+            hostname = os.uname()[1]  # only on unix
+        except AttributeError:
+            # this tends to fail on non-connected hosts, e.g., laptops
+            # on planes
+            hostname = socket.getfqdn()
+
+        try:
+            open(filename, "w").write("%s\n" % hostname)
+        except Exception:
+            log.msg("failed - ignoring")

--- a/slave/buildslave/commands/transfer.py
+++ b/slave/buildslave/commands/transfer.py
@@ -56,7 +56,7 @@ class SlaveFileUploadCommand(TransferCommand):
 
         - ['workdir']:   base directory to use
         - ['slavesrc']:  name of the slave-side file to read from
-        - ['writer']:    RemoteReference to a transfer._FileWriter object
+        - ['writer']:    RemoteReference to a remotetransfer.FileWriter object
         - ['maxsize']:   max size (in bytes) of file to write
         - ['blocksize']: max size for each data block
         - ['keepstamp']: whether to preserve file modified and accessed times
@@ -253,7 +253,7 @@ class SlaveFileDownloadCommand(TransferCommand):
 
         - ['workdir']:   base directory to use
         - ['slavedest']: name of the slave-side file to be created
-        - ['reader']:    RemoteReference to a transfer._FileReader object
+        - ['reader']:    RemoteReference to a buildslave.protocols.base.FileReaderProxy object
         - ['maxsize']:   max size (in bytes) of file to write
         - ['blocksize']: max size for each data block
         - ['mode']:      access mode for the new file

--- a/slave/buildslave/commands/transfer.py
+++ b/slave/buildslave/commands/transfer.py
@@ -56,7 +56,7 @@ class SlaveFileUploadCommand(TransferCommand):
 
         - ['workdir']:   base directory to use
         - ['slavesrc']:  name of the slave-side file to read from
-        - ['writer']:    RemoteReference to a remotetransfer.FileWriter object
+        - ['writer']:    RemoteReference to a buildslave.protocols.base.FileWriterProxy object
         - ['maxsize']:   max size (in bytes) of file to write
         - ['blocksize']: max size for each data block
         - ['keepstamp']: whether to preserve file modified and accessed times

--- a/slave/buildslave/pb.py
+++ b/slave/buildslave/pb.py
@@ -1,0 +1,230 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import os.path
+import signal
+
+from twisted.application import internet
+from twisted.application import service
+from twisted.cred import credentials
+from twisted.internet import error
+from twisted.internet import reactor
+from twisted.internet import task
+from twisted.python import log
+from twisted.spread import pb
+
+from buildslave.base import BotBase
+from buildslave.base import BuildSlaveBase
+from buildslave.base import SlaveBuilderBase
+from buildslave.pbutil import ReconnectingPBClientFactory
+
+
+class UnknownCommand(pb.Error):
+    pass
+
+
+class SlaveBuilderPb(SlaveBuilderBase, pb.Referenceable):
+    pass
+
+
+class BotPb(BotBase, pb.Referenceable):
+    SlaveBuilder = SlaveBuilderPb
+
+
+class BotFactory(ReconnectingPBClientFactory):
+    # 'keepaliveInterval' serves two purposes. The first is to keep the
+    # connection alive: it guarantees that there will be at least some
+    # traffic once every 'keepaliveInterval' seconds, which may help keep an
+    # interposed NAT gateway from dropping the address mapping because it
+    # thinks the connection has been abandoned.  This also gives the operating
+    # system a chance to notice that the master has gone away, and inform us
+    # of such (although this could take several minutes).
+    keepaliveInterval = None  # None = do not use keepalives
+
+    # 'maxDelay' determines the maximum amount of time the slave will wait
+    # between connection retries
+    maxDelay = 300
+
+    keepaliveTimer = None
+    unsafeTracebacks = 1
+    perspective = None
+
+    # for tests
+    _reactor = reactor
+
+    def __init__(self, buildmaster_host, port, keepaliveInterval, maxDelay):
+        ReconnectingPBClientFactory.__init__(self)
+        self.maxDelay = maxDelay
+        self.keepaliveInterval = keepaliveInterval
+        # NOTE: this class does not actually make the TCP connections - this information is
+        # only here to print useful error messages
+        self.buildmaster_host = buildmaster_host
+        self.port = port
+
+    def startedConnecting(self, connector):
+        log.msg("Connecting to %s:%s" % (self.buildmaster_host, self.port))
+        ReconnectingPBClientFactory.startedConnecting(self, connector)
+        self.connector = connector
+
+    def gotPerspective(self, perspective):
+        log.msg("Connected to %s:%s; slave is ready" % (self.buildmaster_host, self.port))
+        ReconnectingPBClientFactory.gotPerspective(self, perspective)
+        self.perspective = perspective
+        try:
+            perspective.broker.transport.setTcpKeepAlive(1)
+        except Exception:
+            log.msg("unable to set SO_KEEPALIVE")
+            if not self.keepaliveInterval:
+                self.keepaliveInterval = 10 * 60
+        self.activity()
+        if self.keepaliveInterval:
+            log.msg("sending application-level keepalives every %d seconds"
+                    % self.keepaliveInterval)
+            self.startTimers()
+
+    def clientConnectionFailed(self, connector, reason):
+        self.connector = None
+        why = reason
+        if reason.check(error.ConnectionRefusedError):
+            why = "Connection Refused"
+        log.msg("Connection to %s:%s failed: %s" % (self.buildmaster_host, self.port, why))
+        ReconnectingPBClientFactory.clientConnectionFailed(self,
+                                                           connector, reason)
+
+    def clientConnectionLost(self, connector, reason):
+        log.msg("Lost connection to %s:%s" % (self.buildmaster_host, self.port))
+        self.connector = None
+        self.stopTimers()
+        self.perspective = None
+        ReconnectingPBClientFactory.clientConnectionLost(self,
+                                                         connector, reason)
+
+    def startTimers(self):
+        assert self.keepaliveInterval
+        assert not self.keepaliveTimer
+
+        def doKeepalive():
+            self.keepaliveTimer = None
+            self.startTimers()
+
+            # Send the keepalive request.  If an error occurs
+            # was already dropped, so just log and ignore.
+            log.msg("sending app-level keepalive")
+            d = self.perspective.callRemote("keepalive")
+            d.addErrback(log.err, "error sending keepalive")
+        self.keepaliveTimer = self._reactor.callLater(self.keepaliveInterval,
+                                                      doKeepalive)
+
+    def stopTimers(self):
+        if self.keepaliveTimer:
+            self.keepaliveTimer.cancel()
+            self.keepaliveTimer = None
+
+    def activity(self, res=None):
+        """Subclass or monkey-patch this method to be alerted whenever there is
+        active communication between the master and slave."""
+        pass
+
+    def stopFactory(self):
+        ReconnectingPBClientFactory.stopFactory(self)
+        self.stopTimers()
+
+
+class BuildSlave(BuildSlaveBase, service.MultiService):
+    Bot = BotPb
+
+    def __init__(self, buildmaster_host, port, name, passwd, basedir,
+                 keepalive, usePTY, keepaliveTimeout=None, umask=None,
+                 maxdelay=300, unicode_encoding=None, allow_shutdown=None):
+
+        # note: keepaliveTimeout is ignored, but preserved here for
+        # backward-compatibility
+
+        service.MultiService.__init__(self)
+        BuildSlaveBase.__init__(self, name, basedir, usePTY, umask=umask, unicode_encoding=unicode_encoding)
+        if keepalive == 0:
+            keepalive = None
+
+        self.shutdown_loop = None
+
+        if allow_shutdown == 'signal':
+            if not hasattr(signal, 'SIGHUP'):
+                raise ValueError("Can't install signal handler")
+        elif allow_shutdown == 'file':
+            self.shutdown_file = os.path.join(basedir, 'shutdown.stamp')
+            self.shutdown_mtime = 0
+
+        self.allow_shutdown = allow_shutdown
+        bf = self.bf = BotFactory(buildmaster_host, port, keepalive, maxdelay)
+        bf.startLogin(credentials.UsernamePassword(name, passwd), client=self.bot)
+        self.connection = c = internet.TCPClient(buildmaster_host, port, bf)
+        c.setServiceParent(self)
+
+    def startService(self):
+        BuildSlaveBase.startService(self)
+
+        if self.allow_shutdown == 'signal':
+            log.msg("Setting up SIGHUP handler to initiate shutdown")
+            signal.signal(signal.SIGHUP, self._handleSIGHUP)
+        elif self.allow_shutdown == 'file':
+            log.msg("Watching %s's mtime to initiate shutdown" % self.shutdown_file)
+            if os.path.exists(self.shutdown_file):
+                self.shutdown_mtime = os.path.getmtime(self.shutdown_file)
+            self.shutdown_loop = l = task.LoopingCall(self._checkShutdownFile)
+            l.start(interval=10)
+
+    def stopService(self):
+        self.bf.continueTrying = 0
+        self.bf.stopTrying()
+        if self.shutdown_loop:
+            self.shutdown_loop.stop()
+            self.shutdown_loop = None
+        return service.MultiService.stopService(self)
+
+    def _handleSIGHUP(self, *args):
+        log.msg("Initiating shutdown because we got SIGHUP")
+        return self.gracefulShutdown()
+
+    def _checkShutdownFile(self):
+        if os.path.exists(self.shutdown_file) and \
+                os.path.getmtime(self.shutdown_file) > self.shutdown_mtime:
+            log.msg("Initiating shutdown because %s was touched" % self.shutdown_file)
+            self.gracefulShutdown()
+
+            # In case the shutdown fails, update our mtime so we don't keep
+            # trying to shutdown over and over again.
+            # We do want to be able to try again later if the master is
+            # restarted, so we'll keep monitoring the mtime.
+            self.shutdown_mtime = os.path.getmtime(self.shutdown_file)
+
+    def gracefulShutdown(self):
+        """Start shutting down"""
+        if not self.bf.perspective:
+            log.msg("No active connection, shutting down NOW")
+            reactor.stop()
+            return
+
+        log.msg("Telling the master we want to shutdown after any running builds are finished")
+        d = self.bf.perspective.callRemote("shutdown")
+
+        def _shutdownfailed(err):
+            if err.check(AttributeError):
+                log.msg("Master does not support slave initiated shutdown.  Upgrade master to 0.8.3 or later to use this feature.")
+            else:
+                log.msg('callRemote("shutdown") failed')
+                log.err(err)
+
+        d.addErrback(_shutdownfailed)
+        return d

--- a/slave/buildslave/test/unit/test_bot.py
+++ b/slave/buildslave/test/unit/test_bot.py
@@ -26,7 +26,8 @@ from twisted.trial import unittest
 
 import buildslave
 
-from buildslave import bot
+from buildslave import base
+from buildslave import pb
 from buildslave.test.fake.remote import FakeRemote
 from buildslave.test.fake.runprocess import Expect
 from buildslave.test.util import command
@@ -41,7 +42,7 @@ class TestBot(unittest.TestCase):
             shutil.rmtree(self.basedir)
         os.makedirs(self.basedir)
 
-        self.real_bot = bot.Bot(self.basedir, False)
+        self.real_bot = base.BotBase(self.basedir, False)
         self.real_bot.startService()
 
         self.bot = FakeRemote(self.real_bot)
@@ -214,7 +215,7 @@ class TestSlaveBuilder(command.CommandTestMixin, unittest.TestCase):
             shutil.rmtree(self.basedir)
         os.makedirs(self.basedir)
 
-        self.bot = bot.Bot(self.basedir, False)
+        self.bot = base.BotBase(self.basedir, False)
         self.bot.startService()
 
         # get a SlaveBuilder object from the bot and wrap it as a fake remote
@@ -384,7 +385,7 @@ class TestSlaveBuilder(command.CommandTestMixin, unittest.TestCase):
 class TestBotFactory(unittest.TestCase):
 
     def setUp(self):
-        self.bf = bot.BotFactory('mstr', 9010, 35, 200)
+        self.bf = pb.BotFactory('mstr', 9010, 35, 200)
 
     # tests
 

--- a/slave/buildslave/test/unit/test_bot.py
+++ b/slave/buildslave/test/unit/test_bot.py
@@ -82,7 +82,11 @@ class TestBot(unittest.TestCase):
         d = self.bot.callRemote("getSlaveInfo")
 
         def check(info):
-            self.assertEqual(info, dict(admin='testy!', foo='bar', environ=os.environ, system=os.name, basedir=self.basedir))
+            self.assertEqual(info, dict(
+                admin='testy!', foo='bar',
+                environ=os.environ, system=os.name, basedir=self.basedir,
+                slave_commands=self.real_bot.remote_getCommands(),
+                version=self.real_bot.remote_getVersion()))
         d.addCallback(check)
         return d
 
@@ -90,7 +94,7 @@ class TestBot(unittest.TestCase):
         d = self.bot.callRemote("getSlaveInfo")
 
         def check(info):
-            self.assertEqual(set(info.keys()), set(['environ', 'system', 'basedir']))
+            self.assertEqual(set(info.keys()), set(['environ', 'system', 'basedir', 'slave_commands', 'version']))
         d.addCallback(check)
         return d
 


### PR DESCRIPTION
These changes for http://trac.buildbot.net/ticket/2437 remove the pb.Referenceable in buildbot protocol.

Introducing proxies that are documented in the cls-protocols.rst file

Despite the size of the patch, there is so much new code actually, just a bunch of refactorization
A new integration test to make sure that transfers are actually working with the proxy.
Other integration tests where already taking care of RemoteCommand