### PR TITLE
Use normpath for directories and files uploads to avoid empty links

### DIFF
--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -118,7 +118,7 @@ class FileUpload(_TransferBuildStep):
 
         self.descriptionDone = "uploading %s" % os.path.basename(source)
         if self.url is not None:
-            self.addURL(os.path.basename(masterdest), self.url)
+            self.addURL(os.path.basename(os.path.normpath(masterdest)), self.url)
 
         # we use maxsize to limit the amount of data on both sides
         fileWriter = remotetransfer.FileWriter(masterdest, self.maxsize, self.mode)
@@ -179,7 +179,7 @@ class DirectoryUpload(_TransferBuildStep):
 
         self.descriptionDone = "uploading %s" % os.path.basename(source)
         if self.url is not None:
-            self.addURL(os.path.basename(masterdest), self.url)
+            self.addURL(os.path.basename(os.path.normpath(masterdest)), self.url)
 
         # we use maxsize to limit the amount of data on both sides
         dirWriter = remotetransfer.DirectoryWriter(masterdest, self.maxsize, self.compress, 0o600)
@@ -288,7 +288,7 @@ class MultipleFileUpload(_TransferBuildStep):
 
     def allUploadsDone(self, result, sources, masterdest):
         if self.url is not None:
-            self.addURL(os.path.basename(masterdest), self.url)
+            self.addURL(os.path.basename(os.path.normpath(masterdest)), self.url)
 
     def start(self):
         self.checkSlaveHasCommand("uploadDirectory")


### PR DESCRIPTION
When using file upload or directory upload step using a `masterdest` ending with a '/' will generate an empty link because of `basename` behavior, using normpath should allow this.
```python
>>> os.path.basename("/home/user/static/")
''
>>> os.path.basename(os.path.normpath("/home/user/static/"))
'static'
```

After this PR I'll add a extra `linkname` parameter to allow custom link for those steps.