### PR TITLE
optimize builds by buildrequests query

### DIFF
--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -134,7 +134,7 @@ class BuildsEndpoint(Db2DataMixin, base.Endpoint):
         # following returns None if no filter
         # true or false, if there is a complete filter
         complete = resultSpec.popBooleanFilter("complete")
-        buildrequestid = resultSpec.popStringFilter("buildrequestid")
+        buildrequestid = resultSpec.popIntegerFilter("buildrequestid")
         builds = yield self.master.db.builds.getBuilds(
             builderid=kwargs.get('builderid'),
             buildrequestid=kwargs.get('buildrequestid', buildrequestid),

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -134,9 +134,10 @@ class BuildsEndpoint(Db2DataMixin, base.Endpoint):
         # following returns None if no filter
         # true or false, if there is a complete filter
         complete = resultSpec.popBooleanFilter("complete")
+        buildrequestid = resultSpec.popStringFilter("buildrequestid")
         builds = yield self.master.db.builds.getBuilds(
             builderid=kwargs.get('builderid'),
-            buildrequestid=kwargs.get('buildrequestid'),
+            buildrequestid=kwargs.get('buildrequestid', buildrequestid),
             workerid=kwargs.get('workerid'),
             complete=complete)
         # returns properties' list

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -18,6 +18,7 @@ from buildbot.data import base
 
 
 class FieldBase(object):
+
     """
     This class implements a basic behavior
     to wrap value into a `Field` instance
@@ -59,6 +60,7 @@ class FieldBase(object):
 
 
 class Property(FieldBase):
+
     """
     Wraps ``property`` type value(s)
 
@@ -66,6 +68,7 @@ class Property(FieldBase):
 
 
 class Filter(FieldBase):
+
     """
     Wraps ``filter`` type value(s)
 
@@ -136,7 +139,11 @@ class ResultSpec(object):
     def popIntegerFilter(self, field):
         eqVals = self.popFilter(field, 'eq')
         if eqVals and len(eqVals) == 1:
-            return int(eqVals[0])
+            try:
+                return int(eqVals[0])
+            except ValueError:
+                raise ValueError("Filter value for {} should be integer, but got: {}".format(
+                    field, eqVals[0]))
 
     def removePagination(self):
         self.limit = self.offset = None

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -133,6 +133,11 @@ class ResultSpec(object):
         if eqVals and len(eqVals) == 1:
             return eqVals[0]
 
+    def popIntegerFilter(self, field):
+        eqVals = self.popFilter(field, 'eq')
+        if eqVals and len(eqVals) == 1:
+            return int(eqVals[0])
+
     def removePagination(self):
         self.limit = self.offset = None
 

--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -164,6 +164,13 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(sorted([b['number'] for b in builds]), [3, 4])
 
     @defer.inlineCallbacks
+    def test_get_buildrequest_via_filter_with_string(self):
+        resultSpec = MockedResultSpec(filters=[resultspec.Filter('buildrequestid', 'eq', ['82'])])
+        builds = yield self.callGet(('builds',), resultSpec=resultSpec)
+        [self.validateData(build) for build in builds]
+        self.assertEqual(sorted([b['number'] for b in builds]), [3, 4])
+
+    @defer.inlineCallbacks
     def test_get_worker(self):
         builds = yield self.callGet(('workers', 13, 'builds'))
         [self.validateData(build) for build in builds]

--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -157,6 +157,13 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(sorted([b['number'] for b in builds]), [3, 4])
 
     @defer.inlineCallbacks
+    def test_get_buildrequest_via_filter(self):
+        resultSpec = MockedResultSpec(filters=[resultspec.Filter('buildrequestid', 'eq', [82])])
+        builds = yield self.callGet(('builds',), resultSpec=resultSpec)
+        [self.validateData(build) for build in builds]
+        self.assertEqual(sorted([b['number'] for b in builds]), [3, 4])
+
+    @defer.inlineCallbacks
     def test_get_worker(self):
         builds = yield self.callGet(('workers', 13, 'builds'))
         [self.validateData(build) for build in builds]

--- a/master/buildbot/test/unit/test_data_resultspec.py
+++ b/master/buildbot/test/unit/test_data_resultspec.py
@@ -256,6 +256,36 @@ class ResultSpec(unittest.TestCase):
         self.assertEqual(rs.popBooleanFilter('bar'), True)
         self.assertEqual(len(rs.filters), 0)
 
+    def test_popStringFilter(self):
+        rs = resultspec.ResultSpec(filters=[
+            resultspec.Filter('foo', 'eq', ['foo']),
+        ])
+        self.assertEqual(rs.popStringFilter('foo'), 'foo')
+
+    def test_popStringFilterSeveral(self):
+        rs = resultspec.ResultSpec(filters=[
+            resultspec.Filter('foo', 'eq', ['foo', 'bar']),
+        ])
+        self.assertEqual(rs.popStringFilter('foo'), None)
+
+    def test_popIntegerFilter(self):
+        rs = resultspec.ResultSpec(filters=[
+            resultspec.Filter('foo', 'eq', ['12']),
+        ])
+        self.assertEqual(rs.popIntegerFilter('foo'), 12)
+
+    def test_popIntegerFilterSeveral(self):
+        rs = resultspec.ResultSpec(filters=[
+            resultspec.Filter('foo', 'eq', ['12', '13']),
+        ])
+        self.assertEqual(rs.popIntegerFilter('foo'), None)
+
+    def test_popIntegerFilterNotInt(self):
+        rs = resultspec.ResultSpec(filters=[
+            resultspec.Filter('foo', 'eq', ['bar']),
+        ])
+        self.assertRaises(ValueError, lambda: rs.popIntegerFilter('foo'))
+
     def test_removeOrder(self):
         rs = resultspec.ResultSpec(order=['foo', '-bar'])
         rs.removeOrder()

--- a/master/docs/developer/cls-resultspec.rst
+++ b/master/docs/developer/cls-resultspec.rst
@@ -74,6 +74,15 @@ Endpoints processing a result specification should take care to replicate this b
         If a filter exists for the field, remove it and return the expected value (True or False); otherwise return None.
         This method correctly handles odd cases like ``field__ne=false``.
 
+    .. py:method:: popStringFilter(field)
+
+        If one string filter exists for the field, remove it and return the expected value (as string); otherwise return None.
+
+    .. py:method:: popIntegerFilter(field)
+
+        If one integer filter exists for the field, remove it and return the expected value (as integer); otherwise return None.
+        raises ValueError if the field is not convertible to integer.
+
     .. py:method:: removePagination()
 
         Remove the pagination attributes (:py:attr:`limit` and :py:attr:`offset`) from the result spec.


### PR DESCRIPTION
since rework of UI, UI search builds by buildrequests using:

https://bboturl/api/v2/builds?buildrequestid=58642
which takes very long, because filtering is implemented in rest layer

While this one is instant:
https://bboturl/api/v2/buildrequests/58642/builds

It is pretty easy to fix this in the data layer, so we fix it there.
We could also fix in the UI layer..
