### PR TITLE
check that ShellCommand command in set in constructor

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -108,11 +108,11 @@ class ShellCommand(buildstep.LoggingBuildStep):
         if command:
             self.setCommand(command)
 
-        if self.__class__ is ShellCommand:
+        if self.__class__ is ShellCommand and not command:
             # ShellCommand class is directly instantiated.
             # Explicitly check that command is set to prevent runtime error
             # later.
-            assert command, "ShellCommand's `command' argument not specified"
+            config.error("ShellCommand's `command' argument is not specified")
 
         # pull out the ones that LoggingBuildStep wants, then upcall
         buildstep_kwargs = {}
@@ -409,13 +409,13 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
         # And upcall to let the base class do its work
         ShellCommand.__init__(self, **kwargs)
 
-        if self.__class__ is WarningCountingShellCommand:
+        if self.__class__ is WarningCountingShellCommand and \
+                not kwargs.get('command'):
             # WarningCountingShellCommand class is directly instantiated.
             # Explicitly check that command is set to prevent runtime error
             # later.
-            assert kwargs.get('command'), \
-                "WarningCountingShellCommand's `command' argument not " \
-                "specified"
+            config.error("WarningCountingShellCommand's `command' argument "
+                         "is not specified")
 
         self.suppressions = []
         self.directoryStack = []

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -410,7 +410,7 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
         ShellCommand.__init__(self, **kwargs)
 
         if self.__class__ is WarningCountingShellCommand:
-            # ShellCommand class is directly instantiated.
+            # WarningCountingShellCommand class is directly instantiated.
             # Explicitly check that command is set to prevent runtime error
             # later.
             assert kwargs.get('command'), \

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -108,6 +108,12 @@ class ShellCommand(buildstep.LoggingBuildStep):
         if command:
             self.setCommand(command)
 
+        # command must be set either on class level (e.g. when specific
+        # subclass with fixed command is used), or in constructor.
+        # If anyone wishes to set command manually later, e.g. in run(),
+        # he should set it to dummy or default value.
+        assert self.command, "ShellCommand's `command' must is not set"
+
         # pull out the ones that LoggingBuildStep wants, then upcall
         buildstep_kwargs = {}
         # workdir is here first positional argument, but it belongs to BuildStep parent

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -112,7 +112,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
             # ShellCommand class is directly instantiated.
             # Explicitly check that command is set to prevent runtime error
             # later.
-            assert self.command, "ShellCommand's `command' is not set"
+            assert command, "ShellCommand's `command' argument not specified"
 
         # pull out the ones that LoggingBuildStep wants, then upcall
         buildstep_kwargs = {}
@@ -408,6 +408,14 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
 
         # And upcall to let the base class do its work
         ShellCommand.__init__(self, **kwargs)
+
+        if self.__class__ is WarningCountingShellCommand:
+            # ShellCommand class is directly instantiated.
+            # Explicitly check that command is set to prevent runtime error
+            # later.
+            assert kwargs.get('command'), \
+                "WarningCountingShellCommand's `command' argument not " \
+                "specified"
 
         self.suppressions = []
         self.directoryStack = []

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -112,7 +112,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
         # subclass with fixed command is used), or in constructor.
         # If anyone wishes to set command manually later, e.g. in run(),
         # he should set it to dummy or default value.
-        assert self.command, "ShellCommand's `command' must is not set"
+        assert self.command, "ShellCommand's `command' is not set"
 
         # pull out the ones that LoggingBuildStep wants, then upcall
         buildstep_kwargs = {}

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -108,11 +108,11 @@ class ShellCommand(buildstep.LoggingBuildStep):
         if command:
             self.setCommand(command)
 
-        # command must be set either on class level (e.g. when specific
-        # subclass with fixed command is used), or in constructor.
-        # If anyone wishes to set command manually later, e.g. in run(),
-        # he should set it to dummy or default value.
-        assert self.command, "ShellCommand's `command' is not set"
+        if self.__class__ is ShellCommand:
+            # ShellCommand class is directly instantiated.
+            # Explicitly check that command is set to prevent runtime error
+            # later.
+            assert self.command, "ShellCommand's `command' is not set"
 
         # pull out the ones that LoggingBuildStep wants, then upcall
         buildstep_kwargs = {}

--- a/master/buildbot/test/regressions/test_steps_shell_WarningCountingShellCommand.py
+++ b/master/buildbot/test/regressions/test_steps_shell_WarningCountingShellCommand.py
@@ -28,7 +28,8 @@ class TestWarningCountingShellCommand(unittest.TestCase):
         # Use a warningExtractor that does not provide line
         # information
         w = WarningCountingShellCommand(
-            warningExtractor=WarningCountingShellCommand.warnExtractWholeLine)
+            warningExtractor=WarningCountingShellCommand.warnExtractWholeLine,
+            command="echo")
 
         # Add suppression manually instead of using suppressionFile
         fileRe = None

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -71,11 +71,6 @@ class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase, configm
             lambda: shell.ShellCommand(workdir='build', command="echo Hello World",
                                        wrongArg1=1, wrongArg2='two'))
 
-    def test_getLegacySummary_no_command(self):
-        step = shell.ShellCommand(workdir='build')
-        step.rendered = True
-        self.assertLegacySummary(step, None)
-
     def test_getLegacySummary_from_empty_command(self):
         # this is more of a regression test for a potential failure, really
         step = shell.ShellCommand(workdir='build', command=' ')

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -318,6 +318,12 @@ class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase, configm
     def test_run_decodeRC_defaults_0_is_failure(self):
         return self.test_run_decodeRC(0, FAILURE, extra_text=" (failure)")
 
+    def test_missing_command_error(self):
+        # this checks that an exception is raised for invalid arguments
+        self.assertRaisesConfigError(
+            "ShellCommand's `command' argument is not specified",
+            lambda: shell.ShellCommand())
+
 
 class TreeSize(steps.BuildStepMixin, unittest.TestCase):
 
@@ -644,7 +650,8 @@ class Configure(unittest.TestCase):
         self.assertEqual(step.command, ['./configure'])
 
 
-class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase):
+class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase,
+                                  configmixin.ConfigErrorsMixin):
 
     def setUp(self):
         return self.setUpBuildStep()
@@ -907,6 +914,13 @@ class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase):
             ('foo:123:text', '(.*):(.*):(.*)', 'foo', 123, 'text')
         self.assertEqual(we(step, line, re.match(pat, line)),
                          (exp_file, exp_lineNo, exp_text))
+
+    def test_missing_command_error(self):
+        # this checks that an exception is raised for invalid arguments
+        self.assertRaisesConfigError(
+            "WarningCountingShellCommand's `command' argument is not "
+            "specified",
+            lambda: shell.WarningCountingShellCommand())
 
 
 class Compile(steps.BuildStepMixin, unittest.TestCase):


### PR DESCRIPTION
This change prevents misconfiguration issues when ShellCommand is
constructed without specifiying `command' argument.