### PR TITLE
nextSlave can choose slave according to ``build request``

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -17,6 +17,7 @@ import re
 import sys
 import warnings
 
+from types import MethodType
 from buildbot import interfaces
 from buildbot import locks
 from buildbot import util
@@ -827,6 +828,11 @@ class BuilderConfig(util_config.ConfiguredMixin):
         self.nextSlave = nextSlave
         if nextSlave and not callable(nextSlave):
             error('nextSlave must be a callable')
+            # Keeping support of the previous nextSlave API
+        if nextSlave and (nextSlave.func_code.co_argcount == 2 or
+                          (isinstance(nextSlave, MethodType) and
+                           nextSlave.func_code.co_argcount == 3)):
+            self.nextSlave = lambda x, y, z: nextSlave(x, y)  # pragma: no cover
         self.nextBuild = nextBuild
         if nextBuild and not callable(nextBuild):
             error('nextBuild must be a callable')

--- a/master/docs/manual/cfg-builders.rst
+++ b/master/docs/manual/cfg-builders.rst
@@ -61,11 +61,11 @@ Other optional keys may be set on each ``BuilderConfig``:
     As soon as they work, you can move them over to the active tag.
 
 ``nextSlave``
-    If provided, this is a function that controls which slave will be assigned future jobs.
-    The function is passed two arguments, the :class:`Builder` object which is assigning a new job, and a list of :class:`SlaveBuilder` objects.
-    The function should return one of the :class:`SlaveBuilder` objects, or ``None`` if none of the available slaves should be used.
-    As an example, for each ``slave`` in the list, ``slave.slave`` will be a :class:`BuildSlave` object, and ``slave.slave.slavename`` is the slave's name.
-    The function can optionally return a Deferred, which should fire with the same results.
+     If provided, this is a function that controls which slave will be assigned future jobs.
+     The function is passed three arguments, the :class:`Builder` object which is assigning a new job, a list of :class:`SlaveBuilder` objects and the :class:`BuildRequest`.
+     The function should return one of the :class:`SlaveBuilder` objects, or ``None`` if none of the available slaves should be used.
+     As an example, for each ``slave`` in the list, ``slave.slave`` will be a :class:`BuildSlave` object, and ``slave.slave.slavename`` is the slave's name.
+     The function can optionally return a Deferred, which should fire with the same results.
 
 ``nextBuild``
     If provided, this is a function that controls which build request will be handled next.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -25,6 +25,9 @@ Deprecations, Removals, and Non-Compatible Changes
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~
 
+* The :py:class:`~buildbot.config.BuilderConfig` ``nextSlave`` keyword argument takes a callable.
+  This callable now receives :py:class:`~buildbot.process.buildrequest.BuildRequest` instance in its signature as 3rd parameter.
+  **For retro-compatibility, all callable taking only 2 parameters will still work**.
 
 Slave
 -----


### PR DESCRIPTION
**Tracked on**: http://trac.buildbot.net/ticket/3275 

For now, I use ``canStartBuild`` method, which is called for **each slave**.

What I need is to be able to select slaves according ``Build Request`` instance in the ``nextSlave`` method **to filter at once all candidates**.

It seems to me a better and cleaner solution than using ``canStartBuild``, as for a large amount of slaves it may impact performances.

*I committed on my branch, a proposal, maybe not the best way to implement it*. 
*I stay opened to your suggestions...*

Seen with @jaredgrubb: " **functors** (as currently used) might not be a good solution..."