### PR TITLE
fix master's dependencies

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -385,15 +385,11 @@ except ImportError:
     pass
 else:
     # dependencies
-    if sys.version_info[0] == 2 and sys.version_info[1] <= 5:
-        zi = 'zope.interface >= 3.6.1'  # the newest that works on Python 2.5
-    else:
-        zi = 'zope.interface >= 4.1.1'  # required for tests, but Twisted requires this anyway
-
     setup_args['install_requires'] = [
         'twisted >= 11.0.0',
         'Jinja2 >= 2.1',
-        zi,
+        'zope.interface >= 4.1.1',  # required for tests, but Twisted requires this anyway
+        'future'
     ]
 
     setup_args['install_requires'] += [


### PR DESCRIPTION
* Python 2.5 is not supported any more, hence to need to handle that
* 'future' module is required (as it brings in 'builtins' module), while  it was not mentioned