### PR TITLE
provide build itself for those who need it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,6 @@ install:
   - (cd master; python setup.py develop)
   - (cd slave;  python setup.py develop)
   # mock is preinstalled on Travis
-  # txgithub requires Twisted >= 12.3.0
-  - pip install txgithub
-  # txrequests support only Python 2.6 and 2.7.
-  - pip install txrequests
 
   # Determine if current configuration is latest
   - |
@@ -63,6 +59,10 @@ install:
     fi;
 
   # Run additional tests only in latest configuration
+  # txrequests support only Python 2.6 and 2.7.
+  - "[ $IS_LATEST = false ] || pip install txrequests"
+  # txgithub requires Twisted >= 12.3.0
+  - "[ $IS_LATEST = false ] || pip install txgithub"
   # Note pylint version is pinned because newer versions can't import zope.interface - http://www.logilab.org/92792
   - "[ $IS_LATEST = false ] || pip install pylint==1.1.0"
   - "[ $IS_LATEST = false ] || pip install pyflakes"

--- a/master/buildbot/status/status_gerrit.py
+++ b/master/buildbot/status/status_gerrit.py
@@ -292,6 +292,7 @@ class GerritStatusPush(StatusReceiverMultiService, buildset.BuildSetSummaryNotif
                         'resultText': resultText,
                         'text': ' '.join(build.getText()),
                         'url': self.master_status.getURLForThing(build),
+                        'build': build
                         }
             buildInfoList = sorted([getBuildInfo(build) for build in builds], key=lambda bi: bi['name'])
 

--- a/master/buildbot/test/unit/test_status_gerrit.py
+++ b/master/buildbot/test/unit/test_status_gerrit.py
@@ -172,6 +172,7 @@ class TestGerritStatusPush(unittest.TestCase):
             for i in xrange(len(buildResults)):
                 info.append({'name': "Builder-%d" % i, 'result': buildResults[i],
                              'resultText': resultText[i], 'text': 'buildText',
+                             'build': buildpairs[i][1],
                              'url': self.THING_URL})
             return str(info)
         return d


### PR DESCRIPTION
Summary callback differs from the review build callback in lack of the
actual build instance: the former only gets particular information about
builds.

In some situations, the build itself is required to do some magic.