### PR TITLE
Don't leak Github Target's builder status subscription

### DIFF
--- a/master/buildbot/status/github.py
+++ b/master/buildbot/status/github.py
@@ -86,21 +86,26 @@ class GitHubStatus(StatusReceiverMultiService):
         self._github = GitHubAPI(oauth2_token=token, baseURL=baseURL)
 
         self._status = None
+        self._builder_status = None
 
     def startService(self):
         StatusReceiverMultiService.startService(self)
         self._status = self.parent.getStatus()
+        self._builder_status = []
         self._status.subscribe(self)
 
     def stopService(self):
         StatusReceiverMultiService.stopService(self)
+        for builder in self._builder_status:
+            builder.unsubscribe(self)
         self._status.unsubscribe(self)
 
-    def builderAdded(self, name_, builder_):
+    def builderAdded(self, name_, builder_status):
         """
         Subscribe to all builders.
         """
-        return self
+        builder_status.subscribe(self)
+        self._builder_status.append(builder_status)
 
     def buildStarted(self, builderName, build):
         """

--- a/master/buildbot/test/unit/test_status_github.py
+++ b/master/buildbot/test/unit/test_status_github.py
@@ -170,11 +170,28 @@ class TestGitHubStatus(unittest.TestCase, logging.LoggingMixin,
 
         self.status._status.subscribe.assert_called_with(self.status)
 
+    def test_stopService(self):
+        """
+        When stopped it will unsubscribe from all statuses.
+        """
+        builderstatus = FakeBuilderStatus()
+
+        result = self.status.builderAdded('builder-name', builderstatus)
+
+        self.status.stopService()
+
+        self.assertEqual(
+            0,
+            self.builderstatus.subscribe_count,
+            'There are still %d outstanding subscriptions'
+            % self.builderstatus.subscribe_count,
+        )
+
     def test_builderAdded(self):
         """
         Status is attached to every builder.
         """
-        result = self.status.builderAdded('builder-name', None)
+        result = self.status.builderAdded('builder-name', FakeBuilderStatus())
 
         self.assertEqual(self.status, result)
 
@@ -546,3 +563,15 @@ class TestGitHubStatus2(TestGitHubStatus):
         result = self.successResultOf(d)
 
         self.assertEqual({}, result)
+
+
+class FakeBuilderStatus(object):
+
+    def __init__(self):
+        self.subscribe_count = 0
+
+    def subscribe(self, _):
+        self.subscribe_count += 1
+
+    def unsubscribe(self, _):
+        self.subscribe_count -= 1


### PR DESCRIPTION
The github status target leaks builder subscriptions on reload. This can result in a huge multiplication on API calls to github, which is ratelimited at 5000 requests per hour. This change saves off a handle to every builder status, and unsubscribes on service stop.