### PR TITLE
REVIEW: first try at an IRC authz module

### DIFF
--- a/master/buildbot/reporters/authz/__init__.py
+++ b/master/buildbot/reporters/authz/__init__.py
@@ -1,0 +1,11 @@
+from buildbot.interfaces import IConfigured
+from zope.interface import implements
+
+class Authz(object):
+    implements(IConfigured)
+
+    def getConfigDict(self):
+        return {}
+
+    def assertUserAllowed(self, **kwargs):
+        raise NotImplementedError()

--- a/master/buildbot/reporters/authz/irc.py
+++ b/master/buildbot/reporters/authz/irc.py
@@ -1,0 +1,33 @@
+from buildbot.reporters.authz import Authz
+
+
+class IrcAuthz(Authz):
+
+    def __init__(self, allowOnlyOps=True):
+        self.channelUsers = {}
+        self.allowOnlyOps = allowOnlyOps
+
+    def addUserstoChannel(self, nicklist, channel):
+        if '%s-tmp' % channel not in self.channelUsers:
+            self.channelUsers['%s-tmp' % channel] = []
+        n = self.channelUsers['%s-tmp' % channel]
+        n += nicklist
+
+    def finalizeAddUsersToChannel(self, channel):
+        if '%s-tmp' % channel not in self.channelUsers:
+            return
+
+        self.channelUsers[channel] = self.channelUsers['%s-tmp' % channel]
+        del self.channelUsers['%s-tmp' % channel]
+
+    def assertAllowPM(self):
+        if self.allowOnlyOps:
+            return False
+        else:
+            return True
+
+    def assertUserAllowed(self, user, channel):
+        if self.allowOnlyOps:
+            return '@%s' % user not in self.channelUsers[channel]
+        else:
+            return True

--- a/master/buildbot/reporters/authz/irc.py
+++ b/master/buildbot/reporters/authz/irc.py
@@ -5,20 +5,19 @@ class IrcAuthz(Authz):
 
     def __init__(self, allowOnlyOps=True):
         self.channelUsers = {}
+        self.tmpChannelUsers = {}
         self.allowOnlyOps = allowOnlyOps
 
     def addUserstoChannel(self, nicklist, channel):
-        if '%s-tmp' % channel not in self.channelUsers:
-            self.channelUsers['%s-tmp' % channel] = []
-        n = self.channelUsers['%s-tmp' % channel]
+        self.tmpChannelUsers.setdefault(channel, default=[])
+        n = self.tmpChannelUsers[channel]
         n += nicklist
 
     def finalizeAddUsersToChannel(self, channel):
-        if '%s-tmp' % channel not in self.channelUsers:
-            return
+        self.tmpChannelUsers.setdefault(channel, default=[])
 
-        self.channelUsers[channel] = self.channelUsers['%s-tmp' % channel]
-        del self.channelUsers['%s-tmp' % channel]
+        self.channelUsers[channel] = self.tmpChannelUsers[channel]
+        del self.tmpChannelUsers[channel]
 
     def assertAllowPM(self):
         if self.allowOnlyOps:

--- a/master/buildbot/reporters/irc.py
+++ b/master/buildbot/reporters/irc.py
@@ -112,6 +112,7 @@ class IrcStatusBot(StatusBot, irc.IRCClient):
             # private message
             if not self.authz.assertAllowPM():
                 self.log('User %s is not allowed to talk to me' % user)
+                self.sendLine("I'm sorry %s, I'm afraid I can't let you do that.")
                 return defer.succeed(None)
             contact = self.getContact(user=user)
             d = contact.handleMessage(message)
@@ -252,7 +253,7 @@ class IRC(service.BuildbotService):
             config.error("allowForce must be boolean, not %r" % (allowForce,))
         if allowShutdown not in (True, False):
             config.error("allowShutdown must be boolean, not %r" % (allowShutdown,))
-        if 'authz' in kwargs.keys():
+        if authz is not None:
             if not isinstance(IrcAuthz, kwargs['authz']):
                 config.error("authz is not an IrcAuthz object")
 
@@ -279,7 +280,7 @@ class IRC(service.BuildbotService):
             notify_events = {}
         self.notify_events = notify_events
         self.allowShutdown = allowShutdown
-        if not authz:
+        if authz is not None:
             self.authz = IrcAuthz(allowOnlyOps=False)
 
         # This function is only called in case of reconfig with changes

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -1014,7 +1014,7 @@ class StatusBot(service.AsyncMultiService):
 
     def __init__(self, tags, notify_events,
                  useRevisions=False, showBlameList=False, useColors=True,
-                 categories=None  # deprecated
+                 categories=None, authz=None  # deprecated
                  ):
         service.AsyncMultiService.__init__(self)
         self.tags = tags or categories
@@ -1022,6 +1022,7 @@ class StatusBot(service.AsyncMultiService):
         self.useColors = useColors
         self.useRevisions = useRevisions
         self.showBlameList = showBlameList
+        self.authz = authz
         self.contacts = {}
 
     def groupChat(self, channel, message):


### PR DESCRIPTION
Right now, this only supports allowing IRC channel ops to talk to the bot. It can be configured in master.cfg as follows:

```
from buildbot.reporters import irc
from buildbot.reporters.authz.irc import IrcAuthz

authz = IrcAuthz(allowOnlyOps=True)
bot = irc.IRC(host='some-host.example.net', nick='my-bb-bot', channels={'#some-channel': ''}, authz=authz)

c['services'] = []
c['services'].append(bot)
```

This is a start to fix Trac ticket [3377](trac.buildbot.net/ticket/3377). I'm submitting this code now for a review, mostly to check if I'm on the right track.