### PR TITLE
Prefer to SIGTERM git instead of killing it outright.

### DIFF
--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -279,6 +279,12 @@ class Expect(object):
         """
         return False
 
+    def nestedExpectations(self):
+        """
+        Any sub-expectations that should be validated.
+        """
+        return []
+
     def __repr__(self):
         return "Expect(" + repr(self.remote_command) + ")"
 

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -233,6 +233,52 @@ class Expect(object):
         for behavior in self.behaviors:
             yield self.runBehavior(behavior[0], behavior[1:], command)
 
+    def expectationPassed(self, exp):
+        """
+        Some expectations need to be able to distinguish pass/fail of
+        nested expectations.
+
+        This will get invoked once for every nested exception and once
+        for self unless anything fails.  Failures are passed to raiseExpectationFailure for
+        handling.
+
+        @param exp: The nested exception that passed or self.
+        """
+        pass
+
+    def raiseExpectationFailure(self, exp, failure):
+        """
+        Some expectations may wish to supress failure.
+        The default expectation does not.
+
+        This will get invoked if the expectations fails on a command.
+
+        @param exp: the expectation that failed.  this could be self or a nested exception
+        """
+        raise failure
+
+    def shouldAssertCommandEqualExpectation(self):
+        """
+        Whether or not we should validate that the current command matches the expecation.
+        Some expectations may not have a way to match a command.
+        """
+        return True
+
+    def shouldRunBehaviors(self):
+        """
+        Whether or not, once the command matches the expectation,
+        the behaviors should be run for this step.
+        """
+        return True
+
+    def shouldKeepMatchingAfter(self, command):
+        """
+        Expectations are by default not kept matching multiple commands.
+
+        Return True if you want to re-use a command for multiple commands.
+        """
+        return False
+
     def __repr__(self):
         return "Expect(" + repr(self.remote_command) + ")"
 

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -64,6 +64,16 @@ class BuildStepMixin(object):
         del remotecommand.FakeRemoteCommand.testcase
 
     # utilities
+    def _getSlaveCommandVersionWrapper(self):
+        originalGetSlaveCommandVersion = self.step.build.getSlaveCommandVersion
+
+        def getSlaveCommandVersion(cmd, oldversion):
+            if cmd == 'shell':
+                if hasattr(self, 'slaveShellCommandVersion'):
+                    return self.slaveShellCommandVersion
+            return originalGetSlaveCommandVersion(cmd, oldversion)
+
+        return getSlaveCommandVersion
 
     def setupStep(self, step, slave_version={'*': "99.99"}, slave_env={},
                   buildFiles=[], wantDefaultWorkdir=True):
@@ -216,6 +226,8 @@ class BuildStepMixin(object):
 
         @returns: Deferred
         """
+        self.step.build.getSlaveCommandVersion = self._getSlaveCommandVersionWrapper()
+
         self.conn = mock.Mock(name="SlaveBuilder(connection)")
         self.step.setupProgress()
         d = self.step.startStep(self.conn)

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -318,6 +318,7 @@ class BuildStepMixin(object):
 
     # callbacks from the running step
 
+    @defer.inlineCallbacks
     def _remotecommand_run(self, command, step, conn, builder_name):
         self.assertEqual(step, self.step)
         self.assertEqual(conn, self.conn)
@@ -348,6 +349,5 @@ class BuildStepMixin(object):
             raise
 
         # let the Expect object show any behaviors that are required
-        d = exp.runBehaviors(command)
-        d.addCallback(lambda _: command)
-        return d
+        yield exp.runBehaviors(command)
+        defer.returnValue(command)


### PR DESCRIPTION
On slaves that support it, send the SIGTERM command first & then SIGKILL
after 30 seconds.  On slaves that don't support it, just try to SIGTERM.

This solves the problem where interrupting a git step (or it timing out)
can leave stale lockfiles around.

Resolves http://trac.buildbot.net/ticket/3269