### PR TITLE
Soft disconnect when 'build_wait_timeout==0'

### DIFF
--- a/master/buildbot/buildslave/base.py
+++ b/master/buildbot/buildslave/base.py
@@ -773,7 +773,7 @@ class AbstractLatentBuildSlave(AbstractBuildSlave):
         self.building.remove(sb.builder_name)
         if not self.building:
             if self.build_wait_timeout == 0:
-                d = self.insubstantiate()
+                d = self._soft_disconnect()
                 # try starting builds for this slave after insubstantiating;
                 # this will cause the slave to re-substantiate immediately if
                 # there are pending build requests.


### PR DESCRIPTION
Insubstantiation of a latent build slave without cleanly disconnecting
can result in a ping failure if a new latent slave is immediately
substantiated.  To prevent this the slave should disconnect cleanly
before being insubstantiated.

  [Broker,2,52.25.93.92] ping finished: failure
  [Broker,2,52.25.93.92] slave ping failed; re-queueing the request

This is easily reproducible by running back-to-back builds.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>