### PR TITLE
RFC: GerritChangeSource: Translate project names

### DIFF
--- a/master/buildbot/status/status_gerrit.py
+++ b/master/buildbot/status/status_gerrit.py
@@ -333,7 +333,7 @@ class GerritStatusPush(StatusReceiverMultiService, buildset.BuildSetSummaryNotif
 
         # Gerrit + Git
         if build.getProperty("event.change.id") is not None:  # used only to verify Gerrit source
-            project = build.getProperty("project")
+            project = build.getProperty("event.change.project")
             revision = build.getProperty("got_revision") or build.getProperty("revision")
 
             # review doesn't really work with multiple revisions, so let's

--- a/master/buildbot/test/unit/test_status_gerrit.py
+++ b/master/buildbot/test/unit/test_status_gerrit.py
@@ -116,7 +116,8 @@ class TestGerritStatusPush(unittest.TestCase):
         'project': TEST_PROJECT,
         'got_revision': TEST_REVISION,
         'revision': TEST_REVISION,
-        'event.change.id': TEST_CHANGE_ID
+        'event.change.id': TEST_CHANGE_ID,
+        'event.change.project': TEST_PROJECT
     }
     THING_URL = 'http://thing.example.com'
 


### PR DESCRIPTION
There are cases where GerritChangeSource returns project names such as
"foo/bar". We need to be able to translate these project names into ones
that Buildbot can handle.