### PR TITLE
Use 'Build' as property source for owners

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -376,7 +376,7 @@ class Build(properties.PropertiesMixin):
         owners = [r.properties['owner'] for r in self.requests
                   if "owner" in r.properties]
         if owners:
-            self.setProperty('owners', owners, self.reason)
+            self.setProperty('owners', owners, 'Build')
         self.text = []  # list of text string lists (text2)
 
     def _addBuildSteps(self, step_factories):


### PR DESCRIPTION
f owners:
    self.setProperty('owners', owners, self.reason)

Is this intended? The source of the property is the reason?
Should not it be 'Build' since it's happening in class Build?
It has not changed since Eight so I might be wrong, but right now the result on the web UI is horrible.

@tardyp :  I agree it makes few sense