### PR TITLE
Fixes CMake documentation example error and typo.

### DIFF
--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -1313,9 +1313,9 @@ In addition to the parameters :bb:step:`ShellCommand` supports, this step accept
     ...
 
     factory.addStep(
-        step.CMake(
+        steps.CMake(
             generator='Ninja',
-            defitions={
+            definitions={
                 'CMAKE_BUILD_TYPE': Property('BUILD_TYPE')
             },
             options=[


### PR DESCRIPTION
This fixes an error in the CMake documentation example and also a typo when using definitions.