### PR TITLE
add reference to github in the README.rst

### DIFF
--- a/master/README.rst
+++ b/master/README.rst
@@ -32,6 +32,11 @@ See http://docs.buildbot.net/current/manual/installation.html
 Briefly: python, Twisted, Jinja2, simplejson, and SQLite.
 Simplejson and SQLite are included with recent versions of Python.
 
+Contributing
+-------------
+
+Please send your patches to https://github.com/buildbot/buildbot/
+
 Support
 -------
 


### PR DESCRIPTION
libraries.io is not managing to link to the git history without it..
https://libraries.io/pypi/buildbot