### PR TITLE
synchronize the twisted dependancies with Autobahn

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -388,7 +388,7 @@ except ImportError:
 else:
     # dependencies
     setup_args['install_requires'] = [
-        'twisted >= 11.0.0',
+        'twisted >= 12.1.0',
         'Jinja2 >= 2.1',
         'zope.interface >= 4.1.1',  # required for tests, but Twisted requires this anyway
         'future'


### PR DESCRIPTION
As per https://github.com/tavendo/AutobahnPython/issues/443

Autobahn is only fully supporting Twisted 12.1. (a few tests fail on 11.1)
I am proposing to use the same minimum version for consistency.
