### PR TITLE
move temporary clone for deploying data module to ignore

### DIFF
--- a/www/data_module/.gitignore
+++ b/www/data_module/.gitignore
@@ -7,3 +7,6 @@ dist
 # Node package manager
 node_modules
 npm-debug.log
+
+# Temporary clone for deploying data module
+/buildbot-data-js/


### PR DESCRIPTION
This directory is created and used by `gulp publish`.
