### PR TITLE
Issue 2464: Makes GitPoller write git based error to log file.

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -28,6 +28,10 @@ from buildbot.util import ascii2unicode
 from buildbot.util.state import StateMixin
 
 
+class GitError(Exception):
+    """Raised when git exits with code 128."""
+
+
 class GitPoller(base.PollingChangeSource, StateMixin):
 
     """This source will poll a remote git repo for changes and submit
@@ -145,7 +149,11 @@ class GitPoller(base.PollingChangeSource, StateMixin):
 
     @defer.inlineCallbacks
     def poll(self):
-        yield self._dovccmd('init', ['--bare', self.workdir])
+        try:
+            yield self._dovccmd('init', ['--bare', self.workdir])
+        except GitError, e:
+            log.msg(e.args[0])
+            return
 
         branches = self.branches
         if branches is True or callable(branches):
@@ -159,8 +167,13 @@ class GitPoller(base.PollingChangeSource, StateMixin):
             '+%s:%s' % (self._removeHeads(branch), self._trackerBranch(branch))
             for branch in branches
         ]
-        yield self._dovccmd('fetch',
-                            [self.repourl] + refspecs, path=self.workdir)
+
+        try:
+            yield self._dovccmd('fetch', [self.repourl] + refspecs,
+                                path=self.workdir)
+        except GitError, e:
+            log.msg(e.args[0])
+            return
 
         revs = {}
         log.msg('gitpoller: processing changes from "%s"' % (self.repourl,))
@@ -311,6 +324,9 @@ class GitPoller(base.PollingChangeSource, StateMixin):
             "utility to handle the result of getProcessOutputAndValue"
             (stdout, stderr, code) = res
             if code != 0:
+                if code == 128:
+                    raise GitError('command %s %s in %s on repourl %s failed with exit code %d: %s'
+                                   % (command, args, path, self.repourl, code, stderr))
                 raise EnvironmentError('command %s %s in %s on repourl %s failed with exit code %d: %s'
                                        % (command, args, path, self.repourl, code, stderr))
             return stdout.strip()


### PR DESCRIPTION
* Added GitError: Called when git returns with status code 128.
* The error message is logged to twistd.log
* Added test.