### PR TITLE
Enhance stop button behavior

### DIFF
--- a/www/base/src/app/builders/build/build.controller.coffee
+++ b/www/base/src/app/builders/build/build.controller.coffee
@@ -24,7 +24,7 @@ class Build extends Controller
         $scope.$watch 'is_stopping', (n, o) ->
             if n == true
                 glTopbarContextualActionsService.setContextualActions [
-                        caption: "Stop on going..."
+                        caption: "Stopping..."
                         icon: "spinner"
                         extra_class: "spin"
                 ]

--- a/www/base/src/app/builders/build/build.controller.coffee
+++ b/www/base/src/app/builders/build/build.controller.coffee
@@ -6,13 +6,28 @@ class Build extends Controller
         buildnumber = _.parseInt($stateParams.build)
 
         $scope.last_build = true
+        $scope.is_stopped = false
+
         $scope.$watch 'build.complete', (n, o) ->
-            if n == false
+            if n == true
+                glTopbarContextualActionsService.setContextualActions []
+
+            else if n == false and not $scope.is_stopped
                 glTopbarContextualActionsService.setContextualActions [
                         caption: "Stop"
                         extra_class: "btn-danger"
-                        action: -> buildbotService.one("builds", $scope.build.buildid).control("stop")
+                        action: ->
+                            $scope.is_stopped = true
+                            buildbotService.one("builds", $scope.build.buildid).control("stop")
                 ]
+
+        $scope.$watch 'is_stopped', (n, o) ->
+            if n == true
+                glTopbarContextualActionsService.setContextualActions [
+                        caption: "Stop on going..."
+                        extra_class: "btn-warning"
+                ]
+
         buildbotService.bindHierarchy($scope, $stateParams, ['builders', 'builds'])
         .then ([builder, build]) ->
             if not build.number? and buildnumber > 1

--- a/www/base/src/app/builders/build/build.controller.coffee
+++ b/www/base/src/app/builders/build/build.controller.coffee
@@ -6,26 +6,27 @@ class Build extends Controller
         buildnumber = _.parseInt($stateParams.build)
 
         $scope.last_build = true
-        $scope.is_stopped = false
+        $scope.is_stopping = false
 
         $scope.$watch 'build.complete', (n, o) ->
             if n == true
                 glTopbarContextualActionsService.setContextualActions []
 
-            else if n == false and not $scope.is_stopped
+            else if n == false and not $scope.is_stopping
                 glTopbarContextualActionsService.setContextualActions [
                         caption: "Stop"
                         extra_class: "btn-danger"
                         action: ->
-                            $scope.is_stopped = true
+                            $scope.is_stopping = true
                             buildbotService.one("builds", $scope.build.buildid).control("stop")
                 ]
 
-        $scope.$watch 'is_stopped', (n, o) ->
+        $scope.$watch 'is_stopping', (n, o) ->
             if n == true
                 glTopbarContextualActionsService.setContextualActions [
                         caption: "Stop on going..."
-                        extra_class: "btn-warning"
+                        icon: "spinner"
+                        extra_class: "spin"
                 ]
 
         buildbotService.bindHierarchy($scope, $stateParams, ['builders', 'builds'])


### PR DESCRIPTION
Currently the stop button was still visible even if
the build was finished.

This patch suggest a new behavior:
- Remove the button from the contextual menu when the build is finished
- Rename the caption to 'Stop on going' once pressed

Signed-off-by: Sebastien Savrimoutou <sebastien.savrimoutou@intel.com>