### PR TITLE
Test for mixed failure of classifyChanges

### DIFF
--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -24,13 +24,13 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
 
     def classifyChanges(self, objectid, classifications):
         def thd(conn):
-            transaction = conn.begin()
             tbl = self.db.model.scheduler_changes
             ins_q = tbl.insert()
             upd_q = tbl.update(
                 ((tbl.c.objectid == objectid)
                  & (tbl.c.changeid == sa.bindparam('wc_changeid'))))
             for changeid, important in classifications.items():
+                transaction = conn.begin()
                 # convert the 'important' value into an integer, since that
                 # is the column type
                 imp_int = important and 1 or 0
@@ -46,7 +46,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                                  wc_changeid=changeid,
                                  important=imp_int)
 
-            transaction.commit()
+                transaction.commit()
         return self.db.pool.do(thd)
 
     def flushChangeClassifications(self, objectid, less_than=None):


### PR DESCRIPTION
Test for an insert failure midway through a classification, in which
case the rollback shouldn't roll back any successful inserts.

Fixes #2696.

(Backport of d8d375352687b6d88ae960416a3d25bce1de4854)