### PR TITLE
test_stop_trigger: fix remote_interruptCommand no attribute error

### DIFF
--- a/master/buildbot/buildslave/protocols/base.py
+++ b/master/buildbot/buildslave/protocols/base.py
@@ -74,7 +74,7 @@ class Connection(object):
     def remoteStartBuild(self, builderName):
         raise NotImplementedError
 
-    def remoteInterruptCommand(self, commandId, why):
+    def remoteInterruptCommand(self, builderName, commandId, why):
         raise NotImplementedError
 
 

--- a/master/buildbot/buildslave/protocols/null.py
+++ b/master/buildbot/buildslave/protocols/null.py
@@ -87,5 +87,6 @@ class Connection(base.Connection):
     def remoteStartBuild(self, builderName):
         return defer.succeed(self.buildslave.bot.builders[builderName].remote_startBuild())
 
-    def remoteInterruptCommand(self, commandId, why):
-        return defer.maybeDeferred(self.buildslave.bot.remote_interruptCommand, commandId, why)
+    def remoteInterruptCommand(self, builderName, commandId, why):
+        slavebuilder = self.buildslave.bot.builders[builderName]
+        return defer.maybeDeferred(slavebuilder.remote_interruptCommand, commandId, why)

--- a/master/buildbot/buildslave/protocols/pb.py
+++ b/master/buildbot/buildslave/protocols/pb.py
@@ -268,8 +268,9 @@ class Connection(base.Connection, pb.Avatar):
         slavebuilder = self.builders.get(builderName)
         return slavebuilder.callRemote('startBuild')
 
-    def remoteInterruptCommand(self, commandId, why):
-        return defer.maybeDeferred(self.mind.callRemote, "interruptCommand",
+    def remoteInterruptCommand(self, builderName, commandId, why):
+        slavebuilder = self.builders.get(builderName)
+        return defer.maybeDeferred(slavebuilder.callRemote, "interruptCommand",
                                    commandId, why)
 
     # perspective methods called by the slave

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -158,7 +158,8 @@ class RemoteCommand(base.RemoteCommandImpl):
         # tell the remote command to halt. Returns a Deferred that will fire
         # when the interrupt command has been delivered.
 
-        d = self.conn.remoteInterruptCommand(self.commandID, str(why))
+        d = self.conn.remoteInterruptCommand(self.builder_name,
+                                             self.commandID, str(why))
         # the slave may not have remote_interruptCommand
         d.addErrback(self._interruptFailed)
         return d

--- a/master/buildbot/test/fake/fakeprotocol.py
+++ b/master/buildbot/test/fake/fakeprotocol.py
@@ -59,6 +59,6 @@ class FakeConnection(base.Connection):
         self.remoteCalls.append(('remoteStartBuild', builderName))
         return defer.succeed(None)
 
-    def remoteInterruptCommand(self, commandId, why):
-        self.remoteCalls.append(('remoteInterruptCommand', commandId, why))
+    def remoteInterruptCommand(self, builderName, commandId, why):
+        self.remoteCalls.append(('remoteInterruptCommand', builderName, commandId, why))
         return defer.succeed(None)

--- a/master/buildbot/test/util/protocols.py
+++ b/master/buildbot/test/util/protocols.py
@@ -65,5 +65,5 @@ class ConnectionInterfaceTest(interfaces.InterfaceTests):
 
     def test_sig_remoteInterruptCommand(self):
         @self.assertArgSpecMatches(self.conn.remoteInterruptCommand)
-        def remoteInterruptCommand(commandId, why):
+        def remoteInterruptCommand(builderName, commandId, why):
             pass


### PR DESCRIPTION
The current execution of  buildbot.test.integration.test_stop_trigger.TriggeringMaster.testTriggerRunsForever
fail randomly, due to different scenarios being executed. They differentiate on whether:
- the remotecommand is not created: it succeeds,
- the remotecommand is created: it fails with a exceptions.AttributeError: BotBase instance has no attribute 'remote_interruptCommand'

This PR aims at fixing the error.
