### PR TITLE
Improve format of configuration file syntax errors

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -19,6 +19,7 @@ import os
 import re
 import sys
 import warnings
+import traceback
 
 from buildbot import interfaces
 from buildbot import locks
@@ -198,6 +199,11 @@ class MasterConfig(util.ComparableMixin):
             except ConfigErrors as e:
                 for err in e.errors:
                     error(err)
+                raise errors
+            except SyntaxError:
+                error("encountered a SyntaxError while parsing config file:\n%s "%
+                    (traceback.format_exc(),),
+                    )    
                 raise errors
             except Exception:
                 log.err(failure.Failure(), 'error while parsing config file:')

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -203,7 +203,7 @@ class MasterConfig(util.ComparableMixin):
             except SyntaxError:
                 error("encountered a SyntaxError while parsing config file:\n%s "%
                     (traceback.format_exc(),),
-                    )    
+                    )
                 raise errors
             except Exception:
                 log.err(failure.Failure(), 'error while parsing config file:')

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -18,8 +18,8 @@ from future.utils import itervalues
 import os
 import re
 import sys
-import warnings
 import traceback
+import warnings
 
 from buildbot import interfaces
 from buildbot import locks

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -201,7 +201,7 @@ class MasterConfig(util.ComparableMixin):
                     error(err)
                 raise errors
             except SyntaxError:
-                error("encountered a SyntaxError while parsing config file:\n%s "%
+                error("encountered a SyntaxError while parsing config file:\n%s " %
                     (traceback.format_exc(),),
                     )
                 raise errors

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -237,7 +237,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
     def test_loadConfig_parse_error(self):
         self.install_config_file('def x:\nbar')
         self.assertRaisesConfigError(
-            re.compile("error while parsing.*traceback in logfile"),
+            re.compile("encountered a SyntaxError while parsing config file:"),
             lambda: config.MasterConfig.loadConfig(
                 self.basedir, self.filename))
         self.assertEqual(len(self.flushLoggedErrors(SyntaxError)), 1)

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -240,7 +240,6 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
             re.compile("encountered a SyntaxError while parsing config file:"),
             lambda: config.MasterConfig.loadConfig(
                 self.basedir, self.filename))
-        self.assertEqual(len(self.flushLoggedErrors(SyntaxError)), 1)
 
     def test_loadConfig_eval_ConfigError(self):
         self.install_config_file("""\

--- a/master/buildbot/test/unit/test_scripts_cleanupdb.py
+++ b/master/buildbot/test/unit/test_scripts_cleanupdb.py
@@ -87,7 +87,7 @@ class TestCleanupDb(misc.StdoutAssertionsMixin, dirs.DirsMixin,
         self.createMasterCfg(extraconfig="++++ # syntaxerror")
         res = yield cleanupdb._cleanupDatabase(mkconfig(basedir='basedir'))
         self.assertEqual(res, 1)
-        self.assertInStdout("error while parsing config")
+        self.assertInStdout("encountered a SyntaxError while parsing config file:")
         # config logs an error via log.err, we must eat it or trial will complain
         self.flushLoggedErrors()
 


### PR DESCRIPTION
Change the format of configuration file syntax errors to make them more
user friendly.

fixes [#3437](http://trac.buildbot.net/ticket/3437)