### PR TITLE
validate.sh: don't clean docs builddir if built in quick mode

### DIFF
--- a/common/validate.sh
+++ b/common/validate.sh
@@ -225,7 +225,11 @@ fi
 
 if git diff --name-only $REVRANGE | grep ^master/docs/ ; then
     status "building docs"
-    make -C master/docs VERSION=latest clean html || not_ok "docs failed"
+    # Don't clean builddir if built in quick mode
+    if ! $quick ; then
+        make -C master/docs clean || not_ok "docs cleanup failed"
+    fi
+    make -C master/docs VERSION=latest html || not_ok "docs failed"
 else
     status "not building docs, because it was not changed"
 fi


### PR DESCRIPTION
Docs rebuilt from scratch takes about 30 seconds on my machine, and only few seconds if only few files are being rebuilt (which is more appropriate for quick mode).
