### PR TITLE
allow '.'s and '_'s in properties Interpolate understands

### DIFF
--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -428,7 +428,7 @@ class Interpolate(util.ComparableMixin, object):
     implements(IRenderable)
     compare_attrs = ('fmtstring', 'args', 'kwargs')
 
-    identifier_re = re.compile(r'^[\w-]*$')
+    identifier_re = re.compile(r'^[\w._-]*$')
 
     def __init__(self, fmtstring, *args, **kwargs):
         self.fmtstring = fmtstring


### PR DESCRIPTION
the current situation is bad since GerritChangeSource produces
properties that contain '.'s and Interpolate does not allow to use them