### PR TITLE
remove Python 2.5 from tox.ini configuration file

### DIFF
--- a/master/tox.ini
+++ b/master/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py25, py26, py27
+envlist = py26, py27
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
* according to the docs Python 2.5 is not supported for master