### PR TITLE
Add flag '--notify' to GerritStatusPush

### DIFF
--- a/master/buildbot/test/unit/test_status_gerrit.py
+++ b/master/buildbot/test/unit/test_status_gerrit.py
@@ -13,17 +13,21 @@
 #
 # Copyright Buildbot Team Members
 
+from buildbot.config import ConfigErrors
 from buildbot.status.results import FAILURE
 from buildbot.status.results import SUCCESS
 from buildbot.status.status_gerrit import GERRIT_LABEL_REVIEWED
 from buildbot.status.status_gerrit import GERRIT_LABEL_VERIFIED
 from buildbot.status.status_gerrit import GerritStatusPush
 from buildbot.status.status_gerrit import makeReviewResult
-from buildbot.test.fake.fakebuild import FakeBuildStatus
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
-from mock import call, Mock
+from buildbot.test.fake.fakebuild import FakeBuildStatus
+from mock import Mock
+from mock import call
+from mock import patch
 from twisted.internet import defer
+from twisted.internet import reactor
 from twisted.trial import unittest
 
 
@@ -225,7 +229,7 @@ class TestGerritStatusPush(unittest.TestCase):
         self.assertEqual(expected1, without_identity._gerritCmd('foo'))
 
         with_identity = GerritStatusPush(
-                identity_file='/path/to/id_rsa', **kwargs)
+            identity_file='/path/to/id_rsa', **kwargs)
         expected2 = [
             'ssh', '-i', '/path/to/id_rsa', 'buildbot@example.com', '-p', '29418',
             'gerrit', 'foo',
@@ -333,3 +337,38 @@ class TestGerritStatusPush(unittest.TestCase):
 
     def test_buildsetComplete_failure_sends_review_legacy(self):
         self.check_single_build_legacy(FAILURE, -1)
+
+    # check all possible values of flag 'notify'
+
+    @patch.object(reactor, 'spawnProcess')
+    @defer.inlineCallbacks
+    def check_notify_flag_in_ssh_command(self, spawn_process, notify, expected_value):
+        gsp = yield GerritStatusPush('host.example.com', 'username',
+                                     reviewCB=testReviewCB, notify=notify)
+
+        gsp.master = yield fakemaster.make_master()
+        gsp.master_status = gsp.master.status
+        gsp.getCachedVersion = yield Mock(return_value="2.9")
+
+        d = yield self.run_fake_single_build(gsp, SUCCESS)
+
+        ssh_args = spawn_process.call_args[0][2]
+        ssh_msg = ' '.join(ssh_args)
+        assert expected_value in ssh_msg, "Flag value wrong or not present"
+
+        defer.returnValue(d)
+
+    @defer.inlineCallbacks
+    def test_valid_notify_flag(self):
+        # If any of these flag values fail, the test fails by
+        # GerritStatusPush raising a ConfigErrors exception.
+
+        yield _get_prepared_gsp(notify=None)
+
+        for flag in ['ALL', 'OWNER', 'OWNER_REVIEWERS', 'NONE']:
+            yield self.check_notify_flag_in_ssh_command(notify=flag,
+                                                        expected_value='--notify %s' % flag)
+
+    @defer.inlineCallbacks
+    def test_invalid_notify_flag(self):
+        yield self.assertRaises(ConfigErrors, _get_prepared_gsp, notify='WRONG_VAL')

--- a/master/buildbot/test/unit/test_status_gerrit.py
+++ b/master/buildbot/test/unit/test_status_gerrit.py
@@ -350,13 +350,11 @@ class TestGerritStatusPush(unittest.TestCase):
         gsp.master_status = gsp.master.status
         gsp.getCachedVersion = yield Mock(return_value="2.9")
 
-        d = yield self.run_fake_single_build(gsp, SUCCESS)
+        yield self.run_fake_single_build(gsp, SUCCESS)
 
         ssh_args = spawn_process.call_args[0][2]
         ssh_msg = ' '.join(ssh_args)
         assert expected_value in ssh_msg, "Flag value wrong or not present"
-
-        defer.returnValue(d)
 
     @defer.inlineCallbacks
     def test_valid_notify_flag(self):

--- a/master/docs/examples/git_gerrit.cfg
+++ b/master/docs/examples/git_gerrit.cfg
@@ -184,7 +184,15 @@ def gerritSummaryCB(buildInfoList, results, status, arg):
                 })
 
 c['buildbotURL'] = 'http://buildbot.example.com/'
+
+# The 'GerritStatusPush' target is used to publish build results in Gerrit
+# To create message (with Code-Review) used function 'gerritReviewCB'
+# Notification about this message will be sent to to all (change owners,
+# reviewers, watchers and any user who has starred the change)
+# https://gerrit-documentation.storage.googleapis.com/Documentation/2.9/cmd-review.html#_options
+
 c['status'].append(status.GerritStatusPush(gerrit_url, gerrit_user,
+                                           notify='ALL',
                                            reviewCB=gerritReviewCB,
                                            reviewArg=c['buildbotURL'],
                                            startCB=gerritStartCB,

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -1478,10 +1478,14 @@ GerritStatusPush
 :class:`GerritStatusPush` sends review of the :class:`Change` back to the Gerrit server, optionally also sending a message when a build is started.
 GerritStatusPush can send a separate review for each build that completes, or a single review summarizing the results for all of the builds.
 
-.. py:class:: GerritStatusPush(server, username, reviewCB, startCB, port, reviewArg, startArg, summaryCB, summaryArg, ...)
+.. py:class:: GerritStatusPush(server, username, notify, reviewCB, startCB, port, reviewArg, startArg, summaryCB, summaryArg, ...)
 
    :param string server: Gerrit SSH server's address to use for push event notifications.
    :param string username: Gerrit SSH server's username.
+   :param string notify: Notify handling that defines to whom email notifications should be sent after the review is stored.
+        Allowed values are NONE, OWNER, OWNER_REVIEWERS and ALL. If not set, the default is ALL.
+        This parameter released in Gerrit 2.9:
+        https://gerrit-documentation.storage.googleapis.com/Documentation/2.9/cmd-review.html#_options
    :param int port: (optional) Gerrit SSH server's port (default: 29418)
    :param reviewCB: (optional) callback that is called each time a build is finished, and that is used to define the message and review approvals depending on the build result.
    :param reviewArg: (optional) argument passed to the review callback.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -31,6 +31,8 @@ Slave
 Features
 ~~~~~~~~
 
+* :bb:status:`GerritStatusPush` now has parameter --notify which is used to control e-mail notifications from Gerrit.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
This flag is used to control e-mail sending by Gerrit when Buildbot leaves review.

For more details see Gerrit v2.9 release notes:
https://gerrit-documentation.storage.googleapis.com/ReleaseNotes/ReleaseNotes-2.9.html#_ssh