### PR TITLE
pass properties to buildset as got a change from PBChangeSource

### DIFF
--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -123,8 +123,13 @@ class BaseBasicScheduler(base.BaseScheduler):
             # unimportant changes
             if not important:
                 return defer.succeed(None)
+
+            properties = {}
+            if hasattr(change, 'properties'):
+                properties = change.properties
             # otherwise, we'll build it right away
             return self.addBuildsetForChanges(reason=self.reason,
+                                              properties=properties,
                                               changeids=[change.number])
 
         timer_name = self.getTimerNameForChange(change)

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -125,9 +125,13 @@ class BaseBasicScheduler(base.BaseScheduler):
             if not important:
                 return defer.succeed(None)
 
+            properties = change.properties
+            if(type(properties) == dict):
+                properties = Properties.fromDict(properties)
+
             # otherwise, we'll build it right away
             return self.addBuildsetForChanges(reason=self.reason,
-                                              properties=change.properties,
+                                              properties=properties,
                                               changeids=[change.number])
 
         timer_name = self.getTimerNameForChange(change)

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -18,6 +18,7 @@ from future.utils import itervalues
 from buildbot import config
 from buildbot import util
 from buildbot.changes import changes
+from buildbot.process.properties import Properties
 from buildbot.changes.filter import ChangeFilter
 from buildbot.schedulers import base
 from buildbot.schedulers import dependent
@@ -124,12 +125,9 @@ class BaseBasicScheduler(base.BaseScheduler):
             if not important:
                 return defer.succeed(None)
 
-            properties = {}
-            if hasattr(change, 'properties'):
-                properties = change.properties
             # otherwise, we'll build it right away
             return self.addBuildsetForChanges(reason=self.reason,
-                                              properties=properties,
+                                              properties=change.properties,
                                               changeids=[change.number])
 
         timer_name = self.getTimerNameForChange(change)


### PR DESCRIPTION
I found I am not able to get properties in canStartChange function when the builder is triggered by buildbot sendchange. And I saw it work when the builder triggered by "force build". So I look into the buildbot source and make the patch to let it can see the properties from sendchange in canStarChange.