### PR TITLE
Properties with value zero not rendered.

### DIFF
--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -609,7 +609,7 @@ class Property(util.ComparableMixin):
 
             @d.addCallback
             def checkDefault(rv):
-                if rv:
+                if rv is not None:
                     return rv
                 else:
                     return props.render(self.default)

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -1164,19 +1164,13 @@ class TestProperty(unittest.TestCase):
         return d
 
     def testIgnoreFalseValue(self):
-        self.props.setProperty("do-tests-string", "", "scheduler")
-        self.props.setProperty("do-tests-int", 0, "scheduler")
-        self.props.setProperty("do-tests-list", [], "scheduler")
         self.props.setProperty("do-tests-None", None, "scheduler")
 
-        value = [Property("do-tests-string", default="Hello!"),
-                 Property("do-tests-int", default="Hello!"),
-                 Property("do-tests-list", default="Hello!"),
-                 Property("do-tests-None", default="Hello!")]
+        value = [Property("do-tests-None", default="Hello!")]
 
         d = self.build.render(value)
         d.addCallback(self.failUnlessEqual,
-                      ["Hello!"] * 4)
+                      ["Hello!"])
         return d
 
     def testDefaultWhenFalse(self):


### PR DESCRIPTION
Since python evaluates 0 as False, properties with 0 are returned as
None.

This is a problem in some cases: For instance, setting properties via buildbot.steps.trigger.Trigger and its set_properties param, e.g. set_properties={"a_property": Property("buildnumber")}. For this first buildnumber 0, this will lead to a_property being None. 