### PR TITLE
Install docs dependencies in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,11 @@ install:
   # astroid > 1.4 is incompatible with pylint 1.1.0
   - "[ $TESTS != lint ] || pip install pylint==1.1.0 pep8==1.5.7 flake8  astroid==1.3.8"
   # TODO: Pin Sphinx version to workaround http://trac.buildbot.net/ticket/3408
-  - "[ $TESTS != docs ] || pip install sphinx==1.3.3"
+  - |
+      [ $TESTS != docs ] || \
+      pip install sphinx==1.3.3 \
+                  sphinxcontrib-blockdiag \
+                  docutils>=0.8 \
 
 before_script:
   # create real MySQL database for tests

--- a/master/docs/Makefile
+++ b/master/docs/Makefile
@@ -10,8 +10,6 @@ TAR_TRANSFORM := $(if $(filter bsdtar,$(TAR_VERSION)),-s /^html/$(VERSION)/,--tr
 docs.tgz: clean html singlehtml images-png
 	sed -e 's!href="index.html#!href="#!g' < _build/singlehtml/index.html > _build/html/full.html
 	tar -C _build $(TAR_TRANSFORM) -zcf $@ html
-pipdeps:
-	pip install sphinxcontrib-blockdiag 'docutils>=0.8'
 
 images:
 	$(MAKE) -C images all

--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -21,6 +21,17 @@ import textwrap
 sys.path.append(os.path.abspath('.'))
 
 # -- General configuration -----------------------------------------------------
+# Check if sphinx is installed
+try:
+    import sphinxcontrib.blockdiag
+    import pkg_resources
+    pkg_resources.require('docutils>=0.8')
+except DistributionNotFound:
+    print("Please run this command to install the dependencies first "
+        "- pip install buildbot[docs]")
+except VersionConflict:
+    print("The version of docutils is not supported. Run this command "
+        "to install the required version - pip install buildbot[docs]")
 
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = '1.0'

--- a/master/setup.py
+++ b/master/setup.py
@@ -426,9 +426,16 @@ else:
             'buildbot-www',
             'buildbot-slave'
         ],
+<<<<<<< HEAD
         'tls': [
             'Twisted[tls] ' + twisted_ver,
         ],
+=======
+        'docs': [
+            'sphinxcontrib-blockdiag',
+            'docutils>=0.8',
+        ]
+>>>>>>> Install docs dependencies in setup.py
     }
 
     if os.getenv('NO_INSTALL_REQS'):


### PR DESCRIPTION
Remove the pip install command from the docs Makefile used for installing the
sphinx distribution. 
Add the distribution to the extras in setup.py so that it can be installed if required by the user. 

fixes #3435
