### PR TITLE
Added a missed instruction: c['schedulers'] = []

### DIFF
--- a/master/docs/tutorial/tour.rst
+++ b/master/docs/tutorial/tour.rst
@@ -349,6 +349,7 @@ Buildbot includes a way for developers to submit patches for testing without com
 To set this up, add the following lines to master.cfg::
 
   from buildbot.scheduler import Try_Userpass
+  c['schedulers'] = []
   c['schedulers'].append(Try_Userpass(
                                       name='try',
                                       builderNames=['runtests'],


### PR DESCRIPTION
The example in the "Adding a 'try' scheduler" section did not work because c had not key 'schedulers':

$ buildbot reconfig master
2015-10-20 11:28:12+0200 [-] error while parsing config file:
  Traceback (most recent call last):
      ...    
  exceptions.KeyError: 'schedulers'