### PR TITLE
treat Row._next_id=None case as if next id should be 1

### DIFF
--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -106,7 +106,8 @@ class Row(object):
         return '%s(**%r)' % (self.__class__.__name__, self.values)
 
     def nextId(self):
-        id, Row._next_id = Row._next_id, (Row._next_id or 1) + 1
+        id = Row._next_id if Row._next_id is not None else 1
+        Row._next_id = id + 1
         return id
 
     def hashColumns(self, *args):


### PR DESCRIPTION
Otherwise first call to Row.nextId() returns None, which leads to failures of
some tests if they are being run first (before other tests initialized next id
to non-None value).