### PR TITLE
ignore spurious logs

### DIFF
--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -36,8 +36,19 @@ if sys.version_info[:2] < (3, 2):
     # WARNINGs and ERRORs will be printed).
     import logging
     _handler = logging.StreamHandler()
-    logging.getLogger().addHandler(_handler)
 
+    # Ignore following Exception logs:
+    #       Traceback (most recent call last):
+    #       File "[..]site-packages/sqlalchemy/pool.py", line 290, in _close_connection
+    #       self._dialect.do_close(connection)
+    #       File "[..]/sqlalchemy/engine/default.py", line 426, in do_close
+    #       dbapi_connection.close()
+    #       ProgrammingError: SQLite objects created in a thread can only be used in that same thread.
+    #       The object was created in thread id 123145306509312 and this is thread id 140735272824832
+    # sqlalchemy is closing pool connections from the main thread, which sqlite does not like
+    # the warning has been there since forever, but would be catched by the next lastResort logger
+    logging.getLogger("sqlalchemy.pool.SingletonThreadPool").addHandler(None)
+    logging.getLogger().addHandler(_handler)
 # import mock so we bail out early if it's not installed
 try:
     import mock


### PR DESCRIPTION
Lots of logs are seen recently in travis about sqlite threads:

Exception closing connection <sqlite3.Connection object at 0x6a80810>
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/sqlalchemy/pool.py", line 290, in _close_connection
    self._dialect.do_close(connection)
  File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/sqlalchemy/engine/default.py", line 426, in do_close
    dbapi_connection.close()
ProgrammingError: SQLite objects created in a thread can only be used in that same thread.The object was created in thread id 140587768477440 and this is thread id 140595138430720

git bisect shows:
https://github.com/buildbot/buildbot/commit/96f09167ecb592b5a4e04d457bdffc3d37a16f28
as the culprit, but actually if you remove, you will still see one instance of following

     No handlers could be found for logger "sqlalchemy.pool.SingletonThreadPool"

when executing:

    trial buildbot.test.unit.test_db_pool.Basic.test_do

I did go back up to 0.8.5, and still see this warning log for this test
so I conclude this warning can be safely ignored

Here is the git bisect method I used:

git bisect run bash check.sh

0 % cat check.sh
make rmpyc >/dev/null
trial buildbot.test.unit.test_db_pool.BasicWithDebug.test_do >/dev/null 2>err
if grep 'SQLite objects created in a thread can only be used in that same thread' err >/dev/null
then
echo bad
exit 1
else
echo good
exit 0
fi

Signed-off-by: Pierre Tardy <pierre.tardy@intel.com>