### PR TITLE
buildbot.status is not available in master any more

### DIFF
--- a/master/buildbot/plugins/__init__.py
+++ b/master/buildbot/plugins/__init__.py
@@ -21,11 +21,10 @@ from buildbot.interfaces import IBuildSlave
 from buildbot.interfaces import IBuildStep
 from buildbot.interfaces import IChangeSource
 from buildbot.interfaces import IScheduler
-from buildbot.interfaces import IStatusReceiver
 from buildbot.plugins.db import get_plugins
 
 
-__all__ = ['changes', 'schedulers', 'buildslave', 'steps', 'status', 'util']
+__all__ = ['changes', 'schedulers', 'buildslave', 'steps', 'util', 'reporters']
 
 
 # Names here match the names of the corresponding Buildbot module, hence
@@ -34,6 +33,5 @@ changes = get_plugins('changes', IChangeSource)
 schedulers = get_plugins('schedulers', IScheduler)
 buildslave = get_plugins('buildslave', IBuildSlave)
 steps = get_plugins('steps', IBuildStep)
-status = get_plugins('status', IStatusReceiver)
 util = get_plugins('util', None)
 reporters = get_plugins('reporters', None)


### PR DESCRIPTION
* remove unnecessary interface
* make sure reporters are exported for 'import *'