### PR TITLE
Add authorization for the rebuild endpoints

### DIFF
--- a/master/buildbot/test/unit/test_www_authz.py
+++ b/master/buildbot/test/unit/test_www_authz.py
@@ -19,6 +19,7 @@ from buildbot.www import authz
 from buildbot.www.authz.endpointmatchers import AnyEndpointMatcher
 from buildbot.www.authz.endpointmatchers import BranchEndpointMatcher
 from buildbot.www.authz.endpointmatchers import ForceBuildEndpointMatcher
+from buildbot.www.authz.endpointmatchers import RebuildBuildEndpointMatcher
 from buildbot.www.authz.endpointmatchers import StopBuildEndpointMatcher
 from buildbot.www.authz.endpointmatchers import ViewBuildsEndpointMatcher
 from buildbot.www.authz.roles import RolesFromEmails
@@ -47,6 +48,7 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
                 ViewBuildsEndpointMatcher(project="*", role="*"),
 
                 StopBuildEndpointMatcher(role="owner"),
+                RebuildBuildEndpointMatcher(role="owner"),
 
                 # nine-* groups can do stuff on the nine branch
                 BranchEndpointMatcher(branch="nine", role="nine-*"),
@@ -116,3 +118,14 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
         # not owner cannot stop
         yield self.assertUserForbidden("builds/13", "stop", {}, "eightuser")
         yield self.assertUserForbidden("buildrequests/82", "stop", {}, "eightuser")
+
+    @defer.inlineCallbacks
+    def test_rebuildBuild(self):
+        # admin can rebuild
+        yield self.assertUserAllowed("builds/13", "rebuild", {}, "homer")
+        # owner can always rebuild
+        yield self.assertUserAllowed("builds/13", "rebuild", {}, "nineuser")
+        yield self.assertUserAllowed("buildrequests/82", "rebuild", {}, "nineuser")
+        # not owner cannot rebuild
+        yield self.assertUserForbidden("builds/13", "rebuild", {}, "eightuser")
+        yield self.assertUserForbidden("buildrequests/82", "rebuild", {}, "eightuser")

--- a/master/buildbot/www/authz/endpointmatchers.py
+++ b/master/buildbot/www/authz/endpointmatchers.py
@@ -159,6 +159,18 @@ class ForceBuildEndpointMatcher(EndpointMatcherBase):
                     defer.returnValue(Match(self.master))
         defer.returnValue(None)
 
+
+class RebuildBuildEndpointMatcher(EndpointMatcherBase):
+
+    def __init__(self, builder=None, **kwargs):
+        self.builder = builder
+        EndpointMatcherBase.__init__(self, **kwargs)
+
+    @defer.inlineCallbacks
+    def match_BuildEndpoint_rebuild(self, epobject, epdict, options):
+        build = yield epobject.get({}, epdict)
+        defer.returnValue(Match(self.master, build=build))
+
 #####
 # not yet implemented
 

--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -436,6 +436,13 @@ Several endpoints  matchers are currently implemented
 
     StopBuildEndpointMatcher grants all rights to a people with given role (usually "admins")
 
+.. py:class:: buildbot.www.authz.endpointmatchers.RebuildBuildEndpointMatcher(builder, role)
+
+    :param builder: name of the builder.
+    :param role: The role needed to get access to such endpoints.
+
+    RebuildBuildEndpointMatcher grants all rights to a people with given role (usually "admins")
+
 Role matchers
 +++++++++++++
 Endpoint matchers are responsible for creating rules to match people and grant them roles.
@@ -491,7 +498,8 @@ Simple config which allows admin people to run everything:
     authz = util.Authz(
       allowRules=[
         util.StopBuildEndpointMatcher(role="admins"),
-        util.ForceBuildEndpointMatcher(role="admins")
+        util.ForceBuildEndpointMatcher(role="admins"),
+        util.RebuildBuildEndpointMatcher(role="admins)
       ],
       roleMatchers=[
         util.RolesFromEmails(admins=["my@email.com"])


### PR DESCRIPTION
This patch will allow one to authorize rebuilding of builds, instead of opening it up to everyone.