### PR TITLE
stop try to reconnect when buildbot tab is hidden

### DIFF
--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -370,5 +370,7 @@ Here is an nginx configuration that is known to work (nginx 1.6.2):
                   proxy_set_header Upgrade $http_upgrade;
                   proxy_set_header Connection "upgrade";
                   proxy_pass http://localhost:5000/ws;
+                  # raise the proxy timeout for the websocket
+                  proxy_read_timeout 6000s;
             }
     }


### PR DESCRIPTION
use html5 visibility api to do this
add a debug setting

This try to workaround and add debugability for http://trac.buildbot.net/ticket/3242
