### PR TITLE
compress logs in a transaction

### DIFF
--- a/master/buildbot/test/integration/test_URLs.py
+++ b/master/buildbot/test/integration/test_URLs.py
@@ -25,7 +25,7 @@ class UrlForBuildMaster(RunMasterBase):
     proto = "null"
 
     @defer.inlineCallbacks
-    def test_transfer(self):
+    def test_url(self):
 
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], SUCCESS)


### PR DESCRIPTION
During the log compression process, there is a time where all the log chunks are deleted
If while that a process reads the log, it will find an empty log.

This happens on integrations tests making them flaky.

This can theorically also happen for reporters even if we did not get any bug reports on that

What we do is to make the delete + re-insert a transaction, so that any read in between will get the old un-compressed version of the chunks (which is an okay answer)

I can reproduce the bug easily with a combination of sleep 2 after delete, and sleep 1 at the begining of getLogLines's thd,
but I dont want to cripple the code to add the necessary syncrhonisation hooks required to unit test this bug.