### PR TITLE
'legacy' SQLAlchemy and SQLAlchemy-Migrate are not supported

### DIFF
--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -73,7 +73,7 @@ SQLAlchemy: http://www.sqlalchemy.org/
   Buildbot requires SQLAlchemy version 0.8.7 or higher.
   SQLAlchemy allows Buildbot to build database schemas and queries for a wide variety of database systems.
 
-SQLAlchemy-Migrate: http://code.google.com/p/sqlalchemy-migrate/
+SQLAlchemy-Migrate: https://sqlalchemy-migrate.readthedocs.org/en/latest/
 
   Buildbot requires SQLAlchemy-Migrate version 0.9.0 or higher.
   Buildbot uses SQLAlchemy-Migrate to manage schema upgrades from version to version.

--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -70,14 +70,12 @@ Jinja2: http://jinja.pocoo.org/
 
 SQLAlchemy: http://www.sqlalchemy.org/
 
-  Buildbot requires SQLAlchemy version 0.8.1 or higher.
+  Buildbot requires SQLAlchemy version 0.8.7 or higher.
   SQLAlchemy allows Buildbot to build database schemas and queries for a wide variety of database systems.
 
 SQLAlchemy-Migrate: http://code.google.com/p/sqlalchemy-migrate/
 
-  Buildbot requires one of the following SQLAlchemy-Migrate versions 0.9 or higher.
-  SQLAlchemy-Migrate-0.9 is required for compatibility with SQLAlchemy versions 0.8.0 and above.
-  As a special case, SQLAlchemy-Migrate-0.7.2 is known to work with SQLAlchemy 0.6.9 and 0.7.10.
+  Buildbot requires SQLAlchemy-Migrate version 0.9.0 or higher.
   Buildbot uses SQLAlchemy-Migrate to manage schema upgrades from version to version.
 
 Python-Dateutil: http://labix.org/python-dateutil

--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -70,7 +70,7 @@ Jinja2: http://jinja.pocoo.org/
 
 SQLAlchemy: http://www.sqlalchemy.org/
 
-  Buildbot requires SQLAlchemy version 0.8.7 or higher.
+  Buildbot requires SQLAlchemy version 0.8.0 or higher.
   SQLAlchemy allows Buildbot to build database schemas and queries for a wide variety of database systems.
 
 SQLAlchemy-Migrate: https://sqlalchemy-migrate.readthedocs.org/en/latest/

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -30,7 +30,6 @@ Deprecations, Removals, and Non-Compatible Changes
   See :bug:`3421` for status and to help out.
 
 * The ``buildbot`` Python dist now (finally) requires SQLAlchemy-0.8.0 or later and SQLAlchemy-Migrate-0.9.0 or later.
-  While the old pinned versions (0.7.10 and 0.7.2, respectively) still work, this compatibility is no longer tested and this configuration should be considered deprecated.
 
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
@tardyp let's get this in beta7 (since these versions don't work on beta7 anyway, I believe)