### PR TITLE
setup properties in time for LatentWorkers to use it

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -193,8 +193,12 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         for rq in self.requests:
             props.updateFromProperties(rq.properties)
 
+        self.builder.setupProperties(props)
+
+    def setupOwnProperties(self):
         # now set some properties of our own, corresponding to the
         # build itself
+        props = self.getProperties()
         props.setProperty("buildnumber", self.number, "Build")
 
         if self.sources and len(self.sources) == 1:
@@ -205,8 +209,6 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
             props.setProperty("repository", source.repository, "Build")
             props.setProperty("codebase", source.codebase, "Build")
             props.setProperty("project", source.project, "Build")
-
-        self.builder.setupProperties(props)
 
     def setupWorkerForBuilder(self, workerforbuilder):
         self.workerforbuilder = workerforbuilder
@@ -257,8 +259,7 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
                                                                       "stop"))
         yield self.master.data.updates.generateNewBuildEvent(self.buildid)
 
-        # now that we have a build_status, we can set properties
-        self.setupProperties()
+        self.setupOwnProperties()
         self.setupWorkerForBuilder(workerforbuilder)
         worker.updateWorkerStatus(buildStarted=self)
 

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -336,6 +336,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
 
         build = self.config.factory.newBuild(buildrequests)
         build.setBuilder(self)
+        build.setupProperties()
         log.msg("starting build %s using worker %s" % (build, workerforbuilder))
 
         # set up locks

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -866,7 +866,7 @@ class TestSetupProperties_MultipleSources(unittest.TestCase):
         self.props[s][n] = v
 
     def test_sourcestamp_properties_not_set(self):
-        self.build.setupProperties()
+        self.build.setupOwnProperties()
         self.assertTrue("codebase" not in self.props["Build"])
         self.assertTrue("revision" not in self.props["Build"])
         self.assertTrue("branch" not in self.props["Build"])
@@ -908,27 +908,27 @@ class TestSetupProperties_SingleSource(unittest.TestCase):
         self.props[s][n] = v
 
     def test_properties_codebase(self):
-        self.build.setupProperties()
+        self.build.setupOwnProperties()
         codebase = self.props["Build"]["codebase"]
         self.assertEqual(codebase, "A")
 
     def test_properties_repository(self):
-        self.build.setupProperties()
+        self.build.setupOwnProperties()
         repository = self.props["Build"]["repository"]
         self.assertEqual(repository, "http://svn-repo-A")
 
     def test_properties_revision(self):
-        self.build.setupProperties()
+        self.build.setupOwnProperties()
         revision = self.props["Build"]["revision"]
         self.assertEqual(revision, "12345")
 
     def test_properties_branch(self):
-        self.build.setupProperties()
+        self.build.setupOwnProperties()
         branch = self.props["Build"]["branch"]
         self.assertEqual(branch, "develop")
 
     def test_property_project(self):
-        self.build.setupProperties()
+        self.build.setupOwnProperties()
         project = self.props["Build"]["project"]
         self.assertEqual(project, '')
 


### PR DESCRIPTION
The image parameter is renderable, but the build's property are the slave subtanciation. As a consequence, when the code render the "image" parameter of DockerLatentWorker, the properties aren't set.

The build properties must be set before worker substanciation
