### PR TITLE
minor fix for influxdb

### DIFF
--- a/master/buildbot/statistics/storage_backends/influxdb_client.py
+++ b/master/buildbot/statistics/storage_backends/influxdb_client.py
@@ -34,6 +34,7 @@ class InfluxStorageService(StatsStorageBase):
                  name="InfluxStorageService"):
         if not InfluxDBClient:
             config.error("Python client for InfluxDB not installed.")
+            return
         self.url = url
         self.port = port
         self.user = user
@@ -43,7 +44,7 @@ class InfluxStorageService(StatsStorageBase):
 
         self.captures = captures
         self.client = InfluxDBClient(self.url, self.port, self.user,
-                                     self.password, self.db)
+                                         self.password, self.db)
         self._inited = True
 
     def thd_postStatsValue(self, post_data, series_name, context=None):

--- a/master/buildbot/statistics/storage_backends/influxdb_client.py
+++ b/master/buildbot/statistics/storage_backends/influxdb_client.py
@@ -44,7 +44,7 @@ class InfluxStorageService(StatsStorageBase):
 
         self.captures = captures
         self.client = InfluxDBClient(self.url, self.port, self.user,
-                                         self.password, self.db)
+                                     self.password, self.db)
         self._inited = True
 
     def thd_postStatsValue(self, post_data, series_name, context=None):

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -725,8 +725,6 @@ Capture Classes
    Instance of this class declares build durations to be recorded for all builders.
    It takes the following arguments:
 
-   ``builder_name``
-     The name of builder whose times are to be recorded.
    ``report_in='seconds'``
      Can be one of three: ``'seconds'``, ``'minutes'``, or ``'hours'``.
      This is the units in which the build time will be reported.


### PR DESCRIPTION
 - fix documenation for CaptureBuildDurationAllBuilders
 - fix when influxdb python is not installed. 
```
2016-03-16 11:08:01+0100 [-] error while parsing config file:
	Traceback (most recent call last):
	  File "/home/xdelannoy/Projects/prototype/env/local/lib/python2.7/site-packages/Twisted-15.5.0-py2.7-linux-x86_64.egg/twisted/python/threadpool.py", line 246, in inContext
	    result = inContext.theWork()
	  File "/home/xdelannoy/Projects/prototype/env/local/lib/python2.7/site-packages/Twisted-15.5.0-py2.7-linux-x86_64.egg/twisted/python/threadpool.py", line 262, in <lambda>
	    inContext.theWork = lambda: context.call(ctx, func, *args, **kw)
	  File "/home/xdelannoy/Projects/prototype/env/local/lib/python2.7/site-packages/Twisted-15.5.0-py2.7-linux-x86_64.egg/twisted/python/context.py", line 118, in callWithContext
	    return self.currentContext().callWithContext(ctx, func, *args, **kw)
	  File "/home/xdelannoy/Projects/prototype/env/local/lib/python2.7/site-packages/Twisted-15.5.0-py2.7-linux-x86_64.egg/twisted/python/context.py", line 81, in callWithContext
	    return func(*args,**kw)
	--- <exception caught here> ---
	  File "/home/xdelannoy/Projects/myGitHub/buildbot-work/src/master/buildbot/config.py", line 204, in loadConfig
	    exec(f, localDict)
	  File "/home/xdelannoy/Projects/prototype/basedir/master.cfg", line 10, in <module>
	    from config import services
	  File "config/services.py", line 24, in <module>
	    InfluxStorageService('localhost', 8086, 'root', 'root', 'test', captures)
	  File "/home/xdelannoy/Projects/myGitHub/buildbot-work/src/master/buildbot/statistics/storage_backends/influxdb_client.py", line 46, in __init__
	    self.password, self.db)
	exceptions.TypeError: 'NoneType' object is not callable
```