### PR TITLE
add a bundle in setup.py

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -391,6 +391,10 @@ else:
             'pylint==1.1.0',
             'pyflakes',
         ],
+        'bundle': [
+            'buildbot-www',
+            'buildbot-slave'
+        ]
     }
 
     if os.getenv('NO_INSTALL_REQS'):


### PR DESCRIPTION
thus you can install full buildbot using:

    pip install 'buildbot[bundle]'

attempt to fix http://trac.buildbot.net/ticket/3311

Having a metapackage would only change the message to

pip install buildbot-bundle

and requires to generate and maintain another package.

@vlovich would that work for you?