### PR TITLE
[eight] Backport of my prior updates in Git (Pull #1649)

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -594,7 +594,7 @@ class Git(Source):
         files = cmd.updates['files'][0]
         if '.git' in files:
             defer.returnValue("update")
-        elif len(files) > 0:
+        elif files:
             defer.returnValue("clobber")
 
         defer.returnValue("clone")

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -122,7 +122,6 @@ class Git(Source):
         self.retryFetch = retryFetch
         self.submodules = submodules
         self.shallow = shallow
-        self.fetchcount = 0
         self.clobberOnFailure = clobberOnFailure
         self.mode = mode
         self.getDescription = getDescription

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -581,7 +581,7 @@ class Git(Source):
         cmd = buildstep.RemoteCommand('listdir',
                                       {'dir': self.workdir,
                                        'logEnviron': self.logEnviron,
-                                       'timeout': self.timeout, })
+                                       'timeout': self.timeout})
         cmd.useLog(self.stdio_log, False)
         yield self.runCommand(cmd)
 

--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -71,7 +71,7 @@ class ITestInterface(IPlugin):
     """
     test interface
     """
-    def hello(name):
+    def hello(self, name):
         "Greets by :param:`name`"
 
 


### PR DESCRIPTION
This backports from the change merged in Pull #1649:
 * move a couple functions to inlineCallbacks
 * remove unused variable
 * also fix a pylint complaint