### PR TITLE
fix management of configured builders

### DIFF
--- a/master/buildbot/buildslave/base.py
+++ b/master/buildbot/buildslave/base.py
@@ -243,7 +243,7 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         self.updateLocks()
 
         bids = [b._builderid for b in self.botmaster.getBuildersForSlave(self.slavename)]
-        yield self.master.data.updates.buildslaveConfigured(self.buildslaveid, bids)
+        yield self.master.data.updates.buildslaveConfigured(self.buildslaveid, self.master.masterid, bids)
 
         # update the attached slave's notion of which builders are attached.
         # This assumes that the relevant builders have already been configured,

--- a/master/buildbot/data/buildslaves.py
+++ b/master/buildbot/data/buildslaves.py
@@ -100,10 +100,11 @@ class Buildslave(base.ResourceType):
 
     @base.updateMethod
     @defer.inlineCallbacks
-    def buildslaveConfigured(self, buildslaveid, buildermasterids):
+    def buildslaveConfigured(self, buildslaveid, masterid, builderids):
         yield self.master.db.buildslaves.buildslaveConfigured(
             buildslaveid=buildslaveid,
-            buildermasterids=buildermasterids)
+            masterid=masterid,
+            builderids=builderids)
 
     @base.updateMethod
     def findBuildslaveId(self, name):

--- a/master/buildbot/db/buildslaves.py
+++ b/master/buildbot/db/buildslaves.py
@@ -36,7 +36,6 @@ class BuildslavesConnectorComponent(base.DBConnectorComponent):
             ))
 
     def buildslaveConfigured(self, buildslaveid, masterid, builderids):
-        print "buildslaveConfigured", buildslaveid, masterid, builderids
 
         def thd(conn):
             # first remove the old configured buildermasterids for this master and slave

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -388,10 +388,11 @@ class FakeUpdates(object):
             masterid=masterid,
             slaveinfo=slaveinfo)
 
-    def buildslaveConfigured(self, buildslaveid, buildermasterids):
+    def buildslaveConfigured(self, buildslaveid, masterid, builderids):
         return self.master.db.buildslaves.buildslaveConfigured(
             buildslaveid=buildslaveid,
-            buildermasterids=buildermasterids)
+            masterid=masterid,
+            builderids=builderids)
 
     def buildslaveDisconnected(self, buildslaveid, masterid):
         return self.master.db.buildslaves.buildslaveDisconnected(

--- a/master/buildbot/test/unit/test_data_buildslaves.py
+++ b/master/buildbot/test/unit/test_data_buildslaves.py
@@ -237,6 +237,13 @@ class Buildslave(interfaces.InterfaceTests, unittest.TestCase):
         def findBuildslaveId(self, name):
             pass
 
+    def test_signature_buildslaveConfigured(self):
+        @self.assertArgSpecMatches(
+            self.master.data.updates.buildslaveConfigured,  # fake
+            self.rtype.buildslaveConfigured)  # real
+        def buildslaveConfigured(self, buildslaveid, masterid, builderids):
+            pass
+
     def test_findBuildslaveId(self):
         # this just passes through to the db method, so test that
         rv = defer.succeed(None)

--- a/master/buildbot/test/unit/test_db_buildslaves.py
+++ b/master/buildbot/test/unit/test_db_buildslaves.py
@@ -42,6 +42,7 @@ class Tests(interfaces.InterfaceTests):
         fakedb.BuilderMaster(id=13, builderid=21, masterid=10),
         fakedb.BuilderMaster(id=14, builderid=20, masterid=11),
         fakedb.BuilderMaster(id=15, builderid=22, masterid=11),
+        fakedb.BuilderMaster(id=16, builderid=22, masterid=10),
         fakedb.ConfiguredBuildslave(
             id=3012, buildslaveid=30, buildermasterid=12),
         fakedb.ConfiguredBuildslave(
@@ -166,7 +167,7 @@ class Tests(interfaces.InterfaceTests):
                               connected_to=[10, 11], configured_on=[
                                   {'builderid': 20, 'masterid': 10},
                                   {'builderid': 20, 'masterid': 11},
-                         ]))
+                              ]))
 
     @defer.inlineCallbacks
     def test_getBuildslave_by_name_not_configured(self):
@@ -242,7 +243,7 @@ class Tests(interfaces.InterfaceTests):
                          dict(id=30, name='zero', slaveinfo={'a': 'b'},
                               configured_on=[
                                   {'masterid': 11, 'builderid': 20},
-                         ], connected_to=[]))
+                              ], connected_to=[]))
 
     @defer.inlineCallbacks
     def test_getBuildslave_with_multiple_masters_builderid_masterid(self):
@@ -254,7 +255,7 @@ class Tests(interfaces.InterfaceTests):
                          dict(id=30, name='zero', slaveinfo={'a': 'b'},
                               configured_on=[
                                   {'masterid': 11, 'builderid': 20},
-                         ], connected_to=[]))
+                              ], connected_to=[]))
 
     @defer.inlineCallbacks
     def test_getBuildslave_by_name_with_multiple_masters_builderid_masterid(self):
@@ -266,7 +267,7 @@ class Tests(interfaces.InterfaceTests):
                          dict(id=30, name='zero', slaveinfo={'a': 'b'},
                               configured_on=[
                                   {'masterid': 11, 'builderid': 20},
-                         ], connected_to=[]))
+                              ], connected_to=[]))
 
     @defer.inlineCallbacks
     def test_getBuildslaves_no_config(self):
@@ -430,6 +431,19 @@ class Tests(interfaces.InterfaceTests):
 
         bs = yield self.db.buildslaves.getBuildslave(self.BS1_ID)
         self.assertEqual(bs['connected_to'], [])
+
+    @defer.inlineCallbacks
+    def test_buildslaveConfigured(self):
+        yield self.insertTestData(self.baseRows + self.multipleMasters)
+        # should remove builder 21, and add 22
+        yield self.db.buildslaves.buildslaveConfigured(
+            buildslaveid=30, masterid=10, builderids=[20, 22])
+
+        bs = yield self.db.buildslaves.getBuildslave(30)
+        self.assertEqual(sorted(bs['configured_on']), sorted([
+            {'builderid': 20, 'masterid': 11},
+            {'builderid': 20, 'masterid': 10},
+            {'builderid': 22, 'masterid': 10}]))
 
 
 class RealTests(Tests):

--- a/master/buildbot/test/unit/test_db_buildslaves.py
+++ b/master/buildbot/test/unit/test_db_buildslaves.py
@@ -99,6 +99,11 @@ class Tests(interfaces.InterfaceTests):
         def buildslaveDisconnected(self, buildslaveid, masterid):
             pass
 
+    def test_signature_buildslaveConfigured(self):
+        @self.assertArgSpecMatches(self.db.buildslaves.buildslaveConfigured)
+        def buildslaveConfigured(self, buildslaveid, masterid, builderids):
+            pass
+
     @defer.inlineCallbacks
     def test_findBuildslaveId_insert(self):
         id = yield self.db.buildslaves.findBuildslaveId(name=u"xyz")

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -737,6 +737,15 @@ buildslaves
 
         Record the given buildslave as no longer attached to the given master.
 
+    .. py:method:: buildslaveConfigured(buildslaveid, masterid, builderids)
+
+        :param integer buildslaveid: the ID of the buildslave
+        :param integer masterid: the ID of the master to which it configured
+        :param list of integer builderids: the ID of the builders to which it is configured
+        :returns: Deferred
+
+        Record the given buildslave as being configured on the given master and for given builders.
+
 changes
 ~~~~~~~
 


### PR DESCRIPTION
Buildermasterid was confused with builderid, and the cleanup was not properly done

Signed-off-by: Pierre Tardy <pierre.tardy@intel.com>