### PR TITLE
GitHub hook: fix backward compatibility

### DIFF
--- a/master/buildbot/status/web/hooks/github.py
+++ b/master/buildbot/status/web/hooks/github.py
@@ -16,6 +16,7 @@
 import hmac
 import logging
 import re
+import warnings
 
 from hashlib import sha1
 
@@ -216,7 +217,10 @@ def getChanges(request, options=None):
         request
             the http request object
     """
-    if options is None:
+    if options is None or (isinstance(options, bool) and options):
+        if options is not None:
+            warnings.warn('Use of True for GitHub hook is deprecated.  '
+                          'Please see the documentation for possible values')
         options = {}
 
     klass = options.get('class', GitHubEventHandler)


### PR DESCRIPTION
* previously GitHub hook could be enabled by specifying
  `change_hook_dialects={'github':True}`; one of the recent changes made
  this non-working