### PR TITLE
[eight] ShellMixin: two minor logging fixes

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -878,7 +878,11 @@ class ShellMixin(object):
                 kwargs['workdir'] = self.build.workdir
 
         # the rest of the args go to RemoteShellCommand
-        cmd = remotecommand.RemoteShellCommand(**kwargs)
+        cmd = remotecommand.RemoteShellCommand(
+            collectStdout=collectStdout,
+            collectStderr=collectStderr,
+            **kwargs
+        )
 
         # set up logging
         if stdio is not None:

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -844,7 +844,12 @@ class ShellMixin(object):
         kwargs.update(overrides)
         stdio = None
         if stdioLogName is not None:
-            stdio = yield self.addLog(stdioLogName)
+            # Reuse an existing log if possible; otherwise, create one.
+            try:
+                stdio = yield self.getLog(stdioLogName)
+            except KeyError:
+                stdio = yield self.addLog(stdioLogName)
+
         kwargs['command'] = flatten(kwargs['command'], (list, tuple))
 
         # check for the usePTY flag


### PR DESCRIPTION
This has two fixes that I found useful:
* collectStdout/collectStderr args are never used. I think this is an oversight.
* passing in the same log name creates new logs each time (eg, a bunch of 'stdio' logs). I think it should reuse the same log if it already exists.

I havent done any unit tests for these. I'm not really sure if those parts are tested?