### PR TITLE
Update __init__.py

### DIFF
--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -21,6 +21,7 @@ from subprocess import Popen, PIPE, STDOUT
 import os
 import re
 
+
 def getVersion(init_file):
     """
     Return BUILDBOT_VERSION environment variable, content of VERSION file, git
@@ -55,5 +56,6 @@ def getVersion(init_file):
         pass
 
     return "latest"
+
 
 version = getVersion(__file__)

--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -17,6 +17,7 @@
 #
 # We can't put this method in utility modules, because they import dependancy packages
 #
+from __future__ import with_statement
 from subprocess import Popen, PIPE, STDOUT
 import os
 import re
@@ -36,7 +37,8 @@ def getVersion(init_file):
     try:
         cwd = os.path.dirname(os.path.abspath(init_file))
         fn = os.path.join(cwd, 'VERSION')
-        return open(fn).read().strip()
+        with open(fn) as f:
+            return f.read().strip()
     except IOError:
         pass
 

--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -12,14 +12,21 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
+#
+# Keep in sync with slave/buildslave/__init__.py
+#
+# We can't put this method in utility modules, because they import dependancy packages
+#
 from __future__ import with_statement
-
 import os
+import re
 
-
-# we can't put this method in utility modules, because they import dependancy packages.
 def getVersion(init_file):
+    """
+    Return BUILDBOT_VERSION environment variable, content of VERSION file, git
+    tag or 'latest'
+    """
+
     try:
         return os.environ['BUILDBOT_VERSION']
     except KeyError:
@@ -28,9 +35,7 @@ def getVersion(init_file):
     try:
         cwd = os.path.dirname(os.path.abspath(init_file))
         fn = os.path.join(cwd, 'VERSION')
-        with open(fn) as vfile:
-            version = vfile.read().strip()
-        return version
+        return open(fn).read().strip()
     except IOError:
         pass
 
@@ -41,8 +46,6 @@ def getVersion(init_file):
     # no matter the number of digits for X, Y and Z
     VERSION_MATCH = re.compile(r'(\d+\.\d+(\.\d+)?)(\w|-)*')
 
-    version = 'latest'
-
     try:
         p = Popen(['git', 'describe', '--tags', '--always'], stdout=PIPE, stderr=STDOUT, cwd=cwd)
         out = p.communicate()[0]
@@ -50,10 +53,10 @@ def getVersion(init_file):
         if (not p.returncode) and out:
             v = VERSION_MATCH.search(out)
             if v:
-                version = v.group(1)
+                return v.group(1)
     except OSError:
         pass
 
-    return version
+    return "latest"
 
 version = getVersion(__file__)

--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -17,7 +17,7 @@
 #
 # We can't put this method in utility modules, because they import dependancy packages
 #
-from __future__ import with_statement
+from subprocess import Popen, PIPE, STDOUT
 import os
 import re
 
@@ -38,9 +38,6 @@ def getVersion(init_file):
         return open(fn).read().strip()
     except IOError:
         pass
-
-    from subprocess import Popen, PIPE, STDOUT
-    import re
 
     # accept version to be coded with 2 or 3 parts (X.Y or X.Y.Z),
     # no matter the number of digits for X, Y and Z

--- a/slave/buildslave/__init__.py
+++ b/slave/buildslave/__init__.py
@@ -50,7 +50,7 @@ def getVersion(init_file):
             v = VERSION_MATCH.search(out)
             if v:
                 version = v.group(1)
-        return version
+                return version
     except OSError:
         pass
     return "latest"

--- a/slave/buildslave/__init__.py
+++ b/slave/buildslave/__init__.py
@@ -12,16 +12,21 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
-# strategy:
 #
-# if there is a VERSION file, use its contents. otherwise, call git to
-# get a version string. if that also fails, use 'latest'.
+# Keep in sync with master/buildbot/__init__.py
 #
+# We can't put this method in utility modules, because they import dependancy packages
+#
+from __future__ import with_statement
 import os
-
+import re
 
 def getVersion(init_file):
+    """
+    Return BUILDBOT_VERSION environment variable, content of VERSION file, git
+    tag or 'latest'
+    """
+
     try:
         return os.environ['BUILDBOT_VERSION']
     except KeyError:
@@ -30,8 +35,7 @@ def getVersion(init_file):
     try:
         cwd = os.path.dirname(os.path.abspath(init_file))
         fn = os.path.join(cwd, 'VERSION')
-        version = open(fn).read().strip()
-        return version
+        return open(fn).read().strip()
     except IOError:
         pass
 
@@ -49,10 +53,10 @@ def getVersion(init_file):
         if (not p.returncode) and out:
             v = VERSION_MATCH.search(out)
             if v:
-                version = v.group(1)
-                return version
+                return v.group(1)
     except OSError:
         pass
+
     return "latest"
 
 version = getVersion(__file__)

--- a/slave/buildslave/__init__.py
+++ b/slave/buildslave/__init__.py
@@ -21,6 +21,7 @@ from subprocess import Popen, PIPE, STDOUT
 import os
 import re
 
+
 def getVersion(init_file):
     """
     Return BUILDBOT_VERSION environment variable, content of VERSION file, git
@@ -55,5 +56,6 @@ def getVersion(init_file):
         pass
 
     return "latest"
+
 
 version = getVersion(__file__)

--- a/slave/buildslave/__init__.py
+++ b/slave/buildslave/__init__.py
@@ -17,6 +17,7 @@
 #
 # We can't put this method in utility modules, because they import dependancy packages
 #
+from __future__ import with_statement
 from subprocess import Popen, PIPE, STDOUT
 import os
 import re
@@ -36,7 +37,8 @@ def getVersion(init_file):
     try:
         cwd = os.path.dirname(os.path.abspath(init_file))
         fn = os.path.join(cwd, 'VERSION')
-        return open(fn).read().strip()
+        with open(fn) as f:
+            return f.read().strip()
     except IOError:
         pass
 

--- a/slave/buildslave/__init__.py
+++ b/slave/buildslave/__init__.py
@@ -17,7 +17,7 @@
 #
 # We can't put this method in utility modules, because they import dependancy packages
 #
-from __future__ import with_statement
+from subprocess import Popen, PIPE, STDOUT
 import os
 import re
 
@@ -38,9 +38,6 @@ def getVersion(init_file):
         return open(fn).read().strip()
     except IOError:
         pass
-
-    from subprocess import Popen, PIPE, STDOUT
-    import re
 
     # accept version to be coded with 2 or 3 parts (X.Y or X.Y.Z),
     # no matter the number of digits for X, Y and Z


### PR DESCRIPTION
Python 2.7.7 (default, Jun  1 2014, 14:21:57) [MSC v.1500 64 bit (AMD64)] on win32

Seen this

```
PS D:\wa\buildbot\slave> C:\Python27\python setup.py install
Traceback (most recent call last):
  File "setup.py", line 29, in <module>
    from buildslave import version
  File "D:\wa\buildbot\slave\buildslave\__init__.py", line 58, in <module>
    version = getVersion(__file__)
  File "D:\wa\buildbot\slave\buildslave\__init__.py", line 53, in getVersion
    return version
UnboundLocalError: local variable 'version' referenced before assignment
```

With this patch, the error is gone.

![I have no idea what I'm doing](http://i.kinja-img.com/gawker-media/image/upload/s--2pfvDNpi--/c_fit,fl_progressive,q_80,w_320/oed0pq8pt9n7yplwzogf.jpg)