### PR TITLE
Fix AttributeError: no attribute 'matchesAnyTag'

### DIFF
--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -240,7 +240,7 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
         l = []
         # respect addition order
         for name in self.botmaster.builderNames:
-            bldr = self.botmaster.builders[name]
+            bldr = self.getBuilder(name)
             if bldr.matchesAnyTag(tags):
                 l.append(name)
         return util.naturalSort(l)


### PR DESCRIPTION
Regression caused by the backport of the tags support feature to eight.

This caused an AttributeError exception whenever the IRC command
'status' was performed.

Log (shortened):
2015-11-25 12:10:25+0100 [XmlStream,client] irc command status
...
".../buildbot/status/master.py", line 244, in getBuilderNames
            if bldr.matchesAnyTag(tags):
        exceptions.AttributeError: 'Builder' object has no attribute 'matchesAnyTag'

This fix makes the behavior equal to nine, using the 'getBuilder'
function.