### PR TITLE
Be less dependent on `.gitconfig` and `.gitattributes` for `git diff` output

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -385,7 +385,7 @@ class GitExtractor(SourceStampExtractor):
         sys.exit(1)
 
     def getPatch(self, res):
-        d = self.dovc(["diff", self.baserev])
+        d = self.dovc(["diff", "--src-prefix=a/", "--dst-prefix=b/", "--no-textconv", "--no-ext-diff", self.baserev])
         d.addCallback(self.readPatch, self.patchlevel)
         return d
 


### PR DESCRIPTION
Using `[diff] noprefix` strips the standard `a/` and `b/` prefixes,
we can restore them using `--src-prefix=a/` and `--dst-prefix=b/`.

This fixes the following error:

    fatal: git diff header lacks filename information when removing 1
    leading pathname components (line 5)

`.gitattributes` can configure special text conversion filters and
external diff programs, we can remove them using `--no-textconv` and
`--no-ext-diff`.

This fixes the following errors:

    error: patch failed: path/to/some/file:123
    error: path/to/some/file: patch does not apply