### PR TITLE
Schedulers: let codebases be specified as a list

### DIFF
--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -66,19 +66,20 @@ class BaseScheduler(ClusteredService, StateMixin):
         known_keys = set(['branch', 'repository', 'revision'])
         if codebases is None:
             config.error("Codebases cannot be None")
+        elif isinstance(codebases, list):
+            codebases = dict((codebase, {}) for codebase in codebases)
+        elif not isinstance(codebases, dict):
+            config.error("Codebases must be a dict of dicts, or list of strings")
         else:
-            if not isinstance(codebases, dict):
-                config.error("Codebases must be a dict of dicts")
-            else:
-                for codebase, attrs in codebases.iteritems():
-                    if not isinstance(attrs, dict):
-                        config.error("Codebases must be a dict of dicts")
-                    else:
-                        unk = set(attrs) - known_keys
-                        if unk:
-                            config.error(
-                                "Unknown codebase keys %s for codebase %s"
-                                % (', '.join(unk), codebase))
+            for codebase, attrs in codebases.iteritems():
+                if not isinstance(attrs, dict):
+                    config.error("Codebases must be a dict of dicts")
+                else:
+                    unk = set(attrs) - known_keys
+                    if unk:
+                        config.error(
+                            "Unknown codebase keys %s for codebase %s"
+                            % (', '.join(unk), codebase))
 
         self.codebases = codebases
 
@@ -271,7 +272,7 @@ class BaseScheduler(ClusteredService, StateMixin):
 
                 ss = {
                     'codebase': codebase,
-                    'repository': cb['repository'],
+                    'repository': cb.get('repository', ''),
                     'branch': cb.get('branch', None),
                     'revision': cb.get('revision', None),
                     'project': '',

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -72,6 +72,10 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
                      {"repository": u"", "branch": u"", "revision": u""}}
         self.makeScheduler(codebases=codebases)
 
+    def test_constructor_codebases_valid_list(self):
+        codebases = ['codebase1']
+        self.makeScheduler(codebases=codebases)
+
     def test_constructor_codebases_invalid(self):
         # scheduler only accepts codebases with at least repository set
         codebases = {"codebase1": {"dictionary": "", "that": "", "fails": ""}}
@@ -83,6 +87,12 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
         sched = self.makeScheduler(codebases={'lib': {'repository': 'librepo'}})
         cbd = yield sched.getCodebaseDict('lib')
         self.assertEqual(cbd, {'repository': 'librepo'})
+
+    @defer.inlineCallbacks
+    def test_getCodebaseDict_constructedFromList(self):
+        sched = self.makeScheduler(codebases=['lib', 'lib2'])
+        cbd = yield sched.getCodebaseDict('lib')
+        self.assertEqual(cbd, {})
 
     def test_getCodebaseDict_not_found(self):
         sched = self.makeScheduler(codebases={'lib': {'repository': 'librepo'}})

--- a/master/docs/manual/cfg-schedulers.rst
+++ b/master/docs/manual/cfg-schedulers.rst
@@ -62,6 +62,11 @@ There are several common arguments for schedulers, although not all are availabl
 
 ``codebases``
     When the scheduler processes data from more than one repository at the same time, a corresponding codebase definition should be passed for each repository.
+
+    This parameter can be specified either as a list of strings (simplest form; use if no special
+    overrides are needed) or as a dictionary of dictionaries (where each dict is a codebase definition
+    as described next).
+
     Each codebase definition is a dictionary with any of the keys: ``repository``, ``branch``, ``revision``.
     The codebase definitions are combined in a dictionary keyed by the name of the codebase.
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -31,6 +31,8 @@ Slave
 Features
 ~~~~~~~~
 
+* Schedulers: the ``codebases`` parameter can now be specified in a simple list-of-strings form.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
I've always been annoyed that schedulers require a list of dictionaries for the 'codebase' parameter. This is espcially bad in eight (I'll do another patch there), but it's just kinda dumb that users must do this:

    SingleBranchScheduler(..., 
                          codebases={ 'foo': {}, 'bar': {} }) # nine
    SingleBranchScheduler(..., 
                          codebases={ 'foo': { 'repository':'' }, 
                                      'bar': { 'repository':'' }}) # eight

rather than just:

    SingleBranchScheduler(..., codebases=['foo', 'bar'])

