### PR TITLE
Do not parse header logs in PyFlakes and PyLint steps

### DIFF
--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -103,6 +103,8 @@ class PyFlakes(ShellCommand):
         first = True
         while True:
             stream, line = yield
+            if stream == 'h':
+                continue
             # the first few lines might contain echoed commands from a 'make
             # pyflakes' step, so don't count these as warnings. Stop ignoring
             # the initial lines as soon as we see one with a colon.
@@ -223,6 +225,8 @@ class PyLint(ShellCommand):
         line_re = None  # decide after first match
         while True:
             stream, line = yield
+            if stream == 'h':
+                continue
             if not line_re:
                 # need to test both and then decide on one
                 if self._parseable_line_re.match(line):

--- a/master/buildbot/test/unit/test_steps_python.py
+++ b/master/buildbot/test/unit/test_steps_python.py
@@ -165,6 +165,18 @@ class PyLint(steps.BuildStepMixin, unittest.TestCase):
         self.expectProperty('pylint-error', 1)
         return self.runStep()
 
+    def test_header_output(self):
+        self.setupStep(python.PyLint(command=['pylint']))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['pylint'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                header='W: 11: Bad indentation. Found 6 spaces, expected 4\n')
+            + 0)
+        self.expectOutcome(result=SUCCESS, state_string='pylint')
+        return self.runStep()
+
     def test_failure(self):
         self.setupStep(python.PyLint(command=['pylint']))
         self.expectCommands(
@@ -358,6 +370,19 @@ class PyFlakes(steps.BuildStepMixin, unittest.TestCase):
                         usePTY='slave-config')
             + 0)
         self.expectOutcome(result=SUCCESS, state_string='pyflakes')
+        return self.runStep()
+
+    def test_content_in_header(self):
+        self.setupStep(python.PyFlakes())
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['make', 'pyflakes'],
+                        usePTY='slave-config')
+            + ExpectShell.log(
+                'stdio',
+                # don't match pyflakes-like output in the header
+                header="foo.py:1: 'bar' imported but unused\n")
+            + 0)
+        self.expectOutcome(result=0, state_string='pyflakes')
         return self.runStep()
 
     def test_unused(self):

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -75,7 +75,8 @@ def _describe_cmd_difference(exp, command):
         print('Keys in expectation missing from command: {0}'.format(missing_in_cmd))
     if diff:
         formatted_diff = ['"{0}": expected {1}, vs actual {2}'.format(*d) for d in diff]
-        print('Key differences between expectation and command: {0}'.format('\n'.join(formatted_diff)))
+        print('Key differences between expectation and command: {0}'.format(
+            '\n'.join(formatted_diff)))
 
 
 class BuildStepMixin(object):
@@ -305,14 +306,13 @@ class BuildStepMixin(object):
                     print(loog.stdout)
                     print(loog.stderr)
 
-            self.assertEqual(result, self.exp_result, "expected result")
+            self.assertEqual(result, self.exp_result)
             if self.exp_state_string:
                 stepStateString = self.master.data.updates.stepStateString
                 stepids = list(stepStateString)
                 assert stepids, "no step state strings were set"
                 self.assertEqual(stepStateString[stepids[0]],
-                                 self.exp_state_string,
-                                 "expected step state strings")
+                                 self.exp_state_string)
             for pn, (pv, ps) in iteritems(self.exp_properties):
                 self.assertTrue(self.properties.hasProperty(pn),
                                 "missing property '%s'" % pn)

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -23,6 +23,8 @@ Features
 Fixes
 ~~~~~
 
+* The :bb:step:`PyFlakes` and :bb:step:`PyLint` steps no longer parse output in Buildbot log headers (:bug:`3337`).
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes #3337.