### PR TITLE
Buildbot slave requires Python 2.6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: python
 # Available Python versions:
 # http://about.travis-ci.org/docs/user/ci-environment/#Python-VM-images
 python:
-  # "2.5" -- not supported by Travis CI anymore
   - "2.6"
   - "2.7"
 

--- a/master/docs/manual/installation.rst
+++ b/master/docs/manual/installation.rst
@@ -26,8 +26,7 @@ At a bare minimum, you'll need the following for both the buildmaster and a buil
 
 Python: http://www.python.org
 
-  Buildbot requires Python-2.6 or later on the master, although Python-2.7 is recommended.
-  The slave runs on Python-2.5.
+  Both Buildbot master and Buildbot slave require Python-2.6, although Python-2.7 is recommended.
 
   Note that this should be a "normal" build of Python.
   Builds of Python with debugging enabled or other unusual build parameters are likely to cause incorrect behavior.
@@ -69,14 +68,6 @@ sqlite3: http://www.sqlite.org
   Buildbot requires SQLite to store its state.
   Version 3.7.0 or higher is recommended, although Buildbot will run against earlier versions -- at the risk of "Database is locked" errors.
   The minimum version is 3.4.0, below which parallel database queries and schema introspection fail.
-
-pysqlite: http://pypi.python.org/pypi/pysqlite
-
-  The SQLite Python package is required for Python-2.5 and earlier (it is already included in Python-2.5 and later, but the version in Python-2.5 has nasty bugs)
-
-simplejson: http://pypi.python.org/pypi/simplejson
-
-  The simplejson package is required for Python-2.5 and earlier (it is already included as json in Python-2.6 and later)
 
 Jinja2: http://jinja.pocoo.org/
 

--- a/slave/setup.py
+++ b/slave/setup.py
@@ -121,21 +121,10 @@ try:
 except ImportError:
     pass
 else:
-    if sys.version_info[:2] >= (2, 6):
-        setup_args['install_requires'] = [
-            'twisted >= 8.0.0',
-            'future',
-        ]
-    else:
-        # Latest supported on Python 2.5 version of Twisted is 12.10, and
-        # pip/easy_install currently can't select correct version of Twisted.
-        # Twisted depends on zope.interface, which became incompatible with
-        # Python 2.5 starting from 4.0.0 release.
-        setup_args['install_requires'] = [
-            'twisted >= 8.0.0, <= 12.1.0',
-            'zope.interface < 4.0.0',
-            'future',
-        ]
+    setup_args['install_requires'] = [
+        'twisted >= 8.0.0',
+        'future',
+    ]
     setup_args['extras_require'] = {
         'test': [
             'mock',


### PR DESCRIPTION
* remove from Travis CI build matrix
* clean up Python 2.5 specific things