### PR TITLE
Fix The LatentBuildslave to support passing a subnet_id for VPC support

### DIFF
--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -151,8 +151,8 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                                                        aws_secret_access_key=secret_identifier)
                 if subnet_id is not None:
                     self.vpc_api_conn = boto.vpc.VPCConnection(region=region_found,
-                                                           aws_access_key_id=identifier,
-                                                           aws_secret_access_key=secret_identifier)
+                                                               aws_access_key_id=identifier,
+                                                               aws_secret_access_key=secret_identifier)
             else:
                 raise ValueError(
                     'The specified region does not exist: ' + region)

--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -57,7 +57,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                  keypair_name='latent_buildbot_slave',
                  security_name='latent_buildbot_slave',
                  spot_instance=False, max_spot_price=1.6, volumes=None,
-                 placement=None, price_multiplier=1.2, tags=None, retry=1,
+                 placement=None, subnet_id=None, price_multiplier=1.2, tags=None, retry=1,
                  retry_price_adjustment=1, product_description='Linux/UNIX',
                  **kwargs):
 
@@ -149,6 +149,10 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                 self.conn = boto.ec2.connect_to_region(region,
                                                        aws_access_key_id=identifier,
                                                        aws_secret_access_key=secret_identifier)
+                if subnet_id is not None:
+                    self.vpc_api_conn = boto.vpc.VPCConnection(region=region_found,
+                                                           aws_access_key_id=identifier,
+                                                           aws_secret_access_key=secret_identifier)
             else:
                 raise ValueError(
                     'The specified region does not exist: ' + region)
@@ -214,6 +218,10 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
         if elastic_ip is not None:
             elastic_ip = self.conn.get_all_addresses([elastic_ip])[0]
         self.elastic_ip = elastic_ip
+        # Make sure the subnet id is valid on the onset, else the vpc subnet does not exist and is invalid
+        if subnet_id is not None:
+            assert self.vpc_api_conn.get_all_subnets([subnet_id])[0]
+        self.subnet_id = subnet_id
         self.tags = tags
 
     def get_image(self):
@@ -282,7 +290,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
         reservation = image.run(
             key_name=self.keypair_name, security_groups=[self.security_name],
             instance_type=self.instance_type, user_data=self.user_data,
-            placement=self.placement)
+            placement=self.placement, subnet_id=self.subnet_id)
         self.instance = reservation.instances[0]
         instance_id, image_id, start_time = self._wait_for_instance(
             reservation)
@@ -376,7 +384,8 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                                                         security_groups=[self.security_name],
                                                         instance_type=self.instance_type,
                                                         user_data=self.user_data,
-                                                        placement=self.placement)
+                                                        placement=self.placement,
+                                                        subnet_id=self.subnet_id)
         request, success = self._wait_for_request(reservations[0])
         if not success:
             return request, None, None, False

--- a/master/buildbot/test/unit/test_buildslave_ec2.py
+++ b/master/buildbot/test/unit/test_buildslave_ec2.py
@@ -118,8 +118,8 @@ class TestEC2LatentBuildSlave(unittest.TestCase):
         bs = ec2.EC2LatentBuildSlave('bot1', 'sekrit', 'm1.large',
                                      identifier='publickey',
                                      secret_identifier='privatekey',
-                                     ami=amis[0].id, 
-                                     subnet_id = subnet.id
+                                     ami=amis[0].id,
+                                     subnet_id=subnet.id
                                      )
         instance_id, image_id, start_time = bs._start_instance()
         self.assertTrue(instance_id.startswith('i-'))

--- a/master/buildbot/test/unit/test_buildslave_ec2.py
+++ b/master/buildbot/test/unit/test_buildslave_ec2.py
@@ -58,6 +58,12 @@ class TestEC2LatentBuildSlave(unittest.TestCase):
         c.terminate_instances([instance.id])
         return c
 
+    def subnetSetup(self):
+        vpc_c = boto.connect_vpc()
+        vpc = vpc_c.create_vpc("10.0.0.0/16")
+        subnet = vpc_c.create_subnet(vpc.id, "10.0.0.0/18")
+        return subnet
+
     @mock_ec2
     def test_constructor_minimal(self):
         c = self.botoSetup()
@@ -103,6 +109,28 @@ class TestEC2LatentBuildSlave(unittest.TestCase):
         self.assertEqual(len(instances), 1)
         self.assertEqual(instances[0].id, instance_id)
         self.assertEqual(instances[0].tags, {})
+
+    @mock_ec2
+    def test_start_instance_with_subnet_id(self):
+        c = self.botoSetup()
+        subnet = self.subnetSetup()
+        amis = c.get_all_images()
+        bs = ec2.EC2LatentBuildSlave('bot1', 'sekrit', 'm1.large',
+                                     identifier='publickey',
+                                     secret_identifier='privatekey',
+                                     ami=amis[0].id, 
+                                     subnet_id = subnet.id
+                                     )
+        instance_id, image_id, start_time = bs._start_instance()
+        self.assertTrue(instance_id.startswith('i-'))
+        self.assertTrue(image_id.startswith('r-'))
+        self.assertTrue(start_time > 0)
+        instances = [i for i in c.get_only_instances()
+                     if i.state != "terminated"]
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0].id, instance_id)
+        self.assertEqual(instances[0].tags, {})
+        self.assertEqual(instances[0].subnet_id, subnet.id)
 
     @mock_ec2
     def test_start_instance_tags(self):


### PR DESCRIPTION
Fix The LatentBuildslave to support passing a subnet_id as AWS makes it mandatory for certain instance types to work