### PR TITLE
WEObserver: Fix Error and Warning detection

### DIFF
--- a/master/buildbot/steps/package/util.py
+++ b/master/buildbot/steps/package/util.py
@@ -25,7 +25,7 @@ class WEObserver(logobserver.LogLineObserver):
         self.errors = []
 
     def outLineReceived(self, line):
-        if 'W: ' in line:
+        if line.startswith('W: '):
             self.warnings.append(line)
-        elif 'E: ' in line:
+        elif line.startswith('E: '):
             self.errors.append(line)


### PR DESCRIPTION
We just had the issue where 'README: ' was in the middle line, and buildbot wrongly flagged this as an error.