### PR TITLE
Send JSON to GitHub instead of form encoded

### DIFF
--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -79,7 +79,7 @@ class GithubStatusPush(http.HttpStatusPushBase):
             payload['context'] = context
 
         return self.session.post('/'.join(
-            [self.baseURL, 'repos', repo_user, repo_name, 'statuses', sha]), payload)
+            [self.baseURL, 'repos', repo_user, repo_name, 'statuses', sha]), json=payload)
 
     @defer.inlineCallbacks
     def send(self, build):

--- a/master/buildbot/test/unit/test_reporter_github.py
+++ b/master/buildbot/test/unit/test_reporter_github.py
@@ -68,18 +68,18 @@ class TestGithubStatusPush(unittest.TestCase, ReporterTestMixin):
         self.assertEqual(
             self.sp.session.post.mock_calls, [
                 call(
-                    'https://api.github.com/repos/buildbot/buildbot/statuses/d34db33fd43db33f', {
-                        'state': 'pending',
-                        'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                        'description': 'Build started.', 'context': 'buildbot/'}),
+                    'https://api.github.com/repos/buildbot/buildbot/statuses/d34db33fd43db33f',
+                    json={'state': 'pending',
+                          'target_url': 'http://localhost:8080/#builders/79/builds/0',
+                          'description': 'Build started.', 'context': 'buildbot/'}),
                 call(
-                    'https://api.github.com/repos/buildbot/buildbot/statuses/d34db33fd43db33f', {
-                        'state': 'success',
-                        'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                        'description': 'Build done.', 'context': 'buildbot/'}),
+                    'https://api.github.com/repos/buildbot/buildbot/statuses/d34db33fd43db33f',
+                    json={'state': 'success',
+                          'target_url': 'http://localhost:8080/#builders/79/builds/0',
+                          'description': 'Build done.', 'context': 'buildbot/'}),
                 call(
-                    'https://api.github.com/repos/buildbot/buildbot/statuses/d34db33fd43db33f', {
-                        'state': 'failure',
-                        'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                        'description': 'Build done.', 'context': 'buildbot/'}),
+                    'https://api.github.com/repos/buildbot/buildbot/statuses/d34db33fd43db33f',
+                    json={'state': 'failure',
+                          'target_url': 'http://localhost:8080/#builders/79/builds/0',
+                          'description': 'Build done.', 'context': 'buildbot/'}),
             ])


### PR DESCRIPTION
GitHub expects a JSON request body