### PR TITLE
Get results of build in StatusPush handler

### DIFF
--- a/master/buildbot/status/status_push.py
+++ b/master/buildbot/status/status_push.py
@@ -340,7 +340,7 @@ class StatusPush(StatusReceiverMultiService):
         d.addErrback(log.err, 'while pushing status message')
 
     def buildFinished(self, builderName, build, results):
-        d = self.push('buildFinished', build=build)
+        d = self.push('buildFinished', build=build, results=results)
         d.addErrback(log.err, 'while pushing status message')
 
     def builderRemoved(self, builderName):

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -25,7 +25,7 @@ Features
 
 * :bb:reporter:`GerritStatusPush` now accepts a ``builders`` parameter.
 
-* Build results (success/failure/etc) are passed to the StatusPush handler.
+* :bb:reporter:`StatusPush` callback now receives build results (success/failure/etc) with the ``buildFinished`` event.
 
 Fixes
 ~~~~~

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -25,6 +25,8 @@ Features
 
 * :bb:reporter:`GerritStatusPush` now accepts a ``builders`` parameter.
 
+* Build results (success/failure/etc) are passed to the StatusPush handler.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
The 'buildFinished' event indicates to the StatusPush callback that the build is complete.  Considering that all steps of the build have completed, it's useful to know whether they all completed successfully or otherwise.

This is easy to accomplish because StatusPush::buildFinished already has the success/error value available. Simply push it with the rest of the event onto the queue.