### PR TITLE
Some clean-up of buildslave unit tests,

### DIFF
--- a/slave/buildslave/test/unit/test_commands_bk.py
+++ b/slave/buildslave/test/unit/test_commands_bk.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildslave.commands import bk
@@ -28,6 +29,7 @@ class TestBK(SourceCommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.patch_getCommand('bk', 'path/to/bk')
         self.clean_environ()
@@ -63,7 +65,7 @@ class TestBK(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
+        yield self.run_command()
+
         # TODO: why the extra quotes?
-        d.addCallback(self.check_sourcedata, '"http://bkdemo.bkbits.net/bk_demo1\n"')
-        return d
+        self.assertSourceData('"http://bkdemo.bkbits.net/bk_demo1\n"')

--- a/slave/buildslave/test/unit/test_commands_bzr.py
+++ b/slave/buildslave/test/unit/test_commands_bzr.py
@@ -15,6 +15,7 @@
 
 import textwrap
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildslave.commands import bzr
@@ -30,6 +31,7 @@ class TestBzr(SourceCommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.patch_getCommand('bzr', 'path/to/bzr')
         self.clean_environ()
@@ -72,6 +74,7 @@ class TestBzr(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "http://bazaar.launchpad.net/~bzr/bzr-gtk/trunk\n")
-        return d
+        yield self.run_command()
+
+        self.assertSourceData(
+            "http://bazaar.launchpad.net/~bzr/bzr-gtk/trunk\n")

--- a/slave/buildslave/test/unit/test_commands_cvs.py
+++ b/slave/buildslave/test/unit/test_commands_cvs.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildslave.commands import cvs
@@ -28,6 +29,7 @@ class TestCVS(SourceCommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.patch_getCommand('cvs', 'path/to/cvs')
         self.clean_environ()
@@ -57,7 +59,7 @@ class TestCVS(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata,
-                      ":pserver:anoncvs@anoncvs.NetBSD.org:/cvsroot\nhtdocs\nNone\n")
-        return d
+        yield self.run_command()
+
+        self.assertSourceData(
+            ":pserver:anoncvs@anoncvs.NetBSD.org:/cvsroot\nhtdocs\nNone\n")

--- a/slave/buildslave/test/unit/test_commands_darcs.py
+++ b/slave/buildslave/test/unit/test_commands_darcs.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildslave.commands import darcs
@@ -28,6 +29,7 @@ class TestDarcs(SourceCommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.patch_getCommand('darcs', 'path/to/darcs')
         self.clean_environ()
@@ -63,9 +65,9 @@ class TestDarcs(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "http://darcs.net\n")
-        return d
+        yield self.run_command()
+
+        self.assertSourceData("http://darcs.net\n")
 
 example_changes = """\
 

--- a/slave/buildslave/test/unit/test_commands_fs.py
+++ b/slave/buildslave/test/unit/test_commands_fs.py
@@ -16,6 +16,8 @@
 import os
 import shutil
 
+from os import errno
+
 from twisted.trial import unittest
 
 from buildslave.commands import fs
@@ -23,12 +25,6 @@ from buildslave.commands import utils
 from buildslave.test.util import compat
 from buildslave.test.util.command import CommandTestMixin
 from twisted.internet import defer
-
-# python-2.4 doesn't have os.errno
-if hasattr(os, 'errno'):
-    errno = os.errno
-else:
-    import errno
 
 
 class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
@@ -325,11 +321,6 @@ class TestListDir(CommandTestMixin, unittest.TestCase):
         open(os.path.join(workdir, 'file2'), "w")
 
         yield self.run_command()
-
-        def any(items):  # not a builtin on python-2.4
-            for i in items:
-                if i:
-                    return True
 
         self.assertIn({'rc': 0},
                       self.get_updates(),

--- a/slave/buildslave/test/unit/test_commands_fs.py
+++ b/slave/buildslave/test/unit/test_commands_fs.py
@@ -20,9 +20,9 @@ from twisted.trial import unittest
 
 from buildslave.commands import fs
 from buildslave.commands import utils
+from buildslave.test.util import compat
 from buildslave.test.util.command import CommandTestMixin
 from twisted.internet import defer
-from twisted.python import runtime
 
 # python-2.4 doesn't have os.errno
 if hasattr(os, 'errno'):
@@ -53,10 +53,10 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
                       self.get_updates(),
                       self.builder.show())
 
+    # we only use rmdirRecursive on windows
+    @compat.skipUnlessPlatformIs("win32")
     @defer.inlineCallbacks
     def test_simple_exception(self):
-        if runtime.platformType == "posix":
-            return  # we only use rmdirRecursive on windows
 
         def fail(dir):
             raise RuntimeError("oh noes")
@@ -111,10 +111,10 @@ class TestCopyDirectory(CommandTestMixin, unittest.TestCase):
                       self.get_updates(),
                       self.builder.show())
 
+    # we only use rmdirRecursive on windows
+    @compat.skipUnlessPlatformIs("win32")
     @defer.inlineCallbacks
     def test_simple_exception(self):
-        if runtime.platformType == "posix":
-            return  # we only use rmdirRecursive on windows
 
         def fail(src, dest):
             raise RuntimeError("oh noes")

--- a/slave/buildslave/test/unit/test_commands_fs.py
+++ b/slave/buildslave/test/unit/test_commands_fs.py
@@ -21,6 +21,7 @@ from twisted.trial import unittest
 from buildslave.commands import fs
 from buildslave.commands import utils
 from buildslave.test.util.command import CommandTestMixin
+from twisted.internet import defer
 from twisted.python import runtime
 
 # python-2.4 doesn't have os.errno
@@ -38,20 +39,21 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.make_command(fs.RemoveDirectory, dict(
             dir='workdir',
         ), True)
-        d = self.run_command()
 
-        def check(_):
-            self.assertFalse(os.path.exists(os.path.abspath(os.path.join(self.basedir, 'workdir'))))
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
 
+        self.assertFalse(os.path.exists(
+            os.path.abspath(os.path.join(self.basedir, 'workdir'))))
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
+
+    @defer.inlineCallbacks
     def test_simple_exception(self):
         if runtime.platformType == "posix":
             return  # we only use rmdirRecursive on windows
@@ -59,31 +61,30 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
         def fail(dir):
             raise RuntimeError("oh noes")
         self.patch(utils, 'rmdirRecursive', fail)
+
         self.make_command(fs.RemoveDirectory, dict(
             dir='workdir',
         ), True)
-        d = self.run_command()
 
-        def check(_):
-            self.assertIn({'rc': -1}, self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
 
+        self.assertIn({'rc': -1}, self.get_updates(), self.builder.show())
+
+    @defer.inlineCallbacks
     def test_multiple_dirs(self):
         self.make_command(fs.RemoveDirectory, dict(
             dir=['workdir', 'sourcedir'],
         ), True)
-        d = self.run_command()
 
-        def check(_):
-            for dirname in ['workdir', 'sourcedir']:
-                self.assertFalse(os.path.exists(os.path.abspath(os.path.join(self.basedir, dirname))))
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
+
+        for dirname in ['workdir', 'sourcedir']:
+            self.assertFalse(os.path.exists(
+                os.path.abspath(os.path.join(self.basedir, dirname))))
+
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
 
 class TestCopyDirectory(CommandTestMixin, unittest.TestCase):
@@ -94,21 +95,23 @@ class TestCopyDirectory(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.make_command(fs.CopyDirectory, dict(
             fromdir='workdir',
             todir='copy',
         ), True)
-        d = self.run_command()
 
-        def check(_):
-            self.assertTrue(os.path.exists(os.path.abspath(os.path.join(self.basedir, 'copy'))))
-            self.assertIn({'rc': 0},  # this may ignore a 'header' : '..', which is OK
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
 
+        self.assertTrue(os.path.exists(
+            os.path.abspath(os.path.join(self.basedir, 'copy'))))
+        # this may ignore a 'header' : '..', which is OK
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
+
+    @defer.inlineCallbacks
     def test_simple_exception(self):
         if runtime.platformType == "posix":
             return  # we only use rmdirRecursive on windows
@@ -120,14 +123,12 @@ class TestCopyDirectory(CommandTestMixin, unittest.TestCase):
             fromdir='workdir',
             todir='copy',
         ), True)
-        d = self.run_command()
 
-        def check(_):
-            self.assertIn({'rc': -1},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
+
+        self.assertIn({'rc': -1},
+                      self.get_updates(),
+                      self.builder.show())
 
 
 class TestMakeDirectory(CommandTestMixin, unittest.TestCase):
@@ -138,46 +139,40 @@ class TestMakeDirectory(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.make_command(fs.MakeDirectory, dict(
             dir='test-dir',
         ), True)
-        d = self.run_command()
 
-        def check(_):
-            self.assertTrue(os.path.exists(os.path.abspath(os.path.join(self.basedir, 'test-dir'))))
-            self.assertUpdates(
-                [{'rc': 0}],
-                self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
 
+        self.assertTrue(os.path.exists(
+            os.path.abspath(os.path.join(self.basedir, 'test-dir'))))
+        self.assertUpdates([{'rc': 0}], self.builder.show())
+
+    @defer.inlineCallbacks
     def test_already_exists(self):
         self.make_command(fs.MakeDirectory, dict(
             dir='workdir',
         ), True)
-        d = self.run_command()
 
-        def check(_):
-            self.assertUpdates(
-                [{'rc': 0}],
-                self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
 
+        self.assertUpdates([{'rc': 0}], self.builder.show())
+
+    @defer.inlineCallbacks
     def test_existing_file(self):
         self.make_command(fs.MakeDirectory, dict(
             dir='test-file',
         ), True)
         open(os.path.join(self.basedir, 'test-file'), "w")
-        d = self.run_command()
 
-        def check(_):
-            self.assertIn({'rc': errno.EEXIST},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
+
+        self.assertIn({'rc': errno.EEXIST},
+                      self.get_updates(),
+                      self.builder.show())
 
 
 class TestStatFile(CommandTestMixin, unittest.TestCase):
@@ -188,51 +183,50 @@ class TestStatFile(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_non_existant(self):
         self.make_command(fs.StatFile, dict(
             file='no-such-file',
         ), True)
-        d = self.run_command()
 
-        def check(_):
-            self.assertIn({'rc': errno.ENOENT},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
 
+        self.assertIn({'rc': errno.ENOENT},
+                      self.get_updates(),
+                      self.builder.show())
+
+    @defer.inlineCallbacks
     def test_directory(self):
         self.make_command(fs.StatFile, dict(
             file='workdir',
         ), True)
-        d = self.run_command()
 
-        def check(_):
-            import stat
-            self.assertTrue(stat.S_ISDIR(self.get_updates()[0]['stat'][stat.ST_MODE]))
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
 
+        import stat
+        self.assertTrue(
+            stat.S_ISDIR(self.get_updates()[0]['stat'][stat.ST_MODE]))
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
+
+    @defer.inlineCallbacks
     def test_file(self):
         self.make_command(fs.StatFile, dict(
             file='test-file',
         ), True)
         open(os.path.join(self.basedir, 'test-file'), "w")
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            import stat
-            self.assertTrue(stat.S_ISREG(self.get_updates()[0]['stat'][stat.ST_MODE]))
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        import stat
+        self.assertTrue(
+            stat.S_ISREG(self.get_updates()[0]['stat'][stat.ST_MODE]))
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_file_workdir(self):
         self.make_command(fs.StatFile, dict(
             file='test-file',
@@ -241,16 +235,14 @@ class TestStatFile(CommandTestMixin, unittest.TestCase):
         os.mkdir(os.path.join(self.basedir, 'wd'))
         open(os.path.join(self.basedir, 'wd', 'test-file'), "w")
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            import stat
-            self.assertTrue(stat.S_ISREG(self.get_updates()[0]['stat'][stat.ST_MODE]))
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        import stat
+        self.assertTrue(
+            stat.S_ISREG(self.get_updates()[0]['stat'][stat.ST_MODE]))
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
 
 class TestGlobPath(CommandTestMixin, unittest.TestCase):
@@ -261,49 +253,47 @@ class TestGlobPath(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_non_existant(self):
         self.make_command(fs.GlobPath, dict(
             path='no-*-file',
         ), True)
-        d = self.run_command()
 
-        def check(_):
-            self.assertEqual(self.get_updates()[0]['files'], [])
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
 
+        self.assertEqual(self.get_updates()[0]['files'], [])
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
+
+    @defer.inlineCallbacks
     def test_directory(self):
         self.make_command(fs.GlobPath, dict(
             path='[wxyz]or?d*',
         ), True)
-        d = self.run_command()
 
-        def check(_):
-            self.assertEqual(self.get_updates()[0]['files'], [os.path.join(self.basedir, 'workdir')])
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        yield self.run_command()
 
+        self.assertEqual(self.get_updates()[0]['files'],
+                         [os.path.join(self.basedir, 'workdir')])
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
+
+    @defer.inlineCallbacks
     def test_file(self):
         self.make_command(fs.GlobPath, dict(
             path='t*-file',
         ), True)
         open(os.path.join(self.basedir, 'test-file'), "w")
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertEqual(self.get_updates()[0]['files'], [os.path.join(self.basedir, 'test-file')])
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.get_updates()[0]['files'],
+                         [os.path.join(self.basedir, 'test-file')])
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
 
 class TestListDir(CommandTestMixin, unittest.TestCase):
@@ -314,19 +304,18 @@ class TestListDir(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_non_existant(self):
         self.make_command(fs.ListDir,
                           dict(dir='no-such-dir'),
                           True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertIn({'rc': errno.ENOENT},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertIn({'rc': errno.ENOENT},
+                      self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_dir(self):
         self.make_command(fs.ListDir, dict(
             dir='workdir',
@@ -335,20 +324,18 @@ class TestListDir(CommandTestMixin, unittest.TestCase):
         open(os.path.join(workdir, 'file1'), "w")
         open(os.path.join(workdir, 'file2'), "w")
 
-        d = self.run_command()
+        yield self.run_command()
 
         def any(items):  # not a builtin on python-2.4
             for i in items:
                 if i:
                     return True
 
-        def check(_):
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-            self.failUnless(any([
-                'files' in upd and sorted(upd['files']) == ['file1', 'file2']
-                for upd in self.get_updates()]),
-                self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
+
+        self.failUnless(any([
+            'files' in upd and sorted(upd['files']) == ['file1', 'file2']
+            for upd in self.get_updates()]),
+            self.builder.show())

--- a/slave/buildslave/test/unit/test_commands_git.py
+++ b/slave/buildslave/test/unit/test_commands_git.py
@@ -37,6 +37,7 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
 
     # tests
 
+    @defer.inlineCallbacks
     def test_run_mode_copy_fresh_sourcedir(self):
         "Test a basic invocation with mode=copy and no existing sourcedir"
         self.patch_getCommand('git', 'path/to/git')
@@ -88,10 +89,12 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "git://github.com/djmitche/buildbot.git master\n")
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(
+            "git://github.com/djmitche/buildbot.git master\n")
+
+    @defer.inlineCallbacks
     def test_run_mode_copy_update_sourcedir(self):
         """test a copy where the sourcedata indicates that the source directory
         can be updated"""
@@ -138,10 +141,12 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "git://github.com/djmitche/buildbot.git master\n")
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(
+            "git://github.com/djmitche/buildbot.git master\n")
+
+    @defer.inlineCallbacks
     def test_run_mode_copy_nonexistant_ref(self):
         self.patch_getCommand('git', 'path/to/git')
         self.clean_environ()
@@ -172,9 +177,9 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        return d
+        yield self.run_command()
 
+    @defer.inlineCallbacks
     def test_run_mode_copy_gerrit_branch(self):
         self.patch_getCommand('git', 'path/to/git')
         self.clean_environ()
@@ -221,9 +226,9 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        return d
+        yield self.run_command()
 
+    @defer.inlineCallbacks
     def test_run_mode_update_fresh(self):
         self.patch_getCommand('git', 'path/to/git')
         self.clean_environ()
@@ -267,10 +272,12 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "git://github.com/djmitche/buildbot.git master\n")
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(
+            "git://github.com/djmitche/buildbot.git master\n")
+
+    @defer.inlineCallbacks
     def test_run_mode_update_existing(self):
         self.patch_getCommand('git', 'path/to/git')
         self.clean_environ()
@@ -307,10 +314,11 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "git://github.com/djmitche/buildbot.git master\n")
-        return d
+        yield self.run_command()
+        self.assertSourceData(
+            "git://github.com/djmitche/buildbot.git master\n")
 
+    @defer.inlineCallbacks
     def test_run_mode_update_existing_known_rev(self):
         self.patch_getCommand('git', 'path/to/git')
         self.clean_environ()
@@ -337,10 +345,12 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "git://github.com/djmitche/buildbot.git master\n")
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(
+            "git://github.com/djmitche/buildbot.git master\n")
+
+    @defer.inlineCallbacks
     def test_run_mode_update_existing_unknown_rev(self):
         self.patch_getCommand('git', 'path/to/git')
         self.clean_environ()
@@ -381,10 +391,12 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "git://github.com/djmitche/buildbot.git master\n")
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(
+            "git://github.com/djmitche/buildbot.git master\n")
+
+    @defer.inlineCallbacks
     def test_run_with_reference(self):
         self.patch_getCommand('git', 'path/to/git')
         self.clean_environ()
@@ -435,10 +447,12 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "git://github.com/djmitche/buildbot.git master\n")
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(
+            "git://github.com/djmitche/buildbot.git master\n")
+
+    @defer.inlineCallbacks
     def test_run_with_shallow_and_rev(self):
         self.patch_getCommand('git', 'path/to/git')
         self.clean_environ()
@@ -473,10 +487,12 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "git://github.com/djmitche/buildbot.git master\n")
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(
+            "git://github.com/djmitche/buildbot.git master\n")
+
+    @defer.inlineCallbacks
     def test_run_with_shallow(self):
         self.patch_getCommand('git', 'path/to/git')
         self.clean_environ()
@@ -523,10 +539,12 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "git://github.com/djmitche/buildbot.git master\n")
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(
+            "git://github.com/djmitche/buildbot.git master\n")
+
+    @defer.inlineCallbacks
     def test_run_with_shallow_and_reference(self):
         self.patch_getCommand('git', 'path/to/git')
         self.clean_environ()
@@ -581,10 +599,12 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "git://github.com/djmitche/buildbot.git master\n")
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(
+            "git://github.com/djmitche/buildbot.git master\n")
+
+    @defer.inlineCallbacks
     def test_run_with_submodules(self):
         self.patch_getCommand('git', 'path/to/git')
         self.clean_environ()
@@ -642,9 +662,10 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "git://github.com/djmitche/buildbot.git master\n")
-        return d
+        yield self.run_command()
+
+        self.assertSourceData(
+            "git://github.com/djmitche/buildbot.git master\n")
 
     def test_sourcedataMatches_no_file(self):
         self.make_command(git.Git, dict(
@@ -665,6 +686,7 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
         ), initial_sourcedata='xyz')
         self.assertTrue(self.cmd.sourcedataMatches())
 
+    @defer.inlineCallbacks
     def do_test_parseGotRevision(self, stdout, exp):
         self.make_command(git.Git, dict(
             workdir='workdir',
@@ -680,12 +702,9 @@ class TestGit(SourceCommandTestMixin, unittest.TestCase):
             return d
         self.cmd._dovccmd = _dovccmd
 
-        d = self.cmd.parseGotRevision()
+        res = yield self.cmd.parseGotRevision()
 
-        def check(res):
-            self.assertEqual(res, exp)
-        d.addCallback(check)
-        return d
+        self.assertEqual(res, exp)
 
     def test_parseGotRevision_bogus(self):
         return self.do_test_parseGotRevision("fatal: Couldn't find revision 1234\n", None)

--- a/slave/buildslave/test/unit/test_commands_hg.py
+++ b/slave/buildslave/test/unit/test_commands_hg.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildslave.commands import hg
@@ -31,6 +32,7 @@ class TestMercurial(SourceCommandTestMixin, unittest.TestCase):
     def patch_sourcedirIsUpdateable(self, result):
         self.cmd.sourcedirIsUpdateable = lambda: result
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.patch_getCommand('hg', 'path/to/hg')
         self.clean_environ()
@@ -83,10 +85,11 @@ class TestMercurial(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "http://bitbucket.org/nicolas17/pyboinc\n")
-        return d
+        yield self.run_command()
 
+        self.assertSourceData("http://bitbucket.org/nicolas17/pyboinc\n")
+
+    @defer.inlineCallbacks
     def test_update_existing(self):
         self.patch_getCommand('hg', 'path/to/hg')
         self.clean_environ()
@@ -131,10 +134,12 @@ class TestMercurial(SourceCommandTestMixin, unittest.TestCase):
             + 0,
         ]
         self.patch_runprocess(*expects)
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "http://bitbucket.org/nicolas17/pyboinc\n")
-        return d
 
+        yield self.run_command()
+
+        self.assertSourceData("http://bitbucket.org/nicolas17/pyboinc\n")
+
+    @defer.inlineCallbacks
     def test_update_existing_change_branch(self):
         self.patch_getCommand('hg', 'path/to/hg')
         self.clean_environ()
@@ -186,10 +191,12 @@ class TestMercurial(SourceCommandTestMixin, unittest.TestCase):
 
         ]
         self.patch_runprocess(*expects)
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "http://bitbucket.org/nicolas17/pyboinc\n")
-        return d
 
+        yield self.run_command()
+
+        self.assertSourceData("http://bitbucket.org/nicolas17/pyboinc\n")
+
+    @defer.inlineCallbacks
     def test_update_handle_emptyupdate(self):
         self.patch_getCommand('hg', 'path/to/hg')
         self.clean_environ()
@@ -242,10 +249,12 @@ class TestMercurial(SourceCommandTestMixin, unittest.TestCase):
             + 0,
         ]
         self.patch_runprocess(*expects)
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "http://bitbucket.org/nicolas17/pyboinc\n")
-        return d
 
+        yield self.run_command()
+
+        self.assertSourceData("http://bitbucket.org/nicolas17/pyboinc\n")
+
+    @defer.inlineCallbacks
     def test_update_existing_change_branch_purge_fail(self):
         self.patch_getCommand('hg', 'path/to/hg')
         self.clean_environ()
@@ -322,6 +331,7 @@ class TestMercurial(SourceCommandTestMixin, unittest.TestCase):
 
         ]
         self.patch_runprocess(*expects)
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "http://bitbucket.org/nicolas17/pyboinc\n")
-        return d
+
+        yield self.run_command()
+
+        self.assertSourceData("http://bitbucket.org/nicolas17/pyboinc\n")

--- a/slave/buildslave/test/unit/test_commands_mtn.py
+++ b/slave/buildslave/test/unit/test_commands_mtn.py
@@ -37,6 +37,7 @@ class TestMonotone(SourceCommandTestMixin, unittest.TestCase):
     def patch_sourcedirIsUpdateable(self, result):
         self.cmd.sourcedirIsUpdateable = lambda: result
 
+    @defer.inlineCallbacks
     def test_no_db(self):
         "Test a basic invocation with mode=copy and no existing sourcedir"
         self.patch_getCommand('mtn', 'path/to/mtn')
@@ -90,10 +91,11 @@ class TestMonotone(SourceCommandTestMixin, unittest.TestCase):
 
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, self.repourl + "?" + self.branch)
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(self.repourl + "?" + self.branch)
+
+    @defer.inlineCallbacks
     def test_db_needs_migrating(self):
         "Test a basic invocation with mode=copy and no existing sourcedir"
         self.patch_getCommand('mtn', 'path/to/mtn')
@@ -149,9 +151,9 @@ class TestMonotone(SourceCommandTestMixin, unittest.TestCase):
 
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, self.repourl + "?" + self.branch)
-        return d
+        yield self.run_command()
+
+        self.assertSourceData(self.repourl + "?" + self.branch)
 
     def test_db_too_new(self):
         "Test a basic invocation with mode=copy and no existing sourcedir"
@@ -184,6 +186,7 @@ class TestMonotone(SourceCommandTestMixin, unittest.TestCase):
         d = self.run_command()
         return self.assertFailure(d, mtn.MonotoneError)
 
+    @defer.inlineCallbacks
     def test_run_mode_copy_fresh_sourcedir(self):
         "Test a basic invocation with mode=copy and no existing sourcedir"
         self.patch_getCommand('mtn', 'path/to/mtn')
@@ -233,10 +236,11 @@ class TestMonotone(SourceCommandTestMixin, unittest.TestCase):
 
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, self.repourl + "?" + self.branch)
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(self.repourl + "?" + self.branch)
+
+    @defer.inlineCallbacks
     def test_run_mode_copy_update_sourcedir(self):
         """test a copy where the sourcedata indicates that the source directory
         can be updated"""
@@ -286,10 +290,11 @@ class TestMonotone(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, self.repourl + "?" + self.branch)
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(self.repourl + "?" + self.branch)
+
+    @defer.inlineCallbacks
     def test_run_mode_update_fresh(self):
         self.patch_getCommand('mtn', 'path/to/mtn')
         self.clean_environ()
@@ -333,10 +338,11 @@ class TestMonotone(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, self.repourl + "?" + self.branch)
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(self.repourl + "?" + self.branch)
+
+    @defer.inlineCallbacks
     def test_run_mode_update_existing(self):
         self.patch_getCommand('mtn', 'path/to/mtn')
         self.clean_environ()
@@ -379,10 +385,11 @@ class TestMonotone(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, self.repourl + "?" + self.branch)
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(self.repourl + "?" + self.branch)
+
+    @defer.inlineCallbacks
     def test_run_mode_update_existing_known_rev(self):
         self.patch_getCommand('mtn', 'path/to/mtn')
         self.clean_environ()
@@ -425,10 +432,11 @@ class TestMonotone(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, self.repourl + "?" + self.branch)
-        return d
+        yield self.run_command()
 
+        self.assertSourceData(self.repourl + "?" + self.branch)
+
+    @defer.inlineCallbacks
     def test_run_mode_update_existing_unknown_rev(self):
         self.patch_getCommand('mtn', 'path/to/mtn')
         self.clean_environ()
@@ -486,11 +494,12 @@ class TestMonotone(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, self.repourl + "?" + self.branch)
-        return d
+        yield self.run_command()
+
+        self.assertSourceData(self.repourl + "?" + self.branch)
 
 # Testing parseGotRevision
+    @defer.inlineCallbacks
     def do_test_parseGotRevision(self, stdout, exp):
         self.patch_getCommand('mtn', 'path/to/mtn')
         self.make_command(mtn.Monotone, dict(
@@ -509,12 +518,9 @@ class TestMonotone(SourceCommandTestMixin, unittest.TestCase):
         self.cmd._dovccmd = _dovccmd
         self.cmd.srcdir = self.cmd.workdir
 
-        d = self.cmd.parseGotRevision()
+        res = yield self.cmd.parseGotRevision()
 
-        def check(res):
-            self.assertEqual(res, exp)
-        d.addCallback(check)
-        return d
+        self.assertEqual(res, exp)
 
     def test_parseGotRevision_bogus(self):
         return self.do_test_parseGotRevision("mtn: misuse: no match for selection '1234'\n", None)

--- a/slave/buildslave/test/unit/test_commands_p4.py
+++ b/slave/buildslave/test/unit/test_commands_p4.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildslave.commands import p4
@@ -29,6 +30,7 @@ class TestP4(SourceCommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.patch_getCommand('p4', 'path/to/p4')
         self.clean_environ()
@@ -98,12 +100,13 @@ View:
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "['p4dserv:1666', 'buildbot_test_10', " +
-                      "'//mydepot/myproj/', 'mytrunk', [], None, %s, 'copy', 'workdir']"
-                      % repr(self.basedir))
-        return d
+        yield self.run_command()
+        self.assertSourceData(
+            "['p4dserv:1666', 'buildbot_test_10', " +
+            "'//mydepot/myproj/', 'mytrunk', [], None, %s, 'copy', 'workdir']"
+            % repr(self.basedir))
 
+    @defer.inlineCallbacks
     def test_simple_unicode_args(self):
         self.patch_getCommand('p4', 'path/to/p4')
         self.clean_environ()
@@ -175,12 +178,11 @@ View:
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata,
-                      "['p4dserv:1666\\xe2\\x98\\x83', "
-                      "'buildbot_test_10\\xe2\\x98\\x83', "
-                      "'//mydepot/myproj/\\xe2\\x98\\x83', "
-                      "'mytrunk\\xe2\\x98\\x83', [], None, %s, 'copy', "
-                      "'workdir']"
-                      % repr(self.basedir))
-        return d
+        yield self.run_command()
+        self.assertSourceData(
+            "['p4dserv:1666\\xe2\\x98\\x83', "
+            "'buildbot_test_10\\xe2\\x98\\x83', "
+            "'//mydepot/myproj/\\xe2\\x98\\x83', "
+            "'mytrunk\\xe2\\x98\\x83', [], None, %s, 'copy', "
+            "'workdir']"
+            % repr(self.basedir))

--- a/slave/buildslave/test/unit/test_commands_svn.py
+++ b/slave/buildslave/test/unit/test_commands_svn.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildslave.commands import svn
@@ -28,6 +29,7 @@ class TestSVN(SourceCommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.patch_getCommand('svn', 'path/to/svn')
         self.patch_getCommand('svnversion', 'path/to/svnversion')
@@ -64,9 +66,9 @@ class TestSVN(SourceCommandTestMixin, unittest.TestCase):
         ]
         self.patch_runprocess(*expects)
 
-        d = self.run_command()
-        d.addCallback(self.check_sourcedata, "http://svn.local/app/trunk\n")
-        return d
+        yield self.run_command()
+
+        self.assertSourceData("http://svn.local/app/trunk\n")
 
 
 class TestGetUnversionedFiles(unittest.TestCase):

--- a/slave/buildslave/test/util/sourcecommand.py
+++ b/slave/buildslave/test/util/sourcecommand.py
@@ -76,10 +76,9 @@ class SourceCommandTestMixin(command.CommandTestMixin):
             return r.start()
         cmd.setFileContents = setFileContents
 
-    def check_sourcedata(self, _, expected_sourcedata):
+    def assertSourceData(self, expected_sourcedata):
         """
         Assert that the sourcedata (from the patched functions - see
-        make_command) is correct.  Use this as a deferred callback.
+        make_command) is correct.
         """
         self.assertEqual(self.sourcedata, expected_sourcedata)
-        return _


### PR DESCRIPTION
* use @defer.inlineCallbacks style
* added proper skip decarators for win32 only tests
* drop python 2.4 hacks