### PR TITLE
Git: add 'origin' option

### DIFF
--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -474,6 +474,36 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.expectOutcome(result=SUCCESS)
         return self.runStep()
 
+    def test_mode_full_clean_no_existing_repo_with_origin(self):
+        self.setupStep(
+            git.Git(repourl='http://github.com/buildbot/buildbot.git',
+                    mode='full', method='clean', origin='foo'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', [])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clone', '--origin', 'foo',
+                                 'http://github.com/buildbot/buildbot.git', '.'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
     def test_mode_full_clobber(self):
         self.setupStep(
             git.Git(repourl='http://github.com/buildbot/buildbot.git',

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -346,6 +346,10 @@ The Git step takes the following arguments:
    (optional): use the specified string as a path to a reference repository on the local machine.
    Git will try to grab objects from this path first instead of the main repository, if they exist.
 
+``origin``
+   (optional): By default, any clone will use the name "origin" as the remote repository (eg, "origin/master").
+   This renderable option allows that to be configured to an alternate name.
+
 ``progress``
    (optional): passes the (``--progress``) flag to (:command:`git fetch`).
    This solves issues of long fetches being killed due to lack of output, but requires Git 1.7.2 or later.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -105,6 +105,8 @@ Individual features and improvements to the Data API are not described on this p
 
 * :bb:chsrc:`GitPoller` now supports detecting new branches
 
+* :bb:step:`Git` supports an "origin" option to give a name to the remote repo.
+
 Reporters
 ~~~~~~~~~
 


### PR DESCRIPTION
Add an "origin" option to allow the name of the remote repository to be changed. This is renderable, so it can be dynamic.