### PR TITLE
[Eight] Allow boto to handle ec2 latent slave auth, deprecate custom credentials file

### DIFF
--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -110,6 +110,8 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                 if not os.path.exists(aws_id_file_path):
                     aws_id_file_path = None
             if aws_id_file_path and os.path.exists(aws_id_file_path):
+                log.msg('WARNING: EC2LatentBuildSlave is using deprecated '
+                        'aws_id file')
                 with open(aws_id_file_path, 'r') as aws_file:
                     identifier = aws_file.readline().strip()
                     secret_identifier = aws_file.readline().strip()

--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -107,15 +107,12 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
             if aws_id_file_path is None:
                 home = os.environ['HOME']
                 aws_id_file_path = os.path.join(home, '.ec2', 'aws_id')
-            if not os.path.exists(aws_id_file_path):
-                raise ValueError(
-                    "Please supply your AWS access key identifier and secret "
-                    "access key identifier either when instantiating this %s "
-                    "or in the %s file (on two lines).\n" %
-                    (self.__class__.__name__, aws_id_file_path))
-            with open(aws_id_file_path, 'r') as aws_file:
-                identifier = aws_file.readline().strip()
-                secret_identifier = aws_file.readline().strip()
+                if not os.path.exists(aws_id_file_path):
+                    aws_id_file_path = None
+            if aws_id_file_path and os.path.exists(aws_id_file_path):
+                with open(aws_id_file_path, 'r') as aws_file:
+                    identifier = aws_file.readline().strip()
+                    secret_identifier = aws_file.readline().strip()
         else:
             assert aws_id_file_path is None, \
                 'if you supply the identifier and secret_identifier, ' \
@@ -160,6 +157,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
             if 'InvalidKeyPair.NotFound' not in e.body:
                 if 'AuthFailure' in e.body:
                     print ('POSSIBLE CAUSES OF ERROR:\n'
+                           '  Did you supply your AWS credentials?\n'
                            '  Did you sign up for EC2?\n'
                            '  Did you put a credit card number in your AWS '
                            'account?\n'

--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -109,7 +109,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                 aws_id_file_path = os.path.join(home, '.ec2', 'aws_id')
                 if not os.path.exists(aws_id_file_path):
                     aws_id_file_path = None
-            if aws_id_file_path and os.path.exists(aws_id_file_path):
+            if aws_id_file_path:
                 log.msg('WARNING: EC2LatentBuildSlave is using deprecated '
                         'aws_id file')
                 with open(aws_id_file_path, 'r') as aws_file:

--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -106,9 +106,9 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                 'supply both or neither of identifier, secret_identifier')
             if aws_id_file_path is None:
                 home = os.environ['HOME']
-                aws_id_file_path = os.path.join(home, '.ec2', 'aws_id')
-                if not os.path.exists(aws_id_file_path):
-                    aws_id_file_path = None
+                default_path = os.path.join(home, '.ec2', 'aws_id')
+                if os.path.exists(default_path):
+                    aws_id_file_path = default_path
             if aws_id_file_path:
                 log.msg('WARNING: EC2LatentBuildSlave is using deprecated '
                         'aws_id file')

--- a/master/docs/manual/cfg-buildslaves.rst
+++ b/master/docs/manual/cfg-buildslaves.rst
@@ -229,11 +229,21 @@ The ``identifier`` argument specifies the AWS `Access Key Id`, and the ``secret_
 
    Whoever has your ``identifier`` and ``secret_identifier`` values can request AWS work charged to your account, so these values need to be carefully protected.
    Another way to specify these access keys is to put them in a separate file.
+   Buildbot supports the standard AWS credentials file.
    You can then make the access privileges stricter for this separate file, and potentially let more people read your main configuration file.
+   If your master is running in EC2, you can also use IAM roles for EC2 to delegate permissions.
 
-By default, you can make an :file:`.ec2` directory in the home folder of the user running the buildbot master.
-In that directory, create a file called :file:`aws_id`.
-The first line of that file should be your access key id; the second line should be your secret access key id.
+You can make an :file:`.aws` directory in the home folder of the user running the buildbot master.
+In that directory, create a file called :file:`credentials`.
+The format of the file should be as follows, replacing ``identifier`` and ``secret_identifier`` with the credentials obtained before.
+
+::
+
+    [default]
+    aws_access_key_id = identifier
+    aws_secret_access_key = secret_identifier
+
+If you are using IAM roles, no config file is required.
 Then you can instantiate the build slave as follows.
 
 ::
@@ -244,8 +254,6 @@ Then you can instantiate the build slave as follows.
        buildslave.EC2LatentBuildSlave('bot1', 'sekrit', 'm1.large',
                                       ami='ami-12345')
     ]
-
-If you want to put the key information in another file, use the ``aws_id_file_path`` initialization argument.
 
 Previous examples used a particular AMI.
 If the Buildbot master will be deployed in a process-controlled environment, it may be convenient to specify the AMI more flexibly.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -46,6 +46,9 @@ Fixes
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Providing Latent AWS EC2 credentails by the .ec2/aws_id file is deprecated:
+  Instead, use the standard .aws/credentials file.
+
 Details
 -------
 


### PR DESCRIPTION
This is a cherrypick of #1770 to eight.

The Buildbot EC2 latent slave code currently uses a custom '.ec2/aws_id' file to store credentials and asserts that credentials are provided explicitly or via this file. This change deprecates the custom file and delegates authentication to boto rather than asserting. This adds support for authenticating via [IAM Roles for EC2 Instances](https://aws.amazon.com/about-aws/whats-new/2012/06/11/Announcing-IAM-Roles-for-EC2-instances/), which was added to Boto in 2.5.1 (boto/boto#811).  It also adds support for the [standardized AWS Credentials file](http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs) which was added to Boto in 2.29.0 (boto/boto#2292).