### PR TITLE
Fail with ConfigError without UnboundLocalError when parsing volumes for DockerLatentWorker fails

### DIFF
--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -79,6 +79,7 @@ class DockerLatentWorker(AbstractLatentWorker):
             except ValueError:
                 config.error("Invalid volume definition for docker "
                              "%s. Skipping..." % volume_string)
+                continue
             self.volumes.append(volume)
 
             ro = False


### PR DESCRIPTION
When volumes configuration has an error in it, loop does not break
correctly. A ConfigError is returned but the  succeeding code actual
fails with an UnboundLocalError as well since volume and bind were
never initialised.

Failure before this change :
```
Restarting buildmaster "FRB Buildmaster"
            self.volumes.append(volume)
        exceptions.UnboundLocalError: local variable 'volume' referenced
before assignment

2016-03-15 21:27:27+0000 [-] Configuration Errors:
2016-03-15 21:27:27+0000 [-]   Invalid volume definition for docker
/tmp/t/tmp/t. Skipping...
2016-03-15 21:27:27+0000 [-]   error while parsing config file: local
variable 'volume' referenced before assignment (traceback in logfile)
2016-03-15 21:27:27+0000 [-] Halting master.
```
Failure after this change :
```
Restarting buildmaster "FRB Buildmaster"
2016-03-15 21:27:19+0000 [-]
2016-03-15 21:27:19+0000 [-] Configuration Errors:
2016-03-15 21:27:19+0000 [-]   Invalid volume definition for docker
/tmp/t/tmp/t. Skipping...
2016-03-15 21:27:19+0000 [-] Halting master.
```