### PR TITLE
fix forcescheduler is overlapped by the sidebar

### DIFF
--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -26,9 +26,9 @@
   }
 }
 
-/* hack to make modal work with ng-animate */
-.modal {
-  display: block !important;
+/* make the sidebar be on the back when dialog is open */
+.modal-open .sidebar {
+    z-index: 0;
 }
 
 /* button bar inside the breadcrum, used for forcesched buttons */


### PR DESCRIPTION
z-index of the sidebar was greater than z-index of the dialog
zero the z-index of the sidebar when dialog is open

Remove hack that is no more needed with more recent version of ng-animate
