### PR TITLE
Enhancement for master housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 MANIFEST
 _trial_temp*
 dist
-/build
+build/
 .build
 *.egg-info
 master/docs/buildbot.html

--- a/master/buildbot/buildslave/manager.py
+++ b/master/buildbot/buildslave/manager.py
@@ -100,6 +100,9 @@ class BuildslaveManager(service.ReconfigurableServiceMixin,
         timer = metrics.Timer("BuildSlaveManager.reconfigServiceSlaves")
         timer.start()
 
+        # first we deconfigure everything to let the slaves register again
+        yield self.master.data.updates.deconfigureAllBuidslavesForMaster(self.master.masterid)
+
         # arrange slaves by name
         old_by_name = dict([(s.slavename, s)
                             for s in list(self)

--- a/master/buildbot/data/buildslaves.py
+++ b/master/buildbot/data/buildslaves.py
@@ -130,3 +130,12 @@ class Buildslave(base.ResourceType):
             masterid=masterid)
         bs = yield self.master.data.get(('buildslaves', buildslaveid))
         self.produceEvent(bs, 'disconnected')
+
+    @base.updateMethod
+    def deconfigureAllBuidslavesForMaster(self, masterid):
+        # unconfigure all slaves for this master
+        return self.master.db.buildslaves.deconfigureAllBuidslavesForMaster(
+            masterid=masterid)
+
+    def _masterDeactivated(self, masterid):
+        return self.deconfigureAllBuidslavesForMaster(masterid)

--- a/master/buildbot/db/buildslaves.py
+++ b/master/buildbot/db/buildslaves.py
@@ -75,9 +75,19 @@ class BuildslavesConnectorComponent(base.DBConnectorComponent):
                              [{'buildslaveid': buildslaveid, 'buildermasterid': buildermasterid}
                               for buildermasterid in buildermasterids])
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
-                # TODO
-                # if the row is already present, silently fail..
+                # if some rows are already present, insert one by one.
                 pass
+            else:
+                return
+
+            for buildermasterid in buildermasterids:
+                # insert them one by one
+                q = cfg_tbl.insert()
+                try:
+                    conn.execute(q, {'buildslaveid': buildslaveid, 'buildermasterid': buildermasterid})
+                except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
+                    # if the row is already present, silently fail..
+                    pass
 
         return self.db.pool.do(thd)
 

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -170,12 +170,16 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         self.status = Status(self)
         self.status.setServiceParent(self)
 
+        self.masterHouskeepingTimer = 0
+
         @defer.inlineCallbacks
         def heartbeat():
             if self.masterid is not None:
                 yield self.data.updates.masterActive(name=self.name,
                                                      masterid=self.masterid)
-            yield self.data.updates.expireMasters()
+            # force housekeeping once a day
+            yield self.data.updates.expireMasters((self.masterHouskeepingTimer % (24 * 60)) == 0)
+            self.masterHouskeepingTimer += 1
         self.masterHeartbeatService = internet.TimerService(60, heartbeat)
         self.masterHeartbeatService.setServiceParent(self)
 

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -127,7 +127,7 @@ class FakeUpdates(object):
         self.thisMasterActive = False
         return defer.succeed(None)
 
-    def expireMasters(self):
+    def expireMasters(self, forceHouseKeeping=False):
         return defer.succeed(None)
 
     @defer.inlineCallbacks
@@ -397,6 +397,10 @@ class FakeUpdates(object):
     def buildslaveDisconnected(self, buildslaveid, masterid):
         return self.master.db.buildslaves.buildslaveDisconnected(
             buildslaveid=buildslaveid,
+            masterid=masterid)
+
+    def deconfigureAllBuidslavesForMaster(self, masterid):
+        return self.master.db.buildslaves.deconfigureAllBuidslavesForMaster(
             masterid=masterid)
 
 

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1343,6 +1343,7 @@ class FakeBuildslavesComponent(FakeDBComponent):
                     name=row.name,
                     info=row.info)
             elif isinstance(row, ConfiguredBuildslave):
+                row.id = row.buildermasterid * 10000 + row.buildslaveid
                 self.configured[row.id] = dict(
                     buildermasterid=row.buildermasterid,
                     buildslaveid=row.buildslaveid)

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1427,12 +1427,14 @@ class FakeBuildslavesComponent(FakeDBComponent):
             self.connected[conn_id] = new_conn
         return defer.succeed(None)
 
-    def buildslaveConfigured(self, buildslaveid, masterid, builderids):
+    def deconfigureAllBuidslavesForMaster(self, masterid):
         buildermasterids = [_id for _id, (builderid, mid) in self.db.builders.builder_masters.items()
                             if mid == masterid]
         for k, v in self.configured.items():
-            if v['buildslaveid'] == buildslaveid and v['buildermasterid'] in buildermasterids:
+            if v['buildermasterid'] in buildermasterids:
                 del self.configured[k]
+
+    def buildslaveConfigured(self, buildslaveid, masterid, builderids):
 
         buildermasterids = [_id for _id, (builderid, mid) in self.db.builders.builder_masters.items()
                             if mid == masterid and builderid in builderids]

--- a/master/buildbot/test/unit/test_data_masters.py
+++ b/master/buildbot/test/unit/test_data_masters.py
@@ -242,7 +242,7 @@ class Master(interfaces.InterfaceTests, unittest.TestCase):
         @self.assertArgSpecMatches(
             self.master.data.updates.expireMasters,  # fake
             self.rtype.expireMasters)  # real
-        def expireMasters(self):
+        def expireMasters(self, forceHouseKeeping=False):
             pass
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_db_buildslaves.py
+++ b/master/buildbot/test/unit/test_db_buildslaves.py
@@ -459,6 +459,27 @@ class Tests(interfaces.InterfaceTests):
             {'builderid': 22, 'masterid': 10}]))
 
     @defer.inlineCallbacks
+    def test_buildslaveConfiguredTwice(self):
+        yield self.insertTestData(self.baseRows + self.multipleMasters)
+
+        # should remove builder 21, and add 22
+        yield self.db.buildslaves.deconfigureAllBuidslavesForMaster(masterid=10)
+
+        yield self.db.buildslaves.buildslaveConfigured(
+            buildslaveid=30, masterid=10, builderids=[20, 22])
+
+        # configure again (should eat the duplicate insertion errors)
+        yield self.db.buildslaves.buildslaveConfigured(
+            buildslaveid=30, masterid=10, builderids=[20, 21, 22])
+
+        bs = yield self.db.buildslaves.getBuildslave(30)
+        self.assertEqual(sorted(bs['configured_on']), sorted([
+            {'builderid': 20, 'masterid': 11},
+            {'builderid': 20, 'masterid': 10},
+            {'builderid': 21, 'masterid': 10},
+            {'builderid': 22, 'masterid': 10}]))
+
+    @defer.inlineCallbacks
     def test_nothingConfigured(self):
         yield self.insertTestData(self.baseRows + self.multipleMasters)
 

--- a/master/buildbot/test/unit/test_db_buildslaves.py
+++ b/master/buildbot/test/unit/test_db_buildslaves.py
@@ -104,6 +104,11 @@ class Tests(interfaces.InterfaceTests):
         def buildslaveConfigured(self, buildslaveid, masterid, builderids):
             pass
 
+    def test_signature_deconfigureAllBuidslavesForMaster(self):
+        @self.assertArgSpecMatches(self.db.buildslaves.deconfigureAllBuidslavesForMaster)
+        def deconfigureAllBuidslavesForMaster(self, masterid):
+            pass
+
     @defer.inlineCallbacks
     def test_findBuildslaveId_insert(self):
         id = yield self.db.buildslaves.findBuildslaveId(name=u"xyz")
@@ -172,7 +177,7 @@ class Tests(interfaces.InterfaceTests):
                               connected_to=[10, 11], configured_on=[
                                   {'builderid': 20, 'masterid': 10},
                                   {'builderid': 20, 'masterid': 11},
-                              ]))
+                                  ]))
 
     @defer.inlineCallbacks
     def test_getBuildslave_by_name_not_configured(self):
@@ -248,7 +253,7 @@ class Tests(interfaces.InterfaceTests):
                          dict(id=30, name='zero', slaveinfo={'a': 'b'},
                               configured_on=[
                                   {'masterid': 11, 'builderid': 20},
-                              ], connected_to=[]))
+                                  ], connected_to=[]))
 
     @defer.inlineCallbacks
     def test_getBuildslave_with_multiple_masters_builderid_masterid(self):
@@ -260,7 +265,7 @@ class Tests(interfaces.InterfaceTests):
                          dict(id=30, name='zero', slaveinfo={'a': 'b'},
                               configured_on=[
                                   {'masterid': 11, 'builderid': 20},
-                              ], connected_to=[]))
+                                  ], connected_to=[]))
 
     @defer.inlineCallbacks
     def test_getBuildslave_by_name_with_multiple_masters_builderid_masterid(self):
@@ -272,7 +277,7 @@ class Tests(interfaces.InterfaceTests):
                          dict(id=30, name='zero', slaveinfo={'a': 'b'},
                               configured_on=[
                                   {'masterid': 11, 'builderid': 20},
-                              ], connected_to=[]))
+                                  ], connected_to=[]))
 
     @defer.inlineCallbacks
     def test_getBuildslaves_no_config(self):
@@ -440,7 +445,10 @@ class Tests(interfaces.InterfaceTests):
     @defer.inlineCallbacks
     def test_buildslaveConfigured(self):
         yield self.insertTestData(self.baseRows + self.multipleMasters)
+
         # should remove builder 21, and add 22
+        yield self.db.buildslaves.deconfigureAllBuidslavesForMaster(masterid=10)
+
         yield self.db.buildslaves.buildslaveConfigured(
             buildslaveid=30, masterid=10, builderids=[20, 22])
 
@@ -449,6 +457,33 @@ class Tests(interfaces.InterfaceTests):
             {'builderid': 20, 'masterid': 11},
             {'builderid': 20, 'masterid': 10},
             {'builderid': 22, 'masterid': 10}]))
+
+    @defer.inlineCallbacks
+    def test_nothingConfigured(self):
+        yield self.insertTestData(self.baseRows + self.multipleMasters)
+
+        # should remove builder 21, and add 22
+        yield self.db.buildslaves.deconfigureAllBuidslavesForMaster(masterid=10)
+        yield self.db.buildslaves.buildslaveConfigured(
+            buildslaveid=30, masterid=10, builderids=[])
+
+        # should only keep builder for master 11
+        bs = yield self.db.buildslaves.getBuildslave(30)
+        self.assertEqual(sorted(bs['configured_on']), sorted([
+            {'builderid': 20, 'masterid': 11}]))
+
+    @defer.inlineCallbacks
+    def test_deconfiguredAllSlaves(self):
+        yield self.insertTestData(self.baseRows + self.multipleMasters)
+
+        res = yield self.db.buildslaves.getBuildslaves(masterid=11)
+        self.assertEqual(len(res), 2)
+
+        # should remove all slave configured for masterid 11
+        yield self.db.buildslaves.deconfigureAllBuidslavesForMaster(masterid=11)
+
+        res = yield self.db.buildslaves.getBuildslaves(masterid=11)
+        self.assertEqual(len(res), 0)
 
 
 class RealTests(Tests):

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -739,7 +739,7 @@ buildslaves
 
     .. py:method:: buildslaveConfigured(buildslaveid, masterid, builderids)
 
-        :param integer buildslaveid: the ID of the buildslave or None
+        :param integer buildslaveid: the ID of the buildslave
         :param integer masterid: the ID of the master to which it configured
         :param list of integer builderids: the ID of the builders to which it is configured
         :returns: Deferred

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -739,12 +739,21 @@ buildslaves
 
     .. py:method:: buildslaveConfigured(buildslaveid, masterid, builderids)
 
-        :param integer buildslaveid: the ID of the buildslave
+        :param integer buildslaveid: the ID of the buildslave or None
         :param integer masterid: the ID of the master to which it configured
         :param list of integer builderids: the ID of the builders to which it is configured
         :returns: Deferred
 
         Record the given buildslave as being configured on the given master and for given builders.
+
+
+    .. py:method:: deconfigureAllBuidslavesForMaster(masterid)
+
+        :param integer masterid: the ID of the master to which it configured
+        :returns: Deferred
+
+        Unregister all the slaves configured to a master for given builders.
+        This shall happen when master disabled or before reconfiguration
 
 changes
 ~~~~~~~

--- a/master/docs/developer/rtype-buildslave.rst
+++ b/master/docs/developer/rtype-buildslave.rst
@@ -149,3 +149,20 @@ All update methods are available as attributes of ``master.data.updates``.
         Record the given buildslave as no longer attached to the given master.
         This method also sends a message indicating the disconnection.
 
+    .. py:method:: buildslaveConfigured(buildslaveid, masterid, builderids)
+
+        :param integer buildslaveid: the ID of the buildslave or None
+        :param integer masterid: the ID of the master to which it configured
+        :param list of integer builderids: the ID of the builders to which it is configured
+        :returns: Deferred
+
+        Record the given buildslave as being configured on the given master and for given builders.
+
+
+    .. py:method:: deconfigureAllBuidslavesForMaster(masterid)
+
+        :param integer masterid: the ID of the master to which it configured
+        :returns: Deferred
+
+        Unregister all the slaves configured to a master for given builders.
+        This shall happen when master disabled or before reconfiguration

--- a/www/base/src/app/builders/builders.controller.coffee
+++ b/www/base/src/app/builders/builders.controller.coffee
@@ -16,7 +16,6 @@ class Builders extends Controller
                     active = true
             return active
         $scope.settings = bbSettingsService.getSettingsGroup("Builders")
-        console.log $scope.settings
         $scope.$watch('settings', ->
             bbSettingsService.save()
         , true)

--- a/www/base/src/app/buildslaves/buildslaves.controller.coffee
+++ b/www/base/src/app/buildslaves/buildslaves.controller.coffee
@@ -1,9 +1,25 @@
 class Buildslaves extends Controller
-    constructor: ($scope, buildbotService) ->
-        buildbotService.all('buildslaves').bind $scope,
-            onchild: (slave) ->
-                console.log slave
-                slave.builders = []
-                slave.configured_on.forEach (c) ->
-                    buildbotService.one('builders', c.builderid).get().then (b) ->
-                        slave.builders.push(b)
+    constructor: ($scope, buildbotService, bbSettingsService) ->
+        $scope.maybeGetMasterNameFromBuilderMaster = (buildermaster) ->
+            activeMasters = 0
+            for master in $scope.masters
+                if master.active
+                    activeMasters += 1
+
+            if activeMasters > 1
+                return "(" + $scope.mastersById[buildermaster.masterid].name.split(":")[0] + ")"
+            return ""
+        $scope.buildersById = {}
+        buildbotService.all('builders').bind $scope,
+            onchild: (builder) ->
+                $scope.buildersById[builder.builderid] = builder
+        $scope.mastersById = {}
+        buildbotService.all('masters').bind $scope,
+            onchild: (master) ->
+                $scope.mastersById[master.masterid] = master
+        buildbotService.all('buildslaves').bind($scope)
+
+        $scope.settings = bbSettingsService.getSettingsGroup("Slaves")
+        $scope.$watch('settings', ->
+            bbSettingsService.save()
+        , true)

--- a/www/base/src/app/buildslaves/buildslaves.route.coffee
+++ b/www/base/src/app/buildslaves/buildslaves.route.coffee
@@ -1,5 +1,5 @@
 class State extends Config
-    constructor: ($stateProvider) ->
+    constructor: ($stateProvider, bbSettingsServiceProvider) ->
 
         # Name of the state
         name = 'buildslaves'
@@ -16,3 +16,13 @@ class State extends Config
             name: name
             url: '/buildslaves'
             data: cfg
+
+        bbSettingsServiceProvider.addSettingsGroup
+            name:'Slaves'
+            caption: 'Slaves page related settings'
+            items:[
+                type:'bool'
+                name:'show_old_slaves'
+                caption:'Show old slaves'
+                default_value: false
+            ]

--- a/www/base/src/app/buildslaves/buildslaves.tpl.jade
+++ b/www/base/src/app/buildslaves/buildslaves.tpl.jade
@@ -6,13 +6,20 @@
                 th Status
                 th Builders
                 th Infos
-            tr(ng-repeat='buildslave in buildslaves')
+            tr(ng-repeat='buildslave in buildslaves',
+               ng-show="settings.show_old_slaves.value || buildslave.configured_on.length > 0")
                 td {{buildslave.name}}
                 td {{buildslave.connected_to.length}} connection
                 td 
-                    span(ng-repeat="builder in buildslave.builders")
-                        a(ui-sref="builder({builder: builder.builderid})")
-                            | {{ builder.name }}
+                    span(ng-repeat="buildermaster in buildslave.configured_on")
+                        a(ui-sref="builder({builder: buildermaster.builderid})")
+                            | {{ buildersById[buildermaster.builderid].name +
+                            |    maybeGetMasterNameFromBuilderMaster(buildermaster)}}
                         | &nbsp;
                 td 
                     rawdata(data='buildslave.slaveinfo')
+    .row
+        .form-group
+            label.checkbox-inline
+                input(type="checkbox" name="{{settings.show_old_slaves.name}}" ng-model="settings.show_old_slaves.value")
+                | {{settings.show_old_slaves.caption}}


### PR DESCRIPTION
While working on slave scalability, I found out that configured slaves where definitely not managed properly.
It should be cleaned up upon master disappear, and reconfiguration
It makes sure master housekeeping is done at least once a day, and at reboot.
This enforce to run new house keeping stuff at upgrading

Im also improving the slave page to make sure it displays in finite time