### PR TITLE
checkconfig: execute it in a reactor

### DIFF
--- a/master/buildbot/scripts/checkconfig.py
+++ b/master/buildbot/scripts/checkconfig.py
@@ -18,6 +18,7 @@ import sys
 
 from buildbot import config
 from buildbot.scripts.base import getConfigFileFromTac
+from buildbot.util import in_reactor
 
 
 def _loadConfig(basedir, configFile, quiet):
@@ -36,6 +37,7 @@ def _loadConfig(basedir, configFile, quiet):
     return 0
 
 
+@in_reactor
 def checkconfig(config):
     quiet = config.get('quiet')
     configFile = config.get('configFile', os.getcwd())

--- a/master/buildbot/test/unit/test_scripts_checkconfig.py
+++ b/master/buildbot/test/unit/test_scripts_checkconfig.py
@@ -142,6 +142,9 @@ class TestCheckconfig(unittest.TestCase):
 
     def setUp(self):
         self.loadConfig = mock.Mock(spec=checkconfig._loadConfig, return_value=3)
+        # checkconfig is decorated with @in_reactor, so strip that decoration
+        # since the reactor is already running
+        self.patch(checkconfig, 'checkconfig', checkconfig.checkconfig._orig)
         self.patch(checkconfig, '_loadConfig', self.loadConfig)
 
     def test_checkconfig_default(self):


### PR DESCRIPTION
For configuration that create deferreds
during the load of the config (for example services), a
reactor is needed.