### PR TITLE
Fix try scheduler, mark test as no longer flaky

### DIFF
--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -143,6 +143,14 @@ class BuildsEndpoint(Db2DataMixin, base.Endpoint):
             buildscol.append(data)
         defer.returnValue(buildscol)
 
+    def startConsuming(self, callback, options, kwargs):
+        builderid = kwargs.get('builderid')
+        if builderid is not None:
+            path = ('builders', str(builderid), 'builds', None, None)
+        else:
+            path = ('builds', None, None)
+        return self.master.mq.startConsuming(callback, path)
+
 
 class Build(base.ResourceType):
 

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -289,7 +289,7 @@ class RemoteBuildRequest(pb.Referenceable):
         builds = yield self.master.data.get(('buildrequests', self.brid, 'builds'))
         for build in builds:
             if build['buildid'] in reportedBuilds:
-                return
+                continue
             reportedBuilds.add(build['buildid'])
             yield subscriber.callRemote('newbuild',
                                         RemoteBuild(self.master, build, self.builderName),

--- a/master/buildbot/test/integration/test_try_client.py
+++ b/master/buildbot/test/integration/test_try_client.py
@@ -23,7 +23,6 @@ from buildbot.clients import tryclient
 from buildbot.schedulers import trysched
 from buildbot.test.util import dirs
 from buildbot.test.util import www
-from buildbot.test.util.decorators import flaky
 from twisted.cred import credentials
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -133,7 +132,7 @@ class Schedulers(dirs.DirsMixin, www.RequiresWwwMixin, unittest.TestCase):
 
         # stub out printStatus, as it's timing-based and thus causes
         # occasional test failures.
-        self.patch(tryclient.Try, 'printStatus', lambda: None)
+        self.patch(tryclient.Try, 'printStatus', lambda _: None)
 
         def output(*msg):
             msg = ' '.join(map(str, msg))
@@ -234,7 +233,6 @@ class Schedulers(dirs.DirsMixin, www.RequiresWwwMixin, unittest.TestCase):
         buildsets = yield self.master.db.buildsets.getBuildsets()
         self.assertEqual(len(buildsets), 1)
 
-    @flaky(bugNumber=2762)
     @defer.inlineCallbacks
     def test_userpass_wait(self):
         yield self.startMaster(


### PR DESCRIPTION
This flaky test wasn't being run, and as a result we weren't seeing
the fact that the scheduler was subscribing to a nonexistent message
stream.

This also fixes a loop that would bail out on seeing just one
duplicate build, rather than simply skipping that build.  I doubt this
ever caused problems, but this is more correct.