### PR TITLE
rework the home page to include recent builds

### DIFF
--- a/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.coffee
@@ -9,6 +9,7 @@ class Buildrequestsummary extends Directive('common')
             controller: '_buildrequestsummaryController'
         }
 
+
 class _buildrequestsummary extends Controller('common')
     constructor: ($scope, dataService, findBuilds) ->
         $scope.$watch "buildrequest.claimed", (n, o) ->

--- a/www/base/src/app/common/directives/buildsticker/buildsicker.less
+++ b/www/base/src/app/common/directives/buildsticker/buildsicker.less
@@ -1,0 +1,11 @@
+
+.buildsticker {
+  width: 100%;
+  margin: 0 2px 2px 0;
+
+  .row {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+}

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.coffee
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.coffee
@@ -3,11 +3,10 @@ class Buildsticker extends Directive('common')
         return {
             replace: true
             restrict: 'E'
-            scope: {build: '='}
+            scope: {build: '=', builder:'='}
             templateUrl: 'views/buildsticker.html'
             controller: '_buildstickerController'
         }
-
 class _buildsticker extends Controller('common')
     constructor: ($scope, dataService, resultsService, $urlMatcherFactory, $location) ->
         $scope.$watch (-> moment().unix()), ->
@@ -18,5 +17,6 @@ class _buildsticker extends Controller('common')
 
         data = dataService.open($scope)
         $scope.$watch 'build', (build) ->
-            data.getBuilders(build.builderid).then (builders) ->
-                $scope.builder = builders[0]
+            if not $scope.builder?
+                data.getBuilders(build.builderid).then (builders) ->
+                    $scope.builder = builders[0]

--- a/www/base/src/app/home/home.controller.coffee
+++ b/www/base/src/app/home/home.controller.coffee
@@ -13,21 +13,21 @@ class Home extends Controller
                     $scope.recent.recent_builds = e.recent_builds
 
         data = dataService.open($scope)
-        $scope.builds_running = data.getBuilds(order: '-started_at', complete: false).getArray()
-        $scope.recent_builds = data.getBuilds(order: '-buildid', complete: true, limit:20).getArray()
+        $scope.buildsRunning = data.getBuilds(order: '-started_at', complete: false).getArray()
+        $scope.recentBuilds = data.getBuilds(order: '-buildid', complete: true, limit:20).getArray()
         $scope.builders = data.getBuilders().getArray()
         buildersById = {}
         $scope.hasBuilds = (b) -> b.builds.length > 0
-        update_builds = ->
+        updateBuilds = ->
             byNumber = (a, b) -> return a.number - b.number
             $scope.builders.forEach (builder) ->
                 builder.builds ?= []
                 buildersById[builder.builderid] = builder
-            $scope.recent_builds.forEach (build) ->
+            $scope.recentBuilds.forEach (build) ->
                 builder = buildersById[build.builderid]
                 if buildersById[build.builderid].builds.indexOf(build) < 0
                     builder.builds.push(build)
                     builder.builds.sort(byNumber)
 
-        $scope.$watch "recent_builds", update_builds, true # deep watch
-        $scope.$watch "builders", update_builds, true # deep watch
+        $scope.$watch "recentBuilds", updateBuilds, true # deep watch
+        $scope.$watch "builders", updateBuilds, true # deep watch

--- a/www/base/src/app/home/home.controller.coffee
+++ b/www/base/src/app/home/home.controller.coffee
@@ -14,3 +14,20 @@ class Home extends Controller
 
         data = dataService.open($scope)
         $scope.builds_running = data.getBuilds(order: '-started_at', complete: false).getArray()
+        $scope.recent_builds = data.getBuilds(order: '-buildid', complete: true, limit:20).getArray()
+        $scope.builders = data.getBuilders().getArray()
+        buildersById = {}
+        $scope.hasBuilds = (b) -> b.builds.length > 0
+        update_builds = ->
+            byNumber = (a, b) -> return a.number - b.number
+            $scope.builders.forEach (builder) ->
+                builder.builds ?= []
+                buildersById[builder.builderid] = builder
+            $scope.recent_builds.forEach (build) ->
+                builder = buildersById[build.builderid]
+                if buildersById[build.builderid].builds.indexOf(build) < 0
+                    builder.builds.push(build)
+                    builder.builds.sort(byNumber)
+
+        $scope.$watch "recent_builds", update_builds, true # deep watch
+        $scope.$watch "builders", update_builds, true # deep watch

--- a/www/base/src/app/home/home.tpl.jade
+++ b/www/base/src/app/home/home.tpl.jade
@@ -6,25 +6,35 @@
           | Should be:
           pre {{baseurl}}
   .row
-    .col-sm-3
-      .well
-        button(ng-click='clear()').btn-small.btn-default.btn
-          i.icon-trash
-            |  Clear History
-        ul.nav.nav-list
-          li
-            small Most recently browsed builds
-          li(ng-repeat='b in recent.recent_builds')
-             a(ng-href='{{b.link}}') {{b.caption}}
-          li.divider
-          li
-            small Most recently browsed builders
-          li(ng-repeat='b in recent.recent_builders')
-             a(ng-href='{{b.link}}') {{b.caption}}
-    .col-sm-8
+    .col-sm-12
       .well
         h2 Welcome to buildbot
         h4 {{ builds_running.length }} Build{{ builds_running.length > 1 ? 's' : '' }} running currently
         ul
-          li.unstyled(ng-repeat="build in builds_running")
+          li.unstyled(ng-repeat="build in builds_running | filter:complete:false")
             buildsticker(build="build")
+        h4 {{ recent_builds.length }} recent builds
+        .row
+            .col-md-4(ng-repeat="builder in builders | filter:hasBuilds")
+                .panel.panel-primary
+                    .panel-heading
+                        h4.panel-title {{ builder.name }}
+                    .panel-body
+                        span(ng-repeat="build in builder.builds")
+                            buildsticker(build="build", builder="builder")
+  .row
+      .col-sm-12
+        .well
+          button(ng-click='clear()').btn-small.btn-default.btn
+            i.icon-trash
+              |  Clear History
+          ul.nav.nav-list
+            li
+              small Most recently browsed builds
+            li(ng-repeat='b in recent.recent_builds')
+               a(ng-href='{{b.link}}') {{b.caption}}
+            li.divider
+            li
+              small Most recently browsed builders
+            li(ng-repeat='b in recent.recent_builders')
+               a(ng-href='{{b.link}}') {{b.caption}}

--- a/www/base/src/app/home/home.tpl.jade
+++ b/www/base/src/app/home/home.tpl.jade
@@ -9,11 +9,11 @@
     .col-sm-12
       .well
         h2 Welcome to buildbot
-        h4 {{ builds_running.length }} Build{{ builds_running.length > 1 ? 's' : '' }} running currently
+        h4 {{ buildsRunning.length }} Build{{ buildsRunning.length > 1 ? 's' : '' }} running currently
         ul
-          li.unstyled(ng-repeat="build in builds_running | filter:complete:false")
+          li.unstyled(ng-repeat="build in buildsRunning | filter:complete:false")
             buildsticker(build="build")
-        h4 {{ recent_builds.length }} recent builds
+        h4 {{ recentBuilds.length }} recent builds
         .row
             .col-md-4(ng-repeat="builder in builders | filter:hasBuilds")
                 .panel.panel-primary

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -116,14 +116,3 @@
 li.unstyled{
   list-style: none;
 }
-
-.buildsticker {
-  width: 200px;
-  margin: 0 10px 10px 0;
-
-  .row {
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-  }
-}


### PR DESCRIPTION
This new home page query the 20 last builds, and group them per builder

![image](https://cloud.githubusercontent.com/assets/109859/11038255/4d09e8c8-8702-11e5-8698-9a230b8422fc.png)
