### PR TITLE
fix flaky test and cryptography gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
 
   # Determine if current configuration is latest
   - |
-    if [[ $TWISTED == latest && \
+    if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $TWISTED == latest && \
           $SQLALCHEMY = latest && $SQLALCHEMY_MIGRATE = latest ]]; then
       export IS_LATEST=true
     else
@@ -83,13 +83,14 @@ install:
   - (cd master; python setup.py develop)
   - (cd slave;  python setup.py develop)
   # mock is preinstalled on Travis
-  # txgithub requires Twisted >= 12.3.0, so we install it only when we test the
-  # latest Twisted to avoid unintended upgrades.
-  - "[ $IS_LATEST = true ] || pip install txgithub"
   # txrequests support only Python 2.6 and 2.7.
   - pip install txrequests
 
   # Run additional tests only in latest configuration
+  # txgithub requires Twisted >= 12.3.0, so we install it only when we test the
+  # latest Twisted to avoid unintended upgrades.
+  # deps of txgithub cryptography requires python 2.7, so we only install txgithub for 2.7
+  - "[ $IS_LATEST = false ] || pip install txgithub"
   # Astroid 1.3.0 dropped Python-2.6 spuport
   - "[ $IS_LATEST = false ] || pip install 'astroid<1.3.0'"
   # Note pylint version is pinned because newer versions can't import zope.interface - http://www.logilab.org/92792

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -146,6 +146,8 @@ class ShellCommand(buildstep.LoggingBuildStep):
         return None
 
     def describe(self, done=False):
+        if self.stopped and not self.rendered:
+            return u"stopped early"
         assert(self.rendered)
         desc = self._describe(done)
         if not desc:


### PR DESCRIPTION
buildbot.test.integration.test_stop_trigger.TriggeringMaster.testTriggerRunsForever
when a build is cancelled early, self.rendered is not set

Signed-off-by: Pierre Tardy <pierre.tardy@intel.com>