### PR TITLE
Add a buildPushesWithNoCommits option to GitPoller to allow the rebuild of already known commits on new branches

### DIFF
--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -712,6 +712,9 @@ It accepts the following arguments:
     Determines when the first poll occurs.
     True = immediately on launch, False = wait for one pollInterval (default).
 
+``buildPushesWithNoCommits``
+    Determine if a push on a new branch with already known commits should trigger a build. (defaults to False).
+
 ``gitbin``
     path to the Git binary, defaults to just ``'git'``
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -20,6 +20,8 @@ Master
 Features
 ~~~~~~~~
 
+* :class:`GitPoller` now has a ``buildPushesWithNoCommits`` option to allow the rebuild of already known commits on new branches.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
This should allow to ease feature branch development when using branch name dependent steps (to build or package stuff).