### PR TITLE
Remove isdir attribute from base change_hook for www endpoint

### DIFF
--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -25,6 +25,8 @@ def fakeMasterForHooks():
     master.addedChanges = []
 
     def addChange(**kwargs):
+        if 'isdir' in kwargs or 'is_dir' in kwargs:
+            return defer.fail(AttributeError('isdir/is_dir is not accepted'))
         master.addedChanges.append(kwargs)
         return defer.succeed(Mock())
     master.addChange = addChange

--- a/master/buildbot/test/unit/test_www_hooks_base.py
+++ b/master/buildbot/test/unit/test_www_hooks_base.py
@@ -1,0 +1,61 @@
+from buildbot.www.change_hook import ChangeHookResource
+
+from buildbot.test.fake.web import FakeRequest
+from buildbot.test.fake.web import fakeMasterForHooks
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+
+def _prepare_base_change_hook():
+    return ChangeHookResource(dialects={
+        'base': True
+    }, master=fakeMasterForHooks())
+
+
+def _prepare_request(payload, headers=None):
+    if headers is None:
+        headers = {
+            "Content-type": "application/x-www-form-urlencoded",
+            "Accept": "text/plain"}
+    else:
+        headers = {}
+
+    if 'comments' not in payload:
+        payload['comments'] = 'test_www_hook_base submission'  # Required field
+
+    request = FakeRequest()
+
+    request.uri = "/change_hook/base"
+    request.method = "POST"
+    request.args = payload
+    request.received_headers.update(headers)
+
+    return request
+
+
+class TestChangeHookConfiguredWithBase(unittest.TestCase):
+
+    def setUp(self):
+        self.changeHook = _prepare_base_change_hook()
+
+    @defer.inlineCallbacks
+    def _check_base_with_change(self, payload):
+        self.request = _prepare_request(payload)
+        yield self.request.test_render(self.changeHook)
+        self.assertEquals(len(self.changeHook.master.addedChanges), 1)
+        change = self.changeHook.master.addedChanges[0]
+        self.assertEquals(change['files'], payload.get('files', []))
+        self.assertEquals(change['properties'], payload.get('properties', {}))
+        self.assertEquals(change['revision'], payload.get('revision'))
+        self.assertEquals(change['author'],
+                          payload.get('author', payload.get('who')))
+        self.assertEquals(change['comments'], payload['comments'])
+        self.assertEquals(change['branch'], payload.get('branch'))
+        self.assertEquals(change['category'], payload.get('category'))
+        self.assertEquals(change['revlink'], payload.get('revlink'))
+        self.assertEquals(change['repository'], payload.get('repository'))
+        self.assertEquals(change['project'], payload.get('project'))
+
+    def test_base_with_no_change(self):
+        self._check_base_with_change({})

--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -63,7 +63,6 @@ def getChanges(request, options=None):
     if not author:
         author = firstOrNothing(args.get('who'))
     comments = firstOrNothing(args.get('comments')).decode('utf-8')
-    isdir = firstOrNothing(args.get('isdir', 0))
     branch = firstOrNothing(args.get('branch'))
     category = firstOrNothing(args.get('category'))
     revlink = firstOrNothing(args.get('revlink'))
@@ -71,7 +70,7 @@ def getChanges(request, options=None):
     project = firstOrNothing(args.get('project'))
 
     chdict = dict(author=author, files=files, comments=comments,
-                  isdir=isdir, revision=revision, when=when,
+                  revision=revision, when=when,
                   branch=branch, category=category, revlink=revlink,
                   properties=properties, repository=repository,
                   project=project)


### PR DESCRIPTION
- isdir was removed elsewhere previously
- Updated unit tests to make sure attribute is not provided by any hook

--
See http://trac.buildbot.net/ticket/3494 for corresponding ticket. Note that this review doesn't address any lingering problems in the CSV mailer from isdir being set.