### PR TITLE
Don't use custom font for log view

### DIFF
--- a/master/buildbot/status/web/files/default.css
+++ b/master/buildbot/status/web/files/default.css
@@ -555,7 +555,6 @@ li {
 /* log view */
 .log * {
 	vlink: #800080;
-	font-family: "Courier New", courier, monotype, monospace;
 }
 
 span.stdout {


### PR DESCRIPTION
Possibly a controversial change, here's my reasoning:
- Let's not force a specific monospace font on the user,
  \<pre\> already renders the text accordingly
- This is an almost raw plain text view, so use the browser defaults
- Courier New is just an awful font