### PR TITLE
Changefilter properties

### DIFF
--- a/master/buildbot/changes/filter.py
+++ b/master/buildbot/changes/filter.py
@@ -83,7 +83,7 @@ class ChangeFilter(ComparableMixin):
             return False
         for chg_attr, (filt_list, filt_re, filt_fn) in self.checks.items():
             if chg_attr.startswith("prop:"):
-                chg_val = change.properties.get(chg_attr.split(":", 1)[1], '')
+                chg_val = change.properties.getProperty(chg_attr.split(":", 1)[1], '')
             else:
                 chg_val = getattr(change, chg_attr, '')
             if filt_list is not None and chg_val not in filt_list:

--- a/master/buildbot/test/fake/change.py
+++ b/master/buildbot/test/fake/change.py
@@ -1,0 +1,34 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.process.properties import Properties
+from buildbot.test.fake.state import State
+
+
+class Change(State):
+
+    project = ''
+    repository = ''
+    branch = ''
+    category = ''
+    codebase = ''
+    properties = {}
+
+    def __init__(self, **kw):
+        State.__init__(self, **kw)
+        # change.properties is a IProperties
+        props = Properties()
+        props.update(self.properties, "test")
+        self.properties = props

--- a/master/buildbot/test/unit/test_changes_filter.py
+++ b/master/buildbot/test/unit/test_changes_filter.py
@@ -18,25 +18,7 @@ import re
 from twisted.trial import unittest
 
 from buildbot.changes import filter
-from buildbot.process.properties import Properties
-from buildbot.test.fake.state import State
-
-
-class Change(State):
-
-    project = ''
-    repository = ''
-    branch = ''
-    category = ''
-    codebase = ''
-    properties = {}
-
-    def __init__(self, **kw):
-        State.__init__(self, **kw)
-        # change.properties is a IProperties
-        props = Properties()
-        props.update(self.properties, "test")
-        self.properties = props
+from buildbot.test.fake.change import Change
 
 
 class ChangeFilter(unittest.TestCase):

--- a/master/buildbot/test/unit/test_changes_filter.py
+++ b/master/buildbot/test/unit/test_changes_filter.py
@@ -24,18 +24,19 @@ from buildbot.test.fake.state import State
 
 class Change(State):
 
-    def __init__(self, **kw):
-        State.__init__(self, **kw)
-        # change.properties is a IProperties
-        props = Properties()
-        props.update(self.properties, "test")
-        self.properties = props
     project = ''
     repository = ''
     branch = ''
     category = ''
     codebase = ''
     properties = {}
+
+    def __init__(self, **kw):
+        State.__init__(self, **kw)
+        # change.properties is a IProperties
+        props = Properties()
+        props.update(self.properties, "test")
+        self.properties = props
 
 
 class ChangeFilter(unittest.TestCase):

--- a/master/buildbot/test/unit/test_changes_filter.py
+++ b/master/buildbot/test/unit/test_changes_filter.py
@@ -18,15 +18,24 @@ import re
 from twisted.trial import unittest
 
 from buildbot.changes import filter
+from buildbot.process.properties import Properties
 from buildbot.test.fake.state import State
 
 
 class Change(State):
+
+    def __init__(self, **kw):
+        State.__init__(self, **kw)
+        # change.properties is a IProperties
+        props = Properties()
+        props.update(self.properties, "test")
+        self.properties = props
     project = ''
     repository = ''
     branch = ''
     category = ''
     codebase = ''
+    properties = {}
 
 
 class ChangeFilter(unittest.TestCase):
@@ -112,7 +121,7 @@ class ChangeFilter(unittest.TestCase):
         self.no(Change(project='p', repository='r', branch='b', category='x'),
                 "three match -> False")
         self.no(Change(project='p', repository='r', branch='b', category='c',
-                codebase='x'), "four match -> False")
+                       codebase='x'), "four match -> False")
         self.yes(Change(project='p', repository='r', branch='b', category='c',
                         codebase='cb'), "all match -> True")
         self.check()
@@ -128,4 +137,15 @@ class ChangeFilter(unittest.TestCase):
                 "none match and fn returns True -> False")
         self.yes(Change(project='p', repository='r', branch='b', category='c', ff=True),
                  "all match and fn returns True -> False")
+        self.check()
+
+    def test_filter_props(self):
+        self.setfilter()
+        self.filt.checks.update(
+            self.filt.createChecks(
+                ("ref-updated", None, None, "prop:event.type"),
+            ))
+        self.yes(Change(properties={'event.type': 'ref-updated'}), "matching property")
+        self.no(Change(properties={'event.type': 'patch-uploaded'}), "non matching property")
+        self.no(Change(properties={}), "no property")
         self.check()

--- a/master/buildbot/test/unit/test_changes_gerritchangesource.py
+++ b/master/buildbot/test/unit/test_changes_gerritchangesource.py
@@ -16,12 +16,14 @@
 import types
 
 from buildbot.changes import gerritchangesource
+from buildbot.test.fake.change import Change
 from buildbot.test.util import changesource
 from buildbot.util import json
 from twisted.trial import unittest
 
 
 class TestGerritHelpers(unittest.TestCase):
+
     def test_proper_json(self):
         self.assertEqual(u"Justin Case <justin.case@example.com>",
                          gerritchangesource._gerrit_user_to_author({
@@ -209,12 +211,8 @@ class TestGerritChangeSource(changesource.ChangeSourceMixin,
 class TestGerritChangeFilter(unittest.TestCase):
 
     def test_basic(self):
-        class Change(object):
 
-            def __init__(self, chdict):
-                self.__dict__ = chdict
-
-        ch = Change(TestGerritChangeSource.expected_change)
+        ch = Change(**TestGerritChangeSource.expected_change)
         f = gerritchangesource.GerritChangeFilter(
             branch=["br"], eventtype=["patchset-created"])
         self.assertTrue(f.filter_change(ch))


### PR DESCRIPTION
This bug is found when gerritChangeFilter is used.


	--- <exception caught here> ---
	  File "/data/travis/sandbox/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1107, in _inlineCallbacks
	    result = g.send(result)
	  File "/data/travis/sandbox/local/lib/python2.7/site-packages/buildbot/schedulers/base.py", line 146, in _changeCallback
	    if change_filter and not change_filter.filter_change(change):
	  File "/data/travis/sandbox/local/lib/python2.7/site-packages/buildbot/changes/filter.py", line 86, in filter_change
	    chg_val = change.properties.get(chg_attr.split(":", 1)[1], '')
	exceptions.AttributeError: 'Properties' object has no attribute 'get'
