### PR TITLE
master: source: git: Respect clobberOnFailure and retryFetch for git-fetch

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -387,6 +387,8 @@ class Git(Source):
             if rc == RC_SUCCESS:
                 fetch_required = False
 
+        abandonOnFailure = not self.retryFetch and not self.clobberOnFailure
+
         if fetch_required:
             command = ['fetch', '-t', self.repourl, self.branch]
             # If the 'progress' option is set, tell git fetch to output
@@ -396,14 +398,13 @@ class Git(Source):
             if self.prog:
                 command.append('--progress')
 
-            yield self._dovccmd(command)
+            yield self._dovccmd(command, abandonOnFailure)
 
         if self.revision:
             rev = self.revision
         else:
             rev = 'FETCH_HEAD'
         command = ['reset', '--hard', rev, '--']
-        abandonOnFailure = not self.retryFetch and not self.clobberOnFailure
         res = yield self._dovccmd(command, abandonOnFailure)
 
         # Rename the branch if needed.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -23,6 +23,8 @@ Features
 Fixes
 ~~~~~
 
+* Git: Respect the clobberOnFailure and retryFetch Git build step parameters when git fetch fails.
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The purpose of the clobberOnFailure and retryFetch parameters is either
retry the git-fetch command or perform a full clone of the repository
if the git-fetch failed. However, we only did that for git-reset and
not git-fetch so rework the code to pass this parameter to the git-fetch
step as well.


(if you plan to make more 0.8.X releases, can you please backport this patch to them as well (assuming the patch is accepted of course)? Thank you)