### PR TITLE
Test for mixed failure of classifyChanges

### DIFF
--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -30,13 +30,13 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
 
     def classifyChanges(self, schedulerid, classifications):
         def thd(conn):
-            transaction = conn.begin()
             tbl = self.db.model.scheduler_changes
             ins_q = tbl.insert()
             upd_q = tbl.update(
                 ((tbl.c.schedulerid == schedulerid)
                  & (tbl.c.changeid == sa.bindparam('wc_changeid'))))
             for changeid, important in classifications.items():
+                transaction = conn.begin()
                 # convert the 'important' value into an integer, since that
                 # is the column type
                 imp_int = important and 1 or 0
@@ -54,7 +54,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                                  wc_changeid=changeid,
                                  important=imp_int)
 
-            transaction.commit()
+                transaction.commit()
         return self.db.pool.do(thd)
 
     def flushChangeClassifications(self, schedulerid, less_than=None):

--- a/master/buildbot/test/unit/test_db_schedulers.py
+++ b/master/buildbot/test/unit/test_db_schedulers.py
@@ -60,16 +60,21 @@ class Tests(interfaces.InterfaceTests):
     @defer.inlineCallbacks
     def test_classifyChanges_again(self):
         # test reclassifying changes, which may happen during some timing
-        # conditions
+        # conditions.  It's important that this test uses multiple changes,
+        # only one of which already exists
         yield self.insertTestData([
             self.ss92,
             self.change3,
+            self.change4,
+            self.change5,
+            self.change6,
             self.scheduler24,
-            fakedb.SchedulerChange(schedulerid=24, changeid=3, important=0),
+            fakedb.SchedulerChange(schedulerid=24, changeid=5, important=0),
         ])
-        yield self.db.schedulers.classifyChanges(24, {3: True})
+        yield self.db.schedulers.classifyChanges(
+                24, {3: True, 4: False, 5: True, 6: False})
         res = yield self.db.schedulers.getChangeClassifications(24)
-        self.assertEqual(res, {3: True})
+        self.assertEqual(res, {3: True, 4: False, 5: True, 6: False})
 
     def test_signature_flushChangeClassifications(self):
         @self.assertArgSpecMatches(


### PR DESCRIPTION
Test for an insert failure midway through a classification, in which
case the rollback shouldn't roll back any successful inserts.

Fixes #2696.