### PR TITLE
Fix GerritStatusPush 'startCB' not work

### DIFF
--- a/master/buildbot/status/status_gerrit.py
+++ b/master/buildbot/status/status_gerrit.py
@@ -323,9 +323,9 @@ class GerritStatusPush(StatusReceiverMultiService, buildset.BuildSetSummaryNotif
             return
 
         # Gerrit + Git
-        if build.getProperty("gerrit_branch") is not None:  # used only to verify Gerrit source
+        if build.getProperty("event.change.id") is not None:  # used only to verify Gerrit source
             project = build.getProperty("project")
-            revision = build.getProperty("got_revision")
+            revision = build.getProperty("got_revision") or build.getProperty("revision")
 
             # review doesn't really work with multiple revisions, so let's
             # just assume it's None there


### PR DESCRIPTION
Fix GerritStatusPush 'startCB' not work with Gerrit+Git.
GerritStatusPush 'startCB' triggers before buildsteps start. But the condition
'startCB' decide to send code reviews is the property 'gerrit_branch' which is
set during the buildbot.steps.source.gerrit.Gerrit buildstep. So use property
'event.change.id' instead of 'gerrit_branch' to verify Gerrit source to ensure
'startCB' works properly.

The property 'got_revision' here also has same problem when 'startCB' triggers.

original proposed in #1570