### PR TITLE
Made Interpolate safe for deepcopy or serialization round-trips

### DIFF
--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -327,7 +327,17 @@ class WithProperties(util.ComparableMixin):
         return s
 
 
-_notHasKey = object()  # Marker object for _Lookup(..., hasKey=...) default
+class _NotHasKey(util.ComparableMixin):
+    """A marker for missing ``hasKey`` parameter.
+
+    To withstand ``deepcopy``, ``reload`` and pickle serialization round trips,
+    check it with ``==`` or ``!=``.
+    """
+    compare_attrs = ()
+
+# any instance of _NotHasKey would do, yet we don't want to create and delete
+# them all the time
+_notHasKey = _NotHasKey()
 
 
 class _Lookup(util.ComparableMixin, object):
@@ -354,7 +364,7 @@ class _Lookup(util.ComparableMixin, object):
             ', defaultWhenFalse=False'
             if not self.defaultWhenFalse else '',
             ', hasKey=%r' % (self.hasKey,)
-            if self.hasKey is not _notHasKey else '',
+            if self.hasKey != _notHasKey else '',
             ', elideNoneAs=%r' % (self.elideNoneAs,)
             if self.elideNoneAs is not None else '')
 
@@ -370,9 +380,9 @@ class _Lookup(util.ComparableMixin, object):
                 rv = yield build.render(value[index])
                 if not rv:
                     rv = yield build.render(self.default)
-                elif self.hasKey is not _notHasKey:
+                elif self.hasKey != _notHasKey:
                     rv = yield build.render(self.hasKey)
-            elif self.hasKey is not _notHasKey:
+            elif self.hasKey != _notHasKey:
                 rv = yield build.render(self.hasKey)
             else:
                 rv = yield build.render(value[index])

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from copy import deepcopy
+
 import mock
 
 from twisted.internet import defer
@@ -408,6 +410,17 @@ class TestInterpolateProperties(unittest.TestCase):
         d.addCallback(self.failUnlessEqual,
                       "echo buildby-blddef")
         return d
+
+    @defer.inlineCallbacks
+    def test_deepcopy(self):
+        # After a deepcopy, Interpolate instances used to lose track
+        # that they didn't have a ``hasKey`` value
+        # see http://trac.buildbot.net/ticket/3505
+        self.props.setProperty("buildername", "linux4", "test")
+        command = deepcopy(
+            Interpolate("echo buildby-%(prop:buildername:-blddef)s"))
+        rendered = yield self.build.render(command)
+        self.assertEqual(rendered, "echo buildby-linux4")
 
     def test_property_colon_tilde_true(self):
         self.props.setProperty("buildername", "winbld", "test")


### PR DESCRIPTION
This squashes and supersedes #2075, to fix https://trac.buildbot.net/ticket/3505 

The marker used in _Lookup to indicate that `hasKey` had
not been supplied actually changes if a deepcopy of the
Interpolate instance is made.
This fix makes any instances of this marker equivalent,
so that it's insensitive to deepcopy, pickling/unpickling
and reload.