### PR TITLE
Improve GitHub status code and update contrib's GitHub webhook

### DIFF
--- a/master/buildbot/test/unit/test_status_github.py
+++ b/master/buildbot/test/unit/test_status_github.py
@@ -43,6 +43,7 @@ else:
     from buildbot.status.github import _getGitHubState
 
 from buildbot.test.fake.fakebuild import FakeBuild
+from buildbot.test.util import config
 from buildbot.test.util import logging
 
 
@@ -53,7 +54,8 @@ class MarkerError(Exception):
     """
 
 
-class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
+class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin,
+                       config.ConfigErrorsMixin):
 
     """
     Unit tests for `GitHubStatus`.
@@ -513,3 +515,34 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
             'Specify both or none of repoOwner and repoName',
             lambda: GitHubStatus(
                 token='token', repoName='name'))
+
+
+class TestGitHubStatus2(TestGitHubStatus):
+
+    """
+    Unit tests for `GitHubStatus` using the repo parameter.
+    """
+
+    def setUp(self):
+        super(TestGitHubStatus2, self).setUp()
+
+        self.status = GitHubStatus(
+            token='token', repo='owner/name')
+
+    def test_getGitHubRepoProperties_skip_no_owner(self):
+        self.status._repo = Interpolate('/name')
+        self.status._sha = Interpolate('sha')
+
+        d = self.status._getGitHubRepoProperties(self.build)
+        result = self.successResultOf(d)
+
+        self.assertEqual({}, result)
+
+    def test_getGitHubRepoProperties_skip_no_name(self):
+        self.status._repo = Interpolate('owner/')
+        self.status._sha = Interpolate('sha')
+
+        d = self.status._getGitHubRepoProperties(self.build)
+        result = self.successResultOf(d)
+
+        self.assertEqual({}, result)

--- a/master/buildbot/test/unit/test_status_github.py
+++ b/master/buildbot/test/unit/test_status_github.py
@@ -488,3 +488,28 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin):
         self.assertLogError(
             error,
             u'Fail to send status "state" for owner/name at sha.')
+
+    def test_repoOverDefined(self):
+        """
+        GitHubStatus will fail to init if all of repoOwner, repoName, and repo
+        are defined.
+        """
+        self.assertRaisesConfigError(
+            'Specify repoOwner and repoName or repo, but not both',
+            lambda: GitHubStatus(
+                token='token', repoOwner='owner', repoName='name',
+                repo='owner/name'))
+
+    def test_repoUnderDefined(self):
+        """
+        GitHubStatus will fail to init if not both repoOwner and repoName
+        are defined.
+        """
+        self.assertRaisesConfigError(
+            'Specify both or none of repoOwner and repoName',
+            lambda: GitHubStatus(
+                token='token', repoOwner='owner'))
+        self.assertRaisesConfigError(
+            'Specify both or none of repoOwner and repoName',
+            lambda: GitHubStatus(
+                token='token', repoName='name'))

--- a/master/contrib/github_buildbot.py
+++ b/master/contrib/github_buildbot.py
@@ -182,10 +182,10 @@ class GitHubBuildBot(resource.Resource):
                 "Ignoring refname `%s': Not a branch or a tag", refname)
             return changes
 
-        branch = m.group(2)
+        refname = m.group(2)
 
         if payload['deleted'] is True:
-            logging.info("Branch %r deleted, ignoring", branch)
+            logging.info("%r deleted, ignoring", refname)
         else:
             changes = []
             for change in payload['commits']:
@@ -193,7 +193,7 @@ class GitHubBuildBot(resource.Resource):
                         and change['id'] != payload['head_commit']['id']:
                     continue
                 changes.append(self.process_change(
-                    change, branch, repo, repo_url))
+                    change, refname, repo, repo_url))
         return changes
 
     def handle_pull_request(self, payload, repo, repo_url):

--- a/master/contrib/github_buildbot.py
+++ b/master/contrib/github_buildbot.py
@@ -154,11 +154,16 @@ class GitHubBuildBot(resource.Resource):
         if 'email' in change['author']:
             who = "%s <%s>" % (who, change['author']['email'])
 
+        comments = change['message']
+        if len(comments) > 1024:
+            trim = " ... (trimmed, commit message exceeds 1024 characters)"
+            comments = comments[:1024 - len(trim)] + trim
+
         return \
             {'revision': change['id'],
              'revlink': change['url'],
              'who': who,
-             'comments': change['message'],
+             'comments': comments,
              'repository': repo_url,
              'files': files,
              'project': repo,


### PR DESCRIPTION
Whole bunch of changes all lumped together here:

1. Updates the structure be closer to the git_buildbot changesource.
2. Adds flag for only reporting the head of a push rather than all commits.
3. Updates fields pulled from GitHub JSON to match the latest APIs
4. Adds support for Pull Requests.
5. Modifies GitHub status reporter to work with GitHub webhook changes by default. 
6. Fixes various bugs.