### PR TITLE
Changed check if patch info should be in blamelist

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -140,7 +140,7 @@ class Build(properties.PropertiesMixin):
             if c.who not in blamelist:
                 blamelist.append(c.who)
         for source in self.sources:
-            if source.patch_info:  # Add patch author to blamelist
+            if source.patch:  # Add patch author to blamelist
                 blamelist.append(source.patch_info[0])
         blamelist.sort()
         return blamelist

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -833,8 +833,8 @@ class TestBuildBlameList(unittest.TestCase):
         r.sources.extend([self.patchSource])
         build = Build([r])
         blamelist = build.blamelist()
-        # If no patch is set, author will not be est 
-        self.assertEqual(blamelist, [])	
+        # If no patch is set, author will not be est
+        self.assertEqual(blamelist, [])
 
 
 class TestSetupProperties_MultipleSources(unittest.TestCase):

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -833,7 +833,8 @@ class TestBuildBlameList(unittest.TestCase):
         r.sources.extend([self.patchSource])
         build = Build([r])
         blamelist = build.blamelist()
-        self.assertEqual(blamelist, ['jeff'])
+        # If no patch is set, author will not be est 
+        self.assertEqual(blamelist, [])	
 
 
 class TestSetupProperties_MultipleSources(unittest.TestCase):


### PR DESCRIPTION
When patch_info is being setup in build_request.py it's being set to (None, None) which makes this check incorrect but patch is being set to None. Now the check patch instead and that resolves the issue outlined in this ticket:

http://trac.buildbot.net/ticket/3194