### PR TITLE
[eight] ShellMixin: workdir should be overridable

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -876,7 +876,7 @@ class ShellMixin(object):
         kwargs['env'].update(self.env)
         kwargs['stdioLogName'] = stdioLogName
         # default the workdir appropriately
-        if not self.workdir:
+        if not kwargs.get('workdir') and not self.workdir:
             if callable(self.build.workdir):
                 kwargs['workdir'] = self.build.workdir(self.build.sources)
             else:

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -74,6 +74,8 @@ Features
 
 * :bb:step:`MasterShellCommand` now renders the ``path`` argument.
 
+* :class:`~buildbot.process.buildstep.ShellMixin`: the ``workdir`` can now be overridden in the call to ``makeRemoteShellCommand``.
+
 * GitHub status target now allows to specify a different base URL for the API (usefule for GitHub enterprise installations).
   This feature requires `txgithub` of version 0.2.0 or better.
 


### PR DESCRIPTION
I was playing with using ShellMixin and needed to be able to override the 'workdir' on makeRemoteShellCommand (I run multiple commands in various places).