### PR TITLE
Fix calling git (previous version led to "No file or directory")

### DIFF
--- a/master/contrib/git_buildbot.py
+++ b/master/contrib/git_buildbot.py
@@ -239,7 +239,7 @@ def gen_update_branch_changes(oldrev, newrev, refname, branch):
 
     logging.info("Branch `%s' updated %s .. %s", branch, oldrev[:8], newrev[:8])
 
-    mergebasecommand = subprocess.Popen("git merge-base %s %s" % (oldrev, newrev), stdout=subprocess.PIPE)
+    mergebasecommand = subprocess.Popen(["git", "merge-base", oldrev, newrev], stdout=subprocess.PIPE)
     (baserev, err) = mergebasecommand.communicate()
     baserev = baserev.strip() # remove newline
     


### PR DESCRIPTION
Previous version caused this:
```
remote: git_buildbot: ERROR: Unhandled exception
remote: Traceback (most recent call last):
remote:   File "hooks/post-receive", line 459, in <module>
remote:     process_changes()
remote:   File "hooks/post-receive", line 346, in process_changes
remote:     process_change(oldrev, newrev, refname)
remote:   File "hooks/post-receive", line 331, in process_change
remote:     process_branch_change(oldrev, newrev, refname, branch)
remote:   File "hooks/post-receive", line 311, in process_branch_change
remote:     gen_update_branch_changes(oldrev, newrev, refname, branch)
remote:   File "hooks/post-receive", line 242, in gen_update_branch_changes
remote:     mergebasecommand = subprocess.Popen("/usr/local/bin/git merge-base %s %s" % (oldrev, newrev), stdout=subprocess.PIPE)
remote:   File "/usr/local/lib/python2.7/subprocess.py", line 710, in __init__
remote:     errread, errwrite)
remote:   File "/usr/local/lib/python2.7/subprocess.py", line 1327, in _execute_child
remote:     raise child_exception
remote: OSError: [Errno 2] No such file or directory
```