### PR TITLE
Fix trac ticket 3207

### DIFF
--- a/master/buildbot/process/logobserver.py
+++ b/master/buildbot/process/logobserver.py
@@ -113,16 +113,12 @@ class BufferLogObserver(LogObserver):
             self.stderr.append(data)
 
     def _get(self, chunks):
-        if chunks is None:
-            return [u'']
-        if len(chunks) > 1:
-            chunks = [''.join(chunks)]
-        elif not chunks:
-            chunks = [u'']
-        return chunks
+        if chunks is None or not chunks:
+            return u''
+        return u''.join(chunks)
 
     def getStdout(self):
-        return self._get(self.stdout)[0]
+        return self._get(self.stdout)
 
     def getStderr(self):
-        return self._get(self.stderr)[0]
+        return self._get(self.stderr)

--- a/master/buildbot/test/unit/test_process_logobserver.py
+++ b/master/buildbot/test/unit/test_process_logobserver.py
@@ -1,0 +1,47 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.process import logobserver
+from twisted.trial import unittest
+
+class BufferedLogObserver(unittest.TestCase):
+
+    def setUp(self):
+        self.log = logobserver.BufferLogObserver(wantStdout=True, wantStderr=True)
+
+    def test_get_stdout_unicode(self):
+        self.log.outReceived('str')
+        self.log.errReceived(u'str')
+
+        self.assertEqual(u'str', self.log.getStdout())
+        self.assertEqual(u'str', self.log.getStderr())
+        self.assertTrue(isinstance(self.log.getStdout(), unicode))
+        self.assertTrue(isinstance(self.log.getStderr(), unicode))
+
+        self.log.outReceived(u'str')
+        self.log.errReceived(u'str')
+
+        self.assertEqual(u'strstr', self.log.getStdout())
+        self.assertEqual(u'strstr', self.log.getStderr())
+        self.assertTrue(isinstance(self.log.getStdout(), unicode))
+        self.assertTrue(isinstance(self.log.getStderr(), unicode))
+
+        self.log.outReceived(u'\u2602')
+        self.log.errReceived(u'\u2602')
+
+        self.assertEqual(u'strstr\u2602', self.log.getStdout())
+        self.assertEqual(u'strstr\u2602', self.log.getStderr())
+        self.assertTrue(isinstance(self.log.getStdout(), unicode))
+        self.assertTrue(isinstance(self.log.getStderr(), unicode))


### PR DESCRIPTION
The unicode output in a log is lost & is treated as an ASCII string when there are multiple chunks.
This can cause exceptions when mixing strings which will validate that the contents of an "ascii" string are ascii.