### PR TITLE
Add toast notification exception interceptor

### DIFF
--- a/www/md_base/src/app/error/error.controller.coffee
+++ b/www/md_base/src/app/error/error.controller.coffee
@@ -1,0 +1,5 @@
+class Error extends Controller
+    constructor: (@$mdToast, @message) ->
+
+    closeToast: ->
+        @$mdToast.hide()

--- a/www/md_base/src/app/error/error.interceptor.coffee
+++ b/www/md_base/src/app/error/error.interceptor.coffee
@@ -1,0 +1,16 @@
+class ExceptionHandlerDecorator extends Config
+    constructor: ($provide) ->
+        name = 'error'
+        $provide.decorator '$exceptionHandler', ($delegate, $injector) ->
+            return (exception, cause) ->
+                $mdToast = $injector.get('$mdToast')
+                $mdToast.show
+                    templateUrl: "views/#{name}.html"
+                    controller: "#{name}Controller"
+                    controllerAs: name
+                    position: 'bottom right'
+                    hideDelay: false
+                    locals:
+                        message: exception.message or exception
+                $delegate(exception, cause)
+        return null

--- a/www/md_base/src/app/error/error.less
+++ b/www/md_base/src/app/error/error.less
@@ -1,0 +1,8 @@
+md-toast.error {
+  background-color: #f44336;
+  color: #ffffff;
+
+  p {
+    margin-right: 15px;
+  }
+}

--- a/www/md_base/src/app/error/error.tpl.jade
+++ b/www/md_base/src/app/error/error.tpl.jade
@@ -1,0 +1,3 @@
+md-toast.error
+    p(flex) ERROR: {{ error.message }}
+    md-button(ng-click='error.closeToast()') ╳


### PR DESCRIPTION
Show errors and uncatched exceptions (eg. `throw 'message'`) in a toast notification.

![image](https://cloud.githubusercontent.com/assets/4157749/7422324/5c4c15e4-ef8c-11e4-9ec5-57d7b9a9d1d3.png)