### PR TITLE
Align requirements documentation with actual requirements

### DIFF
--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -14,8 +14,10 @@ Python: http://www.python.org
 
   Both Buildbot master and Buildbot slave require Python-2.6, although Python-2.7 is recommended.
 
-  Note that this should be a "normal" build of Python.
-  Builds of Python with debugging enabled or other unusual build parameters are likely to cause incorrect behavior.
+  .. note::
+
+    This should be a "normal" build of Python.
+    Builds of Python with debugging enabled or other unusual build parameters are likely to cause incorrect behavior.
 
 Twisted: http://twistedmatrix.com
 
@@ -23,6 +25,10 @@ Twisted: http://twistedmatrix.com
   In upcoming versions of Buildbot, a newer Twisted will also be required on the slave.
   As always, the most recent version is recommended.
   Note that Twisted requires ZopeInterface to be installed as well.
+
+Future:
+
+  As part of ongoing (but as-yet incomplete) work to make Buildbot compatible with Python 3, the master requires the ``future`` module.
 
 Of course, your project's build process will impose additional requirements on the buildslaves.
 These hosts must have all the tools necessary to compile and test your project's source code.
@@ -45,11 +51,16 @@ Pywin32: http://sourceforge.net/projects/pywin32/
 Buildmaster Requirements
 ------------------------
 
+Note that all of these requirements aside from SQLite can easily be installed from the Python package repository, PyPi.
+
 sqlite3: http://www.sqlite.org
 
-  Buildbot requires SQLite to store its state.
+  Buildbot requires a database to store its state, and by default uses SQLite.
   Version 3.7.0 or higher is recommended, although Buildbot will run against earlier versions -- at the risk of "Database is locked" errors.
   The minimum version is 3.4.0, below which parallel database queries and schema introspection fail.
+
+  If you configure a different database engine, then SQLite is not required.
+  however note that Buildbot's own unit tests require SQLite.
 
 Jinja2: http://jinja.pocoo.org/
 
@@ -59,13 +70,13 @@ Jinja2: http://jinja.pocoo.org/
 
 SQLAlchemy: http://www.sqlalchemy.org/
 
-  Buildbot requires SQLAlchemy 0.6.0 or higher.
+  Buildbot requires SQLAlchemy version 0.7.10, or version 0.8.1 or higher
   SQLAlchemy allows Buildbot to build database schemas and queries for a wide variety of database systems.
 
 SQLAlchemy-Migrate: http://code.google.com/p/sqlalchemy-migrate/
 
-  Buildbot requires one of the following SQLAlchemy-Migrate versions: 0.7.1, 0.7.2 and 0.9.
-  SQLAlchemy-Migrate-0.9 is required for compatibility with SQLAlchemy versions 0.8 and above.
+  Buildbot requires one of the following SQLAlchemy-Migrate versions: 0.7.2 or 0.9 or higher.
+  SQLAlchemy-Migrate-0.9 is required for compatibility with SQLAlchemy versions 0.8.0 and above.
   Buildbot uses SQLAlchemy-Migrate to manage schema upgrades from version to version.
 
 Python-Dateutil: http://labix.org/python-dateutil
@@ -74,4 +85,7 @@ Python-Dateutil: http://labix.org/python-dateutil
   This is a small, pure-python library.
   Buildbot will function properly without it if the :bb:sched:`Nightly` scheduler is not used.
 
+Autobahn:
+
+  The master requires Autobahn version 0.10.2 or higher
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -391,14 +391,8 @@ else:
         'twisted >= 12.1.0',
         'Jinja2 >= 2.1',
         'zope.interface >= 4.1.1',  # required for tests, but Twisted requires this anyway
-        'future'
-    ]
-
-    setup_args['install_requires'] += [
-        # sqlalchemy-0.8 betas show issues with sqlalchemy-0.7.2, so stick to 0.7.10
+        'future',
         'sqlalchemy >= 0.6, <= 0.7.10',
-        # buildbot depends on sqlalchemy internals, and this is the tested
-        # version.
         'sqlalchemy-migrate==0.7.2',
         'python-dateutil>=1.5',
         'autobahn >= 0.10.2',


### PR DESCRIPTION
This changes the `setup.py` affect our supported versions and should probably be reflected in the metabuildbot and `.travis.yml`