### PR TITLE
fix web change_hook::base NOT accept unicode parameters: http://trac.buildbot.net/ticket/3346

### DIFF
--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -62,7 +62,7 @@ def getChanges(request, options=None):
     author = firstOrNothing(args.get('author'))
     if not author:
         author = firstOrNothing(args.get('who'))
-    comments = firstOrNothing(args.get('comments'))
+    comments = firstOrNothing(args.get('comments')).decode('utf-8')
     isdir = firstOrNothing(args.get('isdir', 0))
     branch = firstOrNothing(args.get('branch'))
     category = firstOrNothing(args.get('category'))


### PR DESCRIPTION
if submit changes via post_build_request.py with utf-8 in comment,
then got error:
sqlalchemy.exc.ProgrammingError?: (ProgrammingError?) You must not use
8-bit bytestrings unless...
this patch fix this issue