### PR TITLE
Include build properties in gerrit summary callback

### DIFF
--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -326,6 +326,7 @@ class GerritStatusPush(service.BuildbotService):
                 }.get(result, "completed with unknown result %d" % result)
 
                 return {'name': build['builder']['name'],
+                        'properties': build['properties'],
                         'result': result,
                         'resultText': resultText,
                         'text': build['state_string'],


### PR DESCRIPTION
This allows a gerrit summary callback to do some more advanced filtering