### PR TITLE
Don't leak slave passwords in the logs

### DIFF
--- a/slave/buildslave/scripts/create_slave.py
+++ b/slave/buildslave/scripts/create_slave.py
@@ -52,6 +52,8 @@ buildmaster_host = %(host)r
 port = %(port)d
 slavename = %(name)r
 passwd = %(passwd)r
+if "SLAVEPASS" in os.environ:
+    del os.environ['SLAVEPASS']
 keepalive = %(keepalive)d
 usepty = %(usepty)d
 umask = %(umask)s


### PR DESCRIPTION
By default, the latent Docker slaves leak the password of the slave when
the slave is created with `buildslave create-slave`. This commit adds 2
lines to the buildslave.tac file to scrub the password from the
environment, as is shown in the example buildslave.tac for docker
slaves.