### PR TITLE
[Material Design] Current Builds Panel

### DIFF
--- a/www/md_base/src/app/common/directives/builditem/builditem.less
+++ b/www/md_base/src/app/common/directives/builditem/builditem.less
@@ -3,6 +3,7 @@ build-item {
   margin: 5px 0;
   padding: 5px;
   background: rgba(0, 0, 0, 0.05);
+  overflow: hidden;
 
   .inner {
     line-height: 30px;
@@ -25,10 +26,33 @@ build-item {
 
   .status-text {
     width: 15%;
-    min-width: 100px;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
     padding: 0 5px;
+  }
+
+  .time {
+    width: 120px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &.ng-enter, &.ng-leave {
+    -webkit-transition: 0.2s linear all;
+    -moz-transition: 0.2s linear all;
+    -o-transition: 0.2s linear all;
+    transition: 0.2s linear all;
+  }
+
+  &.ng-enter, &.ng-leave.ng-leave-active {
+    opacity: 0;
+    height: 0;
+  }
+
+  &.ng-enter.ng-enter-active, &.ng-leave {
+    opacity: 1;
+    height: 40px;
   }
 }

--- a/www/md_base/src/app/home/panels/current_builds/current_builds.directive.coffee
+++ b/www/md_base/src/app/home/panels/current_builds/current_builds.directive.coffee
@@ -4,5 +4,15 @@ class CurrentBuilds extends Directive
         return {
             restrict: 'E'
             templateUrl: 'views/current_builds_panel.html'
+            controller: '_CurrentBuildsController'
+            controllerAs: 'current'
         }
-    
+
+class _CurrentBuilds extends Controller
+    showBuilders: true
+    constructor: ($scope, buildbotService, bbSettingsService) ->
+        $scope.current_builds = []
+        buildbotService.some('builds',
+            complete: false
+            order:'-started_at'
+        ).bind($scope, dest_key:'current_builds')

--- a/www/md_base/src/app/home/panels/current_builds/current_builds.less
+++ b/www/md_base/src/app/home/panels/current_builds/current_builds.less
@@ -1,0 +1,10 @@
+current-builds {
+  display: block;
+  padding: 12px 0;
+
+  .no-build {
+    color: #666;
+    font-size: 14;
+    text-align: center;
+  }
+}

--- a/www/md_base/src/app/home/panels/current_builds/current_builds_panel.tpl.jade
+++ b/www/md_base/src/app/home/panels/current_builds/current_builds_panel.tpl.jade
@@ -1,1 +1,7 @@
-| current builds panel content
+div.no-build(ng-if="current_builds.length == 0")
+  | No running builds now. Go to 
+  a(ui-sref="builds") builds panel
+  |  to trigger a build.
+
+div.build(ng-repeat="build in current_builds")
+  build-item(build="build", show-builder="current.showBuilders")

--- a/www/md_base/src/app/home/panels/current_builds/current_builds_panel.tpl.jade
+++ b/www/md_base/src/app/home/panels/current_builds/current_builds_panel.tpl.jade
@@ -1,7 +1,6 @@
-div.no-build(ng-if="current_builds.length == 0")
+div.no-build(ng-if="(current_builds|filter:{complete:false}).length == 0")
   | No running builds now. Go to 
   a(ui-sref="builds") builds panel
   |  to trigger a build.
 
-div.build(ng-repeat="build in current_builds")
-  build-item(build="build", show-builder="current.showBuilders")
+build-item.build(ng-repeat="build in current_builds|filter:{complete:false}", build="build", show-builder="current.showBuilders")

--- a/www/md_base/src/app/home/panels/recent_builds/recent_builds.directive.coffee
+++ b/www/md_base/src/app/home/panels/recent_builds/recent_builds.directive.coffee
@@ -11,13 +11,12 @@ class RecentBuilds extends Directive
 
 class _RecentBuilds extends Controller
     showBuilders: true
-    builds: []
     constructor: ($scope, buildbotService, bbSettingsService) ->
         homeSetting = bbSettingsService.getSettingsGroup 'home'
 
-        buildbotService.all('builds').getList(
+        $scope.recent_builds = []
+        buildbotService.some('builds',
             complete: true
             order:'-complete_at'
             limit: homeSetting.n_recent_builds.value
-        ).then (data) =>
-            @builds = data
+        ).bind($scope, dest_key: 'recent_builds')

--- a/www/md_base/src/app/home/panels/recent_builds/recent_builds_panel.tpl.jade
+++ b/www/md_base/src/app/home/panels/recent_builds/recent_builds_panel.tpl.jade
@@ -1,6 +1,5 @@
-div.no-build(ng-if="recent.builds.length == 0")
+div.no-build(ng-if="recent_builds.length == 0")
   | No completed builds yet. Go to 
   a(ui-sref="builds") builds panel
   |  to trigger a build.
-div.build(ng-repeat="build in recent.builds")
-  build-item(build="build", show-builder="recent.showBuilders")
+build-item(ng-repeat="build in recent_builds", build="build", show-builder="recent.showBuilders")


### PR DESCRIPTION
Here is the current builds panel.

![current_panel](https://cloud.githubusercontent.com/assets/557294/8086216/c75803ca-0fc6-11e5-8275-0f7688746772.png)

This panel is not complex, just bind running builds on the scope and display them. I added `enter` and `leave` animation for the `build-item` so there will be a animation when the builds shows or disappears.

There is a problem now. After a build disappeared in the current builds panel, it does not show in the recent panel automatically. I will dig into the `buildbotService` later to see if this problem is able to be solved.