### PR TITLE
Allow self.master to be set so it can be used before service setup.

### DIFF
--- a/master/buildbot/scripts/cleanupdb.py
+++ b/master/buildbot/scripts/cleanupdb.py
@@ -21,7 +21,6 @@ import sys
 
 from buildbot import config as config_module
 from buildbot import monkeypatches
-from buildbot.db import connector
 from buildbot.master import BuildMaster
 from buildbot.scripts import base
 from buildbot.util import in_reactor
@@ -35,8 +34,7 @@ def doCleanupDatabase(config, master_cfg):
 
     master = BuildMaster(config['basedir'])
     master.config = master_cfg
-    print(master.config.logCompressionMethod)
-    db = connector.DBConnector(master, basedir=config['basedir'])
+    db = master.db
 
     yield db.setup(check_version=False, verbose=not config['quiet'])
     res = yield db.logs.getLogs()

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -173,11 +173,10 @@ class RunSteps(unittest.TestCase):
 
         self.slave = BuildSlave('bsl', 'pass')
         self.slave.sendBuilderList = lambda: defer.succeed(None)
-        self.slave.parent = mock.Mock()
+        self.slave.parent = self.master
         self.slave.master.botmaster = mock.Mock()
         self.slave.botmaster.maybeStartBuildsForSlave = lambda sl: None
         self.slave.botmaster.getBuildersForSlave = lambda sl: []
-        self.slave.parent = self.master
         self.slave.startService()
         self.conn = fakeprotocol.FakeConnection(self.master, self.slave)
         yield self.slave.attached(self.conn)

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -124,7 +124,6 @@ class SchedulerManager(unittest.TestCase):
         yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
 
         self.assertIdentical(sch1.parent, None)
-        self.assertIdentical(sch1.master, None)
 
     @defer.inlineCallbacks
     def test_reconfigService_class_name_change(self):

--- a/master/buildbot/test/util/changesource.py
+++ b/master/buildbot/test/util/changesource.py
@@ -48,7 +48,8 @@ class ChangeSourceMixin(object):
             return
         if self.changesource.running:
             yield defer.maybeDeferred(self.changesource.stopService)
-        yield self.changesource.disownServiceParent()
+        if self.changesource.parent:
+            yield self.changesource.disownServiceParent()
         return
 
     def attachChangeSource(self, cs):

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -45,7 +45,7 @@ class ReconfigurableServiceMixin:
             yield svc.reconfigServiceWithBuildbotConfig(new_config)
 
 
-class AsyncService(service.Service):
+class AsyncService(service.Service, object):
 
     @defer.inlineCallbacks
     def setServiceParent(self, parent):

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -91,12 +91,34 @@ class AsyncMultiService(AsyncService, service.MultiService):
         else:
             return defer.succeed(None)
 
+    # Assuming this instance is a child service of the BuildMaster, self.master
+    # is a link to the master.  Since this only occurs when the service
+    # hierarchy is established (so, after the constructor and an synchronous
+    # call to setServiceParent), it's also possible to set self.master
+    # directly.
+
+    def disownServiceParent(self):
+        try:
+            del self.__master
+        except AttributeError:
+            pass
+        return service.MultiService.disownServiceParent(self)
+
     # We recurse over the parent services until we find a MasterService
-    @property
-    def master(self):
+    def __get_master(self):
+        try:
+            return self.__master
+        except AttributeError:
+            pass
         if self.parent is None:
             return None
-        return self.parent.master
+        self.__master = m = self.parent.master
+        return m
+
+    def __set_master(self, master):
+        self.__master = master
+
+    master = property(__get_master, __set_master)
 
 
 class MasterService(AsyncMultiService):

--- a/master/setup.py
+++ b/master/setup.py
@@ -399,7 +399,7 @@ else:
         # version.
         'sqlalchemy-migrate==0.7.2',
         'python-dateutil>=1.5',
-        'autobahn >= 0.10.2',
+        'autobahn >= 0.10.2 <= 0.10.5',
     ]
 
     setup_args['extras_require'] = {

--- a/master/setup.py
+++ b/master/setup.py
@@ -386,7 +386,7 @@ except ImportError:
 else:
     # dependencies
     setup_args['install_requires'] = [
-        'twisted >= 11.0.0, <= 15.0.0',
+        'twisted >= 11.0.0',
         'Jinja2 >= 2.1',
         'zope.interface >= 4.1.1',  # required for tests, but Twisted requires this anyway
         'future'


### PR DESCRIPTION
This also addresses a few testing issues, caches the master property,
and invalidates the cache on disownServiceParent.  Fixes #3329.