### PR TITLE
Allow multiple latent slaves to launch at a time

### DIFF
--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -504,12 +504,12 @@ class BuildRequestDistributor(service.AsyncMultiService):
                 bc = self.createBuildChooser(bldr, self.master)
                 continue
 
-            buildStarted = yield bldr.maybeStartBuild(worker, breqs)
-            if not buildStarted:
-                yield self.master.data.updates.unclaimBuildRequests(brids)
-                # try starting builds again.  If we still have a working worker,
-                # then this may re-claim the same buildrequests
-                self.botmaster.maybeStartBuildsForBuilder(self.name)
+            d = bldr.maybeStartBuild(worker, breqs)
+
+            @d.addCallback
+            def isItStarted(buildStarted):
+                if not buildStarted:
+                    yield self.master.data.updates.unclaimBuildRequests(brids)
 
     def createBuildChooser(self, bldr, master):
         # just instantiate the build chooser requested


### PR DESCRIPTION
So, I think this does what I want in terms of launching latent build slaves in parallel, ticket #3169

However, I can't figure out how to get `isItStarted()` to get called, and I'm not sure how to resolve this. Any assistance is greatly appreciated.