### PR TITLE
Cooldown timers

### DIFF
--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -35,8 +35,14 @@ class BaseBasicScheduler(base.BaseScheduler):
 
     """
 
-    compare_attrs = ['treeStableTimer', 'change_filter', 'fileIsImportant',
-                     'onlyImportant', 'reason', 'coolDownTimer']
+    compare_attrs = [
+        'change_filter',
+        'coolDownTimer',
+        'fileIsImportant',
+        'onlyImportant',
+        'reason',
+        'treeStableTimer',
+    ]
 
     _reactor = reactor  # for tests
 
@@ -140,9 +146,9 @@ class BaseBasicScheduler(base.BaseScheduler):
             if not important:
                 defer.returnValue(None)
             # otherwise, we'll build it right away
-            yield self.addBuildsetForChanges(reason=self.reason,
-                                             changeids=[change.number])
-            defer.returnValue(None)
+            ret = yield self.addBuildsetForChanges(reason=self.reason,
+                                                   changeids=[change.number])
+            defer.returnValue(ret)
 
         timer_name = self.getTimerNameForChange(change)
 

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -521,6 +521,9 @@ class FakeSchedulersComponent(FakeDBComponent):
                                  project=-1, codebase=-1):
         classifications = self.classifications.setdefault(objectid, {})
 
+        # Make a copy so each call gets a private version of this.
+        classifications = dict(classifications)
+
         sentinel = dict(branch=object(), repository=object(),
                         project=object(), codebase=object())
 

--- a/master/docs/manual/cfg-schedulers.rst
+++ b/master/docs/manual/cfg-schedulers.rst
@@ -101,16 +101,15 @@ There are several common arguments for schedulers, although not all are availabl
     If new changes are made during this interval, the timer will be restarted, so really the build will be started after a change and then after this many seconds of inactivity.
 
 ``coolDownTimer``
-    After starting a build, the scheduler will wait this many seconds before it is permitted to
-    start another build.
+    After starting a build, the scheduler will wait this many seconds before it is permitted to start another build.
 
-    If both ``treeStableTimer`` and ``coolDownTimer`` are set, then builds will be started after
-    the tree-stable timer is satisfied, but never closer together than the cooldown timer requires.
-    The cooldown timer starts when the build is actually triggered so any two builds will always be
-    at least ``coolDownTimer`` seconds apart.
+    If both ``treeStableTimer`` and ``coolDownTimer`` are set, then builds will be started after the tree-stable timer is satisfied, but never closer together than the cooldown timer requires.
+    The cooldown timer starts when the build is actually triggered so any two builds will always be at least ``coolDownTimer`` seconds apart.
 
-    Note: a ``buildbot reconfig`` can reset the cooldown timer and cause an immediate build to start
-    if changes are pending. This could cause extra builds that are closer together than intended.
+    .. note::
+
+       Running ``buildbot reconfig`` on a config that changes a scheduler will cause that scheduler to get restarted.
+       If so, the cooldown timer will be reset and may cause an immediate build to start if changes are pending. 
 
 The remaining subsections represent a catalog of the available Scheduler types.
 All these Schedulers are defined in modules under :mod:`buildbot.schedulers`, and the docstrings there are the best source of documentation on the arguments taken by each one.

--- a/master/docs/manual/cfg-schedulers.rst
+++ b/master/docs/manual/cfg-schedulers.rst
@@ -96,6 +96,22 @@ There are several common arguments for schedulers, although not all are availabl
 ``reason``
     A string that will be used as the reason for the triggered build.
 
+``treeStableTimer``
+    The scheduler will wait for this many seconds before starting the build.
+    If new changes are made during this interval, the timer will be restarted, so really the build will be started after a change and then after this many seconds of inactivity.
+
+``coolDownTimer``
+    After starting a build, the scheduler will wait this many seconds before it is permitted to
+    start another build.
+
+    If both ``treeStableTimer`` and ``coolDownTimer`` are set, then builds will be started after
+    the tree-stable timer is satisfied, but never closer together than the cooldown timer requires.
+    The cooldown timer starts when the build is actually triggered so any two builds will always be
+    at least ``coolDownTimer`` seconds apart.
+
+    Note: a ``buildbot reconfig`` can reset the cooldown timer and cause an immediate build to start
+    if changes are pending. This could cause extra builds that are closer together than intended.
+
 The remaining subsections represent a catalog of the available Scheduler types.
 All these Schedulers are defined in modules under :mod:`buildbot.schedulers`, and the docstrings there are the best source of documentation on the arguments taken by each one.
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -23,7 +23,7 @@ Features
 
 * :bb:sched:`Triggerable` now accepts a ``reason`` parameter.
 
-* :bb:status:`GerritStatusPush` now has parameter --notify which is used to control e-mail notifications from Gerrit.
+* :bb:status:`GerritStatusPush` now has parameter ``--notify`` which is used to control e-mail notifications from Gerrit.
 
 * Schedulers: the ``codebases`` parameter can now be specified in a simple list-of-strings form
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -23,6 +23,12 @@ Features
 
 * :bb:sched:`Triggerable` now accepts a ``reason`` parameter.
 
+* :bb:status:`GerritStatusPush` now has parameter --notify which is used to control e-mail notifications from Gerrit.
+
+* Schedulers: the ``codebases`` parameter can now be specified in a simple list-of-strings form
+
+* Schedulers: a ``coolDownTimer`` parameter can limit the frequency that builds are allowed to start.
+
 Fixes
 ~~~~~
 
@@ -39,10 +45,6 @@ Slave
 
 Features
 ~~~~~~~~
-
-* :bb:status:`GerritStatusPush` now has parameter --notify which is used to control e-mail notifications from Gerrit.
-
-* Schedulers: the ``codebases`` parameter can now be specified in a simple list-of-strings form
 
 Fixes
 ~~~~~


### PR DESCRIPTION
This adds a new timer type to Scheduler: the "cooldown timer". This makes it possible to space builds out so they never happen too quickly. 

Tree-stable and Cooldown timers are similar so I've done a little refactoring to allow me to reuse logic across them both.