### PR TITLE
fix for http://trac.buildbot.net/ticket/3369

### DIFF
--- a/master/buildbot/buildslave/base.py
+++ b/master/buildbot/buildslave/base.py
@@ -274,6 +274,8 @@ class AbstractBuildSlave(service.BuildbotService, object):
             yield self.registration.unregister()
             self.registration = None
         self.stopMissingTimer()
+        # mark this slave as configured for zero builders in this master
+        yield self.master.data.updates.buildslaveConfigured(self.buildslaveid, self.master.masterid, [])
         yield service.BuildbotService.stopService(self)
 
     def startMissingTimer(self):
@@ -776,7 +778,7 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
                 # this will cause the slave to re-substantiate immediately if
                 # there are pending build requests.
                 d.addCallback(lambda _:
-                    self.botmaster.maybeStartBuildsForSlave(self.slavename))
+                              self.botmaster.maybeStartBuildsForSlave(self.slavename))
             else:
                 self._setBuildWaitTimer()
 

--- a/master/buildbot/db/buildslaves.py
+++ b/master/buildbot/db/buildslaves.py
@@ -55,40 +55,45 @@ class BuildslavesConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thd)
 
     def buildslaveConfigured(self, buildslaveid, masterid, builderids):
-        # nothing to add
-        if not builderids:
-            return defer.succeed(None)
 
         def thd(conn):
 
-            # get the buildermasterids that are configured
             cfg_tbl = self.db.model.configured_buildslaves
             bm_tbl = self.db.model.builder_masters
-            q = sa.select([bm_tbl.c.id], from_obj=[bm_tbl])
-            q = q.where(bm_tbl.c.masterid == masterid)
-            q = q.where(bm_tbl.c.builderid.in_(builderids))
-            buildermasterids = [row['id'] for row in conn.execute(q)]
 
-            # and insert them
-            q = cfg_tbl.insert()
-            try:
+            # get the buildermasterids that are configured
+            if builderids:
+                q = sa.select([bm_tbl.c.id], from_obj=[bm_tbl])
+                q = q.where(bm_tbl.c.masterid == masterid)
+                q = q.where(bm_tbl.c.builderid.in_(builderids))
+                buildermasterids = set([row['id'] for row in conn.execute(q)])
+            else:
+                buildermasterids = set([])
+
+            j = cfg_tbl
+            j = j.outerjoin(bm_tbl)
+            q = sa.select([cfg_tbl.c.buildermasterid], from_obj=[j])
+            q = q.where(bm_tbl.c.masterid == masterid)
+            q = q.where(cfg_tbl.c.buildslaveid == buildslaveid)
+            oldbuildermasterids = set([row['buildermasterid'] for row in conn.execute(q)])
+
+            todeletebuildermasterids = oldbuildermasterids - buildermasterids
+            toinsertbuildermasterids = buildermasterids - oldbuildermasterids
+            transaction = conn.begin()
+            if todeletebuildermasterids:
+                # delete the buildermasterids that were configured previously, but not configured now
+                q = cfg_tbl.delete()
+                q = q.where(cfg_tbl.c.buildermasterid.in_(list(todeletebuildermasterids)))
+                conn.execute(q)
+
+            # and insert the new ones
+            if toinsertbuildermasterids:
+                q = cfg_tbl.insert()
                 conn.execute(q,
                              [{'buildslaveid': buildslaveid, 'buildermasterid': buildermasterid}
-                              for buildermasterid in buildermasterids])
-            except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
-                # if some rows are already present, insert one by one.
-                pass
-            else:
-                return
+                              for buildermasterid in toinsertbuildermasterids])
 
-            for buildermasterid in buildermasterids:
-                # insert them one by one
-                q = cfg_tbl.insert()
-                try:
-                    conn.execute(q, {'buildslaveid': buildslaveid, 'buildermasterid': buildermasterid})
-                except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
-                    # if the row is already present, silently fail..
-                    pass
+            transaction.commit()
 
         return self.db.pool.do(thd)
 

--- a/master/buildbot/db/buildslaves.py
+++ b/master/buildbot/db/buildslaves.py
@@ -203,7 +203,8 @@ class BuildslavesConnectorComponent(base.DBConnectorComponent):
     def buildslaveDisconnected(self, buildslaveid, masterid):
         def thd(conn):
             tbl = self.db.model.connected_buildslaves
-            q = tbl.delete(whereclause=(tbl.c.buildslaveid == buildslaveid)
-                           & (tbl.c.masterid == masterid))
+            q = tbl.delete(whereclause=(
+                tbl.c.buildslaveid == buildslaveid) &
+                (tbl.c.masterid == masterid))
             conn.execute(q)
         return self.db.pool.do(thd)

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1455,6 +1455,11 @@ class FakeBuildslavesComponent(FakeDBComponent):
                              "builders: %s, master: %s buildermaster:%s" %
                              (builderids, masterid, self.db.builders.builder_masters))
 
+        allbuildermasterids = [_id for _id, (builderid, mid) in iteritems(self.db.builders.builder_masters)
+                               if mid == masterid]
+        for k, v in self.configured.items():
+            if v['buildermasterid'] in allbuildermasterids and v['buildslaveid'] == buildslaveid:
+                del self.configured[k]
         self.insertTestData([ConfiguredBuildslave(buildslaveid=buildslaveid,
                                                   buildermasterid=buildermasterid)
                              for buildermasterid in buildermasterids])

--- a/master/buildbot/test/unit/test_db_buildslaves.py
+++ b/master/buildbot/test/unit/test_db_buildslaves.py
@@ -480,6 +480,32 @@ class Tests(interfaces.InterfaceTests):
             {'builderid': 22, 'masterid': 10}]))
 
     @defer.inlineCallbacks
+    def test_buildslaveReConfigured(self):
+        yield self.insertTestData(self.baseRows + self.multipleMasters)
+
+        # should remove builder 21, and add 22
+        yield self.db.buildslaves.buildslaveConfigured(
+            buildslaveid=30, masterid=10, builderids=[20, 22])
+
+        bs = yield self.db.buildslaves.getBuildslave(30)
+        self.assertEqual(sorted(bs['configured_on']), sorted([
+            {'builderid': 20, 'masterid': 11},
+            {'builderid': 20, 'masterid': 10},
+            {'builderid': 22, 'masterid': 10}]))
+
+    @defer.inlineCallbacks
+    def test_buildslaveUnconfigured(self):
+        yield self.insertTestData(self.baseRows + self.multipleMasters)
+
+        # should remove all builders from master 10
+        yield self.db.buildslaves.buildslaveConfigured(
+            buildslaveid=30, masterid=10, builderids=[])
+
+        bs = yield self.db.buildslaves.getBuildslave(30)
+        self.assertEqual(sorted(bs['configured_on']), sorted([
+            {'builderid': 20, 'masterid': 11}]))
+
+    @defer.inlineCallbacks
     def test_nothingConfigured(self):
         yield self.insertTestData(self.baseRows + self.multipleMasters)
 

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -745,6 +745,7 @@ buildslaves
         :returns: Deferred
 
         Record the given buildslave as being configured on the given master and for given builders.
+        This method will also remove any other builder that were configured previously for same (slave, master) combination.
 
 
     .. py:method:: deconfigureAllBuidslavesForMaster(masterid)


### PR DESCRIPTION
If you change the slave configuration on the master.cfg, and do a buildbot reload then the slave list in the UI is not updated accordingly


This was because the db update algorithm was not properly maintaining the list of buildermasterids for a slave