### PR TITLE
log SQL queries using Python's logging interface + add default logger

### DIFF
--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -79,7 +79,7 @@ class BuildbotEngineStrategy(strategies.ThreadLocalEngineStrategy):
         if u.database:
 
             # Use NullPool instead of the sqlalchemy-0.6.8-default
-            # SingletonThreadpool for sqlite to suppress the error in
+            # SingletonThreadPool for sqlite to suppress the error in
             # http://groups.google.com/group/sqlalchemy/msg/f8482e4721a89589,
             # which also explains that NullPool is the new default in
             # sqlalchemy 0.7 for non-memory SQLite databases.
@@ -90,8 +90,8 @@ class BuildbotEngineStrategy(strategies.ThreadLocalEngineStrategy):
                 u.database = os.path.join(kwargs['basedir'], u.database)
 
         else:
-            # For in-memory database SQLAlchemy will SingletonThreadPool and
-            # we will run connection creation and all queries in the single
+            # For in-memory database SQLAlchemy will use SingletonThreadPool
+            # and we will run connection creation and all queries in the single
             # thread.
             # However connection destruction will be run from the main
             # thread, which is safe in our case, but not safe in general,

--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -89,6 +89,16 @@ class BuildbotEngineStrategy(strategies.ThreadLocalEngineStrategy):
             if not os.path.isabs(u.database[0]):
                 u.database = os.path.join(kwargs['basedir'], u.database)
 
+        else:
+            # For in-memory database SQLAlchemy will SingletonThreadPool and
+            # we will run connection creation and all queries in the single
+            # thread.
+            # However connection destruction will be run from the main
+            # thread, which is safe in our case, but not safe in general,
+            # so SQLite will emit warning about it.
+            # Silence that warning.
+            kwargs.setdefault('connect_args', {})['check_same_thread'] = False
+
         # in-memory databases need exactly one connection
         if not u.database:
             kwargs['pool_size'] = 1

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -27,9 +27,16 @@ import sys
 if sys.version_info[:2] < (3, 2):
     # Setup logging unhandled messages to stderr.
     # Since Python 3.2 similar functionality implemented through
-    # logging.lastResort handler
+    # logging.lastResort handler.
+    # Significant difference between this approach and Python 3.2 last resort
+    # approach is that in the current approach only records with log level
+    # equal or above to the root logger log level will be printed (WARNING by
+    # default). For example, there still will be warnings about missing
+    # handler for log if INFO or DEBUG records will be logged (but at least
+    # WARNINGs and ERRORs will be printed).
     import logging
-    logging.getLogger().addHandler(logging.StreamHandler())
+    _handler = logging.StreamHandler()
+    logging.getLogger().addHandler(_handler)
 
 # import mock so we bail out early if it's not installed
 try:

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -23,6 +23,14 @@ monkeypatches.patch_all(for_tests=True)
 import warnings
 warnings.filterwarnings('always', category=DeprecationWarning)
 
+import sys
+if sys.version_info[:2] < (3, 2):
+    # Setup logging unhandled messages to stderr.
+    # Since Python 3.2 similar functionality implemented through
+    # logging.lastResort handler
+    import logging
+    logging.getLogger().addHandler(logging.StreamHandler())
+
 # import mock so we bail out early if it's not installed
 try:
     import mock

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -117,10 +117,13 @@ class UpgradeTestMixin(db.RealDatabaseMixin):
         self.db.setServiceParent(master)
         yield self.db.setup(check_version=False)
 
-        querylog.log_from_engine(self.db.pool.engine)
+        self._log_level, self._log_propagate = querylog.start_log_queries()
 
     @defer.inlineCallbacks
     def tearDownUpgradeTest(self):
+        querylog.stop_log_queries(level=self._log_level,
+                                  propagate=self._log_propagate)
+
         if self.use_real_db:
             yield self.tearDownRealDatabase()
 

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -117,12 +117,11 @@ class UpgradeTestMixin(db.RealDatabaseMixin):
         self.db.setServiceParent(master)
         yield self.db.setup(check_version=False)
 
-        self._log_level, self._log_propagate = querylog.start_log_queries()
+        self._sql_log_handler = querylog.start_log_queries()
 
     @defer.inlineCallbacks
     def tearDownUpgradeTest(self):
-        querylog.stop_log_queries(level=self._log_level,
-                                  propagate=self._log_propagate)
+        querylog.stop_log_queries(self._sql_log_handler)
 
         if self.use_real_db:
             yield self.tearDownRealDatabase()

--- a/master/buildbot/test/unit/test_db_enginestrategy.py
+++ b/master/buildbot/test/unit/test_db_enginestrategy.py
@@ -88,7 +88,9 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
                          ["sqlite://", 1,  # only one conn at a time
                           dict(basedir='my-base-dir',
                                # note: no poolclass= argument
-                               pool_size=1)])  # extra in-memory args
+                               # extra in-memory args
+                               pool_size=1,
+                               connect_args=dict(check_same_thread=False))])
 
     def test_mysql_simple(self):
         u = url.make_url("mysql://host/dbname")

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -75,13 +75,13 @@ class MigrateTestMixin(db.RealDatabaseMixin, dirs.DirsMixin):
         d.addCallback(lambda _: self.db.pool.do(setup_thd))
 
         def upgrade_thd(engine):
-            querylog.log_from_engine(engine)
-            schema = migrate.versioning.schema.ControlledSchema(engine,
-                                                                self.db.model.repo_path)
-            changeset = schema.changeset(target_version)
-            for version, change in changeset:
-                log.msg('upgrading to schema version %d' % (version + 1))
-                schema.runchange(version, change, 1)
+            with querylog.log_queries():
+                schema = migrate.versioning.schema.ControlledSchema(
+                    engine, self.db.model.repo_path)
+                changeset = schema.changeset(target_version)
+                for version, change in changeset:
+                    log.msg('upgrading to schema version %d' % (version + 1))
+                    schema.runchange(version, change, 1)
         d.addCallback(lambda _: self.db.pool.do_with_engine(upgrade_thd))
 
         def check_table_charsets_thd(engine):

--- a/master/buildbot/test/util/querylog.py
+++ b/master/buildbot/test/util/querylog.py
@@ -15,69 +15,75 @@
 
 from __future__ import absolute_import
 
-import logging
 import contextlib
+import logging
 
 from twisted.python import log
 
-# this class bridges Python's `logging` module into Twisted's log system.
-# SqlAlchemy query logging uses `logging`, so this provides a way to enter
-# queries into the Twisted log file.
+# These routines provides a way to dump SQLAlchemy SQL commands and their
+# results into Twisted's log.
+# Logging wrappers are not re-entrant.
 
 
-class PythonToTwistedHandler(logging.Handler):
+class _QueryToTwistedHandler(logging.Handler):
+
+    def __init__(self, log_query_result=False):
+        logging.Handler.__init__(self)
+
+        self._log_query_result = log_query_result
 
     def emit(self, record):
-        log.msg(record.getMessage())
+        if record.levelno == logging.DEBUG:
+            if self._log_query_result:
+                log.msg("{name}:{thread}:result: {msg}".format(
+                    name=record.name,
+                    thread=record.threadName,
+                    msg=record.getMessage()))
+        else:
+            log.msg("{name}:{thread}:query:  {msg}".format(
+                name=record.name,
+                thread=record.threadName,
+                msg=record.getMessage()))
 
 
-_handler = None
-
-
-def start_log_queries():
-    global _handler
-    if _handler is None:
-        _handler = PythonToTwistedHandler()
+def start_log_queries(log_query_result=False):
+    handler = _QueryToTwistedHandler(log_query_result=log_query_result)
 
     # In 'sqlalchemy.engine' logging namespace SQLAlchemy outputs SQL queries
     # on INFO level, and SQL queries results on DEBUG level.
     logger = logging.getLogger('sqlalchemy.engine')
 
     # TODO: this is not documented field of logger, so it's probably private.
-    prev_level = logger.level
-    logger.setLevel(logging.INFO)
+    handler.prev_level = logger.level
+    logger.setLevel(logging.DEBUG)
 
-    logger.addHandler(_handler)
+    logger.addHandler(handler)
 
     # Do not propagate SQL echoing into ancestor handlers
-    prev_propagate = logger.propagate
+    handler.prev_propagate = logger.propagate
     logger.propagate = False
 
     # Return previous values of settings, so they can be carefully restored
     # later.
-    return prev_level, prev_propagate
+    return handler
 
 
-def stop_log_queries(level=None, propagate=None):
-    assert _handler is not None
+def stop_log_queries(handler):
+    assert isinstance(handler, _QueryToTwistedHandler)
 
     logger = logging.getLogger('sqlalchemy.engine')
-    logger.removeHandler(_handler)
+    logger.removeHandler(handler)
 
     # Restore logger settings or set them to reasonable defaults.
-    if propagate is not None:
-        logger.propagate = propagate
-    else:
-        logger.propagate = True
+    logger.propagate = handler.prev_propagate
 
-    if level is not None:
-        logger.setLevel(level)
-    else:
-        logger.setLevel(logging.NOTSET)
+    logger.setLevel(handler.prev_level)
 
 
 @contextlib.contextmanager
 def log_queries():
-    level, propagate = start_log_queries()
-    yield
-    stop_log_queries(level=level, propagate=propagate)
+    handler = start_log_queries()
+    try:
+        yield
+    finally:
+        stop_log_queries(handler)


### PR DESCRIPTION
Now all unhandled Python log events are printed into `stderr`, instead of generating "No handlers could be found for logger" message.
