### PR TITLE
model.py: restrict index lengths to 255

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,13 @@ env:
   - TWISTED=15.4.0 SQLALCHEMY=latest TESTS=trial
   - TWISTED=latest SQLALCHEMY=latest TESTS=trial
   # Configuration when SQLite database is persistent between running tests
-  # (by default in other tests in-memory SQLite database is used which is 
+  # (by default in other tests in-memory SQLite database is used which is
   # recreated for each test).
   # Helps to detect issues with incorrect database setup/cleanup in tests.
   - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=sqlite:////tmp/test_db.sqlite
   # Configuration that runs tests with real MySQL database
   - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest
+  - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest&storage_engine=InnoDB
   # Configuration that runs tests with real PostgreSQL database with pg8000 and psycopg2 drivers
   - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=postgresql+psycopg2:///bbtest?user=postgres
   - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=postgresql+pg8000:///bbtest?user=postgres

--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -141,7 +141,7 @@ class BuildbotEngineStrategy(strategies.ThreadLocalEngineStrategy):
 
         kwargs['pool_recycle'] = int(u.query.pop('max_idle', 3600))
 
-        # default to the MyISAM storage engine; InnoDB is not supported
+        # default to the MyISAM storage engine
         storage_engine = u.query.pop('storage_engine', 'MyISAM')
         kwargs['connect_args'] = {
             'init_command': 'SET default_storage_engine=%s' % storage_engine,

--- a/master/buildbot/db/migrate/versions/046_mysql_innodb_compatibility.py
+++ b/master/buildbot/db/migrate/versions/046_mysql_innodb_compatibility.py
@@ -1,0 +1,122 @@
+# This file is part of Buildbot. Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+from sqlalchemy.sql import func
+from sqlalchemy.sql import or_
+from twisted.python import log
+
+from buildbot.util import sautils
+from migrate import changeset
+
+
+def _has_incompatible_changes(metadata, migrate_engine):
+    changes = sautils.Table('changes', metadata, autoload=True)
+    c = changes.c
+    q = sa.select([c.changeid]).where(or_(func.length(c.author) > 255,
+                                          func.length(c.branch) > 255,
+                                          func.length(c.revision) > 255,
+                                          func.length(c.category) > 255))
+    invalid_changes = q.execute().fetchall()
+    if invalid_changes:
+
+        def format(res):
+            return ("changes.change={id} "
+                    "have author, branch, revision or category "
+                    "longer than 255)".format(id=res[0]))
+        log.msg(
+            "'changes' table has invalid data:\n"
+            "{0}".format("\n".join(map(format, invalid_changes))))
+        return True
+    return False
+
+
+def _has_incompatible_object_state(metadata, migrate_engine):
+    object_state = sautils.Table('object_state', metadata, autoload=True)
+    c = object_state.c
+    q = sa.select([c.objectid]).where(func.length(c.name) > 255)
+    invalid_object_states = q.execute().fetchall()
+    if invalid_object_states:
+
+        def format(res):
+            return ("object_state.objectid={id}"
+                    " has name longer than 255".format(id=res[0]))
+        log.msg(
+            "'object_state' table has invalid data:\n"
+            "{0}".format("\n".join(map(format, invalid_object_states))))
+        return True
+    return False
+
+
+def _has_incompatible_users(metadata, migrate_engine):
+    users = sautils.Table('users', metadata, autoload=True)
+    c = users.c
+    q = sa.select([c.uid]).where(func.length(c.identifier) > 255)
+    invalid_users = q.execute().fetchall()
+    if invalid_users:
+
+        def format(res):
+            return ("users.uid={id} "
+                    "has identifier longer than 255".format(id=res[0]))
+        log.msg(
+            "'users_state' table has invalid data:\n"
+            "{0}".format("\n".join(map(format, invalid_users))))
+        return True
+    return False
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+    if any([_has_incompatible_changes(metadata, migrate_engine),
+            _has_incompatible_object_state(metadata, migrate_engine),
+            _has_incompatible_users(metadata, migrate_engine)]):
+        raise ValueError('cannot upgrade due to invalid data')
+
+    changeset.alter_column(
+        sa.Column('author', sa.String(255), nullable=False),
+        table='changes',
+        metadata=metadata,
+        engine=migrate_engine)
+
+    changeset.alter_column(
+        sa.Column('branch', sa.String(255), nullable=False),
+        table='changes',
+        metadata=metadata,
+        engine=migrate_engine)
+
+    changeset.alter_column(
+        sa.Column('revision', sa.String(255), nullable=False),
+        table='changes',
+        metadata=metadata,
+        engine=migrate_engine)
+
+    changeset.alter_column(
+        sa.Column('category', sa.String(255), nullable=False),
+        table='changes',
+        metadata=metadata,
+        engine=migrate_engine)
+
+    changeset.alter_column(
+        sa.Column('name', sa.String(255), nullable=False),
+        table='object_state',
+        metadata=metadata,
+        engine=migrate_engine)
+
+    changeset.alter_column(
+        sa.Column('identifier', sa.String(255), nullable=False),
+        table='users',
+        metadata=metadata,
+        engine=migrate_engine)

--- a/master/buildbot/db/migrate/versions/046_mysql_innodb_compatibility.py
+++ b/master/buildbot/db/migrate/versions/046_mysql_innodb_compatibility.py
@@ -92,19 +92,19 @@ def upgrade(migrate_engine):
         engine=migrate_engine)
 
     changeset.alter_column(
-        sa.Column('branch', sa.String(255), nullable=False),
+        sa.Column('branch', sa.String(255)),
         table='changes',
         metadata=metadata,
         engine=migrate_engine)
 
     changeset.alter_column(
-        sa.Column('revision', sa.String(255), nullable=False),
+        sa.Column('revision', sa.String(255)),
         table='changes',
         metadata=metadata,
         engine=migrate_engine)
 
     changeset.alter_column(
-        sa.Column('category', sa.String(255), nullable=False),
+        sa.Column('category', sa.String(255)),
         table='changes',
         metadata=metadata,
         engine=migrate_engine)

--- a/master/buildbot/db/migrate/versions/046_mysql_innodb_compatibility.py
+++ b/master/buildbot/db/migrate/versions/046_mysql_innodb_compatibility.py
@@ -87,7 +87,7 @@ def upgrade(migrate_engine):
     if migrate_engine.dialect.name == 'postgresql':
         # Sql alchemy migrate does not apply changes on postgresql
         def reduce_table_column_length(table, column):
-            return 'ALTER TABLE {} ALTER COLUMN {} TYPE character varying(255)'.format(table, column)
+            return 'ALTER TABLE {0} ALTER COLUMN {1} TYPE character varying(255)'.format(table, column)
         for table, columns in {'changes': ['author', 'branch', 'revision', 'category'],
                                'object_state': ['name'],
                                'users': ['identifier']}.items():

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -323,17 +323,17 @@ class Model(base.DBConnectorComponent):
         sa.Column('changeid', sa.Integer, primary_key=True),
 
         # author's name (usually an email address)
-        sa.Column('author', sa.String(256), nullable=False),
+        sa.Column('author', sa.String(255), nullable=False),
 
         # commit comment
         sa.Column('comments', sa.Text, nullable=False),
 
         # The branch where this change occurred.  When branch is NULL, that
         # means the main branch (trunk, master, etc.)
-        sa.Column('branch', sa.String(256)),
+        sa.Column('branch', sa.String(255)),
 
         # revision identifier for this change
-        sa.Column('revision', sa.String(256)),  # CVS uses NULL
+        sa.Column('revision', sa.String(255)),  # CVS uses NULL
 
         sa.Column('revlink', sa.String(256)),
 
@@ -343,7 +343,7 @@ class Model(base.DBConnectorComponent):
         sa.Column('when_timestamp', sa.Integer, nullable=False),
 
         # an arbitrary string used for filtering changes
-        sa.Column('category', sa.String(256)),
+        sa.Column('category', sa.String(255)),
 
         # repository specifies, along with revision and branch, the
         # source tree in which this change was detected.
@@ -552,7 +552,7 @@ class Model(base.DBConnectorComponent):
         sa.Column("objectid", sa.Integer, sa.ForeignKey('objects.id'),
                   nullable=False),
         # name for this value (local to the object)
-        sa.Column("name", sa.String(length=256), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
         # value, as a JSON string
         sa.Column("value_json", sa.Text, nullable=False),
     )
@@ -567,7 +567,7 @@ class Model(base.DBConnectorComponent):
         sa.Column("uid", sa.Integer, primary_key=True),
 
         # identifier (nickname) for this user; used for display
-        sa.Column("identifier", sa.String(256), nullable=False),
+        sa.Column("identifier", sa.String(255), nullable=False),
 
         # username portion of user credentials for authentication
         sa.Column("bb_username", sa.String(128)),

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -131,11 +131,7 @@ def upgradeMaster(config, _noMonkey=False):
         return
 
     upgradeFiles(config)
-    try:
-        yield upgradeDatabase(config, master_cfg)
-    except Exception as e:
-        print ("[ERROR] cannot upgrade due to: {}".format(e))
-        return
+    yield upgradeDatabase(config, master_cfg)
 
     if not config['quiet']:
         print("upgrade complete")

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -131,7 +131,11 @@ def upgradeMaster(config, _noMonkey=False):
         return
 
     upgradeFiles(config)
-    yield upgradeDatabase(config, master_cfg)
+    try:
+        yield upgradeDatabase(config, master_cfg)
+    except Exception as e:
+        print ("[ERROR] cannot upgrade due to: {}".format(e))
+        return
 
     if not config['quiet']:
         print("upgrade complete")

--- a/master/buildbot/test/unit/test_db_migrate_versions_046_mysql_innodb_compatibility.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_046_mysql_innodb_compatibility.py
@@ -1,0 +1,154 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+from twisted.trial import unittest
+from twisted.internet import defer
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    table_columns = {
+        'changes': ['author', 'branch', 'revision', 'category'],
+        'object_state': ['name'],
+        'users': ['identifier']
+    }
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def _define_old_tables(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        self.changes = sautils.Table(
+            'changes', metadata,
+            # ...
+            sa.Column('changeid', sa.Integer, primary_key=True),
+            sa.Column('author', sa.String(256), nullable=False),
+            sa.Column('branch', sa.String(256)),
+            sa.Column('revision', sa.String(256)),  # CVS uses NULL
+            sa.Column('category', sa.String(256)))
+
+        self.object_state = sautils.Table(
+            "object_state", metadata,
+            # ...
+            sa.Column("objectid", sa.Integer,
+                      # commented not to add objects table
+                      # sa.ForeignKey('objects.id'),
+                      nullable=False),
+            sa.Column("name", sa.String(length=256), nullable=False))
+
+        self.users = sautils.Table(
+            "users", metadata,
+            # ...
+            sa.Column("uid", sa.Integer, primary_key=True),
+            sa.Column("identifier", sa.String(256), nullable=False),
+        )
+
+    def create_tables_thd(self, conn):
+        self._define_old_tables(conn)
+        self.changes.create()
+        self.object_state.create()
+        self.users.create()
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            conn.execute(self.changes.insert(), [
+                dict(changeid=1,
+                     author="a" * 255,
+                     branch="a",
+                     revision="a",
+                     category="a")])
+            conn.execute(self.object_state.insert(), [
+                dict(objectid=1,
+                     name="a" * 255)])
+
+            conn.execute(self.users.insert(), [
+                dict(uid=1,
+                     identifier="a" * 255)])
+
+            # Verify that the columns have been updated to sa.Strint(255)
+            for table, columns in self.table_columns.items():
+                tbl = sautils.Table(table, metadata, autoload=True)
+                for column in columns:
+                    self.assertIsInstance(getattr(tbl.c, column).type, sa.String)
+                    self.assertEquals(getattr(tbl.c, column).type.length, 255)
+
+        return self.do_test_migration(45, 46, setup_thd, verify_thd)
+
+    @defer.inlineCallbacks
+    def do_invalid_test(self, table, value):
+
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+            metadata = sa.MetaData()
+            metadata.bind = conn
+            conn.execute(getattr(self, table).insert(), [value])
+
+        try:
+            yield self.do_test_migration(45, 46, setup_thd, None)
+            self.assertTrue(False)
+        except ValueError as e:
+            self.assertEquals(str(e), 'cannot upgrade due to invalid data')
+
+    def test_invalid_author_in_changes(self):
+        return self.do_invalid_test('changes', dict(changeid=1,
+                                                    author="a" * 256,
+                                                    branch="a",
+                                                    revision="a",
+                                                    category="a"))
+
+    def test_invalid_branch_in_changes(self):
+        return self.do_invalid_test('changes', dict(changeid=1,
+                                                    author="a",
+                                                    branch="a" * 256,
+                                                    revision="a",
+                                                    category="a"))
+
+    def test_invalid_revision_in_changes(self):
+        return self.do_invalid_test('changes', dict(changeid=1,
+                                                    author="a",
+                                                    branch="a",
+                                                    revision="a" * 256,
+                                                    category="a"))
+
+    def test_invalid_category_in_changes(self):
+        return self.do_invalid_test('changes', dict(changeid=1,
+                                                    author="a",
+                                                    branch="a",
+                                                    revision="a",
+                                                    category="a" * 256))
+
+    def test_invalid_name_in_object_state(self):
+        return self.do_invalid_test('object_state', dict(objectid=1,
+                                                         name="a" * 256))
+
+    def test_invalid_identifier_in_users(self):
+        return self.do_invalid_test('users', dict(uid=1,
+                                                  identifier="a" * 256))
+

--- a/master/buildbot/test/unit/test_db_migrate_versions_046_mysql_innodb_compatibility.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_046_mysql_innodb_compatibility.py
@@ -151,4 +151,3 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
     def test_invalid_identifier_in_users(self):
         return self.do_invalid_test('users', dict(uid=1,
                                                   identifier="a" * 256))
-

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -1840,15 +1840,13 @@ Index Length in MySQL
 
 .. index:: single: MySQL; limitations
 
-MySQL only supports about 330-character indexes.  The actual index length is
+MySQL only supports about 330-character indexes. The actual index length is
 1000 bytes, but MySQL uses 3-byte encoding for UTF8 strings.  This is a
 longstanding bug in MySQL - see `"Specified key was too long; max key
 length is 1000 bytes" with utf8 <http://bugs.mysql.com/bug.php?id=4541>`_.
 While this makes sense for indexes used for record lookup, it limits the
 ability to use unique indexes to prevent duplicate rows.
 
-InnoDB has even more severe restrictions on key lengths, which is why the MySQL
-implementation requires a MyISAM storage engine.
 
 Transactions in MySQL
 ~~~~~~~~~~~~~~~~~~~~~

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -1847,6 +1847,8 @@ length is 1000 bytes" with utf8 <http://bugs.mysql.com/bug.php?id=4541>`_.
 While this makes sense for indexes used for record lookup, it limits the
 ability to use unique indexes to prevent duplicate rows.
 
+InnoDB only supports indexes up to 255 unicode characters, which is why
+all indexed columns are limited to 255 characters in Buildbot.
 
 Transactions in MySQL
 ~~~~~~~~~~~~~~~~~~~~~

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -74,8 +74,6 @@ Buildbot requires ``use_unique=True`` and ``charset=utf8``, and will add them au
 
 MySQL defaults to the MyISAM storage engine, but this can be overridden with the ``storage_engine`` URL argument.
 
-Note that, because of InnoDB's extremely short key length limitations, it cannot be used to run Buildbot.
-See http://bugs.mysql.com/bug.php?id=4541 for more information.
 
 .. index:: Postgres
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -26,6 +26,7 @@ Features
 * :class:`DockerLatentWorker` now has a ``hostconfig`` parameter that can be used to setup host configuration when creating a new container.
 * :bb:step:`CMake` build step is added.
   It provides a convenience interface to `CMake <https://cmake.org/cmake/help/latest/>`_ build system.
+* MySQL InnoDB tables are now supported.
 
 Fixes
 ~~~~~
@@ -38,6 +39,7 @@ Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Deprecated ``workdir`` was removed, ``builddir`` property should be used instead.
+* To support MySQL InnoDB, the size of six VARCHAR(256) columns ``changes.(author, branch, category, name); object_state.name; user.identifier`` was reduced to VARCHAR(255).
 
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
mysql/InnoDB tables have a limitation on index size,
regarding string elements.

http://dev.mysql.com/doc/refman/5.7/en/create-index.html
"...a prefix can be up to 767 bytes long for InnoDB tables..."

Some indexed attributes used to overflow that limit
on utf8 databases. This commit reduces the length of those
from 256 to 255 to fit that constraint.