### PR TITLE
reload 'master.cfg' from thread when buildbot is reconfigured

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -348,8 +348,10 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
         changes_made = False
         failed = False
         try:
-            new_config = config.MasterConfig.loadConfig(self.basedir,
-                                                        self.configFileName)
+            # Run the master.cfg in thread, so that it cas use blocking code
+            new_config = yield threads.deferToThread(config.MasterConfig.loadConfig,
+                                                     self.basedir,
+                                                     self.configFileName)
             changes_made = True
             self.config = new_config
 


### PR DESCRIPTION
When buildbot is started, master.cfg is loaded from a thread (see 76c5b0ce6f64f7eeda5e590e1155fabece68812d).
When buildbot is reconfigured, master.cfg is loaded from the main thread. It should be loaded from a thread.