### PR TITLE
Overhaul the monotone source step.

### DIFF
--- a/master/CREDITS
+++ b/master/CREDITS
@@ -248,6 +248,7 @@ Tomaz Muraus
 Umesh Patel
 Unknown tagger
 Wade Brainerd
+Wanner Markus
 William Deegan
 William Siegrist
 Yoz Grahame

--- a/master/buildbot/steps/source/mtn.py
+++ b/master/buildbot/steps/source/mtn.py
@@ -304,7 +304,7 @@ class Monotone(Source):
             if stdout.find("migration needed") >= 0:
                 log.msg("Older format database found, migrating it")
                 yield self._dovccmd(['mtn', 'db', 'migrate', '--db',
-                                         self.database],
+                                     self.database],
                                     workdir='.')
             elif stdout.find("too new, cannot use") >= 0 or \
                     stdout.find("database has no tables") >= 0:

--- a/master/buildbot/steps/source/mtn.py
+++ b/master/buildbot/steps/source/mtn.py
@@ -36,16 +36,15 @@ class Monotone(Source):
     renderables = ['repourl']
     possible_methods = ('clobber', 'copy', 'fresh', 'clean')
 
-    def __init__(self, repourl=None, branch=None, progress=False, mode='incremental',
-                 method=None, **kwargs):
+    def __init__(self, repourl=None, branch=None, progress=False,
+                 mode='incremental', method=None, **kwargs):
 
         self.repourl = repourl
         self.method = method
         self.mode = mode
         self.branch = branch
         self.sourcedata = "%s?%s" % (self.repourl, self.branch)
-        self.databasename = 'db.mtn'
-        self.database = '../db.mtn'
+        self.database = 'db.mtn'
         self.progress = progress
         Source.__init__(self, **kwargs)
         errors = []
@@ -83,14 +82,21 @@ class Monotone(Source):
                 raise BuildSlaveTooOldError("Monotone is not installed on slave")
             return 0
         d.addCallback(lambda _: self._checkDb())
-        d.addCallback(lambda _: self.sourcedirIsPatched())
+        d.addCallback(lambda _: self._retryPull())
 
-        @d.addCallback
-        def checkPatched(patched):
-            if patched:
-                return self.clean()
-            else:
-                return 0
+        # If we're not throwing away the workdir, check if it's
+        # somehow patched or modified and revert.
+        if self.mode != 'full' or self.method not in ('clobber', 'copy'):
+            d.addCallback(lambda _: self.sourcedirIsPatched())
+
+            @d.addCallback
+            def checkPatched(patched):
+                if patched:
+                    return self.clean()
+                else:
+                    return 0
+
+        # Add a mode specific callback
         d.addCallback(self._getAttrGroupMember('mode', self.mode))
 
         if patch:
@@ -111,8 +117,7 @@ class Monotone(Source):
 
         updatable = yield self._sourcedirIsUpdatable()
         if not updatable:
-            yield self._retryClone()
-            yield self._checkout()
+            yield self.clobber()
         elif self.method == 'clean':
             yield self.clean()
             yield self._update()
@@ -126,23 +131,20 @@ class Monotone(Source):
     def mode_incremental(self, _):
         updatable = yield self._sourcedirIsUpdatable()
         if not updatable:
-            yield self._retryClone()
-            yield self._checkout()
+            yield self.clobber()
         else:
-            yield self._pull()
-            yield self._update(dopull=False)
+            yield self._update()
 
     def clobber(self):
         d = self.runRmdir(self.workdir)
-        d.addCallback(lambda _: self.runRmdir(self.databasename))
-        d.addCallback(lambda _: self._retryClone())
         d.addCallback(lambda _: self._checkout())
         return d
 
     def copy(self):
-        cmd = remotecommand.RemoteCommand('rmdir', {'dir': self.workdir,
-                                                    'logEnviron': self.logEnviron,
-                                                    'timeout': self.timeout, })
+        cmd = remotecommand.RemoteCommand('rmdir', {
+            'dir': self.workdir,
+            'logEnviron': self.logEnviron,
+            'timeout': self.timeout, })
         cmd.useLog(self.stdio_log, False)
         d = self.runCommand(cmd)
 
@@ -167,7 +169,8 @@ class Monotone(Source):
         return d
 
     def checkMonotone(self):
-        cmd = remotecommand.RemoteShellCommand(self.workdir, ['mtn', '--version'],
+        cmd = remotecommand.RemoteShellCommand(self.workdir,
+                                               ['mtn', '--version'],
                                                env=self.env,
                                                logEnviron=self.logEnviron,
                                                timeout=self.timeout)
@@ -188,7 +191,8 @@ class Monotone(Source):
         if not ignore_ignored:
             commands.append(['mtn', 'ls', 'ignored'])
         for cmd in commands:
-            stdout = yield self._dovccmd(cmd, collectStdout=True)
+            stdout = yield self._dovccmd(self.workdir, cmd,
+                                         collectStdout=True)
             if len(stdout) == 0:
                 continue
             for filename in stdout.strip().split('\n'):
@@ -216,52 +220,39 @@ class Monotone(Source):
                 return
         defer.returnValue(0)
 
-    def _clone(self, abandonOnFailure=False):
-        command = ['mtn', 'db', 'init', '--db', self.database]
-        d = self._dovccmd(command, abandonOnFailure=abandonOnFailure)
-        d.addCallback(lambda _: self._pull())
-        return d
-
     def _checkout(self, abandonOnFailure=False):
-        command = ['mtn', 'checkout', '.', '--db=%s' % (self.database)]
+        command = ['mtn', 'checkout', self.workdir, '--db', self.database]
         if self.revision:
             command.extend(['--revision', self.revision])
         command.extend(['--branch', self.branch])
+        return self._dovccmd('', command, abandonOnFailure=abandonOnFailure)
 
-        return self._dovccmd(command, abandonOnFailure=abandonOnFailure)
-
-    def _update(self, dopull=True, abandonOnFailure=False):
-        if dopull:
-            d = self._pull()
-        else:
-            d = defer.succeed(0)
-        command = ['mtn', 'update', '--db=%s' % (self.database)]
+    def _update(self, abandonOnFailure=False):
+        command = ['mtn', 'update']
         if self.revision:
             command.extend(['--revision', self.revision])
         else:
-            command.extend(["-r", "h:" + self.branch])
-        command.extend(["-b", self.branch])
-
-        d.addCallback(lambda _: self._dovccmd(command, abandonOnFailure=abandonOnFailure))
-        return d
+            command.extend(['--revision', 'h:' + self.branch])
+        command.extend(['--branch', self.branch])
+        return self._dovccmd(self.workdir, command,
+                             abandonOnFailure=abandonOnFailure)
 
     def _pull(self, abandonOnFailure=False):
-        command = ['mtn', 'pull', self.sourcedata,
-                   '--db=%s' % (self.database)]
+        command = ['mtn', 'pull', self.sourcedata, '--db', self.database]
         if self.progress:
             command.extend(['--ticker=dot'])
         else:
             command.extend(['--ticker=none'])
-        d = self._dovccmd(command, abandonOnFailure=abandonOnFailure)
+        d = self._dovccmd('', command, abandonOnFailure=abandonOnFailure)
         return d
 
-    def _retryClone(self):
+    def _retryPull(self):
         if self.retry:
             abandonOnFailure = (self.retry[1] <= 0)
         else:
             abandonOnFailure = True
 
-        d = self._clone(abandonOnFailure)
+        d = self._pull(abandonOnFailure)
 
         def _retry(res):
             if self.stopped or res == 0:
@@ -272,9 +263,7 @@ class Monotone(Source):
                         % (repeats, delay))
                 self.retry = (delay, repeats - 1)
                 df = defer.Deferred()
-                df.addCallback(lambda _: self.runRmdir(self.workdir))
-                df.addCallback(lambda _: self.runRmdir(self.databasename))
-                df.addCallback(lambda _: self._retryClone())
+                df.addCallback(lambda _: self._retryPull())
                 reactor.callLater(delay, df.callback, None)
                 return df
             return res
@@ -285,7 +274,9 @@ class Monotone(Source):
 
     @defer.inlineCallbacks
     def parseGotRevision(self, _=None):
-        stdout = yield self._dovccmd(['mtn', 'automate', 'select', 'w:'], collectStdout=True)
+        stdout = yield self._dovccmd(self.workdir,
+                                     ['mtn', 'automate', 'select', 'w:'],
+                                     collectStdout=True)
         revision = stdout.strip()
         if len(revision) != 40:
             raise buildstep.BuildStepFailed()
@@ -293,21 +284,21 @@ class Monotone(Source):
         self.updateSourceProperty('got_revision', revision)
         defer.returnValue(0)
 
-    def _dovccmd(self, command, collectStdout=False, initialStdin=None, decodeRC=None,
-                 abandonOnFailure=True, wkdir=None):
+    def _dovccmd(self, workdir, command,
+                 collectStdout=False, initialStdin=None, decodeRC=None,
+                 abandonOnFailure=True):
         if not command:
             raise ValueError("No command specified")
 
         if decodeRC is None:
             decodeRC = {0: SUCCESS}
-        workdir = wkdir or self.workdir
-        cmd = remotecommand.RemoteShellCommand(workdir, command,
-                                               env=self.env,
-                                               logEnviron=self.logEnviron,
-                                               timeout=self.timeout,
-                                               collectStdout=collectStdout,
-                                               initialStdin=initialStdin,
-                                               decodeRC=decodeRC)
+        cmd = buildstep.RemoteShellCommand(workdir, command,
+                                           env=self.env,
+                                           logEnviron=self.logEnviron,
+                                           timeout=self.timeout,
+                                           collectStdout=collectStdout,
+                                           initialStdin=initialStdin,
+                                           decodeRC=decodeRC)
         cmd.useLog(self.stdio_log, False)
         d = self.runCommand(cmd)
 
@@ -322,35 +313,50 @@ class Monotone(Source):
                 return cmd.rc
         return d
 
+    @defer.inlineCallbacks
     def _checkDb(self):
-        d = self._dovccmd(['mtn', 'db', 'info', '--db', self.database], collectStdout=True)
-
-        @d.addCallback
-        def checkInfo(stdout):
-            if stdout.find("does not exist") > 0:
-                log.msg("Database does not exist")
-                return 0
-            elif stdout.find("(migration needed)") > 0:
+        db_exists = yield self.pathExists(self.database)
+        db_needs_init = False
+        if db_exists:
+            stdout = yield self._dovccmd(
+                '', ['mtn', 'db', 'info', '--db', self.database],
+                collectStdout=True)
+            if stdout.find("migration needed") >= 0:
                 log.msg("Older format database found, migrating it")
-                return self._dovccmd(['mtn', 'db', 'migrate', '--db', self.database])
-            elif stdout.find("(too new, cannot use)") > 0:
-                log.msg("The database is of a newer format than mtn can handle...  Abort!")
+                yield self._dovccmd('', ['mtn', 'db', 'migrate', '--db',
+                                         self.database])
+            elif stdout.find("too new, cannot use") >= 0 or \
+                    stdout.find("database has no tables") >= 0:
+                # The database is of a newer format which the slave's
+                # mtn version can not handle. Drop it and pull again
+                # with that monotone version installed on the
+                # slave. Do the same if it's an empty file.
+                yield self.runRmdir(self.database)
+                db_needs_init = True
+            elif stdout.find("not a monotone database") >= 0:
+                # There exists a database file, but it's not a valid
+                # monotone database. Do not delete it, but fail with
+                # an error.
                 raise buildstep.BuildStepFailed()
             else:
                 log.msg("Database exists and compatible")
-                return 0
-        return d
+        else:
+            db_needs_init = True
+            log.msg("Database does not exist")
 
+        if db_needs_init:
+            command = ['mtn', 'db', 'init', '--db', self.database]
+            yield self._dovccmd('', command)
+
+    @defer.inlineCallbacks
     def _sourcedirIsUpdatable(self):
-        d = self.pathExists(self.build.path_module.join(self.workdir, '_MTN'))
+        workdir_path = self.build.path_module.join(self.workdir, '_MTN')
+        workdir_exists = yield self.pathExists(workdir_path)
 
-        @d.addCallback
-        def cont(res):
-            if res:
-                d.addCallback(lambda _: self.pathExists('db.mtn'))
-            else:
-                return False
-        return d
+        if not workdir_exists:
+            log.msg("Workdir does not exist, falling back to a fresh clone")
+
+        defer.returnValue(workdir_exists)
 
     def finish(self, res):
         d = defer.succeed(res)

--- a/master/buildbot/steps/source/mtn.py
+++ b/master/buildbot/steps/source/mtn.py
@@ -142,7 +142,7 @@ class Monotone(Source):
             'logEnviron': self.logEnviron,
             'timeout': self.timeout, })
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
+        yield self.runCommand(cmd)
 
         self.workdir = 'source'
         yield self.mode_incremental()

--- a/master/buildbot/test/unit/test_steps_source_mtn.py
+++ b/master/buildbot/test/unit/test_steps_source_mtn.py
@@ -54,12 +54,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -105,12 +105,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -177,12 +177,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -243,10 +243,10 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 1,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -291,12 +291,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -309,7 +309,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             + 1,
             Expect('rmdir', dict(dir='wkdir', logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
                                  '--db', 'db.mtn', '--branch', 'master'])
             + 0,
@@ -335,10 +335,10 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 1,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -351,7 +351,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             + 1,
             Expect('rmdir', dict(dir='wkdir', logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
                                  '--db', 'db.mtn', '--branch', 'master'])
             + 0,
@@ -377,19 +377,19 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('rmdir', dict(dir='wkdir', logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
                                  '--db', 'db.mtn', '--branch', 'master'])
             + 0,
@@ -415,17 +415,17 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 1,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('rmdir', dict(dir='wkdir', logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
                                  '--db', 'db.mtn', '--branch', 'master'])
             + 0,
@@ -451,10 +451,10 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 1,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -491,12 +491,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -509,7 +509,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             + 1,
             Expect('rmdir', dict(dir='wkdir', logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
                                  '--db', 'db.mtn', '--branch', 'master'])
             + 0,
@@ -535,10 +535,10 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 1,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -551,7 +551,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             + 1,
             Expect('rmdir', dict(dir='wkdir', logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'checkout', 'wkdir',
                                  '--db', 'db.mtn', '--branch', 'master'])
             + 0,
@@ -577,12 +577,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -619,17 +619,17 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
             + 1,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -666,12 +666,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -722,12 +722,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -765,12 +765,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -811,12 +811,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -875,12 +875,12 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -939,15 +939,15 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='migration needed')
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'migrate', '--db', 'db.mtn'])
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -984,7 +984,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='not a monotone database')
@@ -1005,17 +1005,17 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             + 0,
             Expect('stat', dict(file='db.mtn', logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='too new, cannot use')
             + 0,
             Expect('rmdir', dict(dir='db.mtn', logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])
@@ -1050,17 +1050,17 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             + 0,
             Expect('stat', dict(file='db.mtn', logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='database has no tables')
             + 0,
             Expect('rmdir', dict(dir='db.mtn', logEnviron=True))
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'db', 'init', '--db', 'db.mtn'])
             + 0,
-            ExpectShell(workdir='',
+            ExpectShell(workdir='.',
                         command=['mtn', 'pull',
                                  'mtn://localhost/monotone?master',
                                  '--db', 'db.mtn', '--ticker=dot'])

--- a/master/buildbot/test/unit/test_steps_source_mtn.py
+++ b/master/buildbot/test/unit/test_steps_source_mtn.py
@@ -28,7 +28,12 @@ from buildbot.test.util import sourcesteps
 from twisted.internet import error
 
 
-class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.TestCase):
+class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
+                   unittest.TestCase):
+
+    # Just some random revision id to test.
+    REVID = '95215e2a9a9f8b6f5c9664e3807cd34617ea928c'
+    MTN_VER = 'monotone 1.0 (base revision: UNKNOWN_REV)'
 
     def setUp(self):
         return self.setUpSourceStep()
@@ -44,21 +49,25 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
             Expect('stat', dict(file='wkdir/_MTN',
-                                logEnviron=True))
-            + 0,
-            Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -70,20 +79,16 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
                                  logEnviron=True))
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'update', '--db=../db.mtn', '-r', 'h:master', '-b', 'master'])
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
-            + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+            + ExpectShell.log('stdio', stdout=self.REVID)
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()
 
     def test_mode_full_clean_patch(self):
@@ -95,21 +100,25 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
             Expect('stat', dict(file='wkdir/_MTN',
-                                logEnviron=True))
-            + 0,
-            Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -121,20 +130,21 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
                                  logEnviron=True))
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'update', '--db=../db.mtn', '-r', 'h:master', '-b', 'master'])
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                                        slavedest='.buildbot-diff', workdir='wkdir',
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        slavedest='.buildbot-diff',
+                                        workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                                        slavedest='.buildbot-patched', workdir='wkdir',
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        slavedest='.buildbot-patched',
+                                        workdir='wkdir',
                                         mode=None))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -146,12 +156,11 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
-            + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+            + ExpectShell.log('stdio', stdout=self.REVID)
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()
 
     def test_mode_full_clean_patch_fail(self):
@@ -163,21 +172,25 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
             Expect('stat', dict(file='wkdir/_MTN',
-                                logEnviron=True))
-            + 0,
-            Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -189,20 +202,21 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
                                  logEnviron=True))
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'update', '--db=../db.mtn', '-r', 'h:master', '-b', 'master'])
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                                        slavedest='.buildbot-diff', workdir='wkdir',
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        slavedest='.buildbot-diff',
+                                        workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
-                                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                                        slavedest='.buildbot-patched', workdir='wkdir',
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        slavedest='.buildbot-patched',
+                                        workdir='wkdir',
                                         mode=None))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -216,7 +230,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectOutcome(result=FAILURE, state_string="update (failure)")
         return self.runStep()
 
-    def test_mode_full_clean_no_existing_repo(self):
+    def test_mode_full_clean_no_existing_db(self):
         self.setupStep(
             mtn.Monotone(repourl='mtn://localhost/monotone',
                          mode='full', method='clean', branch='master'))
@@ -224,13 +238,68 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
+            + 0,
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 1,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'init', '--db', 'db.mtn'])
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('stat', dict(file='wkdir/_MTN',
+                                logEnviron=True))
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+                        command=['mtn', 'ls', 'unknown'])
+            + ExpectShell.log('stdio',
+                              stdout='file1\nfile2')
+            + 0,
+            Expect('rmdir', dict(dir=['wkdir/file1', 'wkdir/file2'],
+                                 logEnviron=True))
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'automate', 'select', 'w:'])
+            + ExpectShell.log('stdio', stdout=self.REVID)
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
+        return self.runStep()
+
+    def test_mode_full_clean_no_existing_checkout(self):
+        self.setupStep(
+            mtn.Monotone(repourl='mtn://localhost/monotone',
+                         mode='full', method='clean', branch='master'))
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', '--version'])
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
+            + 0,
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
@@ -238,24 +307,61 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
             Expect('stat', dict(file='wkdir/_MTN',
                                 logEnviron=True))
             + 1,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'init', '--db', '../db.mtn'])
+            Expect('rmdir', dict(dir='wkdir', logEnviron=True))
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'checkout', '.', '--db=../db.mtn', '--branch', 'master'])
+            ExpectShell(workdir='',
+                        command=['mtn', 'checkout', 'wkdir',
+                                 '--db', 'db.mtn', '--branch', 'master'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
-            + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+            + ExpectShell.log('stdio', stdout=self.REVID)
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
+        return self.runStep()
+
+    def test_mode_full_clean_from_scratch(self):
+        self.setupStep(
+            mtn.Monotone(repourl='mtn://localhost/monotone',
+                         mode='full', method='clean', branch='master'))
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', '--version'])
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
+            + 0,
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 1,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'init', '--db', 'db.mtn'])
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('stat', dict(file='wkdir/_MTN',
+                                logEnviron=True))
+            + 1,
+            Expect('rmdir', dict(dir='wkdir', logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'checkout', 'wkdir',
+                                 '--db', 'db.mtn', '--branch', 'master'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'automate', 'select', 'w:'])
+            + ExpectShell.log('stdio', stdout=self.REVID)
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()
 
     def test_mode_full_clobber(self):
@@ -266,44 +372,73 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            Expect('stat', dict(file='wkdir/.buildbot-patched',
-                                logEnviron=True))
-            + 1,
-            Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
             + 0,
-            Expect('rmdir', dict(dir='db.mtn',
-                                 logEnviron=True))
+            Expect('rmdir', dict(dir='wkdir', logEnviron=True))
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'init', '--db', '../db.mtn'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'checkout', '.', '--db=../db.mtn', '--branch', 'master'])
+            ExpectShell(workdir='',
+                        command=['mtn', 'checkout', 'wkdir',
+                                 '--db', 'db.mtn', '--branch', 'master'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
-            + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+            + ExpectShell.log('stdio', stdout=self.REVID)
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()
 
-    def test_mode_incremental_repo_non_existing(self):
+    def test_mode_full_clobber_no_existing_db(self):
+        self.setupStep(
+            mtn.Monotone(repourl='mtn://localhost/monotone',
+                         mode='full', method='clobber', branch='master'))
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', '--version'])
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
+            + 0,
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 1,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'init', '--db', 'db.mtn'])
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
+            + 0,
+            Expect('rmdir', dict(dir='wkdir', logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'checkout', 'wkdir',
+                                 '--db', 'db.mtn', '--branch', 'master'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'automate', 'select', 'w:'])
+            + ExpectShell.log('stdio', stdout=self.REVID)
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
+        return self.runStep()
+
+    def test_mode_incremental_no_existing_db(self):
         self.setupStep(
             mtn.Monotone(repourl='mtn://localhost/monotone',
                          mode='incremental', branch='master'))
@@ -311,13 +446,60 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
+            + 0,
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 1,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'init', '--db', 'db.mtn'])
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('stat', dict(file='wkdir/_MTN',
+                                logEnviron=True))
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'automate', 'select', 'w:'])
+            + ExpectShell.log('stdio', stdout=self.REVID)
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
+        return self.runStep()
+
+    def test_mode_incremental_no_existing_checkout(self):
+        self.setupStep(
+            mtn.Monotone(repourl='mtn://localhost/monotone',
+                         mode='incremental', branch='master'))
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', '--version'])
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
+            + 0,
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
@@ -325,24 +507,61 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
             Expect('stat', dict(file='wkdir/_MTN',
                                 logEnviron=True))
             + 1,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'init', '--db', '../db.mtn'])
+            Expect('rmdir', dict(dir='wkdir', logEnviron=True))
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'checkout', '.', '--db=../db.mtn', '--branch', 'master'])
+            ExpectShell(workdir='',
+                        command=['mtn', 'checkout', 'wkdir',
+                                 '--db', 'db.mtn', '--branch', 'master'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
-            + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+            + ExpectShell.log('stdio', stdout=self.REVID)
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
+        return self.runStep()
+
+    def test_mode_incremental_from_scratch(self):
+        self.setupStep(
+            mtn.Monotone(repourl='mtn://localhost/monotone',
+                         mode='incremental', branch='master'))
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', '--version'])
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
+            + 0,
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 1,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'init', '--db', 'db.mtn'])
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('stat', dict(file='wkdir/_MTN',
+                                logEnviron=True))
+            + 1,
+            Expect('rmdir', dict(dir='wkdir', logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'checkout', 'wkdir',
+                                 '--db', 'db.mtn', '--branch', 'master'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'automate', 'select', 'w:'])
+            + ExpectShell.log('stdio', stdout=self.REVID)
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()
 
     def test_mode_incremental(self):
@@ -353,13 +572,20 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
@@ -367,24 +593,17 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
             Expect('stat', dict(file='wkdir/_MTN',
                                 logEnviron=True))
             + 0,
-            Expect('stat', dict(file='db.mtn',
-                                logEnviron=True))
-            + 0,
             ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'update', '--db=../db.mtn', '-r', 'h:master', '-b', 'master'])
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
-            + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+            + ExpectShell.log('stdio', stdout=self.REVID)
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()
 
     def test_mode_incremental_retry(self):
@@ -395,52 +614,43 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
+            + 1,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
             Expect('stat', dict(file='wkdir/_MTN',
                                 logEnviron=True))
-            + 1,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'init', '--db', '../db.mtn'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 1,
-            Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
             + 0,
-            Expect('rmdir', dict(dir='db.mtn',
-                                 logEnviron=True))
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'init', '--db', '../db.mtn'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'checkout', '.', '--db=../db.mtn', '--branch', 'master'])
-            + 0,
-
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
-            + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+            + ExpectShell.log('stdio', stdout=self.REVID)
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()
 
     def test_mode_full_fresh(self):
@@ -451,21 +661,25 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
             Expect('stat', dict(file='wkdir/_MTN',
-                                logEnviron=True))
-            + 0,
-            Expect('stat', dict(file='db.mtn',
                                 logEnviron=True))
             + 0,
             ExpectShell(workdir='wkdir',
@@ -482,64 +696,60 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
                                  logEnviron=True))
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'update', '--db=../db.mtn', '-r', 'h:master', '-b', 'master'])
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
-            + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+            + ExpectShell.log('stdio', stdout=self.REVID)
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()
 
     def test_mode_incremental_given_revision(self):
         self.setupStep(
             mtn.Monotone(repourl='mtn://localhost/monotone',
-                         mode='full', method='clean', branch='master'),
+                         mode='incremental', branch='master'),
             dict(revision='abcdef01',))
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
             Expect('stat', dict(file='wkdir/_MTN',
                                 logEnviron=True))
-            + 1,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'init', '--db', '../db.mtn'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'checkout', '.', '--db=../db.mtn',
-                                 '--revision', 'abcdef01', '--branch', 'master'])
+                        command=['mtn', 'update', '--revision', 'abcdef01',
+                                 '--branch', 'master'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
             + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+                              stdout='abcdef019a9f8b6f5c9664e3807cd34617ea928c')
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', 'abcdef019a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
         return self.runStep()
 
     def test_mode_full_copy(self):
@@ -550,17 +760,21 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            Expect('stat', dict(file='wkdir/.buildbot-patched',
-                                logEnviron=True))
-            + 1,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
+            + 0,
             Expect('rmdir', dict(dir='wkdir',
                                  logEnviron=True,
                                  timeout=1200))
@@ -568,28 +782,20 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
             Expect('stat', dict(file='source/_MTN',
                                 logEnviron=True))
             + 0,
-            Expect('stat', dict(file='db.mtn',
-                                logEnviron=True))
-            + 0,
             ExpectShell(workdir='source',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='source',
-                        command=['mtn', 'update', '--db=../db.mtn', '-r', 'h:master',
-                                 '-b', 'master'])
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
             + 0,
             Expect('cpdir', {'fromdir': 'source', 'todir': 'build',
                              'logEnviron': True, 'timeout': 1200})
             + 0,
             ExpectShell(workdir='build',
                         command=['mtn', 'automate', 'select', 'w:'])
-            + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+            + ExpectShell.log('stdio', stdout=self.REVID)
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()
 
     def test_mode_full_no_method(self):
@@ -600,17 +806,21 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
             + 0,
-            Expect('stat', dict(file='wkdir/.buildbot-patched',
-                                logEnviron=True))
-            + 1,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
+            + 0,
             Expect('rmdir', dict(dir='wkdir',
                                  logEnviron=True,
                                  timeout=1200))
@@ -618,28 +828,20 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
             Expect('stat', dict(file='source/_MTN',
                                 logEnviron=True))
             + 0,
-            Expect('stat', dict(file='db.mtn',
-                                logEnviron=True))
-            + 0,
             ExpectShell(workdir='source',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='source',
-                        command=['mtn', 'update', '--db=../db.mtn', '-r', 'h:master',
-                                 '-b', 'master'])
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
             + 0,
             Expect('cpdir', {'fromdir': 'source', 'todir': 'build',
                              'logEnviron': True, 'timeout': 1200})
             + 0,
             ExpectShell(workdir='build',
                         command=['mtn', 'automate', 'select', 'w:'])
-            + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+            + ExpectShell.log('stdio', stdout=self.REVID)
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()
 
     def test_incorrect_method(self):
@@ -668,13 +870,20 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'db', 'info', '--db', '../db.mtn'])
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
             + ExpectShell.log('stdio',
                               stdout='')
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
             + 0,
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
@@ -690,24 +899,17 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
             Expect('stat', dict(file='wkdir/_MTN',
                                 logEnviron=True))
             + 0,
-            Expect('stat', dict(file='db.mtn',
-                                logEnviron=True))
-            + 0,
             ExpectShell(workdir='wkdir',
-                        command=['mtn', 'pull', 'mtn://localhost/monotone?master',
-                                 '--db=../db.mtn', '--ticker=dot'])
-            + 0,
-            ExpectShell(workdir='wkdir',
-                        command=['mtn', 'update', '--db=../db.mtn', '-r', 'h:master', '-b', 'master'])
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['mtn', 'automate', 'select', 'w:'])
-            + ExpectShell.log('stdio',
-                              stdout='95215e2a9a9f8b6f5c9664e3807cd34617ea928c')
+            + ExpectShell.log('stdio', stdout=self.REVID)
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
-        self.expectProperty('got_revision', '95215e2a9a9f8b6f5c9664e3807cd34617ea928c', 'Monotone')
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()
 
     def test_slave_connection_lost(self):
@@ -718,9 +920,166 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unitte
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['mtn', '--version'])
-            + ExpectShell.log('stdio',
-                              stdout='monotone 1.0 (base revision: a7c3a1d9de1ba7a62c9dd9efee17252234bb502c)')
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
             + ('err', error.ConnectionLost()),
         )
         self.expectOutcome(result=RETRY, state_string="update (retry)")
+        return self.runStep()
+
+    def test_database_migration(self):
+        self.setupStep(
+            mtn.Monotone(repourl='mtn://localhost/monotone',
+                         mode='incremental', branch='master'))
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', '--version'])
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
+            + 0,
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
+            + ExpectShell.log('stdio',
+                              stdout='migration needed')
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'migrate', '--db', 'db.mtn'])
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('stat', dict(file='wkdir/_MTN',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'automate', 'select', 'w:'])
+            + ExpectShell.log('stdio', stdout=self.REVID)
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
+        return self.runStep()
+
+    def test_database_invalid(self):
+        self.setupStep(
+            mtn.Monotone(repourl='mtn://localhost/monotone',
+                         mode='incremental', branch='master'))
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', '--version'])
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
+            + 0,
+            Expect('stat', dict(file='db.mtn',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
+            + ExpectShell.log('stdio',
+                              stdout='not a monotone database')
+            + 0,
+        )
+        self.expectOutcome(result=FAILURE)
+        return self.runStep()
+
+    def test_database_too_new(self):
+        self.setupStep(
+            mtn.Monotone(repourl='mtn://localhost/monotone',
+                         mode='incremental', branch='master'))
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', '--version'])
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
+            + 0,
+            Expect('stat', dict(file='db.mtn', logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
+            + ExpectShell.log('stdio',
+                              stdout='too new, cannot use')
+            + 0,
+            Expect('rmdir', dict(dir='db.mtn', logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'init', '--db', 'db.mtn'])
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('stat', dict(file='wkdir/_MTN', logEnviron=True))
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'automate', 'select', 'w:'])
+            + ExpectShell.log('stdio', stdout=self.REVID)
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
+        return self.runStep()
+
+    def test_database_empty(self):
+        self.setupStep(
+            mtn.Monotone(repourl='mtn://localhost/monotone',
+                         mode='incremental', branch='master'))
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', '--version'])
+            + ExpectShell.log('stdio', stdout=self.MTN_VER)
+            + 0,
+            Expect('stat', dict(file='db.mtn', logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'info', '--db', 'db.mtn'])
+            + ExpectShell.log('stdio',
+                              stdout='database has no tables')
+            + 0,
+            Expect('rmdir', dict(dir='db.mtn', logEnviron=True))
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'db', 'init', '--db', 'db.mtn'])
+            + 0,
+            ExpectShell(workdir='',
+                        command=['mtn', 'pull',
+                                 'mtn://localhost/monotone?master',
+                                 '--db', 'db.mtn', '--ticker=dot'])
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('stat', dict(file='wkdir/_MTN',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'update', '--revision', 'h:master',
+                                 '--branch', 'master'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['mtn', 'automate', 'select', 'w:'])
+            + ExpectShell.log('stdio', stdout=self.REVID)
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty('got_revision', self.REVID, 'Monotone')
         return self.runStep()

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -942,6 +942,10 @@ Monotone step takes the following arguments:
 
   (optional): defaults to ``'incremental'``.
   Specifies whether to clean the build tree or not.
+  In any case, the slave first pulls from the given remote repository
+  to synchronize (or possibly initialize) its local database. The mode
+  and method only affect how the build tree is checked-out or updated
+  from the local database.
 
     ``incremental``
       The source is update, but any built files are left untouched.
@@ -949,6 +953,8 @@ Monotone step takes the following arguments:
     ``full``
       The build tree is clean of any built files.
       The exact method for doing this is controlled by the ``method`` argument.
+      Even in this mode, the revisions already pulled remain in the database
+      and a fresh pull is rarely needed.
 
 ``method``
 
@@ -957,8 +963,8 @@ Monotone step takes the following arguments:
    The full mode has four methods defined:
 
    ``clobber``
-      It removes the build directory entirely then makes full clone from repo.
-      This can be slow as it need to clone whole repository.
+      It removes the build directory entirely then makes fresh checkout from
+      the database.
 
    ``clean``
       This remove all other files except those tracked and ignored by Monotone.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -274,6 +274,11 @@ Steps
 
 * Old-style *source* steps (imported directly from ``buildbot.steps.source``) are no longer supported on the master.
 
+* The monotone source step got an overhaul and can now better manage
+  its database (initialize and/or migrate it, if needed). In the
+  spirit of monotone, buildbot now always keeps the database around,
+  as it's an append-only database.
+
 Changes and Removals
 ....................
 


### PR DESCRIPTION
This is an overhaul of the monotone source step to improve database handling and correct the errors I found working with the buildbot setup for monotone itself. Given that buildbot itself is still eight-ish, I plan to backport, but would appreciate some review, first.