### PR TITLE
Don't delete args while iterating

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -1067,10 +1067,14 @@ class ShellMixin(object):
             else:
                 setattr(self, arg, constructorArgs[arg])
             del constructorArgs[arg]
+        badargs = set()
         for arg in constructorArgs.keys():
             if arg not in BuildStep.parms:
-                bad(arg)
-                del constructorArgs[arg]
+                badargs.add(arg)
+        # delete bad args *after* completing the iteration
+        for arg in badargs:
+            bad(arg)
+            del constructorArgs[arg]
         return constructorArgs
 
     @defer.inlineCallbacks


### PR DESCRIPTION
The unit tests don't operate in a configuration context (where
config.error returns), so it's hard to replicate the issue that way.
Fixes #3208.