### PR TITLE
after failure to insert, re-start the transaction before updating

### DIFF
--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -41,6 +41,8 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                                  important=imp_int)
                 except (sqlalchemy.exc.ProgrammingError,
                         sqlalchemy.exc.IntegrityError):
+                    transaction.rollback()
+                    transaction = conn.begin()
                     # insert failed, so try an update
                     conn.execute(upd_q,
                                  wc_changeid=changeid,


### PR DESCRIPTION
Based on https://github.com/buildbot/buildbot/commit/3874e116549f77e38e71fb55bcb08e481f4b1aab