### PR TITLE
test/util/integration: fix 'new' change race condition

### DIFF
--- a/master/buildbot/test/integration/test_stop_trigger.py
+++ b/master/buildbot/test/integration/test_stop_trigger.py
@@ -85,7 +85,6 @@ def triggeredBuildIsNotCreated():
 
 class TriggeringMaster(RunMasterBase):
     testCasesHandleTheirSetup = True
-    proto = "pb"
 
     change = dict(branch="master",
                   files=["foo.c"],


### PR DESCRIPTION
This commit permits to reproduce the integration test
race condition. At first glance, the "new" change event
is sent, before the associated scheduler's service has
finished starting (or more precisely activating).