### PR TITLE
Support configurable key for StashStatusPush

### DIFF
--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -85,6 +85,7 @@ class FakeBuilderStatus(object):
         self.lastBuildStatus = None
         self._tags = None
         self.name = buildername
+        self.status = mock.Mock()
 
     def setDescription(self, description):
         self._description = description

--- a/master/buildbot/test/unit/test_status_stash.py
+++ b/master/buildbot/test/unit/test_status_stash.py
@@ -18,10 +18,11 @@ from buildbot.status.results import SUCCESS
 from buildbot.status.status_stash import StashStatusPush, INPROGRESS, SUCCESSFUL, FAILED
 from buildbot.test.fake.fakebuild import FakeBuild
 from buildbot.test.util import logging
-from mock import Mock
+from mock import patch
 from twisted.trial import unittest
 
 
+@patch.object(StashStatusPush, 'send')
 class TestStashStatusPush(unittest.TestCase, logging.LoggingMixin):
 
     def setUp(self):
@@ -34,26 +35,23 @@ class TestStashStatusPush(unittest.TestCase, logging.LoggingMixin):
     def tearDown(self):
         pass
 
-    def test_buildStarted_sends_inprogress(self):
+    def test_buildStarted_sends_inprogress(self, mock_send):
         """
         buildStarted should send INPROGRESS
         """
-        self.status.send = Mock()
         self.status.buildStarted('fakeBuilderName', self.build)
-        self.status.send.assert_called_with('fakeBuilderName', self.build, INPROGRESS)
+        mock_send.assert_called_with('fakeBuilderName', self.build, INPROGRESS)
 
-    def test_buildFinished_sends_successful_on_success(self):
+    def test_buildFinished_sends_successful_on_success(self, mock_send):
         """
         buildFinished should send SUCCESSFUL if called with SUCCESS
         """
-        self.status.send = Mock()
         self.status.buildFinished('fakeBuilderName', self.build, SUCCESS)
-        self.status.send.assert_called_with('fakeBuilderName', self.build, SUCCESSFUL)
+        mock_send.assert_called_with('fakeBuilderName', self.build, SUCCESSFUL)
 
-    def test_buildFinished_sends_failed_on_failure(self):
+    def test_buildFinished_sends_failed_on_failure(self, mock_send):
         """
         buildFinished should send FAILED if called with anything other than SUCCESS
         """
-        self.status.send = Mock()
         self.status.buildFinished('fakeBuilderName', self.build, FAILURE)
-        self.status.send.assert_called_with('fakeBuilderName', self.build, FAILED)
+        mock_send.assert_called_with('fakeBuilderName', self.build, FAILED)

--- a/master/buildbot/test/unit/test_status_stash.py
+++ b/master/buildbot/test/unit/test_status_stash.py
@@ -13,13 +13,17 @@
 #
 # Copyright Buildbot Team Members
 
+from buildbot.process.properties import Interpolate
 from buildbot.status.results import FAILURE
 from buildbot.status.results import SUCCESS
 from buildbot.status.status_stash import StashStatusPush, INPROGRESS, SUCCESSFUL, FAILED
 from buildbot.test.fake.fakebuild import FakeBuild
 from buildbot.test.util import logging
+from json import loads
 from mock import patch
+from twisted.internet import defer
 from twisted.trial import unittest
+from twisted.web.http_headers import Headers
 
 
 @patch.object(StashStatusPush, 'send')
@@ -55,3 +59,51 @@ class TestStashStatusPush(unittest.TestCase, logging.LoggingMixin):
         """
         self.status.buildFinished('fakeBuilderName', self.build, FAILURE)
         mock_send.assert_called_with('fakeBuilderName', self.build, FAILED)
+
+
+@patch.object(StashStatusPush, '_send')
+class TestStashStatusSend(unittest.TestCase, logging.LoggingMixin):
+
+    def setUp(self):
+        super(TestStashStatusSend, self).setUp()
+
+        self.setUpLogging()
+        self.build = FakeBuild()
+        self.build.builder.status.getURLForThing.return_value = 'fake_build_url'
+        self.my_key_format = '%(builderName)s-%(branch)s'
+        self.my_name_format = '%(builderName)s-%(branch)s-%(buildNumber)s'
+        self.status = StashStatusPush('fake host', 'fake user', 'fake password',
+                                      key_format=self.my_key_format,
+                                      name_format=self.my_name_format)
+        self.status._sha = Interpolate('fake_sha')
+        self.status._branch = Interpolate('fake_branch')
+        self.status._buildnumber = Interpolate('fake_buildNumber')
+
+    @defer.inlineCallbacks
+    def test_send(self, mock_send):
+        d = yield self.status.send('fakeBuilderName', self.build, INPROGRESS)
+        self.assertEqual(1, mock_send.call_count)
+        args, kwargs = mock_send.call_args
+        self.assertEqual({}, kwargs)
+        self.assertEqual(3, len(args))
+        request_kwargs, body, error_message = args
+        self.assertEqual('fake host/rest/build-status/1.0/commits/fake_sha',
+                         request_kwargs.get('uri', 'No uri present'))
+        self.assertEqual('POST', request_kwargs.get('method', 'No method present'))
+        headers = request_kwargs.get('headers', {})
+        self.assertEqual(Headers({
+                 'content-type': ['application/json; charset=utf-8'],
+                 'accept-language': ['en-US, en;q=0.8'],
+                 'authorization': ['Basic ZmFrZSB1c2VyOmZha2UgcGFzc3dvcmQ='],
+                 'accept': ['*/*']
+            }), request_kwargs.get('headers', 'No headers present'))
+        try:
+            body_dict = loads(body)
+        except ValueError, e:
+            self.fail('body is not JSON: %s' % e)
+        self.assertEqual({
+                'url': 'fake_build_url',
+                'state': 'INPROGRESS',
+                'name': 'fakeBuilderName-fake_branch-fake_buildNumber',
+                'key': 'fakeBuilderName-fake_branch'
+            }, body_dict)

--- a/master/docs/manual/cfg-statustargets.rst
+++ b/master/docs/manual/cfg-statustargets.rst
@@ -1626,7 +1626,9 @@ StashStatusPush
 
     ss = StashStatusPush('https://stash.example.com:8080/',
                          'stash_username',
-                         'secret_password')
+                         'secret_password',
+                         key_format='%(builderName)s-%(branch)s',
+                         name_format='%(builderName)s-%(branch)s-%(buildNumber)s')
 
     c['status'].append(ss)
 
@@ -1639,13 +1641,18 @@ Specifically, it follows the `Updating build status for commits <https://develop
 
 It uses the standard Python Twisted Agent to make REST requests to the stash server.
 It uses HTTP Basic AUTH.
-As a result, we recommend you use https in your base_url rather than http.
+As a result, we recommend you either connect over a secured network or use https in your base_url rather than http.
 If you use https, it requires `pyOpenSSL`.
 
-Configuration requires exactly 3 parameters:
+Configuration requires 3 parameters:
 `base_url` is the base url of the stash host, up to and optionally including the first / of the path.
 `user` is the stash user to post as
 `password` is the stash user's password
+There are also two optional parameters:
+`key_format` is a python format string used to define the aggregation key for builds in stash.
+It defaults to `%(builderName)s` for backwards compatability.
+`name_format` is a python format string used to define the human-readable build name in stash.
+It defaults to `None` which does not include a name parameter in the REST request.
 
 .. [#] Apparently this is the same way http://buildd.debian.org displays build status
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -42,6 +42,8 @@ Features
 
 * :bb:status:`GerritStatusPush` now has parameter --notify which is used to control e-mail notifications from Gerrit.
 
+* StashStatusPush now accepts optional ``key_format`` and ``name_format`` parameters to configure build reporting to Atlassian Stash.
+
 * Schedulers: the ``codebases`` parameter can now be specified in a simple list-of-strings form
 
 Fixes


### PR DESCRIPTION
The key determines how stash aggregates build status reports to decide
which builds are worth reporting separately and which are
simply repeats of previous builds. 

Also includes support for an optional name.