### PR TITLE
Dbconfig

### DIFF
--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -45,7 +45,7 @@ upgrade_message = textwrap.dedent("""\
     The Buildmaster database needs to be upgraded before this version of
     buildbot can run.  Use the following command-line
 
-        buildbot upgrade-master path/to/master
+        buildbot upgrade-master {basedir}
 
     to upgrade the database, and try starting the buildmaster again.  You may
     want to make a backup of your buildmaster before doing so.
@@ -115,7 +115,7 @@ class DBConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
 
             def check_current(res):
                 if not res:
-                    for l in upgrade_message.split('\n'):
+                    for l in upgrade_message.format(basedir=self.master.basedir).split('\n'):
                         log.msg(l)
                     raise exceptions.DatabaseNotReadyError()
             d.addCallback(check_current)

--- a/master/buildbot/db/dbconfig.py
+++ b/master/buildbot/db/dbconfig.py
@@ -50,8 +50,12 @@ class DbConfig(object):
         self.name = name
 
     def getDb(self):
-        db_engine = enginestrategy.create_engine(self.db_url,
-                                                 basedir=self.basedir)
+        try:
+            db_engine = enginestrategy.create_engine(self.db_url,
+                                                     basedir=self.basedir)
+        except Exception:
+            # db_url is probably trash. Just ignore, config.py db part will create proper message
+            return None
         db = FakeDBConnector()
         db.master = FakeMaster()
         db.pool = FakePool()

--- a/master/buildbot/db/dbconfig.py
+++ b/master/buildbot/db/dbconfig.py
@@ -1,0 +1,68 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.db import enginestrategy
+from buildbot.db import model
+from buildbot.db import state
+
+
+class FakeDBConnector(object):
+    pass
+
+
+class FakeCacheManager(object):
+
+    def get_cache(self, cache_name, miss_fn):
+        return None
+
+
+class FakeMaster(object):
+    pass
+
+
+class FakePool(object):
+    pass
+
+
+class DbConfig(object):
+
+    def __init__(self, db_url, basedir, name="config"):
+        self.db_url = db_url
+        self.basedir = basedir
+        self.name = name
+
+    def getDb(self):
+        db_engine = enginestrategy.create_engine(self.db_url,
+                                                 basedir=self.basedir)
+        db = FakeDBConnector()
+        db.master = FakeMaster()
+        db.pool = FakePool()
+        db.pool.engine = db_engine
+        db.master.caches = FakeCacheManager()
+        db.model = model.Model(db)
+        db.state = state.StateConnectorComponent(db)
+        self.objectid = db.state.thdGetObjectId(db_engine, self.name, "DbConfig")['id']
+        return db
+
+    def get(self, name, default=state.StateConnectorComponent.Thunk):
+        db = self.getDb()
+        ret = db.state.thdGetState(db.pool.engine, self.objectid, name, default=default)
+        db.pool.engine.close()
+        return ret
+
+    def set(self, name, value):
+        db = self.getDb()
+        db.state.thdSetState(db.pool.engine, self.objectid, name, value)
+        db.pool.engine.close()

--- a/master/buildbot/db/dbconfig.py
+++ b/master/buildbot/db/dbconfig.py
@@ -38,8 +38,13 @@ class FakePool(object):
 
 class DbConfig(object):
 
-    def __init__(self, db_url, basedir, name="config"):
-        self.db_url = db_url
+    def __init__(self, BuildmasterConfig, basedir, name="config"):
+        if 'db' in BuildmasterConfig:
+            self.db_url = BuildmasterConfig['db']['db_url']
+        elif 'db_url' in BuildmasterConfig:
+            self.db_url = BuildmasterConfig['db_url']
+        else:
+            self.db_url = 'sqlite:///state.sqlite'
         self.basedir = basedir
         self.name = name
 

--- a/master/buildbot/db/dbconfig.py
+++ b/master/buildbot/db/dbconfig.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from buildbot.config import MasterConfig
 from buildbot.db import enginestrategy
 from buildbot.db import model
 from buildbot.db import state
@@ -40,12 +41,7 @@ class FakePool(object):
 class DbConfig(object):
 
     def __init__(self, BuildmasterConfig, basedir, name="config"):
-        if 'db' in BuildmasterConfig:
-            self.db_url = BuildmasterConfig['db']['db_url']
-        elif 'db_url' in BuildmasterConfig:
-            self.db_url = BuildmasterConfig['db_url']
-        else:
-            self.db_url = 'sqlite:///state.sqlite'
+        self.db_url = MasterConfig.getDbUrlFromConfig(BuildmasterConfig, throwErrors=False)
         self.basedir = basedir
         self.name = name
 

--- a/master/buildbot/db/state.py
+++ b/master/buildbot/db/state.py
@@ -33,123 +33,131 @@ class StateConnectorComponent(base.DBConnectorComponent):
 
     def getObjectId(self, name, class_name):
         # defer to a cached method that only takes one parameter (a tuple)
-        return self._getObjectId((name, class_name)
-                                 ).addCallback(lambda objdict: objdict['id'])
+        d = self._getObjectId((name, class_name))
+        d.addCallback(lambda objdict: objdict['id'])
+        return d
 
     @base.cached('objectids')
     def _getObjectId(self, name_class_name_tuple):
         name, class_name = name_class_name_tuple
 
         def thd(conn):
-            objects_tbl = self.db.model.objects
-
-            self.checkLength(objects_tbl.c.name, name)
-            self.checkLength(objects_tbl.c.class_name, class_name)
-
-            def select():
-                q = sa.select([objects_tbl.c.id],
-                              whereclause=((objects_tbl.c.name == name)
-                                           & (objects_tbl.c.class_name == class_name)))
-                res = conn.execute(q)
-                row = res.fetchone()
-                res.close()
-                if not row:
-                    raise _IdNotFoundError
-                return row.id
-
-            def insert():
-                res = conn.execute(objects_tbl.insert(),
-                                   name=name,
-                                   class_name=class_name)
-                return res.inserted_primary_key[0]
-
-            # we want to try selecting, then inserting, but if the insert fails
-            # then try selecting again.  We include an invocation of a hook
-            # method to allow tests to exercise this particular behavior
-            try:
-                return ObjDict(id=select())
-            except _IdNotFoundError:
-                pass
-
-            self._test_timing_hook(conn)
-
-            try:
-                return ObjDict(id=insert())
-            except (sqlalchemy.exc.IntegrityError,
-                    sqlalchemy.exc.ProgrammingError):
-                pass
-
-            return ObjDict(id=select())
-
+            return self.thdGetObjectId(conn, name, class_name)
         return self.db.pool.do(thd)
+
+    def thdGetObjectId(self, conn, name, class_name):
+        objects_tbl = self.db.model.objects
+
+        self.checkLength(objects_tbl.c.name, name)
+        self.checkLength(objects_tbl.c.class_name, class_name)
+
+        def select():
+            q = sa.select([objects_tbl.c.id],
+                          whereclause=((objects_tbl.c.name == name)
+                                       & (objects_tbl.c.class_name == class_name)))
+            res = conn.execute(q)
+            row = res.fetchone()
+            res.close()
+            if not row:
+                raise _IdNotFoundError
+            return row.id
+
+        def insert():
+            res = conn.execute(objects_tbl.insert(),
+                               name=name,
+                               class_name=class_name)
+            return res.inserted_primary_key[0]
+
+        # we want to try selecting, then inserting, but if the insert fails
+        # then try selecting again.  We include an invocation of a hook
+        # method to allow tests to exercise this particular behavior
+        try:
+            return ObjDict(id=select())
+        except _IdNotFoundError:
+            pass
+
+        self._test_timing_hook(conn)
+
+        try:
+            return ObjDict(id=insert())
+        except (sqlalchemy.exc.IntegrityError,
+                sqlalchemy.exc.ProgrammingError):
+            pass
+
+        return ObjDict(id=select())
 
     class Thunk:
         pass
 
     def getState(self, objectid, name, default=Thunk):
         def thd(conn):
-            object_state_tbl = self.db.model.object_state
-
-            q = sa.select([object_state_tbl.c.value_json],
-                          whereclause=((object_state_tbl.c.objectid == objectid)
-                                       & (object_state_tbl.c.name == name)))
-            res = conn.execute(q)
-            row = res.fetchone()
-            res.close()
-
-            if not row:
-                if default is self.Thunk:
-                    raise KeyError("no such state value '%s' for object %d" %
-                                   (name, objectid))
-                return default
-            try:
-                return json.loads(row.value_json)
-            except ValueError:
-                raise TypeError("JSON error loading state value '%s' for %d" %
-                                (name, objectid))
+            return self.thdGetState(conn, objectid, name, default=default)
         return self.db.pool.do(thd)
+
+    def thdGetState(self, conn, objectid, name, default=Thunk):
+        object_state_tbl = self.db.model.object_state
+
+        q = sa.select([object_state_tbl.c.value_json],
+                      whereclause=((object_state_tbl.c.objectid == objectid)
+                                   & (object_state_tbl.c.name == name)))
+        res = conn.execute(q)
+        row = res.fetchone()
+        res.close()
+
+        if not row:
+            if default is self.Thunk:
+                raise KeyError("no such state value '%s' for object %d" %
+                               (name, objectid))
+            return default
+        try:
+            return json.loads(row.value_json)
+        except ValueError:
+            raise TypeError("JSON error loading state value '%s' for %d" %
+                            (name, objectid))
 
     def setState(self, objectid, name, value):
         def thd(conn):
-            object_state_tbl = self.db.model.object_state
-
-            try:
-                value_json = json.dumps(value)
-            except (TypeError, ValueError):
-                raise TypeError("Error encoding JSON for %r" % (value,))
-
-            self.checkLength(object_state_tbl.c.name, name)
-
-            def update():
-                q = object_state_tbl.update(
-                    whereclause=((object_state_tbl.c.objectid == objectid)
-                                 & (object_state_tbl.c.name == name)))
-                res = conn.execute(q, value_json=value_json)
-
-                # check whether that worked
-                return res.rowcount > 0
-
-            def insert():
-                conn.execute(object_state_tbl.insert(),
-                             objectid=objectid,
-                             name=name,
-                             value_json=value_json)
-
-            # try updating; if that fails, try inserting; if that fails, then
-            # we raced with another instance to insert, so let that instance
-            # win.
-
-            if update():
-                return
-
-            self._test_timing_hook(conn)
-
-            try:
-                insert()
-            except (sqlalchemy.exc.IntegrityError, sqlalchemy.exc.ProgrammingError):
-                pass  # someone beat us to it - oh well
-
+            return self.thdSetState(conn, objectid, name, value)
         return self.db.pool.do(thd)
+
+    def thdSetState(self, conn, objectid, name, value):
+        object_state_tbl = self.db.model.object_state
+
+        try:
+            value_json = json.dumps(value)
+        except (TypeError, ValueError):
+            raise TypeError("Error encoding JSON for %r" % (value,))
+
+        self.checkLength(object_state_tbl.c.name, name)
+
+        def update():
+            q = object_state_tbl.update(
+                whereclause=((object_state_tbl.c.objectid == objectid)
+                             & (object_state_tbl.c.name == name)))
+            res = conn.execute(q, value_json=value_json)
+
+            # check whether that worked
+            return res.rowcount > 0
+
+        def insert():
+            conn.execute(object_state_tbl.insert(),
+                         objectid=objectid,
+                         name=name,
+                         value_json=value_json)
+
+        # try updating; if that fails, try inserting; if that fails, then
+        # we raced with another instance to insert, so let that instance
+        # win.
+
+        if update():
+            return
+
+        self._test_timing_hook(conn)
+
+        try:
+            insert()
+        except (sqlalchemy.exc.IntegrityError, sqlalchemy.exc.ProgrammingError):
+            pass  # someone beat us to it - oh well
 
     def _test_timing_hook(self, conn):
         # called so tests can simulate another process inserting a database row

--- a/master/buildbot/test/unit/test_db_dbconfig.py
+++ b/master/buildbot/test/unit/test_db_dbconfig.py
@@ -77,8 +77,8 @@ class TestDbConfigNotInitialized(db.RealDatabaseMixin, unittest.TestCase):
         # as we will open the db twice, we can't use in memory sqlite
         yield self.setUpRealDatabase(table_names=[], sqlite_memory=False)
 
-    def createDbConfig(self):
-        return dbconfig.DbConfig({"db_url": self.db_url}, self.basedir)
+    def createDbConfig(self, db_url=None):
+        return dbconfig.DbConfig({"db_url": db_url or self.db_url}, self.basedir)
 
     def test_default(self):
         def thd():
@@ -90,6 +90,27 @@ class TestDbConfigNotInitialized(db.RealDatabaseMixin, unittest.TestCase):
     def test_error(self):
         def thd():
             db = self.createDbConfig()
+            self.assertRaises(KeyError, db.get, u"slaves")
+
+        return threads.deferToThread(thd)
+
+    def test_bad_url(self):
+        def thd():
+            db = self.createDbConfig("garbage://")
+            self.assertRaises(KeyError, db.get, u"slaves")
+
+        return threads.deferToThread(thd)
+
+    def test_bad_url2(self):
+        def thd():
+            db = self.createDbConfig("trash")
+            self.assertRaises(KeyError, db.get, u"slaves")
+
+        return threads.deferToThread(thd)
+
+    def test_bad_url3(self):
+        def thd():
+            db = self.createDbConfig("sqlite://bad")
             self.assertRaises(KeyError, db.get, u"slaves")
 
         return threads.deferToThread(thd)

--- a/master/buildbot/test/unit/test_db_dbconfig.py
+++ b/master/buildbot/test/unit/test_db_dbconfig.py
@@ -1,0 +1,44 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.db import dbconfig
+from buildbot.test.util import db
+from twisted.internet import defer
+from twisted.internet import threads
+from twisted.trial import unittest
+
+
+class TestDbConfig(db.RealDatabaseMixin, unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        # as we will open the db twice, we can't use in memory sqlite
+        yield self.setUpRealDatabase(table_names=['objects', 'object_state'], sqlite_memory=False)
+        yield threads.deferToThread(self.createDbConfig)
+
+    def createDbConfig(self):
+        self.dbConfig = dbconfig.DbConfig(self.db_url, self.basedir)
+
+    def tearDown(self):
+        return self.tearDownRealDatabase()
+
+    def test_basic(self):
+        def thd():
+            slavesInDB = ['foo', 'bar']
+            self.dbConfig.set(u"slaves", slavesInDB)
+            slaves = self.dbConfig.get(u"slaves")
+            self.assertEqual(slaves, slavesInDB)
+
+        return threads.deferToThread(thd)

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -119,7 +119,7 @@ class RealDatabaseMixin(object):
                 os.makedirs(basedir)
 
         self.db_url = os.environ.get('BUILDBOT_TEST_DB_URL', default)
-
+        self.basedir = basedir
         self.db_engine = enginestrategy.create_engine(self.db_url,
                                                       basedir=basedir)
         # if the caller does not want a pool, we're done.

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -1251,6 +1251,8 @@ state
         Set the state value for ``name`` for the object with id ``objectid``,
         overwriting any existing value.
 
+    Those 3 methods have their threaded equivalent, ``thdGetObjectId``, ``thdGetState``, ``thdSetState`` that are intended to run in synchronous code, (e.g master.cfg environnement)
+
 users
 ~~~~~
 

--- a/master/docs/manual/cfg-dbconfig.rst
+++ b/master/docs/manual/cfg-dbconfig.rst
@@ -1,5 +1,6 @@
 .. bb:cfg:: dbconfig
 
+
 DbConfig
 --------
 
@@ -12,10 +13,30 @@ The design is voluntary simplistic, the focus is on the easy use.
 Example ::
 
     from buildbot.plugins import util, buildslave
-    dbConfig = util.DbConfig(c['db']['db_url'], basedir)
+    c = BuildmasterConfig = {}
+    c['db_url'] = 'mysql://user@pass:mysqlserver/buildbot'
+    dbConfig = util.DbConfig(BuildmasterConfig, basedir)
     slaves = dbConfig.get("slaves")
     c['slaves'] = [
         buildslave.BuildSlave(slave['name'], slave['passwd'],
                               properties=slave.get('properties')),
         for slave in slaves
     ]
+
+
+.. py:class:: DbConfig
+
+    .. py:method:: __init__(BuildmasterConfig, basedir)
+
+        :param BuildmasterConfig: the BuildmasterConfig, where db_url is already configured
+        :param basedir: basedir global variable of the master.cfg run environment. Sqlite urls are relative to this dir.
+
+    .. py:method:: get(name, default=MarkerClass)
+
+        :param name: the name of the config variable to retrieve
+        :param default: In case the config variable has not been set yet, default is returned if defined, else KeyError is raised.
+
+    .. py:method:: set(name, value)
+
+        :param name: the name of the config variable to be set
+        :param value: the value of the config variable to be set

--- a/master/docs/manual/cfg-dbconfig.rst
+++ b/master/docs/manual/cfg-dbconfig.rst
@@ -4,11 +4,12 @@
 DbConfig
 --------
 
-DbConfig is an utility for master.cfg to get easy key/value storage in the buildbot database
+DbConfig is an utility for master.cfg to get easy to use key/value storage in the buildbot database
 
 DbConfig can get and store any jsonable object to the db for use by other masters or separate ui plugins to edit them.
 
-The design is voluntary simplistic, the focus is on the easy use.
+The design is voluntary simplistic, the focus is on the easy use rather than efficiency.
+A separate db connection is created each time get() or set() is called.
 
 Example ::
 

--- a/master/docs/manual/cfg-dbconfig.rst
+++ b/master/docs/manual/cfg-dbconfig.rst
@@ -1,0 +1,21 @@
+.. bb:cfg:: dbconfig
+
+DbConfig
+--------
+
+DbConfig is an utility for master.cfg to get easy key/value storage in the buildbot database
+
+DbConfig can get and store any jsonable object to the db for use by other masters or separate ui plugins to edit them.
+
+The design is voluntary simplistic, the focus is on the easy use.
+
+Example ::
+
+    from buildbot.plugins import util, buildslave
+    dbConfig = util.DbConfig(c['db']['db_url'], basedir)
+    slaves = dbConfig.get("slaves")
+    c['slaves'] = [
+        buildslave.BuildSlave(slave['name'], slave['passwd'],
+                              properties=slave.get('properties')),
+        for slave in slaves
+    ]

--- a/master/docs/manual/configuration.rst
+++ b/master/docs/manual/configuration.rst
@@ -25,3 +25,4 @@ The next section, :doc:`customization`, describes this approach, with frequent r
     cfg-statustargets
     cfg-www
     cfg-services
+    cfg-dbconfig

--- a/master/setup.py
+++ b/master/setup.py
@@ -335,7 +335,7 @@ setup_args = {
             ('buildbot.www.ldapuserinfos', ['LdapUserInfo']),
             ('buildbot.www.oauth2', [
                 'GoogleAuth', 'GitHubAuth']),
-            ('buildbot.db.state', [
+            ('buildbot.db.dbconfig', [
                 'DbConfig'])
         ])
     ])

--- a/master/setup.py
+++ b/master/setup.py
@@ -334,7 +334,9 @@ setup_args = {
                 'UserPasswordAuth', 'HTPasswdAuth', 'RemoteUserAuth']),
             ('buildbot.www.ldapuserinfos', ['LdapUserInfo']),
             ('buildbot.www.oauth2', [
-                'GoogleAuth', 'GitHubAuth'])
+                'GoogleAuth', 'GitHubAuth']),
+            ('buildbot.db.state', [
+                'DbConfig'])
         ])
     ])
 }


### PR DESCRIPTION

    DbConfig is an utility for master.cfg to get easy key/value storage in the buildbot database

    DbConfig can get and store any jsonable object to the db for use by other masters or separate ui plugins to edit them.

    The design is voluntary simplistic, the focus is on the easy use.

    Example ::

        from buildbot.plugins import util, buildslave
        dbConfig = util.DbConfig(c['db']['db_url'], basedir)
        slaves = dbConfig.get("slaves")
        c['slaves'] = [
            buildslave.BuildSlave(slave['name'], slave['passwd'],
                                  properties=slave.get('properties')),
            for slave in slaves
        ]


Goal is to create a ui plugin for editing those configs like I did in buildbot_travis:
![image](https://cloud.githubusercontent.com/assets/109859/6230488/83d7f6e6-b6c0-11e4-96c7-77a3cdfc804e.png)

and this is a multimaster and 12 factor capable way
