### PR TITLE
Large build page

### DIFF
--- a/www/base/src/app/builders/buildrequest/buildrequest.controller.coffee
+++ b/www/base/src/app/builders/buildrequest/buildrequest.controller.coffee
@@ -6,6 +6,11 @@ class Buildrequest extends Controller
                 findBuilds $scope,
                     $scope.buildrequest.buildrequestid,
                     $stateParams.redirect_to_build
+                # when a build is discovered, force the tab to go to that build
+                savedNew = $scope.builds.onNew
+                $scope.builds.onNew = (build) ->
+                    build.active = true
+                    savedNew(build)
 
         doCancel = ->
             $scope.is_cancelling = true
@@ -47,11 +52,10 @@ class Buildrequest extends Controller
             data.getBuilders(buildrequest.builderid).onNew = (builder) ->
                 $scope.builder = builder
                 breadcrumb = [
-                        caption: "buildrequests"
-                        sref: "buildrequests"
-                    ,
                         caption: builder.name
                         sref: "builder({builder:#{buildrequest.builderid}})"
+                    ,
+                        caption: "buildrequests"
                     ,
                         caption: buildrequest.buildrequestid
                         sref: "buildrequest({buildrequest:#{buildrequest.buildrequestid}})"
@@ -59,5 +63,7 @@ class Buildrequest extends Controller
 
                 glBreadcrumbService.setBreadcrumb(breadcrumb)
 
-            data.getBuildsets(buildrequest.buildsetid).onNew = (buildsets) ->
-                $scope.buildset = publicFieldsFilter(buildsets[0])
+            data.getBuildsets(buildrequest.buildsetid).onNew = (buildset) ->
+                $scope.buildset = publicFieldsFilter(buildset)
+                buildset.getProperties().onNew  = (properties) ->
+                    $scope.properties = publicFieldsFilter(properties)

--- a/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.coffee
+++ b/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.coffee
@@ -25,6 +25,7 @@ describe 'buildrequest controller', ->
     beforeEach(inject(injected))
 
     it 'should query for buildrequest', ->
+        dataService.when('buildsets/1/properties', [{a: ['a','b']}])
         dataService.when('buildrequests/1', [{buildrequestid: 1, builderid: 1, buildsetid: 1}])
         dataService.when('builders/1', [{builderid: 1}])
         dataService.when('buildsets/1', [{buildsetid: 1}])
@@ -39,6 +40,7 @@ describe 'buildrequest controller', ->
         expect($scope.builds[0]).toBeDefined()
 
     it 'should query for builds again if first query returns 0', ->
+        dataService.when('buildsets/1/properties', [{a: ['a','b']}])
         dataService.when('buildrequests/1', [{buildrequestid: 1, builderid: 1, buildsetid: 1}])
         dataService.when('builders/1', [{builderid: 1}])
         dataService.when('buildsets/1', [{buildsetid: 1}])
@@ -55,6 +57,7 @@ describe 'buildrequest controller', ->
         expect($scope.builds.length).toBe(2)
 
     it 'should go to build page if build started', ->
+        dataService.when('buildsets/1/properties', [{a: ['a','b']}])
         dataService.when('buildrequests/1', [{buildrequestid: 1, builderid: 3, buildsetid: 1}])
         dataService.when('builders/3', [{builderid: 3}])
         dataService.when('buildsets/1', [{buildsetid: 1}])

--- a/www/base/src/app/builders/buildrequest/buildrequest.tpl.jade
+++ b/www/base/src/app/builders/buildrequest/buildrequest.tpl.jade
@@ -1,16 +1,16 @@
 .container
   .row
-      .col-sm-5
-          h3 Associated builds:
-          .row(ng-repeat="build in builds")
-              buildsummary(buildid="build.buildid", condensed='1')
-      .col-sm-7
-          tabset(justified="true")
-              tab(heading="build {{build.number}}", ng-repeat="build in builds")
-                  rawdata(data="build")
-              tab(heading="buildrequest")
-                  rawdata(data="buildrequest")
-              tab(heading="properties")
-                  rawdata(data="buildset.properties")
-              tab(heading="buildset")
-                  rawdata(data="buildset")
+      tabset(justified="left")
+          tab(heading="build {{build.number}}", active="build.active", ng-repeat="build in builds")
+              buildsummary(build="build")
+          tab(heading="properties")
+              properties(properties="properties")
+          tab(heading="Debug")
+              h4 Buildrequest
+              rawdata(data="buildrequest")
+              h4 Buildset
+              rawdata(data="buildset")
+              h4 Builder
+              rawdata(data="builder")
+              h4 Builds
+              rawdata(data="builds")

--- a/www/base/src/app/builders/builds/build.controller.coffee
+++ b/www/base/src/app/builders/builds/build.controller.coffee
@@ -114,17 +114,20 @@ class Build extends Controller
                     link: "#/builders/#{$scope.builder.builderid}/builds/#{$scope.build.number}"
                     caption: "#{$scope.builder.name} / #{$scope.build.number}"
 
-                $scope.properties = build.getProperties()
+                build.getProperties().onNew = (properties) ->
+                    $scope.properties = properties
                 $scope.changes = build.getChanges()
                 $scope.responsibles = {}
                 $scope.changes.onNew = (change) ->
-                    console.log change
                     $scope.responsibles[change.author_name] = change.author_email
 
-                data.getWorkers(build.workerid).onChange = (workers) ->
-                    $scope.worker = publicFieldsFilter(workers[0])
+                data.getWorkers(build.workerid).onNew = (worker) ->
+                    $scope.worker = publicFieldsFilter(worker)
 
-                data.getBuildrequests(build.buildrequestid).onChange = (buildrequests) ->
-                    $scope.buildrequest = buildrequest = buildrequests[0]
-                    data.getBuildsets(buildrequest.buildsetid).onChange = (buildsets) ->
-                        $scope.buildset = buildsets[0]
+                data.getBuildrequests(build.buildrequestid).onNew = (buildrequest) ->
+                    $scope.buildrequest = buildrequest
+                    data.getBuildsets(buildrequest.buildsetid).onNew = (buildset) ->
+                        $scope.buildset = buildset
+                        if buildset.parent_buildid
+                            data.getBuilds(buildset.parent_buildid).onNew = (build) ->
+                                $scope.parent_build = build

--- a/www/base/src/app/builders/builds/build.tpl.jade
+++ b/www/base/src/app/builders/builds/build.tpl.jade
@@ -13,25 +13,13 @@
             span.badge-status(ng-class="results2class(nextbuild, 'pulse')") &rarr;
         span(ng-if="last_build") Next &rarr;
   .row
-    .col-sm-5
-      buildsummary(ng-if="build", buildid="build.buildid")
-    .col-sm-7
-      .row(ng-if="buildset.parent_buildid")
-          buildsummary(buildid="buildset.parent_buildid", condensed="1", prefix="{{buildset.parent_relationship}}:")
       tabset
+          tab(heading="Build steps")
+              buildsummary(ng-if="build", build="build", parentbuild="parent_build",
+                           parentrelationship="buildset.parent_relationship")
           tab(heading="Build Properties")
-            table.table.table-hover.table-striped.table-condensed
-              thead
-                tr
-                  th.text-left Name
-                  th.text-center Value
-                  th.text-right Source
-              tbody
-                tr(ng-repeat="(name, value) in properties[0] | publicFields")
-                  td.text-left {{ name }}
-                  td.text-center {{ value[0] }}
-                  td.text-right {{ value[1] }}
-          tab(heading="{{worker.name}}")
+              properties(properties="properties")
+          tab(heading="Worker: {{worker.name}}")
             table.table.table-hover.table-striped.table-condensed
               tbody
                   tr
@@ -49,3 +37,10 @@
                         | {{ author }}
           tab(heading="Changes")
               changelist(changes="changes")
+          tab(heading="Debug")
+              h4
+                  a(ui-sref="buildrequest({buildrequest:buildrequest.buildrequestid})")
+                     | Buildrequest:
+              rawdata(data="buildrequest")
+              h4 Buildset:
+              rawdata(data="buildset")

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -1,6 +1,12 @@
 .panel.panel-default(ng-class="results2class(buildsummary.build)")
-  .panel-heading.no-select(ng-click="buildsummary.toggleDetails()")
-    span(ng-if="prefix") {{prefix}}&nbsp;
+  .panel-heading.no-select
+    .btn.btn-xs.btn-default(ng-click="buildsummary.toggleFullDisplay()", title="Expand all step logs")
+        i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':buildsummary.fulldisplay}")
+    .btn.btn-xs.btn-default(ng-click="buildsummary.toggleDetails()", title="Show steps according to their importance")
+        i.fa.fa-expand
+        {{buildsummary.levelOfDetails()}}
+    | &nbsp;
+    span(ng-if="buildsummary.prefix") {{buildsummary.prefix}}&nbsp;
     a(ui-sref="build({builder:buildsummary.builder.builderid, build:buildsummary.build.number})")
       | {{buildsummary.builder.name}}/{{buildsummary.build.number}}
     .pull-right
@@ -12,20 +18,27 @@
         | &nbsp;{{buildsummary.build.state_string}}&nbsp;
       .label(ng-class="results2class(buildsummary.build)")
         | {{results2text(buildsummary.build)}}
+      span(ng-if="buildsummary.parentbuild")
+          | &nbsp;
+          a.label(ng-class="results2class(buildsummary.parentbuild)",
+          ui-sref="build({builder:buildsummary.parentbuilder.builderid, build:buildsummary.parentbuild.number})")
+                | {{buildsummary.parentrelationship}}: 
+                | {{buildsummary.parentbuilder.name}}/{{buildsummary.parentbuild.number}}
   ul.list-group.no-select
-    li.list-group-item(ng-if="buildsummary.isStepDisplayed(step)", ng-repeat="step in buildsummary.steps",
-                       ng-click="step.fulldisplay=!step.fulldisplay")
-      span.pull-right(ng-if="step.started_at")
-        span(ng-show="step.complete")
-            | {{ step.duration| durationformat:'LLL' }}
-        span(ng-show="!step.complete")
-            | {{ buildsummary.now - step.started_at| durationformat:'LLL' }}
-        | &nbsp;{{step.state_string}}
-      span.badge-status(ng-class="results2class(step, 'pulse')")
-        | {{step.number}}
-      | &nbsp;
-      i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':step.fulldisplay}", ng-if="step.logs.length")
-      | &nbsp; {{step.name}}
+    li.list-group-item(ng-if="buildsummary.isStepDisplayed(step)", ng-repeat="step in buildsummary.steps")
+                       
+      div(ng-click="step.fulldisplay=!step.fulldisplay")
+          span.pull-right(ng-if="step.started_at")
+            span(ng-show="step.complete")
+                | {{ step.duration| durationformat:'LLL' }}
+            span(ng-show="!step.complete")
+                | {{ buildsummary.now - step.started_at| durationformat:'LLL' }}
+            | &nbsp;{{step.state_string}}
+          span.badge-status(ng-class="results2class(step, 'pulse')")
+            | {{step.number}}
+          | &nbsp;
+          i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':step.fulldisplay}", ng-if="step.logs.length")
+          | &nbsp; {{step.name}}
       div.anim-stepdetails(ng-show="step.fulldisplay")
         ul
           li(ng-repeat="log in step.logs")

--- a/www/base/src/app/common/directives/properties/properties.directive.coffee
+++ b/www/base/src/app/common/directives/properties/properties.directive.coffee
@@ -1,0 +1,8 @@
+class Properties extends Directive('common')
+    constructor: ->
+        return {
+            replace: true
+            restrict: 'E'
+            scope: {properties: '='}
+            templateUrl: 'views/properties.html'
+        }

--- a/www/base/src/app/common/directives/properties/properties.tpl.jade
+++ b/www/base/src/app/common/directives/properties/properties.tpl.jade
@@ -1,0 +1,11 @@
+table.table.table-hover.table-striped.table-condensed
+  thead
+    tr
+      th.text-left Name
+      th.text-center Value
+      th.text-right Source
+  tbody
+    tr(ng-repeat="(name, value) in properties | publicFields")
+      td.text-left {{ name }}
+      td.text-center {{ value[0] }}
+      td.text-right {{ value[1] }}


### PR DESCRIPTION
I got feedback from several people that the build properties details are not very important for most of the users, and they are using a lot of horizontal space in the current UI.

Here is a proposal on the build page that we could use in order to fix this issue:

The idea is simply to put the build steps as another tab, and make the tabcontainer a full width component. build properties are now one more click away, but you get a full vision on your build, and more spaces for build step names and statuses.

before:
![image](https://cloud.githubusercontent.com/assets/109859/13153508/dc93adbe-d674-11e5-91f7-d10b03b2deb9.png)

after:
Build page:
![image](https://cloud.githubusercontent.com/assets/109859/13181919/9bdbac3e-d72f-11e5-89a0-c2fc906a68ec.png)
Child Buildpage (with parent label)
![image](https://cloud.githubusercontent.com/assets/109859/13182414/e108a4b8-d731-11e5-9a70-a8ee512bf814.png)

Expand buttons:
![image](https://cloud.githubusercontent.com/assets/109859/13181969/d7314ece-d72f-11e5-9f84-56379afb9483.png)
![image](https://cloud.githubusercontent.com/assets/109859/13181977/df14a9c4-d72f-11e5-8183-8f8676c47bc6.png)
![image](https://cloud.githubusercontent.com/assets/109859/13182122/84284eac-d730-11e5-871b-8170a264be16.png)

Buildrequest page:
![image](https://cloud.githubusercontent.com/assets/109859/13181903/8b62f916-d72f-11e5-871f-9d0fc6ad9847.png)


debug page:
![image](https://cloud.githubusercontent.com/assets/109859/13181998/f3007fd0-d72f-11e5-8841-e8c5d4f387bb.png)
