### PR TITLE
Fix `find: paths must precede expression` error in RemovePYCs.

### DIFF
--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -544,6 +544,6 @@ class Trial(ShellCommand):
 
 class RemovePYCs(ShellCommand):
     name = "remove-.pyc"
-    command = ['find', '.', '-name', '*.pyc', '-exec', 'rm', '{}', ';']
+    command = ['find', '.', '-name', "'*.pyc'", '-exec', 'rm', '{}', ';']
     description = ["removing", ".pyc", "files"]
     descriptionDone = ["remove", ".pycs"]


### PR DESCRIPTION
If the working directory for a RemovePYCs build step contains any files matching `*.pyc`, the wildcard will be expanded by the shell before running the `find` command. This results in the build step only removing a single file if there is a .pyc file in the working dir, or failing to run at all with a `paths must precede expression` error if there is more than one such file.

In my case, the command would expand to `find . -name setup_mceditlib.pyc setup_mcedit2.pyc -exec rm {} ;` which gives a `paths must precede expression` error.

This change encloses the wildcard pattern with single-quotes to prevent the shell from expanding it.