### PR TITLE
Remove the getPendingBuildTimes method from base scheduler

### DIFF
--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -116,9 +116,6 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
     def listBuilderNames(self):
         return self.builderNames
 
-    def getPendingBuildTimes(self):
-        return []
-
     # change handling
 
     @defer.inlineCallbacks

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -201,11 +201,6 @@ class BaseBasicScheduler(base.BaseScheduler):
         yield self.master.db.schedulers.flushChangeClassifications(
             self.objectid, less_than=max_changeid + 1)
 
-    def getPendingBuildTimes(self):
-        # This isn't locked, since the caller expects an immediate value,
-        # and in any case, this is only an estimate.
-        return [timer.getTime() for timer in itervalues(self._stable_timers) if timer and timer.active()]
-
 
 class SingleBranchScheduler(BaseBasicScheduler, AbsoluteSourceStampsMixin):
 

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -112,11 +112,6 @@ class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
 
     # Scheduler methods
 
-    def getPendingBuildTimes(self):
-        # take the latest-calculated value of actuateAt as a reasonable
-        # estimate
-        return [self.actuateAt]
-
     def gotChange(self, change, important):
         # both important and unimportant changes on our branch are recorded, as
         # we will include all such changes in any buildsets we start.  Note

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -102,10 +102,6 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
         sched = self.makeScheduler(builderNames=['x', 'y'])
         self.assertEqual(sched.listBuilderNames(), ['x', 'y'])
 
-    def test_getPendingBuildTimes(self):
-        sched = self.makeScheduler()
-        self.assertEqual(sched.getPendingBuildTimes(), [])
-
     @defer.inlineCallbacks
     def test_startConsumingChanges_fileIsImportant_check(self):
         sched = self.makeScheduler()

--- a/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
@@ -179,15 +179,3 @@ class Periodic(scheduler.SchedulerMixin, unittest.TestCase):
         d = sched.getNextBuildTime(20)
         d.addCallback(lambda t: self.assertEqual(t, 33))
         return d
-
-    def test_getPendingBuildTimes(self):
-        sched = self.makeScheduler(name='test', builderNames=['test'],
-                                   periodicBuildTimer=13)
-        self.state['last_build'] = self.clock.seconds() - 10  # so next build should start in 3s
-
-        sched.activate()
-        self.clock.advance(0)  # let it schedule the first build
-        self.assertEqual(sched.getPendingBuildTimes(), [3.0])
-
-        d = sched.deactivate()
-        return d

--- a/master/buildbot/test/unit/test_schedulers_timed_Timed.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Timed.py
@@ -49,18 +49,3 @@ class Timed(scheduler.SchedulerMixin, unittest.TestCase):
 
     # note that most of the heavy-lifting for testing this class is handled by
     # the subclasses' tests, as that's the more natural place for it
-
-    def test_getPendingBuildTimes(self):
-        sched = self.makeScheduler(name='test', builderNames=['foo'])
-
-        sched.activate()
-
-        self.assertEqual(sched.got_lastActuation, None)
-        self.assertEqual(sched.getPendingBuildTimes(), [1060])
-
-        self.clock.advance(1065)
-        self.assertTrue(sched.started_build)
-        self.assertEqual(sched.getPendingBuildTimes(), [1120])
-
-        d = sched.deactivate()
-        return d


### PR DESCRIPTION
This PR is about [tickets 2653](http://trac.buildbot.net/ticket/2653#comment:2), which required remove no longer used method from base scheduler. Due to the discussion under the ticket and the comment in [here](http://trac.buildbot.net/ticket/2653#comment:2), I just remove the getPendingBuildTimes method :)