### PR TITLE
add peer dependencies of dependent packages to dependencies

### DIFF
--- a/www/codeparameter/package.json
+++ b/www/codeparameter/package.json
@@ -5,6 +5,7 @@
         "npm": ">=1.4.0"
     },
     "devDependencies": {
-        "guanlecoja": "~0.4.0"
+        "guanlecoja": "~0.4.0",
+        "gulp": "*"
     }
 }

--- a/www/console_view/package.json
+++ b/www/console_view/package.json
@@ -5,6 +5,7 @@
         "npm": ">=1.4.0"
     },
     "devDependencies": {
-        "guanlecoja": "~0.4.0"
+        "guanlecoja": "~0.4.0",
+        "gulp": "*"
     }
 }

--- a/www/md_base/package.json
+++ b/www/md_base/package.json
@@ -5,7 +5,8 @@
     "gulp-shell": "^0.4.0",
     "gulp-svg-symbols": "^0.3.1",
     "http-proxy": "^1.11.1",
-    "minimist": "^1.1.1"
+    "minimist": "^1.1.1",
+    "gulp": "*"
   },
   "name": "md-base",
   "dependencies": {},

--- a/www/nestedexample/package.json
+++ b/www/nestedexample/package.json
@@ -5,6 +5,7 @@
         "npm": ">=1.4.0"
     },
     "devDependencies": {
-        "guanlecoja": "~0.4.0"
+        "guanlecoja": "~0.4.0",
+        "gulp": "*"
     }
 }

--- a/www/waterfall_view/package.json
+++ b/www/waterfall_view/package.json
@@ -5,6 +5,7 @@
         "npm": ">=1.4.10"
     },
     "devDependencies": {
-        "guanlecoja": "~0.4.0"
+        "guanlecoja": "~0.4.0",
+        "gulp": "*"
     }
 }


### PR DESCRIPTION
Starting from npm@3 peer dependencies are not installed by default.
I believe it's assumed, that if package A depends on package B that
have peer dependency C, A must install C in order to use B.

Discussion of that npm change can be found here: https://github.com/npm/npm/issues/5080

Not sure either `"*"` version of peer dependency should be specified in parent package or specific version.
I think `"*"` version will lead npm to use best matching version that satisfies dependent package.

To reproduce issue that this PR is fixing you can upgrade npm to version newer than 3.0 and try to do clean installation of `buildbot/www/*` packages (with removed `node_modules`).

Similar PR in guanlecoja: https://github.com/buildbot/guanlecoja/pull/3.