### PR TITLE
[nine] Triggerable: should allow reason to be set

### DIFF
--- a/master/buildbot/schedulers/triggerable.py
+++ b/master/buildbot/schedulers/triggerable.py
@@ -26,13 +26,15 @@ from twisted.python import failure
 class Triggerable(base.BaseScheduler):
     implements(ITriggerableScheduler)
 
-    compare_attrs = base.BaseScheduler.compare_attrs
+    compare_attrs = base.BaseScheduler.compare_attrs + ('reason',)
 
-    def __init__(self, name, builderNames, **kwargs):
+    def __init__(self, name, builderNames, reason=None, **kwargs):
         base.BaseScheduler.__init__(self, name, builderNames, **kwargs)
         self._waiters = {}
         self._buildset_complete_consumer = None
-        self.reason = u"The Triggerable scheduler named '%s' triggered this build" % name
+        if reason is None:
+            reason = u"The Triggerable scheduler named '%s' triggered this build" % name
+        self.reason = reason
 
     def trigger(self, waited_for, sourcestamps=None, set_props=None,
                 parent_buildid=None, parent_relationship=None):

--- a/master/buildbot/test/unit/test_schedulers_triggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_triggerable.py
@@ -153,6 +153,10 @@ class Triggerable(scheduler.SchedulerMixin, unittest.TestCase):
         sched = self.makeScheduler()
         self.assertEqual(sched.reason, "The Triggerable scheduler named 'n' triggered this build")
 
+    def test_constructor_explicit_reason(self):
+        sched = self.makeScheduler(reason="Because I said so")
+        self.assertEqual(sched.reason, "Because I said so")
+
     def test_trigger(self):
         sched = self.makeScheduler(codebases={'cb': {'repository': 'r'}})
         # no subscription should be in place yet

--- a/master/docs/manual/cfg-schedulers.rst
+++ b/master/docs/manual/cfg-schedulers.rst
@@ -643,6 +643,8 @@ The parameters are just the basics:
 
 ``properties``
 
+``reason``
+
 ``codebases``
     See :ref:`Configuring-Schedulers`.
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -16,6 +16,8 @@ Features
 ~~~~~~~~
 
 
+* :bb:sched:`Triggerable` now accepts a ``reason`` parameter.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
This is a patch we merged to eight ... simple port to nine.