### PR TITLE
fix race condition with appendlog and finishLog

### DIFF
--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -90,8 +90,10 @@ class Log(object):
     @defer.inlineCallbacks
     def finish(self):
         assert not self.finished
+        yield self.lock.acquire()
         self.finished = True
         yield self.master.data.updates.finishLog(self.logid)
+        yield self.lock.release()
 
         # notify subscribers *after* finishing the log
         self.subPoint.deliver(None, None)


### PR DESCRIPTION
I finally found why we had so much failure with the test_trigger integration test..

log could be finished before the insertion and compression
of the last chunk is finished

This lead to instability of integrations tests.
We can see this more often since we implemented compression
