### PR TITLE
remove deprecated property "workdir"

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -222,7 +222,6 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
                 workerforbuilder.worker.worker_basedir,
                 self.builder.config.workerbuilddir)
             self.setProperty("builddir", builddir, "worker")
-            self.setProperty("workdir", builddir, "worker (deprecated)")
 
         self.workername = workerforbuilder.worker.workername
         self._registerOldWorkerAttr("workername")

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -274,8 +274,7 @@ class TestBuild(unittest.TestCase):
         expected_path = '/srv/buildbot/worker/test'
 
         b.setProperty.assert_has_calls(
-            [call('workdir', expected_path, 'worker (deprecated)'),
-             call('builddir', expected_path, 'worker')],
+            [call('builddir', expected_path, 'worker')],
             any_order=True)
 
     def testBuildLocksAcquired(self):

--- a/master/docs/manual/cfg-properties.rst
+++ b/master/docs/manual/cfg-properties.rst
@@ -82,10 +82,10 @@ The following build properties are set when the build is started, and are availa
 ``scheduler``
     If the build was started from a scheduler, then this property will contain the name of that scheduler.
 
-``workdir``
+``builddir``
     The absolute path of the base working directory on the worker, of the current builder.
 
-.. index:: single: Properties; workdir
+.. index:: single: Properties; builddir
 
 For single codebase builds, where the codebase is `''`, the following :ref:`Source-Stamp-Attributes` are also available as properties: ``branch``, ``revision``, ``repository``, and ``project`` .
 

--- a/master/docs/manual/worker-transition.rst
+++ b/master/docs/manual/worker-transition.rst
@@ -740,10 +740,6 @@ Worker Manager changes
 Properties
 ----------
 
-* ``builddir`` property source changed from ``"slave"`` to ``"worker"``;
-  ``workdir`` property source from ``"slave (deprecated)"`` to
-  ``"worker (deprecated)"``.
-
 * ``slavename`` property is deprecated in favor of ``workername`` property.
   Render of deprecated property will produce warning.
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -29,6 +29,8 @@ Fixes
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Deprecated ``workdir`` was removed, ``builddir`` property should be used instead.
+
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
It was deprecated in eb8526ce01be in favor of "builddir".

Unfortunately docs weren't updated.