### PR TITLE
Fix crash caused by incorrectly appended volume strings

### DIFF
--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -80,7 +80,7 @@ class DockerLatentWorker(AbstractLatentWorker):
                 config.error("Invalid volume definition for docker "
                              "%s. Skipping..." % volume_string)
                 continue
-            self.volumes.append(volume)
+            self.volumes.append(volume_string)
 
             ro = False
             if bind.endswith(':ro') or bind.endswith(':rw'):


### PR DESCRIPTION
Docker volumes are supposed to be a list in the form of
[ '<path>:<bind>', '<path>:<bind>' ]

Current parsing code parses this correctly but zeros out self.volumes
and initializes it again in the form of [ '<path>', '<path>', '<path' ]

This breaks the parser if volumes is parsed again as it is expecting
 <path>:<bind> (a specific example is rebuild)