### PR TITLE
Fix forcescheduler page.

### DIFF
--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.controller.coffee
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.controller.coffee
@@ -1,6 +1,6 @@
 class forceDialog extends Controller
     constructor: ($scope, $state, modal, schedulerid, $rootScope, builderid, dataService) ->
-        dataService.getForceschedulers(schedulerid, subscribe: false).then (schedulers) ->
+        dataService.getForceschedulers(schedulerid, subscribe: false).onChange = (schedulers) ->
             scheduler = schedulers[0]
             # prepare default values
             prepareFields = (fields) ->

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.tpl.jade
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.tpl.jade
@@ -4,7 +4,7 @@
     .modal-body
         div.form-horizontal
             .alert.alert-danger(ng-show="error") {{error}}
-            forcefield(field="rootfield")
+            forcefield(field="rootfield" ng-if="rootfield")
     .modal-footer
       button.btn.btn-default(ng-click="cancel()") Cancel
       button.btn.btn-primary(ng-click="ok()") Start Build


### PR DESCRIPTION
When the scheduler is not yet loaded, the forcefield directive will crash.

I don’t know exactly what triggered this issue, maybe an upgrade of angularjs changed the timing.

Solution is to load the directive only when the scheduler is present in scope

+ minor clean of use of deprecated data-module api