### PR TITLE
Allow function callback for setting codebase in github hook

### DIFF
--- a/master/buildbot/status/web/hooks/github.py
+++ b/master/buildbot/status/web/hooks/github.py
@@ -161,7 +161,9 @@ class GitHubEventHandler(object):
                 'project': project
             }
 
-            if self._codebase is not None:
+            if callable(self._codebase):
+                change['codebase'] = self._codebase(payload)
+            elif self._codebase is not None:
                 change['codebase'] = self._codebase
 
             changes.append(change)

--- a/master/buildbot/test/unit/test_status_web_hooks_github.py
+++ b/master/buildbot/test/unit/test_status_web_hooks_github.py
@@ -28,6 +28,7 @@ from buildbot.test.util import compat
 
 from StringIO import StringIO
 from twisted.trial import unittest
+from twisted.internet import defer
 
 # Sample GITHUB commit payload from http://help.github.com/post-receive-hooks/
 # Added "modfied" and "removed", and change email
@@ -519,3 +520,23 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
             self.assertEqual(self.request.written, expected)
 
         return d
+
+
+class TestChangeHookConfiguredWithCodebaseValue(unittest.TestCase):
+
+    def setUp(self):
+        self.changeHook = _prepare_github_change_hook(codebase='foobar')
+
+    @defer.inlineCallbacks
+    def _check_git_with_change(self, payload):
+        self.request = _prepare_request('push', payload)
+        yield self.request.test_render(self.changeHook)
+        self.assertEquals(len(self.request.addedChanges), 2)
+        change = self.request.addedChanges[0]
+        self.assertEquals(change['codebase'], 'foobar')
+
+    def test_git_with_change_encoded(self):
+        return self._check_git_with_change([gitJsonPayload])
+
+    def test_git_with_change_json(self):
+        return self._check_git_with_change(gitJsonPayload)

--- a/master/buildbot/test/unit/test_status_web_hooks_github.py
+++ b/master/buildbot/test/unit/test_status_web_hooks_github.py
@@ -540,3 +540,28 @@ class TestChangeHookConfiguredWithCodebaseValue(unittest.TestCase):
 
     def test_git_with_change_json(self):
         return self._check_git_with_change(gitJsonPayload)
+
+
+def _codebase_function(payload):
+    return 'foobar-' + payload['repository']['name']
+
+
+class TestChangeHookConfiguredWithCodebaseFunction(unittest.TestCase):
+
+    def setUp(self):
+        self.changeHook = _prepare_github_change_hook(
+            codebase=_codebase_function)
+
+    @defer.inlineCallbacks
+    def _check_git_with_change(self, payload):
+        self.request = _prepare_request('push', payload)
+        yield self.request.test_render(self.changeHook)
+        self.assertEquals(len(self.request.addedChanges), 2)
+        change = self.request.addedChanges[0]
+        self.assertEquals(change['codebase'], 'foobar-github')
+
+    def test_git_with_change_encoded(self):
+        return self._check_git_with_change([gitJsonPayload])
+
+    def test_git_with_change_json(self):
+        return self._check_git_with_change(gitJsonPayload)

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -603,6 +603,7 @@ The GitHub hook has the following parameters:
     If the value is `True`, a secret must be provided, and payloads without signature will be ignored.
 ``codebase`` (default `None`)
     The codebase value to include with created changes.
+    If the value is a function (or any other callable), it will be called with the GitHub event payload as argument and the function must return the codebase value to use for the event.
 ``class`` (default `None`)
     A class to be used for processing incoming payloads.
     If the value is `None` (default), the default class -- :py:class:`buildbot.status.web.hooks.github.GitHubEventHandler` -- will be used.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -87,6 +87,8 @@ Features
 
 * :bb:status:`MailNotifier` no longer forces SSL 3.0 when ``useTls`` is true.
 
+* GitHub change hook now supports function as codebase argument.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
Allow using a function for setting codebase for github change_hook events.  This makes it possible to use it for multiple codebase setups.