### PR TITLE
Gerrit reporter enhancements

### DIFF
--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -363,10 +363,11 @@ class GerritStatusPush(service.BuildbotService):
             revision = getProperty(build, "got_revision") or build.getProperty("revision")
 
             if isinstance(revision, dict):
-                revision = None
                 # in case of the revision is a codebase revision, we just take the revisionfor current codebase
                 if codebase is not None:
                     revision = revision[codebase]
+                else:
+                    revision = None
 
             if project is not None and revision is not None:
                 self.sendCodeReview(project, revision, result)

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -337,7 +337,6 @@ class GerritStatusPush(service.BuildbotService):
 
             result = _handleLegacyResult(self.summaryCB(buildInfoList, Results[buildset['results']],
                                          self.master, self.summaryArg))
-            print builds
             self.sendCodeReviews(builds[0], result)
 
     def sendCodeReviews(self, build, result):

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -152,7 +152,7 @@ class GerritStatusPush(service.BuildbotService):
     def reconfigService(self, server, username, reviewCB=DEFAULT_REVIEW,
                         startCB=None, port=29418, reviewArg=None,
                         startArg=None, summaryCB=DEFAULT_SUMMARY, summaryArg=None,
-                        identity_file=None):
+                        identity_file=None, builders=None):
 
         # If neither reviewCB nor summaryCB were specified, default to sending
         # out "summary" reviews. But if we were given a reviewCB and only a
@@ -178,6 +178,7 @@ class GerritStatusPush(service.BuildbotService):
         self.startArg = startArg
         self.summaryCB = summaryCB
         self.summaryArg = summaryArg
+        self.builders = builders
 
     def _gerritCmd(self, *args):
         '''Construct a command as a list of strings suitable for
@@ -279,8 +280,10 @@ class GerritStatusPush(service.BuildbotService):
     def buildStarted(self, key, build):
         if self.startCB is not None:
             builder = yield self.master.data.get(("builders", build['builderid']))
-            message = self.startCB(builder['name'], build, self.startArg)
-            self.sendCodeReviews(build, message)
+            build['builder'] = builder
+            if self.isBuildReported(build):
+                message = self.startCB(builder['name'], build, self.startArg)
+                self.sendCodeReviews(build, message)
 
     def buildFinished(self, builderName, build, result):
         """Do the SSH gerrit verify command to the server."""
@@ -295,7 +298,11 @@ class GerritStatusPush(service.BuildbotService):
         buildset = yield self.master.data.get(("buildsets", br['buildsetid']))
         yield utils.getDetailsForBuilds(self.master, buildset, [build])
         build['url'] = utils.getURLForBuild(self.master, build['builder']['builderid'], build['number'])
-        self.buildFinished(build['builder']['name'], build, build['results'])
+        if self.isBuildReported(build):
+            self.buildFinished(build['builder']['name'], build, build['results'])
+
+    def isBuildReported(self, build):
+        return self.builders is None or build['builder']['name'] in self.builders
 
     @defer.inlineCallbacks
     def buildsetComplete(self, key, msg):
@@ -309,7 +316,8 @@ class GerritStatusPush(service.BuildbotService):
         self.sendBuildSetSummary(buildset, builds)
 
     def sendBuildSetSummary(self, buildset, builds):
-        if self.summaryCB:
+        builds = filter(self.isBuildReported, builds)
+        if builds and self.summaryCB:
             def getBuildInfo(build):
                 result = build['results']
                 resultText = {
@@ -327,7 +335,9 @@ class GerritStatusPush(service.BuildbotService):
                         }
             buildInfoList = sorted([getBuildInfo(build) for build in builds], key=lambda bi: bi['name'])
 
-            result = _handleLegacyResult(self.summaryCB(buildInfoList, Results[buildset['results']], self.master, self.summaryArg))
+            result = _handleLegacyResult(self.summaryCB(buildInfoList, Results[buildset['results']],
+                                         self.master, self.summaryArg))
+            print builds
             self.sendCodeReviews(builds[0], result)
 
     def sendCodeReviews(self, build, result):
@@ -379,7 +389,7 @@ class GerritStatusPush(service.BuildbotService):
             self.callWithVersion(lambda: self.sendCodeReview(project, revision, result))
             return
 
-        command = self._gerritCmd("review", "--project %s" % str(project))
+        command = self._gerritCmd("review", "--project %s" % (project,))
         message = result.get('message', None)
         if message:
             command.append("--message '%s'" % message.replace("'", "\""))
@@ -395,7 +405,8 @@ class GerritStatusPush(service.BuildbotService):
             for label, value in iteritems(labels):
                 command.extend(add_label(label, value))
 
-        command.append(str(revision))
+        command.append(revision)
+        command = [str(s) for s in command]
         self.spawnProcess(self.LocalPP(self), command[0], command)
 
     def spawnProcess(self, *arg, **kw):

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -296,6 +296,24 @@ class TestGerritStatusPush(unittest.TestCase):
         return d
 
     @defer.inlineCallbacks
+    def test_buildsetComplete_filtered_builder(self):
+        gsp = yield self.setupGerritStatusPush(summaryCB=testSummaryCB)
+        gsp.builders = ["foo"]
+        yield self.run_fake_summary_build(gsp, [FAILURE, FAILURE], FAILURE,
+                                          ["failed", "failed"])
+
+        self.assertFalse(gsp.sendCodeReview.called, "sendCodeReview should not be called")
+
+    @defer.inlineCallbacks
+    def test_buildsetComplete_filtered_matching_builder(self):
+        gsp = yield self.setupGerritStatusPush(summaryCB=testSummaryCB)
+        gsp.builders = ["Builder1"]
+        yield self.run_fake_summary_build(gsp, [FAILURE, FAILURE], FAILURE,
+                                          ["failed", "failed"])
+
+        self.assertTrue(gsp.sendCodeReview.called, "sendCodeReview should be called")
+
+    @defer.inlineCallbacks
     def run_fake_single_build(self, gsp, buildResult, expWarning=False):
         buildset, builds = yield self.setupBuildResults([buildResult], buildResult)
 
@@ -353,6 +371,21 @@ class TestGerritStatusPush(unittest.TestCase):
 
     def test_buildComplete_failure_sends_review_legacy(self):
         return self.check_single_build_legacy(FAILURE, -1)
+
+    # same goes for check_single_build and check_single_build_legacy
+    @defer.inlineCallbacks
+    def test_single_build_filtered(self):
+
+        gsp = yield self.setupGerritStatusPush(reviewCB=testReviewCB,
+                                               startCB=testStartCB)
+
+        gsp.builders = ["Builder0"]
+        yield self.run_fake_single_build(gsp, SUCCESS)
+        self.assertTrue(gsp.sendCodeReview.called, "sendCodeReview should be called")
+        gsp.sendCodeReview = Mock()
+        gsp.builders = ["foo"]
+        yield self.run_fake_single_build(gsp, SUCCESS)
+        self.assertFalse(gsp.sendCodeReview.called, "sendCodeReview should not be called")
 
     def test_defaultReviewCBSuccess(self):
         res = defaultReviewCB("builderName", {}, SUCCESS, None, None)

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -754,6 +754,10 @@ GerritStatusPush can send a separate review for each build that completes, or a 
                       .. literalinclude:: /examples/git_gerrit.cfg
                          :pyobject: gerritSummaryCB
 
+   :param builders: (optional) list of builders to send results for.
+                    This method allows to filter results for a specific set of builder.
+                    By default, or if builders is None, then no filtering is performed.
+
 .. note::
 
    By default, a single summary review is sent; that is, a default :py:func:`summaryCB` is provided, but no :py:func:`reviewCB` or :py:func:`startCB`.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -18,6 +18,8 @@ Features
 
 * :bb:sched:`Triggerable` now accepts a ``reason`` parameter.
 
+* :bb:reporter:`GerritStatusPush` now accepts a ``builders`` parameter.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
- fix a silly bug in gerrit reporters for codebase mode
- add optional builders parameter for only sending status for a specific set of builders