### PR TITLE
Builstep.ShellMixin: reuse logs when they already exist [port from eight]

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -1091,7 +1091,12 @@ class ShellMixin(object):
         kwargs.update(overrides)
         stdio = None
         if stdioLogName is not None:
-            stdio = yield self.addLog(stdioLogName)
+            # Reuse an existing log if possible; otherwise, create one.
+            try:
+                stdio = yield self.getLog(stdioLogName)
+            except KeyError:
+                stdio = yield self.addLog(stdioLogName)
+
         kwargs['command'] = flatten(kwargs['command'], (list, tuple))
 
         # store command away for display
@@ -1124,7 +1129,11 @@ class ShellMixin(object):
         kwargs['workdir'] = self.workdir
 
         # the rest of the args go to RemoteShellCommand
-        cmd = remotecommand.RemoteShellCommand(**kwargs)
+        cmd = remotecommand.RemoteShellCommand(
+            collectStdout=collectStdout,
+            collectStderr=collectStderr,
+            **kwargs
+        )
 
         # set up logging
         if stdio is not None:


### PR DESCRIPTION
This is a port of https://github.com/buildbot/buildbot/pull/1555.