### PR TITLE
fix gerrit change source verbosity

### DIFF
--- a/master/buildbot/changes/base.py
+++ b/master/buildbot/changes/base.py
@@ -25,9 +25,6 @@ from buildbot.util.poll import method as poll_method
 class ChangeSource(service.ClusteredBuildbotService):
     implements(IChangeSource)
 
-    def __init__(self, name):
-        super(ChangeSource, self).__init__(name=name)
-
     def describe(self):
         pass
 
@@ -56,7 +53,7 @@ class ChangeSource(service.ClusteredBuildbotService):
 class PollingChangeSource(ChangeSource):
 
     def __init__(self, name=None, pollInterval=60 * 10, pollAtLaunch=False):
-        ChangeSource.__init__(self, name)
+        ChangeSource.__init__(self, name=name)
         self.pollInterval = pollInterval
         self.pollAtLaunch = pollAtLaunch
 

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -165,7 +165,8 @@ class GerritChangeSource(base.ChangeSource):
         if func is None and event_with_change:
             return self.addChangeFromEvent(properties, event)
         elif func is None:
-            log.msg("unsupported event %s" % (event["type"],))
+            if self.debug:
+                log.msg("unsupported event %s" % (event["type"],))
             return defer.succeed(None)
         else:
             return func(properties, event)

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -75,36 +75,26 @@ class GerritChangeSource(base.ChangeSource):
     STREAM_BACKOFF_MAX = 60
     "(seconds) maximum time to wait before retrying a failed connection"
 
-    def __init__(self,
-                 gerritserver,
-                 username,
-                 gerritport=29418,
-                 identity_file=None,
-                 name=None,
-                 handled_events=("patchset-created", "ref-updated")):
-        """
-        @type  gerritserver: string
-        @param gerritserver: the dns or ip that host the gerrit ssh server,
+    name = None
 
-        @type  gerritport: int
-        @param gerritport: the port of the gerrit ssh server,
+    def checkConfig(self,
+                    gerritserver,
+                    username,
+                    gerritport=29418,
+                    identity_file=None,
+                    handled_events=("patchset-created", "ref-updated"),
+                    debug=False):
+        if self.name is None:
+            self.name = u"GerritChangeSource:%s@%s:%d" % (username, gerritserver, gerritport)
 
-        @type  username: string
-        @param username: the username to use to connect to gerrit,
-
-        @type  identity_file: string
-        @param identity_file: identity file to for authentication (optional),
-
-        @type  handled_events: list
-        @param handled_events: event to be handled (optional).
-        """
-        # TODO: delete API comment when documented
-
-        if not name:
-            name = "GerritChangeSource:%s@%s:%d" % (username, gerritserver, gerritport)
-
-        base.ChangeSource.__init__(self, name=name)
-
+    def reconfigService(self,
+                        gerritserver,
+                        username,
+                        gerritport=29418,
+                        identity_file=None,
+                        name=None,
+                        handled_events=("patchset-created", "ref-updated"),
+                        debug=False):
         self.gerritserver = gerritserver
         self.gerritport = gerritport
         self.username = username
@@ -112,6 +102,7 @@ class GerritChangeSource(base.ChangeSource):
         self.handled_events = list(handled_events)
         self.process = None
         self.wantProcess = False
+        self.debug = debug
         self.streamProcessTimeout = self.STREAM_BACKOFF_MIN
 
     class LocalPP(ProcessProtocol):
@@ -128,11 +119,13 @@ class GerritChangeSource(base.ChangeSource):
             # last line is either empty or incomplete
             self.data = lines.pop(-1)
             for line in lines:
-                log.msg("gerrit: %s" % line)
+                if self.change_source.debug:
+                    log.msg("gerrit: %s" % line)
                 yield self.change_source.lineReceived(line)
 
         def errReceived(self, data):
-            log.msg("gerrit stderr: %s" % data)
+            if self.change_source.debug:
+                log.msg("gerrit stderr: %s" % data)
 
         def processEnded(self, status_object):
             self.change_source.streamProcessStopped()
@@ -259,11 +252,16 @@ class GerritChangeSource(base.ChangeSource):
         else:
             # good startup, but lost connection; restart immediately,
             # and set the timeout to its minimum
+
+            # make sure we log the reconnection, so that it might be detected
+            # and network connectivity fixed
+            log.msg("gerrit stream-events lost connection. Reconnecting...")
             self.startStreamProcess()
             self.streamProcessTimeout = self.STREAM_BACKOFF_MIN
 
     def startStreamProcess(self):
-        log.msg("starting 'gerrit stream-events'")
+        if self.debug:
+            log.msg("starting 'gerrit stream-events'")
         self.lastStreamProcessStart = util.now()
         uri = "%s@%s" % (self.username, self.gerritserver)
         args = [uri, "-p", str(self.gerritport)]

--- a/master/buildbot/changes/pb.py
+++ b/master/buildbot/changes/pb.py
@@ -108,7 +108,7 @@ class PBChangeSource(base.ChangeSource):
             else:
                 name = "PBChangeSource:%s" % (port,)
 
-        base.ChangeSource.__init__(self, name)
+        base.ChangeSource.__init__(self, name=name)
 
         self.user = user
         self.passwd = passwd

--- a/master/buildbot/test/unit/test_changes_gerritchangesource.py
+++ b/master/buildbot/test/unit/test_changes_gerritchangesource.py
@@ -90,6 +90,7 @@ class TestGerritChangeSource(changesource.ChangeSourceMixin,
         s = gerritchangesource.GerritChangeSource(
             host, user, *args, **kwargs)
         self.attachChangeSource(s)
+        s.configureService()
         return s
 
     # tests

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -145,11 +145,14 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
         return self.reconfigService(*sibling._config_args,
                                     **sibling._config_kwargs)
 
+    def configureService(self):
+        # reconfigServiceWithSibling with self, means first configuration
+        return self.reconfigServiceWithSibling(self)
+
     @defer.inlineCallbacks
     def startService(self):
         if not self.configured:
-            # reconfigServiceWithSibling with self, means first configuration
-            yield self.reconfigServiceWithSibling(self)
+            yield self.configureService()
         yield AsyncMultiService.startService(self)
 
     def checkConfig(self, *args, **kwargs):

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -922,21 +922,25 @@ The :bb:chsrc:`GerritChangeSource` class connects to a Gerrit server by its SSH 
 The :bb:chsrc:`GerritChangeSource` accepts the following arguments:
 
 ``gerritserver``
-   the dns or ip that host the gerrit ssh server
+    the dns or ip that host the gerrit ssh server
 
 ``gerritport``
-   the port of the gerrit ssh server
+    the port of the gerrit ssh server
 
 ``username``
-   the username to use to connect to gerrit
+    the username to use to connect to gerrit
 
 ``identity_file``
-   ssh identity file to for authentication (optional).
-   Pay attention to the `ssh passphrase`
+    ssh identity file to for authentication (optional).
+    Pay attention to the `ssh passphrase`
 
 ``handled_events``
-   event to be handled (optional).
-   By default processes `patchset-created` and `ref-updated`
+    event to be handled (optional).
+    By default processes `patchset-created` and `ref-updated`
+
+``debug``
+    Print gerrit event in the log (default False).
+    This allows to debug event content, but will eventually fill your logs with useless gerrit event logs.
 
 By default this class adds a change to the buildbot system for each of the following events:
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -25,6 +25,8 @@ Fixes
 
 * The :bb:step:`PyFlakes` and :bb:step:`PyLint` steps no longer parse output in Buildbot log headers (:bug:`3337`).
 
+* :bb:chsrc:`GerritChangeSource` is now less verbose by default, and has a ``debug`` option to enable the logs.
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
It is not very useful to log all the gerrit events, especially when like me you are connected to  a 2k users gerrit.

This PR fixes reconfig for this change source.

There are still the other change sources to make reconfigurable.