### PR TITLE
Issue 3175: Alow customization of versions info on the About page

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -414,21 +414,18 @@ class MasterConfig(util.ComparableMixin):
         import twisted 
         from buildbot import version as bbversion
 
-        py_version_info = (sys.version_info.major,
-                           sys.version_info.minor,
-                           sys.version_info.micro)
-        pyversion = '.'.join(map(str, py_version_info))
+        pyversion = '.'.join(map(str, sys.version_info[:3]))
 
         tx_version_info= (twisted.version.major,
                           twisted.version.minor,
                           twisted.version.micro)
         txversion = '.'.join(map(str, tx_version_info))
 
-        return {
-            'pyversion': pyversion,
-            'bbversion': bbversion,
-            'txversion': txversion,
-        }
+        return [
+            ('Python version', pyversion),
+            ('Buildbot version', bbversion),
+            ('Twisted version', txversion),
+        ]
 
     def load_db(self, filenamekk, config_dict):
         self.db = dict(db_url=self.getDbUrlFromConfig(config_dict))
@@ -620,12 +617,12 @@ class MasterConfig(util.ComparableMixin):
                   (', '.join(unknown),))
 
         if www_cfg.get('versions') is None:
-            www_cfg['versions'] = {}
+            www_cfg['versions'] = []
 
-        if not isinstance(www_cfg['versions'], dict):
-            error("'versions' must be a dictionary")
+        if not isinstance(www_cfg['versions'], list):
+            error("'versions' must be a list of tuples")
 
-        www_cfg['env_versions'] = self.getEnvironmentVersions()
+        www_cfg['versions'] = self.getEnvironmentVersions() + www_cfg['versions']
 
         self.www.update(www_cfg)
 

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -409,7 +409,28 @@ class MasterConfig(util.ComparableMixin):
 
         return DEFAULT_DB_URL
 
-    def load_db(self, filename, config_dict):
+    @staticmethod
+    def getEnvironmentVersions():
+        import twisted 
+        from buildbot import version as bbversion
+
+        py_version_info = (sys.version_info.major,
+                           sys.version_info.minor,
+                           sys.version_info.micro)
+        pyversion = '.'.join(map(str, py_version_info))
+
+        tx_version_info= (twisted.version.major,
+                          twisted.version.minor,
+                          twisted.version.micro)
+        txversion = '.'.join(map(str, tx_version_info))
+
+        return {
+            'pyversion': pyversion,
+            'bbversion': bbversion,
+            'txversion': txversion,
+        }
+
+    def load_db(self, filenamekk, config_dict):
         self.db = dict(db_url=self.getDbUrlFromConfig(config_dict))
 
     def load_mq(self, filename, config_dict):
@@ -592,11 +613,19 @@ class MasterConfig(util.ComparableMixin):
         allowed = set(['port', 'debug', 'json_cache_seconds',
                        'rest_minimum_version', 'allowed_origins', 'jsonp',
                        'plugins', 'auth', 'avatar_methods', 'logfileName',
-                       'logRotateLength', 'maxRotatedFiles'])
+                       'logRotateLength', 'maxRotatedFiles', 'versions'])
         unknown = set(www_cfg.iterkeys()) - allowed
         if unknown:
             error("unknown www configuration parameter(s) %s" %
                   (', '.join(unknown),))
+
+        if www_cfg.get('versions') is None:
+            www_cfg['versions'] = {}
+
+        if not isinstance(www_cfg['versions'], dict):
+            error("'versions' must be a dictionary")
+
+        www_cfg['env_versions'] = self.getEnvironmentVersions()
 
         self.www.update(www_cfg)
 

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -409,25 +409,7 @@ class MasterConfig(util.ComparableMixin):
 
         return DEFAULT_DB_URL
 
-    @staticmethod
-    def getEnvironmentVersions():
-        import twisted 
-        from buildbot import version as bbversion
-
-        pyversion = '.'.join(map(str, sys.version_info[:3]))
-
-        tx_version_info= (twisted.version.major,
-                          twisted.version.minor,
-                          twisted.version.micro)
-        txversion = '.'.join(map(str, tx_version_info))
-
-        return [
-            ('Python version', pyversion),
-            ('Buildbot version', bbversion),
-            ('Twisted version', txversion),
-        ]
-
-    def load_db(self, filenamekk, config_dict):
+    def load_db(self, filename, config_dict):
         self.db = dict(db_url=self.getDbUrlFromConfig(config_dict))
 
     def load_mq(self, filename, config_dict):

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -616,13 +616,19 @@ class MasterConfig(util.ComparableMixin):
             error("unknown www configuration parameter(s) %s" %
                   (', '.join(unknown),))
 
-        if www_cfg.get('versions') is None:
-            www_cfg['versions'] = []
+        versions = www_cfg.get('versions')
 
-        if not isinstance(www_cfg['versions'], list):
-            error("'versions' must be a list of tuples")
-
-        www_cfg['versions'] = self.getEnvironmentVersions() + www_cfg['versions']
+        if versions is not None:
+            cleaned_versions = []
+            if not isinstance(versions, list):
+                error('Invalid www configuration value of versions')
+            else:
+                for i, v in enumerate(versions):
+                    if not isinstance(v, tuple) or len(v) < 2:
+                        error('Invalid www configuration value of versions')
+                        break
+                    cleaned_versions.append(v)
+            www_cfg['versions'] = cleaned_versions
 
         self.www.update(www_cfg)
 

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -853,6 +853,31 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                     avatar_methods={'name': 'gravatar'},
                                     logfileName='http-access.log'))
 
+    def test_load_www_versions(self):
+        custom_versions = [
+            ('Test Custom Component', '0.0.1'),
+            ('Test Custom Component 2', '0.1.0'),
+        ]
+        self.cfg.load_www(self.filename, {'www': dict(versions=custom_versions)})
+        self.assertResults(www=dict(port=None,
+                                    plugins={}, auth={'name': 'NoAuth'},
+                                    avatar_methods={'name': 'gravatar'},
+                                    versions=custom_versions,
+                                    logfileName='http.log'))
+
+    def test_load_www_versions_not_list(self):
+        custom_versions = {
+            'Test Custom Component': '0.0.1',
+            'Test Custom Component 2': '0.0.2',
+        }
+        self.cfg.load_www(self.filename, {'www': dict(versions=custom_versions)})
+        self.assertConfigError(self.errors, 'Invalid www configuration value of versions')
+
+    def test_load_www_versions_value_invalid(self):
+        custom_versions = [('a', '1'), 'abc', ('b',)]
+        self.cfg.load_www(self.filename, {'www': dict(versions=custom_versions)})
+        self.assertConfigError(self.errors, 'Invalid www configuration value of versions')
+
     def test_load_www_unknown(self):
         self.cfg.load_www(self.filename,
                           dict(www=dict(foo="bar")))

--- a/master/buildbot/test/unit/test_www_config.py
+++ b/master/buildbot/test/unit/test_www_config.py
@@ -40,7 +40,7 @@ class IndexResource(www.WwwTestMixin, unittest.TestCase):
         rsrc.jinja.get_template = lambda x: template
         template.render = lambda configjson, config: configjson
 
-        vjson = json.dumps([] + rsrc.env_versions + custom_versions)
+        vjson = json.dumps(rsrc.getEnvironmentVersions() + custom_versions)
 
         res = yield self.render_resource(rsrc, '/')
         _auth.maybeAutoLogin.assert_called_with(mock.ANY)
@@ -54,9 +54,9 @@ class IndexResource(www.WwwTestMixin, unittest.TestCase):
         exp = exp % vjson
         self.assertIn(res, exp)
 
-        master = self.make_master(url='h:/a/c/', auth=_auth)
+        master = self.make_master(url='h:/a/c/', auth=_auth, versions=custom_versions)
         rsrc.reconfigResource(master.config)
         res = yield self.render_resource(rsrc, '/')
-        exp = '{"titleURL": "http://buildbot.net", "title": "Buildbot", "versions": %s, "auth": {"name": "NoAuth"}, "user": {"anonymous": true}, "buildbotURL": "h:/a/b/", "multiMaster": false, "port": null}'
+        exp = '{"titleURL": "http://buildbot.net", "versions": %s, "title": "Buildbot", "auth": {"name": "NoAuth"}, "user": {"anonymous": true}, "buildbotURL": "h:/a/b/", "multiMaster": false, "port": null}'
         exp = exp % vjson
         self.assertIn(res, exp)

--- a/master/buildbot/test/unit/test_www_config.py
+++ b/master/buildbot/test/unit/test_www_config.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import mock
+import json
 
 from buildbot.test.util import www
 from buildbot.www import auth
@@ -28,7 +29,10 @@ class IndexResource(www.WwwTestMixin, unittest.TestCase):
     def test_render(self):
         _auth = auth.NoAuth()
         _auth.maybeAutoLogin = mock.Mock()
-        master = self.make_master(url='h:/a/b/', auth=_auth)
+
+        custom_versions = [('test compoent', '0.1.2'), ('test component 2', '0.2.1')]
+
+        master = self.make_master(url='h:/a/b/', auth=_auth, versions=custom_versions)
         rsrc = config.IndexResource(master, "foo")
         rsrc.reconfigResource(master.config)
         rsrc.jinja = mock.Mock()
@@ -36,18 +40,23 @@ class IndexResource(www.WwwTestMixin, unittest.TestCase):
         rsrc.jinja.get_template = lambda x: template
         template.render = lambda configjson, config: configjson
 
+        vjson = json.dumps([] + rsrc.env_versions + custom_versions)
+
         res = yield self.render_resource(rsrc, '/')
         _auth.maybeAutoLogin.assert_called_with(mock.ANY)
-        exp = '{"titleURL": "http://buildbot.net", "title": "Buildbot", "auth": {"name": "NoAuth"}, "user": {"anonymous": true}, "buildbotURL": "h:/a/b/", "multiMaster": false, "port": null}'
+        exp = '{"titleURL": "http://buildbot.net", "versions": %s, "title": "Buildbot", "auth": {"name": "NoAuth"}, "user": {"anonymous": true}, "buildbotURL": "h:/a/b/", "multiMaster": false, "port": null}'
+        exp = exp % vjson
         self.assertIn(res, exp)
 
         master.session.user_info = dict(name="me", email="me@me.org")
         res = yield self.render_resource(rsrc, '/')
-        exp = '{"titleURL": "http://buildbot.net", "title": "Buildbot", "auth": {"name": "NoAuth"}, "user": {"email": "me@me.org", "name": "me"}, "buildbotURL": "h:/a/b/", "multiMaster": false, "port": null}'
+        exp = '{"titleURL": "http://buildbot.net", "versions": %s, "title": "Buildbot", "auth": {"name": "NoAuth"}, "user": {"email": "me@me.org", "name": "me"}, "buildbotURL": "h:/a/b/", "multiMaster": false, "port": null}'
+        exp = exp % vjson
         self.assertIn(res, exp)
 
         master = self.make_master(url='h:/a/c/', auth=_auth)
         rsrc.reconfigResource(master.config)
         res = yield self.render_resource(rsrc, '/')
-        exp = '{"titleURL": "http://buildbot.net", "title": "Buildbot", "auth": {"name": "NoAuth"}, "user": {"anonymous": true}, "buildbotURL": "h:/a/b/", "multiMaster": false, "port": null}'
+        exp = '{"titleURL": "http://buildbot.net", "title": "Buildbot", "versions": %s, "auth": {"name": "NoAuth"}, "user": {"anonymous": true}, "buildbotURL": "h:/a/b/", "multiMaster": false, "port": null}'
+        exp = exp % vjson
         self.assertIn(res, exp)

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -40,14 +40,14 @@ class IndexResource(resource.Resource):
 
     def getEnvironmentVersions(self):
         import sys
-        import twisted 
+        import twisted
         from buildbot import version as bbversion
 
         pyversion = '.'.join(map(str, sys.version_info[:3]))
 
-        tx_version_info= (twisted.version.major,
-                          twisted.version.minor,
-                          twisted.version.micro)
+        tx_version_info = (twisted.version.major,
+                           twisted.version.minor,
+                           twisted.version.micro)
         txversion = '.'.join(map(str, tx_version_info))
 
         return [
@@ -75,7 +75,7 @@ class IndexResource(resource.Resource):
 
         www = self.master.config.www
         versions = []
-        versions += self.env_versions 
+        versions += self.env_versions
 
         if isinstance(www.get('versions'), list):
             versions += www['versions']

--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -74,6 +74,22 @@ This server is configured with the :bb:cfg:`www` configuration key, which specif
     The amount of log files that will be kept when rotating
     (Default to the same value as for the :file:`twisted.log` file, set in :file:`buildbot.tac`)
 
+``versions``
+    Custom component versions that you'd like to display on the About page.
+    Buildbot will automatically prepend the versions of python, twisted and buildbot itself to the list.
+
+    ``versions`` should be a list of tuples. for example::
+
+        c['www'] = {
+            # ...
+            'versions': [
+                ('master.cfg', '0.1'),
+                ('OS', 'Ubuntu 14.04'),
+            ]
+        }
+
+    The first element of a tuple stands for the name of the component, the second stands for the corresponding version.
+
 .. note::
 
     The :bb:cfg:`buildbotURL` configuration value gives the base URL that all masters will use to generate links.

--- a/www/base/src/app/about/about.controller.coffee
+++ b/www/base/src/app/about/about.controller.coffee
@@ -1,12 +1,11 @@
 class About extends Controller
     constructor: ($scope, config, buildbotService) ->
-        # todo should get that info from data api: see http://trac.buildbot.net/ticket/3175
-        $scope.config =
-            bbversion: "0.9.0"
-            txversion: "11.0.0"
-            projectname: config.title
-            projecturl: config.titleURL
-            config: config
+        versions = config.versions
+
+        $scope.config = config
+        $scope.versions = config.versions
+        $scope.env_versions = config.env_versions
+
         #$scope.bower_configs = bower_configs
         buildbotService.all('application.spec').getList().then (specs) ->
             $scope.specs = specs

--- a/www/base/src/app/about/about.controller.coffee
+++ b/www/base/src/app/about/about.controller.coffee
@@ -1,10 +1,7 @@
 class About extends Controller
     constructor: ($scope, config, buildbotService) ->
-        versions = config.versions
 
         $scope.config = config
-        $scope.versions = config.versions
-        $scope.env_versions = config.env_versions
 
         #$scope.bower_configs = bower_configs
         buildbotService.all('application.spec').getList().then (specs) ->

--- a/www/base/src/app/about/about.tpl.jade
+++ b/www/base/src/app/about/about.tpl.jade
@@ -7,7 +7,7 @@
             ul
               li Project Infos:
                 a(ng-href="{{config.titleURL}}") {{config.title}}
-              li(ng-repeat="v in config.versions" ng-bind-template="{{v[0]}} version: {{v[1]}}")
+              li(ng-repeat="v in config.versions") {{v[0]}} version: {{v[1]}}
         .row
           small
 

--- a/www/base/src/app/about/about.tpl.jade
+++ b/www/base/src/app/about/about.tpl.jade
@@ -5,12 +5,9 @@
         .row
           .col-sm-4
             ul
-              li Python version: {{config.env_versions.pyversion}}
-              li Buildbot version: {{config.env_versions.bbversion}}
-              li Twisted version: {{config.env_versions.txversion}}
               li Project Infos:
                 a(ng-href="{{config.titleURL}}") {{config.title}}
-              li(ng-repeat="(k, v) in config.versions" ng-bind-template="{{k}}: {{v}}")
+              li(ng-repeat="v in config.versions" ng-bind-template="{{v[0]}}: {{v[1]}}")
         .row
           small
 

--- a/www/base/src/app/about/about.tpl.jade
+++ b/www/base/src/app/about/about.tpl.jade
@@ -5,15 +5,17 @@
         .row
           .col-sm-4
             ul
-              li Buildbot version: {{config.bbversion}}
-              li Twisted version: {{config.txversion}}
+              li Python version: {{config.env_versions.pyversion}}
+              li Buildbot version: {{config.env_versions.bbversion}}
+              li Twisted version: {{config.env_versions.txversion}}
               li Project Infos:
-                a(ng-href="{{config.projecturl}}") {{config.projectname}}
+                a(ng-href="{{config.titleURL}}") {{config.title}}
+              li(ng-repeat="(k, v) in config.versions" ng-bind-template="{{k}}: {{v}}")
         .row
           small
 
             | buildbot-www is configured using:
-            rawdata(data='config.config')
+            rawdata(data='config')
             | buildbot-www is using the following open-source JavaScript libraries:
             dl.dl-horizontal
               div(ng-repeat='module in bower_configs')

--- a/www/base/src/app/about/about.tpl.jade
+++ b/www/base/src/app/about/about.tpl.jade
@@ -7,7 +7,7 @@
             ul
               li Project Infos:
                 a(ng-href="{{config.titleURL}}") {{config.title}}
-              li(ng-repeat="v in config.versions" ng-bind-template="{{v[0]}}: {{v[1]}}")
+              li(ng-repeat="v in config.versions" ng-bind-template="{{v[0]}} version: {{v[1]}}")
         .row
           small
 


### PR DESCRIPTION
This pull request completed the task described in [\#3175](http://trac.buildbot.net/ticket/3175).

Now we can add user-defined versions information by adding a new value to `c['www']` with key named `versions`. The value should be a dictionary described the versions with key as the name of component and value as the the corresponding version. 

The versions of buildbot, python and twisted are now automatically found by server in `config.py` instead of hard coding.

The results looks like:

![custom_versions](https://cloud.githubusercontent.com/assets/557294/6560420/df401de2-c6c4-11e4-9752-81e246c2d219.png)

