### PR TITLE
Fix #3248: BuildStep: fix up interrupt logic

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -389,11 +389,24 @@ class BuildStep(object, properties.PropertiesMixin):
         raise NotImplementedError("your subclass must implement run()")
 
     def interrupt(self, reason):
+        # TODO: consider adding an INTERRUPTED or STOPPED status to use
+        # instead of FAILURE, might make the text a bit more clear.
+        # 'reason' can be a Failure, or text
         self.stopped = True
         if self._acquiringLock:
             lock, access, d = self._acquiringLock
             lock.stopWaitingUntilAvailable(self, access, d)
             d.callback(None)
+
+        if self._step_status.isWaitingForLocks():
+            self.addCompleteLog(
+                'interrupt while waiting for locks', str(reason))
+        else:
+            self.addCompleteLog('interrupt', str(reason))
+
+        if self.cmd:
+            d = self.cmd.interrupt(reason)
+            d.addErrback(log.err, 'while interrupting command')
 
     def releaseLocks(self):
         log.msg("releaseLocks(%s): %s" % (self, self.locks))
@@ -682,21 +695,6 @@ class LoggingBuildStep(BuildStep):
                 newlog = self.addLog(logname)
                 # and tell the RemoteCommand to feed it
                 cmd.useLog(newlog, True)
-
-    def interrupt(self, reason):
-        # TODO: consider adding an INTERRUPTED or STOPPED status to use
-        # instead of FAILURE, might make the text a bit more clear.
-        # 'reason' can be a Failure, or text
-        BuildStep.interrupt(self, reason)
-        if self._step_status.isWaitingForLocks():
-            self.addCompleteLog(
-                'interrupt while waiting for locks', str(reason))
-        else:
-            self.addCompleteLog('interrupt', str(reason))
-
-        if self.cmd:
-            d = self.cmd.interrupt(reason)
-            d.addErrback(log.err, 'while interrupting command')
 
     def checkDisconnect(self, f):
         # this is now handled by self.failed


### PR DESCRIPTION
I'm still testing this patch on my own bot, but wanted to put up for comments. It seems that all the logic in the derived Interrupt function belongs in the base:
 - self.cmd is checked and set in the base
 - 'setWaitingForLocks' is set by the base