### PR TITLE
Install buildbot.statistics master package

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -165,6 +165,8 @@ setup_args = {
         "buildbot.reporters",
         "buildbot.schedulers",
         "buildbot.scripts",
+        "buildbot.statistics",
+        "buildbot.statistics.storage_backends",
         "buildbot.status",
         "buildbot.steps",
         "buildbot.steps.package",


### PR DESCRIPTION
The new `buildbot.statistics` package hasn't been added to `setup.py` yet, leading to issues when doing `buildbot create-master` on a system install. This should fix that :)