### PR TITLE
Fix logic in buildbot.status.builder:BuilderStatus.matchesAnyTag

### DIFF
--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -337,7 +337,7 @@ class BuilderStatus(styles.Versioned):
 
     def matchesAnyTag(self, tags):
         # Need to guard against None with the "or []".
-        return set(self.tags or []).isdisjoint(tags)
+        return not set(self.tags or []).isdisjoint(tags)
 
     def matchesAllTags(self, tags):
         # Need to guard against None with the "or []".

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -337,7 +337,7 @@ class BuilderStatus(styles.Versioned):
 
     def matchesAnyTag(self, tags):
         # Need to guard against None with the "or []".
-        return not set(self.tags or []).isdisjoint(tags)
+        return bool(set(self.tags or []) & set(tags))
 
     def matchesAllTags(self, tags):
         # Need to guard against None with the "or []".

--- a/master/buildbot/test/unit/test_status_builder.py
+++ b/master/buildbot/test/unit/test_status_builder.py
@@ -43,7 +43,7 @@ class TestBuilderStatus(unittest.TestCase):
         sut = self.makeBuilderStatus()
 
         self.assertFalse(sut.matchesAnyTag(set()))
-        self.assertFalse(sut.matchesAnyTag({'any-tag', 'tag'}))
+        self.assertFalse(sut.matchesAnyTag(set(('any-tag', 'tag')))
 
     def test_matchesAnyTag_no_match(self):
         """
@@ -53,8 +53,8 @@ class TestBuilderStatus(unittest.TestCase):
         sut.tags = {'one'}
 
         self.assertFalse(sut.matchesAnyTag(set()))
-        self.assertFalse(sut.matchesAnyTag({'no-such-tag'}))
-        self.assertFalse(sut.matchesAnyTag({'other-tag', 'tag'}))
+        self.assertFalse(sut.matchesAnyTag(set('no-such-tag')))
+        self.assertFalse(sut.matchesAnyTag(set('other-tag', 'tag')))
 
     def test_matchesAnyTag_with_match(self):
         """
@@ -63,5 +63,5 @@ class TestBuilderStatus(unittest.TestCase):
         sut = self.makeBuilderStatus()
         sut.tags = {'one', 'two'}
 
-        self.assertTrue(sut.matchesAnyTag({'two'}))
-        self.assertTrue(sut.matchesAnyTag({'two', 'one'}))
+        self.assertTrue(sut.matchesAnyTag(set('two')))
+        self.assertTrue(sut.matchesAnyTag(set('two', 'one')))

--- a/master/buildbot/test/unit/test_status_builder.py
+++ b/master/buildbot/test/unit/test_status_builder.py
@@ -61,7 +61,7 @@ class TestBuilderStatus(unittest.TestCase):
         Return True when at least one of the requested tags match.
         """
         sut = self.makeBuilderStatus()
-        sut.tags = set('one', 'two')
+        sut.tags = set(('one', 'two'))
 
         self.assertTrue(sut.matchesAnyTag(set(('two',))))
         self.assertTrue(sut.matchesAnyTag(set(('two', 'one'))))

--- a/master/buildbot/test/unit/test_status_builder.py
+++ b/master/buildbot/test/unit/test_status_builder.py
@@ -50,7 +50,7 @@ class TestBuilderStatus(unittest.TestCase):
         Return False when requested tags don't match.
         """
         sut = self.makeBuilderStatus()
-        sut.tags = {'one'}
+        sut.tags = set('one')
 
         self.assertFalse(sut.matchesAnyTag(set()))
         self.assertFalse(sut.matchesAnyTag(set(('no-such-tag',))))
@@ -61,7 +61,7 @@ class TestBuilderStatus(unittest.TestCase):
         Return True when at least one of the requested tags match.
         """
         sut = self.makeBuilderStatus()
-        sut.tags = {'one', 'two'}
+        sut.tags = set('one', 'two')
 
         self.assertTrue(sut.matchesAnyTag(set(('two',))))
         self.assertTrue(sut.matchesAnyTag(set(('two', 'one'))))

--- a/master/buildbot/test/unit/test_status_builder.py
+++ b/master/buildbot/test/unit/test_status_builder.py
@@ -1,0 +1,67 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+"""
+Tests for buildbot.status.builder module.
+"""
+from buildbot.status import builder
+from buildbot.test.fake import fakemaster
+from twisted.trial import unittest
+
+
+class TestBuilderStatus(unittest.TestCase):
+    """
+    Unit tests for BuilderStatus.
+    """
+
+    def makeBuilderStatus(self):
+        """
+        Return a new BuilderStatus.
+        """
+
+        return builder.BuilderStatus(
+            buildername='testing-builder',
+            tags=None,
+            master=fakemaster.make_master(),
+            description=None)
+
+    def test_matchesAnyTag_no_tags(self):
+        """
+        Return False when builder has no tags.
+        """
+        sut = self.makeBuilderStatus()
+
+        self.assertFalse(sut.matchesAnyTag(set()))
+        self.assertFalse(sut.matchesAnyTag({'any-tag', 'tag'}))
+
+    def test_matchesAnyTag_no_match(self):
+        """
+        Return False when requested tags don't match.
+        """
+        sut = self.makeBuilderStatus()
+        sut.tags = {'one'}
+
+        self.assertFalse(sut.matchesAnyTag(set()))
+        self.assertFalse(sut.matchesAnyTag({'no-such-tag'}))
+        self.assertFalse(sut.matchesAnyTag({'other-tag', 'tag'}))
+
+    def test_matchesAnyTag_with_match(self):
+        """
+        Return True when at least one of the requested tags match.
+        """
+        sut = self.makeBuilderStatus()
+        sut.tags = {'one', 'two'}
+
+        self.assertTrue(sut.matchesAnyTag({'two'}))
+        self.assertTrue(sut.matchesAnyTag({'two', 'one'}))

--- a/master/buildbot/test/unit/test_status_builder.py
+++ b/master/buildbot/test/unit/test_status_builder.py
@@ -43,7 +43,7 @@ class TestBuilderStatus(unittest.TestCase):
         sut = self.makeBuilderStatus()
 
         self.assertFalse(sut.matchesAnyTag(set()))
-        self.assertFalse(sut.matchesAnyTag(set(('any-tag', 'tag')))
+        self.assertFalse(sut.matchesAnyTag(set(('any-tag', 'tag'))))
 
     def test_matchesAnyTag_no_match(self):
         """
@@ -53,8 +53,8 @@ class TestBuilderStatus(unittest.TestCase):
         sut.tags = {'one'}
 
         self.assertFalse(sut.matchesAnyTag(set()))
-        self.assertFalse(sut.matchesAnyTag(set('no-such-tag')))
-        self.assertFalse(sut.matchesAnyTag(set('other-tag', 'tag')))
+        self.assertFalse(sut.matchesAnyTag(set(('no-such-tag',))))
+        self.assertFalse(sut.matchesAnyTag(set(('other-tag', 'tag'))))
 
     def test_matchesAnyTag_with_match(self):
         """
@@ -63,5 +63,5 @@ class TestBuilderStatus(unittest.TestCase):
         sut = self.makeBuilderStatus()
         sut.tags = {'one', 'two'}
 
-        self.assertTrue(sut.matchesAnyTag(set('two')))
-        self.assertTrue(sut.matchesAnyTag(set('two', 'one')))
+        self.assertTrue(sut.matchesAnyTag(set(('two',))))
+        self.assertTrue(sut.matchesAnyTag(set(('two', 'one'))))


### PR DESCRIPTION
Problem
======

I think that current logic for matchesAnyTag is wrong.


Changes
=======

I wrote a few tests and update the code.


How to test
=========

Create builders with tags. Go in web status and click on the tags. You should see only builders with have one of the selected tags.

Let me know if something needs to be changes.

Thanks!