### PR TITLE
wrap commands long description with textwrap.dedent

### DIFF
--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -21,6 +21,7 @@
 from __future__ import print_function
 
 import sys
+import textwrap
 
 import sqlalchemy as sa
 
@@ -66,7 +67,7 @@ class UpgradeMasterOptions(base.BasedirMixin, base.SubcommandOptions):
     def getSynopsis(self):
         return "Usage:    buildbot upgrade-master [options] [<basedir>]"
 
-    longdesc = """
+    longdesc = textwrap.dedent("""
     This command takes an existing buildmaster working directory and
     adds/modifies the files there to work with the current version of
     buildbot. When this command is finished, the buildmaster directory should
@@ -89,7 +90,7 @@ class UpgradeMasterOptions(base.BasedirMixin, base.SubcommandOptions):
     When upgrading the database, this command uses the database specified in
     the master configuration file.  If you wish to use a database other than
     the default (sqlite), be sure to set that parameter before upgrading.
-    """
+    """)
 
 
 class CreateMasterOptions(base.BasedirMixin, base.SubcommandOptions):
@@ -118,7 +119,7 @@ class CreateMasterOptions(base.BasedirMixin, base.SubcommandOptions):
     def getSynopsis(self):
         return "Usage:    buildbot create-master [options] [<basedir>]"
 
-    longdesc = """
+    longdesc = textwrap.dedent("""
     This command creates a buildmaster working directory and buildbot.tac file.
     The master will live in <dir> and create various files there.  If
     --relocatable is given, then the resulting buildbot.tac file will be
@@ -145,7 +146,7 @@ class CreateMasterOptions(base.BasedirMixin, base.SubcommandOptions):
     The --db string is stored verbatim in the buildbot.tac file, and
     evaluated at 'buildbot start' time to pass a DBConnector instance into
     the newly-created BuildMaster object.
-    """
+    """)
 
     def postOptions(self):
         base.BasedirMixin.postOptions(self)
@@ -531,10 +532,10 @@ class UserOptions(base.SubcommandOptions):
     ]
     requiredOptions = ['master']
 
-    longdesc = """
+    longdesc = textwrap.dedent("""
     Currently implemented types for --info= are:\n
     git, svn, hg, cvs, darcs, bzr, email
-    """
+    """)
 
     def __init__(self):
         base.SubcommandOptions.__init__(self)
@@ -669,7 +670,7 @@ class CleanupDBOptions(base.BasedirMixin, base.SubcommandOptions):
     def getSynopsis(self):
         return "Usage:    buildbot cleanupdb [options] [<basedir>]"
 
-    longdesc = """
+    longdesc = textwrap.dedent("""
     This command takes an existing buildmaster working directory and
     do some optimization on the database.
 
@@ -681,7 +682,7 @@ class CleanupDBOptions(base.BasedirMixin, base.SubcommandOptions):
     This command uses the database specified in
     the master configuration file.  If you wish to use a database other than
     the default (sqlite), be sure to set that parameter before upgrading.
-    """
+    """)
 
 
 class Options(usage.Options):

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -19,6 +19,7 @@
 import os
 import re
 import sys
+import textwrap
 
 from twisted.python import log
 from twisted.python import reflect
@@ -38,10 +39,10 @@ class MakerBase(usage.Options):
         ["quiet", "q", "Do not emit the commands being run"],
     ]
 
-    longdesc = """
+    longdesc = textwrap.dedent("""
     Operates upon the specified <basedir> (or the current directory, if not
     specified).
-    """
+    """)
 
     # on tab completion, suggest directories as first argument
     if hasattr(usage, 'Completions'):
@@ -125,18 +126,18 @@ class CreateWorkerOptions(MakerBase):
          "'signal' or 'file'"]
     ]
 
-    longdesc = """
+    longdesc = textwrap.dedent("""
     This command creates a buildbot worker directory and buildbot.tac
     file. The bot will use the <name> and <passwd> arguments to authenticate
     itself when connecting to the master. All commands are run in a
     build-specific subdirectory of <basedir>. <master> is a string of the
     form 'hostname[:port]', and specifies where the buildmaster can be reached.
-    port defaults to 9989
+    port defaults to 9989.
 
     The appropriate values for <name>, <passwd>, and <master> should be
     provided to you by the buildmaster administrator. You must choose <basedir>
     yourself.
-    """
+    """)
 
     def validateMasterArgument(self, master_arg):
         """


### PR DESCRIPTION
Twisted reformats description text by removing newlines and rewrapping
text (at least Twisted 16.1.0).

Was:

```
$ buildbot-worker create-worker --help
Usage:    buildbot-worker create-worker [options] <basedir> <master> <name> <passwd>
...
This command creates a buildbot worker directory and buildbot.tac     file.
The bot will use the <name> and <passwd> arguments to authenticate     itself
when connecting to the master. All commands are run in a     build-specific
subdirectory of <basedir>. <master> is a string of the     form
'hostname[:port]', and specifies where the buildmaster can be reached.     port
defaults to 9989      The appropriate values for <name>, <passwd>, and <master>
should be     provided to you by the buildmaster administrator. You must choose
<basedir>     yourself.
```

Now:

```
$ buildbot-worker create-worker --help
...
This command creates a buildbot worker directory and buildbot.tac file. The bot
will use the <name> and <passwd> arguments to authenticate itself when
connecting to the master. All commands are run in a build-specific subdirectory
of <basedir>. <master> is a string of the form 'hostname[:port]', and specifies
where the buildmaster can be reached. port defaults to 9989.  The appropriate
values for <name>, <passwd>, and <master> should be provided to you by the
buildmaster administrator. You must choose <basedir> yourself.
```

This is better, but still not the best result.
This may should be fixed by <https://twistedmatrix.com/trac/ticket/1601>.