### PR TITLE
Updated requirement description for python-dateutils.

### DIFF
--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -81,9 +81,8 @@ SQLAlchemy-Migrate: http://code.google.com/p/sqlalchemy-migrate/
 
 Python-Dateutil: http://labix.org/python-dateutil
 
-  The :bb:sched:`Nightly` scheduler requires Python-Dateutil version 1.5 (the last version to support Python-2.x).
+  Buildbot requires Python-Dateutil in version 1.5 or higher (the last version to support Python-2.x).
   This is a small, pure-python library.
-  Buildbot will function properly without it if the :bb:sched:`Nightly` scheduler is not used.
 
 Autobahn:
 


### PR DESCRIPTION
From reading the release notes for [0.8.11](https://github.com/buildbot/buildbot/blob/v0.8.11/master/docs/relnotes/index.rst)/0.8.12, Buildmaster currently requires python-dateutils regardless of whether the "Nightly" scheduler is used. I therefore adjusted the docs to prevent misunderstandings.