### PR TITLE
#3128: Add buildsticker directive

### DIFF
--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.coffee
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.coffee
@@ -1,0 +1,21 @@
+class Buildsticker extends Directive('common')
+    constructor: (RecursionHelper) ->
+        return {
+            replace: true
+            restrict: 'E'
+            scope: {build: '='}
+            templateUrl: 'views/buildsticker.html'
+            compile: RecursionHelper.compile
+            controller: '_buildstickerController'
+        }
+
+class _buildsticker extends Controller('common')
+    constructor: ($scope, buildbotService, resultsService, $urlMatcherFactory, $location) ->
+        $scope.$watch (-> moment().unix()), ->
+            $scope.now = moment().unix()
+
+        # make resultsService utilities available in the template
+        _.mixin($scope, resultsService)
+
+        $scope.$watch 'build', (build) ->
+            buildbotService.one('builders', build.builderid).bind($scope)

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.coffee
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.coffee
@@ -5,7 +5,6 @@ class Buildsticker extends Directive('common')
             restrict: 'E'
             scope: {build: '='}
             templateUrl: 'views/buildsticker.html'
-            compile: RecursionHelper.compile
             controller: '_buildstickerController'
         }
 

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.coffee
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.coffee
@@ -1,4 +1,54 @@
 beforeEach module 'app'
 
 describe 'buildsticker controller', ->
-  # TODO: write tests for buildsticker
+    buildbotService = mqService = $httpBackend = $rootScope = $compile = null
+
+    injected = ($injector) ->
+        $compile = $injector.get('$compile')
+        $httpBackend = $injector.get('$httpBackend')
+        $location = $injector.get('$location')
+        decorateHttpBackend($httpBackend)
+        $rootScope = $injector.get('$rootScope')
+        mqService = $injector.get('mqService')
+        $controller = $injector.get('$controller')
+        $q = $injector.get('$q')
+
+        # stub out the actual backend of mqservice
+        spyOn(mqService,"setBaseUrl").and.returnValue(null)
+        spyOn(mqService,"startConsuming").and.returnValue($q.when( -> ))
+        spyOn(mqService,"stopConsuming").and.returnValue(null)
+        buildbotService = $injector.get('buildbotService')
+
+    beforeEach(inject(injected))
+
+    afterEach ->
+        $httpBackend.verifyNoOutstandingExpectation()
+        $httpBackend.verifyNoOutstandingRequest()
+
+    it 'directive should generate correct html', ->
+        $httpBackend.expectDataGET('builds/1')
+        buildbotService.one('builds', 1).bind($rootScope)
+        $httpBackend.flush()
+        $httpBackend.expectDataGET('builders/1')
+        element = $compile("<buildsticker build='build'></buildsticker>")($rootScope)
+        $httpBackend.flush()
+        $rootScope.build.started_at = moment.unix() # avoid test failed due to time changes
+        $rootScope.$digest()
+        html = element.html()
+
+        expectHtml = '''
+        <div class="panel-heading no-select">
+            <div class="row">
+                <span ng-class="results2class(build)" class="pull-right label ng-binding results_WARNINGS">WARNINGS</span>
+                <a ui-sref="build({builder:builder.builderid, build:build.number})" class="ng-binding" href="#/builders/2/builds/1">11/1</a>
+            </div>
+            <div class="row">
+                <span ng-show="build.complete" class="pull-right ng-binding ng-hide">0 s</span>
+                <span ng-show="!build.complete" class="pull-right ng-binding">0 s</span>
+                <span class="ng-binding">mystate_string</span>
+            </div>
+        </div>
+        '''
+        expectHtml = (s.trim() for s in expectHtml.split('\n')).join('')
+
+        expect(html).toBe(expectHtml)

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.coffee
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.coffee
@@ -48,8 +48,6 @@ describe 'buildsticker controller', ->
         startedSpan = row1.children().eq(1)
         stateSpan = row1.children().eq(2)
 
-        console.log buildLink.html()
-
         # the link of build should be correct
         expect(buildLink.attr('href')).toBe('#/builders/2/builds/1')
 

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.coffee
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.coffee
@@ -1,0 +1,4 @@
+beforeEach module 'app'
+
+describe 'buildsticker controller', ->
+  # TODO: write tests for buildsticker

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.tpl.jade
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.tpl.jade
@@ -1,0 +1,12 @@
+.panel.panel-default.buildsticker(ng-class="results2class(build)")
+  .panel-heading.no-select
+    .row
+      span.pull-right.label(ng-class="results2class(build)") {{results2text(build)}}
+      a(ui-sref="build({builder:builder.builderid, build:build.number})")
+        | {{builder.name}}/{{build.number}}
+    .row
+      span.pull-right(ng-show="build.complete")
+          | {{(build.complete_at - build.started_at)| durationformat:'LLL' }}
+      span.pull-right(ng-show="!build.complete")
+          | {{(now - build.started_at)| durationformat:'LLL' }}
+      span {{build.state_string}}

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.tpl.jade
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.tpl.jade
@@ -1,5 +1,5 @@
 .panel.panel-default.buildsticker(ng-class="results2class(build)")
-  .panel-heading.no-select
+  .panel-body.no-select
     .row
       span.pull-right.label(ng-class="results2class(build)") {{results2text(build)}}
       a(ui-sref="build({builder:builder.builderid, build:build.number})")

--- a/www/base/src/app/home/home.tpl.jade
+++ b/www/base/src/app/home/home.tpl.jade
@@ -25,6 +25,5 @@
       .well
         h2 Welcome to buildbot
         h4 {{ builds_running.length }} Build{{ builds_running.length > 1 ? 's' : '' }} running currently
-        ul
-          li(ng-repeat="build in builds_running")
-            buildsticker(build="build")
+        .sticker-container
+            buildsticker(build="build" ng-repeat="build in builds_running")

--- a/www/base/src/app/home/home.tpl.jade
+++ b/www/base/src/app/home/home.tpl.jade
@@ -25,5 +25,6 @@
       .well
         h2 Welcome to buildbot
         h4 {{ builds_running.length }} Build{{ builds_running.length > 1 ? 's' : '' }} running currently
-        .sticker-container
-            buildsticker(build="build" ng-repeat="build in builds_running")
+        ul
+          li.unstyled(ng-repeat="build in builds_running")
+            buildsticker(build="build")

--- a/www/base/src/app/home/home.tpl.jade
+++ b/www/base/src/app/home/home.tpl.jade
@@ -27,4 +27,4 @@
         h4 {{ builds_running.length }} Build{{ builds_running.length > 1 ? 's' : '' }} running currently
         ul
           li(ng-repeat="build in builds_running")
-            buildsummary(buildid="build.buildid", condensed="true")
+            buildsticker(build="build")

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -113,8 +113,14 @@
   }
 }
 
+.sticker-container{
+  overflow: hidden;
+}
+
 .buildsticker {
   width: 200px;
+  float: left;
+  margin: 0 10px 10px 0;
 
   .row {
     white-space: nowrap;

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -112,3 +112,13 @@
     background-color: #ccc
   }
 }
+
+.buildsticker {
+  width: 200px;
+
+  .row {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+}

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -113,13 +113,12 @@
   }
 }
 
-.sticker-container{
-  overflow: hidden;
+li.unstyled{
+  list-style: none;
 }
 
 .buildsticker {
   width: 200px;
-  float: left;
   margin: 0 10px 10px 0;
 
   .row {


### PR DESCRIPTION
Adding buildsticker directive. Here's a primary result

![buildsticker](https://cloud.githubusercontent.com/assets/557294/6601878/1d4bf3c4-c853-11e4-95e7-dfdd38f1067e.png)

Is this a desired appearance?

## TODO:
- [x] write tests for this directive