### PR TITLE
Add more renderables for Mock

### DIFF
--- a/master/buildbot/steps/package/rpm/mock.py
+++ b/master/buildbot/steps/package/rpm/mock.py
@@ -46,6 +46,8 @@ class Mock(ShellCommand):
 
     name = "mock"
 
+    renderables = ["root", "resultdir"]
+
     haltOnFailure = 1
     flunkOnFailure = 1
 

--- a/master/buildbot/test/unit/test_steps_package_rpm_mock.py
+++ b/master/buildbot/test/unit/test_steps_package_rpm_mock.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 from buildbot import config
+from buildbot.process.properties import Interpolate
 from buildbot.status.results import SUCCESS
 from buildbot.steps.package.rpm import mock
 from buildbot.test.fake.remotecommand import Expect
@@ -68,6 +69,24 @@ class TestMock(steps.BuildStepMixin, unittest.TestCase):
                                   'state.log': 'RESULT/state.log'})
             + 0)
         self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
+    def test_resultdir_renderable(self):
+        resultdir_text = "RESULT"
+        self.setupStep(mock.Mock(root='TESTROOT', resultdir = Interpolate('%(kw:resultdir)s', resultdir = resultdir_text)))
+        self.expectCommands(
+            Expect('rmdir', {'dir': ['build/RESULT/build.log',
+                                     'build/RESULT/root.log',
+                                     'build/RESULT/state.log']})
+            + 0,
+            ExpectShell(workdir='wkdir', usePTY='slave-config',
+                        command=['mock', '--root', 'TESTROOT',
+                                 '--resultdir', 'RESULT'],
+                        logfiles={'build.log': 'RESULT/build.log',
+                                  'root.log': 'RESULT/root.log',
+                                  'state.log': 'RESULT/state.log'})
+            + 0)
+        self.expectOutcome(result=SUCCESS, state_string="'mock --root ...'")
         return self.runStep()
 
 


### PR DESCRIPTION
Explicitly mark "root", and "resultdir" as renderables. Otherwise we can't pass Property or Interpolate to Mock as the value for any of these two.

Here is a traceback:

Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/buildbot/process/build.py", line 410, in startNextStep
    d = defer.maybeDeferred(s.startStep, self.remote)
  File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 134, in maybeDeferred
    result = f(*args, **kw)
  File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 1187, in unwindGenerator
    return _inlineCallbacks(None, gen, Deferred())
  File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 1045, in _inlineCallbacks
    result = g.send(result)
--- <exception caught here> ---
  File "/usr/lib/python2.7/site-packages/buildbot/process/buildstep.py", line 325, in startStep
    result = yield self.start()
  File "/usr/lib/python2.7/site-packages/buildbot/steps/package/rpm/mock.py", line 90, in start
    lname)
  File "/usr/lib64/python2.7/posixpath.py", line 77, in join
    elif path == '' or path.endswith('/'):
exceptions.AttributeError: Property instance has no attribute 'endswith'


Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>