### PR TITLE
Fix issue with the table 'scheduler_masters'

### DIFF
--- a/master/buildbot/db/masters.py
+++ b/master/buildbot/db/masters.py
@@ -52,11 +52,12 @@ class MastersConnectorComponent(base.DBConnectorComponent):
                 return False  # can't change a row that doesn't exist..
             was_active = bool(rows[0].active)
 
-            # if we're marking inactive, then delete any links to this master
-            sch_mst_tbl = self.db.model.scheduler_masters
-            q = sch_mst_tbl.delete(
-                whereclause=(sch_mst_tbl.c.masterid == masterid))
-            conn.execute(q)
+            if not active:
+                # if we're marking inactive, then delete any links to this master
+                sch_mst_tbl = self.db.model.scheduler_masters
+                q = sch_mst_tbl.delete(
+                    whereclause=(sch_mst_tbl.c.masterid == masterid))
+                conn.execute(q)
 
             # set the state (unconditionally, just to be safe)
             q = tbl.update(whereclause=whereclause)


### PR DESCRIPTION
This table is populated by the SchedulersConnectorComponent::setSchedulerMaster, but deleted by the function MastersConnectorComponent::setMasterState even if the master is active.

If the master is active, the content of this table mustn't be deleted, otherwise schedulers aren't link to a master. As a consequence, when requesting
 - /api/v2/masters/<master_id>/schedulers/<sched_id>, the master field is always null. 
 - /api/v2/schedulers, the master field is always null.
- the Gui page about schedulers (http://127.0.0.1:8020/#/schedulers) the column Master is empty