### PR TITLE
[nine] StringDownload: fix an exception that happens if the transfer fails

### DIFF
--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -61,7 +61,7 @@ class _TransferBuildStep(BuildStep):
 
         @d.addCallback
         def checkResult(_):
-            if cmd.didFail():
+            if writer and cmd.didFail():
                 writer.cancel()
             return FAILURE if cmd.didFail() else SUCCESS
 


### PR DESCRIPTION
This is a port to Nine (where I should have done it first) of GH-1657.

Simple 'None' check is required.
Adding new unit test that does fail without the patch.