### PR TITLE
Use the threadpool from the provided reactor, rather than the global one.

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -222,7 +222,8 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
             # load the configuration file, treating errors as fatal
             try:
                 # run the master.cfg in thread, so that it can use blocking code
-                self.config = yield threads.deferToThread(
+                self.config = yield threads.deferToThreadPool(
+                    _reactor, _reactor.getThreadPool(),
                     config.MasterConfig.loadConfig, self.basedir, self.configFileName)
 
             except config.ConfigErrors as e:

--- a/master/buildbot/test/integration/test_master.py
+++ b/master/buildbot/test/integration/test_master.py
@@ -54,6 +54,8 @@ class RunMaster(dirs.DirsMixin, www.RequiresWwwMixin, unittest.TestCase):
         # like test code to call!)
         mock_reactor = mock.Mock(spec=reactor)
         mock_reactor.callWhenRunning = reactor.callWhenRunning
+        mock_reactor.getThreadPool = reactor.getThreadPool
+        mock_reactor.callFromThread = reactor.callFromThread
 
         # start the service
         yield m.startService(_reactor=mock_reactor)

--- a/master/buildbot/test/integration/test_try_client.py
+++ b/master/buildbot/test/integration/test_try_client.py
@@ -185,6 +185,8 @@ class Schedulers(dirs.DirsMixin, www.RequiresWwwMixin, unittest.TestCase):
         # like test code to call!)
         mock_reactor = mock.Mock(spec=reactor)
         mock_reactor.callWhenRunning = reactor.callWhenRunning
+        mock_reactor.getThreadPool = reactor.getThreadPool
+        mock_reactor.callFromThread = reactor.callFromThread
 
         # start the service
         yield m.startService(_reactor=mock_reactor)

--- a/master/buildbot/test/integration/test_worker_transition.py
+++ b/master/buildbot/test/integration/test_worker_transition.py
@@ -159,6 +159,8 @@ class RunMaster(dirs.DirsMixin, www.RequiresWwwMixin, unittest.TestCase):
         # like test code to call!)
         mock_reactor = mock.Mock(spec=reactor)
         mock_reactor.callWhenRunning = reactor.callWhenRunning
+        mock_reactor.getThreadPool = reactor.getThreadPool
+        mock_reactor.callFromThread = reactor.callFromThread
 
         # mock configuration loading
         @classmethod

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -154,6 +154,8 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
     def make_reactor(self):
         r = mock.Mock()
         r.callWhenRunning = reactor.callWhenRunning
+        r.getThreadPool = reactor.getThreadPool
+        r.callFromThread = reactor.callFromThread
         return r
 
     def patch_loadConfig_fail(self):

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -96,6 +96,8 @@ class RunMasterBase(dirs.DirsMixin, unittest.TestCase):
         # like test code to call!)
         mock_reactor = mock.Mock(spec=reactor)
         mock_reactor.callWhenRunning = reactor.callWhenRunning
+        mock_reactor.getThreadPool = reactor.getThreadPool
+        mock_reactor.callFromThread = reactor.callFromThread
 
         # start the service
         yield m.startService(_reactor=mock_reactor)


### PR DESCRIPTION
I want to introduce some tests that don't interact with a real reactor (so that they can be synchronous). This is one of the places that uses a hard-coded global reactor.