### PR TITLE
Parse value-less items in .gitconfig as equal to `"true"`

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -349,6 +349,8 @@ class GitExtractor(SourceStampExtractor):
         for l in res.split("\n"):
             if l.strip():
                 parts = l.strip().split("=", 2)
+                if len(parts) < 2:
+                    parts.append('true')
                 self.config[parts[0]] = parts[1]
         return self.config
 


### PR DESCRIPTION
Solves a problem when sending the patch when using buildbot try on a
git-managed project.

    Unhandled Error
    Traceback (most recent call last):
      File "/usr/lib/python2.7/dist-packages/twisted/internet/_baseprocess.py", line 60, in maybeCallProcessEnded
        proto.processEnded(Failure(reason))
      File "/usr/lib/python2.7/dist-packages/twisted/internet/utils.py", line 159, in processEnded
        self.deferred.callback((out, err, code))
      File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 368, in callback
        self._startRunCallbacks(result)
      File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 464, in _startRunCallbacks
        self._runCallbacks()
    --- <exception caught here> ---
      File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 551, in _runCallbacks
        current.result = callback(current.result, *args, **kw)
      File "/usr/lib/python2.7/dist-packages/buildbot/clients/tryclient.py", line 306, in parseConfig
        self.config[parts[0]] = parts[1]
    exceptions.IndexError: list index out of range

    (The line numbers may not match the current master.)

As to why defaulting to `"true"`, see the following excerpt of the
`git-config(1)` manpage:

    CONFIGURATION FILE
           [...]

       Syntax
           [...]

           All the other lines (and the remainder of the line after
           the section header) are recognized as setting variables, in
           the form name = value. If there is no equal sign on the
           line, the entire line is taken as name and the variable is
           recognized as boolean "true". The variable names are