### PR TITLE
Jgrubb nine docs

### DIFF
--- a/master/buildbot/scripts/sample.cfg
+++ b/master/buildbot/scripts/sample.cfg
@@ -18,9 +18,8 @@ c = BuildmasterConfig = {}
 c['slaves'] = [buildslave.BuildSlave("example-slave", "pass")]
 
 # 'protocols' contains information about protocols which master will use for
-# communicating with slaves.
-# You must define at least 'port' option that slaves could connect to your master
-# with this protocol.
+# communicating with slaves. You must define at least 'port' option that slaves 
+# could connect to your master with this protocol.
 # 'port' must match the value configured into the buildslaves (with their
 # --master option)
 c['protocols'] = {'pb': {'port': 9989}}
@@ -73,24 +72,22 @@ c['builders'].append(
 
 # 'status' is a list of Status Targets. The results of each build will be
 # pushed to these targets. buildbot/status/*.py has a variety to choose from,
-# including web pages, email senders, and IRC bots.
+# like IRC bots.
 
 c['status'] = []
 
 ####### PROJECT IDENTITY
 
-# the 'title' string will appear at the top of this buildbot
-# installation's html.WebStatus home page (linked to the
-# 'titleURL') and is embedded in the title of the waterfall HTML page.
+# the 'title' string will appear at the top of this buildbot installation's
+# home pages (linked to the 'titleURL').
 
 c['title'] = "Pyflakes"
 c['titleURL'] = "https://launchpad.net/pyflakes"
 
 # the 'buildbotURL' string should point to the location where the buildbot's
-# internal web server (usually the html.WebStatus page) is visible. This
-# typically uses the port number set in the Waterfall 'status' entry, but
-# with an externally-visible host name which the buildbot cannot figure out
-# without some help.
+# internal web server is visible. This typically uses the port number set in 
+# the 'www' entry below, but with an externally-visible host name which the 
+# buildbot cannot figure out without some help.
 
 c['buildbotURL'] = "http://localhost:8020/"
 

--- a/master/docs/manual/installation.rst
+++ b/master/docs/manual/installation.rst
@@ -308,6 +308,15 @@ Beyond this general information, read all of the sections below that apply to ve
 Version-specific Notes
 ~~~~~~~~~~~~~~~~~~~~~~
 
+Upgrading from Buildbot-0.8.x to Buildbot-0.9
+'''''''''''''''''''''''''''''''''''''''''''''
+
+* ``html.WebStatus`` becomes something like: (see <cfg-www>)
+
+.. code-block:: python
+
+    c['www'] = dict(port=8020, plugins=dict(waterfall_view={}, console_view={}))`` 
+
 Upgrading a Buildmaster to Buildbot-0.7.6
 '''''''''''''''''''''''''''''''''''''''''
 


### PR DESCRIPTION
I just (barely) started to get one of my masters ported up to nine and noticed some inaccurate and out-dated information in the docs.

Also, I started a section on eight-to-nine migration notes to start a porting guide. There's only one bullet there, but it's a start. Take a look and see if you like that, or whether you think it should go elsewhere (or even as a separate section/doc)