### PR TITLE
Fix master/buildbot/steps/shell _getLegacySummary

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -185,7 +185,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
         try:
             # if self.cmd is set, then use the RemoteCommand's info
             if self.cmd:
-                command = self.cmd.command
+                command = self.cmd.remote_command
             # otherwise, if we were configured with a command, use that
             elif self.command:
                 command = self.command


### PR DESCRIPTION
Some tracebacks are visible in my master logs saying:
"exceptions.AttributeError: 'RemoteCommand' object has
 no attribute 'command'"

It comes from shell steps that is expecting
"self.cmd.command" when self.cmd is set.
But this attribute is not present in remotecommand.
Using "remote_command" instead of "command" is
fixing the traceback.

Signed-off-by: Sebastien Fusilier <sebastien.fusilier@intel.com>