### PR TITLE
buildbot_pkg: do not set version if already set

### DIFF
--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -144,6 +144,9 @@ class my_build_py(build_py):
 
 def setup_www_plugin(**kw):
     package = kw['packages'][0]
-    setup(version=getVersion(os.path.join(package, "__init__.py")),
-          cmdclass=dict(build=my_build, egg_info=my_egg_info, build_py=my_build_py),
+    if 'version' not in kw:
+        kw['version'] = getVersion(os.path.join(package, "__init__.py"))
+    setup(cmdclass=dict(build=my_build,
+                        egg_info=my_egg_info,
+                        build_py=my_build_py),
           **kw)


### PR DESCRIPTION
This commit permits to one ui plugin to set its
version in the setup.py rather than in the VERSION
file in its root directory.

Change-Id: I20ad0e470682e119599fe90aca28d9fe40a0a8e9