### PR TITLE
Changed statistics service classes to use ABC.

### DIFF
--- a/master/buildbot/statistics/capture.py
+++ b/master/buildbot/statistics/capture.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+import abc
+
 from twisted.internet import defer
 from twisted.internet import threads
 
@@ -24,6 +26,8 @@ class Capture(object):
     """
     Base class for all Capture* classes.
     """
+
+    __metaclass__ = abc.ABCMeta
 
     def __init__(self, routingKey, callback):
         self.routingKey = routingKey
@@ -38,6 +42,7 @@ class Capture(object):
             "build_number": str(msg['number'])
         }
 
+    @abc.abstractmethod
     def consume(self, routingKey, msg):
         raise NotImplementedError
 
@@ -134,6 +139,10 @@ class CaptureBuildTimes(Capture):
         msg = "%s failed on build %s on builder %s." % (self.__class__.__name__,
                                                         build_data['number'], self._builder_name)
         return msg
+
+    @abc.abstractmethod
+    def _retValParams(self, msg):
+        pass
 
 
 class CaptureBuildStartTime(CaptureBuildTimes):

--- a/master/buildbot/statistics/capture.py
+++ b/master/buildbot/statistics/capture.py
@@ -44,7 +44,7 @@ class Capture(object):
 
     @abc.abstractmethod
     def consume(self, routingKey, msg):
-        raise NotImplementedError
+        pass
 
     @defer.inlineCallbacks
     def _store(self, post_data, series_name, context):

--- a/master/buildbot/statistics/storage_backends/base.py
+++ b/master/buildbot/statistics/storage_backends/base.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+import abc
+
 from twisted.internet import defer
 
 
@@ -23,5 +25,8 @@ class StatsStorageBase(object):
     a storage backend
     """
 
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
     def thd_postStatsValue(self, post_data, series_name, context=None):
         return defer.succeed(None)

--- a/master/buildbot/statistics/storage_backends/base.py
+++ b/master/buildbot/statistics/storage_backends/base.py
@@ -15,8 +15,6 @@
 
 import abc
 
-from twisted.internet import defer
-
 
 class StatsStorageBase(object):
 
@@ -29,4 +27,4 @@ class StatsStorageBase(object):
 
     @abc.abstractmethod
     def thd_postStatsValue(self, post_data, series_name, context=None):
-        return defer.succeed(None)
+        pass

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -154,13 +154,6 @@ class TestInfluxDB(TestStatsServicesBase, logging.LoggingMixin):
         svc.thd_postStatsValue("test", "test", "test")
         self.assertLogged("Service.*not initialized")
 
-    def test_storage_backend_base(self):
-        # Just initlize and run thd_postStatsValue
-        svc = StatsStorageBase()
-        r = svc.thd_postStatsValue("test", "test", "test")
-        assert isinstance(r, defer.Deferred)
-        assert r.result == None
-
 
 class TestStatsServicesConsumers(steps.BuildStepMixin, TestStatsServicesBase):
 

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -55,6 +55,16 @@ class TestStatsServicesBase(unittest.TestCase):
         self.stats_service.stopService()
 
 
+class DummyStatsStorageBase(StatsStorageBase):
+
+    """
+    A dummy class to test intialization of StatsStorageBase.
+    """
+
+    def thd_postStatsValue(self, *args, **kwargs):
+        return defer.succeed(None)
+
+
 class TestStatsServicesConfiguration(TestStatsServicesBase):
 
     def test_reconfig_with_no_storage_backends(self):
@@ -153,6 +163,13 @@ class TestInfluxDB(TestStatsServicesBase, logging.LoggingMixin):
         svc._inited = False
         svc.thd_postStatsValue("test", "test", "test")
         self.assertLogged("Service.*not initialized")
+
+    def test_storage_backend_base_failure_on_init(self):
+        svc = DummyStatsStorageBase()
+
+        r = svc.thd_postStatsValue("test", "test", "test")
+        assert isinstance(r, defer.Deferred)
+        assert r.result == None
 
 
 class TestStatsServicesConsumers(steps.BuildStepMixin, TestStatsServicesBase):


### PR DESCRIPTION
Second item on the todo list. This is a very small commit.

I haven't added any tests here because those tests belong in the ABC module itself - testing that an ABC class will raise error when abstract methods aren't implemented in child classes is something that ABC would check in their test own test suite.

@sa2ajj @Stibbons @benallard 

Updated TODO list:

- [x] Style-based changes:
  * Dictionary intialization
  * Extra newlines
  * Private memebers prepended with `_`
  * Change some method names
  * Minor refactoring
    * Changes to some tests
    * storage_backends.py to be divided into files.
  * Some error handling for graceful exits in case of failure.

- [x] Making all superclasses use ABC.
  * Capture
  * CaptureBuildTimes
  * StatsStorageBase

- [ ] Add helper methods for quickly capturing data:
  * Capture a specific data for all builders (properties/times).
  * Capture all properties mathing a regex on all builders.
  * Capture all properties mathing a regex on a list of builders.
  * Capture times (start/end/duration) on a list of builders.

- [ ] Changes to the docs:
  * Fix the format (one sentence per line).
  * Document the changes from the above TODOs.
    * Write about ABC usage and helper methods
  * Add a new tutorial/chapter on the usage of this service.
