### PR TITLE
Optimise the recent changes page

### DIFF
--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -78,8 +78,13 @@ class ChangesEndpoint(FixerMixin, base.Endpoint):
             else:
                 changes = []
         else:
-            changes = yield self.master.db.changes.getChanges()
-
+            # this special case is useful and implemented by the dbapi
+            # so give it a boost
+            if all((resultSpec.limit, resultSpec.offset is None,
+                    resultSpec.order == ['-changeid'])):
+                changes = yield self.master.db.changes.getRecentChanges(resultSpec.limit)
+            else:
+                changes = yield self.master.db.changes.getChanges()
         changes = [(yield self._fixChange(ch)) for ch in changes]
         defer.returnValue(changes)
 

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -80,8 +80,8 @@ class ChangesEndpoint(FixerMixin, base.Endpoint):
         else:
             # this special case is useful and implemented by the dbapi
             # so give it a boost
-            if all((resultSpec.limit, resultSpec.offset is None,
-                    resultSpec.order == ['-changeid'])):
+            if (resultSpec.order == ['-changeid'] and resultSpec.limit and
+                    resultSpec.offset is None):
                 changes = yield self.master.db.changes.getRecentChanges(resultSpec.limit)
             else:
                 changes = yield self.master.db.changes.getChanges()

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -848,7 +848,7 @@ class FakeChangesComponent(FakeDBComponent):
         return defer.succeed(chdicts)
 
     def getChangesCount(self):
-        return len(self.changes)
+        return defer.succeed(len(self.changes))
 
     def getChangesForBuild(self, buildid):
         # the algorithm is too complicated to be worth faked, better patch it ad-hoc

--- a/master/docs/developer/cls-resultspec.rst
+++ b/master/docs/developer/cls-resultspec.rst
@@ -116,4 +116,3 @@ Endpoints processing a result specification should take care to replicate this b
     A property represents an item of a foreign table.
 
     In either case, the values must be passed as a list.
-

--- a/www/base/src/app/changes/changes.controller.coffee
+++ b/www/base/src/app/changes/changes.controller.coffee
@@ -1,4 +1,4 @@
 class Changes extends Controller
     constructor: ($log, $scope, dataService) ->
         data = dataService.open().closeOnDestroy($scope)
-        $scope.changes = data.getChanges(limit:50, order:'-when_timestamp')
+        $scope.changes = data.getChanges(limit:50, order:'-changeid')

--- a/www/base/src/app/changes/changes.controller.coffee
+++ b/www/base/src/app/changes/changes.controller.coffee
@@ -1,4 +1,5 @@
 class Changes extends Controller
     constructor: ($log, $scope, dataService) ->
         data = dataService.open().closeOnDestroy($scope)
+        #  unlike other order, this particular order by changeid is optimised by the backend
         $scope.changes = data.getChanges(limit:50, order:'-changeid')


### PR DESCRIPTION
when change list is becoming large, its very slow to use the soft pagination
As we have a recent change db api. We use it.

Of course we really should do something much nicer with automatic generation of
the sqlalchemy query, but this is *much* more work, so.. post 0.9.0