### PR TITLE
Enhance forcescheduler button

### DIFF
--- a/master/buildbot/data/forceschedulers.py
+++ b/master/buildbot/data/forceschedulers.py
@@ -24,6 +24,7 @@ from twisted.internet import defer
 def forceScheduler2Data(sched):
     ret = dict(all_fields=[],
                name=unicode(sched.name),
+               button_name=unicode(sched.buttonName),
                label=unicode(sched.label),
                builder_names=map(unicode, sched.builderNames))
     ret["all_fields"] = [field.getSpec() for field in sched.all_fields]
@@ -88,6 +89,7 @@ class ForceScheduler(base.ResourceType):
 
     class EntityType(types.Entity):
         name = types.Identifier(20)
+        button_name = types.String()
         label = types.String()
         builder_names = types.List(of=types.Identifier(20))
         all_fields = types.List(of=types.JsonObject())

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -568,8 +568,7 @@ class ForceScheduler(base.BaseScheduler):
                  buttonName="Force Build",
                  codebases=None,
                  label=None,
-                 properties=None,
-                 ):
+                 properties=None):
         """
         Initialize a ForceScheduler.
 
@@ -669,7 +668,7 @@ class ForceScheduler(base.BaseScheduler):
         self.all_fields.extend(self.forcedProperties)
 
         self.reasonString = reasonString
-        self.buttonName = buttonName
+        self.buttonName = name if buttonName is None else buttonName
 
     def checkIfType(self, obj, chkType):
         return isinstance(obj, chkType)

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -668,7 +668,7 @@ class ForceScheduler(base.BaseScheduler):
         self.all_fields.extend(self.forcedProperties)
 
         self.reasonString = reasonString
-        self.buttonName = name if buttonName is None else buttonName
+        self.buttonName = buttonName or name
 
     def checkIfType(self, obj, chkType):
         return isinstance(obj, chkType)

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -565,7 +565,7 @@ class ForceScheduler(base.BaseScheduler):
                  username=UserNameParameter(),
                  reason=StringParameter(name="reason", default="force build", size=20),
                  reasonString="A build was forced by '%(owner)s': %(reason)s",
-                 buttonName="Force Build",
+                 buttonName=None,
                  codebases=None,
                  label=None,
                  properties=None):

--- a/master/buildbot/test/unit/test_data_forceschedulers.py
+++ b/master/buildbot/test/unit/test_data_forceschedulers.py
@@ -113,7 +113,7 @@ expected_default = {
                     'tablabel': '',
                     'type': 'nested'}],
     'builder_names': [u'builder'],
-    'button_name': u'Force Build',
+    'button_name': u'defaultforce',
     'label': u'defaultforce',
     'name': u'defaultforce'}
 

--- a/master/buildbot/test/unit/test_data_forceschedulers.py
+++ b/master/buildbot/test/unit/test_data_forceschedulers.py
@@ -113,6 +113,7 @@ expected_default = {
                     'tablabel': '',
                     'type': 'nested'}],
     'builder_names': [u'builder'],
+    'button_name': u'Force Build',
     'label': u'defaultforce',
     'name': u'defaultforce'}
 

--- a/www/base/src/app/builders/builder/builder.controller.coffee
+++ b/www/base/src/app/builders/builder/builder.controller.coffee
@@ -25,7 +25,8 @@ class Builder extends Controller
             actions = []
             _.forEach forceschedulers, (sch) ->
                 actions.push
-                    caption: sch.name
+                    caption: sch.button_name
+                    extra_class: "btn-primary"
                     action: -> $state.go("builder.forcebuilder", scheduler:sch.name)
 
             # reinstall contextual actions when coming back from forcesched


### PR DESCRIPTION
Currently the button of schedulers are base on the scheduler name.
This name could be sometimes not user friendly.

This patch proposes to :
    - use the attribute 'buttonName' from the instance of ForceScheduler class
    - use class 'btn-primary' for the button