### PR TITLE
load the master.cfg from a thread

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -23,6 +23,7 @@ from twisted.application import internet
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import task
+from twisted.internet import threads
 from twisted.python import components
 from twisted.python import failure
 from twisted.python import log
@@ -207,8 +208,9 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         try:
             # load the configuration file, treating errors as fatal
             try:
-                self.config = config.MasterConfig.loadConfig(self.basedir,
-                                                             self.configFileName)
+                # run the master.cfg in thread, so that it can use blocking code
+                self.config = yield threads.deferToThread(
+                    config.MasterConfig.loadConfig, self.basedir, self.configFileName)
 
             except config.ConfigErrors, e:
                 log.msg("Configuration Errors:")

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -303,6 +303,8 @@ Changes and Removals
 
 * :bb:step:`Trigger` now has a ``getSchedulersAndProperties`` method that can ve overriden to support dynamic triggering.
 
+* ```master.cfg`` is now parsed from a thread. Previously it was run in the main thread, and thus slowing down the master in case of big config, or network access done to generate the config.
+
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
For big configs, parsing the master config can be pretty long, especially if network access is being done.

* Get the lists of slaves on external website, e.g with http://racktables.org/
* get config from external db, e.g from etcd https://coreos.com/using-coreos/etcd/
* next PR will be about storing json data for master.cfg usage in the state table from db: http://docs.buildbot.net/latest/developer/database.html#module-buildbot.db.state

