### PR TITLE
Use parent instead of self.parent in MailNotifier.setServiceParent()

### DIFF
--- a/master/buildbot/status/mail.py
+++ b/master/buildbot/status/mail.py
@@ -465,7 +465,7 @@ class MailNotifier(base.StatusReceiverMultiService, buildset.BuildSetSummaryNoti
                 "customMesg is deprecated; use messageFormatter instead")
 
     def setServiceParent(self, parent):
-        self.master_status = self.parent
+        self.master_status = parent
         self.master_status.subscribe(self)
         self.master = self.master_status.master
         return base.StatusReceiverMultiService.setServiceParent(self, parent)


### PR DESCRIPTION
MailNotifier's setServiceParent() was setting self.master_status to self.parent, which doesn't exist and
I'm guessing the intention is to set it to the parameter parent.

