### PR TITLE
ShellMixin: workdir should be overridable

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -1126,7 +1126,8 @@ class ShellMixin(object):
         kwargs['env'].update(self.env)
         kwargs['stdioLogName'] = stdioLogName
 
-        kwargs['workdir'] = self.workdir
+        if not kwargs.get('workdir'):
+            kwargs['workdir'] = self.workdir
 
         # the rest of the args go to RemoteShellCommand
         cmd = remotecommand.RemoteShellCommand(


### PR DESCRIPTION
This is a port from the patch I made for eight. 
I did remove the doc notice; if it's part of 0.8.11's release notes, I dont think it should be part of 0.9, or?