### PR TITLE
Fix permission errors with mock

### DIFF
--- a/master/buildbot/steps/package/rpm/mock.py
+++ b/master/buildbot/steps/package/rpm/mock.py
@@ -79,7 +79,7 @@ class Mock(ShellCommand):
         if not self.root:
             config.error("You must specify a mock root")
 
-        self.command = ['mock', '--root', self.root]
+        self.command = ['/usr/bin/mock', '--root', self.root]
         if self.resultdir:
             self.command += ['--resultdir', self.resultdir]
 


### PR DESCRIPTION
mock builds fail with a permission error, even if the user running the build
slave was added to the mock group and packages can be built from
the console.

Using /usr/bin/mock as the following error message says fix the problem:

ERROR: [Errno 1] Operation not permitted
ERROR: The most common cause for this error is trying to run /usr/sbin/mock as an unprivileged user.
ERROR: Check your path to make sure that /usr/bin/ is listed before /usr/sbin, or manually run /usr/bin/mock to see if that fixes this problem.