### PR TITLE
Update documentation for packages built using python wheels

### DIFF
--- a/master/docs/manual/installation/installation.rst
+++ b/master/docs/manual/installation/installation.rst
@@ -75,7 +75,7 @@ If you cannot or do not wish to install the buildbot into a site-wide location l
 Running Buildbot's Tests (optional)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you wish, you can run the buildbot unit test suite.
+If you wish, you can run the buildbot unit test suite. You must not be using a wheels packaged version of buildbot or have specified the bdist_wheel flag when building. The test suite is not included with the PyPi packaged version. 
 First, ensure you have the `mock <http://pypi.python.org/pypi/mock>`_ Python module installed from PyPi.
 This module is not required for ordinary Buildbot operation - only to run the tests.
 Note that this is not the same as the Fedora ``mock`` package!

--- a/master/docs/manual/installation/installation.rst
+++ b/master/docs/manual/installation/installation.rst
@@ -75,9 +75,9 @@ If you cannot or do not wish to install the buildbot into a site-wide location l
 Running Buildbot's Tests (optional)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you wish, you can run the buildbot unit test suite. You must not be using a python wheels packaged version 
-of buildbot or have specified the bdist_wheel flag when building. The test suite is not included with 
-the PyPi packaged version. 
+If you wish, you can run the Buildbot unit test suite. 
+You must not be using a python wheels packaged version of Buildbot or have specified the bdist_wheel flag when building. 
+The test suite is not included with the PyPi packaged version. 
 First, ensure you have the `mock <http://pypi.python.org/pypi/mock>`_ Python module installed from PyPi.
 This module is not required for ordinary Buildbot operation - only to run the tests.
 Note that this is not the same as the Fedora ``mock`` package!

--- a/master/docs/manual/installation/installation.rst
+++ b/master/docs/manual/installation/installation.rst
@@ -75,7 +75,9 @@ If you cannot or do not wish to install the buildbot into a site-wide location l
 Running Buildbot's Tests (optional)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you wish, you can run the buildbot unit test suite. You must not be using a wheels packaged version of buildbot or have specified the bdist_wheel flag when building. The test suite is not included with the PyPi packaged version. 
+If you wish, you can run the buildbot unit test suite. You must not be using a python wheels packaged version 
+of buildbot or have specified the bdist_wheel flag when building. The test suite is not included with 
+the PyPi packaged version. 
 First, ensure you have the `mock <http://pypi.python.org/pypi/mock>`_ Python module installed from PyPi.
 This module is not required for ordinary Buildbot operation - only to run the tests.
 Note that this is not the same as the Fedora ``mock`` package!

--- a/master/docs/manual/installation/installation.rst
+++ b/master/docs/manual/installation/installation.rst
@@ -76,7 +76,7 @@ Running Buildbot's Tests (optional)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you wish, you can run the Buildbot unit test suite. 
-You must not be using a python wheels packaged version of Buildbot or have specified the bdist_wheel flag when building. 
+You must not be using a Python wheels packaged version of Buildbot or have specified the bdist_wheel command when building. 
 The test suite is not included with the PyPi packaged version. 
 First, ensure you have the `mock <http://pypi.python.org/pypi/mock>`_ Python module installed from PyPi.
 This module is not required for ordinary Buildbot operation - only to run the tests.


### PR DESCRIPTION
The tests aren't included on packages build in PyPi. Updating documentation to show that.