### PR TITLE
build properties data api rework

### DIFF
--- a/master/buildbot/data/properties.py
+++ b/master/buildbot/data/properties.py
@@ -63,7 +63,7 @@ class Properties(base.ResourceType):
     def setBuildProperties(self, buildid, properties):
         to_update = {}
         oldproperties = yield self.master.data.get(('builds', str(buildid), "properties"))
-        for k, v in properties.asDict().iteritems():
+        for k, v in properties.getProperties().asDict().iteritems():
             if k in oldproperties and oldproperties[k] == v:
                 continue
             to_update[k] = v

--- a/master/buildbot/data/properties.py
+++ b/master/buildbot/data/properties.py
@@ -15,6 +15,7 @@
 
 from buildbot.data import base
 from buildbot.data import types
+from twisted.internet import defer
 
 
 class BuildsetPropertiesEndpoint(base.Endpoint):
@@ -48,7 +49,34 @@ class Properties(base.ResourceType):
 
     entityType = types.SourcedProperties()
 
+    def generateUpdateEvent(self, buildid, newprops):
+        # This event cannot use the produceEvent mecanism, as the properties resource type is a bit specific
+        # (this is a dictionary collection)
+        # We only send the new properties, and count on the client to merge the resulting properties dict
+        # We are good, as there is no way to delete a property.
+        routingKey = ('builds', str(buildid), "properties", "update")
+        newprops = self.sanitizeMessage(newprops)
+        return self.master.mq.produce(routingKey, newprops)
+
     @base.updateMethod
+    @defer.inlineCallbacks
+    def setBuildProperties(self, buildid, properties):
+        to_update = {}
+        oldproperties = yield self.master.data.get(('builds', str(buildid), "properties"))
+        for k, v in properties.asDict().iteritems():
+            if k in oldproperties and oldproperties[k] == v:
+                continue
+            to_update[k] = v
+        if to_update:
+            for k, v in to_update.iteritems():
+                yield self.master.db.builds.setBuildProperty(
+                    buildid, k, v[0], v[1])
+            yield self.generateUpdateEvent(buildid, to_update)
+
+    @base.updateMethod
+    @defer.inlineCallbacks
     def setBuildProperty(self, buildid, name, value, source):
-        return self.master.db.builds.setBuildProperty(
+        res = yield self.master.db.builds.setBuildProperty(
             buildid, name, value, source)
+        yield self.generateUpdateEvent(buildid, dict(name=(value, source)))
+        defer.returnValue(res)

--- a/master/buildbot/data/properties.py
+++ b/master/buildbot/data/properties.py
@@ -13,9 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
+
 from buildbot.data import base
 from buildbot.data import types
-from twisted.internet import defer
 
 
 class BuildsetPropertiesEndpoint(base.Endpoint):
@@ -67,6 +68,7 @@ class Properties(base.ResourceType):
             if k in oldproperties and oldproperties[k] == v:
                 continue
             to_update[k] = v
+
         if to_update:
             for k, v in to_update.iteritems():
                 yield self.master.db.builds.setBuildProperty(

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -26,15 +26,37 @@ from buildbot.test.fake import fakemaster
 from twisted.python import components
 
 
-class FakeBuildStatus(properties.PropertiesMixin, mock.Mock):
-    properties = properties.Properties()
+class FakeBuildStatus(properties.PropertiesMixin, object):
 
-    # work around http://code.google.com/p/mock/issues/detail?id=105
-    def _get_child_mock(self, **kw):
-        return mock.Mock(**kw)
+    def __init__(self):
+        self.properties = properties.Properties()
 
     def getInterestedUsers(self):
         return []
+
+    def setSlavename(self, _):
+        pass
+
+    def setSourceStamps(self, _):
+        pass
+
+    def setReason(self, _):
+        pass
+
+    def setBlamelist(self, _):
+        pass
+
+    def buildStarted(self, _):
+        return True
+
+    setText = mock.Mock()
+    setText2 = mock.Mock()
+    setResults = mock.Mock()
+
+    def buildFinished(self):
+        pass
+
+    getBuilder = mock.Mock()
 
 components.registerAdapter(
     lambda build_status: build_status.properties,

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -50,7 +50,7 @@ class FakeUpdates(service.AsyncService):
         self.claimedBuildRequests = set([])
         self.stepStateString = {}  # { stepid : string }
         self.stepUrls = {}  # { stepid : [(name,url)] }
-
+        self.properties = []
     # extra assertions
 
     def assertProperties(self, sourced, properties):
@@ -320,6 +320,12 @@ class FakeUpdates(service.AsyncService):
         validation.verifyType(self.testcase, 'source', source,
                               validation.StringValidator())
         return defer.succeed(None)
+
+    @defer.inlineCallbacks
+    def setBuildProperties(self, buildid, properties):
+        for k, v, s in properties.getProperties().asList():
+            self.properties.append((buildid, k, v, s))
+            yield self.setBuildProperty(buildid, k, v, s)
 
     def addStep(self, buildid, name):
         validation.verifyType(self.testcase, 'buildid', buildid,

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -40,9 +40,9 @@ from mock import call
 
 
 class FakeChange:
-    properties = Properties()
 
     def __init__(self, number=None):
+        self.properties = Properties()
         self.number = number
         self.who = "me"
 
@@ -634,24 +634,14 @@ class TestBuild(unittest.TestCase):
     def testflushProperties(self):
         b = self.build
 
-        class FakeBuildStatus(Mock):
-            implements(interfaces.IProperties)
         b.build_status = FakeBuildStatus()
-
-        class Properties(Mock):
-
-            def asList(self):
-                return [(u'p', 5, u'fake'),
-                        (u'p2', ['abc', 9], u'mock')]
-        b.master.data.updates.setBuildProperty = Mock()
-        b.build_status.getProperties.return_value = Properties()
-        b.buildid = 42
+        b.setProperty("foo", "bar", "test")
+        b.buildid = 43
         result = 'SUCCESS'
         res = yield b._flushProperties(result)
         self.assertEquals(res, result)
-        b.master.data.updates.setBuildProperty.assert_has_calls([
-            call(42, u'p', 5, u'fake'),
-            call(42, u'p2', ['abc', 9], u'mock')])
+        self.assertEqual(self.master.data.updates.properties,
+                         [(43, u'foo', 'bar', u'test')])
 
     def create_mock_steps(self, names):
         steps = []
@@ -966,6 +956,7 @@ class TestBuildProperties(unittest.TestCase):
             fakemaster.make_master(wantData=True, testcase=self))
         self.build.setBuilder(self.builder)
         self.build_status = FakeBuildStatus()
+        self.build._flushProperties = Mock()
         self.build.startBuild(self.build_status, None, self.slavebuilder)
 
     def test_getProperty(self):

--- a/master/docs/developer/rtype-properties.rst
+++ b/master/docs/developer/rtype-properties.rst
@@ -33,3 +33,11 @@ All update methods are available as attributes of ``master.data.updates``.
         Set a build property.
         If no property with that name exists in that build, a new property will be created.
 
+    .. py:method:: setBuildProperties(buildid, props)
+
+        :param integer buildid: build ID
+        :param IProperties props: Name of the property to set
+
+        Synchronise build properties with the db.
+        This sends only one event in the end of the synch, and only if properties changed.
+        The event contains only the updated properties, for network efficiency reasons.

--- a/master/docs/developer/rtype-properties.rst
+++ b/master/docs/developer/rtype-properties.rst
@@ -39,5 +39,5 @@ All update methods are available as attributes of ``master.data.updates``.
         :param IProperties props: Name of the property to set
 
         Synchronise build properties with the db.
-        This sends only one event in the end of the synch, and only if properties changed.
+        This sends only one event in the end of the sync, and only if properties changed.
         The event contains only the updated properties, for network efficiency reasons.


### PR DESCRIPTION
As per http://trac.buildbot.net/ticket/3255
build properties did not sent even so weren't properly updated in the UI.
It happens that there was some inefficiency in the update properties mecanism that I fix in this commit.
We will only flush the needed properties in the db, and also only send events for the updated properties

A few "mock is evil" cleanups has been done in this commit as well, as I was hunting why unit tests were failing strangely.