### PR TITLE
Require Twisted<=15.0.0 where services aren't new-style classes

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -386,7 +386,7 @@ except ImportError:
 else:
     # dependencies
     setup_args['install_requires'] = [
-        'twisted >= 11.0.0',
+        'twisted >= 11.0.0, <= 15.0.0',
         'Jinja2 >= 2.1',
         'zope.interface >= 4.1.1',  # required for tests, but Twisted requires this anyway
         'future'


### PR DESCRIPTION
Temporary fix..