### PR TITLE
When requesting builds from Data API, properties can be filtered

### DIFF
--- a/master/buildbot/test/unit/test_data_resultspec.py
+++ b/master/buildbot/test/unit/test_data_resultspec.py
@@ -32,42 +32,42 @@ class Filter(unittest.TestCase):
 
     def test_eq(self):
         f = resultspec.Filter('num', 'eq', [10])
-        self.assertEqual(list(f._apply(mklist('num', 5, 10))),
+        self.assertEqual(list(f.apply(mklist('num', 5, 10))),
                          mklist('num', 10))
 
     def test_eq_plural(self):
         f = resultspec.Filter('num', 'eq', [10, 15, 20])
-        self.assertEqual(list(f._apply(mklist('num', 5, 10, 15))),
+        self.assertEqual(list(f.apply(mklist('num', 5, 10, 15))),
                          mklist('num', 10, 15))
 
     def test_ne(self):
         f = resultspec.Filter('num', 'ne', [10])
-        self.assertEqual(list(f._apply(mklist('num', 5, 10))),
+        self.assertEqual(list(f.apply(mklist('num', 5, 10))),
                          mklist('num', 5))
 
     def test_ne_plural(self):
         f = resultspec.Filter('num', 'ne', [10, 15, 20])
-        self.assertEqual(list(f._apply(mklist('num', 5, 10, 15))),
+        self.assertEqual(list(f.apply(mklist('num', 5, 10, 15))),
                          mklist('num', 5))
 
     def test_lt(self):
         f = resultspec.Filter('num', 'lt', [10])
-        self.assertEqual(list(f._apply(mklist('num', 5, 10, 15))),
+        self.assertEqual(list(f.apply(mklist('num', 5, 10, 15))),
                          mklist('num', 5))
 
     def test_le(self):
         f = resultspec.Filter('num', 'le', [10])
-        self.assertEqual(list(f._apply(mklist('num', 5, 10, 15))),
+        self.assertEqual(list(f.apply(mklist('num', 5, 10, 15))),
                          mklist('num', 5, 10))
 
     def test_gt(self):
         f = resultspec.Filter('num', 'gt', [10])
-        self.assertEqual(list(f._apply(mklist('num', 5, 10, 15))),
+        self.assertEqual(list(f.apply(mklist('num', 5, 10, 15))),
                          mklist('num', 15))
 
     def test_ge(self):
         f = resultspec.Filter('num', 'ge', [10])
-        self.assertEqual(list(f._apply(mklist('num', 5, 10, 15))),
+        self.assertEqual(list(f.apply(mklist('num', 5, 10, 15))),
                          mklist('num', 10, 15))
 
 
@@ -227,6 +227,15 @@ class ResultSpec(unittest.TestCase):
         f = resultspec.Filter(field='x', op='gt', values=[23])
         self.assertRaises(AssertionError, lambda:
                           resultspec.ResultSpec(filters=[f]).apply(data))
+
+    def test_popProperties(self):
+        expected = ['prop1', 'prop2']
+        rs = resultspec.ResultSpec(properties=[
+            resultspec.Property('property', 'eq', expected)
+        ])
+        self.assertEqual(len(rs.properties), 1)
+        self.assertEqual(rs.popProperties(), expected)
+        self.assertEqual(len(rs.properties), 0)
 
     def test_popFilter(self):
         rs = resultspec.ResultSpec(filters=[

--- a/master/buildbot/test/unit/test_db_builds.py
+++ b/master/buildbot/test/unit/test_db_builds.py
@@ -127,7 +127,7 @@ class Tests(interfaces.InterfaceTests):
     def test_getBuild(self):
         yield self.insertTestData(self.backgroundData + [self.threeBuilds[0]])
         bdict = yield self.db.builds.getBuild(50)
-        validation.verifyDbDict(self, 'builddict', bdict)
+        validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(bdict, dict(id=50, number=5, buildrequestid=42,
                                      masterid=88, builderid=77, buildslaveid=13,
                                      started_at=epoch2datetime(TIME1), complete_at=None,
@@ -142,7 +142,7 @@ class Tests(interfaces.InterfaceTests):
     def test_getBuildByNumber(self):
         yield self.insertTestData(self.backgroundData + [self.threeBuilds[0]])
         bdict = yield self.db.builds.getBuildByNumber(builderid=77, number=5)
-        validation.verifyDbDict(self, 'builddict', bdict)
+        validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(bdict['id'], 50)
 
     @defer.inlineCallbacks
@@ -150,7 +150,7 @@ class Tests(interfaces.InterfaceTests):
         yield self.insertTestData(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds()
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'builddict', bdict)
+            validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(sorted(bdicts, key=lambda bd: bd['id']),
                          [self.threeBdicts[50], self.threeBdicts[51],
                           self.threeBdicts[52]])
@@ -160,7 +160,7 @@ class Tests(interfaces.InterfaceTests):
         yield self.insertTestData(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(builderid=88)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'builddict', bdict)
+            validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(sorted(bdicts, key=lambda bd: bd['id']),
                          [self.threeBdicts[51]])
 
@@ -169,7 +169,7 @@ class Tests(interfaces.InterfaceTests):
         yield self.insertTestData(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(buildrequestid=42)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'builddict', bdict)
+            validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(sorted(bdicts, key=lambda bd: bd['id']),
                          [self.threeBdicts[50], self.threeBdicts[52]])
 
@@ -178,7 +178,7 @@ class Tests(interfaces.InterfaceTests):
         yield self.insertTestData(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(buildslaveid=13)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'builddict', bdict)
+            validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(sorted(bdicts, key=lambda bd: bd['id']),
                          [self.threeBdicts[50], self.threeBdicts[51]])
 
@@ -187,7 +187,7 @@ class Tests(interfaces.InterfaceTests):
         yield self.insertTestData(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(complete=True)
         for bdict in bdicts:
-            validation.verifyDbDict(self, 'builddict', bdict)
+            validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(sorted(bdicts, key=lambda bd: bd['id']),
                          [self.threeBdicts[52]])
 
@@ -200,7 +200,7 @@ class Tests(interfaces.InterfaceTests):
                                                    buildrequestid=41, buildslaveid=13, masterid=88,
                                                    state_string=u'test test2', _reactor=clock)
         bdict = yield self.db.builds.getBuild(id)
-        validation.verifyDbDict(self, 'builddict', bdict)
+        validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(bdict, {'buildrequestid': 41, 'builderid': 77,
                                  'id': id, 'masterid': 88, 'number': number, 'buildslaveid': 13,
                                  'started_at': epoch2datetime(TIME1),
@@ -219,7 +219,7 @@ class Tests(interfaces.InterfaceTests):
                                                    buildrequestid=41, buildslaveid=13, masterid=88,
                                                    state_string=u'test test2', _reactor=clock)
         bdict = yield self.db.builds.getBuild(id)
-        validation.verifyDbDict(self, 'builddict', bdict)
+        validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(number, 11)
         self.assertEqual(bdict, {'buildrequestid': 41, 'builderid': 77,
                                  'id': id, 'masterid': 88, 'number': number, 'buildslaveid': 13,
@@ -233,7 +233,7 @@ class Tests(interfaces.InterfaceTests):
         yield self.db.builds.setBuildStateString(buildid=50,
                                                  state_string=u'test test2')
         bdict = yield self.db.builds.getBuild(50)
-        validation.verifyDbDict(self, 'builddict', bdict)
+        validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(bdict, dict(id=50, number=5, buildrequestid=42,
                                      masterid=88, builderid=77, buildslaveid=13,
                                      started_at=epoch2datetime(TIME1), complete_at=None,
@@ -246,7 +246,7 @@ class Tests(interfaces.InterfaceTests):
         yield self.insertTestData(self.backgroundData + [self.threeBuilds[0]])
         yield self.db.builds.finishBuild(buildid=50, results=7, _reactor=clock)
         bdict = yield self.db.builds.getBuild(50)
-        validation.verifyDbDict(self, 'builddict', bdict)
+        validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(bdict, dict(id=50, number=5, buildrequestid=42,
                                      masterid=88, builderid=77, buildslaveid=13,
                                      started_at=epoch2datetime(TIME1),
@@ -314,7 +314,7 @@ class RealTests(Tests):
                                                    state_string=u'test test2', _reactor=clock,
                                                    _race_hook=raceHook)
         bdict = yield self.db.builds.getBuild(id)
-        validation.verifyDbDict(self, 'builddict', bdict)
+        validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(number, 8)
         self.assertEqual(bdict, {'buildrequestid': 41, 'builderid': 77,
                                  'id': id, 'masterid': 88, 'number': number, 'buildslaveid': 13,

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -550,7 +550,10 @@ message['builds'].add(None,
                               **_build
                           )))
 
-dbdict['builddict'] = DictValidator(
+# As build's properties are fetched at DATA API level,
+# a distinction shall be made as both are not equal.
+# Validates DB layer
+dbdict['dbbuilddict'] = buildbase = DictValidator(
     id=IntValidator(),
     number=IntValidator(),
     builderid=IntValidator(),
@@ -562,6 +565,9 @@ dbdict['builddict'] = DictValidator(
     state_string=StringValidator(),
     results=NoneOk(IntValidator()),
 )
+
+# Validates DATA API layer
+dbdict['builddict'] = DictValidator(properties=NoneOk(SourcedPropertiesValidator()), **buildbase.keys)
 
 # steps
 

--- a/master/docs/developer/cls-resultspec.rst
+++ b/master/docs/developer/cls-resultspec.rst
@@ -19,8 +19,9 @@ Result specifications are applied in the following order:
  * Filters
  * Order
  * Pagination (limit/offset)
+ * Properties
 
-Only fields are applied to non-collection results.
+Only fields & properties are applied to non-collection results.
 Endpoints processing a result specification should take care to replicate this behavior.
 
 .. py:class:: ResultSpec
@@ -50,10 +51,19 @@ Endpoints processing a result specification should take care to replicate this b
 
         The 0-based index of the first collection item to return.
 
+   .. py:attribute:: properties
+
+        A list of :py:class:`Property` instances to be applied.
+        The result is a logical AND of all properties.
+
     All of the attributes can be supplied as constructor keyword arguments.
 
     Endpoint implementations may call these methods to indicate that they have processed part of the result spec.
     A subsequent call to :py:meth:`apply` will then not waste time re-applying that part.
+
+    .. py:method:: popProperties()
+
+        If a property exists, return its values list and remove it from the result spec.
 
     .. py:method:: popFilter(field, op)
 
@@ -98,3 +108,12 @@ Endpoints processing a result specification should take care to replicate this b
     Many operators, such as "gt", only accept one value.
     Others, such as "eq" or "ne", can accept multiple values.
     In either case, the values must be passed as a list.
+
+.. py:class:: Property(values)
+
+    :param list values: the values on the right side of the operator (``eq``)
+
+    A property represents an item of a foreign table.
+
+    In either case, the values must be passed as a list.
+

--- a/master/docs/developer/rtype-build.rst
+++ b/master/docs/developer/rtype-build.rst
@@ -14,10 +14,23 @@ Builds
     :attr timestamp complete_at: time at which this build was complete, or None if it's still running
     :attr integer results: the results of the build (see :ref:`Build-Result-Codes`), or None if not complete
     :attr unicode state_string: a string giving detail on the state of the build.
+    :attr dict properties: a dictionary of properties attached to build.
 
-    .. todo::
+    .. note:: *properties*
 
-        * Currently build properties aren't available in this resource type
+        This properties dict is only filled out if the `properties filterspec` is set.
+
+        Meaning that, `property filter` allows one to request the Builds DATA API like so:
+
+            * api/v2/builds?property=propKey1&property=propKey2 (returns Build's properties which match given keys)
+            * api/v2/builds?property=* (returns all Build's properties)
+            * api/v2/builds?propKey1&property=propKey2&limit=30 (filters combination)
+
+        .. important::
+
+            When combined with ``field`` filter, to get properties, one should ensure **properties** ``field`` is set.
+
+            * api/v2/builds?field=buildid&field=properties&property=slavename&property=user
 
     .. note::
 


### PR DESCRIPTION
Currently when requesting on Data API for builds (api/v2/builds),
each item (build) returned from the JSON structure,
does not contain the "properties" field.

The drawback of it, is that one's got to request for each build its properties,
which is costly in terms of performance and network usage
(in particular on big range of data).

It should be computed and served from the back-end (Data API).

With this patch, one can request builds properties like this:

- api/v2/builds/1?property=* (return the whole build's properties)
- api/v2/builds/1?property=slavename&property=user (return only desired properties)
- api/v2/builds?property=* (return the whole build's properties)
- api/v2/builds?property=slavename&property=user (return only desired properties)

Other filters can be combined (limit, offset, order, ...)

Note: By default, none properties are returned to avoid breaking API.

Unit tests updated accordingly.
A ticket is available here: [#3284](http://trac.buildbot.net/ticket/3284)