### PR TITLE
Add get() method to Properties

### DIFF
--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -131,6 +131,7 @@ class Properties(util.ComparableMixin):
     def hasProperty(self, name):
         return name in self.properties
 
+    get = getProperty
     has_key = hasProperty
 
     def setProperty(self, name, value, source, runtime=False):


### PR DESCRIPTION
The properties object as passed into a renderer function behaves a lot like a dictionary, so my first instinct has always been to call the get() method, which is ubiquitous on dict-like object in Python.  However, Properties does not provide this, instead providing the same functionality through "getProperty".

Adding a get() alias (similar to how there is already a has_key alias) will make it behave more like what people will expect of a dict-like object.