### PR TITLE
Do_the_hustle

### DIFF
--- a/master/buildbot/status/words.py
+++ b/master/buildbot/status/words.py
@@ -869,6 +869,10 @@ class Contact(base.StatusReceiver):
         reactor.callLater(3.0, self.send, "(>^.^)>")
         reactor.callLater(3.5, self.send, "(7^.^)7")
         reactor.callLater(5.0, self.send, "(>^.^<)")
+        
+    def command_HUSTLE(self, args):
+        reactor.callLater(1.0, self.send, "/me does the hustle")
+    command_COMMANDS.usage = "dondon on #qutebrowser: qutebrowser-bb needs to learn to do the hustle"  
 
     def command_SHUTDOWN(self, args):
         # FIXME: NEED TO THINK ABOUT!


### PR DESCRIPTION
Allows buildbot to do the hustle.

(The idea came up in #qutebrowser@freenode:)
09:09:12   The-Compiler  | qutebrowser-bb: unmute
09:09:12 qutebrowser-bb | I'm baaaaaaaaaaack!
09:11:19           raven_ch | qutebrowser-bb: dance
09:11:20 qutebrowser-bb | <(^.^<)
09:11:21 qutebrowser-bb | <(^.^)>
09:11:22 qutebrowser-bb | (>^.^)>
09:11:23 qutebrowser-bb | (7^.^)7
09:11:24 qutebrowser-bb | (>^.^<)
09:12:25              dondon | qutebrowser-bb: do the hustle
09:12:28        HolySmoke | hrhrhr
09:13:18           raven_ch | qutebrowser-bb: commands
09:13:18 qutebrowser-bb | buildbot commands: commands, dance, destroy, force, hello, help, last, list, mute,
09:13:43              dondon | needs to learn to do the hustle
09:17:54                      --> | HokeySmole (erm) (~youbet@p508059AE.dip0.t-ipconnect.de) has joined #qutebrowser
09:17:59         HolySmoke | HokeySmole: do the hustle
09:17:59                          * | HokeySmole does the hustle
│09:18:04         HolySmoke | happy? :D
│09:18:28         HolySmoke | HokeySmole: quit