### PR TITLE
Update HttpStatusPushBase to accept wantXXX kwargs

### DIFF
--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -43,9 +43,12 @@ class HttpStatusPushBase(service.BuildbotService):
             config.error("builders must be a list or None")
 
     @defer.inlineCallbacks
-    def reconfigService(self, builders=None):
+    def reconfigService(self, builders=None, **kwargs):
         yield service.BuildbotService.reconfigService(self)
         self.builders = builders
+        for k, v in iteritems(kwargs):
+            if k.startswith("want"):
+                self.neededDetails[k] = v
 
     def sessionFactory(self):
         """txrequests mocking endpoint"""
@@ -105,9 +108,6 @@ class HttpStatusPush(HttpStatusPushBase):
         HttpStatusPushBase.reconfigService(self, **kwargs)
         self.serverUrl = serverUrl
         self.auth = (user, password)
-        for k, v in iteritems(kwargs):
-            if k.startswith("want"):
-                self.neededDetails[k] = v
 
     @defer.inlineCallbacks
     def send(self, build):


### PR DESCRIPTION
- Previous, HttpStatusPush nominally accepted them, but also passed them to
  HttpStatusPushBase which did not accept them. However, the base is the class
  responsible for storing the kwargs, so now it configures them as well.

----
I don't see any reason for HttpStatuPushBase to not also configure the wantXXX kwargs since it is the one with the 'neededDetails' member and the one using it. 