### PR TITLE
Make source checkout steps not rely on hard-coded list of modes

### DIFF
--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -161,7 +161,7 @@ class Source(LoggingBuildStep, CompositeStepMixin):
         Returns a list of all members in the attribute group.
         """
         from inspect import getmembers, ismethod
-        methods = getmembers(self, lambda m: ismethod)
+        methods = getmembers(self, ismethod)
         group_prefix = attrGroup + '_'
         group_len = len(group_prefix)
         group_members = [method[0][group_len:]

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -140,6 +140,35 @@ class Source(LoggingBuildStep, CompositeStepMixin):
         if isinstance(self.descriptionSuffix, str):
             self.descriptionSuffix = [self.descriptionSuffix]
 
+    def _hasAttrGroupMember(self, attrGroup, attr):
+        """
+        The hasattr equivalent for attribute groups: returns whether the given
+        member is in the attribute group.
+        """
+        method_name = '%s_%s' % (attrGroup, attr)
+        return hasattr(self, method_name)
+
+    def _getAttrGroupMember(self, attrGroup, attr):
+        """
+        The getattr equivalent for attribute groups: gets and returns the
+        attribute group member.
+        """
+        method_name = '%s_%s' % (attrGroup, attr)
+        return getattr(self, method_name)
+
+    def _listAttrGroupMembers(self, attrGroup):
+        """
+        Returns a list of all members in the attribute group.
+        """
+        from inspect import getmembers, ismethod
+        methods = getmembers(self, lambda m: ismethod)
+        group_prefix = attrGroup + '_'
+        group_len = len(group_prefix)
+        group_members = [method[0][group_len:]
+                         for method in methods
+                         if method[0].startswith(group_prefix)]
+        return group_members
+
     def updateSourceProperty(self, name, value, source=''):
         """
         Update a property, indexing the property by codebase if codebase is not

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -122,10 +122,7 @@ class P4(Source):
         if self.use_tickets and self.p4passwd:
             d.addCallback(self._acquireTicket)
 
-        if self.mode == 'full':
-            d.addCallback(self.full)
-        elif self.mode == 'incremental':
-            d.addCallback(self.incremental)
+        d.addCallback(self._getAttrGroupMember('mode', self.mode))
 
         d.addCallback(self.parseGotRevision)
         d.addCallback(self.finish)
@@ -133,7 +130,7 @@ class P4(Source):
         return d
 
     @defer.inlineCallbacks
-    def full(self, _):
+    def mode_full(self, _):
         if debug_logging:
             log.msg("P4:full()..")
 
@@ -160,7 +157,7 @@ class P4(Source):
             log.msg("P4: full() sync done.")
 
     @defer.inlineCallbacks
-    def incremental(self, _):
+    def mode_incremental(self, _):
         if debug_logging:
             log.msg("P4:incremental()")
 

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -57,7 +57,6 @@ class SVN(Source):
         self.preferLastChangedRev = preferLastChangedRev
         Source.__init__(self, **kwargs)
         errors = []
-        modeMethod = 'mode_' + self.mode
         if not self._hasAttrGroupMember('mode', self.mode):
             errors.append("mode %s is not one of %s" %
                           (self.mode, self._listAttrGroupMembers('mode')))

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -58,8 +58,9 @@ class SVN(Source):
         Source.__init__(self, **kwargs)
         errors = []
         modeMethod = 'mode_' + self.mode
-        if not hasattr(self, modeMethod):
-            errors.append("mode %s is not allowed" % (self.mode))
+        if not self._hasAttrGroupMember('mode', self.mode):
+            errors.append("mode %s is not one of %s" %
+                          (self.mode, self._listAttrGroupMembers('mode')))
         if self.method not in self.possible_methods:
             errors.append("method %s is not one of %s" % (self.method, self.possible_methods))
 
@@ -99,7 +100,7 @@ class SVN(Source):
             else:
                 return 0
 
-        d.addCallback(getattr(self, 'mode_' + self.mode))
+        d.addCallback(self._getAttrGroupMember('mode', self.mode))
 
         if patch:
             d.addCallback(self.patch, patch)

--- a/master/buildbot/test/integration/test_configs.py
+++ b/master/buildbot/test/integration/test_configs.py
@@ -71,7 +71,7 @@ from buildbot.steps.python_twisted import Trial
 from buildbot.steps.shell import Compile
 from buildbot.steps.source.cvs import CVS
 f1 = factory.BuildFactory()
-f1.addStep(CVS(cvsroot=cvsroot, cvsmodule=cvsmodule, login="", mode="copy"))
+f1.addStep(CVS(cvsroot=cvsroot, cvsmodule=cvsmodule, login="", method="copy"))
 f1.addStep(Compile(command=["python", "./setup.py", "build"]))
 # original lacked testChanges=True; this failed at the time
 f1.addStep(Trial(testChanges=True, testpath="."))
@@ -110,7 +110,7 @@ from buildbot.steps.python_twisted import Trial
 from buildbot.steps.shell import Compile
 from buildbot.steps.source.cvs import CVS
 f1 = factory.BuildFactory()
-f1.addStep(CVS(cvsroot=cvsroot, cvsmodule=cvsmodule, login="", mode="copy"))
+f1.addStep(CVS(cvsroot=cvsroot, cvsmodule=cvsmodule, login="", method="copy"))
 f1.addStep(Compile(command=["python", "./setup.py", "build"]))
 f1.addStep(Trial(testChanges=True, testpath="."))
 b1 = {'name': "buildbot-full",

--- a/master/buildbot/test/unit/test_steps_source_base_Source.py
+++ b/master/buildbot/test/unit/test_steps_source_base_Source.py
@@ -15,6 +15,8 @@
 
 import mock
 
+from exceptions import AttributeError
+
 from twisted.trial import unittest
 
 from buildbot.steps.source import Source
@@ -138,3 +140,42 @@ class TestSourceDescription(steps.BuildStepMixin, unittest.TestCase):
                       descriptionDone=['svn', 'update'])
         self.assertEqual(step.description, ['svn', 'update', '(running)'])
         self.assertEqual(step.descriptionDone, ['svn', 'update'])
+
+class AttrGroup(Source):
+
+    def other_method(self):
+        pass
+
+    def mode_full(self):
+        pass
+
+    def mode_incremental(self):
+        pass
+
+class TestSourceAttrGroup(sourcesteps.SourceStepMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpBuildStep()
+
+    def tearDown(self):
+        return self.tearDownBuildStep()
+
+    def test_attrgroup_hasattr(self):
+        step = AttrGroup()
+        self.assertTrue(step._hasAttrGroupMember('mode', 'full'))
+        self.assertTrue(step._hasAttrGroupMember('mode', 'incremental'))
+        self.assertFalse(step._hasAttrGroupMember('mode', 'nothing'))
+
+    def test_attrgroup_getattr(self):
+        step = AttrGroup()
+        self.assertEqual(step._getAttrGroupMember('mode', 'full'),
+                         step.mode_full)
+        self.assertEqual(step._getAttrGroupMember('mode', 'incremental'),
+                         step.mode_incremental)
+        self.assertRaises(AttributeError,
+                          step._getAttrGroupMember, 'mode', 'nothing')
+
+    def test_attrgroup_listattr(self):
+        step = AttrGroup()
+        self.assertEqual(sorted(step._listAttrGroupMembers('mode')),
+                         ['full', 'incremental'])

--- a/master/buildbot/test/unit/test_steps_source_base_Source.py
+++ b/master/buildbot/test/unit/test_steps_source_base_Source.py
@@ -141,6 +141,7 @@ class TestSourceDescription(steps.BuildStepMixin, unittest.TestCase):
         self.assertEqual(step.description, ['svn', 'update', '(running)'])
         self.assertEqual(step.descriptionDone, ['svn', 'update'])
 
+
 class AttrGroup(Source):
 
     def other_method(self):
@@ -151,6 +152,7 @@ class AttrGroup(Source):
 
     def mode_incremental(self):
         pass
+
 
 class TestSourceAttrGroup(sourcesteps.SourceStepMixin, unittest.TestCase):
 


### PR DESCRIPTION
Updated all of the source checkout steps that have a `mode` option to query their methods to determine the available modes. I dubbed this an "attribute group". This pull request only touches the `mode` parameter; the `method` parameter is another that could benefit from this.

Note that I skipped fully converting the p4 step due to a different check of `self.mode`.

This pull request supersedes #1458.