### PR TITLE
Add support for GitLab OAuth2 authentication 

### DIFF
--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -56,11 +56,11 @@ class OAuth2Auth(www.WwwTestMixin, unittest.TestCase):
 
         self.googleAuth = oauth2.GoogleAuth("ggclientID", "clientSECRET")
         self.githubAuth = oauth2.GitHubAuth("ghclientID", "clientSECRET")
-        master = self.make_master(url='h:/a/b/', auth=self.googleAuth)
-        self.googleAuth.reconfigAuth(master, master.config)
-        self.master = master = self.make_master(
-            url='h:/a/b/', auth=self.githubAuth)
-        self.githubAuth.reconfigAuth(master, master.config)
+        self.gitlabAuth = oauth2.GitLabAuth("https://gitlab.test/", "glclientID", "clientSECRET")
+
+        for auth in [self.googleAuth, self.githubAuth, self.gitlabAuth]:
+            self._master = master = self.make_master(url='h:/a/b/', auth=auth)
+            auth.reconfigAuth(master, master.config)
 
     @defer.inlineCallbacks
     def test_getGoogleLoginURL(self):
@@ -86,6 +86,22 @@ class OAuth2Auth(www.WwwTestMixin, unittest.TestCase):
         res = yield self.githubAuth.getLoginURL(None)
         exp = ("https://github.com/login/oauth/authorize?redirect_uri="
                "h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&client_id=ghclientID")
+        self.assertEqual(res, exp)
+
+    @defer.inlineCallbacks
+    def test_getGitLabLoginURL(self):
+        res = yield self.gitlabAuth.getLoginURL('http://redir')
+        exp = ("https://gitlab.test/oauth/authorize"
+               "?state=redirect%3Dhttp%253A%252F%252Fredir"
+               "&redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin"
+               "&response_type=code"
+               "&client_id=glclientID")
+        self.assertEqual(res, exp)
+        res = yield self.gitlabAuth.getLoginURL(None)
+        exp = ("https://gitlab.test/oauth/authorize"
+               "?redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin"
+               "&response_type=code"
+               "&client_id=glclientID")
         self.assertEqual(res, exp)
 
     @defer.inlineCallbacks
@@ -120,6 +136,31 @@ class OAuth2Auth(www.WwwTestMixin, unittest.TestCase):
                           'full_name': 'foo bar'}, res)
 
     @defer.inlineCallbacks
+    def test_GitlabVerifyCode(self):
+        requests.get.side_effect = []
+        requests.post.side_effect = [
+            FakeResponse(dict(access_token="TOK3N"))]
+        self.gitlabAuth.get = mock.Mock(side_effect=[
+            {  # /user
+                "name": "Foo Bar",
+                "username": "fbar",
+                "id": 5,
+                "avatar_url": "https://avatar/fbar.png",
+                "email": "foo@bar",
+                "twitter": "fb",
+            },
+            [  # /groups
+                {"id": 10, "name": "Hello", "path": "hello"},
+                {"id": 20, "name": "Group", "path": "grp"},
+            ]])
+        res = yield self.gitlabAuth.verifyCode("code!")
+        self.assertEqual({"full_name": "Foo Bar",
+                          "username": "fbar",
+                          "email": "foo@bar",
+                          "avatar_url": "https://avatar/fbar.png",
+                          "groups": ["hello", "grp"]}, res)
+
+    @defer.inlineCallbacks
     def test_loginResource(self):
         class fakeAuth(object):
             homeUri = "://me"
@@ -147,6 +188,8 @@ class OAuth2Auth(www.WwwTestMixin, unittest.TestCase):
                                                            'name': 'GitHub', 'oauth2': True})
         self.assertEqual(self.googleAuth.getConfigDict(), {'fa_icon': 'fa-google-plus', 'autologin': False,
                                                            'name': 'Google', 'oauth2': True})
+        self.assertEqual(self.gitlabAuth.getConfigDict(), {'fa_icon': 'fa-git', 'autologin': False,
+                                                           'name': 'GitLab', 'oauth2': True})
 
 # unit tests are not very usefull to write new oauth support
 # so following is an e2e test, which opens a browser, and do the oauth

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -206,11 +206,19 @@ class OAuth2Auth(www.WwwTestMixin, unittest.TestCase):
 #     "CLIENTID": "XX",
 #     "CLIENTSECRET": "XX"
 #  }
+#  "GitLabAuth": {
+#     "INSTANCEURI": "XX",
+#     "CLIENTID": "XX",
+#     "CLIENTSECRET": "XX"
+#  }
 #  }
 
 
 class OAuth2AuthGitHubE2E(www.WwwTestMixin, unittest.TestCase):
     authClass = "GitHubAuth"
+
+    def _instantiateAuth(self, cls, config):
+        return cls(config["CLIENTID"], config["CLIENTSECRET"])
 
     def setUp(self):
         if requests is None:
@@ -219,10 +227,10 @@ class OAuth2AuthGitHubE2E(www.WwwTestMixin, unittest.TestCase):
         if "OAUTHCONF" not in os.environ:
             raise unittest.SkipTest("Need to pass OAUTHCONF path to json file via environ to run this e2e test")
 
-        from buildbot.www import oauth2
         import json
         config = json.load(open(os.environ['OAUTHCONF']))[self.authClass]
-        self.auth = getattr(oauth2, self.authClass)(config["CLIENTID"], config["CLIENTSECRET"])
+        from buildbot.www import oauth2
+        self.auth = self._instantiateAuth(getattr(oauth2, self.authClass), config)
 
         # 5000 has to be hardcoded, has oauth clientids are bound to a fully classified web site
         master = self.make_master(url='http://localhost:5000/', auth=self.auth)
@@ -279,3 +287,10 @@ class OAuth2AuthGitHubE2E(www.WwwTestMixin, unittest.TestCase):
 
 class OAuth2AuthGoogleE2E(OAuth2AuthGitHubE2E):
     authClass = "GoogleAuth"
+
+
+class OAuth2AuthGitLabE2E(OAuth2AuthGitHubE2E):
+    authClass = "GitLabAuth"
+
+    def _instantiateAuth(self, cls, config):
+        return cls(config["INSTANCEURI"], config["CLIENTID"], config["CLIENTSECRET"])

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -179,3 +179,24 @@ class GitHubAuth(OAuth2Auth):
                     email=user['email'],
                     username=user['login'],
                     groups=[org['login'] for org in orgs])
+
+
+class GitLabAuth(OAuth2Auth):
+    name = "GitLab"
+    faIcon = "fa-git"
+
+    def __init__(self, instanceUri, clientId, clientSecret, **kwargs):
+        uri = instanceUri.rstrip("/")
+        self.authUri = "%s/oauth/authorize" % uri
+        self.tokenUri = "%s/oauth/token" % uri
+        self.resourceEndpoint = "%s/api/v3" % uri
+        super(GitLabAuth, self).__init__(clientId, clientSecret, **kwargs)
+
+    def getUserInfoFromOAuthClient(self, c):
+        user = self.get(c, "/user")
+        groups = self.get(c, "/groups")
+        return dict(full_name=user["name"],
+                    username=user["username"],
+                    email=user["email"],
+                    avatar_url=user["avatar_url"],
+                    groups=[g["path"] for g in groups])

--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -212,6 +212,27 @@ The available classes are described here:
 
 .. _GitHub: http://developer.github.com/v3/oauth_authorizations/
 
+.. py:class:: buildbot.www.oauth2.GitLabAuth(instanceUri, clientId, clientSecret)
+
+    :param instanceUri: The URI of your GitLab instance
+    :param clientId: The client ID of your buildbot application
+    :param clientSecret: The client secret of your buildbot application
+
+    This class implements an authentication with GitLab_ single sign-on.
+    It functions almost identically to the :py:class:`~buildbot.www.oauth2.GoogleAuth` class.
+
+    Register your Buildbot instance with the ``BUILDBOT_URL/auth/login`` url as the allowed redirect URI.
+
+    Example::
+
+        from buildbot.plugins import util
+        c['www'] = {
+            # ...
+            'auth': util.GitLabAuth("https://gitlab.com", "clientid", clientsecret"),
+        }
+
+.. _GitLab: http://doc.gitlab.com/ce/integration/oauth_provider.html
+
 .. py:class:: buildbot.www.auth.RemoteUserAuth
 
     :param header: header to use to get the username (defaults to ``REMOTE_USER``)

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -21,6 +21,7 @@ Features
 ~~~~~~~~
 
 * :class:`GitPoller` now has a ``buildPushesWithNoCommits`` option to allow the rebuild of already known commits on new branches.
+* Add GitLab authentication plugin for web UI. See :class:`buildbot.www.oauth2.GitLabAuth`.
 
 Fixes
 ~~~~~

--- a/master/setup.py
+++ b/master/setup.py
@@ -344,7 +344,7 @@ setup_args = {
                 'UserPasswordAuth', 'HTPasswdAuth', 'RemoteUserAuth']),
             ('buildbot.www.ldapuserinfos', ['LdapUserInfo']),
             ('buildbot.www.oauth2', [
-                'GoogleAuth', 'GitHubAuth']),
+                'GoogleAuth', 'GitHubAuth', 'GitLabAuth']),
             ('buildbot.db.dbconfig', [
                 'DbConfig']),
             ('buildbot.www.authz', [


### PR DESCRIPTION
This patch set adds a support for OAuth2 authentication with [GitLab](http://doc.gitlab.com/ce/integration/oauth_provider.html).