### PR TITLE
Fix sigtermTime race.

### DIFF
--- a/slave/buildslave/runprocess.py
+++ b/slave/buildslave/runprocess.py
@@ -780,6 +780,8 @@ class RunProcess:
         self.kill(msg)
 
     def isDead(self):
+        if self.process.pid is None:
+            return True
         pid = int(self.process.pid)
         try:
             os.kill(pid, 0)
@@ -788,6 +790,7 @@ class RunProcess:
         return False  # alive
 
     def checkProcess(self):
+        self.sigtermTimer = None
         if not self.isDead():
             hit = self.sendSig(self.interruptSignal)
         else:


### PR DESCRIPTION
If twisted notices that a process dies between when SIGTERM is sent,
then RunProcess.process.pid will be None, causing checkDead to fail.

In any case, the timer will be leaked, and it will be cancelled after having
been called.