### PR TITLE
Update makefile frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ pep8:
 frontend:
 	$(PIP) install -e pkg
 	$(PIP) install mock
-	for i in www/{base,codeparameter,console_view,waterfall_view}/; do $(PIP) install -e $$i ; done
+	for i in base codeparameter console_view waterfall_view; do $(PIP) install -e www/$$i ; done
 
 # do installation tests. Test front-end can build and install for all install methods
 frontend_install_tests:


### PR DESCRIPTION
`$ make frontend` is failing on Ubuntu 12
```
for i in www/{base,codeparameter,console_view,waterfall_view}/; do pip install -e $i ; done
www/{base,codeparameter,console_view,waterfall_view}/ should either be a path to a local project or a VCS url beginning with svn+, git+, hg+, or bzr+
Makefile:31: recipe for target 'frontend' failed
```