### PR TITLE
Appveyor print packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
   - "copy /y sqlite3.dll %PYTHON%\\DLLs\\"
   
   - "%PYTHON%\\python.exe -m pip install -e pkg -e master[test] -e slave"
+  - "%PYTHON%\\python.exe -m pip list"
 
 build: false
 


### PR DESCRIPTION
Would help with debugging. Currently pip package versions are unknown in appveyor run.