### PR TITLE
buildbotServiceManager: factorize for buildslave manager

### DIFF
--- a/master/buildbot/buildslave/base.py
+++ b/master/buildbot/buildslave/base.py
@@ -312,7 +312,7 @@ class AbstractBuildSlave(service.BuildbotService, object):
         text += " %s\n" % status.getTitleURL()
         text += "\n"
         text += "%s\n" % status.getURLForThing(self.slave_status)
-        subject = "Buildbot: buildslave %s was lost" % self.name
+        subject = "Buildbot: buildslave %s was lost" % (self.name,)
         return self._mail_missing_message(subject, text)
 
     def updateSlave(self):
@@ -396,7 +396,7 @@ class AbstractBuildSlave(service.BuildbotService, object):
         self.slave_status.removeGracefulWatcher(self._gracefulChanged)
         self.slave_status.removePauseWatcher(self._pauseChanged)
         self.slave_status.setConnected(False)
-        log.msg("BuildSlave.detached(%s)" % self.name)
+        log.msg("BuildSlave.detached(%s)" % (self.name,))
         self.master.status.slaveDisconnected(self.name)
         self.releaseLocks()
         yield self.master.data.updates.buildslaveDisconnected(
@@ -422,7 +422,7 @@ class AbstractBuildSlave(service.BuildbotService, object):
 
         if self.conn is None:
             return defer.succeed(None)
-        log.msg("disconnecting old slave %s now" % self.name)
+        log.msg("disconnecting old slave %s now" % (self.name,))
         # When this Deferred fires, we'll be ready to accept the new slave
         return self._disconnect(self.conn)
 
@@ -459,7 +459,7 @@ class AbstractBuildSlave(service.BuildbotService, object):
         return d
 
     def shutdownRequested(self):
-        log.msg("slave %s wants to shut down" % self.name)
+        log.msg("slave %s wants to shut down" % (self.name,))
         self.slave_status.setGraceful(True)
 
     def addSlaveBuilder(self, sb):
@@ -747,7 +747,7 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
         text += "Sincerely,\n"
         text += " The Buildbot\n"
         text += " %s\n" % status.getTitleURL()
-        subject = "Buildbot: buildslave %s never substantiated" % self.name
+        subject = "Buildbot: buildslave %s never substantiated" % (self.name,)
         return self._mail_missing_message(subject, text)
 
     def canStartBuild(self):
@@ -901,12 +901,12 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
 
         @d.addCallback
         def _substantiated(res):
-            log.msg(r"Slave %s substantiated \o/" % self.name)
+            log.msg(r"Slave %s substantiated \o/" % (self.name,))
             self.substantiated = True
             if not self.substantiation_deferred:
-                log.msg("No substantiation deferred for %s" % self.name)
+                log.msg("No substantiation deferred for %s" % (self.name,))
             if self.substantiation_deferred:
-                log.msg("Firing %s substantiation deferred with success" % self.name)
+                log.msg("Firing %s substantiation deferred with success" % (self.name,))
                 d = self.substantiation_deferred
                 self.substantiation_deferred = None
                 self.substantiation_build = None

--- a/master/buildbot/buildslave/base.py
+++ b/master/buildbot/buildslave/base.py
@@ -205,7 +205,7 @@ class AbstractBuildSlave(service.BuildbotService, object):
 
         self.manager = parent
         self.botmaster = parent.master.botmaster
-        return service.AsyncMultiService.setServiceParent(self, parent)
+        return service.BuildbotService.setServiceParent(self, parent)
 
     @defer.inlineCallbacks
     def startService(self):
@@ -215,7 +215,7 @@ class AbstractBuildSlave(service.BuildbotService, object):
             self.name)
 
         yield self._getSlaveInfo()
-        yield service.AsyncMultiService.startService(self)
+        yield service.BuildbotService.startService(self)
 
     @defer.inlineCallbacks
     def reconfigService(self, name, password, max_builds=None,
@@ -269,7 +269,7 @@ class AbstractBuildSlave(service.BuildbotService, object):
             yield self.registration.unregister()
             self.registration = None
         self.stopMissingTimer()
-        yield service.AsyncMultiService.stopService(self)
+        yield service.BuildbotService.stopService(self)
 
     def startMissingTimer(self):
         if self.notify_on_missing and self.missing_timeout and self.parent:

--- a/master/buildbot/buildslave/base.py
+++ b/master/buildbot/buildslave/base.py
@@ -83,7 +83,6 @@ class AbstractBuildSlave(service.BuildbotService, object):
         self.registration = None
 
         # these are set when the service is started
-        self.botmaster = None
         self.manager = None
         self.buildslaveid = None
 
@@ -127,6 +126,12 @@ class AbstractBuildSlave(service.BuildbotService, object):
     def slavename(self):
         # slavename is now an alias to twisted.Service's name
         return self.name
+
+    @property
+    def botmaster(self):
+        if self.master is None:
+            return None
+        return self.master.botmaster
 
     def updateLocks(self):
         """Convert the L{LockAccess} objects in C{self.locks} into real lock
@@ -204,7 +209,6 @@ class AbstractBuildSlave(service.BuildbotService, object):
         # botmaster needs to set before setServiceParent which calls startService
 
         self.manager = parent
-        self.botmaster = parent.master.botmaster
         return service.BuildbotService.setServiceParent(self, parent)
 
     @defer.inlineCallbacks

--- a/master/buildbot/buildslave/base.py
+++ b/master/buildbot/buildslave/base.py
@@ -37,8 +37,7 @@ from buildbot.util import service
 from buildbot.util.eventual import eventually
 
 
-class AbstractBuildSlave(service.ReconfigurableServiceMixin,
-                         service.AsyncMultiService, object):
+class AbstractBuildSlave(service.BuildbotService, object):
 
     """This is the master-side representative for a remote buildbot slave.
     There is exactly one for each slave described in the config file (the
@@ -55,7 +54,7 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
     # reconfig slaves after builders
     reconfig_priority = 64
 
-    def __init__(self, name, password, max_builds=None,
+    def checkConfig(self, name, password, max_builds=None,
                  notify_on_missing=None,
                  missing_timeout=10 * 60,   # Ten minutes
                  properties=None, locks=None, keepalive_interval=3600):
@@ -73,13 +72,11 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
                       can be used
         @type locks: dictionary
         """
-        name = ascii2unicode(name)
+        self.name = name = ascii2unicode(name)
 
         if properties is None:
             properties = {}
 
-        service.AsyncMultiService.__init__(self)
-        self.slavename = name
         self.password = password
 
         # protocol registration
@@ -88,7 +85,6 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         # these are set when the service is started
         self.botmaster = None
         self.manager = None
-        self.master = None
         self.buildslaveid = None
 
         self.slave_status = SlaveStatus(name)
@@ -125,7 +121,12 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         self._old_builder_list = None
 
     def __repr__(self):
-        return "<%s %r>" % (self.__class__.__name__, self.slavename)
+        return "<%s %r>" % (self.__class__.__name__, self.name)
+
+    @property
+    def slavename(self):
+        # slavename is now an alias to twisted.Service's name
+        return self.name
 
     def updateLocks(self):
         """Convert the L{LockAccess} objects in C{self.locks} into real lock
@@ -182,7 +183,7 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         builds."""
         if not self.botmaster:
             return  # oh well..
-        self.botmaster.maybeStartBuildsForSlave(self.slavename)
+        self.botmaster.maybeStartBuildsForSlave(self.name)
 
     def _applySlaveInfo(self, info):
         if not info:
@@ -203,7 +204,6 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         # botmaster needs to set before setServiceParent which calls startService
 
         self.manager = parent
-        self.master = parent.master
         self.botmaster = parent.master.botmaster
         return service.AsyncMultiService.setServiceParent(self, parent)
 
@@ -211,56 +211,57 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
     def startService(self):
         self.updateLocks()
         self.startMissingTimer()
-
         self.buildslaveid = yield self.master.data.updates.findBuildslaveId(
-            self.slavename)
+            self.name)
 
         yield self._getSlaveInfo()
         yield service.AsyncMultiService.startService(self)
 
     @defer.inlineCallbacks
-    def reconfigServiceWithBuildbotConfig(self, new_config):
-        # Given a new BuildSlave, configure this one identically.  Because
-        # BuildSlave objects are remotely referenced, we can't replace them
+    def reconfigService(self, name, password, max_builds=None,
+                        notify_on_missing=None, missing_timeout=3600,
+                        properties=None, locks=None, keepalive_interval=3600):
+        # Given a BuildSlave config arguments, configure this one identically.
+        # Because BuildSlave objects are remotely referenced, we can't replace them
         # without disconnecting the slave, yet there's no reason to do that.
-        new = self.findNewSlaveInstance(new_config)
 
-        assert self.slavename == new.slavename
-        self.password = new.password
+        assert self.name == name
+        self.password = password
+
+        # adopt new instance's configuration parameters
+        self.max_builds = max_builds
+        self.access = []
+        if locks:
+            self.access = locks
+        self.notify_on_missing = notify_on_missing
+
+        if self.missing_timeout != missing_timeout:
+            running_missing_timer = self.missing_timer
+            self.stopMissingTimer()
+            self.missing_timeout = missing_timeout
+            if running_missing_timer:
+                self.startMissingTimer()
+
+        if properties is None:
+            properties = {}
+        self.properties = Properties()
+        self.properties.update(properties, "BuildSlave")
+        self.properties.setProperty("slavename", name, "BuildSlave")
 
         # update our records with the buildslave manager
         if not self.registration:
             self.registration = yield self.master.buildslaves.register(self)
-        yield self.registration.update(new, new_config)
-
-        # adopt new instance's configuration parameters
-        self.max_builds = new.max_builds
-        self.access = new.access
-        self.notify_on_missing = new.notify_on_missing
-
-        if self.missing_timeout != new.missing_timeout:
-            running_missing_timer = self.missing_timer
-            self.stopMissingTimer()
-            self.missing_timeout = new.missing_timeout
-            if running_missing_timer:
-                self.startMissingTimer()
-
-        properties = Properties()
-        properties.updateFromProperties(new.properties)
-        self.properties = properties
+        yield self.registration.update(self, self.master.config)
 
         self.updateLocks()
 
-        bids = [b._builderid for b in self.botmaster.getBuildersForSlave(self.slavename)]
+        bids = [b._builderid for b in self.botmaster.getBuildersForSlave(self.name)]
         yield self.master.data.updates.buildslaveConfigured(self.buildslaveid, self.master.masterid, bids)
 
         # update the attached slave's notion of which builders are attached.
         # This assumes that the relevant builders have already been configured,
         # which is why the reconfig_priority is set low in this class.
         yield self.updateSlave()
-
-        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                   new_config)
 
     @defer.inlineCallbacks
     def stopService(self):
@@ -269,13 +270,6 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
             self.registration = None
         self.stopMissingTimer()
         yield service.AsyncMultiService.stopService(self)
-
-    def findNewSlaveInstance(self, new_config):
-        # TODO: called multiple times per reconfig; use 1-element cache?
-        for sl in new_config.slaves:
-            if sl.slavename == self.slavename:
-                return sl
-        assert 0, "no new slave named '%s'" % self.slavename
 
     def startMissingTimer(self):
         if self.notify_on_missing and self.missing_timeout and self.parent:
@@ -301,7 +295,7 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         status = buildmaster.getStatus()
         text = "The Buildbot working for '%s'\n" % status.getTitle()
         text += ("has noticed that the buildslave named %s went away\n" %
-                 self.slavename)
+                 self.name)
         text += "\n"
         text += ("It last disconnected at %s (buildmaster-local time)\n" %
                  time.ctime(time.time() - self.missing_timeout))  # approx
@@ -314,7 +308,7 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         text += " %s\n" % status.getTitleURL()
         text += "\n"
         text += "%s\n" % status.getURLForThing(self.slave_status)
-        subject = "Buildbot: buildslave %s was lost" % self.slavename
+        subject = "Buildbot: buildslave %s was lost" % self.name
         return self._mail_missing_message(subject, text)
 
     def updateSlave(self):
@@ -381,9 +375,9 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         log.msg("bot attached")
         self.messageReceivedFromSlave()
         self.stopMissingTimer()
-        self.master.status.slaveConnected(self.slavename)
+        self.master.status.slaveConnected(self.name)
         yield self.updateSlave()
-        yield self.botmaster.maybeStartBuildsForSlave(self.slavename)
+        yield self.botmaster.maybeStartBuildsForSlave(self.name)
 
     def messageReceivedFromSlave(self):
         now = time.time()
@@ -398,8 +392,8 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         self.slave_status.removeGracefulWatcher(self._gracefulChanged)
         self.slave_status.removePauseWatcher(self._pauseChanged)
         self.slave_status.setConnected(False)
-        log.msg("BuildSlave.detached(%s)" % self.slavename)
-        self.master.status.slaveDisconnected(self.slavename)
+        log.msg("BuildSlave.detached(%s)" % self.name)
+        self.master.status.slaveDisconnected(self.name)
         self.releaseLocks()
         yield self.master.data.updates.buildslaveDisconnected(
             buildslaveid=self.buildslaveid,
@@ -424,7 +418,7 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
 
         if self.conn is None:
             return defer.succeed(None)
-        log.msg("disconnecting old slave %s now" % self.slavename)
+        log.msg("disconnecting old slave %s now" % self.name)
         # When this Deferred fires, we'll be ready to accept the new slave
         return self._disconnect(self.conn)
 
@@ -447,7 +441,7 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         return d
 
     def sendBuilderList(self):
-        our_builders = self.botmaster.getBuildersForSlave(self.slavename)
+        our_builders = self.botmaster.getBuildersForSlave(self.name)
         blist = [(b.name, b.config.slavebuilddir) for b in our_builders]
         if blist == self._old_builder_list:
             return defer.succeed(None)
@@ -461,7 +455,7 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
         return d
 
     def shutdownRequested(self):
-        log.msg("slave %s wants to shut down" % self.slavename)
+        log.msg("slave %s wants to shut down" % self.name)
         self.slave_status.setGraceful(True)
 
     def addSlaveBuilder(self, sb):
@@ -475,7 +469,7 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
 
     def buildFinished(self, sb):
         """This is called when a build on this slave is finished."""
-        self.botmaster.maybeStartBuildsForSlave(self.slavename)
+        self.botmaster.maybeStartBuildsForSlave(self.name)
 
     def canStartBuild(self):
         """
@@ -561,9 +555,9 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
 
     def _pauseChanged(self, paused):
         if paused is True:
-            self.botmaster.master.status.slavePaused(self.slavename)
+            self.botmaster.master.status.slavePaused(self.name)
         else:
-            self.botmaster.master.status.slaveUnpaused(self.slavename)
+            self.botmaster.master.status.slaveUnpaused(self.name)
 
     def pause(self):
         """Stop running new builds on the slave."""
@@ -572,7 +566,7 @@ class AbstractBuildSlave(service.ReconfigurableServiceMixin,
     def unpause(self):
         """Restart running new builds on the slave."""
         self.slave_status.setPaused(False)
-        self.botmaster.maybeStartBuildsForSlave(self.slavename)
+        self.botmaster.maybeStartBuildsForSlave(self.name)
 
     def isPaused(self):
         return self.slave_status.isPaused()
@@ -691,7 +685,7 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
         def start_instance_result(result):
             # If we don't report success, then preparation failed.
             if not result:
-                log.msg("Slave '%s' does not want to substantiate at this time" % (self.slavename,))
+                log.msg("Slave '%s' does not want to substantiate at this time" % (self.name,))
                 d = self.substantiation_deferred
                 self.substantiation_deferred = None
                 d.callback(False)
@@ -712,7 +706,7 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
     def attached(self, bot):
         if self.substantiation_deferred is None and self.build_wait_timeout >= 0:
             msg = 'Slave %s received connection while not trying to ' \
-                'substantiate.  Disconnecting.' % (self.slavename,)
+                'substantiate.  Disconnecting.' % (self.name,)
             log.msg(msg)
             self._disconnect(bot)
             return defer.fail(RuntimeError(msg))
@@ -740,7 +734,7 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
         status = buildmaster.getStatus()
         text = "The Buildbot working for '%s'\n" % status.getTitle()
         text += ("has noticed that the latent buildslave named %s \n" %
-                 self.slavename)
+                 self.name)
         text += "never substantiated after a request\n"
         text += "\n"
         text += ("The request was made at %s (buildmaster-local time)\n" %
@@ -749,7 +743,7 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
         text += "Sincerely,\n"
         text += " The Buildbot\n"
         text += " %s\n" % status.getTitleURL()
-        subject = "Buildbot: buildslave %s never substantiated" % self.slavename
+        subject = "Buildbot: buildslave %s never substantiated" % self.name
         return self._mail_missing_message(subject, text)
 
     def canStartBuild(self):
@@ -798,7 +792,7 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
         self.building.clear()  # just to be sure
         yield d
         self.insubstantiating = False
-        self.botmaster.maybeStartBuildsForSlave(self.slavename)
+        self.botmaster.maybeStartBuildsForSlave(self.name)
 
     @defer.inlineCallbacks
     def _soft_disconnect(self, fast=False):
@@ -861,7 +855,7 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
 
         @return: a Deferred that indicates when an attached slave has
         accepted the new builders and/or released the old ones."""
-        for b in self.botmaster.getBuildersForSlave(self.slavename):
+        for b in self.botmaster.getBuildersForSlave(self.name):
             if b.name not in self.slavebuilders:
                 b.addLatentSlave(self)
         return AbstractBuildSlave.updateSlave(self)
@@ -903,12 +897,12 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
 
         @d.addCallback
         def _substantiated(res):
-            log.msg(r"Slave %s substantiated \o/" % self.slavename)
+            log.msg(r"Slave %s substantiated \o/" % self.name)
             self.substantiated = True
             if not self.substantiation_deferred:
-                log.msg("No substantiation deferred for %s" % self.slavename)
+                log.msg("No substantiation deferred for %s" % self.name)
             if self.substantiation_deferred:
-                log.msg("Firing %s substantiation deferred with success" % self.slavename)
+                log.msg("Firing %s substantiation deferred with success" % self.name)
                 d = self.substantiation_deferred
                 self.substantiation_deferred = None
                 self.substantiation_build = None

--- a/master/buildbot/buildslave/manager.py
+++ b/master/buildbot/buildslave/manager.py
@@ -64,10 +64,8 @@ class BuildslaveManager(service.BuildbotServiceManager):
 
     def __init__(self, master):
         service.AsyncMultiService.__init__(self)
-        self.setName('buildslaves')
-        self.master = master
 
-        self.pb = bbpb.Listener(self.master)
+        self.pb = bbpb.Listener(master)
         self.pb.setServiceParent(self)
 
         # BuildslaveRegistration instances keyed by buildslave name

--- a/master/buildbot/buildslave/manager.py
+++ b/master/buildbot/buildslave/manager.py
@@ -66,7 +66,7 @@ class BuildslaveManager(service.BuildbotServiceManager):
         service.AsyncMultiService.__init__(self)
 
         self.pb = bbpb.Listener(master)
-        self.pb.setServiceParent(self)
+        self.pb.setServiceParent(master)
 
         # BuildslaveRegistration instances keyed by buildslave name
         self.registrations = {}

--- a/master/buildbot/buildslave/manager.py
+++ b/master/buildbot/buildslave/manager.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 
 from buildbot.buildslave.protocols import pb as bbpb
-from buildbot.interfaces import IBuildSlave
 from buildbot.process import metrics
 from buildbot.util import misc
 from buildbot.util import service

--- a/master/buildbot/buildslave/protocols/pb.py
+++ b/master/buildbot/buildslave/protocols/pb.py
@@ -23,6 +23,7 @@ from twisted.spread import pb
 
 
 class Listener(base.Listener):
+    name = "pbListener"
 
     def __init__(self, master):
         assert master

--- a/master/buildbot/buildslave/protocols/pb.py
+++ b/master/buildbot/buildslave/protocols/pb.py
@@ -25,6 +25,7 @@ from twisted.spread import pb
 class Listener(base.Listener):
 
     def __init__(self, master):
+        assert master
         base.Listener.__init__(self, master)
 
         # username : (password, portstr, PBManager registration)
@@ -205,8 +206,7 @@ class Connection(base.Connection, pb.Avatar):
         remoteCommand = RemoteCommand(remoteCommand)
         args = self.createArgsProxies(args)
         return slavebuilder.callRemote('startCommand',
-                                       remoteCommand, commandId, commandName, args
-                                       )
+                                       remoteCommand, commandId, commandName, args)
 
     @defer.inlineCallbacks
     def remoteShutdown(self):

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -125,6 +125,10 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         self.name = self.name.decode('ascii', 'replace')
         self.masterid = None
 
+    @property
+    def master(self):
+        return self
+
     def create_child_services(self):
         # note that these are order-dependent.  If you get the order wrong,
         # you'll know it, as the master will fail to start.

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -173,6 +173,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
         self.service_manager = service.BuildbotServiceManager()
         self.service_manager.setServiceParent(self)
+        self.service_manager.reconfig_priority = 1000
 
         self.masterHouskeepingTimer = 0
 

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -67,7 +67,7 @@ class LogRotation(object):
         self.maxRotatedFiles = 10
 
 
-class BuildMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
+class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
     # frequency with which to reclaim running builds; this should be set to
     # something fairly long, to avoid undue database load
@@ -124,10 +124,6 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService)
                                 os.path.abspath(self.basedir or '.')))
         self.name = self.name.decode('ascii', 'replace')
         self.masterid = None
-
-    @property
-    def master(self):
-        return self
 
     def create_child_services(self):
         # note that these are order-dependent.  If you get the order wrong,

--- a/master/buildbot/status/mail.py
+++ b/master/buildbot/status/mail.py
@@ -470,7 +470,6 @@ class MailNotifier(base.StatusReceiverMultiService, buildset.BuildSetSummaryNoti
     def setServiceParent(self, parent):
         self.master_status = parent
         self.master_status.subscribe(self)
-        self.master = self.master_status.master
         return base.StatusReceiverMultiService.setServiceParent(self, parent)
 
     def startService(self):

--- a/master/buildbot/status/status_gerrit.py
+++ b/master/buildbot/status/status_gerrit.py
@@ -246,7 +246,6 @@ class GerritStatusPush(StatusReceiverMultiService, buildset.BuildSetSummaryNotif
         StatusReceiverMultiService.setServiceParent(self, parent)
         self.master_status = self.parent
         self.master_status.subscribe(self)
-        self.master = self.master_status.master
 
     def startService(self):
         print """Starting up."""

--- a/master/buildbot/test/fake/bslavemanager.py
+++ b/master/buildbot/test/fake/bslavemanager.py
@@ -71,5 +71,6 @@ class FakeBuildslaveRegistration(object):
         return defer.succeed(None)
 
     def update(self, slave_config, global_config):
-        self.updates.append(slave_config.slavename)
+        if slave_config.slavename not in self.updates:
+            self.updates.append(slave_config.slavename)
         return defer.succeed(None)

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -59,11 +59,10 @@ class FakeCaches(object):
         return FakeCache(name, miss_fn)
 
 
-class FakeStatus(object):
+class FakeStatus(service.BuildbotService):
 
-    def __init__(self, master):
-        self.master = master
-        self.lastBuilderStatus = None
+    name = "status"
+    lastBuilderStatus = None
 
     def builderAdded(self, name, basedir, tags=None, description=None):
         bs = FakeBuilderStatus(self.master)
@@ -87,6 +86,18 @@ class FakeStatus(object):
 
     def getURLForBuildrequest(self, buildrequestid):
         return "URLForBuildrequest/%d" % (buildrequestid,)
+
+    def subscribe(self, _):
+        pass
+
+    def getTitle(self):
+        return "myBuildbot"
+
+    def getURLForThing(self, _):
+        return "h://thing"
+
+    def getBuildbotURL(self):
+        return "h://bb.me"
 
 
 class FakeBuilderStatus(object):
@@ -152,6 +163,7 @@ class FakeMaster(service.MasterService):
     """
 
     def __init__(self, master_id=fakedb.FakeBuildRequestsComponent.MASTER_ID):
+        service.MasterService.__init__(self)
         self._master_id = master_id
         self.config = config.MasterConfig()
         self.caches = FakeCaches()
@@ -159,13 +171,12 @@ class FakeMaster(service.MasterService):
         self.basedir = 'basedir'
         self.botmaster = FakeBotMaster(master=self)
         self.botmaster.parent = self
-        self.status = FakeStatus(self)
-        self.status.master = self
+        self.status = FakeStatus()
+        self.status.setServiceParent(self)
         self.name = 'fake:/master'
         self.masterid = master_id
         self.buildslaves = bslavemanager.FakeBuildslaveManager(self)
         self.log_rotation = FakeLogRotation()
-        service.MasterService.__init__(self)
 
     def getObjectId(self):
         return defer.succeed(self._master_id)

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -165,14 +165,22 @@ class FakeMaster(object):
         self.buildslaves = bslavemanager.FakeBuildslaveManager(self)
         self.log_rotation = FakeLogRotation()
 
+    @property
+    def master(self):
+        return self
+
     def getObjectId(self):
         return defer.succeed(self._master_id)
 
     def subscribeToBuildRequests(self, callback):
         pass
 
+    def removeService(self, child):
+        pass
 
 # Leave this alias, in case we want to add more behavior later
+
+
 def make_master(wantMq=False, wantDb=False, wantData=False,
                 testcase=None, url=None, **kwargs):
     master = FakeMaster(**kwargs)

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -165,6 +165,7 @@ class FakeMaster(service.MasterService):
         self.masterid = master_id
         self.buildslaves = bslavemanager.FakeBuildslaveManager(self)
         self.log_rotation = FakeLogRotation()
+        service.MasterService.__init__(self)
 
     def getObjectId(self):
         return defer.succeed(self._master_id)

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -25,6 +25,7 @@ from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemq
 from buildbot.test.fake import pbmanager
 from buildbot.test.fake.botmaster import FakeBotMaster
+from buildbot.util import service
 from twisted.internet import defer
 from zope.interface import implements
 
@@ -141,7 +142,7 @@ class FakeLogRotation(object):
     maxRotatedFiles = 42
 
 
-class FakeMaster(object):
+class FakeMaster(service.MasterService):
 
     """
     Create a fake Master instance: a Mock with some convenience
@@ -165,17 +166,10 @@ class FakeMaster(object):
         self.buildslaves = bslavemanager.FakeBuildslaveManager(self)
         self.log_rotation = FakeLogRotation()
 
-    @property
-    def master(self):
-        return self
-
     def getObjectId(self):
         return defer.succeed(self._master_id)
 
     def subscribeToBuildRequests(self, callback):
-        pass
-
-    def removeService(self, child):
         pass
 
 # Leave this alias, in case we want to add more behavior later

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -173,7 +173,8 @@ class RunSteps(unittest.TestCase):
 
         self.slave = BuildSlave('bsl', 'pass')
         self.slave.sendBuilderList = lambda: defer.succeed(None)
-        self.slave.botmaster = mock.Mock()
+        self.slave.parent = mock.Mock()
+        self.slave.master.botmaster = mock.Mock()
         self.slave.botmaster.maybeStartBuildsForSlave = lambda sl: None
         self.slave.botmaster.getBuildersForSlave = lambda sl: []
         self.slave.parent = self.master

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -175,6 +175,7 @@ class RunSteps(unittest.TestCase):
         self.slave.sendBuilderList = lambda: defer.succeed(None)
         self.slave.botmaster = mock.Mock()
         self.slave.botmaster.maybeStartBuildsForSlave = lambda sl: None
+        self.slave.botmaster.getBuildersForSlave = lambda sl: []
         self.slave.parent = self.master
         self.slave.startService()
         self.conn = fakeprotocol.FakeConnection(self.master, self.slave)

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -175,7 +175,7 @@ class RunSteps(unittest.TestCase):
         self.slave.sendBuilderList = lambda: defer.succeed(None)
         self.slave.botmaster = mock.Mock()
         self.slave.botmaster.maybeStartBuildsForSlave = lambda sl: None
-        self.slave.master = self.master
+        self.slave.parent = self.master
         self.slave.startService()
         self.conn = fakeprotocol.FakeConnection(self.master, self.slave)
         yield self.slave.attached(self.conn)

--- a/master/buildbot/test/integration/test_customservices.py
+++ b/master/buildbot/test/integration/test_customservices.py
@@ -31,7 +31,7 @@ class CustomServiceMaster(RunMasterBase):
 
         self.assertEqual(build['steps'][0]['state_string'], 'num reconfig: 1')
 
-        myService = self.master.namedServices['myService']
+        myService = self.master.service_manager.namedServices['myService']
         self.assertEqual(myService.num_reconfig, 1)
         self.assertTrue(myService.running)
 
@@ -46,7 +46,7 @@ class CustomServiceMaster(RunMasterBase):
 
         yield self.master.reconfig()
 
-        myService2 = self.master.namedServices['myService2']
+        myService2 = self.master.service_manager.namedServices['myService2']
 
         self.assertTrue(myService2.running)
         self.assertEqual(myService2.num_reconfig, 3)
@@ -55,7 +55,7 @@ class CustomServiceMaster(RunMasterBase):
         yield self.master.reconfig()
 
         # second service removed
-        self.assertNotIn('myService2', self.master.namedServices)
+        self.assertNotIn('myService2', self.master.service_manager.namedServices)
         self.assertFalse(myService2.running)
         self.assertEqual(myService2.num_reconfig, 3)
         self.assertEqual(myService.num_reconfig, 4)
@@ -79,7 +79,7 @@ def masterConfig():
     class MyShellCommand(ShellCommand):
 
         def getResultSummary(self):
-            service = self.master.namedServices['myService']
+            service = self.master.service_manager.namedServices['myService']
             return dict(step=u"num reconfig: %d" % (service.num_reconfig,))
 
     class MyService(BuildbotService):

--- a/master/buildbot/test/integration/test_slave_comm.py
+++ b/master/buildbot/test/integration/test_slave_comm.py
@@ -147,6 +147,7 @@ class TestSlaveComm(unittest.TestCase):
     @ivar connector: outbound TCP connection from slave to master
     """
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.master = fakemaster.make_master(testcase=self, wantMq=True,
                                              wantData=True, wantDb=True)
@@ -154,15 +155,17 @@ class TestSlaveComm(unittest.TestCase):
         # set the slave port to a loopback address with unspecified
         # port
         self.pbmanager = self.master.pbmanager = pbmanager.PBManager()
-        self.pbmanager.startService()
+        self.pbmanager.setServiceParent(self.master)
 
         self.buildslaves = self.master.buildslaves = bslavemanager.BuildslaveManager(self.master)
-        self.buildslaves.startService()
+        self.buildslaves.setServiceParent(self.master)
 
         self.botmaster = botmaster.BotMaster(self.master)
-        self.botmaster.startService()
+        self.botmaster.setServiceParent(self.master)
 
         self.master.status = master.Status(self.master)
+        self.master.botmaster = self.botmaster
+        yield self.master.startService()
 
         self.buildslave = None
         self.port = None

--- a/master/buildbot/test/integration/test_slave_comm.py
+++ b/master/buildbot/test/integration/test_slave_comm.py
@@ -165,6 +165,7 @@ class TestSlaveComm(unittest.TestCase):
 
         self.master.status = master.Status(self.master)
         self.master.botmaster = self.botmaster
+        self.master.data.updates.buildslaveConfigured = lambda *a, **k: None
         yield self.master.startService()
 
         self.buildslave = None

--- a/master/buildbot/test/unit/test_buildslave_base.py
+++ b/master/buildbot/test/unit/test_buildslave_base.py
@@ -192,7 +192,7 @@ class TestAbstractBuildSlave(unittest.TestCase):
         old.missing_timer = mock.Mock(name='missing_timer')
         yield old.startService()
 
-        yield old.reconfigService(*new._config_args, **new._config_kwargs)
+        yield old.reconfigServiceWithSibling(new)
 
     @defer.inlineCallbacks
     def test_reconfigService_attrs(self):
@@ -237,8 +237,6 @@ class TestAbstractBuildSlave(unittest.TestCase):
     def test_stopService(self):
         slave = self.createBuildslave()
         yield slave.startService()
-
-        yield slave.reconfigService(*slave._config_args, **slave._config_kwargs)
 
         reg = slave.registration
 
@@ -446,7 +444,7 @@ class TestAbstractBuildSlave(unittest.TestCase):
         yield slave.startService()
 
         yield slave.shutdown()
-        self.assertEqual(slave.conn.remoteCalls, [('remoteShutdown',)])
+        self.assertEqual(slave.conn.remoteCalls, [('remoteSetBuilderList', []), ('remoteShutdown',)])
 
     @defer.inlineCallbacks
     def test_slave_shutdown_not_connected(self):

--- a/master/buildbot/test/unit/test_buildslave_base.py
+++ b/master/buildbot/test/unit/test_buildslave_base.py
@@ -110,9 +110,7 @@ class RealBuildSlaveItfc(unittest.TestCase, BuildSlaveInterfaceTests):
         self.buildslaves = bslavemanager.FakeBuildslaveManager(self.master)
         self.master.botmaster = self.botmaster
         self.master.buildslaves = self.buildslaves
-        self.sl.parent = self.master
-        self.sl.botmaster = self.botmaster
-        self.sl.manager = self.buildslaves
+        self.sl.setServiceParent(self.master.buildslaves)
         self.conn = fakeprotocol.FakeConnection(self.master, self.sl)
         return self.sl.attached(self.conn)
 
@@ -133,17 +131,16 @@ class TestAbstractBuildSlave(unittest.TestCase):
     def setUp(self):
         self.master = fakemaster.make_master(wantDb=True, wantData=True,
                                              testcase=self)
-        self.botmaster = botmaster.FakeBotMaster(self.master)
+        self.botmaster = self.master.botmaster
         self.buildslaves = bslavemanager.FakeBuildslaveManager(self.master)
         self.clock = task.Clock()
         self.patch(reactor, 'callLater', self.clock.callLater)
         self.patch(reactor, 'seconds', self.clock.seconds)
 
-    def createBuildslave(self, name='bot', password='pass', attached=False, **kwargs):
+    def createBuildslave(self, name='bot', password='pass', attached=False, configured=True, **kwargs):
         slave = ConcreteBuildSlave(name, password, **kwargs)
-        slave.parent = self.master
-        slave.botmaster = self.botmaster
-        slave.manager = self.buildslaves
+        if configured:
+            slave.setServiceParent(self.buildslaves)
         if attached:
             slave.conn = fakeprotocol.FakeConnection(self.master, slave)
         return slave
@@ -201,7 +198,7 @@ class TestAbstractBuildSlave(unittest.TestCase):
                                     notify_on_missing=['me@me.com'],
                                     missing_timeout=120,
                                     properties={'a': 'b'})
-        new = self.createBuildslave('bot', 'pass',
+        new = self.createBuildslave('bot', 'pass', configured=False,
                                     max_builds=3,
                                     notify_on_missing=['her@me.com'],
                                     missing_timeout=121,
@@ -395,6 +392,7 @@ class TestAbstractBuildSlave(unittest.TestCase):
     def test_attached_callsMaybeStartBuildsForSlave(self):
         slave = self.createBuildslave()
         yield slave.startService()
+        yield slave.reconfigServiceWithSibling(slave)
 
         conn = fakeprotocol.FakeConnection(slave.master, slave)
         conn.info = {}

--- a/master/buildbot/test/unit/test_status_gerrit.py
+++ b/master/buildbot/test/unit/test_status_gerrit.py
@@ -91,8 +91,8 @@ def _get_prepared_gsp(*args, **kwargs):
     parameters.
     """
     gsp = GerritStatusPush('host.example.com', 'username', *args, **kwargs)
-
-    gsp.master = fakemaster.make_master()
+    master = fakemaster.make_master()
+    gsp.setServiceParent(master.status)
     gsp.master_status = gsp.master.status
 
     gsp.sendCodeReview = Mock()

--- a/master/buildbot/test/unit/test_status_mail.py
+++ b/master/buildbot/test/unit/test_status_mail.py
@@ -77,6 +77,11 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         self.master = fakemaster.make_master(testcase=self,
                                              wantData=True, wantDb=True, wantMq=True)
 
+    def setupMailNotifier(self, mn):
+        self.status = self.master.status
+        mn.setServiceParent(self.status)
+        self.status.setServiceParent(self.master)
+
     def do_test_createEmail_cte(self, funnyChars, expEncoding):
         builds = [FakeBuildStatus(name='build')]
         msgdict = create_msgdict(funnyChars)
@@ -288,10 +293,7 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
             fakedb.Build(number=0, buildrequestid=12, buildslaveid=13,
                          masterid=92),
         ])
-        mn.master = self.master
-
-        self.status = Mock()
-        mn.master_status = Mock()
+        self.setupMailNotifier(mn)
         mn.master_status.getBuilder = fakeGetBuilder
         mn.buildMessageDict = Mock()
         mn.buildMessageDict.return_value = {"body": "body", "type": "text",
@@ -347,10 +349,7 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
             fakedb.Build(number=0, buildrequestid=11, buildslaveid=13,
                          masterid=92),
         ])
-        mn.master = self.master
-
-        self.status = Mock()
-        mn.master_status = Mock()
+        self.setupMailNotifier(mn)
         mn.master_status.getBuilder = fakeGetBuilder
         mn.buildMessageDict = Mock()
         mn.buildMessageDict.return_value = {"body": "body", "type": "text",
@@ -405,7 +404,7 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
             fakedb.Build(number=0, buildrequestid=11, buildslaveid=13,
                          masterid=92),
         ])
-        mn.master = self.master
+        self.setupMailNotifier(mn)
 
         builder = Mock()
         builder.getBuild = fakeGetBuild
@@ -419,8 +418,6 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         build.getBuilder.return_value = builder
         build.getResults.return_value = build.results
 
-        self.status = Mock()
-        mn.master_status = Mock()
         mn.master_status.getBuilder = fakeGetBuilder
 
         ss1 = FakeSource(revision='111222', codebase='testlib1')
@@ -482,7 +479,7 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
             fakedb.Build(number=0, buildrequestid=11, buildslaveid=13,
                          masterid=22),
         ])
-        mn.master = self.master
+        self.setupMailNotifier(mn)
 
         builder = Mock()
         builder.getBuild = fakeGetBuild
@@ -496,8 +493,6 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         build.getBuilder.return_value = builder
         build.getResults.return_value = build.results
 
-        self.status = Mock()
-        mn.master_status = Mock()
         mn.master_status.getBuilder = fakeGetBuilder
 
         ss1 = FakeSource(revision='111222', codebase='testlib1')
@@ -798,8 +793,8 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
             return ["Big Bob <bob@mayhem.net>"]
         build.getResponsibleUsers = _getResponsibleUsers
 
-        mn.master = self.master
-        self.status = mn.master_status = mn.buildMessageDict = Mock()
+        self.setupMailNotifier(mn)
+        mn.buildMessageDict = Mock()
         mn.master_status.getBuilder = fakeGetBuilder
         mn.buildMessageDict.return_value = {"body": "body", "type": "text"}
 
@@ -924,8 +919,8 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         build1.getSourceStamps = fakeGetSSlist(ss1)
         build2.getSourceStamps = fakeGetSSlist(ss2)
 
-        mn.master = self.master
-        self.status = mn.master_status = mn.buildMessageDict = Mock()
+        self.setupMailNotifier(mn)
+        mn.buildMessageDict = Mock()
         mn.master_status.getBuilder = fakeGetBuilder
         mn.buildMessageDict.return_value = {"body": "body", "type": "text"}
 

--- a/master/buildbot/test/unit/test_util_service.py
+++ b/master/buildbot/test/unit/test_util_service.py
@@ -547,7 +547,7 @@ class fakeConfig(object):
     pass
 
 
-class fakeMaster(service.AsyncMultiService, service.ReconfigurableServiceMixin):
+class fakeMaster(service.MasterService, service.ReconfigurableServiceMixin):
     pass
 
 
@@ -622,3 +622,116 @@ class BuildbotService(unittest.TestCase):
 
     def testChecksDone(self):
         self.assertRaises(config.ConfigErrors, lambda: MyService(1, name="foo"))
+
+
+class BuildbotServiceManager(unittest.TestCase):
+
+    def setUp(self):
+        self.master = fakeMaster()
+
+    @defer.inlineCallbacks
+    def prepareService(self):
+        self.master.config = fakeConfig()
+        serv = MyService(1, a=2, name="basic")
+        self.master.config.services = {"basic": serv}
+        self.manager = service.BuildbotServiceManager()
+        yield self.manager.setServiceParent(self.master)
+        yield self.master.startService()
+        yield self.master.reconfigServiceWithBuildbotConfig(self.master.config)
+        defer.returnValue(serv)
+
+    @defer.inlineCallbacks
+    def testNominal(self):
+        yield self.prepareService()
+        self.assertEqual(self.manager.namedServices["basic"].config, ((1,), dict(a=2)))
+
+    @defer.inlineCallbacks
+    def testReconfigNoChange(self):
+        serv = yield self.prepareService()
+        serv.config = None  # 'de-configure' the service
+        # reconfigure with the same config
+        serv2 = MyService(1, a=2, name="basic")
+        self.master.config.services = {"basic": serv2}
+
+        # reconfigure the master
+        yield self.master.reconfigServiceWithBuildbotConfig(self.master.config)
+        # the first service is still used
+        self.assertIdentical(self.manager.namedServices["basic"], serv)
+        # the second service is not used
+        self.assertNotIdentical(self.manager.namedServices["basic"], serv2)
+
+        # reconfigServiceWithConstructorArgs was not called
+        self.assertEqual(serv.config, None)
+
+    @defer.inlineCallbacks
+    def testReconfigWithChanges(self):
+        serv = yield self.prepareService()
+        serv.config = None  # 'de-configure' the service
+
+        # reconfigure with the differnt config
+        serv2 = MyService(1, a=4, name="basic")
+        self.master.config.services = {"basic": serv2}
+
+        # reconfigure the master
+        yield self.master.reconfigServiceWithBuildbotConfig(self.master.config)
+        # the first service is still used
+        self.assertIdentical(self.manager.namedServices["basic"], serv)
+        # the second service is not used
+        self.assertNotIdentical(self.manager.namedServices["basic"], serv2)
+
+        # reconfigServiceWithConstructorArgs was called with new config
+        self.assertEqual(serv.config, ((1,), dict(a=4)))
+
+    def testNoName(self):
+        self.assertRaises(ValueError, lambda: MyService(1, a=2))
+
+    def testChecksDone(self):
+        self.assertRaises(config.ConfigErrors, lambda: MyService(1, name="foo"))
+
+    @defer.inlineCallbacks
+    def testReconfigWithNew(self):
+        serv = yield self.prepareService()
+
+        # reconfigure with the new service
+        serv2 = MyService(1, a=4, name="basic2")
+        self.master.config.services['basic2'] = serv2
+
+        # the second service is not there yet
+        self.assertIdentical(self.manager.namedServices.get("basic2"), None)
+
+        # reconfigure the master
+        yield self.master.reconfigServiceWithBuildbotConfig(self.master.config)
+
+        # the first service is still used
+        self.assertIdentical(self.manager.namedServices["basic"], serv)
+        # the second service is created
+        self.assertIdentical(self.manager.namedServices["basic2"], serv2)
+
+        # reconfigServiceWithConstructorArgs was called with new config
+        self.assertEqual(serv2.config, ((1,), dict(a=4)))
+
+    @defer.inlineCallbacks
+    def testReconfigWithDeleted(self):
+        serv = yield self.prepareService()
+        self.assertEqual(serv.running, True)
+
+        # remove all
+        self.master.config.services = {}
+
+        # reconfigure the master
+        yield self.master.reconfigServiceWithBuildbotConfig(self.master.config)
+
+        # the first service is still used
+        self.assertIdentical(self.manager.namedServices.get("basic"), None)
+        self.assertEqual(serv.running, False)
+
+    @defer.inlineCallbacks
+    def testConfigDict(self):
+        yield self.prepareService()
+        self.assertEqual(self.manager.getConfigDict(), {
+            'childs': [{
+                'args': (1,),
+                'class': 'buildbot.test.unit.test_util_service.MyService',
+                'kwargs': {'a': 2},
+                'name': 'basic'}],
+            'name': 'services'})

--- a/master/buildbot/test/util/changesource.py
+++ b/master/buildbot/test/util/changesource.py
@@ -52,8 +52,11 @@ class ChangeSourceMixin(object):
     def attachChangeSource(self, cs):
         "Set up a change source for testing; sets its .master attribute"
         self.changesource = cs
-        self.changesource.master = self.master
-
+        # FIXME some changesource does not have master property yet but mailchangesource has :-/
+        try:
+            self.changesource.master = self.master
+        except AttributeError:
+            self.changesource.setServiceParent(self.master)
         # also, now that changesources are ClusteredServices, setting up
         # the clock here helps in the unit tests that check that behavior
         self.changesource.clock = task.Clock()

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -232,15 +232,7 @@ class AsyncMultiService(AsyncService, service.MultiService):
     def master(self):
         if self.parent is None:
             return None
-        # cache the result if not None
-        master = self.parent.master
-        if master is not None:
-            # note that with this caching, that the object will always keep a reference to master, even if disowned
-            # from the system
-            # There is no circular reference, as the reference from master to the child will disappear with disown
-            # and master object is never recreated
-            self.master = master
-        return master
+        return self.parent.master
 
 
 class MasterService(AsyncMultiService):
@@ -251,7 +243,8 @@ class MasterService(AsyncMultiService):
         return self
 
 
-class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.ComparableMixin):
+class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.ComparableMixin,
+                      ReconfigurableServiceMixin):
     compare_attrs = ('name', '_config_args', '_config_kwargs')
     name = None
     configured = False
@@ -356,4 +349,4 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
 
         for svc in reconfigurable_services:
             config_sibling = new_by_name[svc.name]
-            yield child.reconfigServiceWithSibling(config_sibling)
+            yield svc.reconfigServiceWithSibling(config_sibling)

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -17,6 +17,7 @@ from twisted.application import service
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.python import log
+from twisted.python import reflect
 
 from buildbot import util
 from buildbot.util import config
@@ -238,9 +239,9 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin,
         name = kwargs.pop("name", None)
         if name is not None:
             self.name = name
+        self.checkConfig(*args, **kwargs)
         if self.name is None:
             raise ValueError("%s: must pass a name to constructor" % type(self))
-        self.checkConfig(*args, **kwargs)
         self._config_args = args
         self._config_kwargs = kwargs
         AsyncMultiService.__init__(self)
@@ -263,12 +264,82 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin,
         return self.reconfigService(*config_sibling._config_args,
                                     **config_sibling._config_kwargs)
 
-    def setServiceParent(self, parent):
-        self.master = parent
-        return AsyncService.setServiceParent(self, parent)
+    @property
+    def master(self):
+        if self.parent is None:
+            return None
+        return self.parent.master
 
     def checkConfig(self, *args, **kwargs):
         return defer.succeed(True)
 
     def reconfigService(self, *args, **kwargs):
         return defer.succeed(None)
+
+
+class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
+                             ReconfigurableServiceMixin, util.ComparableMixin):
+    compare_attrs = ('name', '_config_args', '_config_kwargs', 'config_attr')
+    config_attr = "services"
+    name = None
+    configured = False
+
+    def getConfigDict(self):
+        return {'name': self.name,
+                'childs': [v.getConfigDict()
+                           for v in self.namedServices.values()]}
+
+    @defer.inlineCallbacks
+    def reconfigServiceWithBuildbotConfig(self, new_config):
+
+        # arrange childs by name
+        old_by_name = self.namedServices
+        old_set = set(old_by_name.iterkeys())
+        new_config_attr = getattr(new_config, self.config_attr)
+        if isinstance(new_config_attr, list):
+            new_by_name = dict([(s.name, s)
+                                for s in new_config_attr])
+        elif isinstance(new_config_attr, dict):
+            new_by_name = new_config_attr
+        else:
+            raise TypeError("config.%s should be a list or dictionary" % (self.config_attr))
+        new_set = set(new_by_name.iterkeys())
+
+        # calculate new childs, by name, and removed childs
+        removed_names, added_names = util.diffSets(old_set, new_set)
+
+        # find any childs for which the fully qualified class name has
+        # changed, and treat those as an add and remove
+        for n in old_set & new_set:
+            old = old_by_name[n]
+            new = new_by_name[n]
+            # detect changed class name
+            if reflect.qual(old.__class__) != reflect.qual(new.__class__):
+                removed_names.add(n)
+                added_names.add(n)
+
+        if removed_names or added_names:
+            log.msg("adding %d new %s, removing %d" %
+                    (len(added_names), self.config_attr, len(removed_names)))
+
+            for n in removed_names:
+                child = old_by_name[n]
+
+                yield child.disownServiceParent()
+
+            for n in added_names:
+                child = new_by_name[n]
+                yield child.setServiceParent(self)
+
+        for n, child in self.namedServices.iteritems():
+            # get from the config object its sibling config
+            config_sibling = new_by_name[n]
+            # only reconfigure if different as ComparableMixin says.
+            if child.configured and config_sibling == child:
+                continue
+            yield child.reconfigService(*config_sibling._config_args,
+                                        **config_sibling._config_kwargs)
+
+    def setServiceParent(self, parent):
+        self.master = parent
+        return AsyncService.setServiceParent(self, parent)

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -348,5 +348,7 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
         reconfigurable_services.sort(key=lambda svc: -svc.reconfig_priority)
 
         for svc in reconfigurable_services:
-            config_sibling = new_by_name[svc.name]
+            if not svc.name:
+                raise ValueError("%r: child %r should have a defined name attribute", self, svc)
+            config_sibling = new_by_name.get(svc.name)
             yield svc.reconfigServiceWithSibling(config_sibling)


### PR DESCRIPTION
This factorize the buildslave manager child management code to be used
by other managers.

Buildslaves are becoming BuildbotServices, with generic constructor, checkConfig(), and reconfigService()

Notable changes:
- slave.slavename -> slave.name
  This makes naming more generic. slave.slavename is kept as an aliased property

- slave.master -> property
  Special property of BuildbotService climb up the parents until master is found


Baby step for reporter api...