### PR TITLE
Add context field to GitHubStatus updates

### DIFF
--- a/master/buildbot/status/github.py
+++ b/master/buildbot/status/github.py
@@ -49,6 +49,7 @@ def _getGitHubState(results):
 
 
 class GitHubStatus(StatusReceiverMultiService):
+
     """
     Send build status to GitHub.
 
@@ -59,7 +60,7 @@ class GitHubStatus(StatusReceiverMultiService):
 
     def __init__(self, token, repoOwner, repoName, sha=None,
                  startDescription=None, endDescription=None,
-                 baseURL=None):
+                 baseURL=None, context=None):
         """
         Token for GitHub API.
         """
@@ -71,6 +72,7 @@ class GitHubStatus(StatusReceiverMultiService):
         self._sha = sha or Interpolate("%(src::revision)s")
         self._repoOwner = repoOwner
         self._repoName = repoName
+        self._context = context or Interpolate("buildbot/%(prop:buildername)s")
         self._startDescription = startDescription or "Build started."
         self._endDescription = endDescription or "Build done."
 
@@ -166,10 +168,11 @@ class GitHubStatus(StatusReceiverMultiService):
         """
         Return a dictionary with GitHub related properties from `build`.
         """
-        repoOwner, repoName, sha = yield defer.gatherResults([
+        repoOwner, repoName, sha, context = yield defer.gatherResults([
             build.render(self._repoOwner),
             build.render(self._repoName),
             build.render(self._sha),
+            build.render(self._context),
         ])
 
         if not repoOwner or not repoName:
@@ -185,6 +188,7 @@ class GitHubStatus(StatusReceiverMultiService):
             'sha': sha,
             'targetURL': self._status.getURLForThing(build),
             'buildNumber': str(build.getNumber()),
+            'context': context,
         }
         defer.returnValue(result)
 
@@ -200,6 +204,7 @@ class GitHubStatus(StatusReceiverMultiService):
             state=status['state'].encode('utf-8'),
             target_url=status['targetURL'].encode('utf-8'),
             description=status['description'].encode('utf-8'),
+            context=status['context'].encode('utf-8'),
         )
 
         success_message = (

--- a/master/buildbot/test/unit/test_status_github.py
+++ b/master/buildbot/test/unit/test_status_github.py
@@ -132,6 +132,8 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
         self.assertEqual(status._sha, Interpolate("%(src::revision)s"))
         self.assertEqual(status._startDescription, "Build started.")
         self.assertEqual(status._endDescription, "Build done.")
+        self.assertEqual(status._context,
+                         Interpolate("buildbot/%(prop:buildername)s"))
 
     def test_custom_github_url(self):
         """
@@ -271,6 +273,7 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
             'sha': '123',
             'targetURL': 'http://example.tld',
             'buildNumber': '1',
+            'context': 'context',
         }
         self.status._sendGitHubStatus = Mock(return_value=defer.succeed(None))
         self.build.getTimes = lambda: (1, None)
@@ -286,6 +289,7 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
             'sha': '123',
             'targetURL': 'http://example.tld',
             'buildNumber': '1',
+            'context': 'context',
             # Augmented arguments.
             'state': 'pending',
             'description': 'Build started.',
@@ -330,6 +334,7 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
             'sha': '123',
             'targetURL': 'http://example.tld',
             'buildNumber': '1',
+            'context': 'context',
         }
         self.status._sendGitHubStatus = Mock(return_value=defer.succeed(None))
         self.build.getTimes = lambda: (1, 3)
@@ -346,6 +351,7 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
             'sha': '123',
             'targetURL': 'http://example.tld',
             'buildNumber': '1',
+            'context': 'context',
             # Augmented arguments.
             'state': 'success',
             'description': 'Build done.',
@@ -398,6 +404,7 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
         self.status._repoOwner = Interpolate('owner')
         self.status._repoName = Interpolate('name')
         self.status._sha = Interpolate('sha')
+        self.status._context = Interpolate('context')
         self.status._status = Mock()
         self.status._status.getURLForThing = lambda build: 'http://example.org'
         self.build.getNumber = lambda: 1
@@ -411,8 +418,8 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
             'repoOwner': 'owner',
             'sha': 'sha',
             'targetURL': 'http://example.org',
-        },
-            result)
+            'context': 'context',
+        }, result)
 
     def test_getGitHubState(self):
         """
@@ -435,6 +442,7 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
             'state': u'state-resum\xe9',
             'targetURL': u'targetURL-resum\xe9',
             'description': u'description-resum\xe9',
+            'context': u'context-resum\xe9',
         }
         self.status._github.repos.createStatus = Mock(
             return_value=defer.succeed(None))
@@ -450,6 +458,7 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
             state='state-resum\xc3\xa9',
             target_url='targetURL-resum\xc3\xa9',
             description='description-resum\xc3\xa9',
+            context='context-resum\xc3\xa9',
         )
 
         self.assertLog(
@@ -468,6 +477,7 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
             'state': u'state',
             'targetURL': u'targetURL',
             'description': u'description',
+            'context': u'context',
         }
         error = MarkerError('fail-send-status')
         self.status._github.repos.createStatus = Mock(

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -763,10 +763,12 @@ GitHubStatus
     repoOwner = Interpolate("%(prop:github_repo_owner)s")
     repoName = Interpolate("%(prop:github_repo_name)s")
     sha = Interpolate("%(src::revision)s")
+    context = Interpolate("buildbot/%(prop:buildername)s")
     gs = status.GitHubStatus(token='githubAPIToken',
                              repoOwner=repoOwner,
                              repoName=repoName,
                              sha=sha,
+                             context=context,
                              startDescription='Build started.',
                              endDescription='Build done.')
     buildbot_bbtools = util.BuilderConfig(
@@ -796,6 +798,9 @@ This allow using a single :class:`GitHubStatus` for multiple projects.
 By default `sha` is defined as: `%(src::revision)s`.
 
 In case any of `repoOwner`, `repoName` or `sha` returns `None`, `False` or empty string, the plugin will skip sending the status.
+
+The `context` argument is passed to GitHub to differentiate between statuses. A static string can be passed or :class:`Interpolate` for dynamic substitution.
+The default context is `buildbot/%(prop:buildername)s`.
 
 You can define custom start and end build messages using the `startDescription` and `endDescription` optional interpolation arguments.
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -129,6 +129,8 @@ Their API has slightly to changed in order to adapt to the new data API.
 
 * :bb:reporter:`MailNotifier` no longer forces SSL 3.0 when ``useTls`` is true.
 
+* :class:`~buildbot.status.github.GitHubStatus` now accepts a ``context`` parameter to be passed to the GitHub Status API.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
Adds support for 'contexts' for the GitHub status API.
The default context string is 'continuous-integration/buildbot/'
followed by the builder name.
The context can be configured by passing it to the constructor.
(refs [#2876](http://trac.buildbot.net/ticket/2876))