### PR TITLE
Ignore .idea directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ _build
 master/setuptools_trial*
 master/buildbot/www/static/js/default/
 sandbox
+.idea/


### PR DESCRIPTION
This directory is added when one uses PyCharm (it stores project information), but should never be in the repository.