### PR TITLE
Teach HttpStatusPush and StashStatusPush reporters correct response syntax

### DIFF
--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -112,5 +112,5 @@ class HttpStatusPush(HttpStatusPushBase):
     @defer.inlineCallbacks
     def send(self, build):
         response = yield self.session.post(self.serverUrl, build, auth=self.auth)
-        if response.status != 200:
-            log.msg("%s: unable to upload status: %s", response.status, response.content)
+        if response.status_code != 200:
+            log.msg("%s: unable to upload status: %s" % (response.status_code, response.content))

--- a/master/buildbot/reporters/stash.py
+++ b/master/buildbot/reporters/stash.py
@@ -48,5 +48,5 @@ class StashStatusPush(http.HttpStatusPushBase):
             body = {'state': status, 'key': build['builder']['name'], 'url': build['url']}
             stash_uri = self.base_url + sha
             response = yield self.session.post(stash_uri, body, auth=self.auth)
-            if response.status != 200:
+            if response.status_code != 200:
                 log.msg("%s: unable to upload stash status: %s" % (response.status, response.content))


### PR DESCRIPTION
A couple small bugs I encountered while copying this code to make a buildset monitor. 

HTTPStep has the correct implementation already, and I don't see it being used elsewhere. No unit tests to update as far as I can tell; the existing TestHttpStatusPush and TestStackStatusPush classes seem focused on mocking sure the right calls are made and I don't see a quick way to extend them to mock out responses.