### PR TITLE
Add support for running npm commands on Windows

### DIFF
--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -104,8 +104,14 @@ def build_js(cmd):
         npm_bin = check_output("npm bin").strip()
         assert npm_version != "", "need nodejs and npm installed in current PATH"
         assert LooseVersion(npm_version) >= LooseVersion("1.4"), "npm < 1.4 (%s)" % (npm_version)
-        cmd.spawn(['npm', 'install'])
-        cmd.spawn([os.path.join(npm_bin, "gulp"), 'prod', '--notests'])
+        npm_cmd = ['npm', 'install']
+        gulp_cmd = [os.path.join(npm_bin, "gulp"), 'prod', '--notests']
+        if os.name == 'nt':
+            subprocess.call(npm_cmd, shell=True)
+            subprocess.call(gulp_cmd, shell=True)
+        else:
+            cmd.spawn(npm_cmd)
+            cmd.spawn(gulp_cmd)
 
     cmd.copy_tree(os.path.join(package, 'static'), os.path.join("build", "lib", package, "static"))
 


### PR DESCRIPTION
This is the only form of ```npm``` commands that work on my PC:
 ```subprocess.call([...], shell=True)```

Enviroment:
* Windows 7 SP1 x64
* Python 2.7.10

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/buildbot/buildbot/1865)
<!-- Reviewable:end -->
