### PR TITLE
Upgrade print to print_function, replace some with log.msg

### DIFF
--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -172,7 +172,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
         except boto.exception.EC2ResponseError as e:
             if 'InvalidKeyPair.NotFound' not in e.body:
                 if 'AuthFailure' in e.body:
-                    print ('POSSIBLE CAUSES OF ERROR:\n'
+                    log.msg('POSSIBLE CAUSES OF ERROR:\n'
                            '  Did you sign up for EC2?\n'
                            '  Did you put a credit card number in your AWS '
                            'account?\n'

--- a/master/buildbot/clients/base.py
+++ b/master/buildbot/clients/base.py
@@ -15,6 +15,7 @@
 
 
 from twisted.spread import pb
+from twisted.python import log
 
 
 class StatusClient(pb.Referenceable):
@@ -28,47 +29,47 @@ class StatusClient(pb.Referenceable):
         self.events = events
 
     def connected(self, remote):
-        print "connected"
+        log.msg("connected")
         self.remote = remote
         remote.callRemote("subscribe", self.events, 5, self)
 
     def remote_builderAdded(self, buildername, builder):
-        print "builderAdded", buildername
+        log.msg("builderAdded", buildername)
 
     def remote_builderRemoved(self, buildername):
-        print "builderRemoved", buildername
+        log.msg("builderRemoved", buildername)
 
     def remote_builderChangedState(self, buildername, state, eta):
-        print "builderChangedState", buildername, state, eta
+        log.msg("builderChangedState", buildername, state, eta)
 
     def remote_buildStarted(self, buildername, build):
-        print "buildStarted", buildername
+        log.msg("buildStarted", buildername)
 
     def remote_buildFinished(self, buildername, build, results):
-        print "buildFinished", results
+        log.msg("buildFinished", results)
 
     def remote_buildETAUpdate(self, buildername, build, eta):
-        print "ETA", buildername, eta
+        log.msg("ETA", buildername, eta)
 
     def remote_stepStarted(self, buildername, build, stepname, step):
-        print "stepStarted", buildername, stepname
+        log.msg("stepStarted", buildername, stepname)
 
     def remote_stepFinished(self, buildername, build, stepname, step, results):
-        print "stepFinished", buildername, stepname, results
+        log.msg("stepFinished", buildername, stepname, results)
 
     def remote_stepETAUpdate(self, buildername, build, stepname, step,
                              eta, expectations):
-        print "stepETA", buildername, stepname, eta
+        log.msg("stepETA", buildername, stepname, eta)
 
     def remote_logStarted(self, buildername, build, stepname, step,
                           logname, log):
-        print "logStarted", buildername, stepname
+        log.msg("logStarted", buildername, stepname)
 
     def remote_logFinished(self, buildername, build, stepname, step,
                            logname, log):
-        print "logFinished", buildername, stepname
+        log.msg("logFinished", buildername, stepname)
 
     def remote_logChunk(self, buildername, build, stepname, step, logname, log,
                         channel, text):
         ChunkTypes = ["STDOUT", "STDERR", "HEADER"]
-        print "logChunk[%s]: %s" % (ChunkTypes[channel], text)
+        log.msg("logChunk[%s]: %s" % (ChunkTypes[channel], text))

--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -47,7 +47,7 @@ class SourceStamp(object):
 
 
 def output(*msg):
-    print ' '.join(map(str, msg))
+    log.msg(' '.join(map(str, msg)))
 
 
 class SourceStampExtractor:

--- a/master/buildbot/db/pool.py
+++ b/master/buildbot/db/pool.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
 
 import inspect
 import os
@@ -101,7 +102,7 @@ class DBThreadPool(threadpool.ThreadPool):
         log_msg = log.msg
         if verbose:
             def _log_msg(m):
-                print m
+                print(m)
             log_msg = _log_msg
 
         pool_size = 5

--- a/master/buildbot/manhole.py
+++ b/master/buildbot/manhole.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
+
 import base64
 import binascii
 import os
@@ -315,7 +317,7 @@ class ArbitraryCheckerManhole(_BaseManhole, ComparableMixin):
 
 def show(x):
     """Display the data attributes of an object in a readable format"""
-    print "data attributes of %r" % (x,)
+    print("data attributes of %r" % (x,))
     names = dir(x)
     maxlen = max([0] + [len(n) for n in names])
     for k in names:
@@ -334,5 +336,5 @@ def show(x):
             v = "%s (%d elements)" % (v, len(v))
         else:
             v = str(t)
-        print "%*s : %s" % (maxlen, k, v)
+        print("%*s : %s" % (maxlen, k, v))
     return x

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -36,6 +36,7 @@ from distutils.version import LooseVersion
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet.protocol import ProcessProtocol
+from twisted.python import log
 
 # Cache the version that the gerrit server is running for this many seconds
 GERRIT_VERSION_CACHE_TIMEOUT = 600
@@ -200,18 +201,18 @@ class GerritStatusPush(service.BuildbotService):
         def outReceived(self, data):
             vstr = "gerrit version "
             if not data.startswith(vstr):
-                print "Error: Cannot interpret gerrit version info:", data
+                log.msg("Error: Cannot interpret gerrit version info:", data)
                 return
             vers = data[len(vstr):]
-            print "gerrit version:", vers
+            log.msg("gerrit version:", vers)
             self.gerrit_version = LooseVersion(vers)
 
         def errReceived(self, data):
-            print "gerriterr:", data
+            log.msg("gerriterr:", data)
 
         def processEnded(self, status_object):
             if status_object.value.exitCode:
-                print "gerrit version status: ERROR:", status_object
+                log.msg("gerrit version status: ERROR:", status_object)
                 return
             if self.gerrit_version:
                 self.func(self.gerrit_version)
@@ -241,16 +242,16 @@ class GerritStatusPush(service.BuildbotService):
             self.status = status
 
         def outReceived(self, data):
-            print "gerritout:", data
+            log.msg("gerritout:", data)
 
         def errReceived(self, data):
-            print "gerriterr:", data
+            log.msg("gerriterr:", data)
 
         def processEnded(self, status_object):
             if status_object.value.exitCode:
-                print "gerrit status: ERROR:", status_object
+                log.msg("gerrit status: ERROR:", status_object)
             else:
-                print "gerrit status: OK"
+                log.msg("gerrit status: OK")
 
     @defer.inlineCallbacks
     def startService(self):

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
+
 import copy
 import os
 import stat
@@ -22,7 +24,7 @@ from twisted.python import usage
 
 def isBuildmasterDir(dir):
     def print_error(error_message):
-        print "%s\ninvalid buildmaster directory '%s'" % (error_message, dir)
+        print("%s\ninvalid buildmaster directory '%s'" % (error_message, dir))
 
     buildbot_tac = os.path.join(dir, "buildbot.tac")
     try:
@@ -134,7 +136,7 @@ class SubcommandOptions(usage.Options):
             if os.path.isdir(d):
                 if runtime.platformType != 'win32':
                     if os.stat(d)[stat.ST_UID] != os.getuid():
-                        print "skipping %s because you don't own it" % d
+                        print("skipping %s because you don't own it" % d)
                         continue  # security, skip other people's directories
                 optfile = os.path.join(d, "options")
                 if os.path.exists(optfile):
@@ -143,7 +145,7 @@ class SubcommandOptions(usage.Options):
                             options = f.read()
                         exec options in localDict
                     except Exception:
-                        print "error while reading %s" % optfile
+                        print("error while reading %s" % optfile)
                         raise
                     break
 

--- a/master/buildbot/scripts/checkconfig.py
+++ b/master/buildbot/scripts/checkconfig.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
 
 import os
 import sys
@@ -27,13 +28,13 @@ def _loadConfig(basedir, configFile, quiet):
             basedir, configFile)
     except config.ConfigErrors as e:
         if not quiet:
-            print >> sys.stderr, "Configuration Errors:"
+            print("Configuration Errors:", file=sys.stderr)
             for e in e.errors:
-                print >> sys.stderr, "  " + e
+                print("  " + e, file=sys.stderr)
         return 1
 
     if not quiet:
-        print "Config file is good!"
+        print("Config file is good!")
     return 0
 
 
@@ -48,8 +49,8 @@ def checkconfig(config):
             configFile = getConfigFileFromTac(basedir)
         except (SyntaxError, ImportError) as e:
             if not quiet:
-                print "Unable to load 'buildbot.tac' from '%s':" % basedir
-                print e
+                print("Unable to load 'buildbot.tac' from '%s':" % basedir)
+                print(e)
             return 1
     else:
         basedir = os.getcwd()

--- a/master/buildbot/scripts/create_master.py
+++ b/master/buildbot/scripts/create_master.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
+
 import jinja2
 import os
 
@@ -27,10 +29,10 @@ from twisted.python import util
 def makeBasedir(config):
     if os.path.exists(config['basedir']):
         if not config['quiet']:
-            print "updating existing installation"
+            print("updating existing installation")
         return
     if not config['quiet']:
-        print "mkdir", config['basedir']
+        print("mkdir", config['basedir'])
     os.mkdir(config['basedir'])
 
 
@@ -49,11 +51,11 @@ def makeTAC(config):
             oldcontents = f.read()
         if oldcontents == contents:
             if not config['quiet']:
-                print "buildbot.tac already exists and is correct"
+                print("buildbot.tac already exists and is correct")
             return
         if not config['quiet']:
-            print "not touching existing buildbot.tac"
-            print "creating buildbot.tac.new instead"
+            print("not touching existing buildbot.tac")
+            print("creating buildbot.tac.new instead")
         tacfile += ".new"
     with open(tacfile, "wt") as f:
         f.write(contents)
@@ -63,7 +65,7 @@ def makeSampleConfig(config):
     source = util.sibpath(__file__, "sample.cfg")
     target = os.path.join(config['basedir'], "master.cfg.sample")
     if not config['quiet']:
-        print "creating %s" % target
+        print("creating %s" % target)
     with open(source, "rt") as f:
         config_sample = f.read()
     if config['db']:
@@ -78,12 +80,12 @@ def makePublicHtml(config):
     webdir = os.path.join(config['basedir'], "public_html")
     if os.path.exists(webdir):
         if not config['quiet']:
-            print "public_html/ already exists: not replacing"
+            print("public_html/ already exists: not replacing")
         return
     else:
         os.mkdir(webdir)
     if not config['quiet']:
-        print "populating public_html/"
+        print("populating public_html/")
 
 
 @defer.inlineCallbacks
@@ -101,7 +103,7 @@ def createDB(config, _noMonkey=False):
     db = connector.DBConnector(master, config['basedir'])
     yield db.setup(check_version=False, verbose=not config['quiet'])
     if not config['quiet']:
-        print "creating database (%s)" % (master_cfg.db['db_url'],)
+        print("creating database (%s)" % (master_cfg.db['db_url'],))
     yield db.model.upgrade()
 
 
@@ -115,6 +117,6 @@ def createMaster(config):
     yield createDB(config)
 
     if not config['quiet']:
-        print "buildmaster configured in %s" % (config['basedir'],)
+        print("buildmaster configured in %s" % (config['basedir'],))
 
     defer.returnValue(0)

--- a/master/buildbot/scripts/logwatcher.py
+++ b/master/buildbot/scripts/logwatcher.py
@@ -12,7 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
+from __future__ import print_function
 
 import os
 import platform
@@ -43,7 +43,7 @@ class TailProcess(protocol.ProcessProtocol):
         self.lw.dataReceived(data)
 
     def errReceived(self, data):
-        print "ERR: '%s'" % (data,)
+        print("ERR: '%s'" % (data,))
 
 
 class LogWatcher(LineOnlyReceiver):
@@ -120,7 +120,7 @@ class LogWatcher(LineOnlyReceiver):
             self.in_reconfig = True
 
         if self.in_reconfig:
-            print line
+            print(line)
 
         # certain lines indicate progress, so we "cancel" the timeout
         # and it will get re-added when it fires

--- a/master/buildbot/scripts/processwwwindex.py
+++ b/master/buildbot/scripts/processwwwindex.py
@@ -12,7 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
+from __future__ import print_function
 
 import jinja2
 import os
@@ -32,11 +32,11 @@ def processwwwindex(config):
     master_service = WWWService(master)
 
     if not config.get('index-file'):
-        print "Path to the index.html file is required with option --index-file or -i"
+        print("Path to the index.html file is required with option --index-file or -i")
         defer.returnValue(1)
     path = config.get('index-file')
     if not os.path.isfile(path):
-        print "Invalid path to index.html"
+        print("Invalid path to index.html")
         defer.returnValue(2)
 
     main_dir = os.path.dirname(path)

--- a/master/buildbot/scripts/reconfig.py
+++ b/master/buildbot/scripts/reconfig.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
+
 import os
 import platform
 import signal
@@ -31,7 +33,7 @@ class Reconfigurator:
     def run(self, basedir, quiet):
         # Returns "Microsoft" for Vista and "Windows" for other versions
         if platform.system() in ("Windows", "Microsoft"):
-            print "Reconfig (through SIGHUP) is not supported on Windows."
+            print("Reconfig (through SIGHUP) is not supported on Windows.")
             return
 
         with open(os.path.join(basedir, "twistd.pid"), "rt") as f:
@@ -57,29 +59,29 @@ class Reconfigurator:
     def sighup(self):
         if self.sent_signal:
             return
-        print "sending SIGHUP to process %d" % self.pid
+        print("sending SIGHUP to process %d" % self.pid)
         self.sent_signal = True
         os.kill(self.pid, signal.SIGHUP)
 
     def success(self, res):
-        print """
+        print("""
 Reconfiguration appears to have completed successfully.
-"""
+""")
 
     def failure(self, why):
         self.rc = 1
         if why.check(BuildmasterTimeoutError):
-            print "Never saw reconfiguration finish."
+            print("Never saw reconfiguration finish.")
         elif why.check(ReconfigError):
-            print """
+            print("""
 Reconfiguration failed. Please inspect the master.cfg file for errors,
 correct them, then try 'buildbot reconfig' again.
-"""
+""")
         elif why.check(IOError):
             # we were probably unable to open the file in the first place
             self.sighup()
         else:
-            print "Error while following twistd.log: %s" % why
+            print("Error while following twistd.log: %s" % why)
 
 
 @in_reactor

--- a/master/buildbot/scripts/restart.py
+++ b/master/buildbot/scripts/restart.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
+
 from buildbot.scripts import base
 from buildbot.scripts import start
 from buildbot.scripts import stop
@@ -27,5 +29,5 @@ def restart(config):
     if stop.stop(config, wait=True) != 0:
         return 1
     if not quiet:
-        print "now restarting buildbot process.."
+        print("now restarting buildbot process..")
     return start.start(config)

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -18,6 +18,8 @@
 #
 # Also don't forget to mirror your changes on command-line options in manual
 # pages and texinfo documentation.
+from __future__ import print_function
+
 import sqlalchemy as sa
 import sys
 
@@ -688,7 +690,7 @@ class Options(usage.Options):
 
     def opt_version(self):
         import buildbot
-        print "Buildbot version: %s" % buildbot.version
+        print("Buildbot version: %s" % buildbot.version)
         usage.Options.opt_version(self)
 
     def opt_verbose(self):
@@ -705,10 +707,11 @@ def run():
     try:
         config.parseOptions(sys.argv[1:])
     except usage.error as e:
-        print "%s:  %s" % (sys.argv[0], e)
-        print
+        print("%s:  %s" % (sys.argv[0], e))
+        print()
+
         c = getattr(config, 'subOptions', config)
-        print str(c)
+        print(str(c))
         sys.exit(1)
 
     subconfig = config.subOptions

--- a/master/buildbot/scripts/sendchange.py
+++ b/master/buildbot/scripts/sendchange.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
 
 import sys
 import traceback
@@ -48,9 +49,9 @@ def sendchange(config):
                      repository=repository, vc=vc, project=project, revlink=revlink,
                      codebase=codebase)
     except Exception:
-        print "change not sent:"
+        print("change not sent:")
         traceback.print_exc(file=sys.stdout)
         defer.returnValue(1)
     else:
-        print "change sent successfully"
+        print("change sent successfully")
         defer.returnValue(0)

--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -12,7 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
+from __future__ import print_function
 
 import os
 import sys
@@ -30,7 +30,7 @@ class Follower:
 
     def follow(self, basedir):
         self.rc = 0
-        print "Following twistd.log until startup finished.."
+        print("Following twistd.log until startup finished..")
         lw = LogWatcher(os.path.join(basedir, "twistd.log"))
         d = lw.start()
         d.addCallbacks(self._success, self._failure)
@@ -38,29 +38,29 @@ class Follower:
         return self.rc
 
     def _success(self, _):
-        print "The buildmaster appears to have (re)started correctly."
+        print("The buildmaster appears to have (re)started correctly.")
         self.rc = 0
         reactor.stop()
 
     def _failure(self, why):
         if why.check(BuildmasterTimeoutError):
-            print """
+            print("""
 The buildmaster took more than 10 seconds to start, so we were unable to
 confirm that it started correctly. Please 'tail twistd.log' and look for a
 line that says 'BuildMaster is Running' to verify correct startup.
-"""
+""")
         elif why.check(ReconfigError):
-            print """
+            print("""
 The buildmaster appears to have encountered an error in the master.cfg config
 file during startup. Please inspect and fix master.cfg, then restart the
 buildmaster.
-"""
+""")
         else:
-            print """
+            print("""
 Unable to confirm that the buildmaster started correctly. You may need to
 stop it, fix the config file, and restart.
-"""
-            print why
+""")
+            print(why)
         self.rc = 1
         reactor.stop()
 

--- a/master/buildbot/scripts/stop.py
+++ b/master/buildbot/scripts/stop.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
+
 import errno
 import os
 import signal
@@ -36,7 +38,7 @@ def stop(config, signame="TERM", wait=False):
             pid = int(f.read().strip())
     except Exception:
         if not config['quiet']:
-            print "buildmaster not running"
+            print("buildmaster not running")
         return 0
 
     signum = getattr(signal, "SIG" + signame)
@@ -47,7 +49,7 @@ def stop(config, signame="TERM", wait=False):
             raise
         else:
             if not config['quiet']:
-                print "buildmaster not running"
+                print("buildmaster not running")
             try:
                 os.unlink(pidfile)
             except OSError:
@@ -56,7 +58,7 @@ def stop(config, signame="TERM", wait=False):
 
     if not wait:
         if not quiet:
-            print "sent SIG%s to process" % signame
+            print("sent SIG%s to process" % signame)
         return 0
 
     time.sleep(0.1)
@@ -69,10 +71,10 @@ def stop(config, signame="TERM", wait=False):
             os.kill(pid, 0)
         except OSError:
             if not quiet:
-                print "buildbot process %d is dead" % pid
+                print("buildbot process %d is dead" % pid)
             return 0
         time.sleep(1)
         count += 1
     if not quiet:
-        print "never saw process go away"
+        print("never saw process go away")
     return 1

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
+
 import os
 import sys
 import traceback
@@ -29,30 +31,30 @@ from twisted.python import util
 
 def checkBasedir(config):
     if not config['quiet']:
-        print "checking basedir"
+        print("checking basedir")
 
     if not base.isBuildmasterDir(config['basedir']):
         return False
 
     if runtime.platformType != 'win32':  # no pids on win32
         if not config['quiet']:
-            print "checking for running master"
+            print("checking for running master")
         pidfile = os.path.join(config['basedir'], 'twistd.pid')
         if os.path.exists(pidfile):
-            print "'%s' exists - is this master still running?" % (pidfile,)
+            print("'%s' exists - is this master still running?" % (pidfile,))
             return False
 
     tac = base.getConfigFromTac(config['basedir'])
     if tac:
         if isinstance(tac.get('rotateLength', 0), str):
-            print "ERROR: rotateLength is a string, it should be a number"
-            print "ERROR: Please, edit your buildbot.tac file and run again"
-            print "ERROR: See http://trac.buildbot.net/ticket/2588 for more details"
+            print("ERROR: rotateLength is a string, it should be a number")
+            print("ERROR: Please, edit your buildbot.tac file and run again")
+            print("ERROR: See http://trac.buildbot.net/ticket/2588 for more details")
             return False
         if isinstance(tac.get('maxRotatedFiles', 0), str):
-            print "ERROR: maxRotatedFiles is a string, it should be a number"
-            print "ERROR: Please, edit your buildbot.tac file and run again"
-            print "ERROR: See http://trac.buildbot.net/ticket/2588 for more details"
+            print("ERROR: maxRotatedFiles is a string, it should be a number")
+            print("ERROR: Please, edit your buildbot.tac file and run again")
+            print("ERROR: See http://trac.buildbot.net/ticket/2588 for more details")
             return False
 
     return True
@@ -60,18 +62,19 @@ def checkBasedir(config):
 
 def loadConfig(config, configFileName='master.cfg'):
     if not config['quiet']:
-        print "checking %s" % configFileName
+        print("checking %s" % configFileName)
 
     try:
         master_cfg = config_module.MasterConfig.loadConfig(
             config['basedir'], configFileName)
     except config_module.ConfigErrors as e:
-        print "Errors loading configuration:"
+        print("Errors loading configuration:")
+
         for msg in e.errors:
-            print "  " + msg
+            print("  " + msg)
         return
     except Exception:
-        print "Errors loading configuration:"
+        print("Errors loading configuration:")
         traceback.print_exc(file=sys.stdout)
         return
 
@@ -87,38 +90,38 @@ def installFile(config, target, source, overwrite=False):
         if old_contents != new_contents:
             if overwrite:
                 if not config['quiet']:
-                    print "%s has old/modified contents" % target
-                    print " overwriting it with new contents"
+                    print("%s has old/modified contents" % target)
+                    print(" overwriting it with new contents")
                 with open(target, "wt") as f:
                     f.write(new_contents)
             else:
                 if not config['quiet']:
-                    print "%s has old/modified contents" % target
-                    print " writing new contents to %s.new" % target
+                    print("%s has old/modified contents" % target)
+                    print(" writing new contents to %s.new" % target)
                 with open(target + ".new", "wt") as f:
                     f.write(new_contents)
         # otherwise, it's up to date
     else:
         if not config['quiet']:
-            print "creating %s" % target
+            print("creating %s" % target)
         with open(target, "wt") as f:
             f.write(new_contents)
 
 
 def upgradeFiles(config):
     if not config['quiet']:
-        print "upgrading basedir"
+        print("upgrading basedir")
 
     webdir = os.path.join(config['basedir'], "public_html")
     if not os.path.exists(webdir):
         if not config['quiet']:
-            print "creating public_html"
+            print("creating public_html")
         os.mkdir(webdir)
 
     templdir = os.path.join(config['basedir'], "templates")
     if not os.path.exists(templdir):
         if not config['quiet']:
-            print "creating templates"
+            print("creating templates")
         os.mkdir(templdir)
 
     installFile(config, os.path.join(config['basedir'], "master.cfg.sample"),
@@ -129,24 +132,24 @@ def upgradeFiles(config):
     root_html = os.path.join(templdir, "root.html")
     if os.path.exists(index_html):
         if os.path.exists(root_html):
-            print "Notice: %s now overrides %s" % (root_html, index_html)
-            print "        as the latter is not used by buildbot anymore."
-            print "        Decide which one you want to keep."
+            print("Notice: %s now overrides %s" % (root_html, index_html))
+            print("        as the latter is not used by buildbot anymore.")
+            print("        Decide which one you want to keep.")
         else:
             try:
-                print "Notice: Moving %s to %s." % (index_html, root_html)
-                print "        You can (and probably want to) remove it if " \
-                    "you haven't modified this file."
+                print("Notice: Moving %s to %s." % (index_html, root_html))
+                print("        You can (and probably want to) remove it if "
+                    "you haven't modified this file.")
                 os.renames(index_html, root_html)
             except Exception as e:
-                print "Error moving %s to %s: %s" % (index_html, root_html,
-                                                     str(e))
+                print("Error moving %s to %s: %s" % (index_html, root_html,
+                                                     str(e)))
 
 
 @defer.inlineCallbacks
 def upgradeDatabase(config, master_cfg):
     if not config['quiet']:
-        print "upgrading database (%s)" % (master_cfg.db['db_url'])
+        print("upgrading database (%s)" % (master_cfg.db['db_url']))
 
     master = BuildMaster(config['basedir'])
     master.config = master_cfg
@@ -172,8 +175,9 @@ def upgradeMaster(config, _noMonkey=False):
     try:
         configFile = base.getConfigFileFromTac(config['basedir'])
     except (SyntaxError, ImportError) as e:
-        print "Unable to load 'buildbot.tac' from '%s':" % config['basedir']
-        print e
+        print("Unable to load 'buildbot.tac' from '%s':" % config['basedir'])
+        print(e)
+
         defer.returnValue(1)
         return
     master_cfg = loadConfig(config, configFile)
@@ -185,6 +189,6 @@ def upgradeMaster(config, _noMonkey=False):
     yield upgradeDatabase(config, master_cfg)
 
     if not config['quiet']:
-        print "upgrade complete"
+        print("upgrade complete")
 
     defer.returnValue(0)

--- a/master/buildbot/scripts/user.py
+++ b/master/buildbot/scripts/user.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
 
 from buildbot.clients import usersclient
 from buildbot.process.users import users
@@ -44,6 +45,6 @@ def user(config):
     uc = usersclient.UsersClient(master, username, passwd, port)
     output = yield uc.send(op, bb_username, bb_password, ids, info)
     if output:
-        print output
+        print(output)
 
     defer.returnValue(0)

--- a/master/buildbot/status/status_stash.py
+++ b/master/buildbot/status/status_stash.py
@@ -121,7 +121,7 @@ class StashStatusPush(StatusReceiverMultiService,
         self.master = self.master_status.master
 
     def startService(self):
-        print """Starting up StashStatusPush"""
+        log.msg("""Starting up StashStatusPush""")
         self.summarySubscribe()
         StatusReceiverMultiService.startService(self)
 

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
 
 from buildbot import config
 from buildbot.schedulers.forcesched import AnyPropertyParameter
@@ -333,11 +334,11 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                 try:
                     import xerox
                     formated = self.formatJsonForTest(gotJson)
-                    print "You may update the test with (copied to clipboard):\n" + formated
+                    print("You may update the test with (copied to clipboard):\n" + formated)
                     xerox.copy(formated)
                     input()
                 except ImportError:
-                    print "Note: for quick fix, pip install xerox"
+                    print("Note: for quick fix, pip install xerox")
             self.assertEqual(gotJson, expectJson)
 
         sched = self.makeScheduler(properties=[prop])

--- a/master/buildbot/test/unit/test_scripts_start.py
+++ b/master/buildbot/test/unit/test_scripts_start.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
+
 import os
 import sys
 import time
@@ -84,7 +86,7 @@ class TestStart(misc.StdoutAssertionsMixin, dirs.DirsMixin, unittest.TestCase):
         @d.addCallback
         def cb(res):
             self.assertEquals(res, ('', '', 0))
-            print res
+            print(res)
         return d
 
     def test_start_quiet(self):
@@ -93,7 +95,7 @@ class TestStart(misc.StdoutAssertionsMixin, dirs.DirsMixin, unittest.TestCase):
         @d.addCallback
         def cb(res):
             self.assertEquals(res, ('', '', 0))
-            print res
+            print(res)
         return d
 
     @flaky(bugNumber=2760)

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
 
 import StringIO
 import mock
@@ -241,20 +242,20 @@ class RunMasterBase(dirs.DirsMixin, unittest.TestCase):
     def printBuild(self, build, out=sys.stdout):
         # helper for debugging: print a build
         yield self.enrichBuild(build, wantSteps=True, wantProperties=True, wantLogs=True)
-        print >> out, "*** BUILD %d *** ==> %s (%s)" % (build['buildid'], build['state_string'],
-                                                        statusToString(build['results']))
+        print("*** BUILD %d *** ==> %s (%s)" % (build['buildid'], build['state_string'],
+              statusToString(build['results'])), file=out)
         for step in build['steps']:
-            print >> out, "    *** STEP %s *** ==> %s (%s)" % (step['name'], step['state_string'],
-                                                               statusToString(step['results']))
+            print("    *** STEP %s *** ==> %s (%s)" % (step['name'], step['state_string'],
+                  statusToString(step['results'])), file=out)
             for url in step['urls']:
-                print >> out, "       url:%s (%s)" % (url['name'], url['url'])
+                print("       url:%s (%s)" % (url['name'], url['url']), file=out)
             for log in step['logs']:
-                print >> out, "        log:%s (%d)" % (log['name'], log['num_lines'])
+                print("        log:%s (%d)" % (log['name'], log['num_lines']), file=out)
                 if step['results'] != SUCCESS:
                     self.printLog(log, out)
 
     def printLog(self, log, out):
-        print >> out, " " * 8 + "*********** LOG: %s *********" % (log['name'],)
+        print(" " * 8 + "*********** LOG: %s *********" % (log['name'],), file=out)
         if log['type'] == 's':
             for line in log['contents']['content'].splitlines():
                 linetype = line[0]
@@ -265,7 +266,7 @@ class RunMasterBase(dirs.DirsMixin, unittest.TestCase):
                 if linetype == 'e':
                     # red
                     line = "\x1b[31m" + line + "\x1b[0m"
-                print " " * 8 + line
+                print(" " * 8 + line)
         else:
-            print >> out, log['contents']['content']
-        print >> out, " " * 8 + "********************************"
+            print(log['contents']['content'], file=out)
+        print(" " * 8 + "********************************", file=out)

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
 
 import mock
 
@@ -230,8 +231,8 @@ class BuildStepMixin(object):
             # in case of unexpected result, display logs in stdout for debugging failing tests
             if result != self.exp_result:
                 for loog in self.step.logs.values():
-                    print loog.stdout
-                    print loog.stderr
+                    print(loog.stdout)
+                    print(loog.stderr)
 
             self.assertEqual(result, self.exp_result, "expected result")
             if self.exp_state_string:

--- a/master/buildbot/util/croniter.py
+++ b/master/buildbot/util/croniter.py
@@ -5,6 +5,7 @@
 # Pyflakes warnings corrected
 
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 import re
 
@@ -311,4 +312,4 @@ if __name__ == '__main__':
     base = datetime(2010, 1, 25)
     itr = croniter('0 0 1 * *', base)
     n1 = itr.get_next(datetime)
-    print n1
+    print(n1)

--- a/master/buildbot/util/pickle.py
+++ b/master/buildbot/util/pickle.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
+
 import cPickle
 import cStringIO
 import new
@@ -177,7 +179,7 @@ class ChangeMaster:  # pragma: no cover
                 newfiles.append(filename)
             c.files = newfiles
         if not quiet:
-            print "converted %d strings" % nconvert
+            print("converted %d strings" % nconvert)
 substituteClasses['buildbot.changes.changes', 'ChangeMaster'] = ChangeMaster
 
 
@@ -761,17 +763,17 @@ class StepProgress:
 
     def start(self):
         if self.debug:
-            print "StepProgress.start[%s]" % self.name
+            print("StepProgress.start[%s]" % self.name)
         self.startTime = util.now()
 
     def setProgress(self, metric, value):
         """The step calls this as progress is made along various axes."""
         if self.debug:
-            print "setProgress[%s][%s] = %s" % (self.name, metric, value)
+            print("setProgress[%s][%s] = %s" % (self.name, metric, value))
         self.progress[metric] = value
         if self.debug:
             r = self.remaining()
-            print " step remaining:", r
+            print(" step remaining:", r)
         self.buildProgress.newProgress()
 
     def finish(self):
@@ -779,7 +781,7 @@ class StepProgress:
         overall. It should be called after the last .setProgress has been
         done for each axis."""
         if self.debug:
-            print "StepProgress.finish[%s]" % self.name
+            print("StepProgress.finish[%s]" % self.name)
         self.stopTime = util.now()
         self.buildProgress.stepFinished(self.name)
 
@@ -874,7 +876,7 @@ class BuildProgress(pb.Referenceable):
     def newProgress(self):
         r = self.remaining()
         if self.debug:
-            print " remaining:", r
+            print(" remaining:", r)
         if r is not None:
             self.sendAllUpdates()
 
@@ -1014,15 +1016,15 @@ class Expectations:
             new_ = self.wavg(old, current)
             self.times[name] = new_
             if self.debug:
-                print "new expected time[%s] = %s, old %s, cur %s" % \
-                      (name, new_, old, current)
+                print("new expected time[%s] = %s, old %s, cur %s" %
+                      (name, new_, old, current))
 
             for metric, current in stepprogress.progress.items():
                 old = self.steps[name].get(metric)
                 new_ = self.wavg(old, current)
                 if self.debug:
-                    print "new expectation[%s][%s] = %s, old %s, cur %s" % \
-                          (name, metric, new_, old, current)
+                    print("new expectation[%s][%s] = %s, old %s, cur %s" %
+                          (name, metric, new_, old, current))
                 self.steps[name][metric] = new_
 
     def expectedBuildTime(self):


### PR DESCRIPTION
Assumptions made:
* Script modules use print()
* Any print prefaced with "if not quiet:" or "if debug:" use print()
* Any print that print to a specific stream use print(""; file=stream)
* Any prints in test files use print()
* Any other prints have become log.msg()

Also manhole.py uses print(), not sure if that is the correct choice