### PR TITLE
GitHubAuth: Grab the user's primary email address

### DIFF
--- a/master/buildbot/test/unit/test_www_avatar.py
+++ b/master/buildbot/test/unit/test_www_avatar.py
@@ -42,6 +42,19 @@ class AvatarResource(www.WwwTestMixin, unittest.TestCase):
                                     'def654fccc4a4d8?s=32&d=retro'))
 
     @defer.inlineCallbacks
+    def test_github(self):
+        master = self.make_master(url='http://a/b/', auth=auth.NoAuth(), avatar_methods=[avatar.AvatarGitHub()])
+        rsrc = avatar.AvatarResource(master)
+        rsrc.reconfigResource(master.config)
+
+        res = yield self.render_resource(rsrc, '/?email=schacon@gmail.com')
+        self.assertEquals(res, {'redirected': 'https://avatars.githubusercontent.com/u/70?v=3&s=32'})
+
+        # Test if we get the same response from the cache
+        res = yield self.render_resource(rsrc, '/?email=schacon@gmail.com')
+        self.assertEquals(res, {'redirected': 'https://avatars.githubusercontent.com/u/70?v=3&s=32'})
+
+    @defer.inlineCallbacks
     def test_custom(self):
         class CustomAvatar(avatar.AvatarBase):
 

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -82,11 +82,12 @@ class OAuth2Auth(www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_getGithubLoginURL(self):
         res = yield self.githubAuth.getLoginURL('http://redir')
-        exp = ("https://github.com/login/oauth/authorize?state=redirect%3Dhttp%253A%252F%252Fredir&redirect_uri="
-               "h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&client_id=ghclientID")
+        exp = ("https://github.com/login/oauth/authorize?scope=user%3Aemail&state="
+               "redirect%3Dhttp%253A%252F%252Fredir&redirect_uri=h%3A%2Fa%2Fb%2F"
+               "auth%2Flogin&response_type=code&client_id=ghclientID")
         self.assertEqual(res, exp)
         res = yield self.githubAuth.getLoginURL(None)
-        exp = ("https://github.com/login/oauth/authorize?redirect_uri="
+        exp = ("https://github.com/login/oauth/authorize?scope=user%3Aemail&redirect_uri="
                "h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&client_id=ghclientID")
         self.assertEqual(res, exp)
 

--- a/master/buildbot/www/avatar.py
+++ b/master/buildbot/www/avatar.py
@@ -16,6 +16,8 @@ from future.moves.urllib.parse import urlencode
 from future.moves.urllib.parse import urljoin
 
 import hashlib
+import json
+import urllib
 
 from twisted.internet import defer
 
@@ -28,6 +30,29 @@ class AvatarBase(config.ConfiguredMixin):
 
     def getUserAvatar(self, email, size, defaultAvatarUrl):
         raise NotImplementedError()
+
+
+class AvatarGitHub(AvatarBase):
+    name = "github"
+    cache = {}
+
+    def getUserAvatar(self, email, size, defaultAvatarUrl):
+        url = self.cache.get(email)
+        if url:
+            raise resource.Redirect(url)
+
+        # https://developer.github.com/v3/search/#search-users
+        url = 'https://api.github.com/search/users?'
+        url += urllib.urlencode({'q': email, 'in': 'email', 'type': 'user'})
+        try:
+            res = json.loads(urllib.urlopen(url).read())
+            github_url = res['items'][0]['avatar_url']
+        except:
+            # Redirect to the default image if *something* fails
+            raise resource.Redirect(str(defaultAvatarUrl))
+        github_url += '&' + urllib.urlencode({'s': str(size)})
+        self.cache[email] = str(github_url)
+        raise resource.Redirect(str(github_url))
 
 
 class AvatarGravatar(AvatarBase):

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -170,11 +170,17 @@ class GitHubAuth(OAuth2Auth):
     name = "GitHub"
     faIcon = "fa-github"
     authUri = 'https://github.com/login/oauth/authorize'
+    authUriAdditionalParams = {'scope': 'user:email'}
     tokenUri = 'https://github.com/login/oauth/access_token'
     resourceEndpoint = 'https://api.github.com'
 
     def getUserInfoFromOAuthClient(self, c):
         user = self.get(c, '/user')
+        emails = self.get(c, '/user/emails')
+        for email in emails:
+            if email.get('primary', False):
+                user['email'] = email['email']
+                break
         orgs = self.get(c, join('/users', user['login'], "orgs"))
         return dict(full_name=user['name'],
                     email=user['email'],

--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -203,8 +203,7 @@ The available classes are described here:
     Register your Buildbot instance with the ``BUILDBOT_URL/auth/login`` url as the allowed redirect URI.
 
     The user's email-address (for e.g. authorization) is set to the "primary" address set by the user in GitHub.
-    When using group-based authorization, the user's groups are equal to the names of the GitHub organizations the user
-    is a member of.
+    When using group-based authorization, the user's groups are equal to the names of the GitHub organizations the user is a member of.
 
     Example::
 
@@ -579,11 +578,13 @@ More complex config with separation per branch:
     )
     c['www']['authz'] = authz
 
-Using GitHub authentication and allowing access to all endpoints for users in the "BuildBot" organisation:
+Using GitHub authentication and allowing access to all endpoints for users in the "Buildbot" organisation, using the
+avatars from GitHub:
 
 .. code-block:: python
 
     from buildbot.plugins import *
+    avatars = util.AvatarGitHub()
     authz = util.Authz(
       allowRules=[
         util.AnyEndpointMatcher(role="BuildBot", defaultDeny=True)
@@ -595,3 +596,4 @@ Using GitHub authentication and allowing access to all endpoints for users in th
     auth=util.GitHubAuth('CLIENT_ID', 'CLIENT_SECRET')
     c['www']['auth'] = auth
     c['www']['authz'] = authz
+    c['www']['avatar_methods'] = avatars

--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -202,6 +202,10 @@ The available classes are described here:
 
     Register your Buildbot instance with the ``BUILDBOT_URL/auth/login`` url as the allowed redirect URI.
 
+    The user's email-address (for e.g. authorization) is set to the "primary" address set by the user in GitHub.
+    When using group-based authorization, the user's groups are equal to the names of the GitHub organizations the user
+    is a member of.
+
     Example::
 
         from buildbot.plugins import util
@@ -573,4 +577,21 @@ More complex config with separation per branch:
             RolesFromOwner(role="owner")
         ]
     )
+    c['www']['authz'] = authz
+
+Using GitHub authentication and allowing access to all endpoints for users in the "BuildBot" organisation:
+
+.. code-block:: python
+
+    from buildbot.plugins import *
+    authz = util.Authz(
+      allowRules=[
+        util.AnyEndpointMatcher(role="BuildBot", defaultDeny=True)
+      ],
+      roleMatchers=[
+        util.RolesFromGroups()
+      ]
+    )
+    auth=util.GitHubAuth('CLIENT_ID', 'CLIENT_SECRET')
+    c['www']['auth'] = auth
     c['www']['authz'] = authz

--- a/master/setup.py
+++ b/master/setup.py
@@ -350,7 +350,7 @@ setup_args = {
                 ('repo.DownloadsFromProperties',
                  'RepoDownloadsFromProperties')]),
             ('buildbot.steps.shellsequence', ['ShellArg']),
-            ('buildbot.www.avatar', ['AvatarGravatar']),
+            ('buildbot.www.avatar', ['AvatarGravatar', 'AvatarGitHub']),
             ('buildbot.www.auth', [
                 'UserPasswordAuth', 'HTPasswdAuth', 'RemoteUserAuth']),
             ('buildbot.www.ldapuserinfo', ['LdapUserInfo']),


### PR DESCRIPTION
Github doesn't provide any email address in the normal oauth response, so we request an extra permission and assign the user's primary email to the email field in buildbot.