### PR TITLE
reporters/gerrit: provide build itself for summary callback

### DIFF
--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -329,7 +329,8 @@ class GerritStatusPush(service.BuildbotService):
                         'result': result,
                         'resultText': resultText,
                         'text': build['state_string'],
-                        'url': utils.getURLForBuild(self.master, build['builder']['builderid'], build['number'])
+                        'url': utils.getURLForBuild(self.master, build['builder']['builderid'], build['number']),
+                        'build': build
                         }
             buildInfoList = sorted([getBuildInfo(build) for build in builds], key=lambda bi: bi['name'])
 

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -132,12 +132,13 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
         self.master.db.changes.getChangesForBuild = getChangesForBuild
         defer.returnValue((buildset, builds))
 
-    def makeBuildInfo(self, buildResults, resultText):
+    def makeBuildInfo(self, buildResults, resultText, builds):
         info = []
         for i in xrange(len(buildResults)):
             info.append({'name': u"Builder%d" % i, 'result': buildResults[i],
                          'resultText': resultText[i], 'text': u'buildText',
-                         'url': "http://localhost:8080/#builders/%d/builds/%d" % (79 + i, i)})
+                         'url': "http://localhost:8080/#builders/%d/builds/%d" % (79 + i, i),
+                         'build': builds[i]})
         return info
 
     @defer.inlineCallbacks
@@ -147,7 +148,7 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
         yield gsp.buildsetComplete('buildset.98.complete'.split("."),
                                    buildset)
 
-        info = self.makeBuildInfo(buildResults, resultText)
+        info = self.makeBuildInfo(buildResults, resultText, builds)
         if expWarning:
             self.assertEqual([w['message'] for w in self.flushWarnings()],
                              ['The Gerrit status callback uses the old '
@@ -348,10 +349,10 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
         self.assertEqual(res['labels'], {})
 
     def test_defaultSummaryCB(self):
-        info = self.makeBuildInfo([SUCCESS, FAILURE], ["yes", "no"])
+        info = self.makeBuildInfo([SUCCESS, FAILURE], ["yes", "no"], [None, None])
         res = defaultSummaryCB(info, SUCCESS, None, None)
         self.assertEqual(res['labels'], {'Verified': -1})
-        info = self.makeBuildInfo([SUCCESS, SUCCESS], ["yes", "yes"])
+        info = self.makeBuildInfo([SUCCESS, SUCCESS], ["yes", "yes"], [None, None])
         res = defaultSummaryCB(info, SUCCESS, None, None)
         self.assertEqual(res['labels'], {'Verified': 1})
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -30,6 +30,7 @@ Features
 * :class:`~buildbot.reporters.http.HttpStatusPush` has been ported to reporter API.
 * :class:`~buildbot.reporters.stash.StashStatusPush` has been ported to reporter API.
 * :class:`~buildbot.reporters.github.GithubStatusPush` has been ported to reporter API.
+* `summaryCB` of :bb:reporter:`GerritStatusPush` now gets not only pre-processed information but the actual build as well.
 
 Fixes
 ~~~~~


### PR DESCRIPTION
Summary callback differs from the build review callback in lack of the
actual build instance: the former gets only particular information about
builds.

In some situations, the build itself is required to do some magic.

(Ported from eight)