### PR TITLE
Git: Do 'submodule sync' before 'submodule update'

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -228,12 +228,14 @@ class Git(Source):
         else:
             yield self._fetchOrFallback()
 
+        yield self._syncSubmodule(None)
         yield self._updateSubmodule(None)
 
     def clean(self):
         command = ['clean', '-f', '-f', '-d']
         d = self._dovccmd(command)
         d.addCallback(self._fetchOrFallback)
+        d.addCallback(self._syncSubmodule)
         d.addCallback(self._updateSubmodule)
         d.addCallback(self._cleanSubmodule)
         return d
@@ -254,6 +256,7 @@ class Git(Source):
         else:
             yield self._doClobber()
             yield self._fullCloneOrFallback()
+        yield self._syncSubmodule()
         yield self._updateSubmodule()
         yield self._cleanSubmodule()
 
@@ -510,6 +513,12 @@ class Git(Source):
         if not changes:
             return None
         return changes[-1].revision
+
+    def _syncSubmodule(self, _=None):
+        if self.submodules:
+            return self._dovccmd(['submodule', 'sync'])
+        else:
+            return defer.succeed(0)
 
     def _updateSubmodule(self, _=None):
         if self.submodules:

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -931,6 +931,9 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
+                        command=['git', 'submodule', 'sync'])
+            + 0,
+            ExpectShell(workdir='wkdir',
                         command=['git', 'submodule', 'update', '--init', '--recursive', '--force'])
             + 0,
             ExpectShell(workdir='wkdir',

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -95,6 +95,8 @@ Fixes
 * :bb:step:`MasterShellCommand` now correctly logs the working directory where it was run.
 * With Git(), force the updating submodules to ensure local changes by the build are overwitten.
   This both ensures more consistent builds and avoids errors when updating submodules.
+* With Git(), make sure 'git submodule sync' is called before 'git submodule update' to update
+  stale remote urls (:bb:bug:`2155`).
 
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
See 'git submodule sync' man page:
"This is useful when submodule URLs change upstream
and you need to update your local repositories accordingly."

Fixes [#2155](http://trac.buildbot.net/ticket/2155)