### PR TITLE
Betarelease

### DIFF
--- a/common/maketarballs.sh
+++ b/common/maketarballs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+find . -name VERSION -exec rm {} \;
+rm -rf dist
+mkdir dist
+for pkg in pkg master slave pkg www/base www/console_view www/waterfall_view
+do
+  pip install -e ${pkg}
+  (
+    cd ${pkg}
+    rm -rf dist
+    python setup.py sdist
+  )
+  cp ${pkg}/dist/* dist/
+  pip wheel ${pkg} -w dist
+done

--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -43,7 +43,7 @@ def getVersion(init_file):
 
     # accept version to be coded with 2 or 3 parts (X.Y or X.Y.Z),
     # no matter the number of digits for X, Y and Z
-    VERSION_MATCH = re.compile(r'(\d+\.\d+(\.\d+)?)(\w|-)*')
+    VERSION_MATCH = re.compile(r'(\d+\.\d+(\.\d+)?(\w|-)*)')
 
     try:
         p = Popen(['git', 'describe', '--tags', '--always'], stdout=PIPE, stderr=STDOUT, cwd=cwd)

--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -17,9 +17,14 @@
 #
 # We can't put this method in utility modules, because they import dependancy packages
 #
-from subprocess import Popen, PIPE, STDOUT
+from __future__ import with_statement
+
 import os
 import re
+
+from subprocess import PIPE
+from subprocess import Popen
+from subprocess import STDOUT
 
 
 def getVersion(init_file):

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -50,7 +50,7 @@ def getVersion(init_file):
 
     # accept version to be coded with 2 or 3 parts (X.Y or X.Y.Z),
     # no matter the number of digits for X, Y and Z
-    VERSION_MATCH = re.compile(r'(\d+\.\d+(\.\d+)?)(\w|-)*')
+    VERSION_MATCH = re.compile(r'(\d+\.\d+(\.\d+)?(\w|-)*)')
 
     try:
         p = Popen(['git', 'describe', '--tags', '--always'], stdout=PIPE, stderr=STDOUT, cwd=cwd)

--- a/slave/buildslave/__init__.py
+++ b/slave/buildslave/__init__.py
@@ -18,9 +18,13 @@
 # We can't put this method in utility modules, because they import dependancy packages
 #
 from __future__ import with_statement
-from subprocess import Popen, PIPE, STDOUT
+
 import os
 import re
+
+from subprocess import PIPE
+from subprocess import Popen
+from subprocess import STDOUT
 
 
 def getVersion(init_file):

--- a/slave/buildslave/__init__.py
+++ b/slave/buildslave/__init__.py
@@ -44,7 +44,7 @@ def getVersion(init_file):
 
     # accept version to be coded with 2 or 3 parts (X.Y or X.Y.Z),
     # no matter the number of digits for X, Y and Z
-    VERSION_MATCH = re.compile(r'(\d+\.\d+(\.\d+)?)(\w|-)*')
+    VERSION_MATCH = re.compile(r'(\d+\.\d+(\.\d+)?(\w|-)*)')
 
     try:
         p = Popen(['git', 'describe', '--tags', '--always'], stdout=PIPE, stderr=STDOUT, cwd=cwd)


### PR DESCRIPTION
fix the version matching code to include b1 or p1 according to pep440.

So that we can generate sdist without having to force a export BUILDBOT_VERSION

for review, because I wonder why this wasn't already working like that. I might miss something