### PR TITLE
remove more self.master = master instances

### DIFF
--- a/master/buildbot/buildslave/manager.py
+++ b/master/buildbot/buildslave/manager.py
@@ -66,7 +66,7 @@ class BuildslaveManager(MeasuredBuildbotServiceManager):
     def __init__(self, master):
         service.AsyncMultiService.__init__(self)
 
-        self.pb = bbpb.Listener(master)
+        self.pb = bbpb.Listener()
         self.pb.setServiceParent(master)
 
         # BuildslaveRegistration instances keyed by buildslave name

--- a/master/buildbot/buildslave/protocols/base.py
+++ b/master/buildbot/buildslave/protocols/base.py
@@ -18,10 +18,7 @@ from buildbot.util import subscription
 
 
 class Listener(service.ReconfigurableServiceMixin, service.AsyncMultiService):
-
-    def __init__(self, master):
-        service.AsyncMultiService.__init__(self)
-        self.master = master
+    pass
 
 
 class Connection(object):

--- a/master/buildbot/buildslave/protocols/pb.py
+++ b/master/buildbot/buildslave/protocols/pb.py
@@ -25,9 +25,8 @@ from twisted.spread import pb
 class Listener(base.Listener):
     name = "pbListener"
 
-    def __init__(self, master):
-        assert master
-        base.Listener.__init__(self, master)
+    def __init__(self):
+        base.Listener.__init__(self)
 
         # username : (password, portstr, PBManager registration)
         self._registrations = {}

--- a/master/buildbot/changes/manager.py
+++ b/master/buildbot/changes/manager.py
@@ -35,12 +35,7 @@ class ChangeManager(service.ReconfigurableServiceMixin, service.AsyncMultiServic
 
     implements(interfaces.IEventSource)
 
-    name = "changemanager"
-
-    def __init__(self, master):
-        service.AsyncMultiService.__init__(self)
-        self.setName('change_manager')
-        self.master = master
+    name = "change_manager"
 
     @defer.inlineCallbacks
     def reconfigServiceWithBuildbotConfig(self, new_config):

--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -54,13 +54,16 @@ class DataConnector(service.AsyncService):
         'buildbot.data.root',
         'buildbot.data.properties',
     ]
+    name = "data"
 
-    def __init__(self, master):
-        self.setName('data')
-        self.master = master
+    def __init__(self):
 
         self.matcher = pathmatch.Matcher()
         self.rootLinks = []  # links from the root of the API
+
+    @defer.inlineCallbacks
+    def setServiceParent(self, parent):
+        yield service.AsyncService.setServiceParent(self, parent)
         self._setup()
 
     def _scanModule(self, mod, _noSetattr=False):

--- a/master/buildbot/db/base.py
+++ b/master/buildbot/db/base.py
@@ -29,13 +29,16 @@ class DBConnectorComponent(object):
 
     def __init__(self, connector):
         self.db = connector
-        self.master = connector.master
 
         # set up caches
         for method in dir(self.__class__):
             o = getattr(self, method)
             if isinstance(o, CachedMethod):
                 setattr(self, method, o.get_cached_method(self))
+
+    @property
+    def master(self):
+        return self.db.master
 
     _isCheckLengthNecessary = None
 

--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -64,10 +64,9 @@ class DBConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
     # periodic cleanup actions on this schedule.
     CLEANUP_PERIOD = 3600
 
-    def __init__(self, master, basedir):
+    def __init__(self, basedir):
         service.AsyncMultiService.__init__(self)
         self.setName('db')
-        self.master = master
         self.basedir = basedir
 
         # not configured yet - we don't build an engine until the first
@@ -77,6 +76,9 @@ class DBConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         # set up components
         self._engine = None  # set up in reconfigService
         self.pool = None  # set up in reconfigService
+
+    def setServiceParent(self, p):
+        d = service.AsyncMultiService.setServiceParent(self, p)
         self.model = model.Model(self)
         self.changes = changes.ChangesConnectorComponent(self)
         self.changesources = changesources.ChangeSourcesConnectorComponent(self)
@@ -97,6 +99,7 @@ class DBConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         self.cleanup_timer = internet.TimerService(self.CLEANUP_PERIOD,
                                                    self._doCleanup)
         self.cleanup_timer.setServiceParent(self)
+        return d
 
     def setup(self, check_version=True, verbose=True):
         db_url = self.configured_url = self.master.config.db['db_url']

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -141,10 +141,10 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         self.buildslaves = bslavemanager.BuildslaveManager(self)
         self.buildslaves.setServiceParent(self)
 
-        self.change_svc = ChangeManager(self)
+        self.change_svc = ChangeManager()
         self.change_svc.setServiceParent(self)
 
-        self.botmaster = BotMaster(self)
+        self.botmaster = BotMaster()
         self.botmaster.setServiceParent(self)
 
         self.scheduler_manager = SchedulerManager()
@@ -153,22 +153,22 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         self.user_manager = UserManagerManager(self)
         self.user_manager.setServiceParent(self)
 
-        self.db = dbconnector.DBConnector(self, self.basedir)
+        self.db = dbconnector.DBConnector(self.basedir)
         self.db.setServiceParent(self)
 
-        self.mq = mqconnector.MQConnector(self)
+        self.mq = mqconnector.MQConnector()
         self.mq.setServiceParent(self)
 
-        self.data = dataconnector.DataConnector(self)
+        self.data = dataconnector.DataConnector()
         self.data.setServiceParent(self)
 
-        self.www = wwwservice.WWWService(self)
+        self.www = wwwservice.WWWService()
         self.www.setServiceParent(self)
 
-        self.debug = debug.DebugServices(self)
+        self.debug = debug.DebugServices()
         self.debug.setServiceParent(self)
 
-        self.status = Status(self)
+        self.status = Status()
         self.status.setServiceParent(self)
 
         self.service_manager = service.BuildbotServiceManager()

--- a/master/buildbot/mq/base.py
+++ b/master/buildbot/mq/base.py
@@ -20,10 +20,7 @@ from twisted.python import log
 
 
 class MQBase(service.AsyncService):
-
-    def __init__(self, master):
-        self.setName('mq-implementation')
-        self.master = master
+    name = 'mq-implementation'
 
 
 class QueueRef(object):

--- a/master/buildbot/mq/connector.py
+++ b/master/buildbot/mq/connector.py
@@ -25,11 +25,10 @@ class MQConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
             'keys': set(['debug']),
         },
     }
+    name = 'mq'
 
-    def __init__(self, master):
+    def __init__(self):
         service.AsyncMultiService.__init__(self)
-        self.setName('mq')
-        self.master = master
         self.impl = None  # set in setup
         self.impl_type = None  # set in setup
 
@@ -42,7 +41,7 @@ class MQConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         assert typ in self.classes  # this is checked by MasterConfig
         self.impl_type = typ
         cls = namedObject(self.classes[typ]['class'])
-        self.impl = cls(self.master)
+        self.impl = cls()
 
         # set up the impl as a child service
         self.impl.setServiceParent(self)

--- a/master/buildbot/mq/simple.py
+++ b/master/buildbot/mq/simple.py
@@ -24,8 +24,8 @@ from twisted.python import log
 
 class SimpleMQ(service.ReconfigurableServiceMixin, base.MQBase):
 
-    def __init__(self, master):
-        base.MQBase.__init__(self, master)
+    def __init__(self):
+        base.MQBase.__init__(self)
         self.qrefs = []
         self.persistent_qrefs = {}
         self.debug = False

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -32,11 +32,10 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
     them."""
 
     debug = 0
+    name = "botmaster"
 
-    def __init__(self, master):
+    def __init__(self):
         service.AsyncMultiService.__init__(self)
-        self.setName("botmaster")
-        self.master = master
 
         self.builders = {}
         self.builderNames = []

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -287,7 +287,7 @@ class BasicBuildChooser(BuildChooserBase):
         return self.bldr.canStartBuild(slave, breq)
 
 
-class BuildRequestDistributor(service.AsyncService):
+class BuildRequestDistributor(service.AsyncMultiService):
 
     """
     Special-purpose class to handle distributing build requests to builders by
@@ -303,8 +303,8 @@ class BuildRequestDistributor(service.AsyncService):
     BuildChooser = BasicBuildChooser
 
     def __init__(self, botmaster):
+        service.AsyncMultiService.__init__(self)
         self.botmaster = botmaster
-        self.master = botmaster.master
 
         # lock to ensure builders are only sorted once at any time
         self.pending_builders_lock = defer.DeferredLock()

--- a/master/buildbot/process/debug.py
+++ b/master/buildbot/process/debug.py
@@ -18,11 +18,10 @@ from twisted.internet import defer
 
 
 class DebugServices(service.ReconfigurableServiceMixin, service.AsyncMultiService):
+    name = 'debug_services'
 
-    def __init__(self, master):
+    def __init__(self):
         service.AsyncMultiService.__init__(self)
-        self.setName('debug_services')
-        self.master = master
 
         self.debug_port = None
         self.debug_password = None

--- a/master/buildbot/process/debug.py
+++ b/master/buildbot/process/debug.py
@@ -33,12 +33,10 @@ class DebugServices(service.ReconfigurableServiceMixin, service.AsyncMultiServic
         if new_config.manhole != self.manhole:
             if self.manhole:
                 yield self.manhole.disownServiceParent()
-                self.manhole.master = None
                 self.manhole = None
 
             if new_config.manhole:
                 self.manhole = new_config.manhole
-                self.manhole.master = self.master
                 yield self.manhole.setServiceParent(self)
 
         # chain up
@@ -52,5 +50,4 @@ class DebugServices(service.ReconfigurableServiceMixin, service.AsyncMultiServic
 
         # clean up
         if self.manhole:
-            self.manhole.master = None
             self.manhole = None

--- a/master/buildbot/process/users/manager.py
+++ b/master/buildbot/process/users/manager.py
@@ -35,10 +35,8 @@ class UserManagerManager(util_service.ReconfigurableServiceMixin,
         for mgr in list(self):
             yield defer.maybeDeferred(lambda:
                                       mgr.disownServiceParent())
-            mgr.master = None
 
         for mgr in new_config.user_managers:
-            mgr.master = self.master
             yield mgr.setServiceParent(self)
 
         # reconfig any newly-added change sources, as well as existing

--- a/master/buildbot/scripts/cleanupdb.py
+++ b/master/buildbot/scripts/cleanupdb.py
@@ -21,7 +21,6 @@ import sys
 
 from buildbot import config as config_module
 from buildbot import monkeypatches
-from buildbot.db import connector
 from buildbot.master import BuildMaster
 from buildbot.scripts import base
 from buildbot.util import in_reactor
@@ -36,8 +35,7 @@ def doCleanupDatabase(config, master_cfg):
     master = BuildMaster(config['basedir'])
     master.config = master_cfg
     print(master.config.logCompressionMethod)
-    db = connector.DBConnector(master, basedir=config['basedir'])
-
+    db = master.db
     yield db.setup(check_version=False, verbose=not config['quiet'])
     res = yield db.logs.getLogs()
     i = 0

--- a/master/buildbot/scripts/create_master.py
+++ b/master/buildbot/scripts/create_master.py
@@ -19,7 +19,6 @@ import os
 
 from buildbot import config as config_module
 from buildbot import monkeypatches
-from buildbot.db import connector
 from buildbot.master import BuildMaster
 from buildbot.util import in_reactor
 from twisted.internet import defer
@@ -100,7 +99,7 @@ def createDB(config, _noMonkey=False):
     master_cfg.db['db_url'] = config['db']
     master = BuildMaster(config['basedir'])
     master.config = master_cfg
-    db = connector.DBConnector(master, config['basedir'])
+    db = master.db
     yield db.setup(check_version=False, verbose=not config['quiet'])
     if not config['quiet']:
         print("creating database (%s)" % (master_cfg.db['db_url'],))

--- a/master/buildbot/scripts/processwwwindex.py
+++ b/master/buildbot/scripts/processwwwindex.py
@@ -29,8 +29,8 @@ from twisted.internet import defer
 @defer.inlineCallbacks
 def processwwwindex(config):
     master = yield fakemaster.make_master()
-    master_service = WWWService(master)
-
+    master_service = WWWService()
+    master_service.setServiceParent(master)
     if not config.get('index-file'):
         print("Path to the index.html file is required with option --index-file or -i")
         defer.returnValue(1)

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -97,8 +97,9 @@ def upgradeDatabase(config, master_cfg):
 
     master = BuildMaster(config['basedir'])
     master.config = master_cfg
-    db = connector.DBConnector(master, basedir=config['basedir'])
-
+    master.db.disownServiceParent()
+    db = connector.DBConnector(basedir=config['basedir'])
+    db.setServiceParent(master)
     yield db.setup(check_version=False, verbose=not config['quiet'])
     yield db.model.upgrade()
     yield db.masters.setAllMastersActiveLongTimeAgo()

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -80,20 +80,9 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
     def reconfigServiceWithBuildbotConfig(self, new_config):
         # remove the old listeners, then add the new
         for sr in list(self):
-            yield defer.maybeDeferred(lambda:
-                                      sr.disownServiceParent())
-
-            # WebStatus instances tend to "hang around" longer than we'd like -
-            # if there's an ongoing HTTP request, or even a connection held
-            # open by keepalive, then users may still be talking to an old
-            # WebStatus.  So WebStatus objects get to keep their `master`
-            # attribute, but all other status objects lose theirs.  And we want
-            # to test this without importing WebStatus, so we use name
-            if not sr.__class__.__name__.endswith('WebStatus'):
-                sr.master = None
+            yield sr.disownServiceParent()
 
         for sr in new_config.status:
-            sr.master = self.master
             yield sr.setServiceParent(self)
 
         # reconfig any newly-added change sources, as well as existing

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -34,12 +34,8 @@ from zope.interface import implements
 class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
     implements(interfaces.IStatus)
 
-    def __init__(self, master):
+    def __init__(self):
         service.AsyncMultiService.__init__(self)
-        self.master = master
-        self.botmaster = master.botmaster
-        self.buildslaves = master.buildslaves
-        self.basedir = master.basedir
         self.watchers = []
         # No default limit to the log size
         self.logMaxSize = None
@@ -51,6 +47,18 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         self._buildset_sub = None
         self._build_request_sub = None
         self._change_sub = None
+
+    @property
+    def botmaster(self):
+        return self.master.botmaster
+
+    @property
+    def buildslaves(self):
+        return self.master.buildslaves
+
+    @property
+    def basedir(self):
+        return self.master.basedir
 
     # service management
 

--- a/master/buildbot/status/words.py
+++ b/master/buildbot/status/words.py
@@ -145,7 +145,8 @@ class Contact(base.StatusReceiver):
         """
         assert user or channel, "At least one of user or channel must be set"
         self.bot = bot
-        self.master = bot.master
+        # hack for self.master, but this module needs a much bigger rework
+        self.setServiceParent(bot.master)
         self.notify_events = {}
         self.subscribed = []
         self.build_subscriptions = []

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -18,10 +18,9 @@ from buildbot.util import service
 
 class FakeBotMaster(service.AsyncMultiService):
 
-    def __init__(self, master):
+    def __init__(self):
         service.AsyncMultiService.__init__(self)
         self.setName("fake-botmaster")
-        self.master = master
         self.locks = {}
         self.builders = {}
         self.buildsStartedForSlaves = []

--- a/master/buildbot/test/fake/bslavemanager.py
+++ b/master/buildbot/test/fake/bslavemanager.py
@@ -19,10 +19,9 @@ from twisted.internet import defer
 
 class FakeBuildslaveManager(service.AsyncMultiService):
 
-    def __init__(self, master):
+    def __init__(self):
         service.AsyncMultiService.__init__(self)
         self.setName('buildslaves')
-        self.master = master
 
         # BuildslaveRegistration instances keyed by buildslave name
         self.registrations = {}

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -29,6 +29,7 @@ from buildbot.db import schedulers
 from buildbot.test.util import validation
 from buildbot.util import datetime2epoch
 from buildbot.util import json
+from buildbot.util import service
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -2375,7 +2376,7 @@ class FakeTagsComponent(FakeDBComponent):
         return defer.succeed(id)
 
 
-class FakeDBConnector(object):
+class FakeDBConnector(service.AsyncMultiService):
 
     """
     A stand-in for C{master.db} that operates without an actual database
@@ -2386,10 +2387,10 @@ class FakeDBConnector(object):
     see their documentation for more.
     """
 
-    def __init__(self, master, testcase):
+    def __init__(self, testcase):
+        service.AsyncMultiService.__init__(self)
         # reset the id generator, for stable id's
         Row._next_id = 1000
-        self.master = master
         self.t = testcase
         self.checkForeignKeys = False
         self._components = []

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -172,13 +172,14 @@ class FakeMaster(service.MasterService):
         self.caches = FakeCaches()
         self.pbmanager = pbmanager.FakePBManager()
         self.basedir = 'basedir'
-        self.botmaster = FakeBotMaster(master=self)
-        self.botmaster.parent = self
+        self.botmaster = FakeBotMaster()
+        self.botmaster.setServiceParent(self)
         self.status = FakeStatus()
         self.status.setServiceParent(self)
         self.name = 'fake:/master'
         self.masterid = master_id
-        self.buildslaves = bslavemanager.FakeBuildslaveManager(self)
+        self.buildslaves = bslavemanager.FakeBuildslaveManager()
+        self.buildslaves.setServiceParent(self)
         self.log_rotation = FakeLogRotation()
         self.db = mock.Mock()
         self.next_objectid = 0
@@ -211,10 +212,12 @@ def make_master(wantMq=False, wantDb=False, wantData=False,
         wantMq = wantDb = True
     if wantMq:
         assert testcase is not None, "need testcase for wantMq"
-        master.mq = fakemq.FakeMQConnector(master, testcase)
+        master.mq = fakemq.FakeMQConnector(testcase)
+        master.mq.setServiceParent(master)
     if wantDb:
         assert testcase is not None, "need testcase for wantDb"
-        master.db = fakedb.FakeDBConnector(master, testcase)
+        master.db = fakedb.FakeDBConnector(testcase)
+        master.db.setServiceParent(master)
     if wantData:
         master.data = fakedata.FakeDataConnector(master, testcase)
     return master

--- a/master/buildbot/test/fake/fakemq.py
+++ b/master/buildbot/test/fake/fakemq.py
@@ -14,11 +14,12 @@
 # Copyright Buildbot Team Members
 
 from buildbot.test.util import validation
+from buildbot.util import service
 from buildbot.util import tuplematch
 from twisted.internet import defer
 
 
-class FakeMQConnector(object):
+class FakeMQConnector(service.AsyncMultiService):
 
     # a fake connector that doesn't actually bridge messages from production to
     # consumption, and thus doesn't do any topic handling or persistence
@@ -27,8 +28,8 @@ class FakeMQConnector(object):
     # is set to false:
     verifyMessages = True
 
-    def __init__(self, master, testcase):
-        self.master = master
+    def __init__(self, testcase):
+        service.AsyncMultiService.__init__(self)
         self.testcase = testcase
         self.setup_called = False
         self.productions = []

--- a/master/buildbot/test/integration/test_slave_comm.py
+++ b/master/buildbot/test/integration/test_slave_comm.py
@@ -157,13 +157,16 @@ class TestSlaveComm(unittest.TestCase):
         self.pbmanager = self.master.pbmanager = pbmanager.PBManager()
         self.pbmanager.setServiceParent(self.master)
 
+        # remove the fakeServiceParent from fake service hierarchy, and replace by a real one
+        yield self.master.buildslaves.disownServiceParent()
         self.buildslaves = self.master.buildslaves = bslavemanager.BuildslaveManager(self.master)
         self.buildslaves.setServiceParent(self.master)
 
-        self.botmaster = botmaster.BotMaster(self.master)
+        self.botmaster = botmaster.BotMaster()
         self.botmaster.setServiceParent(self.master)
 
-        self.master.status = master.Status(self.master)
+        self.master.status = master.Status()
+        self.master.status.setServiceParent(self.master)
         self.master.botmaster = self.botmaster
         self.master.data.updates.buildslaveConfigured = lambda *a, **k: None
         yield self.master.startService()

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -113,7 +113,8 @@ class UpgradeTestMixin(db.RealDatabaseMixin):
 
         self.master = master = fakemaster.make_master()
         master.config.db['db_url'] = self.db_url
-        self.db = connector.DBConnector(master, self.basedir)
+        self.db = connector.DBConnector(self.basedir)
+        self.db.setServiceParent(master)
         yield self.db.setup(check_version=False)
 
         querylog.log_from_engine(self.db.pool.engine)
@@ -674,7 +675,8 @@ class TestWeirdChanges(change_import.ChangeImportMixin, unittest.TestCase):
         @d.addCallback
         def make_dbc(_):
             master = fakemaster.make_master()
-            self.db = connector.DBConnector(master, self.basedir)
+            self.db = connector.DBConnector(self.basedir)
+            self.db.setServiceParent(master)
             return self.db.setup(check_version=False)
         # note the connector isn't started, as we're testing upgrades
         return d

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -63,14 +63,17 @@ class Www(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase):
         master = fakemaster.FakeMaster()
 
         master.config.db = dict(db_url=self.db_url)
-        master.db = dbconnector.DBConnector(master, 'basedir')
+        master.db = dbconnector.DBConnector('basedir')
+        master.db.setServiceParent(master)
         yield master.db.setup(check_version=False)
 
         master.config.mq = dict(type='simple')
-        master.mq = mqconnector.MQConnector(master)
+        master.mq = mqconnector.MQConnector()
+        master.mq.setServiceParent(master)
         master.mq.setup()
 
-        master.data = dataconnector.DataConnector(master)
+        master.data = dataconnector.DataConnector()
+        master.data.setServiceParent(master)
 
         master.config.www = dict(
             port='tcp:0:interface=127.0.0.1',
@@ -78,7 +81,8 @@ class Www(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase):
             auth=auth.NoAuth(),
             avatar_methods=[],
             logfileName='http.log')
-        master.www = wwwservice.WWWService(master)
+        master.www = wwwservice.WWWService()
+        master.www.setServiceParent(master)
         yield master.www.startService()
         yield master.www.reconfigServiceWithBuildbotConfig(master.config)
 

--- a/master/buildbot/test/regressions/test_import_unicode_changes.py
+++ b/master/buildbot/test/regressions/test_import_unicode_changes.py
@@ -28,7 +28,8 @@ class TestUnicodeChanges(change_import.ChangeImportMixin, unittest.TestCase):
         def make_dbc(_):
             master = fakemaster.make_master()
             master.config.db['db_url'] = self.db_url
-            self.db = DBConnector(master, self.basedir)
+            self.db = DBConnector(self.basedir)
+            self.db.setServiceParent(master)
             return self.db.setup(check_version=False)
 
         # note the connector isn't started, as we're testing upgrades

--- a/master/buildbot/test/unit/test_buildslave_base.py
+++ b/master/buildbot/test/unit/test_buildslave_base.py
@@ -106,9 +106,9 @@ class RealBuildSlaveItfc(unittest.TestCase, BuildSlaveInterfaceTests):
 
     def callAttached(self):
         self.master = fakemaster.make_master(testcase=self, wantData=True)
-        self.botmaster = botmaster.FakeBotMaster(self.master)
-        self.buildslaves = bslavemanager.FakeBuildslaveManager(self.master)
-        self.master.botmaster = self.botmaster
+        self.master.buildslaves.disownServiceParent()
+        self.buildslaves = bslavemanager.FakeBuildslaveManager()
+        self.buildslaves.setServiceParent(self.master)
         self.master.buildslaves = self.buildslaves
         self.sl.setServiceParent(self.master.buildslaves)
         self.conn = fakeprotocol.FakeConnection(self.master, self.sl)
@@ -132,7 +132,9 @@ class TestAbstractBuildSlave(unittest.TestCase):
         self.master = fakemaster.make_master(wantDb=True, wantData=True,
                                              testcase=self)
         self.botmaster = self.master.botmaster
-        self.buildslaves = bslavemanager.FakeBuildslaveManager(self.master)
+        self.master.buildslaves.disownServiceParent()
+        self.buildslaves = bslavemanager.FakeBuildslaveManager()
+        self.buildslaves.setServiceParent(self.master)
         self.clock = task.Clock()
         self.patch(reactor, 'callLater', self.clock.callLater)
         self.patch(reactor, 'seconds', self.clock.seconds)

--- a/master/buildbot/test/unit/test_buildslave_manager.py
+++ b/master/buildbot/test/unit/test_buildslave_manager.py
@@ -53,8 +53,10 @@ class TestBuildSlaveManager(unittest.TestCase):
         self.buildslaves = bslavemanager.BuildslaveManager(self.master)
         self.buildslaves.setServiceParent(self.master)
         # slaves expect a botmaster as well as a manager.
-        self.botmaster = botmaster.BotMaster(self.master)
+        self.master.botmaster.disownServiceParent()
+        self.botmaster = botmaster.BotMaster()
         self.master.botmaster = self.botmaster
+        self.master.botmaster.setServiceParent(self.master)
 
         self.new_config = mock.Mock()
         self.buildslaves.startService()

--- a/master/buildbot/test/unit/test_buildslave_protocols_base.py
+++ b/master/buildbot/test/unit/test_buildslave_protocols_base.py
@@ -27,7 +27,8 @@ class TestListener(unittest.TestCase):
 
     def test_constructor(self):
         master = fakemaster.make_master()
-        listener = base.Listener(master)
+        listener = base.Listener()
+        listener.setServiceParent(master)
         self.assertEqual(listener.master, master)
 
 

--- a/master/buildbot/test/unit/test_buildslave_protocols_pb.py
+++ b/master/buildbot/test/unit/test_buildslave_protocols_pb.py
@@ -29,14 +29,19 @@ class TestListener(unittest.TestCase):
     def setUp(self):
         self.master = fakemaster.make_master()
 
+    def makeListener(self):
+        listener = pb.Listener()
+        listener.setServiceParent(self.master)
+        return listener
+
     def test_constructor(self):
-        listener = pb.Listener(self.master)
+        listener = self.makeListener()
         self.assertEqual(listener.master, self.master)
         self.assertEqual(listener._registrations, {})
 
     @defer.inlineCallbacks
     def test_updateRegistration_simple(self):
-        listener = pb.Listener(self.master)
+        listener = self.makeListener()
         reg = yield listener.updateRegistration('example', 'pass', 'tcp:1234')
         self.assertEqual(self.master.pbmanager._registrations,
                          [('tcp:1234', 'example', 'pass')])
@@ -44,7 +49,7 @@ class TestListener(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_updateRegistration_pass_changed(self):
-        listener = pb.Listener(self.master)
+        listener = self.makeListener()
         listener.updateRegistration('example', 'pass', 'tcp:1234')
         reg1 = yield listener.updateRegistration('example', 'pass1', 'tcp:1234')
         self.assertEqual(listener._registrations['example'], ('pass1', 'tcp:1234', reg1))
@@ -52,7 +57,7 @@ class TestListener(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_updateRegistration_port_changed(self):
-        listener = pb.Listener(self.master)
+        listener = self.makeListener()
         listener.updateRegistration('example', 'pass', 'tcp:1234')
         reg1 = yield listener.updateRegistration('example', 'pass', 'tcp:4321')
         self.assertEqual(listener._registrations['example'], ('pass', 'tcp:4321', reg1))
@@ -60,7 +65,7 @@ class TestListener(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_getPerspective(self):
-        listener = pb.Listener(self.master)
+        listener = self.makeListener()
         buildslave = mock.Mock()
         buildslave.slavename = 'test'
         mind = mock.Mock()

--- a/master/buildbot/test/unit/test_changes_manager.py
+++ b/master/buildbot/test/unit/test_changes_manager.py
@@ -16,6 +16,7 @@
 import mock
 
 from buildbot.changes import manager
+from buildbot.test.fake import fakemaster
 from buildbot.util import service
 from twisted.trial import unittest
 
@@ -27,8 +28,9 @@ class FakeChangeSource(service.ClusteredBuildbotService):
 class TestChangeManager(unittest.TestCase):
 
     def setUp(self):
-        self.master = mock.Mock()
-        self.cm = manager.ChangeManager(self.master)
+        self.master = fakemaster.make_master()
+        self.cm = manager.ChangeManager()
+        self.cm.setServiceParent(self.master)
         self.new_config = mock.Mock()
 
     def make_sources(self, n):

--- a/master/buildbot/test/unit/test_data_connector.py
+++ b/master/buildbot/test/unit/test_data_connector.py
@@ -103,7 +103,8 @@ class TestDataConnector(unittest.TestCase, Tests):
     def setUp(self):
         self.master = fakemaster.make_master(testcase=self,
                                              wantMq=True)
-        self.data = connector.DataConnector(self.master)
+        self.data = connector.DataConnector()
+        self.data.setServiceParent(self.master)
 
 
 class DataConnector(unittest.TestCase):
@@ -112,7 +113,8 @@ class DataConnector(unittest.TestCase):
         self.master = fakemaster.make_master()
         # don't load by default
         self.patch(connector.DataConnector, 'submodules', [])
-        self.data = connector.DataConnector(self.master)
+        self.data = connector.DataConnector()
+        self.data.setServiceParent(self.master)
 
     def patchFooPattern(self):
         cls = type('FooEndpoint', (base.Endpoint,), {})

--- a/master/buildbot/test/unit/test_data_root.py
+++ b/master/buildbot/test/unit/test_data_root.py
@@ -51,7 +51,9 @@ class SpecEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def setUp(self):
         self.setUpEndpoint()
         # replace fakeConnector with real DataConnector
-        self.master.data = connector.DataConnector(self.master)
+        self.master.data.disownServiceParent()
+        self.master.data = connector.DataConnector()
+        self.master.data.setServiceParent(self.master)
 
     def tearDown(self):
         self.tearDownEndpoint()

--- a/master/buildbot/test/unit/test_db_builds.py
+++ b/master/buildbot/test/unit/test_db_builds.py
@@ -326,8 +326,8 @@ class RealTests(Tests):
 class TestFakeDB(unittest.TestCase, Tests):
 
     def setUp(self):
-        self.master = fakemaster.make_master()
-        self.db = fakedb.FakeDBConnector(self.master, self)
+        self.master = fakemaster.make_master(wantDb=True, testcase=self)
+        self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData
 

--- a/master/buildbot/test/unit/test_db_buildslaves.py
+++ b/master/buildbot/test/unit/test_db_buildslaves.py
@@ -517,7 +517,8 @@ class TestFakeDB(unittest.TestCase, Tests):
 
     def setUp(self):
         self.master = fakemaster.make_master()
-        self.db = fakedb.FakeDBConnector(self.master, self)
+        self.db = fakedb.FakeDBConnector(self)
+        self.db.setServiceParent(self.master)
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData
 

--- a/master/buildbot/test/unit/test_db_changes.py
+++ b/master/buildbot/test/unit/test_db_changes.py
@@ -822,8 +822,8 @@ class RealTests(Tests):
 class TestFakeDB(unittest.TestCase, Tests):
 
     def setUp(self):
-        self.master = fakemaster.make_master()
-        self.db = fakedb.FakeDBConnector(self.master, self)
+        self.master = fakemaster.make_master(wantDb=True, testcase=self)
+        self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData
 

--- a/master/buildbot/test/unit/test_db_connector.py
+++ b/master/buildbot/test/unit/test_db_connector.py
@@ -40,8 +40,8 @@ class DBConnector(db.RealDatabaseMixin, unittest.TestCase):
 
         self.master = fakemaster.make_master()
         self.master.config = config.MasterConfig()
-        self.db = connector.DBConnector(self.master,
-                                        os.path.abspath('basedir'))
+        self.db = connector.DBConnector(os.path.abspath('basedir'))
+        self.db.setServiceParent(self.master)
 
     @defer.inlineCallbacks
     def tearDown(self):

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -470,8 +470,8 @@ class RealTests(Tests):
 class TestFakeDB(unittest.TestCase, Tests):
 
     def setUp(self):
-        self.master = fakemaster.make_master()
-        self.db = fakedb.FakeDBConnector(self.master, self)
+        self.master = fakemaster.make_master(wantDb=True, testcase=self)
+        self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData
 

--- a/master/buildbot/test/unit/test_db_masters.py
+++ b/master/buildbot/test/unit/test_db_masters.py
@@ -204,8 +204,8 @@ class TestFakeDB(unittest.TestCase, Tests):
     def setUp(self):
         self.clock = task.Clock()
         self.clock.advance(SOMETIME)
-        self.master = fakemaster.make_master()
-        self.db = fakedb.FakeDBConnector(self.master, self)
+        self.master = fakemaster.make_master(wantDb=True, testcase=self)
+        self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData
 

--- a/master/buildbot/test/unit/test_db_steps.py
+++ b/master/buildbot/test/unit/test_db_steps.py
@@ -326,8 +326,8 @@ class RealTests(Tests):
 class TestFakeDB(unittest.TestCase, Tests):
 
     def setUp(self):
-        self.master = fakemaster.make_master()
-        self.db = fakedb.FakeDBConnector(self.master, self)
+        self.master = fakemaster.make_master(wantDb=True, testcase=self)
+        self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData
 

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -41,7 +41,9 @@ class OldTriggeringMethods(unittest.TestCase):
         self.master = master.BuildMaster(basedir=None)
 
         self.master.data = fakedata.FakeDataConnector(self.master, self)
-        self.master.db = fakedb.FakeDBConnector(self.master, self)
+        self.master.data.setServiceParent(self.master)
+        self.db = self.master.db = fakedb.FakeDBConnector(self)
+        self.db.setServiceParent(self.master)
         self.master.db.insertTestData([
             fakedb.Change(changeid=1, author='this is a test'),
         ])
@@ -136,9 +138,12 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
                        classmethod(lambda cls, b, f: cls()))
 
             self.master = master.BuildMaster(self.basedir)
-            self.db = self.master.db = fakedb.FakeDBConnector(self.master, self)
-            self.mq = self.master.mq = fakemq.FakeMQConnector(self.master, self)
+            self.db = self.master.db = fakedb.FakeDBConnector(self)
+            self.db.setServiceParent(self.master)
+            self.mq = self.master.mq = fakemq.FakeMQConnector(self)
+            self.mq.setServiceParent(self.master)
             self.data = self.master.data = fakedata.FakeDataConnector(self.master, self)
+            self.data.setServiceParent(self.master)
 
         return d
 

--- a/master/buildbot/test/unit/test_mq.py
+++ b/master/buildbot/test/unit/test_mq.py
@@ -128,4 +128,5 @@ class TestSimpleMQ(unittest.TestCase, RealTests):
 
     def setUp(self):
         self.master = fakemaster.make_master()
-        self.mq = simple.SimpleMQ(self.master)
+        self.mq = simple.SimpleMQ()
+        self.mq.setServiceParent(self.master)

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -17,6 +17,7 @@ import mock
 
 from buildbot.mq import base
 from buildbot.mq import connector
+from buildbot.test.fake import fakemaster
 from buildbot.util import service
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -40,9 +41,10 @@ class FakeMQ(service.ReconfigurableServiceMixin, base.MQBase):
 class MQConnector(unittest.TestCase):
 
     def setUp(self):
-        self.master = mock.Mock(name='master')
+        self.master = fakemaster.make_master()
         self.mqconfig = self.master.config.mq = {}
-        self.conn = connector.MQConnector(self.master)
+        self.conn = connector.MQConnector()
+        self.conn.setServiceParent(self.master)
 
     def patchFakeMQ(self, name='fake'):
         self.patch(connector.MQConnector, 'classes',

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -26,7 +26,9 @@ from twisted.trial import unittest
 class TestCleanShutdown(unittest.TestCase):
 
     def setUp(self):
-        self.botmaster = BotMaster(mock.Mock())
+        master = fakemaster.make_master(testcase=self, wantData=True)
+        self.botmaster = BotMaster()
+        self.botmaster.setServiceParent(master)
         self.reactor = mock.Mock()
         self.botmaster.startService()
 
@@ -114,7 +116,9 @@ class TestBotMaster(unittest.TestCase):
         self.master = fakemaster.make_master(testcase=self, wantMq=True,
                                              wantData=True)
         self.master.mq = self.master.mq
-        self.botmaster = BotMaster(self.master)
+        self.master.botmaster.disownServiceParent()
+        self.botmaster = BotMaster()
+        self.botmaster.setServiceParent(self.master)
         self.new_config = mock.Mock()
         self.botmaster.startService()
 

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -31,7 +31,6 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake import fakeprotocol
 from buildbot.test.fake import slave
 from buildbot.test.fake.fakebuild import FakeBuildStatus
-from buildbot.test.fake.fakemaster import FakeBotMaster
 from twisted.internet import defer
 from twisted.trial import unittest
 from zope.interface import implements
@@ -130,8 +129,6 @@ class TestBuild(unittest.TestCase):
 
         self.request = r
         self.master = fakemaster.make_master(wantData=True, testcase=self)
-
-        self.master.botmaster = FakeBotMaster(master=self.master)
 
         self.slave = slave.FakeSlave(self.master)
         self.slave.attached(None)

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -61,6 +61,7 @@ class TestBRDBase(unittest.TestCase):
         self.master.caches = fakemaster.FakeCaches()
         self.master.config.prioritizeBuilders = prioritizeBuilders
         self.brd = buildrequestdistributor.BuildRequestDistributor(self.botmaster)
+        self.brd.parent = self.botmaster
         self.brd.startService()
 
         # TODO: this is a terrible way to detect the "end" of the test -

--- a/master/buildbot/test/unit/test_process_debug.py
+++ b/master/buildbot/test/unit/test_process_debug.py
@@ -17,6 +17,7 @@ import mock
 
 from buildbot import config
 from buildbot.process import debug
+from buildbot.test.fake import fakemaster
 from buildbot.util import service
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -34,9 +35,10 @@ class TestDebugServices(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_reconfigService_manhole(self):
-        master = mock.Mock(name='master')
-        ds = debug.DebugServices(master)
-        ds.startService()
+        master = fakemaster.make_master()
+        ds = debug.DebugServices()
+        ds.setServiceParent(master)
+        yield master.startService()
 
         # start off with no manhole
         yield ds.reconfigServiceWithBuildbotConfig(self.config)
@@ -59,8 +61,8 @@ class TestDebugServices(unittest.TestCase):
         self.config.manhole = manhole
         yield ds.reconfigServiceWithBuildbotConfig(self.config)
 
-        # stop the service, and see that it unregisters
-        yield ds.stopService()
+        # disown the service, and see that it unregisters
+        yield ds.disownServiceParent()
 
         self.assertFalse(manhole.running)
         self.assertIdentical(manhole.master, None)

--- a/master/buildbot/test/unit/test_process_users_manual.py
+++ b/master/buildbot/test/unit/test_process_users_manual.py
@@ -286,7 +286,7 @@ class TestCommandlineUserManager(unittest.TestCase, ManualUsersMixin):
         self.manual_component = manual.CommandlineUserManager(username="user",
                                                               passwd="userpw",
                                                               port="9990")
-        self.manual_component.master = self.master
+        self.manual_component.setServiceParent(self.master)
 
     def test_no_userpass(self):
         d = defer.maybeDeferred(lambda: manual.CommandlineUserManager())

--- a/master/buildbot/test/unit/test_scripts_cleanupdb.py
+++ b/master/buildbot/test/unit/test_scripts_cleanupdb.py
@@ -104,7 +104,8 @@ class TestCleanupDb(misc.StdoutAssertionsMixin, dirs.DirsMixin,
                                                   'buildslaves'])
         master = fakemaster.make_master()
         master.config.db['db_url'] = self.db_url
-        self.db = DBConnector(master, self.basedir)
+        self.db = DBConnector(self.basedir)
+        self.db.setServiceParent(master)
         self.db.pool = self.db_pool
 
         # we reuse the fake db background data from db.logs unit tests

--- a/master/buildbot/test/unit/test_status_buildset.py
+++ b/master/buildbot/test/unit/test_status_buildset.py
@@ -50,7 +50,6 @@ class TestBuildSetSummaryNotifierMixin(unittest.TestCase):
             return {"Builder0": builders[0], "Builder1": builders[1], "Builder2": builders[2]}[buildername]
 
         notifier.master_status.getBuilder = fakeGetBuilder
-        notifier.master.db = fakedb.FakeDBConnector(notifier.master, self)
 
         notifier.master.db.insertTestData([
             fakedb.Master(id=92),

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -106,7 +106,8 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
         m = self.master
         m.db.checkForeignKeys = True
         self.build.builder.botmaster = m.botmaster
-        m.status = master.Status(m)
+        m.status = master.Status()
+        m.status.setServiceParent(m)
         m.config.buildbotURL = "baseurl/"
         m.scheduler_manager = FakeSchedulerManager()
 

--- a/master/buildbot/test/unit/test_www_hooks_poller.py
+++ b/master/buildbot/test/unit/test_www_hooks_poller.py
@@ -43,8 +43,8 @@ class TestPollingChangeHook(unittest.TestCase):
         self.request.method = "GET"
 
         master = self.request.site.master
-        master.change_svc = ChangeManager(master)
-
+        master.change_svc = ChangeManager()
+        master.change_svc.setServiceParent(master)
         self.changesrc = self.Subclass("example", 21)
         self.changesrc.setServiceParent(master.change_svc)
         if activate:

--- a/master/buildbot/test/unit/test_www_service.py
+++ b/master/buildbot/test/unit/test_www_service.py
@@ -42,7 +42,8 @@ class Test(www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
         self.master = fakemaster.make_master()
-        self.svc = self.master.www = service.WWWService(self.master)
+        self.svc = self.master.www = service.WWWService()
+        self.svc.setServiceParent(self.master)
 
     def makeConfig(self, **kwargs):
         pwd = os.getcwd()

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -44,7 +44,8 @@ class MigrateTestMixin(db.RealDatabaseMixin, dirs.DirsMixin):
         @d.addCallback
         def make_dbc(_):
             master = fakemaster.make_master()
-            self.db = connector.DBConnector(master, self.basedir)
+            self.db = connector.DBConnector(self.basedir)
+            self.db.setServiceParent(master)
             self.db.pool = self.db_pool
         return d
 

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -36,11 +36,10 @@ from zope.interface import implements
 
 
 class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
+    name = 'www'
 
-    def __init__(self, master):
+    def __init__(self):
         service.AsyncMultiService.__init__(self)
-        self.setName('www')
-        self.master = master
 
         self.port = None
         self.port_service = None

--- a/master/contrib/fakemaster.py
+++ b/master/contrib/fakemaster.py
@@ -130,10 +130,10 @@ class CmdInterface(basic.LineReceiver):
             self.transport.write("\n# ")
 
 
-class FakeMaster(service.AsyncMultiService):
+class FakeMaster(service.MasterService):
 
     def __init__(self, port):
-        service.AsyncMultiService.__init__(self)
+        service.MasterService.__init__(self)
         self.setName("fakemaster")
 
         self.dispatcher = Dispatcher()
@@ -149,7 +149,7 @@ class FakeMaster(service.AsyncMultiService):
         self.slavePort.setServiceParent(self)
 
         stdio.StandardIO(self.stdio)
-        return service.AsyncMultiService.startService(self)
+        return service.MasterService.startService(self)
 
     def getPerspective(self, mind, avatarID):
         self.bot = FakeBot()


### PR DESCRIPTION
method: 

- trial -x buildbot.unit
- fix the setMaster, by properly setting the service hierarchy.

TODO: 
- [x] 73 crashes in the unit tests