### PR TITLE
Make legible the hello.cfg example.

### DIFF
--- a/master/docs/examples/hello.cfg
+++ b/master/docs/examples/hello.cfg
@@ -1,72 +1,71 @@
 # -*- python -*-
 # ex: set syntax=python:
 
-from buildbot.plugins import *
+from buildbot.plugins import buildslave
+from buildbot.plugins import changes
+from buildbot.plugins import util
+from buildbot.plugins import steps
 
-BuildmasterConfig = c = {}
+SVN_REP = "file:///usr/home/warner/stuff/Projects/BuildBot/demo/SVN-Repository"
+CVS_REP = "/usr/home/warner/stuff/Projects/BuildBot/demo/Repository"
+DARCS_REP = "http://localhost/~warner/hello-darcs"
 
-c['slaves'] = [buildslave.BuildSlave("bot1", "sekrit")]
 
-c['change_source'] = changes.PBChangeSource(prefix="trunk")
-c['builders'] = []
+def _standard_build(checkout_step, test_step=None):
+    if test_step is None:
+        test_step = steps.Test(command=["make", "check"])
 
-if True:
-    f = util.BuildFactory()
-    f.addStep(steps.CVS(cvsroot="/usr/home/warner/stuff/Projects/BuildBot/demo/Repository",
-                        cvsmodule="hello",
-                        mode="clobber",
-                        checkoutDelay=6,
-                        alwaysUseLatest=True))
-    f.addStep(steps.Configure())
-    f.addStep(steps.Compile())
-    f.addStep(steps.Test(command=["make", "check"]))
-    b1 = {
-        "name": "cvs-hello",
-        "slavename": "bot1",
-        "builddir": "cvs-hello",
-        "factory": f
-    }
-    c['builders'].append(b1)
+    build_factory = util.BuildFactory()
+    build_factory.addStep(checkout_step)
+    build_factory.addStep(steps.Configure())
+    build_factory.addStep(steps.Compile())
+    build_factory.addStep(test_step)
 
-if True:
-    svnrep="file:///usr/home/warner/stuff/Projects/BuildBot/demo/SVN-Repository"
-    f = util.BuildFactory()
-    f.addStep(steps.SVN(repourl=svnrep+"/hello", mode="update"))
-    f.addStep(steps.Configure())
-    f.addStep(steps.Compile()),
-    f.addStep(steps.Test(command=["make", "check"]))
-    b1 = {
-        "name": "svn-hello",
-        "slavename": "bot1",
-        "builddir": "svn-hello",
-        "factory": f
-    }
-    c['builders'].append(b1)
+    return build_factory
 
-if True:
-    f = util.BuildFactory()
-    f.addStep(steps.Darcs(repourl="http://localhost/~warner/hello-darcs",
-                          mode="copy"))
-    f.addStep(steps.Configure(command=["/bin/sh", "./configure"]))
-    f.addStep(steps.Compile())
-    f.addStep(steps.Test(command=["make", "check"]))
-    b1 = {
-        "name": "darcs-hello",
-        "slavename": "bot1",
-        "builddir": "darcs-hello",
-        "factory": f
-    }
-    c['builders'].append(b1)
-
-c['title'] = "Hello"
-c['titleURL'] = "http://www.hello.example.com/"
-c['buildbotURL'] = "http://localhost:8080"
-
-c['slavePortnum'] = 8007
-c['manhole'] = util.PasswordManhole(9900, "username", "password")
-
-c['www'] = {
-    'port': 8080
+# pylint: disable=invalid-name
+BuildmasterConfig = {
+    'title': "Hello",
+    'titleURL': "http://www.hello.example.com/",
+    'www': {'port': 8080},
+    'buildbotURL': "http://localhost:8080",
+    'change_source': changes.PBChangeSource(prefix="trunk"),
+    'manhole': util.PasswordManhole(9900, "username", "password"),
+    'slavePortnum': 8007,
+    'slaves': [
+        buildslave.BuildSlave("bot1", "sekrit"),
+    ],
+    'builders': [
+        {
+            "name": "cvs-hello",
+            "slavename": "bot1",
+            "builddir": "cvs-hello",
+            "factory": _standard_build(
+                steps.CVS(
+                    cvsroot=CVS_REP,
+                    cvsmodule="hello",
+                    mode="clobber",
+                    checkoutDelay=6,
+                    alwaysUseLatest=True
+                )
+            )
+        },
+        {
+            "name": "svn-hello",
+            "slavename": "bot1",
+            "builddir": "svn-hello",
+            "factory": _standard_build(
+                steps.SVN(repourl=SVN_REP+"/hello", mode="update")
+            )
+        },
+        {
+            "name": "darcs-hello",
+            "slavename": "bot1",
+            "builddir": "darcs-hello",
+            "factory": _standard_build(
+                steps.Darcs(repourl=DARCS_REP, mode="copy")
+            )
+        },
+    ],
 }
-
 # vim:ft=python


### PR DESCRIPTION
Note, **super untested**, I don't have a working buildbot to try this with ATM.

General code cleanup; get rid of single variables names, don't use * imports, use functions to reduce duplicated code, a focus on showing the user the meaningful part of the example.

I assume 'BuildmasterConfig' is some magic namespace that must be declared, so I excluded it from pylint's checks.