### PR TITLE
Material UI : generate force build form according to fields definition returned from server

### DIFF
--- a/www/md_base/guanlecoja/config.coffee
+++ b/www/md_base/guanlecoja/config.coffee
@@ -55,7 +55,7 @@ config =
                 version: '0.10.1'
                 files: 'angular-moment.js'
             'buildbot-data':
-                version: '~1.0.10'
+                version: '~1.0.11'
                 files: 'dist/buildbot-data.js'
             lodash:
                 version: '~2.4.1'

--- a/www/md_base/src/app/builds/builder/forcedialog/builds.forcedialog.tpl.jade
+++ b/www/md_base/src/app/builds/builder/forcedialog/builds.forcedialog.tpl.jade
@@ -3,48 +3,11 @@ md-dialog.force-dialog
     div.md-toolbar-tools
       h2 Force build
   md-dialog-content
-    div.fieldset(layout="column")
-      md-input-container(md-is-error="forcedialog.field_errors.username")
-        label Username
-        input(ng-model="forcedialog.fields.username")
-      md-input-container(md-is-error="forcedialog.field_errors.reason")
-        label Build Reason
-        input(ng-model="forcedialog.fields.reason")
-
-    div.fieldset(layout="column", layout-gt-md="row")
-      md-input-container(flex, flex-gt-md="50", md-is-error="forcedialog.field_errors.project")
-        label Project
-        input(ng-model="forcedialog.fields.project")
-      md-input-container(flex, flex-gt-md="50", md-is-error="forcedialog.field_errors.repository")
-        label Repository
-        input(ng-model="forcedialog.fields.repository")
-    div.fieldset(layout="column", layout-gt-md="row")
-      md-input-container(flex, flex-gt-md="50", md-is-error="forcedialog.field_errors.branch")
-        label Branch
-        input(ng-model="forcedialog.fields.branch")
-      md-input-container(flex, flex-gt-md="50", md-is-error="forcedialog.field_errors.revision")
-        label Revision
-        input(ng-model="forcedialog.fields.revision")
-    div.errors(ng-messages="forcedialog.field_errors", ng-if="forcedialog.field_errors")
-      div(ng-message="username")
-        b Username: 
-        | {{ forcedialog.field_errors.username }}
-      div(ng-message="reason")
-        b Reason: 
-        | {{ forcedialog.field_errors.reason}}
-      div(ng-message="project")
-        b Project: 
-        | {{ forcedialog.field_errors.project }}
-      div(ng-message="repository")
-        b Repository: 
-        | {{ forcedialog.field_errors.repository }}
-      div(ng-message="branch")
-        b Branch: 
-        | {{ forcedialog.field_errors.branch }}
-      div(ng-message="revision")
-        b Revision: 
-        | {{ forcedialog.field_errors.revision }}
-
+    forcebuild-form(
+      model="forcedialog.data",
+      fields="forcedialog.fields",
+      errors="forcedialog.field_errors"
+    )
   div.md-actions(layout="row")
     span(flex)
     md-button(ng-click="forcedialog.cancel()") Cancel

--- a/www/md_base/src/app/builds/builder/forcedialog/forcedialog.controller.coffee
+++ b/www/md_base/src/app/builds/builder/forcedialog/forcedialog.controller.coffee
@@ -1,6 +1,6 @@
 class ForceDialog extends Controller
-
-    fields: {}
+    data: {}
+    fields: []
     field_errors: null
 
     cancel: ->
@@ -8,7 +8,7 @@ class ForceDialog extends Controller
 
     confirm: ->
         param = builderid: @builder.builderid
-        _.extend param, @fields
+        _.extend param, @data
         @forceBuild param
 
     forceBuildSuccess: ->
@@ -31,11 +31,13 @@ class ForceDialog extends Controller
         res.then (=> @forceBuildSuccess()), (data) => @forceBuildFail(data.error)
 
     constructor: (@builder, @scheduler, @dataService, @restService, @$mdDialog) ->
+        @fields = @scheduler.all_fields
+
         parseFields = (field) =>
             if field.nested
                 parseFields(subfield) for subfield in field.fields
             else if field.name
-                @fields[field.name] = field.default
+                @data[field.name] = field.default
 
-        parseFields(field) for field in @scheduler.all_fields
+        parseFields(field) for field in @fields
 

--- a/www/md_base/src/app/builds/builder/forcedialog/forcedialog.controller.coffee
+++ b/www/md_base/src/app/builds/builder/forcedialog/forcedialog.controller.coffee
@@ -8,7 +8,7 @@ class ForceDialog extends Controller
 
     confirm: ->
         param = builderid: @builder.builderid
-        _.extend param, @data
+        angular.extend param, @data
         @forceBuild param
 
     forceBuildSuccess: ->

--- a/www/md_base/src/app/builds/builder/forcedialog/forcedialog.controller.coffee
+++ b/www/md_base/src/app/builds/builder/forcedialog/forcedialog.controller.coffee
@@ -16,21 +16,17 @@ class ForceDialog extends Controller
         @$mdDialog.hide()
 
     forceBuildFail: (error) ->
-        if error.code == -32602
+        if error.code == -32602 # Non-networking error
             @field_errors = data.error.message
         else
             alert "Unexpected error occurs, please try again."
             @field_errors = null
 
     forceBuild: (param) ->
-        res = @restService.post 'forceschedulers/force',
-            id: @dataService.getNextId()
-            jsonrpc: '2.0'
-            method: 'force'
-            params: param
+        res = @dataService.control 'forceschedulers/force', 'force', param
         res.then (=> @forceBuildSuccess()), (data) => @forceBuildFail(data.error)
 
-    constructor: (@builder, @scheduler, @dataService, @restService, @$mdDialog) ->
+    constructor: (@builder, @scheduler, @dataService, @$mdDialog) ->
         @fields = @scheduler.all_fields
 
         parseFields = (field) =>

--- a/www/md_base/src/app/builds/builder/forcedialog/forcedialog.less
+++ b/www/md_base/src/app/builds/builder/forcedialog/forcedialog.less
@@ -1,9 +1,2 @@
 .force-dialog {
-  .errors {
-    color: red;
-
-    div {
-      margin: 5px;
-    }
-  }
 }

--- a/www/md_base/src/app/common/directives/changeitem/changeitem.spec.coffee
+++ b/www/md_base/src/app/common/directives/changeitem/changeitem.spec.coffee
@@ -5,8 +5,6 @@ describe 'changeitem', ->
     injected = ($injector) ->
         $compile = $injector.get('$compile')
         $rootScope = $injector.get('$rootScope')
-        webSocketService = $injector.get('webSocketService')
-        spyOn(webSocketService, 'getWebSocket').and.returnValue({})
 
     beforeEach inject injected
 

--- a/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.directive.coffee
+++ b/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.directive.coffee
@@ -1,0 +1,14 @@
+class ForcebuildForm extends Directive
+
+    constructor: ->
+        return {
+            restrict: 'E'
+            templateUrl: 'views/buildstep.html'
+            controller: '_ForcebuildFormController'
+            controllerAs: 'form'
+            bindToController: true
+            scope:
+                fields: '='
+        }
+
+class _ForcebuildForm extends Controller

--- a/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.directive.coffee
+++ b/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.directive.coffee
@@ -23,7 +23,7 @@ class _ForcebuildForm extends Controller
         elem.attr(attributes) if attributes
         return elem
 
-    labelElemnt: (text) ->
+    labelElement: (text) ->
         text = text.trim().replace /:$/, ''
         return null if not text
         label = @element 'label'
@@ -101,7 +101,7 @@ class _ForcebuildForm extends Controller
             'required': field.required
             'ng-model': "form.model.#{ field.name }"
             'md-is-error': "form.errors.#{ field.name }"
-        container.append @labelElemnt field.label
+        container.append @labelElement field.label
         container.append input
         elem.append container
         return elem
@@ -113,7 +113,7 @@ class _ForcebuildForm extends Controller
             'required': field.required
             'ng-model': "form.model.#{ field.name }"
             'md-is-error': "form.errors.#{ field.name }"
-        container.append @labelElemnt field.label
+        container.append @labelElement field.label
         container.append textarea
         elem.append container
         return elem
@@ -126,7 +126,7 @@ class _ForcebuildForm extends Controller
             'required': field.required
             'ng-model': "form.model.#{ field.name }"
             'md-is-error': "form.errors.#{ field.name }"
-        container.append @labelElemnt field.label
+        container.append @labelElement field.label
         container.append input
         elem.append container
         return elem
@@ -152,7 +152,7 @@ class _ForcebuildForm extends Controller
             f = @element 'md-option', value: choice
             f.text(choice)
             select.append f
-        container.append @labelElemnt field.label
+        container.append @labelElement field.label
         container.append select
         elem.append container
         return elem

--- a/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.directive.coffee
+++ b/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.directive.coffee
@@ -3,12 +3,158 @@ class ForcebuildForm extends Directive
     constructor: ->
         return {
             restrict: 'E'
-            templateUrl: 'views/buildstep.html'
             controller: '_ForcebuildFormController'
             controllerAs: 'form'
             bindToController: true
             scope:
+                model: '='
                 fields: '='
+                errors: '='
         }
 
 class _ForcebuildForm extends Controller
+
+    constructor: ($scope, $element, $compile) ->
+        elem = $compile(@buildfields())($scope)
+        console.log elem
+        $element.append elem
+
+    element: (tag, attributes) ->
+        elem = angular.element("<#{tag}></#{tag}>")
+        elem.attr(attributes) if attributes
+        return elem
+
+    labelElemnt: (text) ->
+        text = text.trim().replace /:$/, ''
+        return null if not text
+        label = @element 'label'
+        label.text(text)
+        return label
+
+    buildfields: ->
+        elem = @element 'div', class: 'inner'
+        for field in @fields
+            elem.append @buildfield(field)
+        return elem
+
+    buildfield: (field) ->
+        console.log field
+        if field.type == 'nested'
+            # Build layout
+            switch field.layout
+                when 'vertical'
+                    return @verticalLayout(field)
+                when 'tab'
+                    return @tabLayout(field)
+                else
+                    return @simpleLayout(field)
+        else
+            # Build normal fields
+            switch field.type
+                when 'textarea'
+                    return @textareaField(field)
+                when 'int'
+                    return @intField(field)
+                when 'list'
+                    return @listField(field)
+                when 'bool'
+                    return @boolField(field)
+                else
+                    return @textField(field)
+
+    verticalLayout: (field) ->
+        layout = if field.columns > 1 then 'row' else 'column'
+        elem = @element 'div',
+            'class': 'vertical-layout'
+            'layout-gt-md': layout
+            'layout-wrap': 'layout-wrap'
+        flex = 'flex'
+        flex = '50' if field.columns == 2
+        flex = '33' if field.columns == 3
+        for subfield in field.fields
+            f = @buildfield(subfield)
+            f.attr {flex: 'flex', 'flex-gt-md': flex}
+            elem.append f
+        return elem
+
+    tabLayout: (field) ->
+        elem = @element 'div', class: 'tab-layout'
+        tabs = @element 'md-tabs',
+            'md-dynamic-height': 'md-dynamic-height'
+            'md-border-bottom': 'md-border-bottom'
+
+        for f in field.fields
+            tab = @element 'md-tab', label: f.label
+            tab.append @buildfield(f)
+            tabs.append tab
+
+        elem.append tabs
+        return elem
+
+    simpleLayout: (field) ->
+        elem = @element 'div', class: 'simple-layout'
+        elem.append(@buildfield(f)) for f in field.fields
+        return elem
+
+    textField: (field) ->
+        elem = @element 'div', class: 'text-field field'
+        container = @element 'md-input-container'
+        input = @element 'input',
+            'required': field.required
+            'ng-model': "form.model.#{ field.name }"
+            'md-is-error': "form.errors.#{ field.name }"
+        container.append @labelElemnt field.label
+        container.append input
+        elem.append container
+        return elem
+
+    textareaField: (field) ->
+        elem = @element 'div', class: 'textarea-field field'
+        container = @element 'md-input-container'
+        textarea = @element 'textarea',
+            'required': field.required
+            'ng-model': "form.model.#{ field.name }"
+            'md-is-error': "form.errors.#{ field.name }"
+        container.append @labelElemnt field.label
+        container.append textarea
+        elem.append container
+        return elem
+
+    intField: (field) ->
+        elem = @element 'div', class: 'int-field field'
+        container = @element 'md-input-container'
+        input = @element 'input',
+            'type': 'number'
+            'required': field.required
+            'ng-model': "form.model.#{ field.name }"
+            'md-is-error': "form.errors.#{ field.name }"
+        container.append @labelElemnt field.label
+        container.append input
+        elem.append container
+        return elem
+
+    boolField: (field) ->
+        elem = @element 'div', class: 'bool-field field'
+        checkbox = @element 'md-checkbox',
+            'ng-model': "form.model.#{ field.name }"
+            'md-is-error': "form.errors.#{ field.name }"
+        chechbox.text field.label.trim().replace /:$/, ''
+        elem.append checkbox
+        return elem
+
+    listField: (field) ->
+        elem = @element 'div', class: 'list-field field'
+        container = @element 'md-input-container'
+        select = @element 'md-select',
+            'required': field.required
+            'ng-model': "form.model.#{ field.name }"
+            'multiple': field.multiple
+            'md-is-error': "form.errors.#{ field.name }"
+        for choice in field.choices
+            f = @element 'md-option', value: choice
+            f.text(choice)
+            select.append f
+        container.append @labelElemnt field.label
+        container.append select
+        elem.append container
+        return elem

--- a/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.directive.coffee
+++ b/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.directive.coffee
@@ -16,7 +16,6 @@ class _ForcebuildForm extends Controller
 
     constructor: ($scope, $element, $compile) ->
         elem = $compile(@buildfields())($scope)
-        console.log elem
         $element.append elem
 
     element: (tag, attributes) ->
@@ -38,7 +37,6 @@ class _ForcebuildForm extends Controller
         return elem
 
     buildfield: (field) ->
-        console.log field
         if field.type == 'nested'
             # Build layout
             switch field.layout

--- a/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.less
+++ b/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.less
@@ -1,2 +1,4 @@
 forcebuild-form {
+  display: block;
+  overflow: hidden;
 }

--- a/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.less
+++ b/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.less
@@ -1,0 +1,2 @@
+forcebuild-form {
+}

--- a/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.spec.coffee
+++ b/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.spec.coffee
@@ -1,0 +1,19 @@
+beforeEach module 'app'
+
+describe 'forcebuildform', ->
+
+    $compile = $rootScope = $httpBackend = dataService = scope = RESULTS_TEXT = null
+    injected = ($injector) ->
+        $compile = $injector.get('$compile')
+        $rootScope = $injector.get('$rootScope')
+        $httpBackend = $injector.get('$httpBackend')
+        decorateHttpBackend($httpBackend)
+        $q = $injector.get('$q')
+        webSocketService = $injector.get('webSocketService')
+        spyOn(webSocketService, 'getWebSocket').and.returnValue({})
+        dataService = $injector.get('dataService')
+        spyOn(dataService, 'startConsuming').and.returnValue($q.resolve())
+        scope = $rootScope.$new()
+        RESULTS_TEXT = $injector.get('RESULTS_TEXT')
+
+    beforeEach inject injected

--- a/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.spec.coffee
+++ b/www/md_base/src/app/common/directives/forcebuildform/forcebuildform.spec.coffee
@@ -2,7 +2,7 @@ beforeEach module 'app'
 
 describe 'forcebuildform', ->
 
-    $compile = $rootScope = $httpBackend = dataService = scope = RESULTS_TEXT = null
+    $compile = $rootScope = $httpBackend = dataService = scope = null
     injected = ($injector) ->
         $compile = $injector.get('$compile')
         $rootScope = $injector.get('$rootScope')
@@ -14,6 +14,30 @@ describe 'forcebuildform', ->
         dataService = $injector.get('dataService')
         spyOn(dataService, 'startConsuming').and.returnValue($q.resolve())
         scope = $rootScope.$new()
-        RESULTS_TEXT = $injector.get('RESULTS_TEXT')
 
     beforeEach inject injected
+
+    it 'should show fields correctly', ->
+        $rootScope.fields =
+            type: 'nested'
+            layout: 'simple'
+            fields:[
+                type: 'int'
+                label: 'intlabel'
+            ,
+                type: 'textarea'
+                label: 'textarealabel'
+            ,
+                type: 'text'
+                label: 'textlabel'
+            ,
+                type: 'bool'
+                label: 'boollabel'
+            ,
+                type: 'list'
+                label: 'listlabel'
+                choices: ['a', 'b', 'c']
+            ]
+        $rootScope.data = {}
+        elem = $compile('<forcebuild-form fields="fields" data="data"></forcebuild-form>')($rootScope)
+        $rootScope.digest()


### PR DESCRIPTION
This PR is to enable the front end to generate the form for force build according to definitions that is returned by the server (which in return can be customized in config). And we are able to trigger a build with formal ways from new `dataService`. So the whole UI is now close to usable.

The only thing left undone is the tests for the new directive `forcebuild-form`. The reason is that the new dataService of @tothandras removed the dependency of `websocketService`, which is a dependency for request mocking and spying in tests. So many of the tests will be failed and it is hard to write and debug the tests. We may have to wait for some time for new HTTP and web socket mocking structure under new `dataService`.

@tardyp  The tests for this directive need not HTTP mocking, so I'm wondering if there is a way to run only part of the tests instead of all of them.

TextField, TextareaField, IntField, BoolField and ListField are all supported. The form generated looks like:
![screen shot 2015-08-24 at 9 39 35 pm](https://cloud.githubusercontent.com/assets/557294/9441439/a8a976da-4aa8-11e5-87f0-43c65a9626fb.png)



