### PR TITLE
Fix bug where build did not have 'got_revision' property

### DIFF
--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -369,7 +369,7 @@ class GerritStatusPush(service.BuildbotService):
         if getProperty(build, "event.change.id") is not None:  # used only to verify Gerrit source
             project = getProperty(build, "event.change.project")
             codebase = getProperty(build, "codebase")
-            revision = getProperty(build, "got_revision") or build.getProperty("revision")
+            revision = getProperty(build, "got_revision") or getProperty(build, "revision")
 
             if isinstance(revision, dict):
                 # in case of the revision is a codebase revision, we just take the revisionfor current codebase


### PR DESCRIPTION
If a build does not have the "got_revision" property, we hit the "or" path which seems to have missed an update to the new helper function getProperty(build, "prop") from the older build.getProperty('prop').