### PR TITLE
[Eight] Schedulers: let codebases be specified as a list

### DIFF
--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -98,17 +98,21 @@ class BaseScheduler(service.MultiService, ComparableMixin, StateMixin):
 
         # Set the codebases that are necessary to process the changes
         # These codebases will always result in a sourcestamp with or without changes
-        if codebases is not None:
-            if not isinstance(codebases, dict):
-                config.error("Codebases must be a dict of dicts")
+        if codebases is None:
+            codebases = BaseScheduler.DefaultCodebases
+        elif isinstance(codebases, list):
+            codebases = dict(
+                (codebase, {'repository': ''})
+                for codebase in codebases
+            )
+        elif not isinstance(codebases, dict):
+            config.error("Codebases must be a dict of dicts, or list of strings")
+        else:
             for codebase, codebase_attrs in codebases.iteritems():
                 if not isinstance(codebase_attrs, dict):
                     config.error("Codebases must be a dict of dicts")
-                if (codebases != BaseScheduler.DefaultCodebases and
-                        'repository' not in codebase_attrs):
+                if codebases != BaseScheduler.DefaultCodebases and 'repository' not in codebase_attrs:
                     config.error("The key 'repository' is mandatory in codebases")
-        else:
-            config.error("Codebases cannot be None")
 
         self.codebases = codebases
 
@@ -382,7 +386,7 @@ class BaseScheduler(service.MultiService, ComparableMixin, StateMixin):
                 # codebase has no changes
                 # create a sourcestamp that has no changes
                 cb = self.getCodebaseDict(codebase)
-                args['repository'] = cb['repository']
+                args['repository'] = cb.get('repository', '')
                 args['branch'] = cb.get('branch', None)
                 args['revision'] = cb.get('revision', None)
                 args['changeids'] = set()

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -37,7 +37,7 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
         self.tearDownScheduler()
 
     def makeScheduler(self, name='testsched', builderNames=['a', 'b'],
-                      properties={}, codebases={'': {}}):
+                      properties={}, codebases=base.BaseScheduler.DefaultCodebases):
         sched = self.attachScheduler(
             base.BaseScheduler(name=name, builderNames=builderNames,
                                properties=properties, codebases=codebases),
@@ -56,6 +56,10 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
 
     def test_constructor_codebases_valid(self):
         codebases = {"codebase1": {"repository": "", "branch": "", "revision": ""}}
+        self.makeScheduler(codebases=codebases)
+
+    def test_constructor_codebases_valid_list(self):
+        codebases = ['codebase1']
         self.makeScheduler(codebases=codebases)
 
     def test_constructor_codebases_invalid(self):

--- a/master/docs/manual/cfg-schedulers.rst
+++ b/master/docs/manual/cfg-schedulers.rst
@@ -62,8 +62,12 @@ There are several common arguments for schedulers, although not all are availabl
 
 ``codebases``
     When the scheduler processes data from more than 1 repository at the same time then a corresponding codebase definition should be passed for each repository.
-    A codebase definition is a dictionary with one or more of the following keys: repository, branch, revision.
-    The codebase definitions have also to be passed as dictionary.
+
+    This parameter can be specified either as a list of strings (simplest form; use if no special
+    overrides are needed) or as a dictionary of dictionaries (where each dict is a codebase definition
+    as described next).
+
+    A codebase definition is a dictionary with one or more of the following keys: repository, branch, revision. The codebase definitions are combined in a dictionary keyed by the name of the codebase.
 
     .. code-block:: python
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -40,6 +40,8 @@ Features
 
 * :bb:status:`GerritStatusPush` now has parameter --notify which is used to control e-mail notifications from Gerrit.
 
+* Schedulers: the ``codebases`` parameter can now be specified in a simple list-of-strings form
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
This is a backport of #1751.