### PR TITLE
master requires Python 2.6: clean up tasks

### DIFF
--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -17,8 +17,6 @@
 #
 # We can't put this method in utility modules, because they import dependancy packages
 #
-from __future__ import with_statement
-
 import os
 import re
 

--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
 import time
 from datetime import datetime
 
@@ -25,7 +26,6 @@ from buildbot.util import ascii2unicode
 from buildbot.util import datetime2epoch
 from buildbot.util import deferredLocked
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class BitbucketPullrequestPoller(base.PollingChangeSource):

--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 import time
-
 from datetime import datetime
 
 from twisted.internet import defer

--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -23,8 +23,8 @@ from twisted.web import html
 from zope.interface import implements
 
 from buildbot import interfaces
-from buildbot import util
 from buildbot.process.properties import Properties
+from buildbot import util
 from buildbot.util import datetime2epoch
 
 

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 
+import json
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet.protocol import ProcessProtocol
@@ -22,7 +24,6 @@ from twisted.python import log
 from buildbot.changes import base
 from buildbot.changes.filter import ChangeFilter
 from buildbot import util
-from buildbot.util import json
 
 
 class GerritChangeFilter(ChangeFilter):

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -19,9 +19,9 @@ from twisted.internet import reactor
 from twisted.internet.protocol import ProcessProtocol
 from twisted.python import log
 
-from buildbot import util
 from buildbot.changes import base
 from buildbot.changes.filter import ChangeFilter
+from buildbot import util
 from buildbot.util import json
 
 

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -24,8 +24,8 @@ from twisted.internet import defer
 from twisted.internet import utils
 from twisted.python import log
 
-from buildbot import util
 from buildbot.changes import base
+from buildbot import util
 
 # these split_file_* functions are available for use as values to the
 # split_file= argument.

--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -17,7 +17,6 @@ import os
 import random
 import re
 import shlex
-import string
 import sys
 import time
 
@@ -644,7 +643,7 @@ class Try(pb.Referenceable):
                     # separators, as it's simpler to do it like this. And then we
                     # just need to get all of them together using the slice and
                     # also remove the quotes from those that were quoted.
-                    argv = [string.strip(a, '"') for a in
+                    argv = [arg.strip('"') for arg in
                             re.split(r'''([^" ]+|"[^"]+")''', ssh_command)[1::2]]
                 else:
                     # Do use standard tokenization logic under POSIX.

--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
 import os
 import random
 import re
@@ -32,7 +33,6 @@ from twisted.python.procutils import which
 from twisted.spread import pb
 
 from buildbot.status import builder
-from buildbot.util import json
 from buildbot.util import now
 from buildbot.util.eventual import fireEventually
 

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -12,16 +12,15 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-from future.utils import iteritems
-from future.utils import itervalues
+from future.utils import (iteritems,
+                          itervalues)
 
 import os
 import re
 import sys
 import traceback
-import warnings
-
 from types import MethodType
+import warnings
 
 from zope.interface import implementer
 
@@ -30,7 +29,6 @@ from twisted.python import log
 
 from buildbot import interfaces
 from buildbot import locks
-from buildbot import util
 from buildbot.revlinks import default_revlink_matcher
 from buildbot.util import ComparableMixin
 from buildbot.util import config as util_config
@@ -163,7 +161,7 @@ class FileLoader(ComparableMixin, object):
         return config
 
 
-class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
+class MasterConfig(ComparableMixin, WorkerAPICompatMixin):
 
     def __init__(self):
         # local import to avoid circular imports

--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -17,10 +17,10 @@
 from future.utils import iteritems
 
 import datetime
+import json
 import re
 
 from buildbot import util
-from buildbot.util import json
 
 
 class Type(object):

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
+
 import sqlalchemy as sa
 
 from twisted.internet import defer
@@ -20,7 +22,6 @@ from twisted.internet import reactor
 from buildbot.db import NULL
 from buildbot.db import base
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class BuildsConnectorComponent(base.DBConnectorComponent):

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -15,6 +15,8 @@
 """
 Support for buildsets in the database
 """
+import json
+
 import sqlalchemy as sa
 
 from twisted.internet import defer
@@ -24,7 +26,6 @@ from buildbot.db import NULL
 from buildbot.db import base
 from buildbot.util import datetime2epoch
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class BsDict(dict):

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -19,6 +19,8 @@ Support for changes in the database
 from future.utils import iteritems
 from future.utils import itervalues
 
+import json
+
 import sqlalchemy as sa
 
 from twisted.internet import defer
@@ -28,7 +30,6 @@ from twisted.python import log
 from buildbot.db import base
 from buildbot.util import datetime2epoch
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class ChDict(dict):

--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -12,7 +12,6 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
 """
 A wrapper around `sqlalchemy.create_engine` that handles all of the
 special cases that Buildbot needs.  Those include:
@@ -20,7 +19,6 @@ special cases that Buildbot needs.  Those include:
  - pool_recycle for MySQL
  - %(basedir) substitution
  - optimal thread pool size calculation
-
 """
 
 import migrate
@@ -28,7 +26,6 @@ import os
 import re
 
 import sqlalchemy as sa
-
 from sqlalchemy.engine import strategies
 from sqlalchemy.engine import url
 from sqlalchemy.pool import NullPool

--- a/master/buildbot/db/migrate/versions/001_initial.py
+++ b/master/buildbot/db/migrate/versions/001_initial.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 
+import json
 import os
 
 import sqlalchemy as sa
@@ -21,7 +22,6 @@ import sqlalchemy as sa
 from twisted.persisted import styles
 
 from buildbot.db.migrate_utils import test_unicode
-from buildbot.util import json
 from buildbot.util import pickle
 from buildbot.util import sautils
 

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -12,7 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-
+from migrate import exceptions
 import migrate
 import migrate.versioning.repository
 

--- a/master/buildbot/db/state.py
+++ b/master/buildbot/db/state.py
@@ -12,11 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
+
 import sqlalchemy as sa
 import sqlalchemy.exc
 
 from buildbot.db import base
-from buildbot.util import json
 
 
 class _IdNotFoundError(Exception):

--- a/master/buildbot/db/steps.py
+++ b/master/buildbot/db/steps.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
+
 import sqlalchemy as sa
 
 from twisted.internet import defer
@@ -19,7 +21,6 @@ from twisted.internet import reactor
 
 from buildbot.db import base
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class StepsConnectorComponent(base.DBConnectorComponent):

--- a/master/buildbot/db/types/json.py
+++ b/master/buildbot/db/types/json.py
@@ -12,10 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import absolute_import
+
+import json
+
 from sqlalchemy.types import Text
 from sqlalchemy.types import TypeDecorator
-
-from buildbot.util import json
 
 
 class JsonObject(TypeDecorator):

--- a/master/buildbot/manhole.py
+++ b/master/buildbot/manhole.py
@@ -19,12 +19,11 @@ import binascii
 import os
 import types
 
-from builtins import str
-
 from twisted.application import strports
+from twisted.conch.insults import insults
 from twisted.conch import manhole
 from twisted.conch import telnet
-from twisted.conch.insults import insults
+
 try:
     from twisted.conch import checkers as conchc, manhole_ssh
     _hush_pyflakes = [manhole_ssh, conchc]

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -30,7 +30,6 @@ from zope.interface import implements
 
 import buildbot
 import buildbot.pbmanager
-
 from buildbot import config
 from buildbot import interfaces
 from buildbot import monkeypatches

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -20,10 +20,10 @@ from twisted.internet import reactor
 from twisted.python import log
 
 from buildbot import locks
-from buildbot import util
 from buildbot.process import metrics
 from buildbot.process.builder import Builder
 from buildbot.process.buildrequestdistributor import BuildRequestDistributor
+from buildbot import util
 from buildbot.util import service
 
 

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -24,8 +24,8 @@ from twisted.python import log
 
 from zope.interface import implements
 
-from buildbot import interfaces
 from buildbot.data import resultspec
+from buildbot import interfaces
 from buildbot.process import buildrequest
 from buildbot.process import workerforbuilder
 from buildbot.process.build import Build

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -15,11 +15,8 @@
 from future.utils import iteritems
 from future.utils import itervalues
 
-try:
-    import cStringIO as StringIO
-    assert StringIO
-except ImportError:
-    import StringIO
+# Check when finally switching to Python 3
+from io import BytesIO
 import re
 
 from twisted.internet import defer
@@ -214,7 +211,7 @@ class SyncLogFileWrapper(logobserver.LogObserver):
 
     def readlines(self):
         alltext = "".join(self.getChunks([self.STDOUT], onlyText=True))
-        io = StringIO.StringIO(alltext)
+        io = BytesIO(alltext)
         return io.readlines()
 
     def getChunks(self, channels=None, onlyText=False):

--- a/master/buildbot/process/metrics.py
+++ b/master/buildbot/process/metrics.py
@@ -33,11 +33,10 @@ Basic architecture:
 """
 from future.utils import iteritems
 
+from collections import deque
+from collections import defaultdict
 import gc
 import os
-
-from collections import defaultdict
-from collections import deque
 # Make use of the resource module if we can
 try:
     import resource

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -15,6 +15,7 @@
 from future.utils import iteritems
 
 import collections
+import json
 import re
 import weakref
 
@@ -28,7 +29,6 @@ from buildbot import util
 from buildbot.interfaces import IProperties
 from buildbot.interfaces import IRenderable
 from buildbot.util import flatten
-from buildbot.util import json
 from buildbot.worker_transition import reportDeprecatedWorkerNameUsage
 
 

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -20,10 +20,10 @@ from twisted.python import log
 from twisted.python.failure import Failure
 from twisted.spread import pb
 
-from buildbot import util
 from buildbot.process import metrics
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
+from buildbot import util
 from buildbot.util.eventual import eventually
 from buildbot.worker.protocols import base
 from buildbot.worker_transition import WorkerAPICompatMixin

--- a/master/buildbot/process/remotetransfer.py
+++ b/master/buildbot/process/remotetransfer.py
@@ -13,14 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+# Check when finally switching to Python 3
+from io import BytesIO
 import os
 import tarfile
 import tempfile
-try:
-    from cStringIO import StringIO
-    assert StringIO
-except ImportError:
-    from StringIO import StringIO
 
 
 from buildbot.worker.protocols import base
@@ -195,4 +192,4 @@ class StringFileReader(FileReader):
     """
 
     def __init__(self, s):
-        FileReader.__init__(self, StringIO(s))
+        FileReader.__init__(self, BytesIO(s))

--- a/master/buildbot/process/users/users.py
+++ b/master/buildbot/process/users/users.py
@@ -12,9 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import os
-
 from hashlib import sha1
+import os
 
 from twisted.internet import defer
 from twisted.python import log

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -14,10 +14,8 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 
-import re
-
-from StringIO import StringIO
-
+# Check when finally switching to Python 3
+from io import BytesIO
 # this incantation teaches email to output utf-8 using 7- or 8-bit encoding,
 # although it has no effect before python-2.7.
 from email import charset
@@ -26,6 +24,7 @@ from email.message import Message
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formatdate
+import re
 
 try:
     from twisted.mail.smtp import ESMTPSenderFactory
@@ -492,7 +491,7 @@ class MailNotifier(service.BuildbotService):
 
         sender_factory = ESMTPSenderFactory(
             self.smtpUser, self.smtpPassword,
-            self.fromaddr, recipients, StringIO(s),
+            self.fromaddr, recipients, BytesIO(s),
             result, requireTransportSecurity=self.useTls,
             requireAuthentication=useAuth)
 

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -22,11 +22,11 @@ from twisted.internet import reactor
 from twisted.python import log
 
 from buildbot import config
-from buildbot import util
 from buildbot.changes import changes
 from buildbot.changes.filter import ChangeFilter
 from buildbot.schedulers import base
 from buildbot.schedulers import dependent
+from buildbot import util
 from buildbot.util import NotABranch
 from buildbot.util.codebase import AbsoluteSourceStampsMixin
 

--- a/master/buildbot/schedulers/dependent.py
+++ b/master/buildbot/schedulers/dependent.py
@@ -16,10 +16,10 @@ from twisted.internet import defer
 
 from buildbot import config
 from buildbot import interfaces
-from buildbot import util
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.schedulers import base
+from buildbot import util
 
 
 class Dependent(base.BaseScheduler):

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -21,12 +21,12 @@ from twisted.python import log
 from zope.interface import implements
 
 from buildbot import config
-from buildbot import util
 from buildbot.changes.filter import ChangeFilter
 from buildbot.interfaces import ITriggerableScheduler
 from buildbot.process import buildstep
 from buildbot.process import properties
 from buildbot.schedulers import base
+from buildbot import util
 from buildbot.util import croniter
 from buildbot.util.codebase import AbsoluteSourceStampsMixin
 

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 
+import json
 import os
 
 from twisted.internet import defer
@@ -25,7 +26,6 @@ from buildbot import pbutil
 from buildbot.process.properties import Properties
 from buildbot.schedulers import base
 from buildbot.util import ascii2unicode
-from buildbot.util import json
 from buildbot.util import netstrings
 from buildbot.util.maildir import MaildirService
 

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -15,12 +15,11 @@
 from __future__ import print_function
 
 import copy
+from contextlib import contextmanager
 import os
 import stat
 import sys
 import traceback
-
-from contextlib import contextmanager
 
 from twisted.internet import defer
 from twisted.python import runtime

--- a/master/buildbot/scripts/cleanupdb.py
+++ b/master/buildbot/scripts/cleanupdb.py
@@ -21,8 +21,8 @@ import sys
 from twisted.internet import defer
 
 from buildbot import config as config_module
-from buildbot import monkeypatches
 from buildbot.master import BuildMaster
+from buildbot import monkeypatches
 from buildbot.scripts import base
 from buildbot.util import in_reactor
 

--- a/master/buildbot/scripts/cleanupdb.py
+++ b/master/buildbot/scripts/cleanupdb.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 from __future__ import print_function
-from __future__ import with_statement
 
 import os
 import sys

--- a/master/buildbot/scripts/create_master.py
+++ b/master/buildbot/scripts/create_master.py
@@ -24,8 +24,8 @@ from twisted.internet import defer
 from twisted.python import util
 
 from buildbot import config as config_module
-from buildbot import monkeypatches
 from buildbot.master import BuildMaster
+from buildbot import monkeypatches
 from buildbot.util import in_reactor
 
 

--- a/master/buildbot/scripts/dataspec.py
+++ b/master/buildbot/scripts/dataspec.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
 import os
 import sys
 
@@ -20,7 +21,6 @@ from twisted.internet import defer
 from buildbot.data import connector
 from buildbot.test.fake import fakemaster
 from buildbot.util import in_reactor
-from buildbot.util import json
 
 
 @in_reactor

--- a/master/buildbot/scripts/processwwwindex.py
+++ b/master/buildbot/scripts/processwwwindex.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from __future__ import print_function
 
+import json
 import os
 
 import jinja2
@@ -22,7 +23,6 @@ from twisted.internet import defer
 
 from buildbot.test.fake import fakemaster
 from buildbot.util import in_reactor
-from buildbot.util import json
 from buildbot.www import auth
 from buildbot.www.config import IndexResource
 from buildbot.www.service import WWWService

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -21,6 +21,9 @@ import traceback
 from twisted.internet import defer
 from twisted.python import util
 
+from twisted.internet import defer
+from twisted.python import util
+
 from buildbot import monkeypatches
 from buildbot.db import connector
 from buildbot.master import BuildMaster

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -25,11 +25,11 @@ from twisted.python import log
 from zope.interface import implements
 
 from buildbot import interfaces
-from buildbot import util
 from buildbot.changes import changes
 from buildbot.status import builder
 from buildbot.status import buildrequest
 from buildbot.status import buildset
+from buildbot import util
 from buildbot.util import bbcollections
 from buildbot.util import pickle
 from buildbot.util import service

--- a/master/buildbot/steps/subunit.py
+++ b/master/buildbot/steps/subunit.py
@@ -12,7 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-from StringIO import StringIO
+#
+# Check when finally switching to Python 3
+from io import BytesIO
 from unittest import TestResult
 
 from buildbot.process import logobserver
@@ -42,7 +44,7 @@ class SubunitLogObserver(logobserver.LogLineObserver, TestResult):
         self.PROGRESS_SET = PROGRESS_SET
         self.PROGRESS_PUSH = PROGRESS_PUSH
         self.PROGRESS_POP = PROGRESS_POP
-        self.warningio = StringIO()
+        self.warningio = BytesIO()
         self.protocol = TestProtocolServer(self, self.warningio)
         self.skips = []
         self.seen_tags = set()  # don't yet know what tags does in subunit

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
 import os
 import stat
 
@@ -26,7 +27,6 @@ from buildbot.process.buildstep import BuildStep
 from buildbot.process.buildstep import FAILURE
 from buildbot.process.buildstep import SKIPPED
 from buildbot.process.buildstep import SUCCESS
-from buildbot.util import json
 from buildbot.util.eventual import eventually
 from buildbot.worker_transition import WorkerAPICompatMixin
 from buildbot.worker_transition import reportDeprecatedWorkerNameUsage

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -15,6 +15,8 @@
 from future.utils import iteritems
 from future.utils import itervalues
 
+import json
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import failure
@@ -22,7 +24,6 @@ from twisted.python import failure
 from buildbot.data import connector
 from buildbot.db.buildrequests import AlreadyClaimedError
 from buildbot.test.util import validation
-from buildbot.util import json
 from buildbot.util import service
 
 

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -24,6 +24,7 @@ from future.utils import itervalues
 import base64
 import copy
 import hashlib
+import json
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -33,7 +34,6 @@ from buildbot.db import changesources
 from buildbot.db import schedulers
 from buildbot.test.util import validation
 from buildbot.util import datetime2epoch
-from buildbot.util import json
 from buildbot.util import service
 
 # Fake DB Rows

--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -12,7 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-from StringIO import StringIO
+#
+# Check when finally switching to Python 3
+from io import BytesIO
 
 from mock import Mock
 
@@ -53,7 +55,7 @@ class FakeRequest(Mock):
             args = {}
 
         self.args = args
-        self.content = StringIO(content)
+        self.content = BytesIO(content)
         self.site = Mock()
         self.site.buildbot_service = Mock()
         self.uri = '/'

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -14,7 +14,8 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 
-from StringIO import StringIO
+# Check when finally switching to Python 3
+from io import BytesIO
 
 import mock
 
@@ -125,7 +126,7 @@ class OldBuildEPYDoc(shell.ShellCommand):
         return defer.succeed(None)
 
     def createSummary(self, log):
-        for line in StringIO(log.getText()):
+        for line in BytesIO(log.getText()):
             # what we do with the line isn't important to the test
             assert line in ('some\n', 'output\n')
 

--- a/master/buildbot/test/integration/test_trigger.py
+++ b/master/buildbot/test/integration/test_trigger.py
@@ -12,7 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import StringIO
+#
+# Check when finally switching to Python 3
+from io import BytesIO
 
 from twisted.internet import defer
 
@@ -56,7 +58,7 @@ class TriggeringMaster(RunMasterBase):
         self.assertEqual(build['steps'][1]['state_string'], 'triggered trigsched')
         builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), 2)
-        dump = StringIO.StringIO()
+        dump = BytesIO()
         for b in builds:
             yield self.printBuild(b, dump)
         # depending on the environment the number of lines is different between test hosts

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -19,11 +19,9 @@ import textwrap
 
 import migrate
 import migrate.versioning.api
-
 from migrate.versioning import schemadiff
 
 import sqlalchemy as sa
-
 from sqlalchemy.engine import reflection
 
 from twisted.internet import defer

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -22,7 +22,6 @@ from twisted.spread import pb
 from twisted.trial import unittest
 
 import buildbot
-
 from buildbot import config
 from buildbot import pbmanager
 from buildbot import worker

--- a/master/buildbot/test/integration/test_worker_transition.py
+++ b/master/buildbot/test/integration/test_worker_transition.py
@@ -23,8 +23,6 @@ from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.trial import unittest
 
-import buildbot.worker
-
 from buildbot import config
 from buildbot.interfaces import IConfigLoader
 from buildbot.master import BuildMaster
@@ -32,7 +30,7 @@ from buildbot.test.util import dirs
 from buildbot.test.util import www
 from buildbot.test.util.warnings import assertNotProducesWarnings
 from buildbot.test.util.warnings import assertProducesWarning
-from buildbot.test.util.warnings import assertProducesWarnings
+import buildbot.worker
 from buildbot.worker_transition import DeprecatedWorkerAPIWarning
 from buildbot.worker_transition import DeprecatedWorkerNameWarning
 

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
+
 from twisted.internet import defer
 from twisted.internet import protocol
 from twisted.internet import reactor
@@ -25,7 +27,6 @@ from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import db
 from buildbot.test.util import www
-from buildbot.util import json
 from buildbot.www import auth
 from buildbot.www import service as wwwservice
 

--- a/master/buildbot/test/unit/test_changes_bitbucket.py
+++ b/master/buildbot/test/unit/test_changes_bitbucket.py
@@ -12,9 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import re
-
 from datetime import datetime
+import re
 
 from twisted.internet import defer
 from twisted.internet import reactor

--- a/master/buildbot/test/unit/test_changes_gerritchangesource.py
+++ b/master/buildbot/test/unit/test_changes_gerritchangesource.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 
+import json
 import types
 
 from twisted.trial import unittest
@@ -21,7 +22,6 @@ from twisted.trial import unittest
 from buildbot.changes import gerritchangesource
 from buildbot.test.fake.change import Change
 from buildbot.test.util import changesource
-from buildbot.util import json
 
 
 class TestGerritHelpers(unittest.TestCase):

--- a/master/buildbot/test/unit/test_clients_tryclient.py
+++ b/master/buildbot/test/unit/test_clients_tryclient.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
+
 from twisted.trial import unittest
 
 from buildbot.clients import tryclient
-from buildbot.util import json
 
 
 class createJobfile(unittest.TestCase):

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import datetime
+import json
 
 import mock
 
@@ -29,7 +30,6 @@ from buildbot.test.util import validation
 from buildbot.util import UTC
 from buildbot.util import datetime2epoch
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class Tests(interfaces.InterfaceTests):

--- a/master/buildbot/test/unit/test_db_migrate_versions_011_add_buildrequest_claims.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_011_add_buildrequest_claims.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
-
 from sqlalchemy.engine import reflection
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_migrate_versions_016_restore_buildrequest_indices.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_016_restore_buildrequest_indices.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
-
 from sqlalchemy.engine import reflection
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_migrate_versions_017_restore_other_indices.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_017_restore_other_indices.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
-
 from sqlalchemy.engine import reflection
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_migrate_versions_018_add_sourcestampset.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_018_add_sourcestampset.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
-
 from sqlalchemy.engine import reflection
 
 from twisted.python import log

--- a/master/buildbot/test/unit/test_db_migrate_versions_045_worker_transition.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_045_worker_transition.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
-
 from sqlalchemy.engine.reflection import Inspector
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
 import os
 
 from autobahn.wamp.types import EventDetails
@@ -24,7 +25,6 @@ from twisted.trial import unittest
 
 from buildbot.mq import wamp
 from buildbot.test.fake import fakemaster
-from buildbot.util import json
 from buildbot.wamp import connector
 
 

--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -23,10 +23,9 @@ from twisted.trial import unittest
 
 from zope.interface import implements
 
-import buildbot.plugins.db
-
 from buildbot.errors import PluginDBError
 from buildbot.interfaces import IPlugin
+import buildbot.plugins.db
 from buildbot.test.util.warnings import assertNotProducesWarnings
 from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.worker_transition import DeprecatedWorkerAPIWarning

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -15,6 +15,8 @@
 from __future__ import print_function
 from future.utils import iteritems
 
+import json
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -35,7 +37,6 @@ from buildbot.schedulers.forcesched import oneCodebase
 from buildbot.test.util import scheduler
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.warnings import assertProducesWarning
-from buildbot.util import json
 from buildbot.worker_transition import DeprecatedWorkerNameWarning
 
 

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -20,6 +20,9 @@ import sys
 import mock
 
 import twisted
+from twisted.internet import defer
+from twisted.protocols import basic
+from twisted.trial import unittest
 
 from twisted.internet import defer
 from twisted.protocols import basic

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import cStringIO as StringIO
+import json
 import os
 import shutil
 import sys
@@ -31,7 +32,6 @@ from twisted.trial import unittest
 from buildbot.schedulers import trysched
 from buildbot.test.util import dirs
 from buildbot.test.util import scheduler
-from buildbot.util import json
 
 
 class TryBase(unittest.TestCase):

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -12,7 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import cStringIO as StringIO
+#
+# Check when finally switching to Python 3
+from io import BytesIO
 import json
 import os
 import shutil
@@ -175,7 +177,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
         sched = trysched.Try_Jobdir(
             name='tsched', builderNames=['a'], jobdir='foo')
         self.assertRaises(
-            trysched.BadJobfile, sched.parseJob, StringIO.StringIO(''))
+            trysched.BadJobfile, sched.parseJob, BytesIO(''))
 
     def test_parseJob_longer_than_netstring_MAXLENGTH(self):
         self.patch(basic.NetstringReceiver, 'MAX_LENGTH', 100)
@@ -186,7 +188,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
         )
         jobstr += 'x' * 200
 
-        test_temp_file = StringIO.StringIO(jobstr)
+        test_temp_file = BytesIO(jobstr)
 
         self.assertRaises(trysched.BadJobfile,
                           lambda: sched.parseJob(test_temp_file))
@@ -196,13 +198,13 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             name='tsched', builderNames=['a'], jobdir='foo')
         self.assertRaises(
             trysched.BadJobfile, sched.parseJob,
-            StringIO.StringIO('this is not a netstring'))
+            BytesIO('this is not a netstring'))
 
     def test_parseJob_invalid_version(self):
         sched = trysched.Try_Jobdir(
             name='tsched', builderNames=['a'], jobdir='foo')
         self.assertRaises(
-            trysched.BadJobfile, sched.parseJob, StringIO.StringIO('1:9,'))
+            trysched.BadJobfile, sched.parseJob, BytesIO('1:9,'))
 
     def makeNetstring(self, *strings):
         return ''.join(['%d:%s,' % (len(s), s) for s in strings])
@@ -214,7 +216,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             '1', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob, {
             'baserev': '1234',
             'branch': 'trunk',
@@ -237,7 +239,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             '1', 'extid', '', '', '1', 'this is my diff, -- ++, etc.',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['branch'], None)
         self.assertEqual(parsedjob['baserev'], None)
 
@@ -247,7 +249,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
         jobstr = self.makeNetstring(
             '1', 'extid', '', '', '1', 'this is my diff, -- ++, etc.'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['builderNames'], [])
 
     def test_parseJob_v1_no_properties(self):
@@ -256,7 +258,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
         jobstr = self.makeNetstring(
             '1', 'extid', '', '', '1', 'this is my diff, -- ++, etc.'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['properties'], {})
 
     def test_parseJob_v2(self):
@@ -267,7 +269,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             'repo', 'proj',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob, {
             'baserev': '1234',
             'branch': 'trunk',
@@ -291,7 +293,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             'repo', 'proj',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['branch'], None)
         self.assertEqual(parsedjob['baserev'], None)
 
@@ -302,7 +304,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             '2', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj',
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['builderNames'], [])
 
     def test_parseJob_v2_no_properties(self):
@@ -312,7 +314,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             '2', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj',
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['properties'], {})
 
     def test_parseJob_v3(self):
@@ -323,7 +325,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             'repo', 'proj', 'who',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob, {
             'baserev': '1234',
             'branch': 'trunk',
@@ -347,7 +349,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             'repo', 'proj', 'who',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['branch'], None)
         self.assertEqual(parsedjob['baserev'], None)
 
@@ -358,7 +360,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             '3', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj', 'who'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['builderNames'], [])
 
     def test_parseJob_v3_no_properties(self):
@@ -368,7 +370,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             '3', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj', 'who'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['properties'], {})
 
     def test_parseJob_v4(self):
@@ -379,7 +381,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             'repo', 'proj', 'who', 'comment',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob, {
             'baserev': '1234',
             'branch': 'trunk',
@@ -403,7 +405,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             'repo', 'proj', 'who', 'comment',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['branch'], None)
         self.assertEqual(parsedjob['baserev'], None)
 
@@ -414,7 +416,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             '4', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj', 'who', 'comment'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['builderNames'], [])
 
     def test_parseJob_v4_no_properties(self):
@@ -424,7 +426,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             '4', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj', 'who', 'comment'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['properties'], {})
 
     def test_parseJob_v5(self):
@@ -439,7 +441,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
                 'comment': 'comment', 'builderNames': ['buildera', 'builderc'],
                 'properties': {'foo': 'bar'},
             }))
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob, {
             'baserev': '1234',
             'branch': 'trunk',
@@ -463,7 +465,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             'repo', 'proj', 'who', 'comment',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['branch'], None)
         self.assertEqual(parsedjob['baserev'], None)
 
@@ -479,7 +481,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
                 'comment': 'comment', 'builderNames': [],
                 'properties': {'foo': 'bar'},
             }))
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['builderNames'], [])
 
     def test_parseJob_v5_no_properties(self):
@@ -494,7 +496,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
                 'comment': 'comment', 'builderNames': ['buildera', 'builderb'],
                 'properties': {},
             }))
-        parsedjob = sched.parseJob(StringIO.StringIO(jobstr))
+        parsedjob = sched.parseJob(BytesIO(jobstr))
         self.assertEqual(parsedjob['properties'], {})
 
     def test_parseJob_v5_invalid_json(self):
@@ -502,7 +504,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
             name='tsched', builderNames=['buildera', 'builderb'], jobdir='foo')
         jobstr = self.makeNetstring('5', '{"comment": "com}')
         self.assertRaises(
-            trysched.BadJobfile, sched.parseJob, StringIO.StringIO(jobstr))
+            trysched.BadJobfile, sched.parseJob, BytesIO(jobstr))
 
     # handleJobFile
 

--- a/master/buildbot/test/unit/test_scripts_base.py
+++ b/master/buildbot/test/unit/test_scripts_base.py
@@ -12,7 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import cStringIO
+#
+# Check when finally switching to Python 3
+from io import BytesIO
 import os
 import string
 import textwrap
@@ -32,7 +34,7 @@ class TestIBD(dirs.DirsMixin, misc.StdoutAssertionsMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpDirs('test')
-        self.stdout = cStringIO.StringIO()
+        self.stdout = BytesIO()
         self.setUpStdoutAssertions()
 
     def test_isBuildmasterDir_no_dir(self):

--- a/master/buildbot/test/unit/test_scripts_checkconfig.py
+++ b/master/buildbot/test/unit/test_scripts_checkconfig.py
@@ -14,7 +14,8 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 
-import cStringIO
+# Check when finally switching to Python 3
+from io import BytesIO
 import os
 import re
 import sys
@@ -56,8 +57,8 @@ class TestConfigLoader(dirs.DirsMixin, unittest.TestCase):
                 f.write(contents)
 
         old_stdout, old_stderr = sys.stdout, sys.stderr
-        stdout = sys.stdout = cStringIO.StringIO()
-        stderr = sys.stderr = cStringIO.StringIO()
+        stdout = sys.stdout = BytesIO()
+        stderr = sys.stderr = BytesIO()
         try:
             checkconfig._loadConfig(
                 basedir='configdir', configFile="master.cfg", quiet=False)

--- a/master/buildbot/test/unit/test_scripts_processwwwindex.py
+++ b/master/buildbot/test/unit/test_scripts_processwwwindex.py
@@ -12,12 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
 import tempfile
 
 from twisted.trial import unittest
 
 from buildbot.scripts import processwwwindex
-from buildbot.util import json
 
 
 class TestUsersClient(unittest.TestCase):

--- a/master/buildbot/test/unit/test_scripts_runner.py
+++ b/master/buildbot/test/unit/test_scripts_runner.py
@@ -12,8 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import cStringIO
 import getpass
+# Check when finally switching to Python 3
+from io import BytesIO
 import os
 import sys
 
@@ -837,7 +838,7 @@ class TestRun(unittest.TestCase):
 
     def test_run_bad(self):
         self.patch(sys, 'argv', ['buildbot', 'my', '-l'])
-        stdout = cStringIO.StringIO()
+        stdout = BytesIO()
         self.patch(sys, 'stdout', stdout)
         try:
             runner.run()

--- a/master/buildbot/test/unit/test_scripts_start.py
+++ b/master/buildbot/test/unit/test_scripts_start.py
@@ -19,6 +19,9 @@ import sys
 import time
 
 import twisted
+from twisted.internet.utils import getProcessOutputAndValue
+from twisted.python import versions
+from twisted.trial import unittest
 
 from twisted.internet.utils import getProcessOutputAndValue
 from twisted.python import versions

--- a/master/buildbot/test/unit/test_scripts_tryserver.py
+++ b/master/buildbot/test/unit/test_scripts_tryserver.py
@@ -12,10 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from cStringIO import StringIO
 import os
 import sys
-
-from cStringIO import StringIO
 
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_scripts_tryserver.py
+++ b/master/buildbot/test/unit/test_scripts_tryserver.py
@@ -12,7 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-from cStringIO import StringIO
+#
+# Check when finally switching to Python 3
+from io import BytesIO
 import os
 import sys
 
@@ -31,7 +33,7 @@ class TestStatusLog(dirs.DirsMixin, unittest.TestCase):
 
     def test_trycmd(self):
         config = dict(jobdir='jobdir')
-        inputfile = StringIO('this is my try job')
+        inputfile = BytesIO('this is my try job')
         self.patch(sys, 'stdin', inputfile)
 
         rc = tryserver.tryserver(config)

--- a/master/buildbot/test/unit/test_steps_subunit.py
+++ b/master/buildbot/test/unit/test_steps_subunit.py
@@ -12,7 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import StringIO
+#
+# Check when finally switching to Python 3
+from io import BytesIO
 
 import mock
 
@@ -40,7 +42,7 @@ class TestSetPropertiesFromEnv(steps.BuildStepMixin, unittest.TestCase):
         self.logobserver.errors = []
         self.logobserver.skips = []
         self.logobserver.testsRun = 0
-        self.logobserver.warningio = StringIO.StringIO()
+        self.logobserver.warningio = BytesIO()
         self.patch(subunit, 'SubunitLogObserver',
                    lambda: self.logobserver)
         return self.setUpBuildStep()

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -15,6 +15,7 @@
 from future.utils import iteritems
 
 from cStringIO import StringIO
+import json
 import os
 import shutil
 import stat
@@ -38,7 +39,6 @@ from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.util import steps
 from buildbot.test.util.warnings import assertNotProducesWarnings
 from buildbot.test.util.warnings import assertProducesWarning
-from buildbot.util import json
 from buildbot.worker_transition import DeprecatedWorkerAPIWarning
 from buildbot.worker_transition import DeprecatedWorkerNameWarning
 

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -14,13 +14,12 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 
+from cStringIO import StringIO
 import os
 import shutil
 import stat
 import tarfile
 import tempfile
-
-from cStringIO import StringIO
 
 from mock import Mock
 

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -14,7 +14,8 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 
-from cStringIO import StringIO
+# Check when finally switching to Python 3
+from io import BytesIO
 import json
 import os
 import shutil
@@ -68,10 +69,10 @@ def downloadString(memoizer, timestamp=None):
 
 def uploadTarFile(filename, **members):
     def behavior(command):
-        f = StringIO()
+        f = BytesIO()
         archive = tarfile.TarFile(fileobj=f, name=filename, mode='w')
         for name, content in iteritems(members):
-            archive.addfile(tarfile.TarInfo(name), StringIO(content))
+            archive.addfile(tarfile.TarInfo(name), BytesIO(content))
         writer = command.args['writer']
         writer.remote_write(f.getvalue())
         writer.remote_unpack()

--- a/master/buildbot/test/unit/test_test_util_gpo.py
+++ b/master/buildbot/test/unit/test_test_util_gpo.py
@@ -15,7 +15,6 @@
 import sys
 
 import twisted
-
 from twisted.internet import utils
 from twisted.trial import reporter
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_util_pickle.py
+++ b/master/buildbot/test/unit/test_util_pickle.py
@@ -12,7 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import cStringIO
+#
+# Check when finally switching to Python 3
+from io import BytesIO
 
 from twisted.trial import unittest
 
@@ -35,7 +37,7 @@ class Tests(unittest.TestCase):
         self.assertIsInstance(obj[1], TestClass)
 
     def test_load(self):
-        f = cStringIO.StringIO(self.simplePickle)
+        f = BytesIO(self.simplePickle)
         obj = pickle.load(f)
         self.assertSimplePickleContents(obj)
 

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -18,10 +18,9 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-import buildbot.test.fake.openstack as novaclient
-
 from buildbot import config
 from buildbot import interfaces
+import buildbot.test.fake.openstack as novaclient
 from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.worker import openstack
 from buildbot.worker_transition import DeprecatedWorkerNameWarning

--- a/master/buildbot/test/unit/test_www_hooks_bitbucket.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucket.py
@@ -18,10 +18,9 @@ import calendar
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
-import buildbot.www.change_hook as change_hook
-
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+import buildbot.www.change_hook as change_hook
 
 
 gitJsonPayload = """{

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -12,22 +12,20 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import hmac
-
-from StringIO import StringIO
 from calendar import timegm
 from hashlib import sha1
+import hmac
+from StringIO import StringIO
 
 from twisted.internet import defer
 from twisted.trial import unittest
 
+from buildbot.test.fake.web import fakeMasterForHooks
+from buildbot.test.fake.web import FakeRequest
 from buildbot.www.change_hook import ChangeHookResource
 from buildbot.www.hooks.github import _HEADER_CT
 from buildbot.www.hooks.github import _HEADER_EVENT
 from buildbot.www.hooks.github import _HEADER_SIGNATURE
-
-from buildbot.test.fake.web import FakeRequest
-from buildbot.test.fake.web import fakeMasterForHooks
 
 
 # Sample GITHUB commit payload from http://help.github.com/post-receive-hooks/

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -15,7 +15,8 @@
 from calendar import timegm
 from hashlib import sha1
 import hmac
-from StringIO import StringIO
+# Check when finally switching to Python 3
+from io import BytesIO
 
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -286,7 +287,7 @@ def _prepare_request(event, payload, _secret=None, headers=None):
     }
 
     if isinstance(payload, str):
-        request.content = StringIO(payload)
+        request.content = BytesIO(payload)
         request.received_headers[_HEADER_CT] = _CT_JSON
 
         if _secret is not None:

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -19,10 +19,9 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-import buildbot.www.change_hook as change_hook
-
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+import buildbot.www.change_hook as change_hook
 
 
 # Sample GITHUB commit payload from http://help.github.com/post-receive-hooks/

--- a/master/buildbot/test/unit/test_www_hooks_gitorious.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitorious.py
@@ -16,10 +16,9 @@ import calendar
 
 from twisted.trial import unittest
 
-import buildbot.www.change_hook as change_hook
-
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+import buildbot.www.change_hook as change_hook
 
 
 # Sample Gitorious commit payload

--- a/master/buildbot/test/unit/test_www_hooks_googlecode.py
+++ b/master/buildbot/test/unit/test_www_hooks_googlecode.py
@@ -18,10 +18,9 @@ import StringIO
 
 from twisted.trial import unittest
 
-import buildbot.www.change_hook as change_hook
-
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+import buildbot.www.change_hook as change_hook
 
 
 # Sample Google Code commit payload extracted from a Google Code test project

--- a/master/buildbot/test/unit/test_www_hooks_googlecode.py
+++ b/master/buildbot/test/unit/test_www_hooks_googlecode.py
@@ -14,7 +14,9 @@
 # Copyright 2011 Louis Opter <kalessin@kalessin.fr>
 #
 # Written from the github change hook unit test
-import StringIO
+#
+# Check when finally switching to Python 3
+from io import BytesIO
 
 from twisted.trial import unittest
 
@@ -51,7 +53,7 @@ class TestChangeHookConfiguredWithGoogleCodeChange(unittest.TestCase):
     def setUp(self):
         self.request = FakeRequest()
         # Google Code simply transmit the payload as an UTF-8 JSON body
-        self.request.content = StringIO.StringIO(googleCodeJsonBody)
+        self.request.content = BytesIO(googleCodeJsonBody)
         self.request.received_headers = {
             'Google-Code-Project-Hosting-Hook-Hmac': '85910bf93ba5c266402d9328b0c7a856',
             'Content-Length': '509',

--- a/master/buildbot/test/unit/test_www_hooks_poller.py
+++ b/master/buildbot/test/unit/test_www_hooks_poller.py
@@ -17,12 +17,11 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-import buildbot.www.change_hook as change_hook
-
 from buildbot import util
 from buildbot.changes import base
 from buildbot.changes.manager import ChangeManager
 from buildbot.test.fake.web import FakeRequest
+import buildbot.www.change_hook as change_hook
 
 
 class TestPollingChangeHook(unittest.TestCase):

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
 import os
 import webbrowser
 
@@ -31,7 +32,6 @@ from twisted.web.resource import Resource
 from twisted.web.server import Site
 
 from buildbot.test.util import www
-from buildbot.util import json
 if requests:
     from buildbot.www import oauth2
 
@@ -229,7 +229,6 @@ class OAuth2AuthGitHubE2E(www.WwwTestMixin, unittest.TestCase):
         if "OAUTHCONF" not in os.environ:
             raise unittest.SkipTest("Need to pass OAUTHCONF path to json file via environ to run this e2e test")
 
-        import json
         config = json.load(open(os.environ['OAUTHCONF']))[self.authClass]
         from buildbot.www import oauth2
         self.auth = self._instantiateAuth(getattr(oauth2, self.authClass), config)

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -15,6 +15,7 @@
 from future.utils import iteritems
 from future.utils import itervalues
 
+import json
 import re
 
 import mock
@@ -24,7 +25,6 @@ from twisted.trial import unittest
 
 from buildbot.test.fake import endpoint
 from buildbot.test.util import www
-from buildbot.util import json
 from buildbot.www import authz
 from buildbot.www import rest
 from buildbot.www.rest import BadRequest

--- a/master/buildbot/test/unit/test_www_sse.py
+++ b/master/buildbot/test/unit/test_www_sse.py
@@ -13,13 +13,13 @@
 #
 # Copyright Buildbot Team Members
 import datetime
+import json
 
 from twisted.trial import unittest
 
 from buildbot.test.unit import test_data_changes
 from buildbot.test.util import www
 from buildbot.util import datetime2epoch
-from buildbot.util import json
 from buildbot.www import sse
 
 

--- a/master/buildbot/test/unit/test_www_ws.py
+++ b/master/buildbot/test/unit/test_www_ws.py
@@ -12,12 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
+
 from mock import Mock
 
 from twisted.trial import unittest
 
 from buildbot.test.util import www
-from buildbot.util import json
 from buildbot.www import ws
 
 

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -15,7 +15,8 @@
 from __future__ import print_function
 from future.utils import itervalues
 
-import StringIO
+# Check when finally switching to Python 3
+from io import BytesIO
 import os
 import sys
 
@@ -113,7 +114,7 @@ class RunMasterBase(dirs.DirsMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def tearDown(self):
         if not self._passed:
-            dump = StringIO.StringIO()
+            dump = BytesIO()
             print("FAILED! dumping build db for debug", file=dump)
             builds = yield self.master.data.get(("builds",))
             for build in builds:

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -12,7 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import cStringIO
+#
+# Check when finally switching to Python 3
+from io import BytesIO
 import os
 import sys
 
@@ -42,7 +44,7 @@ class StdoutAssertionsMixin(object):
     """
 
     def setUpStdoutAssertions(self):
-        self.stdout = cStringIO.StringIO()
+        self.stdout = BytesIO()
         self.patch(sys, 'stdout', self.stdout)
 
     def assertWasQuiet(self):

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -17,10 +17,10 @@
 from future.utils import iteritems
 
 import datetime
+import json
 import re
 
 from buildbot.util import UTC
-from buildbot.util import json
 
 # Base class
 

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -15,8 +15,9 @@
 from future.moves.urllib.parse import unquote as urlunquote
 from future.utils import iteritems
 
-from cStringIO import StringIO
 import cgi
+# Check when finally switching to Python 3
+from io import BytesIO
 import json
 import os
 from uuid import uuid1
@@ -169,7 +170,7 @@ class WwwTestMixin(RequiresWwwMixin):
         id = id or self.UUID
         request = self.make_request(path)
         request.method = "POST"
-        request.content = StringIO(requestJson or json.dumps(
+        request.content = BytesIO(requestJson or json.dumps(
             {"jsonrpc": "2.0", "method": action, "params": params, "id": id}))
         request.input_headers = {'content-type': content_type}
         rv = rsrc.render(request)

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -15,10 +15,9 @@
 from future.moves.urllib.parse import unquote as urlunquote
 from future.utils import iteritems
 
+from cStringIO import StringIO
 import cgi
 import os
-
-from cStringIO import StringIO
 from uuid import uuid1
 
 import mock

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -17,6 +17,7 @@ from future.utils import iteritems
 
 from cStringIO import StringIO
 import cgi
+import json
 import os
 from uuid import uuid1
 
@@ -28,7 +29,6 @@ from twisted.internet import defer
 from twisted.web import server
 
 from buildbot.test.fake import fakemaster
-from buildbot.util import json
 from buildbot.www import auth
 from buildbot.www import authz
 

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -172,26 +172,6 @@ def ascii2unicode(x):
         return x
     return unicode(x, 'ascii')
 
-# place a working json module at 'buildbot.util.json'.  Code is adapted from
-# Paul Wise <pabs@debian.org>:
-#   http://lists.debian.org/debian-python/2010/02/msg00016.html
-# json doesn't exist as a standard module until python2.6
-# However python2.6's json module is much slower than simplejson, so we prefer
-# to use simplejson if available.
-try:
-    import simplejson as json
-    assert json
-except ImportError:
-    import json  # python 2.6 or 2.7
-try:
-    _tmp = json.loads
-except AttributeError:
-    import warnings
-    import sys
-    warnings.warn("Use simplejson, not the old json module.")
-    sys.modules.pop('json')  # get rid of the bad json module
-    import simplejson as json
-
 
 def toJson(obj):
     if isinstance(obj, datetime.datetime):
@@ -372,7 +352,7 @@ def command_to_string(command):
 
 
 __all__ = [
-    'naturalSort', 'now', 'formatInterval', 'ComparableMixin', 'json',
+    'naturalSort', 'now', 'formatInterval', 'ComparableMixin',
     'safeTranslate', 'none_or_str',
     'NotABranch', 'deferredLocked', 'UTC',
     'diffSets', 'makeList', 'in_reactor', 'string2boolean',

--- a/master/buildbot/util/pickle.py
+++ b/master/buildbot/util/pickle.py
@@ -18,9 +18,9 @@ from future.utils import itervalues
 
 from bz2 import BZ2File
 from collections import defaultdict
-from collections import defaultdict
-from cStringIO import StringIO
 import cPickle
+# Check when finally switching to Python 3
+from io import BytesIO
 from functools import reduce
 from gzip import GzipFile
 import new
@@ -704,7 +704,7 @@ class HTMLLogFile(LogFile):
         # buildbot <= 0.8.8 stored all html logs in the html property
         if 'html' in self.__dict__:
             buf = "%d:%d%s," % (len(self.html) + 1, STDERR, self.html)
-            self.openfile = StringIO(buf)
+            self.openfile = BytesIO(buf)
             del self.__dict__['html']
 substituteClasses['buildbot.status.logfile', 'HTMLLogFile'] = HTMLLogFile
 substituteClasses['buildbot.status.builder', 'HTMLLogFile'] = HTMLLogFile
@@ -1075,7 +1075,7 @@ def load(file):
 
 
 def loads(str):
-    file = StringIO(str)
+    file = BytesIO(str)
     return _makeUnpickler(file).load()
 
 dump = cPickle.dump

--- a/master/buildbot/util/pickle.py
+++ b/master/buildbot/util/pickle.py
@@ -16,17 +16,16 @@ from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 
+from bz2 import BZ2File
+from collections import defaultdict
+from collections import defaultdict
+from cStringIO import StringIO
 import cPickle
-import cStringIO
+from functools import reduce
+from gzip import GzipFile
 import new
 import os
 import sys
-
-from bz2 import BZ2File
-from cStringIO import StringIO
-from collections import defaultdict
-from functools import reduce
-from gzip import GzipFile
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -1076,7 +1075,7 @@ def load(file):
 
 
 def loads(str):
-    file = cStringIO.StringIO(str)
+    file = StringIO(str)
     return _makeUnpickler(file).load()
 
 dump = cPickle.dump

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -16,7 +16,6 @@
 from future.utils import itervalues
 
 import time
-
 from email.message import Message
 from email.utils import formatdate
 

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -16,9 +16,15 @@
 # Needed so that this module name don't clash with docker-py on older python.
 from __future__ import absolute_import
 
+from io import BytesIO
 import socket
 
-from io import BytesIO
+try:
+    import docker
+    from docker import client
+    _hush_pyflakes = [docker, client]
+except ImportError:
+    client = None
 
 try:
     import docker

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 
 from io import BytesIO
+import json
 import socket
 
 try:
@@ -39,7 +40,6 @@ from twisted.python import log
 
 from buildbot import config
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate
-from buildbot.util import json
 from buildbot.worker import AbstractLatentWorker
 
 

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
 import os
 import posixpath
 
@@ -22,7 +23,6 @@ from twisted.python import log
 from twisted.web.error import Error
 
 from buildbot.interfaces import IConfigured
-from buildbot.util import json
 from buildbot.www import resource
 
 

--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -17,7 +17,7 @@
 #  and inspired from code from the Chromium project
 # otherwise, Andrew Melo <andrew.melo@gmail.com> wrote the rest
 # but "the rest" is pretty minimal
-from buildbot.util import json
+import json
 
 
 def getChanges(request, options=None):

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -12,19 +12,16 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import hmac
-import logging
-import re
-
-from hashlib import sha1
-
 from dateutil.parser import parse as dateparse
-
+from hashlib import sha1
+import hmac
 try:
     import json
     assert json
 except ImportError:
     import simplejson as json
+import logging
+import re
 
 from twisted.python import log
 

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -12,16 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-from dateutil.parser import parse as dateparse
 from hashlib import sha1
 import hmac
-try:
-    import json
-    assert json
-except ImportError:
-    import simplejson as json
+import json
 import logging
 import re
+
+from dateutil.parser import parse as dateparse
 
 from twisted.python import log
 

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -12,13 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import json
 import re
 
 from dateutil.parser import parse as dateparse
 
 from twisted.python import log
-
-from buildbot.util import json
 
 
 def _process_change(payload, user, repo, repo_url, project, codebase=None):

--- a/master/buildbot/www/hooks/gitorious.py
+++ b/master/buildbot/www/hooks/gitorious.py
@@ -15,14 +15,9 @@
 #
 # note: this file is based on github.py
 import re
+import json
 
 from dateutil.parser import parse as dateparse
-
-try:
-    import json
-    assert json
-except ImportError:
-    import simplejson as json
 
 from twisted.python import log
 

--- a/master/buildbot/www/hooks/googlecode.py
+++ b/master/buildbot/www/hooks/googlecode.py
@@ -15,10 +15,9 @@
 #
 # Quite inspired from the github hook.
 import hmac
+import json
 
 from twisted.python import log
-
-from buildbot.util import json
 
 
 class GoogleCodeAuthFailed(Exception):

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -16,6 +16,7 @@ from future.moves.urllib.parse import parse_qs
 from future.moves.urllib.parse import urlencode
 from future.utils import iteritems
 
+import json
 from posixpath import join
 
 import requests
@@ -23,7 +24,6 @@ import requests
 from twisted.internet import defer
 from twisted.internet import threads
 
-from buildbot.util import json
 from buildbot.www import auth
 from buildbot.www import resource
 

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -18,6 +18,7 @@ from future.utils import iteritems
 from contextlib import contextmanager
 import datetime
 import fnmatch
+import json
 import mimetools
 import re
 
@@ -27,7 +28,6 @@ from twisted.web.error import Error
 
 from buildbot.data import exceptions
 from buildbot.data import resultspec
-from buildbot.util import json
 from buildbot.util import toJson
 from buildbot.www import resource
 from buildbot.www.authz import Forbidden

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -15,12 +15,11 @@
 from future.moves.urllib.parse import urlparse
 from future.utils import iteritems
 
+from contextlib import contextmanager
 import datetime
 import fnmatch
 import mimetools
 import re
-
-from contextlib import contextmanager
 
 from twisted.internet import defer
 from twisted.python import log

--- a/master/buildbot/www/sse.py
+++ b/master/buildbot/www/sse.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.utils import itervalues
 
+import json
 import uuid
 
 from twisted.python import log
@@ -21,7 +22,6 @@ from twisted.web import resource
 from twisted.web import server
 
 from buildbot.data.exceptions import InvalidPathError
-from buildbot.util import json
 from buildbot.util import toJson
 
 

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -14,6 +14,8 @@
 # Copyright  Team Members
 from future.utils import itervalues
 
+import json
+
 from autobahn.twisted.resource import WebSocketResource
 from autobahn.twisted.websocket import WebSocketServerFactory
 from autobahn.twisted.websocket import WebSocketServerProtocol
@@ -21,7 +23,6 @@ from autobahn.twisted.websocket import WebSocketServerProtocol
 from twisted.internet import defer
 from twisted.python import log
 
-from buildbot.util import json
 from buildbot.util import toJson
 
 

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -480,15 +480,6 @@ The ``@poll.method`` decorator makes this behavior easy and reliable.
         Force a call to the decorated method now.
         If the decorated method is currently running, another call will begin as soon as it completes.
 
-:py:mod:`buildbot.util.json`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. py:module:: buildbot.util.json
-
-This package is just an import of the best available JSON module.
-Use it instead of a more complex conditional import of :mod:`simplejson` or :mod:`json`::
-
-    from buildbot.util import json
 
 :py:mod:`buildbot.util.maildir`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Since master requires Python 2.6, certain things could be cleaned up:

* `with` statement is available
* `json` module is part of Python and it's fast
* certain functions `string` module offers could be used directly on string instances
* `io` module is available (using `BytesIO` since `StringIO` is for unicode strings only; this needs to be reviewed in future)

In addition, imports are re-ordered according to PEP-8 (with exceptions :smile:)