### PR TITLE
Docker worker network config

### DIFF
--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -54,7 +54,6 @@ class TestDockerLatentWorker(unittest.TestCase):
         bs = self.ConcreteWorker('bot', 'pass', 'http://localhost:2375', 'worker', networking_config='host')
         self.assertEqual(bs.networking_config, 'host')
 
-
     def test_constructor_minimal(self):
         # Minimal set of parameters
         bs = self.ConcreteWorker('bot', 'pass', 'tcp://1234:2375', 'worker')

--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -50,6 +50,11 @@ class TestDockerLatentWorker(unittest.TestCase):
         self.assertEqual(bs.dockerfile, None)
         self.assertEqual(bs.image, 'myworker')
 
+    def test_constructor_networking_config(self):
+        bs = self.ConcreteWorker('bot', 'pass', 'http://localhost:2375', 'worker', networking_config='host')
+        self.assertEqual(bs.networking_config, 'host')
+
+
     def test_constructor_minimal(self):
         # Minimal set of parameters
         bs = self.ConcreteWorker('bot', 'pass', 'tcp://1234:2375', 'worker')

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -60,8 +60,7 @@ class DockerLatentWorker(AbstractLatentWorker):
 
     def __init__(self, name, password, docker_host, image=None, command=None,
                  volumes=None, dockerfile=None, version=None, tls=None, followStartupLogs=False,
-                 masterFQDN=None, hostconfig=None, networking_config='bridge'
-                 **kwargs):
+                 masterFQDN=None, hostconfig=None, networking_config='bridge', **kwargs):
 
         if not client:
             config.error("The python module 'docker-py>=1.4' is needed to use a"

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -60,7 +60,7 @@ class DockerLatentWorker(AbstractLatentWorker):
 
     def __init__(self, name, password, docker_host, image=None, command=None,
                  volumes=None, dockerfile=None, version=None, tls=None, followStartupLogs=False,
-                 masterFQDN=None, hostconfig=None,
+                 masterFQDN=None, hostconfig=None, networking_config='bridge'
                  **kwargs):
 
         if not client:
@@ -72,6 +72,7 @@ class DockerLatentWorker(AbstractLatentWorker):
 
         self.volumes = []
         self.binds = {}
+        self.networking_config = networking_config
         self.followStartupLogs = followStartupLogs
         for volume_string in (volumes or []):
             try:
@@ -166,7 +167,8 @@ class DockerLatentWorker(AbstractLatentWorker):
             name='%s_%s' % (self.workername, id(self)),
             volumes=self.volumes,
             environment=self.createEnvironment(),
-            host_config=host_conf
+            host_config=host_conf,
+            networking_config=self.networking_config
         )
 
         if instance.get('Id') is None:

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -220,6 +220,9 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     (optional)
     Extra host configuration parameters passed as a dictionary used to create HostConfig object. See `docker-py's HostConfig documentation <http://docker-py.readthedocs.org/en/latest/hostconfig/>`_ for all the supported options.
 
+``networking_config``
+  Set the network configuration for the docker container. It can be one the following: 'bridge', 'host', container:<NAME or ID>, none. The default is bridge. This option is equivalent to using the ``--net=`` command line parameter in docker. 
+
 Setting up Volumes
 ..................
 


### PR DESCRIPTION
This PR allows the networking config to be set when launching a latent docker worker. 