### PR TITLE
handle related builds: cancel and stop

### DIFF
--- a/master/buildbot/steps/gerrit.py
+++ b/master/buildbot/steps/gerrit.py
@@ -1,0 +1,86 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.steps.master import CancelRelatedBuilds
+from buildbot.steps.master import StopRelatedBuilds
+
+_EVENT_TYPE = 'event.type'
+_CHANGE_NO_PROP = 'event.change.number'
+_PATCHSET_NO_PROP = 'event.patchSet.number'
+
+
+def _get_change_spec(properties):
+    if _EVENT_TYPE not in properties:
+        return None
+
+    change_no = properties.getProperty(_CHANGE_NO_PROP)
+    patchset_no = properties.getProperty(_PATCHSET_NO_PROP)
+
+    if change_no is not None and patchset_no is not None:
+        return change_no, patchset_no
+    else:
+        return None
+
+
+def pre_process(source_stamps):
+    result = dict()
+
+    for source_stamp in source_stamps:
+        for change in source_stamp.changes:
+            change_spec = _get_change_spec(change.properties)
+
+            if change_spec is not None:
+                result[change.codebase] = change_spec
+
+    if not result:
+        return None
+
+    return result
+
+
+def is_relevant(ours, theirs):
+    if ours is None:
+        return False
+
+    result = dict()
+
+    for source_stamp in theirs:
+        for change in source_stamp.changes:
+            our_change_spec = ours.get(change.codebase)
+            if our_change_spec is None:
+                continue
+
+            change_spec = _get_change_spec(change.properties)
+
+            if change_spec is not None:
+                result[change.codebase] = (
+                    our_change_spec[0] == change_spec[0] and
+                    our_change_spec[1] > change_spec[1])
+
+    return all([result.get(key, False) for key in ours.keys()])
+
+
+class CancelGerritRelatedBuilds(CancelRelatedBuilds):
+    def __init__(self, **kwargs):
+        CancelRelatedBuilds.__init__(self, preProcess=pre_process,
+                                     isRelevant=is_relevant, **kwargs)
+
+
+class StopGerritRelatedBuilds(StopRelatedBuilds):
+    def __init__(self, **kwargs):
+        StopRelatedBuilds.__init__(self, preProcess=pre_process,
+                                   isRelevant=is_relevant,
+                                   reason='A new patch set for the same change'
+                                          'is submitted', **kwargs)

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -18,13 +18,17 @@ import pprint
 import re
 import types
 
-from buildbot.process.buildstep import BuildStep
-from buildbot.process.buildstep import FAILURE
-from buildbot.process.buildstep import SUCCESS
 from twisted.internet import error
 from twisted.internet import reactor
 from twisted.internet.protocol import ProcessProtocol
 from twisted.python import runtime
+from twisted.internet import defer
+
+from buildbot import config
+from buildbot import interfaces
+from buildbot.process.buildstep import BuildStep
+from buildbot.process.buildstep import FAILURE
+from buildbot.process.buildstep import SUCCESS
 
 
 class MasterShellCommand(BuildStep):
@@ -242,3 +246,134 @@ class LogRenderable(BuildStep):
         self.addCompleteLog(name='Output', text=content)
         self.step_status.setText(self.describe(done=True))
         self.finished(SUCCESS)
+
+
+class _HandleRelatedBuilds(BuildStep):
+    def __init__(self, builderNames=None, isRelevant=None, preProcess=None,
+                 **kwargs):
+        BuildStep.__init__(self, **kwargs)
+
+        self._builder_names = builderNames
+
+        if isRelevant is None:
+            config.error('You must provide a function to check '
+                         'if a build is relevant')
+        if not callable(isRelevant):
+            config.error('isRelevant must be a callable')
+
+        if preProcess is None:
+            preProcess = lambda x: x
+
+        if not callable(preProcess):
+            config.error('preProcess must be callable')
+
+        self._is_relevant = isRelevant
+        self._pre_process = preProcess
+
+    def get_candidates(self, builder_names):
+        _hush_pyflakes = [builder_names]
+        del _hush_pyflakes
+        raise NotImplementedError
+
+    def handle_candidate(self, control):
+        _hush_pyflakes = [control]
+        del _hush_pyflakes
+        raise NotImplementedError
+
+    @defer.inlineCallbacks
+    def run(self):
+        all_names = self.master.botmaster.builderNames[:]
+
+        if self._builder_names is None:
+            builder_names = all_names
+        else:
+            builder_names = [name for name in self._builder_names in all_names]
+
+        ours = self._pre_process(self.build.sources)
+
+        candidates = yield self.get_candidates(builder_names)
+
+        for control, theirs in candidates:
+            if self._is_relevant(ours, theirs):
+                self.handle_candidate(control)
+
+        # This step can never fail
+        defer.returnValue(SUCCESS)
+
+
+class CancelRelatedBuilds(_HandleRelatedBuilds):
+    name = 'CancelRelatedBuilds'
+    description = ['Checking']
+    descriptionDone = ['Checked']
+
+    def __init__(self, builderNames=None, isRelevant=None, preProcess=None,
+                 **kwargs):
+        _HandleRelatedBuilds.__init__(self, builderNames, isRelevant,
+                                      preProcess)
+
+    @defer.inlineCallbacks
+    def get_candidates(self, builder_names):
+        result = []
+
+        master_control = interfaces.IControl(self.master)
+
+        for name in builder_names:
+            builder_control = master_control.getBuilder(name)
+
+            pending = yield builder_control.getPendingBuildRequestControls()
+
+            # How can it even return None?
+            if pending is None:
+                continue
+
+            for buildrequest in pending:
+                result.append((buildrequest,
+                               [buildrequest.original_request.source]))
+
+        defer.returnValue(result)
+
+    def handle_candidate(self, control):
+        control.cancel()
+
+
+class StopRelatedBuilds(_HandleRelatedBuilds):
+    name = 'StopRelatedBuilds'
+    description = ['Checking']
+    descriptionDone = ['Checked']
+
+    def __init__(self, builderNames=None, isRelevant=None, preProcess=None,
+                 reason=None, **kwargs):
+        _HandleRelatedBuilds.__init__(self, builderNames, isRelevant,
+                                      preProcess)
+
+        if reason is None:
+            reason = 'Stopped by StopRelatedBuilds'
+
+        self._reason = reason
+
+    @defer.inlineCallbacks
+    def get_candidates(self, builder_names):
+        result = []
+
+        master_status = self.master.status
+        master_control = interfaces.IControl(self.master)
+
+        for name in builder_names:
+            builder_status = master_status.getBuilder(name)
+
+            state, current_builds = builder_status.getState()
+
+            if not current_builds:
+                continue
+
+            builder_control = master_control.getBuilder(name)
+
+            for build in current_builds:
+                source_stamps = yield build.getSourceStamps()
+                result.append((builder_control.getBuild(build.getNumber()),
+                               source_stamps))
+
+        defer.returnValue(result)
+
+    def handle_candidate(self, control):
+        control.stopBuild(self._reason)

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -2574,6 +2574,117 @@ LogRenderable
 This build step takes content which can be renderable and logs it in a pretty-printed format.
 It can be useful for debugging properties during a build.
 
+.. _handle-related-builds:
+
+Handling Related Builds
+-----------------------
+
+There are situations when you want to cancel and/or stop related builds (for example, when the Buildbot is configured to build every new change, however build results for an older change might not be relevant any more).
+To handle these situations Buildbot offers two build steps (which are executed on master):
+
+* CancelRelatedBuilds
+* StopRelatedBuilds
+
+These steps work in a pretty much same way: they look at possible candidates' source stamps and decide whether the step is relevant based on own source stamp.
+If the source stamps are somehow relevant (decided by a function provided as a parameter), then the corresponding build request will be cancelled, or the corresponding build will be stopped.
+
+.. bb:step:: CancelRelatedBuilds
+
+CancelRelatedBuilds
++++++++++++++++++++
+
+.. py:class:: buildbot.steps.master.CancelRelatedBuilds
+
+Beside `common parameters <Buildstep-Common-Parameters>`_ `CancelRelatedBuilds` accepts following parameters:
+
+``builderNames``
+    This is the set of builders which this step will check for possible candidates.
+    Possible values:
+
+    ``None``
+        check all builders known to the system
+
+    list of strings
+        check only these builders
+
+``preProcess``
+    This is an optional parameter to specify a function that would preprocess own build's source stamp.
+    This might be useful if the computations are extensive and there could be a lot of possible candidates to check.
+    Default: just use own build's source stamp.
+
+    .. code-block:: python
+
+        def preProcess(source_stamps):
+            """
+            :returns: what is passed as the first argument to `isRelevant`
+            """
+
+``isRelevant``
+    This is a mandatory parameter to specify a function that would take two parameters: own source stamps (possibly pre-processed) and the source stamps of the candidate build request.
+    If this function returns `True`, the candidate will be cancelled.
+
+    .. code-block:: python
+
+        def isRelevant(own_source_stamps, their_source_stamps):
+            """
+            :type own_source_stamps: either list(SourceStamp) or what is returned by `preProcess`
+            :type their_source_stamps: list(SourceStamp)
+            """
+
+    .. note::
+
+       It is possible that by the time the cancel request is sent, the corresponding build request is already started to build.
+
+.. bb:step:: StopRelatedBuilds
+
+StopRelatedBuilds
++++++++++++++++++
+
+.. py:class:: buildbot.steps.master.StopRelatedBuilds
+
+Beside `common parameters <Buildstep-Common-Parameters>`_ `StopRelatedBuilds` accepts following parameters:
+
+``builderNames``
+    This is the set of builders which this step will check for possible candidates.
+    Possible values:
+
+    ``None``
+        check all builders known to the system
+
+    list of strings
+        check only these builders
+
+``preProcess``
+    This is an optional parameter to specify a function that would preprocess own build's source stamp.
+    This might be useful if the computations are extensive and there could be a lot of possible candidates to check.
+    Default: just use own build's source stamp.
+
+    .. code-block:: python
+
+        def preProcess(source_stamps):
+            """
+            :returns: what is passed as the first argument to `isRelevant`
+            """
+
+``isRelevant``
+    This is a mandatory parameter to specify a function that would take two parameters: own source stamp (possibly pre-processed) and the source stamp of the candidate build.
+    If this function returns `True`, the candidate will be stopped.
+
+    .. code-block:: python
+
+        def isRelevant(own_source_stamps, their_source_stamps):
+            """
+            :type own_source_stamps: either list(SourceStamp) or what is returned by `preProcess`
+            :type their_source_stamps: list(SourceStamp)
+            """
+
+    .. note::
+
+       It is possible that by the time the stop request is sent, the corresponding build request is already finished.
+
+``reason`` (default: `Stopped by StopRelatedBuilds`)
+    This is an optional parameter to specify a string that will be used as a reason for stopping candidates.
+
 .. index:: Properties; from steps
 
 .. _Setting-Properties:

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -2259,7 +2259,7 @@ To run trial tests manually, you run the :command:`trial` executable and tell it
 The most common way of doing this is with a module name.
 For petmail, this might look like :command:`trial petmail.test`, which would locate all the :file:`test_*.py` files under :file:`petmail/test/`, running every test case it could find in them.
 Unlike the ``unittest.py`` that comes with Python, it is not necessary to run the :file:`test_foo.py` as a script; you always let trial do the importing and running.
-The step's ``tests``` parameter controls which tests trial will run: it can be a string or a list of strings.
+The step's ``tests`` parameter controls which tests trial will run: it can be a string or a list of strings.
 
 To find the test cases, the Python search path must allow something like ``import petmail.test`` to work.
 For packages that don't use a separate top-level :file:`lib` directory, ``PYTHONPATH=.`` will work, and will use the test cases (and the code they are testing) in-place.

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -2585,6 +2585,11 @@ To handle these situations Buildbot offers two build steps (which are executed o
 * CancelRelatedBuilds
 * StopRelatedBuilds
 
+and specific implementation for Gerrit
+
+* CancelGerritRelatedBuilds
+* StopGerritRelatedBuilds
+
 These steps work in a pretty much same way: they look at possible candidates' source stamps and decide whether the step is relevant based on own source stamp.
 If the source stamps are somehow relevant (decided by a function provided as a parameter), then the corresponding build request will be cancelled, or the corresponding build will be stopped.
 
@@ -2684,6 +2689,47 @@ Beside `common parameters <Buildstep-Common-Parameters>`_ `StopRelatedBuilds` ac
 
 ``reason`` (default: `Stopped by StopRelatedBuilds`)
     This is an optional parameter to specify a string that will be used as a reason for stopping candidates.
+
+.. bb:step:: CancelGerritRelatedBuilds
+
+CancelGerritRelatedBuilds
++++++++++++++++++++++++++
+
+This is a convenience step that provides `preProcess` and `isRelevant` parameters to constructor of `CancelRelatedBuilds`.
+It's a rough equivalent of:
+
+.. code-block:: python
+
+    from buildbot.plugins import steps, util
+
+    class CancelGerritRelatedBuilds(CancelRelatedBuilds):
+        def __init__(self, **kwargs):
+            CancelRelatedBuilds.__init__(
+                self,
+                preProcess=util.gerrit.pre_process,
+                isRelevant=util.gerrit.is_relevant,
+                **kwargs)
+
+.. bb:step:: StopGerritRelatedBuilds
+
+StopGerritRelatedBuilds
++++++++++++++++++++++++
+
+This is a convenience step that provides `preProcess`, `isRelevant` and `reason` parameters to constructor of `StopRelatedBuilds`.
+It's a rough equivalent of:
+
+.. code-block:: python
+
+    from buildbot.plugins import steps, util
+
+    class StopGerritRelatedBuilds(StopRelatedBuilds):
+        def __init__(self, **kwargs):
+            StopRelatedBuilds.__init__(
+                self,
+                preProcess=util.gerrit.pre_process,
+                isRelevant=util.gerrit.is_relevant,
+                reason='A new patch set for the same change is submitted',
+                **kwargs)
 
 .. index:: Properties; from steps
 

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -619,7 +619,7 @@ Note carefully that the names in the :file:`options` file usually do not match t
 ``master``
     Equivalent to :option:`--master` for :bb:cmdline:`debugclient` and :bb:cmdline:`sendchange`.
     This option is used for two purposes.
-    It is the location of the ``debugPort`` for ``debugclient`` and the location of the :class:`pb.PBChangeSource` for ```sendchange``.
+    It is the location of the ``debugPort`` for ``debugclient`` and the location of the :class:`pb.PBChangeSource` for ``sendchange``.
     Generally these are the same port.
 
 ``debugPassword``

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -179,7 +179,7 @@ No other sub-projects or branches will be tracked.
 If we want our ChangeSource to follow multiple branches, we have to do two things.
 First we have to change our ``svnurl=`` argument to watch more than just ``amanda/trunk``.
 We will set it to ``amanda`` so that we'll see both the trunk and all the branches.
-Second, we have to tell :bb:chsrc:`SVNPoller` how to split the ``({PROJECT-plus-BRANCH})({FILEPATH})`` strings it gets from the repository out into ``({BRANCH})`` and ``({FILEPATH})```.
+Second, we have to tell :bb:chsrc:`SVNPoller` how to split the ``({PROJECT-plus-BRANCH})({FILEPATH})`` strings it gets from the repository out into ``({BRANCH})`` and ``({FILEPATH})``.
 
 We do the latter by providing a ``split_file`` function.
 This function is responsible for splitting something like ``branches/3_3/common-src/amanda.h`` into ``branch='branches/3_3'`` and ``filepath='common-src/amanda.h'``.

--- a/master/docs/manual/installation.rst
+++ b/master/docs/manual/installation.rst
@@ -588,7 +588,7 @@ As of this release, you will need to install ``buildbot-slave`` to run a slave.
 
 Any automatic startup scripts that had run ``buildbot start`` for previous versions should be changed to run ``buildslave start`` instead.
 
-If you are running a version later than 0.8.1, then you can skip the remainder of this section: the ```upgrade-slave`` command will take care of this.
+If you are running a version later than 0.8.1, then you can skip the remainder of this section: the ``upgrade-slave`` command will take care of this.
 If you are upgrading directly to 0.8.1, read on.
 
 The existing :file:`buildbot.tac` for any buildslaves running older versions will need to be edited or replaced.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -16,6 +16,9 @@ Features
 
 * :bb:step:`Git` supports an "origin" option to give a name to the remote repo.
 
+* two new general steps are added to handle related builds -- :bb:step:`CancelRelatedBuilds` and :bb:step:`StopRelatedBuilds` -- as well as Gerrit specific ones -- :bb:step:`CancelGerritRelatedBuilds` and :bb:step:`StopGerritRelatedBuilds`.
+  More information in :ref:`the manual <handle-related-builds>`.
+
 Fixes
 ~~~~~
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -244,7 +244,8 @@ setup_args = {
                 'HTTPStep', 'POST', 'GET', 'PUT', 'DELETE', 'HEAD',
                 'OPTIONS']),
             ('buildbot.steps.master', [
-                'MasterShellCommand', 'SetProperty', 'LogRenderable']),
+                'MasterShellCommand', 'SetProperty', 'LogRenderable',
+                'CancelRelatedBuilds', 'StopRelatedBuilds']),
             ('buildbot.steps.maxq', ['MaxQ']),
             ('buildbot.steps.mswin', ['Robocopy']),
             ('buildbot.steps.mtrlogobserver', ['MTR']),

--- a/master/setup.py
+++ b/master/setup.py
@@ -240,6 +240,8 @@ setup_args = {
         ]),
         ('buildbot.steps', [
             ('buildbot.process.buildstep', ['BuildStep']),
+            ('buildbot.steps.gerrit', [
+                'CancelGerritRelatedBuilds', 'StopGerritRelatedBuilds']),
             ('buildbot.steps.http', [
                 'HTTPStep', 'POST', 'GET', 'PUT', 'DELETE', 'HEAD',
                 'OPTIONS']),
@@ -335,6 +337,9 @@ setup_args = {
             ('buildbot.status.web.auth', [
                 'BasicAuth', 'HTPasswdAprAuth', 'HTPasswdAuth', 'UsersAuth']),
             ('buildbot.status.web.authz', ['Authz']),
+            ('buildbot.steps.gerrit', [
+                ('gerrit.pre_process', 'pre_process'),
+                ('gerrit.is_relevant', 'is_relevant')]),
             ('buildbot.steps.mtrlogobserver', ['EqConnectionPool']),
             ('buildbot.steps.source.repo', [
                 ('repo.DownloadsFromChangeSource',


### PR DESCRIPTION
@djmitche, @tardyp, @jaredgrubb what do you think?

I need this in context of Gerrit triggered builds, when a new patch set is submitted old build requests need to be cancelled (not to waste resources)

This is based on eight for two reasons:
* this is what I currently use
* I am not sure if things did not change that much in master