### PR TITLE
EC2 latent slave bug fixes

### DIFF
--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -27,6 +27,8 @@ from buildbot.worker_transition import reportDeprecatedWorkerNameUsage
 
 try:
     import boto
+    import boto.ec2
+    import boto.exception
 except ImportError:
     boto = None
 

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -434,7 +434,12 @@ class EC2LatentWorker(AbstractLatentWorker):
                 log.msg('%s %s has waited %d minutes for instance %s' %
                         (self.__class__.__name__, self.workername, duration // 60,
                          self.instance.id))
-            self.instance.update()
+            try:
+                self.instance.update()
+            except boto.exception.EC2ResponseError as e:
+                # AWS is eventaully consistent
+                if 'InvalidInstanceID.NotFound' not in e.body:
+                    raise
 
         if self.instance.state == RUNNING:
             self.output = self.instance.get_console_output()
@@ -458,8 +463,21 @@ class EC2LatentWorker(AbstractLatentWorker):
     def _wait_for_request(self, reservation):
         duration = 0
         interval = self._poll_resolution
-        requests = self.conn.get_all_spot_instance_requests(
-            request_ids=[reservation.id])
+        requests = None
+        while not requests:
+            time.sleep(interval)
+            duration += interval
+            if duration % 60 == 0:
+                log.msg('%s %s has waited %d minutes for spot request %s' %
+                        (self.__class__.__name__, self.slavename,
+                         duration // 60, reservation.id))
+            try:
+                requests = self.conn.get_all_spot_instance_requests(
+                    request_ids=[reservation.id])
+            except boto.exception.EC2ResponseError as e:
+                # AWS is eventaully consistent
+                if 'InvalidSpotInstanceRequestID.NotFound' not in e.body:
+                    raise
         request = requests[0]
         request_status = request.status.code
         while request_status in SPOT_REQUEST_PENDING_STATES:

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -63,7 +63,7 @@ class EC2LatentWorker(AbstractLatentWorker):
                  spot_instance=False, max_spot_price=1.6, volumes=None,
                  placement=None, price_multiplier=1.2, tags=None, retry=1,
                  retry_price_adjustment=1, product_description='Linux/UNIX',
-                 **kwargs):
+                 instance_profile_arn=None, **kwargs):
 
         if not boto:
             config.error("The python module 'boto' is needed to use a "
@@ -125,6 +125,7 @@ class EC2LatentWorker(AbstractLatentWorker):
         self.retry = retry
         self.attempt = 1
         self.product_description = product_description
+        self.instance_profile_arn = instance_profile_arn
         if None not in [placement, region]:
             self.placement = '%s%s' % (region, placement)
         else:
@@ -297,7 +298,8 @@ class EC2LatentWorker(AbstractLatentWorker):
         reservation = image.run(
             key_name=self.keypair_name, security_groups=[self.security_name],
             instance_type=self.instance_type, user_data=self.user_data,
-            placement=self.placement)
+            placement=self.placement,
+            instance_profile_arn=self.instance_profile_arn)
         self.instance = reservation.instances[0]
         instance_id, image_id, start_time = self._wait_for_instance(
             reservation)


### PR DESCRIPTION
Few improvements to the EC2 latent slave code. Will backport 2-4 to eight once this is merged.

1. Fix EC2 latent slaves, which are broken on master due to missing imports.
2. Plumb through the instance_profile_arn parameter, which allows the slave instance to be delegated AWS credentials.
3. Handle AWS eventual consistency. EC2 may return not found for a short period of time after a resource is created.
4. Add tags to spot instances, tag resources as soon as possible, and do so in an eventual consistency safe manner.