### PR TITLE
Install correct version in bundle

### DIFF
--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -65,7 +65,7 @@ Now that we are ready, we need to install buildbot:
 
 .. code-block:: bash
 
-  ./bin/pip install buildbot
+  ./bin/pip install buildbot[bundle]
 
 Now that buildbot is installed, it's time to create the master:
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -425,10 +425,10 @@ else:
             'pyflakes',
         ],
         'bundle': [
-            "buildbot-www=={}".format(bundle_version),
-            "buildbot-slave=={}".format(bundle_version),
-            "buildbot-waterfall-view=={}".format(bundle_version),
-            "buildbot-console-view=={}".format(bundle_version),
+            "buildbot-www=={0}".format(bundle_version),
+            "buildbot-slave=={0}".format(bundle_version),
+            "buildbot-waterfall-view=={0}".format(bundle_version),
+            "buildbot-console-view=={0}".format(bundle_version),
         ],
         'tls': [
             'Twisted[tls] ' + twisted_ver,

--- a/master/setup.py
+++ b/master/setup.py
@@ -396,6 +396,8 @@ if sys.version_info[:2] == (2, 6):
 else:
     twisted_ver = ">= 12.1.0"
 
+bundle_version = version.split("-")[0]
+
 try:
     # If setuptools is installed, then we'll add setuptools-specific arguments
     # to the setup args.
@@ -423,10 +425,10 @@ else:
             'pyflakes',
         ],
         'bundle': [
-            "buildbot-www==0.9.0b7",
-            "buildbot-slave==0.9.0b7",
-            "buildbot-waterfall-view==0.9.0b7",
-            "buildbot-console-view==0.9.0b7",
+            "buildbot-www=={}".format(bundle_version),
+            "buildbot-slave=={}".format(bundle_version),
+            "buildbot-waterfall-view=={}".format(bundle_version),
+            "buildbot-console-view=={}".format(bundle_version),
         ],
         'tls': [
             'Twisted[tls] ' + twisted_ver,

--- a/master/setup.py
+++ b/master/setup.py
@@ -423,8 +423,10 @@ else:
             'pyflakes',
         ],
         'bundle': [
-            'buildbot-www',
-            'buildbot-slave'
+            "buildbot-www==0.9.0b7",
+            "buildbot-slave==0.9.0b7",
+            "buildbot-waterfall-view==0.9.0b7",
+            "buildbot-console-view==0.9.0b7",
         ],
         'tls': [
             'Twisted[tls] ' + twisted_ver,


### PR DESCRIPTION
Currently the instructions in the first run tutorial don't work as you have to install more packages than just buildbot in order to be able to run buildbot.  I've updated the [bundle] extras option to include the correct version of these.  I've also updated the docs to reflect the new command.

Unfortunately the docs are still slightly wrong, as you need to type `./bin/pip install buildbot[bundle]==0.9.0b7` at the moment (because pip still defaults to 0.8), but I didn't want to hardcode a version number in the docs, and I could work out how to get a variable to work in Sphinx (eg `./bin/pip install buildbot[bundle]=={{version}}`).

