### PR TITLE
base.py: support earlier buildbot.tac

### DIFF
--- a/master/docs/relnotes/0.9.0b1.rst
+++ b/master/docs/relnotes/0.9.0b1.rst
@@ -257,6 +257,11 @@ Deprecations, Removals, and Non-Compatible Changes
   Previously, it would return the original value.
   Instead, it now returns an array with the original value as the sole element.
 
+
+* ``buildbot.tac`` does not support ``print`` statements anymore. Such files should now use ``print``
+  as a function instead (see https://docs.python.org/3.0/whatsnew/3.0.html#print-is-a-function
+  for more details). Note that this applies to both python2.x and python3.x runtimes.
+
 WebStatus
 .........
 


### PR DESCRIPTION
Fixes
http://trac.buildbot.net/ticket/3318
that created a regression introduced by
201f0d9cbcffefb4062668c03ca95558f6a6b8c7

the regression being buildbot not supporting
buildbot.tac files containing
print someString
lines anymore.