### PR TITLE
Issue 2464: Makes GitPoller show small error message and not a full traceback.

### DIFF
--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -285,6 +285,19 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
                 'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
             })
 
+    def test_poll_GitError(self):
+        # Raised when git exits with status code 128
+        self.expectCommands(
+            gpo.Expect('git', 'init', '--bare', 'gitpoller-work')
+            .exit(128),
+        )
+
+        d = self.assertFailure(self.poller._dovccmd('init', ['--bare',
+                               'gitpoller-work']), gitpoller.GitError)
+
+        d.addCallback(lambda _: self.assertAllCommandsRan())
+        return d
+
     def test_poll_nothingNew(self):
         # Test that environment variables get propagated to subprocesses
         # (See #2116)


### PR DESCRIPTION
Ref: [Issue 2464](http://trac.buildbot.net/ticket/2464)

When the error occurs on Git's end, we should not show the full taceback to the users (since it's not a problem with buildbot). This PR takes the Exception's error message and pushes it to stderr. 