### PR TITLE
Add docker host config support

### DIFF
--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -61,7 +61,9 @@ class TestDockerLatentWorker(unittest.TestCase):
 
     def test_constructor_all_docker_parameters(self):
         # Volumes have their own tests
-        bs = self.ConcreteWorker('bot', 'pass', 'unix:///var/run/docker.sock', 'worker_img', ['/bin/sh'], dockerfile="FROM ubuntu", version='1.9', tls=True)
+        bs = self.ConcreteWorker('bot', 'pass', 'unix:///var/run/docker.sock', 'worker_img', ['/bin/sh'],
+                                 dockerfile="FROM ubuntu", version='1.9', tls=True,
+                                 hostconfig={'network_mode': 'fake', 'dns': ['1.1.1.1', '1.2.3.4']})
         self.assertEqual(bs.workername, 'bot')
         self.assertEqual(bs.password, 'pass')
         self.assertEqual(bs.image, 'worker_img')
@@ -70,6 +72,7 @@ class TestDockerLatentWorker(unittest.TestCase):
         self.assertEqual(bs.volumes, [])
         self.assertEqual(bs.binds, {})
         self.assertEqual(bs.client_args, {'base_url': 'unix:///var/run/docker.sock', 'version': '1.9', 'tls': True})
+        self.assertEqual(bs.hostconfig, {'network_mode': 'fake', 'dns': ['1.1.1.1', '1.2.3.4']})
 
     def test_volume_no_suffix(self):
         bs = self.ConcreteWorker('bot', 'pass', 'tcp://1234:2375', 'worker', ['bin/bash'], volumes=['/src/webapp:/opt/webapp'])

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -60,7 +60,7 @@ class DockerLatentWorker(AbstractLatentWorker):
 
     def __init__(self, name, password, docker_host, image=None, command=None,
                  volumes=None, dockerfile=None, version=None, tls=None, followStartupLogs=False,
-                 masterFQDN=None,
+                 masterFQDN=None, hostconfig=None,
                  **kwargs):
 
         if not client:
@@ -99,6 +99,7 @@ class DockerLatentWorker(AbstractLatentWorker):
         if masterFQDN is None:
             masterFQDN = socket.getfqdn()
         self.masterFQDN = masterFQDN
+        self.hostconfig = hostconfig or {}
         # Prepare the parameters for the Docker Client object.
         self.client_args = {'base_url': docker_host}
         if version is not None:
@@ -156,7 +157,8 @@ class DockerLatentWorker(AbstractLatentWorker):
                 'Image "%s" not found on docker host.' % image
             )
 
-        host_conf = docker_client.create_host_config(binds=self.binds)
+        self.hostconfig['binds'] = self.binds
+        host_conf = docker_client.create_host_config(**self.hostconfig)
 
         instance = docker_client.create_container(
             image,

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -216,6 +216,10 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     Address of the master the worker should connect to. Use if you master machine does not have proper fqdn.
     This value is passed to the docker image via environment variable ``BUILDMASTER``
 
+``hostconfig``
+    (optional)
+    Extra host configuration parameters passed as a dictionary used to create HostConfig object. See `docker-py's HostConfig documentation <http://docker-py.readthedocs.org/en/latest/hostconfig/>`_ for all the supported options.
+
 Setting up Volumes
 ..................
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -22,11 +22,13 @@ Features
 
 * :class:`GitPoller` now has a ``buildPushesWithNoCommits`` option to allow the rebuild of already known commits on new branches.
 * Add GitLab authentication plugin for web UI. See :class:`buildbot.www.oauth2.GitLabAuth`.
+* :class:`DockerLatentWorker` now has a ``hostconfig`` parameter that can be used to setup host configuration when creating a new container.
 
 Fixes
 ~~~~~
 
 * Fix loading :class:`~buildbot.ldapuserinfo.LdapUserInfo` plugin and its documentation (:bug:`3371`).
+* Fix deprecation warnings seen with docker-py >= 1.4 when passing arguments to ``docker_client.start()``.
 
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Add ability to specify host configuration while creating a
docker latent worker. Currently regularly used options like --net and --dns cannot be provided while creating a docker latent worker, resulting in a broken worker as this often breaks network access

A new hostconfig parameter is added that accepts host config options as a dict, complete list of supported options can be found [here](https://docker-py.readthedocs.org/en/latest/hostconfig/).