### PR TITLE
Dev/api help urlencoding

### DIFF
--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -353,7 +353,7 @@ class HelpResource(HtmlResource):
     def content(self, request, cxt):
         cxt['level'] = self.parent_level
         cxt['text'] = ToHtml(self.text)
-        cxt['children'] = [n for n in self.parent_children if n != 'help']
+        cxt['children'] = [(urllib.quote(n, ''), n) for n in self.parent_children if n != 'help']
         cxt['flags'] = ToHtml(FLAGS)
         cxt['examples'] = ToHtml(EXAMPLES).replace(
             'href="/json',

--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -750,7 +750,7 @@ For help on any sub directory, use url /child/help
                 break
         if not builder:
             return
-        EXAMPLES = EXAMPLES.replace('<A_BUILDER>', builder.getName())
+        EXAMPLES = EXAMPLES.replace('<A_BUILDER>', urllib.quote(builder.getName(), ''))
         build = builder.getBuild(-1)
         if build:
             EXAMPLES = EXAMPLES.replace('<A_BUILD>', str(build.getNumber()))

--- a/master/buildbot/status/web/templates/jsonhelp.html
+++ b/master/buildbot/status/web/templates/jsonhelp.html
@@ -11,9 +11,9 @@
 {% if children %}
 <p>Child Nodes</p>
 <ul>
-{% for child in children %}
-    <li><a href="{{ child|e }}">{{ child|e }}</a>
-        (<a href="{{ child|e }}/help">{{ child|e }}/help</a>)
+{% for child_quoted, child in children %}
+    <li><a href="{{ child_quoted|e }}">{{ child|e }}</a>
+        (<a href="{{ child_quoted|e }}/help">{{ child|e }}/help</a>)
     </li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
We have a lot of builders with slashes in their names. This PR contains commits that makes links to such builders work in the web status/JSON API/help sections.