### PR TITLE
Update dictionary iteration to py2/py3 compatability

### DIFF
--- a/master/buildbot/buildslave/base.py
+++ b/master/buildbot/buildslave/base.py
@@ -13,6 +13,7 @@
 #
 # Portions Copyright Buildbot Team Members
 # Portions Copyright Canonical Ltd. 2009
+from future.utils import itervalues
 
 import time
 
@@ -497,7 +498,7 @@ class AbstractBuildSlave(service.BuildbotService, object):
             return False
 
         if self.max_builds:
-            active_builders = [sb for sb in self.slavebuilders.values()
+            active_builders = [sb for sb in itervalues(self.slavebuilders)
                                if sb.isBusy()]
             if len(active_builders) >= self.max_builds:
                 return False
@@ -553,7 +554,7 @@ class AbstractBuildSlave(service.BuildbotService, object):
         and has no active builders."""
         if not self.slave_status.getGraceful():
             return
-        active_builders = [sb for sb in self.slavebuilders.values()
+        active_builders = [sb for sb in itervalues(self.slavebuilders)
                            if sb.isBusy()]
         if active_builders:
             return

--- a/master/buildbot/buildslave/protocols/base.py
+++ b/master/buildbot/buildslave/protocols/base.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 from buildbot.util import service
 from buildbot.util import subscription
@@ -34,8 +35,8 @@ class Connection(object):
     # This method replace all Impl args by their Proxy protocol implementation
     def createArgsProxies(self, args):
         newargs = {}
-        for k, v in args.iteritems():
-            for implclass, proxyclass in self.proxies.items():
+        for k, v in iteritems(args):
+            for implclass, proxyclass in iteritems(self.proxies):
                 if isinstance(v, implclass):
                     v = proxyclass(v)
             newargs[k] = v

--- a/master/buildbot/buildslave/protocols/pb.py
+++ b/master/buildbot/buildslave/protocols/pb.py
@@ -12,8 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
 from __future__ import absolute_import
+from future.utils import itervalues
 
 from buildbot.buildslave.protocols import base
 from twisted.internet import defer
@@ -236,7 +236,7 @@ class Connection(base.Connection, pb.Avatar):
         # remote builder, which will cause the slave buildbot process to exit.
         def old_way():
             d = None
-            for b in self.buildslave.slavebuilders.values():
+            for b in itervalues(self.buildslave.slavebuilders):
                 if b.remote:
                     d = b.mind.callRemote("shutdown")
                     break

--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import time
 
 from buildbot.util import datetime2epoch
@@ -75,7 +77,7 @@ class Change:
         change.files = sorted(chdict['files'])
 
         change.properties = Properties()
-        for n, (v, s) in chdict['properties'].iteritems():
+        for n, (v, s) in iteritems(chdict['properties']):
             change.properties.setProperty(n, v, s)
 
         return defer.succeed(change)

--- a/master/buildbot/changes/filter.py
+++ b/master/buildbot/changes/filter.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import re
 
@@ -80,7 +81,7 @@ class ChangeFilter(ComparableMixin):
     def filter_change(self, change):
         if self.filter_fn is not None and not self.filter_fn(change):
             return False
-        for chg_attr, (filt_list, filt_re, filt_fn) in self.checks.items():
+        for chg_attr, (filt_list, filt_re, filt_fn) in iteritems(self.checks):
             if chg_attr.startswith("prop:"):
                 chg_val = change.properties.getProperty(chg_attr.split(":", 1)[1], '')
             else:

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 from buildbot import util
 from buildbot.changes import base
@@ -156,7 +157,7 @@ class GerritChangeSource(base.ChangeSource):
 
         # flatten the event dictionary, for easy access with WithProperties
         def flatten(properties, base, event):
-            for k, v in event.items():
+            for k, v in iteritems(event):
                 name = "%s.%s" % (base, k)
                 if isinstance(v, dict):
                     flatten(properties, name, v)

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 import itertools
 import os
@@ -260,14 +261,14 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         # initial run, don't parse all history
         if not self.lastRev:
             return
-        if newRev in self.lastRev.values():
+        if newRev in itervalues(self.lastRev):
             # TODO: no new changes on this branch
             # should we just use the lastRev again, but with a different branch?
             pass
 
         # get the change list
         revListArgs = ([r'--format=%H', r'%s' % newRev] +
-                       [r'^%s' % rev for rev in self.lastRev.values()] +
+                       [r'^%s' % rev for rev in itervalues(self.lastRev)] +
                        [r'--'])
         self.changeCount = 0
         results = yield self._dovccmd('log', revListArgs, path=self.workdir)

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -15,6 +15,7 @@
 # Based on the work of Dave Peticolas for the P4poll
 # Changed to svn (using xml.dom.minidom) by Niklaus Giger
 # Hacked beyond recognition by Brian Warner
+
 from twisted.internet import defer
 from twisted.internet import utils
 from twisted.python import log
@@ -382,7 +383,7 @@ class SVNPoller(base.PollingChangeSource, util.ComparableMixin):
                         if key in where:
                             branches[branch][key] = where[key]
 
-            for branch in branches.keys():
+            for branch in branches:
                 action = branches[branch]['action']
                 files = branches[branch]['files']
 

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -12,25 +12,28 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import itervalues
+
 import os
 import re
 import sys
 import warnings
 
-from types import MethodType
 from buildbot import interfaces
 from buildbot import locks
 from buildbot import util
 from buildbot.revlinks import default_revlink_matcher
 from buildbot.util import config as util_config
+from buildbot.util import identifiers as util_identifiers
 from buildbot.util import safeTranslate
 from buildbot.util import service as util_service
-from buildbot.util import identifiers as util_identifiers
 from buildbot.www import auth
 from buildbot.www import avatar
 from buildbot.www.authz import authz
 from twisted.python import failure
 from twisted.python import log
+from types import MethodType
 
 
 class ConfigErrors(Exception):
@@ -340,7 +343,7 @@ class MasterConfig(util.ComparableMixin):
 
         protocols = config_dict.get('protocols', {})
         if isinstance(protocols, dict):
-            for proto, options in protocols.iteritems():
+            for proto, options in iteritems(protocols):
                 if not isinstance(proto, str):
                     error("c['protocols'] keys must be strings")
                 if not isinstance(options, dict):
@@ -453,8 +456,7 @@ class MasterConfig(util.ComparableMixin):
             if not isinstance(caches, dict):
                 error("c['caches'] must be a dictionary")
             else:
-                valPairs = caches.items()
-                for (name, value) in valPairs:
+                for (name, value) in iteritems(caches):
                     if not isinstance(value, int):
                         error("value for cache size '%s' must be an integer"
                               % name)
@@ -611,7 +613,8 @@ class MasterConfig(util.ComparableMixin):
                        'logRotateLength', 'maxRotatedFiles', 'versions',
                        'change_hook_dialects', 'change_hook_auth',
                        'custom_templates_dir'])
-        unknown = set(www_cfg.iterkeys()) - allowed
+        unknown = set(list(www_cfg)) - allowed
+
         if unknown:
             error("unknown www configuration parameter(s) %s" %
                   (', '.join(unknown),))
@@ -659,7 +662,7 @@ class MasterConfig(util.ComparableMixin):
 
         # check that all builders are implemented on this master
         unscheduled_buildernames = set([b.name for b in self.builders])
-        for s in self.schedulers.itervalues():
+        for s in itervalues(self.schedulers):
             for n in s.listBuilderNames():
                 if n in unscheduled_buildernames:
                     unscheduled_buildernames.remove(n)
@@ -674,7 +677,7 @@ class MasterConfig(util.ComparableMixin):
 
         all_buildernames = set([b.name for b in self.builders])
 
-        for s in self.schedulers.itervalues():
+        for s in itervalues(self.schedulers):
             for n in s.listBuilderNames():
                 if n not in all_buildernames:
                     error("Unknown builder '%s' in scheduler '%s'"
@@ -734,7 +737,7 @@ class MasterConfig(util.ComparableMixin):
     def check_ports(self):
         ports = set()
         if self.protocols:
-            for proto, options in self.protocols.iteritems():
+            for proto, options in iteritems(self.protocols):
                 if proto == 'null':
                     port = -1
                 else:

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
+
 
 import copy
 
@@ -146,7 +148,7 @@ class Buildset(base.ResourceType):
             submitted_at=epoch2datetime(submitted_at),
             parent_buildid=parent_buildid, parent_relationship=parent_relationship)
 
-        yield BuildRequestCollapser(self.master, brids.values()).collapse()
+        yield BuildRequestCollapser(self.master, list(itervalues(brids))).collapse()
 
         # get each of the sourcestamps for this buildset (sequentially)
         bsdict = yield self.master.db.buildsets.getBuildset(bsid)
@@ -156,7 +158,7 @@ class Buildset(base.ResourceType):
 
         # notify about the component build requests
         brResource = self.master.data.getResourceType("buildrequest")
-        brResource.generateEvent(brids.values(), 'new')
+        brResource.generateEvent(list(itervalues(brids)), 'new')
 
         # and the buildset itself
         msg = dict(

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 from buildbot.data import base
 
@@ -152,7 +153,7 @@ class ResultSpec(object):
             fields = set(self.fields)
 
             def includeFields(d):
-                return dict((k, v) for k, v in d.iteritems()
+                return dict((k, v) for k, v in iteritems(d)
                             if k in fields)
             applyFields = includeFields
         else:

--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 
 # See "Type Validation" in master/docs/developer/tests.rst
+from future.utils import iteritems
+
 
 import datetime
 import re
@@ -180,7 +182,7 @@ class SourcedProperties(Type):
         if not isinstance(object, dict):  # we want a dict, and NOT a subclass
             yield "%s is not sourced properties (not a dict)" % (name,)
             return
-        for k, v in object.iteritems():
+        for k, v in iteritems(object):
             if not isinstance(k, unicode):
                 yield "%s property name %r is not unicode" % (name, k)
             if not isinstance(v, tuple) or len(v) != 2:
@@ -230,7 +232,7 @@ class Dict(Type):
                     fields=[dict(name=k,
                                  type=v.name,
                                  type_spec=v.getSpec())
-                            for k, v in self.contents.items()
+                            for k, v in iteritems(self.contents)
                             ])
 
 
@@ -264,7 +266,7 @@ class Entity(Type):
 
     def __init__(self, name):
         fields = {}
-        for k, v in self.__class__.__dict__.iteritems():
+        for k, v in iteritems(self.__class__.__dict__):
             if isinstance(v, Type):
                 fields[k] = v
         self.fields = fields
@@ -300,5 +302,5 @@ class Entity(Type):
                     fields=[dict(name=k,
                                  type=v.name,
                                  type_spec=v.getSpec())
-                            for k, v in self.fields.items()
+                            for k, v in iteritems(self.fields)
                             ])

--- a/master/buildbot/db/buildslaves.py
+++ b/master/buildbot/db/buildslaves.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 import sqlalchemy as sa
 
@@ -175,7 +176,7 @@ class BuildslavesConnectorComponent(base.DBConnectorComponent):
                     continue
                 rv[row.buildslaveid]['connected_to'].append(row.masterid)
 
-            return rv.values()
+            return list(itervalues(rv))
         return self.db.pool.do(thd)
 
     def buildslaveConnected(self, buildslaveid, masterid, slaveinfo):

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -16,6 +16,8 @@
 """
 Support for changes in the database
 """
+from future.utils import iteritems
+from future.utils import itervalues
 
 import sqlalchemy as sa
 
@@ -68,7 +70,7 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
             properties = {}
 
         # verify that source is 'Change' for each property
-        for pv in properties.values():
+        for pv in itervalues(properties):
             assert pv[1] == 'Change', ("properties must be qualified with"
                                        "source 'Change'")
 
@@ -129,7 +131,7 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
                     dict(changeid=changeid,
                          property_name=k,
                          property_value=json.dumps(v))
-                    for k, v in properties.iteritems()
+                    for k, v in iteritems(properties)
                 ]
                 for i in inserts:
                     self.checkLength(tbl.c.property_name,
@@ -185,11 +187,11 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
                 toChanges[ss['codebase']] = yield self.getChangeFromSSid(ss['ssid'])
         else:
             # If no successfull previous build, then we need to catch all changes
-            for cb in fromChanges.keys():
+            for cb in fromChanges:
                 toChanges[cb] = {'changeid': None}
 
         # For each codebase, append changes until we match the parent
-        for cb, change in fromChanges.iteritems():
+        for cb, change in iteritems(fromChanges):
             if change and change['changeid'] != toChanges.get(cb, {}).get('changeid'):
                 changes.append(change)
                 while ((toChanges.get(cb, {}).get('changeid') not in change['parent_changeids']) and

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 import sqlalchemy as sa
 
@@ -59,7 +60,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                         "gz": {"id": 1, "dumps": dumps_gzip, "read": read_gzip},
                         "bz2": {"id": 2, "dumps": dumps_bz2, "read": read_bz2},
                         "lz4": {"id": 3, "dumps": dumps_lz4, "read": read_lz4}}
-    COMPRESSION_BYID = dict((x["id"], x) for x in COMPRESSION_MODE.itervalues())
+    COMPRESSION_BYID = dict((x["id"], x) for x in itervalues(COMPRESSION_MODE))
     total_raw_bytes = 0
     total_compressed_bytes = 0
 

--- a/master/buildbot/db/migrate/versions/001_initial.py
+++ b/master/buildbot/db/migrate/versions/001_initial.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import os
 import sqlalchemy as sa
 
@@ -199,8 +201,9 @@ def import_changes(migrate_engine):
                 revlink=c.revlink,
                 when_timestamp=c.when,
                 category=c.category)
-            values = dict([(k, remove_none(v)) for k, v in values.iteritems()])
-        except UnicodeDecodeError as e:
+
+            values = dict([(k, remove_none(v)) for k, v in iteritems(values)])
+        except UnicodeDecodeError, e:
             raise UnicodeError("Trying to import change data as UTF-8 failed.  Please look at contrib/fix_changes_pickle_encoding.py: %s" % str(e))
 
         migrate_engine.execute(changes.insert(), **values)
@@ -227,7 +230,7 @@ def import_changes(migrate_engine):
                                    changeid=c.number,
                                    filename=filename)
 
-        for propname, propvalue in c.properties.properties.items():
+        for propname, propvalue in iteritems(c.properties.properties):
             encoded_value = json.dumps(propvalue)
             migrate_engine.execute(change_properties.insert(),
                                    changeid=c.number,

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import sqlalchemy as sa
 import sqlalchemy.exc
@@ -35,7 +36,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
             upd_q = tbl.update(
                 ((tbl.c.schedulerid == schedulerid)
                  & (tbl.c.changeid == sa.bindparam('wc_changeid'))))
-            for changeid, important in classifications.items():
+            for changeid, important in iteritems(classifications):
                 transaction = conn.begin()
                 # convert the 'important' value into an integer, since that
                 # is the column type

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -12,7 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
+from future.utils import iteritems
 
 import datetime
 import os
@@ -432,7 +432,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
                                for f in kwargs['files']]
         if kwargs.get('properties'):
             kwargs['properties'] = dict((ascii2unicode(k), v)
-                                        for k, v in kwargs['properties'].iteritems())
+                                        for k, v in iteritems(kwargs['properties']))
 
         # pass the converted call on to the data API
         changeid = yield self.data.updates.addChange(**kwargs)

--- a/master/buildbot/pbmanager.py
+++ b/master/buildbot/pbmanager.py
@@ -125,7 +125,7 @@ class Dispatcher(service.AsyncService):
 
     def __repr__(self):
         return "<pbmanager.Dispatcher for %s on %s>" % \
-            (", ".join(self.users.keys()), self.portstr)
+            (", ".join(list(self.users)), self.portstr)
 
     def startService(self):
         assert not self.port

--- a/master/buildbot/plugins/db.py
+++ b/master/buildbot/plugins/db.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 #
 # pylint: disable=C0111
+from future.utils import iteritems
+from future.utils import itervalues
 
 from buildbot.errors import PluginDBError
 from buildbot.interfaces import IPlugin
@@ -66,7 +68,7 @@ class _NSNode(object):
         self._children = dict()
 
     def load(self):
-        for child in self._children.values():
+        for child in itervalues(self._children):
             child.load()
 
     def add(self, name, entry):
@@ -136,13 +138,13 @@ class _NSNode(object):
 
     def _info_all(self):
         result = []
-        for key, child in self._children.items():
+        for key, child in iteritems(self._children):
             if isinstance(child, _PluginEntry):
                 result.append((key, child.info))
             else:
                 result.extend([
                     ('%s.%s' % (key, name), value)
-                    for name, value in child.info_all().items()
+                    for name, value in iteritems(child.info_all())
                 ])
         return result
 
@@ -208,7 +210,7 @@ class _Plugins(object):
     @property
     def names(self):
         # Expensive operation
-        return self.info_all().keys()
+        return list(self.info_all())
 
     def info(self, name):
         """
@@ -269,14 +271,14 @@ class _PluginDB(object):
         """
         get a list of registered namespaces
         """
-        return self._namespaces.keys()
+        return list(self._namespaces)
 
     def info(self):
         """
         get information about all plugins in registered namespaces
         """
         result = dict()
-        for name, namespace in self._namespaces.items():
+        for name, namespace in iteritems(self._namespaces):
             result[name] = namespace.info_all()
         return result
 

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -12,7 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
+from future.utils import iteritems
+from future.utils import itervalues
 
 from buildbot import locks
 from buildbot import util
@@ -114,20 +115,20 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
     @metrics.countMethod('BotMaster.slaveLost()')
     def slaveLost(self, bot):
         metrics.MetricCountEvent.log("BotMaster.attached_slaves", -1)
-        for name, b in self.builders.items():
+        for name, b in iteritems(self.builders):
             if bot.slavename in b.config.slavenames:
                 b.detached(bot)
 
     @metrics.countMethod('BotMaster.getBuildersForSlave()')
     def getBuildersForSlave(self, slavename):
-        return [b for b in self.builders.values()
+        return [b for b in itervalues(self.builders)
                 if slavename in b.config.slavenames]
 
     def getBuildernames(self):
         return self.builderNames
 
     def getBuilders(self):
-        return self.builders.values()
+        return list(itervalues(self.builders))
 
     @defer.inlineCallbacks
     def startService(self):
@@ -136,7 +137,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             builderid = msg['builderid']
             buildername = None
             # convert builderid to buildername
-            for builder in self.builders.values():
+            for builder in itervalues(self.builders):
                 if builderid == (yield builder.getBuilderId()):
                     buildername = builder.name
                     break
@@ -181,10 +182,10 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         old_by_name = dict([(b.name, b)
                             for b in list(self)
                             if isinstance(b, Builder)])
-        old_set = set(old_by_name.iterkeys())
+        old_set = set(old_by_name)
         new_by_name = dict([(bc.name, bc)
                             for bc in new_config.builders])
-        new_set = set(new_by_name.iterkeys())
+        new_set = set(new_by_name)
 
         # calculate new builders, by name, and removed builders
         removed_names, added_names = util.diffSets(old_set, new_set)
@@ -211,7 +212,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
                 builder.master = self.master
                 yield builder.setServiceParent(self)
 
-        self.builderNames = self.builders.keys()
+        self.builderNames = list(self.builders)
 
         yield self.master.data.updates.updateBuilderList(
             self.master.masterid,
@@ -229,7 +230,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         if self.buildrequest_consumer_unclaimed:
             self.buildrequest_consumer_unclaimed.stopConsuming()
             self.buildrequest_consumer_unclaimed = None
-        for b in self.builders.values():
+        for b in itervalues(self.builders):
             b.builder_status.addPointEvent(["master", "shutdown"])
             b.builder_status.saveYourself()
         return service.AsyncMultiService.stopService(self)

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -180,7 +180,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
         for b in self.building:
             if b.build_status and b.build_status.number == number:
                 return b
-        for b in self.old_building.keys():
+        for b in self.old_building:
             if b.build_status and b.build_status.number == number:
                 return b
         return None

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import itervalues
 
 import calendar
 
@@ -108,7 +110,7 @@ class TempSourceStamp(object):
 
         assert all(
             isinstance(val, (unicode, type(None), int))
-            for attr, val in result.items()
+            for attr, val in iteritems(result)
         ), result
         return result
 
@@ -117,10 +119,10 @@ class TempChange(object):
     # temporary fake change
 
     def __init__(self, d):
-        for k, v in d.items():
+        for k, v in iteritems(d):
             setattr(self, k, v)
         self.properties = properties.Properties()
-        for k, v in d['properties'].items():
+        for k, v in iteritems(d['properties']):
             self.properties.setProperty(k, v[0], v[1])
         self.who = d['author']
 
@@ -259,7 +261,7 @@ class BuildRequest(object):
             defer.returnValue(False)
             return
 
-        for c, selfSS in selfSources.iteritems():
+        for c, selfSS in iteritems(selfSources):
             otherSS = otherSources[c]
             if selfSS['revision'] != otherSS['revision']:
                 defer.returnValue(False)
@@ -283,9 +285,9 @@ class BuildRequest(object):
     def mergeSourceStampsWith(self, others):
         """ Returns one merged sourcestamp for every codebase """
         # get all codebases from all requests
-        all_codebases = set(self.sources.iterkeys())
+        all_codebases = set(self.sources)
         for other in others:
-            all_codebases |= set(other.sources.iterkeys())
+            all_codebases |= set(other.sources)
 
         all_merged_sources = {}
         # walk along the codebases
@@ -303,7 +305,7 @@ class BuildRequest(object):
             # looking at changeids and picking the highest-numbered.
             all_merged_sources[codebase] = all_sources[-1]
 
-        return [source for source in all_merged_sources.itervalues()]
+        return list(itervalues(all_merged_sources))
 
     def mergeReasons(self, others):
         """Return a reason for the merged build request."""

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import itervalues
 
 try:
     import cStringIO as StringIO
@@ -309,7 +311,7 @@ class BuildStep(results.ResultComputingConfigMixin,
 
         if kwargs:
             config.error("%s.__init__ got unexpected keyword argument(s) %s"
-                         % (self.__class__, kwargs.keys()))
+                         % (self.__class__, list(kwargs)))
         self._pendingLogObservers = []
 
         if not isinstance(self.name, str):
@@ -901,7 +903,7 @@ class LoggingBuildStep(BuildStep):
         d.addErrback(self.failed)
 
     def setupLogfiles(self, cmd, logfiles):
-        for logname, remotefilename in logfiles.items():
+        for logname, remotefilename in iteritems(logfiles):
             if self.lazylogfiles:
                 # Ask RemoteCommand to watch a logfile, but only add
                 # it when/if we see any data.
@@ -1081,7 +1083,7 @@ class ShellMixin(object):
             else:
                 setattr(self, arg, constructorArgs[arg])
             del constructorArgs[arg]
-        for arg in constructorArgs.keys():
+        for arg in constructorArgs:
             if arg not in BuildStep.parms:
                 bad(arg)
                 del constructorArgs[arg]
@@ -1148,7 +1150,7 @@ class ShellMixin(object):
         # set up logging
         if stdio is not None:
             cmd.useLog(stdio, False)
-        for logname, remotefilename in self.logfiles.items():
+        for logname, remotefilename in iteritems(self.logfiles):
             if self.lazylogfiles:
                 # it's OK if this does, or does not, return a Deferred
                 callback = lambda cmd_arg, logname=logname: self.addLog(
@@ -1187,7 +1189,7 @@ def regex_log_evaluator(cmd, _, regexes):
         if worst_status(worst, possible_status) == possible_status:
             if isinstance(err, (basestring)):
                 err = re.compile(".*%s.*" % err, re.DOTALL)
-            for l in cmd.logs.values():
+            for l in itervalues(cmd.logs):
                 if err.search(l.getText()):
                     worst = possible_status
     return worst

--- a/master/buildbot/process/cache.py
+++ b/master/buildbot/process/cache.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 from buildbot.util import lru
 from buildbot.util import service
@@ -60,7 +61,7 @@ class CacheManager(service.ReconfigurableServiceMixin, service.AsyncService):
 
     def reconfigServiceWithBuildbotConfig(self, new_config):
         self.config = new_config.caches
-        for name, cache in self._caches.iteritems():
+        for name, cache in iteritems(self._caches):
             cache.set_max_size(new_config.caches.get(name,
                                                      self.DEFAULT_CACHE_SIZE))
 
@@ -71,4 +72,4 @@ class CacheManager(service.ReconfigurableServiceMixin, service.AsyncService):
         return dict([
             (n, dict(hits=c.hits, refhits=c.refhits,
                      misses=c.misses, max_size=c.max_size))
-            for n, c in self._caches.iteritems()])
+            for n, c in iteritems(self._caches)])

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 import re
 
@@ -179,7 +180,7 @@ class StreamLog(Log):
 
     @defer.inlineCallbacks
     def finish(self):
-        for lbf in self.lbfs.values():
+        for lbf in itervalues(self.lbfs):
             yield lbf.flush()
         yield super(StreamLog, self).finish()
 

--- a/master/buildbot/process/metrics.py
+++ b/master/buildbot/process/metrics.py
@@ -31,6 +31,8 @@ Basic architecture:
           \/
     MetricWatcher
 """
+from future.utils import iteritems
+
 from collections import deque
 
 from buildbot import util
@@ -219,7 +221,7 @@ class MetricCountHandler(MetricHandler):
             self._counters[metric.counter] += metric.count
 
     def keys(self):
-        return self._counters.keys()
+        return list(self._counters)
 
     def get(self, counter):
         return self._counters[counter]
@@ -247,7 +249,7 @@ class MetricTimeHandler(MetricHandler):
         self._timers[metric.timer].append(metric.elapsed)
 
     def keys(self):
-        return self._timers.keys()
+        return list(self._timers)
 
     def get(self, timer):
         return self._timers[timer].average
@@ -478,13 +480,13 @@ class MetricLogObserver(util_service.ReconfigurableServiceMixin,
 
     def asDict(self):
         retval = {}
-        for interface, handler in self.handlers.iteritems():
+        for interface, handler in iteritems(self.handlers):
             retval.update(handler.asDict())
         return retval
 
     def report(self):
         try:
-            for interface, handler in self.handlers.iteritems():
+            for interface, handler in iteritems(self.handlers):
                 report = handler.report()
                 if not report:
                     continue

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import collections
 import re
@@ -63,7 +64,7 @@ class Properties(util.ComparableMixin):
     @classmethod
     def fromDict(cls, propDict):
         properties = cls()
-        for name, (value, source) in propDict.iteritems():
+        for name, (value, source) in iteritems(propDict):
             properties.setProperty(name, value, source)
         return properties
 
@@ -93,22 +94,22 @@ class Properties(util.ComparableMixin):
 
     def asList(self):
         """Return the properties as a sorted list of (name, value, source)"""
-        l = sorted([(k, v[0], v[1]) for k, v in self.properties.iteritems()])
+        l = sorted([(k, v[0], v[1]) for k, v in iteritems(self.properties)])
         return l
 
     def asDict(self):
         """Return the properties as a simple key:value dictionary,
         properly unicoded"""
-        return dict((k, (v, s)) for k, (v, s) in self.properties.iteritems())
+        return dict((k, (v, s)) for k, (v, s) in iteritems(self.properties))
 
     def __repr__(self):
         return ('Properties(**' +
-                repr(dict((k, v[0]) for k, v in self.properties.iteritems())) +
+                repr(dict((k, v[0]) for k, v in iteritems(self.properties))) +
                 ')')
 
     def update(self, dict, source, runtime=False):
         """Update this object from a dictionary, with an explicit source specified."""
-        for k, v in dict.items():
+        for k, v in iteritems(dict):
             self.setProperty(k, v, source, runtime=runtime)
 
     def updateFromProperties(self, other):
@@ -119,7 +120,7 @@ class Properties(util.ComparableMixin):
     def updateFromPropertiesNoRuntime(self, other):
         """Update this object based on another object, but don't
         include properties that were marked as runtime."""
-        for k, v in other.properties.iteritems():
+        for k, v in iteritems(other.properties):
             if k not in other.runtime:
                 self.properties[k] = v
 
@@ -286,7 +287,7 @@ class WithProperties(util.ComparableMixin):
         self.args = args
         if not self.args:
             self.lambda_subs = lambda_subs
-            for key, val in self.lambda_subs.iteritems():
+            for key, val in iteritems(self.lambda_subs):
                 if not callable(val):
                     raise ValueError('Value for lambda substitution "%s" must be callable.' % key)
         elif lambda_subs:
@@ -300,7 +301,7 @@ class WithProperties(util.ComparableMixin):
                 strings.append(pmap[name])
             s = self.fmtstring % tuple(strings)
         else:
-            for k, v in self.lambda_subs.iteritems():
+            for k, v in iteritems(self.lambda_subs):
                 pmap.add_temporary_value(k, v(build))
             s = self.fmtstring % pmap
         return s
@@ -364,7 +365,7 @@ def _getInterpolationList(fmtstring):
     # TODO: Verify that no positional substitutions are requested
     dd = collections.defaultdict(str)
     fmtstring % dd
-    return dd.keys()
+    return list(dd)
 
 
 class _PropertyDict(object):
@@ -734,7 +735,7 @@ class _DictRenderer(object):
     implements(IRenderable)
 
     def __init__(self, value):
-        self.value = _ListRenderer([_TupleRenderer((k, v)) for k, v in value.iteritems()])
+        self.value = _ListRenderer([_TupleRenderer((k, v)) for k, v in iteritems(value)])
 
     def getRenderingFor(self, build):
         d = self.value.getRenderingFor(build)

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 
 from buildbot import util
 from buildbot.buildslave.protocols import base
@@ -263,7 +265,7 @@ class RemoteCommand(base.RemoteCommandImpl):
     @defer.inlineCallbacks
     def remoteUpdate(self, update):
         if self.debug:
-            for k, v in update.items():
+            for k, v in iteritems(update):
                 log.msg("Update[%s]: %s" % (k, v))
         if "stdout" in update:
             # 'stdout': data
@@ -299,7 +301,7 @@ class RemoteCommand(base.RemoteCommandImpl):
             delta = (util.now() - self._startTime) - self._remoteElapsed
             metrics.MetricTimeEvent.log("RemoteCommand.overhead", delta)
 
-        for name, loog in self.logs.items():
+        for name, loog in iteritems(self.logs):
             if self._closeWhenFinished[name]:
                 if maybeFailure:
                     loog = yield self._unwrap(loog)

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -17,6 +17,7 @@
 """Push events to gerrit
 
 ."""
+from future.utils import iteritems
 
 import time
 
@@ -390,7 +391,7 @@ class GerritStatusPush(service.BuildbotService):
             else:
                 add_label = _new_add_label
 
-            for label, value in labels.items():
+            for label, value in iteritems(labels):
                 command.extend(add_label(label, value))
 
         command.append(str(revision))

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -12,7 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
+from future.utils import iteritems
 
 import re
 
@@ -371,7 +371,7 @@ class MailNotifier(service.BuildbotService):
                 props = Properties.fromDict(builds[0]['properties'])
                 extraHeaders = yield props.render(extraHeaders)
 
-            for k, v in extraHeaders.items():
+            for k, v in iteritems(extraHeaders):
                 if k in m:
                     twlog.msg("Warning: Got header " + k +
                               " in self.extraHeaders "

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 
 from buildbot import config
 from buildbot import interfaces
@@ -70,7 +72,7 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
         elif not isinstance(codebases, dict):
             config.error("Codebases must be a dict of dicts, or list of strings")
         else:
-            for codebase, attrs in codebases.iteritems():
+            for codebase, attrs in iteritems(codebases):
                 if not isinstance(attrs, dict):
                     config.error("Codebases must be a dict of dicts")
                 else:

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import itervalues
 
 from buildbot import config
 from buildbot import util
@@ -108,7 +110,7 @@ class BaseBasicScheduler(base.BaseScheduler):
 
         @util.deferredLocked(self._stable_timers_lock)
         def cancel_timers():
-            for timer in self._stable_timers.values():
+            for timer in itervalues(self._stable_timers):
                 if timer:
                     timer.cancel()
             self._stable_timers.clear()
@@ -158,7 +160,7 @@ class BaseBasicScheduler(base.BaseScheduler):
                 self.objectid)
 
         # call gotChange for each change, after first fetching it from the db
-        for changeid, important in classifications.iteritems():
+        for changeid, important in iteritems(classifications):
             chdict = yield self.master.db.changes.getChange(changeid)
 
             if not chdict:
@@ -202,7 +204,7 @@ class BaseBasicScheduler(base.BaseScheduler):
     def getPendingBuildTimes(self):
         # This isn't locked, since the caller expects an immediate value,
         # and in any case, this is only an estimate.
-        return [timer.getTime() for timer in self._stable_timers.values() if timer and timer.active()]
+        return [timer.getTime() for timer in itervalues(self._stable_timers) if timer and timer.active()]
 
 
 class SingleBranchScheduler(BaseBasicScheduler, AbsoluteSourceStampsMixin):

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 from zope.interface import implements
 
@@ -140,7 +141,7 @@ class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
 
         # if onlyIfChanged is True, then we will skip this build if no
         # important changes have occurred since the last invocation
-        if self.onlyIfChanged and not any(classifications.itervalues()):
+        if self.onlyIfChanged and not any(itervalues(classifications)):
             log.msg(("%s scheduler <%s>: skipping build " +
                      "- No important changes on configured branch") %
                     (self.__class__.__name__, self.name))
@@ -157,7 +158,7 @@ class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
         else:
             # There are no changes, but onlyIfChanged is False, so start
             # a build of the latest revision, whatever that is
-            sourcestamps = [dict(codebase=cb) for cb in self.codebases.keys()]
+            sourcestamps = [dict(codebase=cb) for cb in self.codebases]
             yield self.addBuildsetForSourceStampsWithDefaults(
                 reason=self.reason,
                 sourcestamps=sourcestamps)
@@ -360,7 +361,7 @@ class NightlyTriggerable(NightlyBase):
                                          lastTrigger[3])
                 # handle state from before Buildbot-0.9.0
                 elif isinstance(lastTrigger[0], dict):
-                    self._lastTrigger = (lastTrigger[0].values(),
+                    self._lastTrigger = (list(itervalues(lastTrigger[0])),
                                          properties.Properties.fromDict(lastTrigger[1]),
                                          None,
                                          None)

--- a/master/buildbot/schedulers/triggerable.py
+++ b/master/buildbot/schedulers/triggerable.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
+
 
 from zope.interface import implements
 
@@ -86,7 +88,7 @@ class Triggerable(base.BaseScheduler):
         # and errback any outstanding deferreds
         if self._waiters:
             msg = 'Triggerable scheduler stopped before build was complete'
-            for d, brids in self._waiters.values():
+            for d, brids in itervalues(self._waiters):
                 d.errback(failure.Failure(RuntimeError(msg)))
             self._waiters = {}
 

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import os
 
@@ -246,11 +247,11 @@ class RemoteBuildSetStatus(pb.Referenceable):
     @defer.inlineCallbacks
     def remote_getBuildRequests(self):
         brids = dict()
-        for builderid, brid in self.brids.iteritems():
+        for builderid, brid in iteritems(self.brids):
             builderDict = yield self.master.data.get(('builders', builderid))
             brids[builderDict['name']] = brid
         defer.returnValue([(n, RemoteBuildRequest(self.master, n, brid))
-                           for n, brid in brids.iteritems()])
+                           for n, brid in iteritems(brids)])
 
 
 class RemoteBuildRequest(pb.Referenceable):

--- a/master/buildbot/scripts/create_master.py
+++ b/master/buildbot/scripts/create_master.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 from __future__ import print_function
+from future.utils import iteritems
+
 
 import jinja2
 import os
@@ -41,7 +43,7 @@ def makeTAC(config):
     env = jinja2.Environment(loader=loader, undefined=jinja2.StrictUndefined)
     env.filters['repr'] = repr
     tpl = env.get_template('buildbot_tac.tmpl')
-    cxt = dict((k.replace('-', '_'), v) for k, v in config.iteritems())
+    cxt = dict((k.replace('-', '_'), v) for k, v in iteritems(config))
     contents = tpl.render(cxt)
 
     tacfile = os.path.join(config['basedir'], "buildbot.tac")

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -253,10 +253,10 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
         self.currentStep = None
         self.finished = util.now()
 
-        for r in self.updates.keys():
-            if self.updates[r] is not None:
-                self.updates[r].cancel()
-                del self.updates[r]
+        for update in self.updates:
+            if self.updates[update] is not None:
+                self.updates[update].cancel()
+                del self.updates[update]
 
         watchers = self.finishedWatchers
         self.finishedWatchers = []

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
+
 import itertools
 import os
 import re
@@ -196,7 +198,7 @@ class BuilderStatus(styles.Versioned):
             # upgradeToVersionNN methods all set this.
             versioneds = styles.versionedsToUpgrade
             styles.doUpgrade()
-            if True in [hasattr(o, 'wasUpgraded') for o in versioneds.values()]:
+            if True in [hasattr(o, 'wasUpgraded') for o in itervalues(versioneds)]:
                 log.msg("re-writing upgraded build pickle")
                 build.saveYourself()
 
@@ -605,7 +607,7 @@ class BuilderStatus(styles.Versioned):
         # Collect build numbers.
         # Important: Only grab the *cached* builds numbers to reduce I/O.
         current_builds = [b.getNumber() for b in self.currentBuilds]
-        cached_builds = sorted(set(self.buildCache.keys() + current_builds))
+        cached_builds = sorted(set(list(self.buildCache) + current_builds))
 
         result = {
             # Constant

--- a/master/buildbot/status/irc.py
+++ b/master/buildbot/status/irc.py
@@ -211,7 +211,7 @@ class IRC(base.StatusReceiverMultiService):
                  ):
         base.StatusReceiverMultiService.__init__(self)
 
-        deprecated_params = kwargs.keys()
+        deprecated_params = list(kwargs)
         if deprecated_params:
             config.error("%s are deprecated" % (",".join(deprecated_params)))
 

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import itervalues
+
+
 import os
 import urllib
 
@@ -239,7 +243,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         return self.botmaster.builders[name].builder_status
 
     def getSlaveNames(self):
-        return self.buildslaves.slaves.keys()
+        return list(iteritems(self.buildslaves.slaves))
 
     def getSlave(self, slavename):
         return self.buildslaves.slaves[slavename].slave_status
@@ -351,7 +355,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             # upgradeToVersionNN methods all set this.
             versioneds = styles.versionedsToUpgrade
             styles.doUpgrade()
-            if True in [hasattr(o, 'wasUpgraded') for o in versioneds.values()]:
+            if True in [hasattr(o, 'wasUpgraded') for o in itervalues(versioneds)]:
                 log.msg("re-writing upgraded builder pickle")
                 builder_status.saveYourself()
 
@@ -419,7 +423,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         builderid = msg['builderid']
         buildername = None
         # convert builderid to buildername
-        for b in self.botmaster.builders.values():
+        for b in itervalues(self.botmaster.builders):
             if builderid == (yield b.getBuilderId()):
                 buildername = b.name
                 break

--- a/master/buildbot/status/persistent_queue.py
+++ b/master/buildbot/status/persistent_queue.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 import os
 
 from buildbot.util import pickle

--- a/master/buildbot/status/status_push.py
+++ b/master/buildbot/status/status_push.py
@@ -17,6 +17,7 @@ Push events to an abstract receiver.
 
 Implements the HTTP receiver.
 """
+from future.utils import iteritems
 
 import datetime
 import os
@@ -239,7 +240,7 @@ class StatusPush(StatusReceiverMultiService):
         packet['started'] = self.state['started']
         packet['event'] = event
         packet['payload'] = {}
-        for obj_name, obj in objs.items():
+        for obj_name, obj in iteritems(objs):
             if hasattr(obj, 'asDict'):
                 obj = obj.asDict()
             if self.filter:

--- a/master/buildbot/status/words.py
+++ b/master/buildbot/status/words.py
@@ -321,7 +321,7 @@ class Contact(base.StatusReceiver):
             raise UsageError("try 'notify on|off <EVENT>'")
 
     def list_notified_events(self):
-        self.send("The following events are being notified: %r" % self.notify_events.keys())
+        self.send("The following events are being notified: %r" % list(self.notify_events))
 
     def notify_for(self, *events):
         for event in events:

--- a/master/buildbot/steps/http.py
+++ b/master/buildbot/steps/http.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 
 from buildbot import config
 from buildbot.process.buildstep import BuildStep
@@ -110,13 +112,13 @@ class HTTPStep(BuildStep):
         log.addHeader('Performing %s request to %s\n' % (self.method, self.url))
         if self.params:
             log.addHeader('Parameters:\n')
-            for k, v in requestkwargs.get("params", {}).iteritems():
+            for k, v in iteritems(requestkwargs.get("params", {})):
                 log.addHeader('\t%s: %s\n' % (k, v))
         data = requestkwargs.get("data", None)
         if data:
             log.addHeader('Data:\n')
             if isinstance(data, dict):
-                for k, v in data.iteritems():
+                for k, v in iteritems(data):
                     log.addHeader('\t%s: %s\n' % (k, v))
             else:
                 log.addHeader('\t%s\n' % data)
@@ -148,7 +150,7 @@ class HTTPStep(BuildStep):
         log = self.getLog('log')
 
         log.addHeader('Request Header:\n')
-        for k, v in response.request.headers.iteritems():
+        for k, v in iteritems(response.request.headers):
             log.addHeader('\t%s: %s\n' % (k, v))
 
         log.addStdout('URL: %s\n' % response.url)
@@ -159,7 +161,7 @@ class HTTPStep(BuildStep):
             log.addStderr('Status: %s\n' % response.status_code)
 
         log.addHeader('Response Header:\n')
-        for k, v in response.headers.iteritems():
+        for k, v in iteritems(response.headers):
             log.addHeader('\t%s: %s\n' % (k, v))
 
         log.addStdout(' ------ Content ------\n%s' % response.text)

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 
 from builtins import bytes
 from builtins import str
@@ -111,7 +113,7 @@ class MasterShellCommand(BuildStep):
         else:
             assert isinstance(self.env, dict)
             env = self.env
-            for key, v in self.env.iteritems():
+            for key, v in iteritems(self.env):
                 if isinstance(v, list):
                     # Need to do os.pathsep translation.  We could either do that
                     # by replacing all incoming ':'s with os.pathsep, or by
@@ -126,7 +128,7 @@ class MasterShellCommand(BuildStep):
             def subst(match):
                 return os.environ.get(match.group(1), "")
             newenv = {}
-            for key, v in env.iteritems():
+            for key, v in iteritems(env):
                 if v is not None:
                     if not isinstance(v, basestring):
                         raise RuntimeError("'env' values must be strings or "

--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 
 import re
@@ -201,7 +202,7 @@ class PyLint(ShellCommand):
 
     _re_groupname = 'errtype'
     _msgtypes_re_str = '(?P<%s>[%s])' % (
-        _re_groupname, ''.join(_MESSAGES.keys()))
+        _re_groupname, ''.join(list(_MESSAGES)))
     _default_line_re = re.compile(
         r'^%s(\d{4})?: *\d+(, *\d+)?:.+' % _msgtypes_re_str)
     _parseable_line_re = re.compile(
@@ -240,7 +241,7 @@ class PyLint(ShellCommand):
     def createSummary(self, log):
         counts, summaries = self.counts, self.summaries
         self.descriptionDone = self.descriptionDone[:]
-        for msg, fullmsg in self._MESSAGES.items():
+        for msg, fullmsg in iteritems(self._MESSAGES):
             if counts[msg]:
                 self.descriptionDone.append("%s=%d" % (fullmsg, counts[msg]))
                 self.addCompleteLog(fullmsg, "\n".join(summaries[msg]))

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -12,7 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
+from future.utils import iteritems
 
 import inspect
 import re
@@ -112,7 +112,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
         buildstep_kwargs = {}
         # workdir is here first positional argument, but it belongs to BuildStep parent
         kwargs['workdir'] = workdir
-        for k in kwargs.keys()[:]:
+        for k in list(kwargs):
             if k in self.__class__.parms:
                 buildstep_kwargs[k] = kwargs[k]
                 del kwargs[k]
@@ -121,7 +121,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
         # check validity of arguments being passed to RemoteShellCommand
         invalid_args = []
         valid_rsc_args = inspect.getargspec(remotecommand.RemoteShellCommand.__init__)[0]
-        for arg in kwargs.keys():
+        for arg in kwargs:
             if arg not in valid_rsc_args:
                 invalid_args.append(arg)
         # Raise Configuration error in case invalid arguments are present
@@ -329,21 +329,21 @@ class SetPropertyFromCommand(ShellCommand):
             new_props = self.extract_fn(cmd.rc,
                                         self.observer.getStdout(),
                                         self.observer.getStderr())
-            for k, v in new_props.items():
+            for k, v in iteritems(new_props):
                 self.setProperty(k, v, "SetPropertyFromCommand Step")
             self.property_changes = new_props
 
     def createSummary(self, log):
         if self.property_changes:
             props_set = ["%s: %r" % (k, v)
-                         for k, v in self.property_changes.items()]
+                         for k, v in iteritems(self.property_changes)]
             self.addCompleteLog('property changes', "\n".join(props_set))
 
     def describe(self, done=False):
         if len(self.property_changes) > 1:
             return ["%d properties set" % len(self.property_changes)]
         elif len(self.property_changes) == 1:
-            return ["property '%s' set" % self.property_changes.keys()[0]]
+            return ["property '%s' set" % list(self.property_changes)[0]]
         else:
             # let ShellCommand describe
             return ShellCommand.describe(self, done)

--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 from buildbot import config
 from buildbot.process import buildstep
@@ -32,7 +33,7 @@ class ShellArg(results.ResultComputingConfigMixin):
                          "must not be None" % (name,))
         self.command = command
         self.logfile = logfile
-        for k, v in kwargs.iteritems():
+        for k, v in iteritems(kwargs):
             if k not in self.resultConfig:
                 config.error("the parameter '%s' is not "
                              "handled by ShellArg" % (k,))

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 from distutils.version import LooseVersion
 from twisted.internet import defer
@@ -332,7 +333,7 @@ class Git(Source):
     def _dovccmd(self, command, abandonOnFailure=True, collectStdout=False, initialStdin=None):
         full_command = ['git']
         if self.config is not None:
-            for name, value in self.config.iteritems():
+            for name, value in iteritems(self.config):
                 full_command.append('-c')
                 full_command.append('%s=%s' % (name, value))
         full_command.extend(command)

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import itervalues
 
 from buildbot import config
 from buildbot.interfaces import ITriggerableScheduler
@@ -132,7 +134,7 @@ class Trigger(BuildStep):
                 codebase = ss.get('codebase', '')
                 assert codebase not in ss_for_trigger, "codebase specified multiple times"
                 ss_for_trigger[codebase] = ss
-            return ss_for_trigger.values()
+            return list(itervalues(ss_for_trigger))
 
         if self.alwaysUseLatest:
             return []
@@ -150,7 +152,7 @@ class Trigger(BuildStep):
                 if codebase in got:
                     ss_for_trigger[codebase]['revision'] = got[codebase]
 
-        return ss_for_trigger.values()
+        return list(itervalues(ss_for_trigger))
 
     @defer.inlineCallbacks
     def worstStatus(self, overall_results, rclist):
@@ -172,7 +174,7 @@ class Trigger(BuildStep):
                 results, brids = results
 
             if was_cb:  # errors were already logged in worstStatus
-                for builderid, br in brids.iteritems():
+                for builderid, br in iteritems(brids):
                     builderDict = yield self.master.data.get(("builders", builderid))
                     builds = yield self.master.db.builds.getBuilds(buildrequestid=br)
                     for build in builds:
@@ -214,7 +216,7 @@ class Trigger(BuildStep):
                 yield self.addLogWithException(e)
                 results = EXCEPTION
 
-            self.brids.extend(brids.values())
+            self.brids.extend(itervalues(brids))
             for brid in brids.values():
                 # put the url to the brids, so that we can have the status from the beginning
                 url = self.master.status.getURLForBuildrequest(brid)

--- a/master/buildbot/test/fake/endpoint.py
+++ b/master/buildbot/test/fake/endpoint.py
@@ -15,6 +15,7 @@
 
 # This is a static resource type and set of endpoints uesd as common data by
 # tests.
+from future.utils import itervalues
 
 from buildbot.data import base
 from buildbot.data import types
@@ -38,7 +39,7 @@ class TestsEndpoint(base.Endpoint):
 
     def get(self, resultSpec, kwargs):
         # results are sorted by ID for test stability
-        return defer.succeed(sorted(testData.values(), key=lambda v: v['id']))
+        return defer.succeed(sorted(itervalues(testData), key=lambda v: v['id']))
 
 
 class RawTestsEndpoint(base.Endpoint):

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import itervalues
 
 from buildbot.data import connector
 from buildbot.db.buildrequests import AlreadyClaimedError
@@ -53,7 +55,7 @@ class FakeUpdates(service.AsyncService):
 
     def assertProperties(self, sourced, properties):
         self.testcase.assertIsInstance(properties, dict)
-        for k, v in properties.iteritems():
+        for k, v in iteritems(properties):
             self.testcase.assertIsInstance(k, unicode)
             if sourced:
                 self.testcase.assertIsInstance(v, tuple)
@@ -240,14 +242,14 @@ class FakeUpdates(service.AsyncService):
         validation.verifyType(self.testcase, 'scheduler name', name,
                               validation.StringValidator())
         if name not in self.schedulerIds:
-            self.schedulerIds[name] = max([0] + self.schedulerIds.values()) + 1
+            self.schedulerIds[name] = max([0] + list(itervalues(self.schedulerIds))) + 1
         return defer.succeed(self.schedulerIds[name])
 
     def findChangeSourceId(self, name):
         validation.verifyType(self.testcase, 'changesource name', name,
                               validation.StringValidator())
         if name not in self.changesourceIds:
-            self.changesourceIds[name] = max([0] + self.changesourceIds.values()) + 1
+            self.changesourceIds[name] = max([0] + list(itervalues(self.changesourceIds))) + 1
         return defer.succeed(self.changesourceIds[name])
 
     def findBuilderId(self, name):
@@ -362,7 +364,7 @@ class FakeUpdates(service.AsyncService):
                               validation.StringValidator())
         validation.verifyType(self.testcase, 'type', type,
                               validation.IdentifierValidator(1))
-        logid = max([0] + self.logs.keys()) + 1
+        logid = max([0] + list(self.logs)) + 1
         self.logs[logid] = dict(name=name, type=type, content=[], finished=False)
         return defer.succeed(logid)
 

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -18,6 +18,8 @@ A complete re-implementation of the database connector components, but without
 using a database.  These classes should pass the same tests as are applied to
 the real connector components.
 """
+from future.utils import iteritems
+from future.utils import itervalues
 
 import base64
 import copy
@@ -82,10 +84,10 @@ class Row(object):
             setattr(self, col, [])
         for col in self.dicts:
             setattr(self, col, {})
-        for col in kwargs.keys():
+        for col in kwargs:
             assert col in self.defaults, "%s is not a valid column" % col
         # cast to unicode
-        for k, v in self.values.iteritems():
+        for k, v in iteritems(self.values):
             if isinstance(v, str):
                 self.values[k] = unicode(v)
         # calculate any necessary hashes
@@ -651,7 +653,7 @@ class FakeChangeSourcesComponent(FakeDBComponent):
     # component methods
 
     def findChangeSourceId(self, name):
-        for cs_id, cs_name in self.changesources.iteritems():
+        for cs_id, cs_name in iteritems(self.changesources):
             if cs_name == name:
                 return defer.succeed(cs_id)
         new_id = (max(self.changesources) + 1) if self.changesources else 1
@@ -758,7 +760,7 @@ class FakeChangesComponent(FakeDBComponent):
             properties = {}
 
         if self.changes:
-            changeid = max(self.changes.iterkeys()) + 1
+            changeid = max(list(self.changes)) + 1
         else:
             changeid = 500
 
@@ -793,12 +795,12 @@ class FakeChangesComponent(FakeDBComponent):
 
     def getLatestChangeid(self):
         if self.changes:
-            return defer.succeed(max(self.changes.iterkeys()))
+            return defer.succeed(max(list(self.changes)))
         return defer.succeed(None)
 
     def getParentChangeIds(self, branch, repository, project, codebase):
         if self.changes:
-            for changeid, change in self.changes.iteritems():
+            for changeid, change in iteritems(self.changes):
                 if (change['branch'] == branch and
                         change['repository'] == repository and
                         change['project'] == project and
@@ -827,7 +829,7 @@ class FakeChangesComponent(FakeDBComponent):
         return defer.succeed(chdicts)
 
     def getChanges(self):
-        chdicts = [self._chdict(v) for v in self.changes.values()]
+        chdicts = [self._chdict(v) for v in itervalues(self.changes)]
         return defer.succeed(chdicts)
 
     def getChangesCount(self):
@@ -838,7 +840,7 @@ class FakeChangesComponent(FakeDBComponent):
         raise NotImplementedError("Please patch in tests to return appropriate results")
 
     def getChangeFromSSid(self, ssid):
-        chdicts = [self._chdict(v) for v in self.changes.values() if v['sourcestampid'] == ssid]
+        chdicts = [self._chdict(v) for v in itervalues(self.changes) if v['sourcestampid'] == ssid]
         if chdicts:
             return defer.succeed(chdicts[0])
         else:
@@ -880,7 +882,7 @@ class FakeChangesComponent(FakeDBComponent):
     def fakeAddChangeInstance(self, change):
         if not hasattr(change, 'number') or not change.number:
             if self.changes:
-                changeid = max(self.changes.iterkeys()) + 1
+                changeid = max(list(self.changes)) + 1
             else:
                 changeid = 500
         else:
@@ -933,7 +935,7 @@ class FakeSchedulersComponent(FakeDBComponent):
     def flushChangeClassifications(self, schedulerid, less_than=None):
         if less_than is not None:
             classifications = self.classifications.setdefault(schedulerid, {})
-            for changeid in classifications.keys():
+            for changeid in list(classifications):
                 if changeid < less_than:
                     del classifications[changeid]
         else:
@@ -950,31 +952,31 @@ class FakeSchedulersComponent(FakeDBComponent):
         if branch != -1:
             # filter out the classifications for the requested branch
             classifications = dict(
-                (k, v) for (k, v) in classifications.iteritems()
+                (k, v) for (k, v) in iteritems(classifications)
                 if self.db.changes.changes.get(k, sentinel)['branch'] == branch)
 
         if repository != -1:
             # filter out the classifications for the requested branch
             classifications = dict(
-                (k, v) for (k, v) in classifications.iteritems()
+                (k, v) for (k, v) in iteritems(classifications)
                 if self.db.changes.changes.get(k, sentinel)['repository'] == repository)
 
         if project != -1:
             # filter out the classifications for the requested branch
             classifications = dict(
-                (k, v) for (k, v) in classifications.iteritems()
+                (k, v) for (k, v) in iteritems(classifications)
                 if self.db.changes.changes.get(k, sentinel)['project'] == project)
 
         if codebase != -1:
             # filter out the classifications for the requested branch
             classifications = dict(
-                (k, v) for (k, v) in classifications.iteritems()
+                (k, v) for (k, v) in iteritems(classifications)
                 if self.db.changes.changes.get(k, sentinel)['codebase'] == codebase)
 
         return defer.succeed(classifications)
 
     def findSchedulerId(self, name):
-        for sch_id, sch_name in self.schedulers.iteritems():
+        for sch_id, sch_name in iteritems(self.schedulers):
             if sch_name == name:
                 return defer.succeed(sch_id)
         new_id = (max(self.schedulers) + 1) if self.schedulers else 1
@@ -1098,7 +1100,7 @@ class FakeSourceStampsComponent(FakeDBComponent):
         new_ssdict = dict(branch=branch, revision=revision, codebase=codebase,
                           patchid=patchid, repository=repository, project=project,
                           created_at=_mkdt(_reactor.seconds()))
-        for id, ssdict in self.sourcestamps.iteritems():
+        for id, ssdict in iteritems(self.sourcestamps):
             keys = ['branch', 'revision', 'repository',
                     'codebase', 'project', 'patchid']
             if [ssdict[k] for k in keys] == [new_ssdict[k] for k in keys]:
@@ -1240,7 +1242,7 @@ class FakeBuildsetsComponent(FakeDBComponent):
 
     def getBuildsets(self, complete=None):
         rv = []
-        for bs in self.buildsets.itervalues():
+        for bs in itervalues(self.buildsets):
             if complete is not None:
                 if complete and bs['complete']:
                     rv.append(self._row2dict(bs))
@@ -1364,7 +1366,7 @@ class FakeBuildslavesComponent(FakeDBComponent):
     def findBuildslaveId(self, name, _reactor=reactor):
         validation.verifyType(self.t, 'name', name,
                               validation.IdentifierValidator(50))
-        for m in self.buildslaves.itervalues():
+        for m in itervalues(self.buildslaves):
             if m['name'] == name:
                 return defer.succeed(m['id'])
         id = len(self.buildslaves) + 1
@@ -1375,7 +1377,7 @@ class FakeBuildslavesComponent(FakeDBComponent):
         return defer.succeed(id)
 
     def _getBuildslaveByName(self, name):
-        for slave in self.buildslaves.itervalues():
+        for slave in itervalues(self.buildslaves):
             if slave['name'] == name:
                 return slave
         return None
@@ -1383,7 +1385,7 @@ class FakeBuildslavesComponent(FakeDBComponent):
     def getBuildslave(self, buildslaveid=None, name=None, masterid=None, builderid=None):
         # get the id and the slave
         if buildslaveid is None:
-            for slave in self.buildslaves.itervalues():
+            for slave in itervalues(self.buildslaves):
                 if slave['name'] == name:
                     buildslaveid = slave['id']
                     break
@@ -1403,7 +1405,7 @@ class FakeBuildslavesComponent(FakeDBComponent):
         if masterid is not None or builderid is not None:
             builder_masters = self.db.builders.builder_masters
             slaves = []
-            for sl in self.buildslaves.itervalues():
+            for sl in itervalues(self.buildslaves):
                 configured = [cfg for cfg in self.configured.itervalues()
                               if cfg['buildslaveid'] == sl['id']]
                 pairs = [builder_masters[cfg['buildermasterid']]
@@ -1419,7 +1421,7 @@ class FakeBuildslavesComponent(FakeDBComponent):
                         continue
                 slaves.append(sl)
         else:
-            slaves = self.buildslaves.values()
+            slaves = list(itervalues(self.buildslaves))
 
         return defer.succeed([
             self._mkdict(sl, builderid, masterid)
@@ -1432,13 +1434,13 @@ class FakeBuildslavesComponent(FakeDBComponent):
         if slave is not None:
             slave['info'] = slaveinfo
         new_conn = dict(masterid=masterid, buildslaveid=buildslaveid)
-        if new_conn not in self.connected.itervalues():
-            conn_id = max([0] + self.connected.keys()) + 1
+        if new_conn not in itervalues(self.connected):
+            conn_id = max([0] + list(self.connected)) + 1
             self.connected[conn_id] = new_conn
         return defer.succeed(None)
 
     def deconfigureAllBuidslavesForMaster(self, masterid):
-        buildermasterids = [_id for _id, (builderid, mid) in self.db.builders.builder_masters.items()
+        buildermasterids = [_id for _id, (builderid, mid) in iteritems(self.db.builders.builder_masters)
                             if mid == masterid]
         for k, v in self.configured.items():
             if v['buildermasterid'] in buildermasterids:
@@ -1446,7 +1448,7 @@ class FakeBuildslavesComponent(FakeDBComponent):
 
     def buildslaveConfigured(self, buildslaveid, masterid, builderids):
 
-        buildermasterids = [_id for _id, (builderid, mid) in self.db.builders.builder_masters.items()
+        buildermasterids = [_id for _id, (builderid, mid) in iteritems(self.db.builders.builder_masters)
                             if mid == masterid and builderid in builderids]
         if len(buildermasterids) != len(builderids):
             raise ValueError("Some builders are not configured for this master: "
@@ -1460,7 +1462,7 @@ class FakeBuildslavesComponent(FakeDBComponent):
 
     def buildslaveDisconnected(self, buildslaveid, masterid):
         del_conn = dict(masterid=masterid, buildslaveid=buildslaveid)
-        for id, conn in self.connected.iteritems():
+        for id, conn in iteritems(self.connected):
             if conn == del_conn:
                 del self.connected[id]
                 break
@@ -1468,7 +1470,7 @@ class FakeBuildslavesComponent(FakeDBComponent):
 
     def _configuredOn(self, buildslaveid, builderid=None, masterid=None):
         cfg = []
-        for cs in self.configured.itervalues():
+        for cs in itervalues(self.configured):
             if cs['buildslaveid'] != buildslaveid:
                 continue
             bid, mid = self.db.builders.builder_masters[cs['buildermasterid']]
@@ -1481,7 +1483,7 @@ class FakeBuildslavesComponent(FakeDBComponent):
 
     def _connectedTo(self, buildslaveid, masterid=None):
         conns = []
-        for cs in self.connected.itervalues():
+        for cs in itervalues(self.connected):
             if cs['buildslaveid'] != buildslaveid:
                 continue
             if masterid is not None and cs['masterid'] != masterid:
@@ -1513,7 +1515,7 @@ class FakeStateComponent(FakeDBComponent):
 
         for row in rows:
             if isinstance(row, ObjectState):
-                assert row.objectid in self.objects.values()
+                assert row.objectid in list(itervalues(self.objects))
                 self.states[row.objectid][row.name] = row.value_json
 
     # component methods
@@ -1552,7 +1554,7 @@ class FakeStateComponent(FakeDBComponent):
         id = self.objects[(name, class_name)] = self._newId()
         self.objects[(name, class_name)] = id
         self.states[id] = dict((k, json.dumps(v))
-                               for k, v in kwargs.iteritems())
+                               for k, v in iteritems(kwargs))
         return id
 
     # assertions
@@ -1563,7 +1565,7 @@ class FakeStateComponent(FakeDBComponent):
         state = self.states[objectid]
         for k in missing_keys:
             self.t.assertFalse(k in state, "%s in %s" % (k, state))
-        for k, v in kwargs.iteritems():
+        for k, v in iteritems(kwargs):
             self.t.assertIn(k, state)
             self.t.assertEqual(json.loads(state[k]), v,
                                "state is %r" % (state,))
@@ -1571,7 +1573,7 @@ class FakeStateComponent(FakeDBComponent):
     def assertStateByClass(self, name, class_name, **kwargs):
         objectid = self.objects[(name, class_name)]
         state = self.states[objectid]
-        for k, v in kwargs.iteritems():
+        for k, v in iteritems(kwargs):
             self.t.assertIn(k, state)
             self.t.assertEqual(json.loads(state[k]), v,
                                "state is %r" % (state,))
@@ -1620,7 +1622,7 @@ class FakeBuildRequestsComponent(FakeDBComponent):
     def getBuildRequests(self, builderid=None, complete=None, claimed=None,
                          bsid=None, branch=None, repository=None):
         rv = []
-        for br in self.reqs.itervalues():
+        for br in itervalues(self.reqs):
             if builderid and br.builderid != builderid:
                 continue
             if complete is not None:
@@ -1718,7 +1720,7 @@ class FakeBuildRequestsComponent(FakeDBComponent):
     def unclaimExpiredRequests(self, old, _reactor=reactor):
         old_epoch = _reactor.seconds() - old
 
-        for br in self.reqs.itervalues():
+        for br in itervalues(self.reqs):
             if br.complete == 1:
                 continue
 
@@ -1744,7 +1746,7 @@ class FakeBuildRequestsComponent(FakeDBComponent):
 
     def assertMyClaims(self, claimed_brids):
         self.t.assertEqual(
-            [id for (id, brc) in self.claims.iteritems()
+            [id for (id, brc) in iteritems(self.claims)
              if brc.masterid == self.MASTER_ID],
             claimed_brids)
 
@@ -1795,14 +1797,14 @@ class FakeBuildsComponent(FakeDBComponent):
         return defer.succeed(self._row2dict(row))
 
     def getBuildByNumber(self, builderid, number):
-        for row in self.builds.itervalues():
+        for row in itervalues(self.builds):
             if row['builderid'] == builderid and row['number'] == number:
                 return defer.succeed(self._row2dict(row))
         return defer.succeed(None)
 
     def getBuilds(self, builderid=None, buildrequestid=None, buildslaveid=None, complete=None):
         ret = []
-        for (id, row) in self.builds.items():
+        for (id, row) in iteritems(self.builds):
             if builderid is not None and row['builderid'] != builderid:
                 continue
             if buildrequestid is not None and row['buildrequestid'] != buildrequestid:
@@ -1820,7 +1822,7 @@ class FakeBuildsComponent(FakeDBComponent):
         validation.verifyType(self.t, 'state_string', state_string,
                               validation.StringValidator())
         id = self._newId()
-        number = max([0] + [r['number'] for r in self.builds.itervalues()
+        number = max([0] + [r['number'] for r in itervalues(self.builds)
                             if r['builderid'] == builderid]) + 1
         self.builds[id] = dict(id=id, number=number,
                                buildrequestid=buildrequestid, builderid=builderid,
@@ -1898,7 +1900,7 @@ class FakeStepsComponent(FakeDBComponent):
         else:
             if number is None and name is None:
                 return defer.fail(RuntimeError("specify both name and number"))
-            for row in self.steps.itervalues():
+            for row in itervalues(self.steps):
                 if row['buildid'] != buildid:
                     continue
                 if number is not None and row['number'] != number:
@@ -1925,7 +1927,7 @@ class FakeStepsComponent(FakeDBComponent):
         validation.verifyType(self.t, 'name', name,
                               validation.IdentifierValidator(50))
         # get a unique name and number
-        build_steps = [r for r in self.steps.itervalues()
+        build_steps = [r for r in itervalues(self.steps)
                        if r['buildid'] == buildid]
         if build_steps:
             number = max([r['number'] for r in build_steps]) + 1
@@ -2046,7 +2048,7 @@ class FakeLogsComponent(FakeDBComponent):
     def getLogs(self, stepid=None):
         return defer.succeed([
             self._row2dict(row)
-            for row in self.logs.itervalues()
+            for row in itervalues(self.logs)
             if row['stepid'] == stepid])
 
     def getLogLines(self, logid, first_line, last_line):
@@ -2217,7 +2219,7 @@ class FakeMastersComponent(FakeDBComponent):
                     last_active=_mkdt(row.last_active))
 
     def findMasterId(self, name, _reactor=reactor):
-        for m in self.masters.itervalues():
+        for m in itervalues(self.masters):
             if m['name'] == name:
                 return defer.succeed(m['id'])
         id = len(self.masters) + 1
@@ -2278,7 +2280,7 @@ class FakeBuildersComponent(FakeDBComponent):
                                               []).append(row.tagid)
 
     def findBuilderId(self, name, _reactor=reactor):
-        for m in self.builders.itervalues():
+        for m in itervalues(self.builders):
             if m['name'] == name:
                 return defer.succeed(m['id'])
         id = len(self.builders) + 1
@@ -2290,14 +2292,14 @@ class FakeBuildersComponent(FakeDBComponent):
         return defer.succeed(id)
 
     def addBuilderMaster(self, builderid=None, masterid=None):
-        if (builderid, masterid) not in self.builder_masters.itervalues():
+        if (builderid, masterid) not in list(itervalues(self.builder_masters)):
             self.insertTestData([
                 BuilderMaster(builderid=builderid, masterid=masterid),
             ])
         return defer.succeed(None)
 
     def removeBuilderMaster(self, builderid=None, masterid=None):
-        for id, tup in self.builder_masters.iteritems():
+        for id, tup in iteritems(self.builder_masters):
             if tup == (builderid, masterid):
                 del self.builder_masters[id]
                 break
@@ -2305,7 +2307,7 @@ class FakeBuildersComponent(FakeDBComponent):
 
     def getBuilder(self, builderid):
         if builderid in self.builders:
-            masterids = [bm[1] for bm in self.builder_masters.itervalues()
+            masterids = [bm[1] for bm in itervalues(self.builder_masters)
                          if bm[0] == builderid]
             bldr = self.builders[builderid].copy()
             bldr['masterids'] = sorted(masterids)
@@ -2315,7 +2317,7 @@ class FakeBuildersComponent(FakeDBComponent):
     def getBuilders(self, masterid=None):
         rv = []
         for builderid, bldr in self.builders.iteritems():
-            masterids = [bm[1] for bm in self.builder_masters.itervalues()
+            masterids = [bm[1] for bm in itervalues(self.builder_masters)
                          if bm[0] == builderid]
             bldr = bldr.copy()
             bldr['masterids'] = sorted(masterids)
@@ -2366,7 +2368,7 @@ class FakeTagsComponent(FakeDBComponent):
                     name=row.name)
 
     def findTagId(self, name, _reactor=reactor):
-        for m in self.tags.itervalues():
+        for m in itervalues(self.tags):
             if m['name'] == name:
                 return defer.succeed(m['id'])
         id = len(self.tags) + 1

--- a/master/buildbot/test/fake/libvirt.py
+++ b/master/buildbot/test/fake/libvirt.py
@@ -48,7 +48,7 @@ class Connection(object):
         return d
 
     def listDomainsID(self):
-        return self.domains.keys()
+        return list(self.domains)
 
     def lookupByName(self, name):
         return self.domains[name]

--- a/master/buildbot/test/fake/logfile.py
+++ b/master/buildbot/test/fake/logfile.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 from buildbot import util
 from buildbot.util import lineboundaries
@@ -75,7 +76,7 @@ class FakeLogFile(object):
         return defer.Deferred()
 
     def flushFakeLogfile(self):
-        for lbf in self.lbfs.values():
+        for lbf in itervalues(self.lbfs):
             lbf.flush()
 
     def finish(self):

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 from buildbot.status.results import FAILURE
 from buildbot.status.results import SUCCESS
@@ -194,7 +195,7 @@ class Expect(object):
         if behavior == 'rc':
             command.rc = args[0]
             d = defer.succeed(None)
-            for log in command.logs.values():
+            for log in itervalues(command.logs):
                 if hasattr(log, 'unwrap'):
                     # We're handling an old style log that was
                     # used in an old style step. We handle the necessary

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import mock
 
@@ -223,7 +224,7 @@ class RunSteps(unittest.TestCase):
 
     def assertLogs(self, exp_logs):
         got_logs = {}
-        for id, l in self.master.data.updates.logs.iteritems():
+        for id, l in iteritems(self.master.data.updates.logs):
             self.failUnless(l['finished'])
             got_logs[l['name']] = ''.join(l['content'])
         self.assertEqual(got_logs, exp_logs)

--- a/master/buildbot/test/regressions/test_shell_command_properties.py
+++ b/master/buildbot/test/regressions/test_shell_command_properties.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 import mock
 
@@ -60,7 +61,7 @@ class FakeBuildRequest:
         self.properties = Properties()
 
     def mergeSourceStampsWith(self, others):
-        return [source for source in self.sources.itervalues()]
+        return [source for source in itervalues(self.sources)]
 
     def mergeReasons(self, others):
         return self.reason

--- a/master/buildbot/test/unit/test_changes_gerritchangesource.py
+++ b/master/buildbot/test/unit/test_changes_gerritchangesource.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import types
 
@@ -150,7 +151,7 @@ class TestGerritChangeSource(changesource.ChangeSourceMixin,
         def check(_):
             self.failUnlessEqual(len(self.master.data.updates.changesAdded), 1)
             c = self.master.data.updates.changesAdded[0]
-            for k, v in c.items():
+            for k, v in iteritems(c):
                 self.assertEqual(self.expected_change[k], v)
         return d
 

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import __builtin__
 import mock
 import os
@@ -162,7 +164,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
         config_file = textwrap.dedent(config_file)
         with open(os.path.join(self.basedir, self.filename), "w") as f:
             f.write(config_file)
-        for file, contents in other_files.items():
+        for file, contents in iteritems(other_files):
             with open(file, "w") as f:
                 f.write(contents)
 
@@ -187,7 +189,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
         expected.update(global_defaults)
         got = dict([
             (attr, getattr(cfg, attr))
-            for attr, exp in expected.iteritems()])
+            for attr, exp in iteritems(expected)])
         got = interfaces.IConfigured(got).getConfigDict()
         expected = interfaces.IConfigured(expected).getConfigDict()
         self.assertEqual(got, expected)
@@ -363,7 +365,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.failIf(self.errors, self.errors.errors)
         got = dict([
             (attr, getattr(self.cfg, attr))
-            for attr, exp in expected.iteritems()])
+            for attr, exp in iteritems(expected)])
         got = interfaces.IConfigured(got).getConfigDict()
         expected = interfaces.IConfigured(expected).getConfigDict()
 
@@ -1160,7 +1162,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
     def assertAttributes(self, cfg, **expected):
         got = dict([
             (attr, getattr(cfg, attr))
-            for attr, exp in expected.iteritems()])
+            for attr, exp in iteritems(expected)])
         self.assertEqual(got, expected)
 
     # tests

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -493,7 +493,7 @@ class RealTests(Tests):
 
                 # one buildset_sourcestamps row
                 r = conn.execute(self.db.model.buildset_sourcestamps.select())
-                self.assertEqual(r.keys(), [u'id', u'buildsetid', u'sourcestampid'])
+                self.assertEqual(list(r.keys()), [u'id', u'buildsetid', u'sourcestampid'])
                 self.assertEqual(r.fetchall(), [(1, bsid, 234)])
             return self.db.pool.do(thd)
         d.addCallback(check)

--- a/master/buildbot/test/unit/test_db_changes.py
+++ b/master/buildbot/test/unit/test_db_changes.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import sqlalchemy as sa
 
@@ -754,7 +755,7 @@ class RealTests(Tests):
             buildRows = [fakedb.Buildset(id=lastID["buildsetid"],
                                          reason='foo',
                                          submitted_at=1300305012, results=-1)]
-            for cb, ss in codebase_ss.iteritems():
+            for cb, ss in iteritems(codebase_ss):
                 lastID["buildsetSourceStampid"] += 1
                 buildRows.append(
                     fakedb.BuildsetSourceStamp(id=lastID["buildsetSourceStampid"],

--- a/master/buildbot/test/unit/test_db_sourcestamps.py
+++ b/master/buildbot/test/unit/test_db_sourcestamps.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 from buildbot.db import sourcestamps
 from buildbot.test.fake import fakedb
@@ -186,7 +187,7 @@ class Tests(interfaces.InterfaceTests):
 
         def check(ssdict):
             validation.verifyDbDict(self, 'ssdict', ssdict)
-            self.assertEqual(dict((k, v) for k, v in ssdict.iteritems()
+            self.assertEqual(dict((k, v) for k, v in iteritems(ssdict)
                                   if k.startswith('patch_')),
                              dict(patch_body='hello, world',
                                   patch_level=3,

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import mock
 import random
@@ -104,7 +105,7 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
     def setSlaveBuilders(self, slavebuilders):
         """C{slaves} maps name : available"""
         self.bldr.slaves = []
-        for name, avail in slavebuilders.iteritems():
+        for name, avail in iteritems(slavebuilders):
             sb = mock.Mock(spec=['isAvailable'], name=name)
             sb.name = name
             sb.isAvailable.return_value = avail

--- a/master/buildbot/test/unit/test_process_buildrequest.py
+++ b/master/buildbot/test/unit/test_process_buildrequest.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 import mock
 
@@ -209,7 +210,7 @@ class TestBuildRequest(unittest.TestCase):
 
         def check(br):
             # check enough of the source stamp to verify it found the changes
-            self.assertEqual([ss.ssid for ss in br.sources.values()], [234])
+            self.assertEqual([ss.ssid for ss in itervalues(br.sources)], [234])
 
             self.assertEqual(br.reason, 'triggered')
 

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import mock
 
@@ -100,7 +101,7 @@ class TestBRDBase(unittest.TestCase):
 
     def addSlaves(self, slavebuilders):
         """C{slaves} maps name : available"""
-        for name, avail in slavebuilders.iteritems():
+        for name, avail in iteritems(slavebuilders):
             sb = mock.Mock(spec=['isAvailable'], name=name)
             sb.name = name
             sb.isAvailable.return_value = avail
@@ -275,7 +276,7 @@ class Test(TestBRDBase):
     def do_test_sortBuilders(self, prioritizeBuilders, oldestRequestTimes,
                              expected, returnDeferred=False):
         self.useMock_maybeStartBuildsOnBuilder()
-        self.addBuilders(oldestRequestTimes.keys())
+        self.addBuilders(list(oldestRequestTimes))
         self.master.config.prioritizeBuilders = prioritizeBuilders
 
         def mklambda(t):  # work around variable-binding issues
@@ -284,12 +285,12 @@ class Test(TestBRDBase):
             else:
                 return lambda: t
 
-        for n, t in oldestRequestTimes.iteritems():
+        for n, t in iteritems(oldestRequestTimes):
             if t is not None:
                 t = epoch2datetime(t)
             self.builders[n].getOldestRequestTime = mklambda(t)
 
-        d = self.brd._sortBuilders(oldestRequestTimes.keys())
+        d = self.brd._sortBuilders(list(oldestRequestTimes))
 
         def check(result):
             self.assertEqual(result, expected)

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 import mock
 
@@ -412,8 +413,8 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
         self.assertEqual(len(self.flushLoggedErrors(AssertionError)), 1)
 
     def checkSummary(self, got, step, build=None):
-        self.failUnless(all(isinstance(k, unicode) for k in got.keys()))
-        self.failUnless(all(isinstance(k, unicode) for k in got.values()))
+        self.failUnless(all(isinstance(k, unicode) for k in got))
+        self.failUnless(all(isinstance(k, unicode) for k in itervalues(got)))
         exp = {u'step': step}
         if build:
             exp[u'build'] = build

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 from buildbot.reporters import utils
 from buildbot.reporters.gerrit import GERRIT_LABEL_REVIEWED
@@ -159,7 +160,7 @@ class TestGerritStatusPush(unittest.TestCase):
                 fakedb.BuildProperty(buildid=20 + i, name="slavename", value="sl"),
                 fakedb.BuildProperty(buildid=20 + i, name="reason", value="because"),
             ])
-            for k, v in self.TEST_PROPS.items():
+            for k, v in iteritems(self.TEST_PROPS):
                 self.db.insertTestData([
                     fakedb.BuildProperty(buildid=20 + i, name=k, value=v)
                     ])

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from __future__ import print_function
+from future.utils import iteritems
 
 from buildbot import config
 from buildbot.schedulers.forcesched import AnyPropertyParameter
@@ -364,7 +365,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
         if expectKind is None:
             expect_props[name] = (expect, 'Force Build Form')
         elif expectKind is dict:
-            for k, v in expect.iteritems():
+            for k, v in iteritems(expect):
                 expect_props[k] = (v, 'Force Build Form')
         else:
             self.fail("expectKind is wrong type!")

--- a/master/buildbot/test/unit/test_schedulers_triggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_triggerable.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 import mock
 
@@ -101,12 +102,12 @@ class Triggerable(scheduler.SchedulerMixin, unittest.TestCase):
         for expected_ss, actual_ss in zip(sourcestamps, actual_sourcestamps):
             actual_ss = actual_ss.copy()
             # We don't care if the actual sourcestamp has *more* attributes than expected.
-            for key in actual_ss.keys():
+            for key in list(actual_ss.keys()):
                 if key not in expected_ss:
                     del actual_ss[key]
             self.assertEqual(expected_ss, actual_ss)
 
-        for brid in brids.values():
+        for brid in itervalues(brids):
             buildrequest = yield self.master.db.buildrequests.getBuildRequest(brid)
             self.assertEqual(
                 buildrequest,

--- a/master/buildbot/test/unit/test_scripts_checkconfig.py
+++ b/master/buildbot/test/unit/test_scripts_checkconfig.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import cStringIO
 import mock
 import os
@@ -40,7 +42,7 @@ class TestConfigLoader(dirs.DirsMixin, unittest.TestCase):
         configFile = os.path.join('configdir', 'master.cfg')
         with open(configFile, "w") as f:
             f.write(config)
-        for filename, contents in other_files.iteritems():
+        for filename, contents in iteritems(other_files):
             if isinstance(filename, type(())):
                 fn = os.path.join('configdir', *filename)
                 dn = os.path.dirname(fn)

--- a/master/buildbot/test/unit/test_scripts_create_master.py
+++ b/master/buildbot/test/unit/test_scripts_create_master.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
+
 import mock
 import os
 
@@ -64,7 +66,7 @@ class TestCreateMaster(misc.StdoutAssertionsMixin, unittest.TestCase):
         def check(rc):
             self.assertEqual(rc, 0)
             self.assertEqual(calls, functions)
-            for repl in repls.values():
+            for repl in itervalues(repls):
                 repl.assert_called_with(config)
         return d
 

--- a/master/buildbot/test/unit/test_status_persistent_queue.py
+++ b/master/buildbot/test/unit/test_status_persistent_queue.py
@@ -12,7 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
+from future.utils import iteritems
 
 import os
 
@@ -42,7 +42,7 @@ class test_Queues(dirs.DirsMixin, unittest.TestCase):
         WriteFile(os.path.join('fake_dir', '8'), 'foo8')
         queue = PersistentQueue(MemoryQueue(3),
                                 DiskQueue('fake_dir', 5, pickleFn=str, unpickleFn=str))
-        self.assertEqual(['foo3', 'foo5', 'foo8'], queue.items())
+        self.assertEqual(['foo3', 'foo5', 'foo8'], list(iteritems(queue)))
         self.assertEqual(3, queue.nbItems())
         self.assertEqual(['foo3', 'foo5', 'foo8'], queue.popChunk())
 
@@ -50,7 +50,7 @@ class test_Queues(dirs.DirsMixin, unittest.TestCase):
         self.assertTrue(IQueue.providedBy(q))
         self.assertEqual(8, q.maxItems())
         self.assertEqual(0, q.nbItems())
-        self.assertEqual([], q.items())
+        self.assertEqual([], list(iteritems(q)))
 
         for i in range(4):
             self.assertEqual(None, q.pushItem(i), str(i))
@@ -58,86 +58,86 @@ class test_Queues(dirs.DirsMixin, unittest.TestCase):
         self.assertEqual([0, 1, 2, 3], q.items())
         self.assertEqual(4, q.nbItems())
         if isinstance(q, PersistentQueue):
-            self.assertEqual([0, 1, 2], q.primaryQueue.items())
-            self.assertEqual([3], q.secondaryQueue.items())
+            self.assertEqual([0, 1, 2], list(iteritems(q.primaryQueue)))
+            self.assertEqual([3], list(iteritems(q.secondaryQueue)))
 
         self.assertEqual(None, q.save())
-        self.assertEqual([0, 1, 2, 3], q.items())
+        self.assertEqual([0, 1, 2, 3], list(iteritems(q)))
         self.assertEqual(4, q.nbItems())
         if isinstance(q, PersistentQueue):
-            self.assertEqual([], q.primaryQueue.items())
-            self.assertEqual([0, 1, 2, 3], q.secondaryQueue.items())
+            self.assertEqual([], list(iteritems(q.primaryQueue)))
+            self.assertEqual([0, 1, 2, 3], list(iteritems(q.secondaryQueue)))
 
         for i in range(4):
             self.assertEqual(None, q.pushItem(i + 4), str(i + 4))
             self.assertEqual(i + 5, q.nbItems(), str(i + 4))
-        self.assertEqual([0, 1, 2, 3, 4, 5, 6, 7], q.items())
+        self.assertEqual([0, 1, 2, 3, 4, 5, 6, 7], list(iteritems(q)))
         self.assertEqual(8, q.nbItems())
         if isinstance(q, PersistentQueue):
-            self.assertEqual([0, 1, 2], q.primaryQueue.items())
-            self.assertEqual([3, 4, 5, 6, 7], q.secondaryQueue.items())
+            self.assertEqual([0, 1, 2], list(iteritems(q.primaryQueue)))
+            self.assertEqual([3, 4, 5, 6, 7], list(iteritems(q.secondaryQueue)))
 
         self.assertEqual(0, q.pushItem(8))
         self.assertEqual(8, q.nbItems())
-        self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8], q.items())
+        self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8], list(iteritems(q)))
         if isinstance(q, PersistentQueue):
-            self.assertEqual([1, 2, 3], q.primaryQueue.items())
-            self.assertEqual([4, 5, 6, 7, 8], q.secondaryQueue.items())
+            self.assertEqual([1, 2, 3], list(iteritems(q.primaryQueue)))
+            self.assertEqual([4, 5, 6, 7, 8], list(iteritems(q.secondaryQueue)))
 
         self.assertEqual([1, 2], q.popChunk(2))
-        self.assertEqual([3, 4, 5, 6, 7, 8], q.items())
+        self.assertEqual([3, 4, 5, 6, 7, 8], list(iteritems(q)))
         self.assertEqual(6, q.nbItems())
         if isinstance(q, PersistentQueue):
-            self.assertEqual([3], q.primaryQueue.items())
-            self.assertEqual([4, 5, 6, 7, 8], q.secondaryQueue.items())
+            self.assertEqual([3], list(iteritems(q.primaryQueue)))
+            self.assertEqual([4, 5, 6, 7, 8], list(iteritems(q.secondaryQueue)))
 
         self.assertEqual([3], q.popChunk(1))
-        self.assertEqual([4, 5, 6, 7, 8], q.items())
+        self.assertEqual([4, 5, 6, 7, 8], list(iteritems(q)))
         self.assertEqual(5, q.nbItems())
         if isinstance(q, PersistentQueue):
-            self.assertEqual([], q.primaryQueue.items())
-            self.assertEqual([4, 5, 6, 7, 8], q.secondaryQueue.items())
+            self.assertEqual([], list(iteritems(q.primaryQueue)))
+            self.assertEqual([4, 5, 6, 7, 8], list(iteritems(q.secondaryQueue)))
 
         self.assertEqual(None, q.save())
         self.assertEqual(5, q.nbItems())
-        self.assertEqual([4, 5, 6, 7, 8], q.items())
+        self.assertEqual([4, 5, 6, 7, 8], list(iteritems(q)))
         if isinstance(q, PersistentQueue):
-            self.assertEqual([], q.primaryQueue.items())
-            self.assertEqual([4, 5, 6, 7, 8], q.secondaryQueue.items())
+            self.assertEqual([], list(iteritems(q.primaryQueue)))
+            self.assertEqual([4, 5, 6, 7, 8], list(iteritems(q.secondaryQueue)))
 
         self.assertEqual(None, q.insertBackChunk([2, 3]))
-        self.assertEqual([2, 3, 4, 5, 6, 7, 8], q.items())
+        self.assertEqual([2, 3, 4, 5, 6, 7, 8], list(iteritems(q)))
         self.assertEqual(7, q.nbItems())
         if isinstance(q, PersistentQueue):
-            self.assertEqual([2, 3], q.primaryQueue.items())
-            self.assertEqual([4, 5, 6, 7, 8], q.secondaryQueue.items())
+            self.assertEqual([2, 3], list(iteritems(q.primaryQueue)))
+            self.assertEqual([4, 5, 6, 7, 8], list(iteritems(q.secondaryQueue)))
 
         self.assertEqual([0], q.insertBackChunk([0, 1]))
-        self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8], q.items())
+        self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8], list(iteritems(q)))
         self.assertEqual(8, q.nbItems())
         if isinstance(q, PersistentQueue):
-            self.assertEqual([1, 2, 3], q.primaryQueue.items())
-            self.assertEqual([4, 5, 6, 7, 8], q.secondaryQueue.items())
+            self.assertEqual([1, 2, 3], list(iteritems(q.primaryQueue)))
+            self.assertEqual([4, 5, 6, 7, 8], list(iteritems(q.secondaryQueue)))
 
         self.assertEqual([10, 11], q.insertBackChunk([10, 11]))
-        self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8], q.items())
+        self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8], list(iteritems(q)))
         self.assertEqual(8, q.nbItems())
         if isinstance(q, PersistentQueue):
-            self.assertEqual([1, 2, 3], q.primaryQueue.items())
-            self.assertEqual([4, 5, 6, 7, 8], q.secondaryQueue.items())
+            self.assertEqual([1, 2, 3], list(iteritems(q.primaryQueue)))
+            self.assertEqual([4, 5, 6, 7, 8], list(iteritems(q.secondaryQueue)))
 
         self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8], q.popChunk(8))
-        self.assertEqual([], q.items())
+        self.assertEqual([], list(iteritems(q)))
         self.assertEqual(0, q.nbItems())
         if isinstance(q, PersistentQueue):
-            self.assertEqual([], q.primaryQueue.items())
-            self.assertEqual([], q.secondaryQueue.items())
+            self.assertEqual([], list(iteritems(q.primaryQueue)))
+            self.assertEqual([], list(iteritems(q.secondaryQueue)))
 
         self.assertEqual([], q.popChunk())
         self.assertEqual(0, q.nbItems())
         if isinstance(q, PersistentQueue):
-            self.assertEqual([], q.primaryQueue.items())
-            self.assertEqual([], q.secondaryQueue.items())
+            self.assertEqual([], list(iteritems(q.primaryQueue)))
+            self.assertEqual([], list(iteritems(q.secondaryQueue)))
 
     def testMemoryQueue(self):
         self._test_helper(MemoryQueue(maxItems=8))

--- a/master/buildbot/test/unit/test_status_words.py
+++ b/master/buildbot/test/unit/test_status_words.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import mock
 import re
@@ -122,7 +123,7 @@ class TestContactChannel(unittest.TestCase):
         clock = task.Clock()
         self.patch(reactor, 'callLater', clock.callLater)
         self.patch_send()
-        silly_prompt, silly_response = self.contact.silly.items()[0]
+        silly_prompt, silly_response = list(iteritems(self.contact.silly))[0]
 
         self.contact.doSilly(silly_prompt)
         clock.pump([0.5] * 20)
@@ -551,7 +552,7 @@ class TestContactChannel(unittest.TestCase):
         ])
 
     def test_handleMessage_silly(self):
-        silly_prompt = self.contact.silly.keys()[0]
+        silly_prompt = list(self.contact.silly)[0]
         self.contact.doSilly = mock.Mock()
         d = self.contact.handleMessage(silly_prompt)
 

--- a/master/buildbot/test/unit/test_steps_source_repo.py
+++ b/master/buildbot/test/unit/test_steps_source_repo.py
@@ -31,7 +31,7 @@ class RepoURL(unittest.TestCase):
     def oneTest(self, props, expected):
         p = Properties()
         p.update(props, "test")
-        r = repo.RepoDownloadsFromProperties(props.keys())
+        r = repo.RepoDownloadsFromProperties(list(props))
         self.assertEqual(r.getRenderingFor(p), expected)
 
     def test_parse1(self):

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import os
 import shutil
 import stat
@@ -65,7 +67,7 @@ def uploadTarFile(filename, **members):
     def behavior(command):
         f = StringIO()
         archive = tarfile.TarFile(fileobj=f, name=filename, mode='w')
-        for name, content in members.iteritems():
+        for name, content in iteritems(members):
             archive.addfile(tarfile.TarInfo(name), StringIO(content))
         writer = command.args['writer']
         writer.remote_write(f.getvalue())

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -169,7 +169,7 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
             # check the URLs
             stepUrls = self.master.data.updates.stepUrls
             if stepUrls:
-                got_added_urls = stepUrls[stepUrls.keys()[0]]
+                got_added_urls = stepUrls[list(stepUrls)[0]]
             else:
                 got_added_urls = []
             self.assertEqual(sorted(got_added_urls),

--- a/master/buildbot/test/unit/test_util_debounce.py
+++ b/master/buildbot/test/unit/test_util_debounce.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 from buildbot.util import debounce
 from twisted.internet import defer
@@ -52,7 +53,7 @@ class DebounceTest(unittest.TestCase):
     def scenario(self, events):
         dbs = dict((k, DebouncedClass())
                    for k in set([n for n, _, _ in events]))
-        for db in dbs.values():
+        for db in itervalues(dbs):
             db.maybe._reactor = self.clock
         while events:
             n, t, e = events.pop(0)
@@ -85,7 +86,7 @@ class DebounceTest(unittest.TestCase):
                 db.stopDeferreds.pop()
             else:
                 self.fail("unknown scenario event %s" % e)
-            for db in dbs.values():
+            for db in itervalues(dbs):
                 self.assertEqual(db.calls, db.expCalls)
 
     def test_called_once(self):

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import itervalues
 
 import mock
 import re
@@ -21,7 +23,8 @@ from buildbot.test.util import www
 from buildbot.util import json
 from buildbot.www import authz
 from buildbot.www import rest
-from buildbot.www.rest import JSONRPC_CODES, BadRequest
+from buildbot.www.rest import BadRequest
+from buildbot.www.rest import JSONRPC_CODES
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -297,14 +300,14 @@ class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
     def test_api_collection(self):
         yield self.render_resource(self.rsrc, '/test')
         self.assertRestCollection(typeName='tests',
-                                  items=endpoint.testData.values(),
+                                  items=list(itervalues(endpoint.testData)),
                                   total=8)
 
     @defer.inlineCallbacks
     def do_test_api_collection_pagination(self, query, ids, links):
         yield self.render_resource(self.rsrc, '/test' + query)
         self.assertRestCollection(typeName='tests',
-                                  items=[v for k, v in endpoint.testData.iteritems()
+                                  items=[v for k, v in iteritems(endpoint.testData)
                                          if k in ids],
                                   total=8)
 
@@ -392,7 +395,7 @@ class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
         yield self.render_resource(self.rsrc, '/test?field=success&field=info')
         self.assertRestCollection(typeName='tests',
                                   items=[{'success': v['success'], 'info': v['info']}
-                                         for v in endpoint.testData.values()],
+                                         for v in itervalues(endpoint.testData)],
                                   total=8)
 
     @defer.inlineCallbacks
@@ -407,7 +410,7 @@ class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
     def test_api_collection_simple_filter(self):
         yield self.render_resource(self.rsrc, '/test?success=yes')
         self.assertRestCollection(typeName='tests',
-                                  items=[v for v in endpoint.testData.values()
+                                  items=[v for v in itervalues(endpoint.testData)
                                          if v['success']],
                                   total=5)
 
@@ -415,7 +418,7 @@ class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
     def test_api_collection_operator_filter(self):
         yield self.render_resource(self.rsrc, '/test?info__lt=skipped')
         self.assertRestCollection(typeName='tests',
-                                  items=[v for v in endpoint.testData.values()
+                                  items=[v for v in itervalues(endpoint.testData)
                                          if v['info'] < 'skipped'],
                                   total=4)
 
@@ -423,7 +426,7 @@ class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
     def test_api_collection_order(self):
         yield self.render_resource(self.rsrc, '/test?order=info')
         self.assertRestCollection(typeName='tests',
-                                  items=sorted(endpoint.testData.values(),
+                                  items=sorted(list(itervalues(endpoint.testData)),
                                                key=lambda v: v['info']),
                                   total=8, orderSignificant=True)
 
@@ -444,7 +447,7 @@ class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
         yield self.render_resource(self.rsrc, '/test?success=false&limit=2')
         # note that the limit/offset and total are *after* the filter
         self.assertRestCollection(typeName='tests',
-                                  items=sorted([v for v in endpoint.testData.values()
+                                  items=sorted([v for v in itervalues(endpoint.testData)
                                                 if not v['success']], key=lambda v: v['id'])[:2],
                                   total=3)
 

--- a/master/buildbot/test/util/gpo.py
+++ b/master/buildbot/test/util/gpo.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 from twisted.internet import defer
 from twisted.internet import utils
@@ -67,7 +68,7 @@ class GetProcessOutputMixin:
 
     def _check_env(self, env):
         env = env or {}
-        for var, value in self._gpo_expect_env.items():
+        for var, value in iteritems(self._gpo_expect_env):
             self.assertEqual(env.get(var), value,
                              'Expected environment to have %s = %r' % (var, value))
 

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from __future__ import print_function
+from future.utils import itervalues
 
 import StringIO
 import mock
@@ -94,7 +95,7 @@ class RunMasterBase(dirs.DirsMixin, unittest.TestCase):
 
         if self.proto == 'pb':
             # We find out the slave port automatically
-            slavePort = m.pbmanager.dispatchers.values()[0].port.getHost().port
+            slavePort = list(itervalues(m.pbmanager.dispatchers))[0].port.getHost().port
 
             # create a slave, and attach it to the master, it will be started, and stopped
             # along with the master

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 from __future__ import print_function
+from future.utils import iteritems
+from future.utils import itervalues
+
 
 import mock
 
@@ -241,19 +244,19 @@ class BuildStepMixin(object):
 
             # in case of unexpected result, display logs in stdout for debugging failing tests
             if result != self.exp_result:
-                for loog in self.step.logs.values():
+                for loog in itervalues(self.step.logs):
                     print(loog.stdout)
                     print(loog.stderr)
 
             self.assertEqual(result, self.exp_result, "expected result")
             if self.exp_state_string:
                 stepStateString = self.master.data.updates.stepStateString
-                stepids = stepStateString.keys()
+                stepids = list(stepStateString)
                 assert stepids, "no step state strings were set"
                 self.assertEqual(stepStateString[stepids[0]],
                                  self.exp_state_string,
                                  "expected step state strings")
-            for pn, (pv, ps) in self.exp_properties.iteritems():
+            for pn, (pv, ps) in iteritems(self.exp_properties):
                 self.assertTrue(self.properties.hasProperty(pn),
                                 "missing property '%s'" % pn)
                 self.assertEqual(self.properties.getProperty(pn),
@@ -264,7 +267,7 @@ class BuildStepMixin(object):
             for pn in self.exp_missing_properties:
                 self.assertFalse(self.properties.hasProperty(pn),
                                  "unexpected property '%s'" % pn)
-            for l, contents in self.exp_logfiles.iteritems():
+            for l, contents in iteritems(self.exp_logfiles):
                 self.assertEqual(
                     self.step.logs[l].stdout, contents, "log '%s' contents" % l)
             # XXX TODO: hidden

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 # See "Type Validation" in master/docs/developer/tests.rst
+from future.utils import iteritems
 
 import datetime
 import re
@@ -207,7 +208,7 @@ class SourcedPropertiesValidator(Validator):
         if not isinstance(object, dict):
             yield "%s is not sourced properties (not a dict)" % (name,)
             return
-        for k, v in object.iteritems():
+        for k, v in iteritems(object):
             if not isinstance(k, unicode):
                 yield "%s property name %r is not unicode" % (name, k)
             if not isinstance(v, tuple) or len(v) != 2:

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import cgi
 import mock
@@ -200,7 +201,7 @@ class WwwTestMixin(RequiresWwwMixin):
         if responseCode is not None:
             got['responseCode'] = self.request.responseCode
             exp['responseCode'] = responseCode
-        for header, value in headers.iteritems():
+        for header, value in iteritems(headers):
             got[header] = self.request.headers.get(header)
             exp[header] = value
         self.assertEqual(got, exp)

--- a/master/buildbot/util/config.py
+++ b/master/buildbot/util/config.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import re
 
@@ -51,7 +52,7 @@ class _DictConfigured(object):
         self.value = value
 
     def getConfigDict(self):
-        return dict([(k, IConfigured(v).getConfigDict()) for k, v in self.value.iteritems()])
+        return dict([(k, IConfigured(v).getConfigDict()) for k, v in iteritems(self.value)])
 
 registerAdapter(_DictConfigured, dict, IConfigured)
 

--- a/master/buildbot/util/lru.py
+++ b/master/buildbot/util/lru.py
@@ -70,7 +70,7 @@ class LRUCache(object):
         return result
 
     def keys(self):
-        return self.cache.keys()
+        return list(self.cache)
 
     def set_max_size(self, max_size):
         if self.max_size == max_size:

--- a/master/buildbot/util/pathmatch.py
+++ b/master/buildbot/util/pathmatch.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import re
 
@@ -73,7 +74,7 @@ class Matcher(object):
             raise KeyError('No match for %r' % (path,))
 
     def iterPatterns(self):
-        return self._patterns.iteritems()
+        return list(iteritems(self._patterns))
 
     def _compile(self):
         self._by_length = {}

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 from twisted.application import service
 from twisted.internet import defer
@@ -335,14 +336,14 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
     def getConfigDict(self):
         return {'name': self.name,
                 'childs': [v.getConfigDict()
-                           for v in self.namedServices.values()]}
+                           for v in itervalues(self.namedServices)]}
 
     @defer.inlineCallbacks
     def reconfigServiceWithBuildbotConfig(self, new_config):
 
         # arrange childs by name
         old_by_name = self.namedServices
-        old_set = set(old_by_name.iterkeys())
+        old_set = set(old_by_name)
         new_config_attr = getattr(new_config, self.config_attr)
         if isinstance(new_config_attr, list):
             new_by_name = dict([(s.name, s)
@@ -351,7 +352,7 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
             new_by_name = new_config_attr
         else:
             raise TypeError("config.%s should be a list or dictionary" % (self.config_attr))
-        new_set = set(new_by_name.iterkeys())
+        new_set = set(new_by_name)
 
         # calculate new childs, by name, and removed childs
         removed_names, added_names = util.diffSets(old_set, new_set)

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import requests
 
@@ -120,7 +121,7 @@ class OAuth2Auth(auth.AuthBase):
                     content = json.loads(response.content)
                 except ValueError:
                     content = parse_qs(response.content)
-                    for k, v in content.items():
+                    for k, v in iteritems(content):
                         content[k] = v[0]
             else:
                 content = response.content

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import datetime
 import fnmatch
@@ -66,8 +67,8 @@ class RestRootResource(resource.Resource):
         resource.Resource.__init__(self, master)
 
         min_vers = master.config.www.get('rest_minimum_version', 0)
-        latest = max(self.version_classes.iterkeys())
-        for version, klass in self.version_classes.iteritems():
+        latest = max(list(self.version_classes))
+        for version, klass in iteritems(self.version_classes):
             if version < min_vers:
                 continue
             child = klass(master)

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
 
 import os
 
@@ -129,7 +130,7 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             raise RuntimeError("could not find buildbot-www; is it installed?")
 
         root = self.apps.get('base').resource
-        for key, plugin in new_config.www.get('plugins', {}).items():
+        for key, plugin in iteritems(new_config.www.get('plugins', {})):
             log.msg("initializing www plugin %r" % (key,))
             if key not in self.apps:
                 raise RuntimeError("could not find plugin %s; is it installed?" % (key,))

--- a/master/buildbot/www/sse.py
+++ b/master/buildbot/www/sse.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
 
 import uuid
 
@@ -33,7 +34,7 @@ class Consumer(object):
         if key is not None:
             self.qrefs[key].stopConsuming()
         else:
-            for qref in self.qrefs.values():
+            for qref in itervalues(self.qrefs):
                 qref.stopConsuming()
             self.qrefs = {}
 

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright  Team Members
+from future.utils import itervalues
 
 from buildbot.util import json
 from buildbot.util import toJson
@@ -109,7 +110,7 @@ class WsProtocol(WebSocketServerProtocol):
 
     def connectionLost(self, reason):
         log.msg("connection lost", system=self)
-        for qref in self.qrefs.values():
+        for qref in itervalues(self.qrefs):
             qref.stopConsuming()
         self.qrefs = None  # to be sure we don't add any more
 


### PR DESCRIPTION
I have tried to do things one way, and stick to it throughout the code.

There is a function in the python-future package that allows creation of lists from dictionaries.
so instead of ```list(itersomething(dict))``` it can be written as ``` listsomething(dict) ```. I can implement this if it seems like a good idea