### PR TITLE
waterfall: fix  ReferenceError

### DIFF
--- a/www/waterfall_view/src/module/main.module.coffee
+++ b/www/waterfall_view/src/module/main.module.coffee
@@ -50,9 +50,9 @@ class Waterfall extends Controller
 
         # Load data (builds and builders)
         builders = @dataService.getBuilders()
-        $scope.builders = builders.getArray()
+        @$scope.builders = builders.getArray()
         builds = @dataService.getBuilds({limit: @c.limit, order: '-complete_at'})
-        $scope.builds = builds.getArray()
+        @$scope.builds = builds.getArray()
 
         $q.all([d3Service.get(), builders, builds]).then ([@d3, @builders, @builds]) =>
 


### PR DESCRIPTION
Currently waterfall is broken (http://nine.buildbot.net/#/waterfall) because of a ReferenceError.

This patch fix it.