### PR TITLE
[eight] FIx sphinx errors

### DIFF
--- a/master/docs/developer/plugins-publish.rst
+++ b/master/docs/developer/plugins-publish.rst
@@ -37,7 +37,9 @@ Buildbot supports several kinds of pluggable components:
 
 which are described in :doc:`../manual/plugins`.
 
-Once you have your component packaged, it's quite straightforward: you just need to add a few lines to the ``entry_points`` parameter of your call of ``setup`` function in :file:`setup.py` file::
+Once you have your component packaged, it's quite straightforward: you just need to add a few lines to the ``entry_points`` parameter of your call of ``setup`` function in :file:`setup.py` file:
+
+.. code-block:: python
 
     setup(
         ...
@@ -53,7 +55,9 @@ Once you have your component packaged, it's quite straightforward: you just need
 (You might have seen different ways to specify the value for ``entry_points``, however they all do the same thing.
 Full description of possible ways is available in `setuptools documentation <http://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins>`_.)
 
-After the :file:`setup.py` file is updated, you can build and install it::
+After the :file:`setup.py` file is updated, you can build and install it:
+
+.. code-block:: bash
 
     $ python setup.py build
     $ sudo python setup.py install

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -166,17 +166,21 @@ At the moment, Buildbot contains two implementations of most source steps:
    Both implementations perform the checkout on the slave side.
    The difference is where the parameters are processed and where the logic is implemented.
 
-   The old source steps are imported like this::
+   The old source steps are imported like this:
+
+   .. code-block:: python
 
        from buildbot.steps.source.oldsource import Git
 
-       ... Git ...
+       # ... Git ...
 
-    while new source steps are in separate Python modules for each version-control system and, using the plugin infrastructure are available as::
+    while new source steps are in separate Python modules for each version-control system and, using the plugin infrastructure are available as:
+
+   .. code-block:: python
 
        from buildbot.plugins import steps
 
-       ... steps.Git ...
+       # ... steps.Git ...
 
 
 New users should, where possible, use the new implementations.
@@ -846,7 +850,9 @@ This rendereable integrates with :bb:chsrc:`GerritChangeSource`, and will automa
 
    You can use the two above Rendereable in conjuction by using the class ``buildbot.process.properties.FlattenList``
 
-for example::
+for example:
+
+.. code-block:: python
 
     ftom buildbot.plugins import steps, util
 

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -641,7 +641,9 @@ The parameters are:
 
 :guilabel:`Secret`
     Any value.
-    If you provide a non-empty value (recommended), make sure that your hook is configured to use it::
+    If you provide a non-empty value (recommended), make sure that your hook is configured to use it:
+
+    .. code-block:: python
 
         c['status'].append(status.WebStatus(...,
                                             change_hook_dialects={
@@ -1530,6 +1532,7 @@ GerritStatusPush can send a separate review for each build that completes, or a 
                           }
 
                       .. literalinclude:: /examples/git_gerrit.cfg
+                         :language: python
                          :pyobject: gerritSummaryCB
 
    :param string identity_file: (optional) Gerrit SSH identity file.

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -225,7 +225,9 @@ It can also be specified with a single ``try_builders`` option in :file:`.buildb
 
     try_builders = ["full-OSX", "full-win32", "full-linux"]
 
-If you are using the PB approach, you can get the names of the builders that are configured for the try scheduler using the ``get-builder-names`` argument::
+If you are using the PB approach, you can get the names of the builders that are configured for the try scheduler using the ``get-builder-names`` argument:
+
+.. code-block:: bash
 
     buildbot try --get-builder-names --connect=pb --master=... --username=... --passwd=...
 

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -1020,7 +1020,9 @@ Distribute a Buildbot Plug-In
 First of all, you must prepare a Python package (if you do not know what that is, please check :doc:`../developer/plugins-publish`, where you can find a couple of pointers to tutorials).
 
 When you have a package, you will have a special file called :file:`setup.py`.
-This file needs to be updated to include a pointer to your new step::
+This file needs to be updated to include a pointer to your new step:
+
+.. code-block:: python
 
     setup(
         ...


### PR DESCRIPTION
When I ran "make docs" I got a bunch of warning-as-errors. This patch fixes them.

Was anyone else getting these? Maybe my sphinx is too old/new and that's why no one else sees them?