### PR TITLE
 improve tag filtering in builder page

### DIFF
--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -20,6 +20,8 @@ Master
 Features
 ~~~~~~~~
 
+* Builders ui page has improved tag filtering capabilities
+
 Fixes
 ~~~~~
 

--- a/www/base/src/app/builders/builders.tpl.jade
+++ b/www/base/src/app/builders/builders.tpl.jade
@@ -5,6 +5,27 @@
           th Builder Name
           th Builds
           th
+            span(ng-init="help=false", ng-click="help=!help")
+                i.fa.fa-question-circle(style="position:relative")
+                    .popover.bottom.anim-popover(ng-if="help",
+                       style="display:block;min-width:600px;left:-300px;top:30px")
+                        h5.popover-title
+                            | Tags filtering
+                        .popover-content
+                            p
+                              b
+                                  pre +{tag}
+                              | all tags with '+' must be present in the builder tags
+                            p
+                              b
+                                  pre -{tag}
+                              | no tags with '-' must be present in the builder tags
+                            p
+                              b
+                                  pre {tag}
+                              | at least one of the filtered tag should be present
+                            p url bar is updated with you filter configuration, so you can bookmark your filters!
+                        .arrow
             span(ng-show="tags_filter.length==0") Tags
             span(ng-show="tags_filter.length < 5", ng-repeat="tag in tags_filter")
                 span.label.label-success(ng-click="toggleTag(tag)")

--- a/www/data_module/src/specification.constant.coffee
+++ b/www/data_module/src/specification.constant.coffee
@@ -73,7 +73,7 @@ class Specification extends Constant
                     'builds/n:number/steps/n:number/logs/i:slug/contents'
                     'builds/n:number/steps/n:number/logs/i:slug/raw'
                 ]
-                static: true
+                static: false
             buildrequests:
                 id: 'buildrequestid'
                 fields: [
@@ -127,7 +127,7 @@ class Specification extends Constant
                 ]
                 root: true
                 paths: []
-                static: true
+                static: false
             changes:
                 id: 'changeid'
                 fields: [
@@ -170,7 +170,7 @@ class Specification extends Constant
                 ]
                 root: true
                 paths: []
-                static: true
+                static: false
             masters:
                 id: 'masterid'
                 fields: [
@@ -194,7 +194,7 @@ class Specification extends Constant
                     'schedulers'
                     'schedulers/n:schedulerid'
                 ]
-                static: true
+                static: false
             schedulers:
                 id: 'schedulerid'
                 fields: [
@@ -204,7 +204,7 @@ class Specification extends Constant
                 ]
                 root: true
                 paths: []
-                static: true
+                static: false
             sourcestamps:
                 id: 'ssid'
                 fields: [


### PR DESCRIPTION
when you have a lot of builders, its not handy to see what you want.

+tag means all tags with + must be present in the builder tags
-tag means no tags with - must be present in the builder tags
tag means at least one of the filtered tag might be present

