### PR TITLE
Added sanity check for  parameter for CaptureBuildDuration.

### DIFF
--- a/master/buildbot/statistics/capture.py
+++ b/master/buildbot/statistics/capture.py
@@ -19,6 +19,7 @@ import re
 from twisted.internet import defer
 from twisted.internet import threads
 
+from buildbot import config
 from buildbot.errors import CaptureCallbackError
 
 
@@ -266,6 +267,11 @@ class CaptureBuildDuration(CaptureBuildTimes):
     """
 
     def __init__(self, builder_name, report_in='seconds', callback=None):
+        if report_in not in ['seconds', 'minutes', 'hours']:
+            config.error("Error during initialization of class %s."
+                         " `report_in` parameter must be one of 'seconds', 'minutes' or 'hours'"
+                         % (self.__class__.__name__))
+
         def default_callback(start_time, end_time):
             divisor = 1
             # it's a closure

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -361,6 +361,10 @@ class TestStatsServicesConsumers(steps.BuildStepMixin, TestStatsServicesBase):
         yield self.build_time_capture_helper('hours')
         self.assertEqual('duration', self.fake_storage_service.stored_data[0][0].keys()[0])
 
+    def test_build_duration_report_in_error(self):
+        self.assertRaises(config.ConfigErrors,
+                          lambda: capture.CaptureBuildDuration('builder1', report_in='foobar'))
+
     @defer.inlineCallbacks
     def test_build_duration_capturing_alt_callback(self):
         def cb(*args, **kwargs):


### PR DESCRIPTION
Added sanity check for `report_in` parameter in `CaptureBuildDuration` according to the commit message https://github.com/prasoon2211/buildbot/commit/64e091772f47514069776adba600918002327f8c#commitcomment-12982136 for PR #1824 