### PR TITLE
docs: docker: make example code match text

### DIFF
--- a/master/docs/manual/cfg-buildslaves-docker.rst
+++ b/master/docs/manual/cfg-buildslaves-docker.rst
@@ -139,7 +139,7 @@ The following example will add a Docker latent slave for docker running at the f
 
     from buildbot.plugins import buildslave
     c['slaves'] = [
-        buildslave.DockerLatentBuildSlave('minion1', 'sekrit',
+        buildslave.DockerLatentBuildSlave('docker', 'password',
                                           docker_host='tcp://localhost:2375',
                                           image='my_project_slave')
     ]


### PR DESCRIPTION
The username/password didn't match what the text said it should be.