### PR TITLE
Ref ticket 3230: Change latex_show_urls configuration option to inline.

### DIFF
--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -229,8 +229,11 @@ latex_logo = os.path.join('_images', 'header-text-transparent.png')
 # If true, show page references after internal links.
 # latex_show_pagerefs = False
 
-# If true, show URL addresses after external links.
-latex_show_urls = True
+# Three possible values for this option (see sphinx config manual) are:
+# 1. 'no' – do not display URLs (default)
+# 2. 'footnote' – display URLs in footnotes
+# 3. 'inline' – display URLs inline in parentheses
+latex_show_urls = 'inline'
 
 # Additional stuff for the LaTeX preamble.
 # latex_preamble = ''


### PR DESCRIPTION
The release of sphinx 1.3 caused travis builds to fail. This commit fixes it.