### PR TITLE
p4poller: do not rely on server time to get a list of changes

### DIFF
--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -214,7 +214,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
             args.extend(['-P', self._getPasswd()])
         args.extend(['changes'])
         if self.last_change is not None:
-            args.extend(['%s...@%d,now' % (self.p4base, self.last_change + 1)])
+            args.extend(['%s...@%d,#head' % (self.p4base, self.last_change + 1)])
         else:
             args.extend(['-m', '1', '%s...' % (self.p4base,)])
 

--- a/master/buildbot/test/unit/test_changes_p4poller.py
+++ b/master/buildbot/test/unit/test_changes_p4poller.py
@@ -134,7 +134,7 @@ class TestP4Poller(changesource.ChangeSourceMixin,
                      **kwargs))
         self.expectCommands(
             gpo.Expect('p4', 'changes', '-m', '1', '//depot/myproject/...').stdout(first_p4changes),
-            gpo.Expect('p4', 'changes', '//depot/myproject/...@2,now').stdout(second_p4changes),
+            gpo.Expect('p4', 'changes', '//depot/myproject/...@2,#head').stdout(second_p4changes),
         )
         encoded_p4change = p4change.copy()
         encoded_p4change[3] = encoded_p4change[3].encode(encoding)
@@ -236,7 +236,7 @@ class TestP4Poller(changesource.ChangeSourceMixin,
                      p4base='//depot/myproject/',
                      split_file=lambda x: x.split('/', 1)))
         self.expectCommands(
-            gpo.Expect('p4', 'changes', '//depot/myproject/...@3,now').stdout(second_p4changes),
+            gpo.Expect('p4', 'changes', '//depot/myproject/...@3,#head').stdout(second_p4changes),
         )
         self.add_p4_describe_result(2, p4change[2])
         self.add_p4_describe_result(3, 'Perforce client error:\n...')
@@ -302,7 +302,7 @@ class TestP4Poller(changesource.ChangeSourceMixin,
                      p4base='//depot/myproject/',
                      split_file=get_simple_split))
         self.expectCommands(
-            gpo.Expect('p4', 'changes', '//depot/myproject/...@51,now').stdout(third_p4changes),
+            gpo.Expect('p4', 'changes', '//depot/myproject/...@51,#head').stdout(third_p4changes),
         )
         self.add_p4_describe_result(5, p4change[5])
 
@@ -356,7 +356,7 @@ class TestP4Poller(changesource.ChangeSourceMixin,
                      split_file=get_simple_split,
                      server_tz="Europe/Berlin"))
         self.expectCommands(
-            gpo.Expect('p4', 'changes', '//depot/myproject/...@51,now').stdout(third_p4changes),
+            gpo.Expect('p4', 'changes', '//depot/myproject/...@51,#head').stdout(third_p4changes),
         )
         self.add_p4_describe_result(5, p4change[5])
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -32,6 +32,8 @@ Fixes
 
 * :bb:chsrc:`GerritChangeSource` is now less verbose by default, and has a ``debug`` option to enable the logs.
 
+* :bb:chsrc:`P4Source` no longer relies on the perforce server time to poll for new changes.
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#head is equivalent to now but does not depend on the p4 server time.

This is to workaround an issue I have where the p4 mirror server I polls is an hour behind of the server I commit to and so changes are delayed by an hour (both are in the same timezone). Need to fix this server side, but Buildbot also should not depend on the server time for getting changes.