### PR TITLE
Wampmq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ master/docs/buildbot.info-2
 .project
 .pydevproject
 .settings
+*/build/
 master/docs/buildbot
 master/docs/version.texinfo
 master/docs/docs.tgz

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -351,6 +351,8 @@ class MasterConfig(util.ComparableMixin):
                     error("Both c['slavePortnum'] and c['protocols']['pb']['port']"
                           " defined, recommended to remove slavePortnum and leave"
                           " only c['protocols']['pb']['port']")
+                if proto == "wamp":
+                    self.check_wamp_proto(options)
         else:
             error("c['protocols'] must be dict")
             return

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -17,20 +17,20 @@ import re
 import sys
 import warnings
 
-from types import MethodType
 from buildbot import interfaces
 from buildbot import locks
 from buildbot import util
 from buildbot.revlinks import default_revlink_matcher
 from buildbot.util import config as util_config
+from buildbot.util import identifiers as util_identifiers
 from buildbot.util import safeTranslate
 from buildbot.util import service as util_service
-from buildbot.util import identifiers as util_identifiers
 from buildbot.www import auth
 from buildbot.www import avatar
 from buildbot.www.authz import authz
 from twisted.python import failure
 from twisted.python import log
+from types import MethodType
 
 
 class ConfigErrors(Exception):

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -55,6 +55,7 @@ from buildbot.util import check_functional_environment
 from buildbot.util import datetime2epoch
 from buildbot.util import service
 from buildbot.util.eventual import eventually
+from buildbot.wamp import connector as wampconnector
 from buildbot.www import service as wwwservice
 
 #
@@ -156,6 +157,9 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         self.db = dbconnector.DBConnector(self.basedir)
         self.db.setServiceParent(self)
 
+        self.wamp = wampconnector.WampConnector(self)
+        self.wamp.setServiceParent(self)
+
         self.mq = mqconnector.MQConnector()
         self.mq.setServiceParent(self)
 
@@ -186,7 +190,8 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
             yield self.data.updates.expireMasters((self.masterHouskeepingTimer % (24 * 60)) == 0)
             self.masterHouskeepingTimer += 1
         self.masterHeartbeatService = internet.TimerService(60, heartbeat)
-        self.masterHeartbeatService.setServiceParent(self)
+        # we do setServiceParent only when the master is configured
+        # master should advertise itself only at that time
 
     # setup and reconfig handling
 
@@ -284,12 +289,12 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         log.msg("BuildMaster is running")
 
     @defer.inlineCallbacks
-    def stopService(self):
-        if self.running:
-            yield service.AsyncMultiService.stopService(self)
+    def stopService(self, _reactor=reactor):
         if self.masterid is not None:
             yield self.data.updates.masterStopped(
                 name=self.name, masterid=self.masterid)
+        if self.running:
+            yield service.AsyncMultiService.stopService(self)
 
         log.msg("BuildMaster is stopped")
         self._master_initialized = False
@@ -327,6 +332,11 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
                 self.reconfig_requested = False
                 self.reconfig()
             return res
+
+        @d.addCallback
+        def advertiseItself(res):
+            if self.masterHeartbeatService.parent is None:
+                self.masterHeartbeatService.setServiceParent(self)
 
         d.addErrback(log.err, 'while reconfiguring')
 

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -157,7 +157,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         self.db = dbconnector.DBConnector(self.basedir)
         self.db.setServiceParent(self)
 
-        self.wamp = wampconnector.WampConnector(self)
+        self.wamp = wampconnector.WampConnector()
         self.wamp.setServiceParent(self)
 
         self.mq = mqconnector.MQConnector()

--- a/master/buildbot/mq/connector.py
+++ b/master/buildbot/mq/connector.py
@@ -24,6 +24,10 @@ class MQConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
             'class': "buildbot.mq.simple.SimpleMQ",
             'keys': set(['debug']),
         },
+        'wamp': {
+            'class': "buildbot.mq.wamp.WampMQ",
+            'keys': set(["router_url", "debug", "realm", "debug_websockets", "debug_lowlevel"]),
+        },
     }
     name = 'mq'
 

--- a/master/buildbot/mq/wamp.py
+++ b/master/buildbot/mq/wamp.py
@@ -37,12 +37,12 @@ class WampMQ(service.ReconfigurableServiceMixin, base.MQBase):
 
     @classmethod
     def messageTopic(cls, routingKey):
-        routingKey = [key if key is not None else u"1" for key in routingKey]
-        return cls.NAMESPACE + u"." + u".".join(routingKey)
+        ifNone = lambda v, default: default if v is None else v
+        return cls.NAMESPACE + u"." + u".".join([ifNone(key, "") for key in routingKey])
 
     def _produce(self, routingKey, data):
         _data = json.loads(json.dumps(data, default=toJson))
-        options = PublishOptions(excludeMe=False)
+        options = PublishOptions(exclude_me=False)
         return self.master.wamp.publish(self.messageTopic(routingKey), dict(topic=routingKey, data=_data), options=options)
 
     def startConsuming(self, callback, _filter, persistent_name=None):

--- a/master/buildbot/mq/wamp.py
+++ b/master/buildbot/mq/wamp.py
@@ -1,0 +1,92 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from autobahn.wamp.exception import TransportLost
+from autobahn.wamp.types import PublishOptions
+from autobahn.wamp.types import SubscribeOptions
+
+from twisted.internet import defer
+
+from buildbot.mq import base
+from buildbot.util import service
+from buildbot.util import toJson
+
+import json
+
+
+class WampMQ(service.ReconfigurableServiceMixin, base.MQBase):
+    NAMESPACE = u"org.buildbot.mq"
+
+    def __init__(self, master):
+        base.MQBase.__init__(self, master)
+
+    def produce(self, routingKey, data):
+        self._produce(routingKey, data)
+
+    @classmethod
+    def messageTopic(cls, routingKey):
+        routingKey = [key if key is not None else u"1" for key in routingKey]
+        return cls.NAMESPACE + u"." + u".".join(routingKey)
+
+    def _produce(self, routingKey, data):
+        _data = json.loads(json.dumps(data, default=toJson))
+        options = PublishOptions(excludeMe=False)
+        return self.master.wamp.publish(self.messageTopic(routingKey), dict(topic=routingKey, data=_data), options=options)
+
+    def startConsuming(self, callback, _filter, persistent_name=None):
+        if persistent_name is not None:
+            print "wampmq: persistant queues are not persisted!", persistent_name, _filter
+
+        qr = QueueRef(callback)
+
+        self._startConsuming(qr, callback, _filter)
+        return defer.succeed(qr)
+
+    def _startConsuming(self, qr, callback, _filter, persistent_name=None):
+        return qr.subscribe(self.master.wamp, _filter)
+
+
+class QueueRef(base.QueueRef):
+
+    def __init__(self, callback):
+        base.QueueRef.__init__(self, callback)
+        self.unreg = None
+
+    @defer.inlineCallbacks
+    def subscribe(self, service, _filter):
+        self.filter = _filter
+        self.emulated = False
+        if None in _filter:
+            options = SubscribeOptions(match=u"wildcard")
+        else:
+            options = None
+        _filter = WampMQ.messageTopic(_filter)
+        self.unreg = yield service.subscribe(self.invoke, _filter, options=options)
+        if self.callback is None:
+            yield self.stopConsuming()
+
+    def invoke(self, msg):
+        return base.QueueRef.invoke(self, msg[u'topic'], msg[u'data'])
+
+    @defer.inlineCallbacks
+    def stopConsuming(self):
+        self.callback = None
+        if self.unreg is not None:
+            unreg = self.unreg
+            self.unreg = None
+            try:
+                yield unreg.unsubscribe()
+            except TransportLost:
+                pass

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -1,0 +1,125 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import mock
+
+from autobahn.wamp.types import SubscribeOptions
+from buildbot.mq import wamp
+from twisted.internet import defer
+from twisted.trial import unittest
+
+
+class ComparableSubscribeOptions(SubscribeOptions):
+
+    def __eq__(self, other):
+        if not isinstance(other, SubscribeOptions):
+            return False
+        return self.match == other.match
+
+    __repr__ = SubscribeOptions.__str__
+
+
+class FakeWampConnector(object):
+    # a fake wamp connector with only one queue
+
+    def topic_match(self, topic):
+        topic = topic.split(".")
+        owntopic = self.topic.split(".")
+        if len(topic) != len(owntopic):
+            return False
+        for i in xrange(len(topic)):
+            if owntopic[i] != "" and topic[i] != owntopic[i]:
+                return False
+        return True
+
+    def subscribe(self, callback, topic=None, options=None):
+        # record the topic, and to make sure subsequent publish
+        # are correct
+        self.topic = topic
+        # we record the qref_cb
+        self.qref_cb = callback
+
+    def publish(self, topic, data, options=None):
+        # make sure the topic is compatible with what was subscribed
+        assert self.topic_match(topic)
+        self.last_data = data
+        self.qref_cb(data)
+
+
+class TopicMatch(unittest.TestCase):
+    # test unit tests
+
+    def test_topic_match(self):
+        matches = [("a.b.c", "a.b.c"),
+                   ("a..c", "a.c.c"),
+                   ("a.b.", "a.b.c"),
+                   (".b.", "a.b.c"),
+                   ]
+        for i, j in matches:
+            w = FakeWampConnector()
+            w.topic = i
+            self.assertTrue(w.topic_match(j))
+
+    def test_topic_not_match(self):
+        matches = [("a.b.c", "a.b.d"),
+                   ("a..c", "a.b.d"),
+                   ("a.b.", "a.c.c"),
+                   (".b.", "a.a.c"),
+                   ]
+        for i, j in matches:
+            w = FakeWampConnector()
+            w.topic = i
+            self.assertFalse(w.topic_match(j))
+
+
+class WampMQ(unittest.TestCase):
+
+    def setUp(self):
+        self.master = mock.Mock(name='master')
+        self.master.wamp = FakeWampConnector()
+        self.mq = wamp.WampMQ(self.master)
+
+    @defer.inlineCallbacks
+    def test_startConsuming_basic(self):
+        self.master.wamp.subscribe = mock.Mock()
+        yield self.mq.startConsuming(None, ('a', 'b'))
+        self.master.wamp.subscribe.assert_called_with(mock.ANY, u'org.buildbot.mq.a.b', options=None)
+
+    @defer.inlineCallbacks
+    def test_startConsuming_wildcard(self):
+        self.master.wamp.subscribe = mock.Mock()
+        yield self.mq.startConsuming(None, ('a', None))
+        options = ComparableSubscribeOptions(match=u"wildcard")
+        self.master.wamp.subscribe.assert_called_with(mock.ANY, u'org.buildbot.mq.a.', options=options)
+
+    @defer.inlineCallbacks
+    def test_forward_data(self):
+        callback = mock.Mock()
+        yield self.mq.startConsuming(callback, ('a', 'b'))
+        # _produce returns a deferred
+        yield self.mq._produce(('a', 'b'), 'foo')
+        # calling produce should eventually call the callback with decoding of topic
+        callback.assert_called_with(('a', 'b'), 'foo')
+        self.assertEqual(self.master.wamp.last_data, {'data': u'foo', 'topic': ('a', 'b')})
+
+    @defer.inlineCallbacks
+    def test_forward_data_wildcard(self):
+        callback = mock.Mock()
+        yield self.mq.startConsuming(callback, ('a', None))
+        # _produce returns a deferred
+        yield self.mq._produce(('a', 'b'), 'foo')
+        # calling produce should eventually call the callback with decoding of topic
+        callback.assert_called_with(('a', 'b'), 'foo')
+        self.assertEqual(self.master.wamp.last_data, {'data': u'foo', 'topic': ('a', 'b')})

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -94,7 +94,7 @@ class TopicMatch(unittest.TestCase):
 class WampMQ(unittest.TestCase):
 
     """
-        Excercices the code with a faked wamp router:
+        Stimulate the code with a fake wamp router:
         A router which only accepts one subscriber on one topic
     """
 
@@ -166,9 +166,9 @@ class WampMQReal(unittest.TestCase):
             raise unittest.SkipTest(self.HOW_TO_RUN)
         self.master = fakemaster.make_master()
         self.mq = wamp.WampMQ()
-        self.mq.setServiceParent(self.master)
+        yield self.mq.setServiceParent(self.master)
         self.connector = self.master.wamp = connector.WampConnector()
-        self.connector.setServiceParent(self.master)
+        yield self.connector.setServiceParent(self.master)
         yield self.master.startService()
         config = FakeConfig()
         config.mq['router_url'] = os.environ["WAMP_ROUTER_URL"]

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -15,8 +15,10 @@
 
 import mock
 
-from autobahn.wamp.types import SubscribeOptions
 from buildbot.mq import wamp
+from buildbot.util import json
+
+from autobahn.wamp.types import SubscribeOptions
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -55,7 +57,7 @@ class FakeWampConnector(object):
         # make sure the topic is compatible with what was subscribed
         assert self.topic_match(topic)
         self.last_data = data
-        self.qref_cb(data)
+        self.qref_cb(json.loads(json.dumps(data)))
 
 
 class TopicMatch(unittest.TestCase):

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -14,10 +14,14 @@
 # Copyright Buildbot Team Members
 
 import mock
+import os
 
 from buildbot.mq import wamp
+from buildbot.test.fake import fakemaster
 from buildbot.util import json
+from buildbot.wamp import connector
 
+from autobahn.wamp.types import EventDetails
 from autobahn.wamp.types import SubscribeOptions
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -57,7 +61,8 @@ class FakeWampConnector(object):
         # make sure the topic is compatible with what was subscribed
         assert self.topic_match(topic)
         self.last_data = data
-        self.qref_cb(json.loads(json.dumps(data)))
+        details = EventDetails(1, topic=topic)
+        self.qref_cb(json.loads(json.dumps(data)), details=details)
 
 
 class TopicMatch(unittest.TestCase):
@@ -88,22 +93,29 @@ class TopicMatch(unittest.TestCase):
 
 class WampMQ(unittest.TestCase):
 
+    """
+        Excercices the code with a faked wamp router:
+        A router which only accepts one subscriber on one topic
+    """
+
     def setUp(self):
-        self.master = mock.Mock(name='master')
+        self.master = fakemaster.make_master()
         self.master.wamp = FakeWampConnector()
-        self.mq = wamp.WampMQ(self.master)
+        self.mq = wamp.WampMQ()
+        self.mq.setServiceParent(self.master)
 
     @defer.inlineCallbacks
     def test_startConsuming_basic(self):
         self.master.wamp.subscribe = mock.Mock()
         yield self.mq.startConsuming(None, ('a', 'b'))
-        self.master.wamp.subscribe.assert_called_with(mock.ANY, u'org.buildbot.mq.a.b', options=None)
+        options = ComparableSubscribeOptions(details_arg='details')
+        self.master.wamp.subscribe.assert_called_with(mock.ANY, u'org.buildbot.mq.a.b', options=options)
 
     @defer.inlineCallbacks
     def test_startConsuming_wildcard(self):
         self.master.wamp.subscribe = mock.Mock()
         yield self.mq.startConsuming(None, ('a', None))
-        options = ComparableSubscribeOptions(match=u"wildcard")
+        options = ComparableSubscribeOptions(match=u"wildcard", details_arg='details')
         self.master.wamp.subscribe.assert_called_with(mock.ANY, u'org.buildbot.mq.a.', options=options)
 
     @defer.inlineCallbacks
@@ -114,7 +126,7 @@ class WampMQ(unittest.TestCase):
         yield self.mq._produce(('a', 'b'), 'foo')
         # calling produce should eventually call the callback with decoding of topic
         callback.assert_called_with(('a', 'b'), 'foo')
-        self.assertEqual(self.master.wamp.last_data, {'data': u'foo', 'topic': ('a', 'b')})
+        self.assertEqual(self.master.wamp.last_data, u'foo')
 
     @defer.inlineCallbacks
     def test_forward_data_wildcard(self):
@@ -124,4 +136,65 @@ class WampMQ(unittest.TestCase):
         yield self.mq._produce(('a', 'b'), 'foo')
         # calling produce should eventually call the callback with decoding of topic
         callback.assert_called_with(('a', 'b'), 'foo')
-        self.assertEqual(self.master.wamp.last_data, {'data': u'foo', 'topic': ('a', 'b')})
+        self.assertEqual(self.master.wamp.last_data, u'foo')
+
+
+class FakeConfig(object):
+    mq = dict(type='wamp', router_url="wss://foo", realm="buildbot",
+              debug_websockets=False,  # set if connection looks bad
+              debug_lowlevel=True,  # set if protocol looks bad
+              )
+
+
+class WampMQReal(unittest.TestCase):
+
+    """
+        Tests a little bit more painful to run, but which involve real communication with
+        a wamp router
+    """
+    HOW_TO_RUN = """ \
+        define WAMP_ROUTER_URL to a wamp router to run this test\
+        e.g: WAMP_ROUTER_URL=ws://localhost:8000/ws
+    """
+    # if connection is bad, this test can timeout easily
+    # we reduce the timeout to help maintain the sanity of the developer
+    timeout = 2
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        if "WAMP_ROUTER_URL" not in os.environ:
+            raise unittest.SkipTest(self.HOW_TO_RUN)
+        self.master = fakemaster.make_master()
+        self.mq = wamp.WampMQ()
+        self.mq.setServiceParent(self.master)
+        self.connector = self.master.wamp = connector.WampConnector()
+        self.connector.setServiceParent(self.master)
+        yield self.master.startService()
+        config = FakeConfig()
+        config.mq['router_url'] = os.environ["WAMP_ROUTER_URL"]
+        yield self.connector.reconfigServiceWithBuildbotConfig(config)
+
+    def tearDown(self):
+        return self.master.stopService()
+
+    @defer.inlineCallbacks
+    def test_forward_data(self):
+        d = defer.Deferred()
+        callback = mock.Mock(side_effect=lambda *a, **kw: d.callback(None))
+        yield self.mq.startConsuming(callback, ('a', 'b'))
+        # _produce returns a deferred
+        yield self.mq._produce(('a', 'b'), 'foo')
+        # calling produce should eventually call the callback with decoding of topic
+        yield d
+        callback.assert_called_with(('a', 'b'), 'foo')
+
+    @defer.inlineCallbacks
+    def test_forward_data_wildcard(self):
+        d = defer.Deferred()
+        callback = mock.Mock(side_effect=lambda *a, **kw: d.callback(None))
+        yield self.mq.startConsuming(callback, ('a', None))
+        # _produce returns a deferred
+        yield self.mq._produce(('a', 'b'), 'foo')
+        # calling produce should eventually call the callback with decoding of topic
+        yield d
+        callback.assert_called_with(('a', 'b'), 'foo')

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -142,7 +142,7 @@ class WampMQ(unittest.TestCase):
 class FakeConfig(object):
     mq = dict(type='wamp', router_url="wss://foo", realm="buildbot",
               debug_websockets=False,  # set if connection looks bad
-              debug_lowlevel=True,  # set if protocol looks bad
+              debug_lowlevel=False,  # set if protocol looks bad
               )
 
 

--- a/master/buildbot/test/unit/test_wamp_connector.py
+++ b/master/buildbot/test/unit/test_wamp_connector.py
@@ -56,7 +56,7 @@ class WampConnector(unittest.TestCase):
     def setUp(self):
         master = fakemaster.make_master()
         self.connector = TestedWampConnector()
-        self.connector.setServiceParent(master)
+        yield self.connector.setServiceParent(master)
         yield master.startService()
         yield self.connector.reconfigServiceWithBuildbotConfig(FakeConfig())
 

--- a/master/buildbot/test/unit/test_wamp_connector.py
+++ b/master/buildbot/test/unit/test_wamp_connector.py
@@ -27,7 +27,7 @@ class FakeMaster(service.AsyncMultiService):
 
 
 class FakeConfig(object):
-    mq = dict(wamp=dict(router_url="wss://foo", realm="bb"))
+    mq = dict(type='wamp', router_url="wss://foo", realm="bb")
 
 
 class FakeService(service.AsyncMultiService):

--- a/master/buildbot/test/unit/test_wamp_connector.py
+++ b/master/buildbot/test/unit/test_wamp_connector.py
@@ -1,0 +1,94 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import mock
+
+from buildbot.util import service
+from buildbot.wamp import connector
+from twisted.internet import defer
+from twisted.trial import unittest
+
+
+class FakeMaster(service.AsyncMultiService):
+    name = "master"
+    masterid = 1
+
+
+class FakeConfig(object):
+    mq = dict(wamp=dict(router_url="wss://foo", realm="bb"))
+
+
+class FakeService(service.AsyncMultiService):
+    name = "fakeWampService"
+    # Fake wamp service
+    # just call the maker on demand by the test
+
+    def __init__(self, url, realm, make, extra=None,
+                 debug=False, debug_wamp=False, debug_app=False):
+        service.AsyncMultiService.__init__(self)
+        self.make = make
+        self.extra = extra
+
+    def gotConnection(self):
+        self.make(None)
+        r = self.make(self)
+        r.publish = mock.Mock(spec=r.publish)
+        r.register = mock.Mock(spec=r.register)
+        r.subscribe = mock.Mock(spec=r.subscribe)
+        r.onJoin(None)
+
+
+class TestedWampConnector(connector.WampConnector):
+    serviceClass = FakeService
+
+
+class WampConnector(unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        master = FakeMaster()
+        self.connector = TestedWampConnector(master)
+        yield master.startService()
+        yield self.connector.reconfigServiceWithBuildbotConfig(FakeConfig())
+
+    @defer.inlineCallbacks
+    def test_startup(self):
+        d = self.connector.getService()
+        self.connector.app.gotConnection()
+        yield d
+        self.connector.service.publish.assert_called_with("org.buildbot.1.connected")
+
+    @defer.inlineCallbacks
+    def test_subscribe(self):
+        d = self.connector.subscribe('callback', 'topic', 'options')
+        self.connector.app.gotConnection()
+        yield d
+        self.connector.service.subscribe.assert_called_with('callback', 'topic', 'options')
+
+    @defer.inlineCallbacks
+    def test_publish(self):
+        d = self.connector.publish('topic', 'data', 'options')
+        self.connector.app.gotConnection()
+        yield d
+        self.connector.service.publish.assert_called_with('topic', 'data', options='options')
+
+    @defer.inlineCallbacks
+    def test_OnLeave(self):
+        d = self.connector.getService()
+        self.connector.app.gotConnection()
+        yield d
+        self.assertTrue(self.connector.master.running)
+        self.connector.service.onLeave(None)
+        self.assertFalse(self.connector.master.running)

--- a/master/buildbot/wamp/connector.py
+++ b/master/buildbot/wamp/connector.py
@@ -1,0 +1,159 @@
+# This file is part of .  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright  Team Members
+
+from autobahn.twisted.wamp import ApplicationSession
+from autobahn.twisted.wamp import Service
+from autobahn.twisted.websocket import WampWebSocketClientFactory
+from autobahn.wamp.exception import TransportLost
+
+from twisted.internet import defer
+from twisted.python import failure
+from twisted.python import log
+
+from buildbot.util import service
+
+
+class BuildbotWampWebSocketClientFactory(WampWebSocketClientFactory):
+
+    def __init__(self, master, *args, **kw):
+        self.master = master
+        WampWebSocketClientFactory.__init__(self, *args, **kw)
+
+    @defer.inlineCallbacks
+    def clientConnectionFailed(self, connector, reason):
+        print "wamp router connection failed!", reason
+        yield WampWebSocketClientFactory.clientConnectionFailed(self, connector, reason)
+        yield self.master.stopService()
+
+
+class BuildbotWampService(Service):
+
+    def factory(self, *args, **kwargs):
+        return BuildbotWampWebSocketClientFactory(self.extra['master'], *args, **kwargs)
+
+
+class MasterService(ApplicationSession, service.AsyncMultiService):
+
+    """
+    concatenation of all the wamp services of buildbot
+    """
+
+    def __init__(self, config):
+        ApplicationSession.__init__(self)
+        service.AsyncMultiService.__init__(self)
+        self.config = config
+        self.master = config.extra['master']
+        self.setServiceParent(config.extra['parent'])
+
+    @defer.inlineCallbacks
+    def onJoin(self, details):
+        for handler in [self] + self.services:
+            yield self.register(handler)
+            yield self.subscribe(handler)
+        yield self.publish("org.buildbot.%s.connected" % (self.master.masterid))
+        self.parent.service = self
+        self.parent.serviceDeferred.callback(self)
+
+    @defer.inlineCallbacks
+    def onLeave(self, details):
+        # first implementation: we skip the reconnection problem
+        # Just stop the service, and crash the master. Relaunch will be done by the process manager
+        yield self.master.stopService()
+
+
+def make(config):
+
+    if config:
+        return MasterService(config)
+    else:
+        # if no config given, return a description of this WAMPlet ..
+        return {'label': 'Buildbot master wamplet',
+                'description': 'This contains all the wamp methods provided by a buildbot master'}
+
+
+class WampConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService):
+
+    def __init__(self, master):
+        service.AsyncMultiService.__init__(self)
+        self.setName('wamp')
+        self.master = master
+        self.app = self.router_url = None
+        self.serviceDeferred = defer.Deferred()
+        self.service = None
+
+    def getService(self):
+        if self.service is not None:
+            return defer.succeed(self.service)
+        d = defer.Deferred()
+
+        @self.serviceDeferred.addCallback
+        def gotService(service):
+            d.callback(service)
+            return service
+        return d
+
+    @defer.inlineCallbacks
+    def publish(self, topic, data, options=None):
+        service = yield self.getService()
+        try:
+            ret = yield service.publish(topic, data, options=options)
+        except TransportLost:
+            log.err(failure.Failure(), "while publishing event " + topic)
+            return
+        defer.returnValue(ret)
+
+    @defer.inlineCallbacks
+    def call(self, topic, *args, **kwargs):
+        service = yield self.getService()
+        ret = yield service.call(topic, *args, **kwargs)
+        defer.returnValue(ret)
+
+    @defer.inlineCallbacks
+    def register(self, callback, topic=None, options=None):
+        service = yield self.getService()
+        ret = yield service.register(callback, topic, options)
+        defer.returnValue(ret)
+
+    @defer.inlineCallbacks
+    def subscribe(self, callback, topic=None, options=None):
+        service = yield self.getService()
+        ret = yield service.subscribe(callback, topic, options)
+        defer.returnValue(ret)
+
+    def reconfigServiceWithBuildbotConfig(self, new_config):
+        wamp = new_config.mq.get('wamp', {})
+        router_url = wamp.get('router_url', None)
+
+        # This is not a good idea to allow people to switch the router via reconfig
+        # how would we continue the current transactions ?
+        # how would we tell the slaves to switch router ?
+        if self.app is not None and self.router_url != router_url:
+            raise ValueError("Cannot use different wamp router url when reconfiguring")
+        if router_url is None:
+            return
+        self.router_url = router_url
+        self.app = BuildbotWampService(
+            url=self.router_url,
+            extra=dict(master=self.master, parent=self),
+            realm=wamp.get('realm'),
+            make=make,
+            debug=wamp.get('debug_websockets', False),
+            debug_wamp=wamp.get('debug_lowlevel', False),
+            debug_app=wamp.get('debug', False)
+        )
+
+        self.app.setServiceParent(self)
+        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                    new_config)

--- a/master/buildbot/wamp/connector.py
+++ b/master/buildbot/wamp/connector.py
@@ -110,6 +110,7 @@ class WampConnector(service.ReconfigurableServiceMixin, service.AsyncMultiServic
         ret = yield service.subscribe(callback, topic, options)
         defer.returnValue(ret)
 
+    @defer.inlineCallbacks
     def reconfigServiceWithBuildbotConfig(self, new_config):
         if new_config.mq.get('type', 'simple') != "wamp":
             return
@@ -135,6 +136,6 @@ class WampConnector(service.ReconfigurableServiceMixin, service.AsyncMultiServic
             debug_app=wamp.get('debug', False)
         )
 
-        self.app.setServiceParent(self)
-        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                    new_config)
+        yield self.app.setServiceParent(self)
+        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
+                                                                                   new_config)

--- a/master/docs/developer/mq.rst
+++ b/master/docs/developer/mq.rst
@@ -105,10 +105,49 @@ Simple
 
 .. py:module:: buildbot.mq.simple
 
-.. py:class:: SimpleConnector
+.. py:class:: SimpleMQ
 
     The :py:class:`SimpleMQ` class implements a local equivalent of a message-queueing server.
     It is intended for Buildbot installations with only one master.
+
+Wamp
+....
+
+.. py:module:: buildbot.mq.wamp
+
+.. py:class:: WampMQ
+
+    The :py:class:`WampMQ` class implements message-queueing using a wamp router.
+    This class translates the semantics of the buildbot mq api to the semantics of the wamp messaging system.
+    A notable difference is that autobahn API does not send the original topic to the callback, so we need to include it inside the data part, for the case of the wildcard subscriber.
+    Example message that is sent via wamp is:
+
+    .. code-block:: python
+
+        topic = "org.buildbot.builds.1.new"
+        data = {
+            "topic": ['builds', '1', 'new']
+            "data": {'builderid': 10,
+                     'buildid': 1,
+                     'buildrequestid': 13,
+                     'buildslaveid': 20,
+                     'complete': False,
+                     'complete_at': None,
+                     'masterid': 824,
+                     'number': 1,
+                     'results': None,
+                     'started_at': 1,
+                     'state_string': u'created'}
+        }
+
+.. py:module:: buildbot.wamp.connector
+
+.. py:class:: WampConnector
+
+    The :py:class:`WampConnector` class implements a buildbot service for wamp.
+    It is managed outside of the mq module as this protocol can also be reused for slave protocol.
+    The connector support queuing of requests until the wamp connection is created, but do not support disconnection and reconnection.
+    There is a chicken and egg problem at the buildbot initialization phasis, so the produce messages are actually not sent with deferred.
 
 .. _queue-schema:
 

--- a/master/docs/developer/mq.rst
+++ b/master/docs/developer/mq.rst
@@ -119,25 +119,24 @@ Wamp
 
     The :py:class:`WampMQ` class implements message-queueing using a wamp router.
     This class translates the semantics of the buildbot mq api to the semantics of the wamp messaging system.
-    A notable difference is that autobahn API does not send the original topic to the callback, so we need to include it inside the data part, for the case of the wildcard subscriber.
+    The message route is translated to a wamp topic by joining with dot and prefixing with buildbot namespace.
     Example message that is sent via wamp is:
 
     .. code-block:: python
 
-        topic = "org.buildbot.builds.1.new"
+        topic = "org.buildbot.mq.builds.1.new"
         data = {
-            "topic": ['builds', '1', 'new']
-            "data": {'builderid': 10,
-                     'buildid': 1,
-                     'buildrequestid': 13,
-                     'buildslaveid': 20,
-                     'complete': False,
-                     'complete_at': None,
-                     'masterid': 824,
-                     'number': 1,
-                     'results': None,
-                     'started_at': 1,
-                     'state_string': u'created'}
+            'builderid': 10,
+            'buildid': 1,
+            'buildrequestid': 13,
+            'buildslaveid': 20,
+            'complete': False,
+            'complete_at': None,
+            'masterid': 824,
+            'number': 1,
+            'results': None,
+            'started_at': 1,
+            'state_string': u'created'
         }
 
 .. py:module:: buildbot.wamp.connector
@@ -147,6 +146,7 @@ Wamp
     The :py:class:`WampConnector` class implements a buildbot service for wamp.
     It is managed outside of the mq module as this protocol can also be reused for slave protocol.
     The connector support queuing of requests until the wamp connection is created, but do not support disconnection and reconnection.
+    Reconnection will be supported as part of a next release of AutobahnPython (https://github.com/tavendo/AutobahnPython/issues/295).
     There is a chicken and egg problem at the buildbot initialization phasis, so the produce messages are actually not sent with deferred.
 
 .. _queue-schema:

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -130,7 +130,7 @@ Wamp
         'router_url': 'ws://url/to/crossbar'
         'realm': 'buildbot'
         'debug' : False,
-        'debug_websocket' : False,
+        'debug_websockets' : False,
         'debug_lowlevel' : False,
     }
 

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -120,6 +120,40 @@ For example, if a change is received, but the master shuts down before the sched
 
 The ``debug`` key, which defaults to False, can be used to enable logging of every message produced on this master.
 
+Wamp
+++++
+
+.. code-block:: python
+
+    c['mq'] = {
+        'type' : 'wamp',
+        'router_url': 'ws://url/to/crossbar'
+        'realm': 'buildbot'
+        'debug' : False,
+        'debug_websocket' : False,
+        'debug_lowlevel' : False,
+    }
+
+This is a MQ implementation using `wamp <http://wamp.ws/>`_ protocol.
+This implementation uses `Python Autobahn <http://autobahn.ws>`_ wamp client library, and is fully asynchronous (no use of threads)
+To use this implementation, you need a wamp router like `Crossbar <http://crossbar.io>`_.
+The implementation does not yet support wamp authentication yet.
+This MQ allows buildbot to run in multi-master mode.
+
+Note that this implementation also does not support message persistence across a restart of the master.
+For example, if a change is received, but the master shuts down before the schedulers can create build requests for it, then those schedulers will not be notified of the change when the master starts again.
+
+`router_url` key is mandatory, and should point to your router websocket url.
+Buildbot is only supporting wamp over websocket, which is a sub-protocol of http.
+SSL is supported using ``wss://`` instead of ``ws://``.
+You must use a router with very reliable connection to the master.
+If for some reason, the wamp connection is lost, then the master will stop, and should be restarted via a process manager.
+
+`realm` key is optional and defaults to ``buildbot``, and configures the wamp realm to use for your buildbot messages.
+
+The ``debug`` key, which defaults to False, can be used to enable logging of every message produced on this master.
+``debug_websocket`` and ``debug_lowlevel``, enable more debug logs in autobahn.
+
 .. bb:cfg:: multiMaster
 
 .. _Multi-master-mode:

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -6,8 +6,8 @@ Release Notes for Buildbot |version|
     Most simply need an additional bulleted list item, but more significant
     changes can be given a subsection of their own.
 
-The following are the release notes for Buildbot 0.9.1
-Buildbot 0.9.1 was released on the ...
+The following are the release notes for Buildbot 0.9.0b2
+Buildbot 0.9.0b2 was released on the ...
 
 Master
 ------
@@ -30,6 +30,10 @@ Slave
 
 Features
 ~~~~~~~~
+
+* Buildbot now supports wamp as a mq backend.
+  This allows to run a multi-master configuration.
+  See :ref:`MQ-Specification`.
 
 Fixes
 ~~~~~

--- a/master/setup.py
+++ b/master/setup.py
@@ -176,6 +176,7 @@ setup_args = {
         "buildbot.steps.package.rpm",
         "buildbot.steps.source",
         "buildbot.util",
+        "buildbot.wamp",
         "buildbot.www",
         "buildbot.www.hooks",
         "buildbot.www.authz",


### PR DESCRIPTION

This is a MQ implementation using [wamp](http://wamp.ws/)  protocol.
This implementation uses [Python Autobahn](http://autobahn.ws) wamp client library, and is fully asynchronous (no use of threads)
To use this implementation, you need a wamp router like [Crossbar](http://crossbar.io).
The implementation does not yet support wamp authentication yet.
This MQ allows buildbot to run in multi-master mode.

Note that this implementation also does not support message persistence across a restart of the master.
For example, if a change is received, but the master shuts down before the schedulers can create build requests for it, then those schedulers will not be notified of the change when the master starts again.
