### PR TITLE
Add a `maxcpus` buildslave property

### DIFF
--- a/master/docs/developer/master-slave.rst
+++ b/master/docs/developer/master-slave.rst
@@ -61,6 +61,8 @@ The slave-side Bot object has the following remote methods:
         OS the slave is running (extracted from Python's os.name)
     ``basedir``
         base directory where slave is running
+    ``numcpus``
+        number of CPUs on the slave, either as configured or as detected (since buildbot-slave version 0.9.0)
 
 :meth:`~buildslave.bot.Bot.remote_getVersion`
     Returns the slave's version

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -37,6 +37,9 @@ Features
   This allows to run a multi-master configuration.
   See :ref:`MQ-Specification`.
 
+* The Buildbot slave now includes the number of CPUs in the information it supplies to the master on connection.
+  This value is autodetected, but can be overridden with the ``--numcpus`` argument to ``buildslave create-slave``.
+
 Fixes
 ~~~~~
 

--- a/slave/buildslave/base.py
+++ b/slave/buildslave/base.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+import multiprocessing
 import os.path
 import socket
 import sys
@@ -241,6 +242,7 @@ class BotBase(service.MultiService):
     def __init__(self, basedir, usePTY, unicode_encoding=None):
         service.MultiService.__init__(self)
         self.basedir = basedir
+        self.numcpus = None
         self.usePTY = usePTY
         self.unicode_encoding = unicode_encoding or sys.getfilesystemencoding() or 'ascii'
         self.builders = {}
@@ -317,9 +319,12 @@ class BotBase(service.MultiService):
                 filename = os.path.join(basedir, f)
                 if os.path.isfile(filename):
                     files[f] = open(filename, "r").read()
+        if not self.numcpus:
+            self.numcpus = multiprocessing.cpu_count()
         files['environ'] = os.environ.copy()
         files['system'] = os.name
         files['basedir'] = self.basedir
+        files['numcpus'] = self.numcpus
 
         files['version'] = self.remote_getVersion()
         files['slave_commands'] = self.remote_getCommands()

--- a/slave/buildslave/pb.py
+++ b/slave/buildslave/pb.py
@@ -147,7 +147,8 @@ class BuildSlave(BuildSlaveBase, service.MultiService):
 
     def __init__(self, buildmaster_host, port, name, passwd, basedir,
                  keepalive, usePTY, keepaliveTimeout=None, umask=None,
-                 maxdelay=300, unicode_encoding=None, allow_shutdown=None):
+                 maxdelay=300, numcpus=None, unicode_encoding=None,
+                 allow_shutdown=None):
 
         # note: keepaliveTimeout is ignored, but preserved here for
         # backward-compatibility
@@ -157,6 +158,7 @@ class BuildSlave(BuildSlaveBase, service.MultiService):
         if keepalive == 0:
             keepalive = None
 
+        self.numcpus = numcpus
         self.shutdown_loop = None
 
         if allow_shutdown == 'signal':

--- a/slave/buildslave/scripts/create_slave.py
+++ b/slave/buildslave/scripts/create_slave.py
@@ -36,7 +36,7 @@ if basedir == '.':
 # directory; do not edit it.
 application = service.Application('buildslave')
 """,
-"""
+                    """
 try:
   from twisted.python.logfile import LogFile
   from twisted.python.log import ILogObserver, FileLogObserver
@@ -47,7 +47,7 @@ except ImportError:
   # probably not yet twisted 8.2.0 and beyond, can't set log yet
   pass
 """,
-"""
+                    """
 buildmaster_host = %(host)r
 port = %(port)d
 slavename = %(name)r
@@ -56,11 +56,12 @@ keepalive = %(keepalive)d
 usepty = %(usepty)d
 umask = %(umask)s
 maxdelay = %(maxdelay)d
+numcpus = %(numcpus)s
 allow_shutdown = %(allow-shutdown)s
 
 s = BuildSlave(buildmaster_host, port, slavename, passwd, basedir,
                keepalive, usepty, umask=umask, maxdelay=maxdelay,
-               allow_shutdown=allow_shutdown)
+               numcpus=numcpus, allow_shutdown=allow_shutdown)
 s.setServiceParent(application)
 
 """]
@@ -156,7 +157,7 @@ def _makeInfoFiles(basedir, quiet):
 
         if not quiet:
             log.msg("Creating %s, you need to edit it appropriately." %
-                os.path.join("info", file))
+                    os.path.join("info", file))
 
         try:
             open(filepath, "wt").write(contents)

--- a/slave/buildslave/scripts/runner.py
+++ b/slave/buildslave/scripts/runner.py
@@ -20,9 +20,9 @@ import os
 import re
 import sys
 
+from twisted.python import log
 from twisted.python import reflect
 from twisted.python import usage
-from twisted.python import log
 
 
 # the create/start/stop commands should all be run as the same user,
@@ -129,6 +129,8 @@ class CreateSlaveOptions(MakerBase):
          "Use --umask=022 to be world-readable"],
         ["maxdelay", None, 300,
          "Maximum time between connection attempts"],
+        ["numcpus", None, "None",
+         "Number of available cpus to use on a build. "],
         ["log-size", "s", "10000000",
          "size at which to rotate twisted log files"],
         ["log-count", "l", "10",
@@ -213,6 +215,11 @@ class CreateSlaveOptions(MakerBase):
         if not re.match(r'^\d+$', self['umask']) and \
                 self['umask'] != 'None':
             raise usage.UsageError("umask parameter needs to be an number"
+                                   " or None")
+
+        if not re.match(r'^\d+$', self['numcpus']) and \
+                self['numcpus'] != 'None':
+            raise usage.UsageError("numcpus parameter needs to be an number"
                                    " or None")
 
         if self['allow-shutdown'] not in [None, 'signal', 'file']:

--- a/slave/buildslave/test/unit/test_bot.py
+++ b/slave/buildslave/test/unit/test_bot.py
@@ -16,6 +16,7 @@
 from builtins import range
 
 import mock
+import multiprocessing
 import os
 import shutil
 
@@ -88,7 +89,8 @@ class TestBot(unittest.TestCase):
                 admin='testy!', foo='bar',
                 environ=os.environ, system=os.name, basedir=self.basedir,
                 slave_commands=self.real_bot.remote_getCommands(),
-                version=self.real_bot.remote_getVersion()))
+                version=self.real_bot.remote_getVersion(),
+                numcpus=multiprocessing.cpu_count()))
         d.addCallback(check)
         return d
 
@@ -96,7 +98,7 @@ class TestBot(unittest.TestCase):
         d = self.bot.callRemote("getSlaveInfo")
 
         def check(info):
-            self.assertEqual(set(info.keys()), set(['environ', 'system', 'basedir', 'slave_commands', 'version']))
+            self.assertEqual(set(info.keys()), set(['environ', 'system', 'numcpus', 'basedir', 'slave_commands', 'version']))
         d.addCallback(check)
         return d
 

--- a/slave/buildslave/test/unit/test_scripts_create_slave.py
+++ b/slave/buildslave/test/unit/test_scripts_create_slave.py
@@ -488,6 +488,7 @@ class TestCreateSlave(misc.LoggingMixin, unittest.TestCase):
         "log-count": 8,
         "keepalive": 4,
         "maxdelay": 2,
+        "numcpus": None,
 
         # arguments
         "host": "masterhost",
@@ -616,6 +617,7 @@ class TestCreateSlave(misc.LoggingMixin, unittest.TestCase):
             options["keepalive"],
             options["usepty"],
             umask=options["umask"],
+            numcpus=options["numcpus"],
             maxdelay=options["maxdelay"],
             allow_shutdown=options["allow-shutdown"])
 

--- a/slave/buildslave/test/unit/test_scripts_runner.py
+++ b/slave/buildslave/test/unit/test_scripts_runner.py
@@ -187,7 +187,7 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
 
         opts = self.parse("--force", "--relocatable", "--no-logrotate",
                           "--keepalive=4", "--usepty=0", "--umask=022",
-                          "--maxdelay=3", "--log-size=2", "--log-count=1",
+                          "--maxdelay=3", "--numcpus=4", "--log-size=2", "--log-count=1",
                           "--allow-shutdown=file", *self.req_args)
         self.assertOptions(opts,
                            {"force": True,
@@ -196,6 +196,7 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
                             "usepty": 0,
                             "umask": "022",
                             "maxdelay": 3,
+                            "numcpus": "4",
                             "log-size": 2,
                             "log-count": "1",
                             "allow-shutdown": "file",
@@ -234,6 +235,11 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
         self.assertRaisesRegexp(usage.UsageError,
                                 "log-count parameter needs to be an number or None",
                                 self.parse, "--log-count=X", *self.req_args)
+
+    def test_inv_numcpus(self):
+        self.assertRaisesRegexp(usage.UsageError,
+                                "numcpus parameter needs to be an number or None",
+                                self.parse, "--numcpus=X", *self.req_args)
 
     def test_inv_umask(self):
         self.assertRaisesRegexp(usage.UsageError,


### PR DESCRIPTION
This should add the property 'maxcpus' to a buildslaves configuration.
If 'maxcpus' is not specified it defaults to 'None' which uses
'multiprocessing.cpu_count()' to receive the max amount of CPUs.

(rebased from https://github.com/buildbot/buildbot/pull/1426, +pep8)

This is an update of #1426.

This still needs more work, though: the value is totally ignored on the master side.  In fact, I don't think any slave information is easily available to custom steps.

Am I missing something?