### PR TITLE
fix deprecated source step name: 'git' => 'Svn'

### DIFF
--- a/slave/buildslave/commands/removed.py
+++ b/slave/buildslave/commands/removed.py
@@ -22,8 +22,16 @@ class RemovedSourceCommand(base.SourceBaseCommand):
     def start(self):
         self.sendStatus(
             {"header":
-             "slave-side source checkout for '%s' is no longer supported by "
-             "build slave of version %s\n" % (self.name, buildslave.version)})
+             "slave-side source checkout for '{0}' is no longer supported by "
+             "build slave of version {1}\n"
+             "\n"
+             "Since BuildBot 0.9 old source checkout method with logic on slave-side\n"
+             "buildbot.steps.source.{0} was removed (deprecated since BuildBot 0.8)\n"
+             "\n"
+             "Instead please use new method which has its logic on master-side and has unified params list.\n"
+             "Using the plugin infrastructure it's available as buildbot.plugins.{0}\n"
+             "\n"
+             .format(self.name, buildslave.version)})
         self.sendStatus({"rc": 1})
 
 

--- a/slave/buildslave/commands/removed.py
+++ b/slave/buildslave/commands/removed.py
@@ -28,7 +28,7 @@ class RemovedSourceCommand(base.SourceBaseCommand):
 
 
 class Svn(RemovedSourceCommand):
-    name = "Svn"
+    name = "SVN"
 
 
 class Bk(RemovedSourceCommand):

--- a/slave/buildslave/commands/removed.py
+++ b/slave/buildslave/commands/removed.py
@@ -28,7 +28,7 @@ class RemovedSourceCommand(base.SourceBaseCommand):
 
 
 class Svn(RemovedSourceCommand):
-    name = "git"
+    name = "Svn"
 
 
 class Bk(RemovedSourceCommand):


### PR DESCRIPTION
fix deprecated source step name: 'git' => 'Svn'