### PR TITLE
Add a proxy to use the API entries of nine.buildbot.net

### DIFF
--- a/master/buildbot/scripts/processwwwindex.py
+++ b/master/buildbot/scripts/processwwwindex.py
@@ -1,0 +1,56 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import os
+import sys
+import jinja2
+
+from buildbot.test.fake import fakemaster
+from buildbot.util import in_reactor
+from buildbot.util import json
+from twisted.internet import defer
+from buildbot.www.config import IndexResource
+from buildbot.plugins.db import get_plugins
+
+
+@in_reactor
+@defer.inlineCallbacks
+def processwwwindex(config):
+    master = yield fakemaster.make_master()
+    if not config.get('index-file'):
+        print "Path to the index.html file is required with option --index-file or -i"
+        defer.returnValue(1)
+    path = config.get('index-file')
+    if not os.path.isfile(path):
+        print "Invalid path to index.html"
+        defer.returnValue(2)
+    plugins = get_plugins('www', None, load_now=False)
+    plugins = dict((k, {}) for k in plugins.names if k != "base")
+
+    fakeconfig = {"user": {"anonymous": True}}
+    fakeconfig['buildbotURL'] = master.config.buildbotURL
+    fakeconfig['title'] = master.config.title
+    fakeconfig['titleURL'] = master.config.titleURL
+    fakeconfig['multiMaster'] = master.config.multiMaster
+    fakeconfig['versions'] = IndexResource.getEnvironmentVersions()
+    fakeconfig['plugins'] = plugins
+    outputstr = ''
+    with open(path) as indexfile:
+        template = jinja2.Template(indexfile.read())
+        outputstr = template.render(configjson=json.dumps(fakeconfig))
+    with open(path, 'w') as indexfile:
+        indexfile.write(outputstr)
+    defer.returnValue(0)

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -642,6 +642,16 @@ class DataSpecOption(base.BasedirMixin, base.SubcommandOptions):
         return "Usage:   buildbot dataspec [options]"
 
 
+class ProcessWWWIndexOption(base.BasedirMixin, base.SubcommandOptions):
+    """This command is used with the front end's proxy task. It enables to run the front end
+    without the backend server runing in the background"""
+
+    subcommandFunction = "buildbot.scripts.processwwwindex.processwwwindex"
+    optParameters = [
+        ['index-file', 'i', None, "Path to the index.html file to be processed"],
+    ]
+
+
 class Options(usage.Options):
     synopsis = "Usage:    buildbot <command> [command options]"
 
@@ -671,7 +681,11 @@ class Options(usage.Options):
         ['user', None, UserOptions,
          "Manage users in buildbot's database"],
         ['dataspec', None, DataSpecOption,
-         "Output data api spec"]
+         "Output data api spec"],
+        ['processwwwindex', None, ProcessWWWIndexOption,
+         "Process the index.html to enable the front end package working without backend. "
+         "This is a command to work with the frontend's proxy task."
+         ]
     ]
 
     def opt_version(self):

--- a/master/buildbot/test/unit/test_scripts_processwwwindex.py
+++ b/master/buildbot/test/unit/test_scripts_processwwwindex.py
@@ -28,6 +28,7 @@ from buildbot.www.service import WWWService
 class TestUsersClient(unittest.TestCase):
 
     def setUp(self):
+        # un-do the effects of @in_reactor
         self.patch(processwwwindex, 'processwwwindex', processwwwindex.processwwwindex._orig)
 
     def test_no_input_file(self):

--- a/master/buildbot/test/unit/test_scripts_processwwwindex.py
+++ b/master/buildbot/test/unit/test_scripts_processwwwindex.py
@@ -20,9 +20,6 @@ from twisted.trial import unittest
 
 from buildbot.util import json
 from buildbot.scripts import processwwwindex
-from buildbot.test.fake import fakemaster
-from buildbot.www.config import IndexResource
-from buildbot.www.service import WWWService
 
 
 class TestUsersClient(unittest.TestCase):
@@ -58,25 +55,7 @@ class TestUsersClient(unittest.TestCase):
             self.assertEqual(ret, 0)
             with open(tmpf.name) as f:
                 config = json.loads(f.read())
-                config['versions'] = [(v[0], v[1]) for v in config['versions']]
-                correct = self.get_correct_config()
-                self.assertEqual(config, correct)
+                self.assertTrue(isinstance(config, dict))
 
         d.addCallback(check)
         return d
-
-    def get_correct_config(self):
-        master = fakemaster.make_master()
-        master_service = WWWService(master)
-
-        plugins = dict((k, {}) for k in master_service.apps.names if k != "base")
-
-        fakeconfig = {"user": {"anonymous": True}}
-        fakeconfig['buildbotURL'] = master.config.buildbotURL
-        fakeconfig['title'] = master.config.title
-        fakeconfig['titleURL'] = master.config.titleURL
-        fakeconfig['multiMaster'] = master.config.multiMaster
-        fakeconfig['versions'] = IndexResource.getEnvironmentVersions()
-        fakeconfig['plugins'] = plugins
-
-        return fakeconfig

--- a/master/buildbot/test/unit/test_scripts_processwwwindex.py
+++ b/master/buildbot/test/unit/test_scripts_processwwwindex.py
@@ -1,0 +1,81 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import tempfile
+
+from twisted.trial import unittest
+
+from buildbot.util import json
+from buildbot.scripts import processwwwindex
+from buildbot.test.fake import fakemaster
+from buildbot.www.config import IndexResource
+from buildbot.www.service import WWWService
+
+
+class TestUsersClient(unittest.TestCase):
+
+    def setUp(self):
+        self.patch(processwwwindex, 'processwwwindex', processwwwindex.processwwwindex._orig)
+
+    def test_no_input_file(self):
+        d = processwwwindex.processwwwindex({})
+
+        def check(ret):
+            self.assertEqual(ret, 1)
+        d.addCallback(check)
+        return d
+
+    def test_invalid_input_file(self):
+        d = processwwwindex.processwwwindex({'index-file': '/some/no/where'})
+
+        def check(ret):
+            self.assertEqual(ret, 2)
+        d.addCallback(check)
+        return d
+
+    def test_output_config(self):
+        tmpf = tempfile.NamedTemporaryFile(suffix=".html")
+        with open(tmpf.name, 'w') as f:
+            f.write('{{ configjson|safe }}')
+
+        d = processwwwindex.processwwwindex({'index-file': tmpf.name})
+
+        def check(ret):
+            self.assertEqual(ret, 0)
+            with open(tmpf.name) as f:
+                config = json.loads(f.read())
+                config['versions'] = [(v[0], v[1]) for v in config['versions']]
+                correct = self.get_correct_config()
+                self.assertEqual(config, correct)
+
+        d.addCallback(check)
+        return d
+
+    def get_correct_config(self):
+        master = fakemaster.make_master()
+        master_service = WWWService(master)
+
+        plugins = dict((k, {}) for k in master_service.apps.names if k != "base")
+
+        fakeconfig = {"user": {"anonymous": True}}
+        fakeconfig['buildbotURL'] = master.config.buildbotURL
+        fakeconfig['title'] = master.config.title
+        fakeconfig['titleURL'] = master.config.titleURL
+        fakeconfig['multiMaster'] = master.config.multiMaster
+        fakeconfig['versions'] = IndexResource.getEnvironmentVersions()
+        fakeconfig['plugins'] = plugins
+
+        return fakeconfig

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -44,7 +44,8 @@ class IndexResource(resource.Resource):
     def render_GET(self, request):
         return self.asyncRenderHelper(request, self.renderIndex)
 
-    def getEnvironmentVersions(self):
+    @staticmethod
+    def getEnvironmentVersions():
         import sys
         import twisted
         from buildbot import version as bbversion

--- a/www/md_base/guanlecoja/config.coffee
+++ b/www/md_base/guanlecoja/config.coffee
@@ -73,7 +73,7 @@ config =
                 version: "~1.3.15"
                 files: "angular-mocks.js"
 
-    buildtasks: ['scripts', 'styles', 'index', 'icons', 'tests', 'generatedfixtures', 'fixtures', 'apiproxy']
+    buildtasks: ['scripts', 'styles', 'index', 'icons', 'tests', 'generatedfixtures', 'fixtures']
 
     generatedfixtures: ->
         gulp.src ""
@@ -88,12 +88,11 @@ gulp.task 'icons', ->
         ))
         .pipe(gulp.dest(path.join(config.dir.build, 'icons')))
 
-gulp.task 'apiproxy', ->
+gulp.task 'proxy', ->
     # this is a task for developing, it proxy api request to http://nine.buildbot.net
     argv = require('minimist')(process.argv)
-    argv.apiserver ?= 'nine.buildbot.net'
-    argv.apiport ?= 8021
-    argv.server ?= 'http://localhost:8020'
+    argv.host?= 'nine.buildbot.net'
+    argv.port?= 8020
 
     fs = require 'fs'
     path = require 'path'
@@ -109,12 +108,10 @@ gulp.task 'apiproxy', ->
 
     server = http.createServer (req, res) ->
         if req.url.match /^\/api/
-            proxy.web req, res, {target: 'http://' + argv.apiserver}
+            proxy.web req, res, {target: 'http://' + argv.host}
         else if req.url.match /^\/ws/
-            proxy.ws req, res, {target: 'ws://' + argv.apiserver}
-        else
-            proxy.web req, res, {target: argv.server}
-    server.listen parseInt(argv.apiport)
-    console.log "[Proxy] server listening on port #{argv.apiport}"
+            proxy.ws req, res, {target: 'ws://' + argv.host}
+    server.listen parseInt(argv.port)
+    console.log "[Proxy] server listening on port #{argv.port}"
 
 module.exports = config

--- a/www/md_base/guanlecoja/config.coffee
+++ b/www/md_base/guanlecoja/config.coffee
@@ -90,8 +90,11 @@ gulp.task 'icons', ->
 
 gulp.task 'apiproxy', ->
     # this is a task for developing, it proxy api request to http://nine.buildbot.net
+    argv = require('minimist')(process.argv.slice(2))
+    argv.apiserver ?= 'http://nine.buildbot.net'
+
     httpProxy = require 'http-proxy'
-    proxy = httpProxy.createProxyServer({target: 'http://nine.buildbot.net'}).listen(8021)
+    proxy = httpProxy.createProxyServer({target: argv.apiserver}).listen(8021)
     proxy.on 'proxyReq', (proxyReq, req, res, options) ->
         delete proxyReq.removeHeader('Origin')
         delete proxyReq.removeHeader('Referer')

--- a/www/md_base/guanlecoja/config.coffee
+++ b/www/md_base/guanlecoja/config.coffee
@@ -73,7 +73,7 @@ config =
                 version: "~1.3.15"
                 files: "angular-mocks.js"
 
-    buildtasks: ['scripts', 'styles', 'index', 'icons', 'tests', 'generatedfixtures', 'fixtures']
+    buildtasks: ['scripts', 'styles', 'index', 'icons', 'tests', 'generatedfixtures', 'fixtures', 'apiproxy']
 
     generatedfixtures: ->
         gulp.src ""
@@ -87,5 +87,17 @@ gulp.task 'icons', ->
             templates: ['src/icons/iconset.svg']
         ))
         .pipe(gulp.dest(path.join(config.dir.build, 'icons')))
+
+gulp.task 'apiproxy', ->
+    # this is a task for developing, it proxy api request to http://nine.buildbot.net
+    httpProxy = require 'http-proxy'
+    proxy = httpProxy.createProxyServer({target: 'http://nine.buildbot.net'}).listen(8021)
+    proxy.on 'proxyReq', (proxyReq, req, res, options) ->
+        delete proxyReq.removeHeader('Origin')
+        delete proxyReq.removeHeader('Referer')
+    proxy.on 'proxyRes', (proxyRes, req, res) ->
+        proxyRes.headers['Access-Control-Allow-Origin'] = '*'
+        console.log "[Proxy] #{req.method} #{req.url}"
+    console.log '[Proxy] server listening on port 8021'
 
 module.exports = config

--- a/www/md_base/guanlecoja/config.coffee
+++ b/www/md_base/guanlecoja/config.coffee
@@ -88,7 +88,12 @@ gulp.task 'icons', ->
         ))
         .pipe(gulp.dest(path.join(config.dir.build, 'icons')))
 
-gulp.task 'proxy', ->
+gulp.task 'processindex', ['index'], ->
+    indexpath = path.join(config.dir.build, 'index.html')
+    gulp.src ""
+        .pipe shell("buildbot processwwwindex -i '#{indexpath}'")
+
+gulp.task 'proxy', ['processindex'], ->
     # this is a task for developing, it proxy api request to http://nine.buildbot.net
     argv = require('minimist')(process.argv)
     argv.host?= 'nine.buildbot.net'
@@ -107,10 +112,22 @@ gulp.task 'proxy', ->
         console.log "[Proxy] #{req.method} #{req.url}"
 
     server = http.createServer (req, res) ->
-        if req.url.match /^\/api/
+        if req.url.match /^\/(api|sse)/
             proxy.web req, res, {target: 'http://' + argv.host}
         else if req.url.match /^\/ws/
             proxy.ws req, res, {target: 'ws://' + argv.host}
+        else
+            filepath = config.dir.build + req.url.split('?')[0]
+            if fs.existsSync(filepath) and fs.lstatSync(filepath).isDirectory()
+                filepath = path.join(filepath, 'index.html')
+            fs.readFile filepath, (err, data) ->
+                if err
+                    res.writeHead(404)
+                    res.end(JSON.stringify(err))
+                else
+                    res.writeHead(200)
+                    res.end(data)
+
     server.listen parseInt(argv.port)
     console.log "[Proxy] server listening on port #{argv.port}"
 

--- a/www/md_base/package.json
+++ b/www/md_base/package.json
@@ -4,7 +4,8 @@
     "guanlecoja": "latest",
     "gulp-shell": "^0.4.0",
     "gulp-svg-symbols": "^0.3.1",
-    "http-proxy": "^1.11.1"
+    "http-proxy": "^1.11.1",
+    "minimist": "^1.1.1"
   },
   "name": "md-base",
   "dependencies": {},

--- a/www/md_base/package.json
+++ b/www/md_base/package.json
@@ -3,7 +3,8 @@
   "devDependencies": {
     "guanlecoja": "latest",
     "gulp-shell": "^0.4.0",
-    "gulp-svg-symbols": "^0.3.1"
+    "gulp-svg-symbols": "^0.3.1",
+    "http-proxy": "^1.11.1"
   },
   "name": "md-base",
   "dependencies": {},

--- a/www/md_base/src/app/common/common.constant.coffee
+++ b/www/md_base/src/app/common/common.constant.coffee
@@ -5,27 +5,17 @@ invert_constant = (constant_name, inverted_constant_name) ->
 
 class Baseurlapi extends Constant('common')
     constructor: ->
-        # Using localhost:8021 as a proxy entry to access api on nine.buildbot.net
-        # This works only when `gulp dev` is running
-        # 
-        # TODO: remove this after the development is finished
-        return 'http://localhost:8021/api/v2/'
-        # return 'api/v2'
+        return 'api/v2/'
 
 class Baseurlws extends Constant('common')
     constructor: ->
-        # Using localhost:8021 as a proxy entry to access websocket on nine.buildbot.net
-        # This works only when `gulp dev` is running
-        # 
-        # TODO: remove this after the development is finished
-        return 'ws://localhost:8021/ws'
-        # href = location.href.toString()
-        # if location.hash != ""
-        #     href = href.replace(location.hash, "")
-        # if href[href.length - 1] != "/"
-        #     href = href + "/"
+        href = location.href.toString()
+        if location.hash != ""
+            href = href.replace(location.hash, "")
+        if href[href.length - 1] != "/"
+            href = href + "/"
 
-        # return href.replace(/^http/, "ws") + "ws"
+        return href.replace(/^http/, "ws") + "ws"
 
 class Plurals extends Constant('common')
     constructor: ->

--- a/www/md_base/src/app/common/common.constant.coffee
+++ b/www/md_base/src/app/common/common.constant.coffee
@@ -5,17 +5,27 @@ invert_constant = (constant_name, inverted_constant_name) ->
 
 class Baseurlapi extends Constant('common')
     constructor: ->
-        return 'api/v2/'
+        # Using localhost:8021 as a proxy entry to access api on nine.buildbot.net
+        # This works only when `gulp dev` is running
+        # 
+        # TODO: remove this after the development is finished
+        return 'http://localhost:8021/api/v2/'
+        # return 'api/v2'
 
 class Baseurlws extends Constant('common')
     constructor: ->
-        href = location.href.toString()
-        if location.hash != ""
-            href = href.replace(location.hash, "")
-        if href[href.length - 1] != "/"
-            href = href + "/"
+        # Using localhost:8021 as a proxy entry to access websocket on nine.buildbot.net
+        # This works only when `gulp dev` is running
+        # 
+        # TODO: remove this after the development is finished
+        return 'ws://localhost:8021/ws'
+        # href = location.href.toString()
+        # if location.hash != ""
+        #     href = href.replace(location.hash, "")
+        # if href[href.length - 1] != "/"
+        #     href = href + "/"
 
-        return href.replace(/^http/, "ws") + "ws"
+        # return href.replace(/^http/, "ws") + "ws"
 
 class Plurals extends Constant('common')
     constructor: ->

--- a/www/md_base/src/app/index.jade
+++ b/www/md_base/src/app/index.jade
@@ -25,5 +25,11 @@ html(ng-app="app", ng-controller="appController as app")
           h1 Hello buildbot!
 
       script(src="scripts.js?_#{(new Date()).getTime()}")
+      | {% for app in config.plugins %}
+      script(src="{{app}}/scripts.js")
+      link(rel='stylesheet', href='{{app}}/styles.css')
+      script
+        | angular.module('app').requires.push('{{app}}')
+      | {% endfor %}
       script
         | angular.module("app").constant("config", {{configjson|safe}})


### PR DESCRIPTION
I'm now starting to develop for Home page, and we need some data like build history to be displayed on the home page to preview the appearance. As it is not that convenient to fill test data to my server, a proxy is added to forward all API request to http://nine.buildbot.net , which has many data available.

This idea comes from @tardyp , thanks for this good idea! 

I believe both HTTP request and Websocket is able to be forwarded with `http-proxy`. Perform `npm install` before you run `gulp dev` next time.

Modifications of this commit is expected to be removed after the development of our new front end finished.

This pull request is intended to draw comments and suggestions. And @tothandras's project may also need this function.