### PR TITLE
fixes for reverse proxies

### DIFF
--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -83,19 +83,19 @@ class V2RootResource(www.WwwTestMixin, unittest.TestCase):
     def test_default_origin(self):
         self.master.config.buildbotURL = 'http://server/path/'
         self.rsrc.reconfigResource(self.master.config)
-        self.assertEqual([r.pattern for r in self.rsrc.origins], ['http\\:\\/\\/server\\Z(?ms)'])
+        self.assertEqual([r.pattern for r in self.rsrc.origins], [r'http\:\/\/server\Z(?ms)'])
 
         self.master.config.buildbotURL = 'http://server/'
         self.rsrc.reconfigResource(self.master.config)
-        self.assertEqual([r.pattern for r in self.rsrc.origins], ['http\\:\\/\\/server\\Z(?ms)'])
+        self.assertEqual([r.pattern for r in self.rsrc.origins], [r'http\:\/\/server\Z(?ms)'])
 
         self.master.config.buildbotURL = 'http://server:8080/'
         self.rsrc.reconfigResource(self.master.config)
-        self.assertEqual([r.pattern for r in self.rsrc.origins], ['http\\:\\/\\/server\\:8080\\Z(?ms)'])
+        self.assertEqual([r.pattern for r in self.rsrc.origins], [r'http\:\/\/server\:8080\Z(?ms)'])
 
         self.master.config.buildbotURL = 'https://server:8080/'
         self.rsrc.reconfigResource(self.master.config)
-        self.assertEqual([r.pattern for r in self.rsrc.origins], ['https\\:\\/\\/server\\:8080\\Z(?ms)'])
+        self.assertEqual([r.pattern for r in self.rsrc.origins], [r'https\:\/\/server\:8080\Z(?ms)'])
 
 
 class V2RootResource_CORS(www.WwwTestMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -59,7 +59,7 @@ class RestRootResource(www.WwwTestMixin, unittest.TestCase):
 class V2RootResource(www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
-        self.master = self.make_master(url='h:/')
+        self.master = self.make_master(url='http://server/path/')
         self.master.data._scanModule(endpoint)
         self.rsrc = rest.V2RootResource(self.master)
         self.rsrc.reconfigResource(self.master.config)
@@ -79,6 +79,23 @@ class V2RootResource(www.WwwTestMixin, unittest.TestCase):
     def test_invalid_http_method(self):
         yield self.render_resource(self.rsrc, '/', method='PATCH')
         self.assertSimpleError('invalid HTTP method', 400)
+
+    def test_default_origin(self):
+        self.master.config.buildbotURL = 'http://server/path/'
+        self.rsrc.reconfigResource(self.master.config)
+        self.assertEqual([r.pattern for r in self.rsrc.origins], ['http\\:\\/\\/server\\Z(?ms)'])
+
+        self.master.config.buildbotURL = 'http://server/'
+        self.rsrc.reconfigResource(self.master.config)
+        self.assertEqual([r.pattern for r in self.rsrc.origins], ['http\\:\\/\\/server\\Z(?ms)'])
+
+        self.master.config.buildbotURL = 'http://server:8080/'
+        self.rsrc.reconfigResource(self.master.config)
+        self.assertEqual([r.pattern for r in self.rsrc.origins], ['http\\:\\/\\/server\\:8080\\Z(?ms)'])
+
+        self.master.config.buildbotURL = 'https://server:8080/'
+        self.rsrc.reconfigResource(self.master.config)
+        self.assertEqual([r.pattern for r in self.rsrc.origins], ['https\\:\\/\\/server\\:8080\\Z(?ms)'])
 
 
 class V2RootResource_CORS(www.WwwTestMixin, unittest.TestCase):

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -29,6 +29,7 @@ from contextlib import contextmanager
 from twisted.internet import defer
 from twisted.python import log
 from twisted.web.error import Error
+from urlparse import urlparse
 
 
 class BadRequest(Exception):
@@ -370,8 +371,9 @@ class V2RootResource(resource.Resource):
                 request.write(data)
 
     def reconfigResource(self, new_config):
-        # buildbotURL will always ends with a '/', not the Origin header.
-        origin_self = new_config.buildbotURL.rstrip('/')
+        # buildbotURL may contain reverse proxy path, Origin header is just scheme + host + port
+        buildbotURL = urlparse(new_config.buildbotURL)
+        origin_self = buildbotURL.scheme + "://" + buildbotURL.netloc
         # pre-translate the origin entries in the config
         self.origins = [re.compile(fnmatch.translate(o.lower()))
                         for o in new_config.www.get('allowed_origins',

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -2,6 +2,7 @@
 @import "../../libs/bootstrap/less/bootstrap.less";
 @import "../../libs/font-awesome/less/font-awesome.less";
 @import (inline) "../../libs/guanlecoja-ui/styles.css";
+@fa-font-path: "./fonts";
 
 // Import colors and animation stylesheet
 @import "animations.less";


### PR DESCRIPTION
When buildbot sits behind reverse proxies:

- fonts where fetched using /fonts instead of /proxypath/fonts
- selforigin was miscaculated. /proxypath/ should be dropped from buildbotURL=http://server/proxypath -> origin is http://server
