### PR TITLE
Source Base: add a 'do with retry' function

### DIFF
--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -34,6 +34,10 @@ Deprecations, Removals, and Non-Compatible Changes
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~
 
+* :class:`~buildbot.steps.source.base.Source` now has a ``doWithRetry`` method to help make it easier
+  to retry actions in a source step (using the Source.retry parameter). The various derived source
+  classes (eg, Svn and Git) have been adjusted to use that.
+
 Slave
 -----
 


### PR DESCRIPTION
There's a lot of duplicated 'retry' code across the source classes. I moved that logic into the Source base class and adjusted the derived classes to use it. (This is all preliminary to me making Git-fetch more retry-happy).