### PR TITLE
configure logging for buildbot-worker runner

### DIFF
--- a/worker/buildbot_worker/commands/repo.py
+++ b/worker/buildbot_worker/commands/repo.py
@@ -13,12 +13,13 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import print_function
+
 import os
 import re
 import textwrap
 
 from twisted.internet import defer
-from twisted.python import log
 
 from buildbot_worker import runprocess
 from buildbot_worker.commands.base import AbandonChain
@@ -67,8 +68,8 @@ class Repo(SourceBaseCommand):
         return os.path.join(self.builder.basedir, self.srcdir)
 
     def sourcedirIsUpdateable(self):
-        log.msg(os.path.join(self._fullSrcdir(), ".repo"))
-        log.msg(os.path.isdir(os.path.join(self._fullSrcdir(), ".repo")))
+        print(os.path.join(self._fullSrcdir(), ".repo"))
+        print(os.path.isdir(os.path.join(self._fullSrcdir(), ".repo")))
         return os.path.isdir(os.path.join(self._fullSrcdir(), ".repo"))
 
     def _repoCmd(self, command, cb=None, abandonOnFailure=True, **kwargs):

--- a/worker/buildbot_worker/scripts/base.py
+++ b/worker/buildbot_worker/scripts/base.py
@@ -13,14 +13,14 @@
 #
 # Copyright Buildbot Team Members
 
-import os
+from __future__ import print_function
 
-from twisted.python import log
+import os
 
 
 def isWorkerDir(dir):
     def print_error(error_message):
-        log.msg("%s\ninvalid worker directory '%s'" % (error_message, dir))
+        print("%s\ninvalid worker directory '%s'" % (error_message, dir))
 
     buildbot_tac = os.path.join(dir, "buildbot.tac")
     try:

--- a/worker/buildbot_worker/scripts/create_worker.py
+++ b/worker/buildbot_worker/scripts/create_worker.py
@@ -13,9 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
-import os
+from __future__ import print_function
 
-from twisted.python import log
+import os
 
 workerTACTemplate = ["""
 import os
@@ -87,11 +87,11 @@ def _makeBaseDir(basedir, quiet):
     """
     if os.path.exists(basedir):
         if not quiet:
-            log.msg("updating existing installation")
+            print("updating existing installation")
         return
 
     if not quiet:
-        log.msg("mkdir", basedir)
+        print("mkdir", basedir)
 
     try:
         os.mkdir(basedir)
@@ -122,12 +122,12 @@ def _makeBuildbotTac(basedir, tac_file_contents, quiet):
 
         if oldcontents == tac_file_contents:
             if not quiet:
-                log.msg("buildbot.tac already exists and is correct")
+                print("buildbot.tac already exists and is correct")
             return
 
         if not quiet:
-            log.msg("not touching existing buildbot.tac")
-            log.msg("creating buildbot.tac.new instead")
+            print("not touching existing buildbot.tac")
+            print("creating buildbot.tac.new instead")
 
         tacfile = os.path.join(basedir, "buildbot.tac.new")
 
@@ -158,8 +158,8 @@ def _makeInfoFiles(basedir, quiet):
             return False
 
         if not quiet:
-            log.msg("Creating %s, you need to edit it appropriately." %
-                    os.path.join("info", file))
+            print("Creating %s, you need to edit it appropriately." %
+                  os.path.join("info", file))
 
         try:
             open(filepath, "wt").write(contents)
@@ -171,7 +171,7 @@ def _makeInfoFiles(basedir, quiet):
     path = os.path.join(basedir, "info")
     if not os.path.exists(path):
         if not quiet:
-            log.msg("mkdir", path)
+            print("mkdir", path)
         try:
             os.mkdir(path)
         except OSError as exception:
@@ -190,11 +190,11 @@ def _makeInfoFiles(basedir, quiet):
 
     if not os.path.exists(access_uri):
         if not quiet:
-            log.msg("Not creating %s - add it if you wish" %
-                    os.path.join("info", "access_uri"))
+            print("Not creating %s - add it if you wish" %
+                  os.path.join("info", "access_uri"))
 
     if created and not quiet:
-        log.msg("Please edit the files in %s appropriately." % path)
+        print("Please edit the files in %s appropriately." % path)
 
 
 def createWorker(config):
@@ -219,11 +219,11 @@ def createWorker(config):
         _makeBuildbotTac(basedir, contents, quiet)
         _makeInfoFiles(basedir, quiet)
     except CreateWorkerError as exception:
-        log.msg("%s\nfailed to configure worker in %s" %
-                (exception, config['basedir']))
+        print("%s\nfailed to configure worker in %s" %
+              (exception, config['basedir']))
         return 1
 
     if not quiet:
-        log.msg("worker configured in %s" % basedir)
+        print("worker configured in %s" % basedir)
 
     return 0

--- a/worker/buildbot_worker/scripts/logwatcher.py
+++ b/worker/buildbot_worker/scripts/logwatcher.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import print_function
+
 import os
 import platform
 
@@ -20,7 +22,6 @@ from twisted.internet import defer
 from twisted.internet import error
 from twisted.internet import protocol
 from twisted.internet import reactor
-from twisted.python import log
 from twisted.protocols.basic import LineOnlyReceiver
 from twisted.python.failure import Failure
 
@@ -51,7 +52,7 @@ class TailProcess(protocol.ProcessProtocol):
         self.lw.dataReceived(data)
 
     def errReceived(self, data):
-        log.msg("ERR: '%s'" % (data,))
+        print("ERR: '%s'" % (data,))
 
 
 class LogWatcher(LineOnlyReceiver):
@@ -126,7 +127,7 @@ class LogWatcher(LineOnlyReceiver):
             self.processtype = "worker"
 
         if self.in_reconfig:
-            log.msg(line)
+            print(line)
 
         if "message from master: attached" in line:
             return self.finished("buildslave")

--- a/worker/buildbot_worker/scripts/restart.py
+++ b/worker/buildbot_worker/scripts/restart.py
@@ -13,7 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.python import log
+from __future__ import print_function
 
 from buildbot_worker.scripts import base
 from buildbot_worker.scripts import start
@@ -31,8 +31,8 @@ def restart(config):
         stop.stopWorker(basedir, quiet)
     except stop.WorkerNotRunning:
         if not quiet:
-            log.msg("no old worker process found to stop")
+            print("no old worker process found to stop")
     if not quiet:
-        log.msg("now restarting worker process..")
+        print("now restarting worker process..")
 
     return start.startWorker(basedir, quiet, config['nodaemon'])

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -16,6 +16,8 @@
 # N.B.: don't import anything that might pull in a reactor yet. Some of our
 # subcommands want to load modules that need the gtk reactor.
 
+from __future__ import print_function
+
 import os
 import re
 import sys
@@ -24,10 +26,6 @@ import textwrap
 from twisted.python import log
 from twisted.python import reflect
 from twisted.python import usage
-from twisted.python.log import ILogObserver
-from twisted.python.log import textFromEventDict
-
-from zope.interface import implementer
 
 
 # the create/start/stop commands should all be run as the same user,
@@ -242,26 +240,15 @@ class Options(usage.Options):
             raise usage.UsageError("must specify a command")
 
 
-@implementer(ILogObserver)
-class StdoutLogger(object):
-
-    def __call__(self, event):
-        text = textFromEventDict(event)
-        if text is not None:
-            print(text)
-
-
 def run():
-    log.addObserver(StdoutLogger())
-
     config = Options()
     try:
         config.parseOptions()
     except usage.error as e:
-        log.msg("%s:  %s" % (sys.argv[0], e))
-        log.msg()
+        print("%s:  %s" % (sys.argv[0], e))
+        print()
         c = getattr(config, 'subOptions', config)
-        log.msg(str(c))
+        print(str(c))
         sys.exit(1)
 
     subconfig = config.subOptions

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -229,7 +229,7 @@ class Options(usage.Options):
 
     def opt_version(self):
         import buildbot_worker
-        log.msg("worker version: %s" % buildbot_worker.version)
+        print("worker version: %s" % buildbot_worker.version)
         usage.Options.opt_version(self)
 
     def opt_verbose(self):

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -21,9 +21,14 @@ import re
 import sys
 import textwrap
 
+from twisted.logger import ILogObserver
+from twisted.logger import formatEvent
+from twisted.logger import globalLogBeginner
 from twisted.python import log
 from twisted.python import reflect
 from twisted.python import usage
+
+from zope.interface import implementer
 
 
 # the create/start/stop commands should all be run as the same user,
@@ -238,7 +243,18 @@ class Options(usage.Options):
             raise usage.UsageError("must specify a command")
 
 
+@implementer(ILogObserver)
+class StdoutLogger(object):
+
+    def __call__(self, event):
+        print(formatEvent(event))
+
+
 def run():
+    globalLogBeginner.beginLoggingTo(
+        [StdoutLogger()],
+        redirectStandardIO=False)
+
     config = Options()
     try:
         config.parseOptions()

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -21,12 +21,11 @@ import re
 import sys
 import textwrap
 
-from twisted.logger import ILogObserver
-from twisted.logger import formatEvent
-from twisted.logger import globalLogBeginner
 from twisted.python import log
 from twisted.python import reflect
 from twisted.python import usage
+from twisted.python.log import ILogObserver
+from twisted.python.log import textFromEventDict
 
 from zope.interface import implementer
 
@@ -247,13 +246,13 @@ class Options(usage.Options):
 class StdoutLogger(object):
 
     def __call__(self, event):
-        print(formatEvent(event))
+        text = textFromEventDict(event)
+        if text is not None:
+            print(text)
 
 
 def run():
-    globalLogBeginner.beginLoggingTo(
-        [StdoutLogger()],
-        redirectStandardIO=False)
+    log.addObserver(StdoutLogger())
 
     config = Options()
     try:

--- a/worker/buildbot_worker/scripts/start.py
+++ b/worker/buildbot_worker/scripts/start.py
@@ -13,10 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import print_function
+
 import os
 import sys
 import time
-from twisted.python import log
 
 from buildbot_worker.scripts import base
 
@@ -27,7 +28,7 @@ class Follower(object):
         from twisted.internet import reactor
         from buildbot_worker.scripts.logwatcher import LogWatcher
         self.rc = 0
-        log.msg("Following twistd.log until startup finished..")
+        print("Following twistd.log until startup finished..")
         lw = LogWatcher("twistd.log")
         d = lw.start()
         d.addCallbacks(self._success, self._failure)
@@ -36,7 +37,7 @@ class Follower(object):
 
     def _success(self, processtype):
         from twisted.internet import reactor
-        log.msg("The %s appears to have (re)started correctly." % processtype)
+        print("The %s appears to have (re)started correctly." % processtype)
         self.rc = 0
         reactor.stop()
 
@@ -45,13 +46,13 @@ class Follower(object):
         from buildbot_worker.scripts.logwatcher import BuildmasterTimeoutError, \
             ReconfigError, WorkerTimeoutError, WorkerDetectedError
         if why.check(BuildmasterTimeoutError):
-            log.msg("""
+            print("""
 The worker took more than 10 seconds to start, so we were unable to
 confirm that it started correctly. Please 'tail twistd.log' and look for a
 line that says 'configuration update complete' to verify correct startup.
 """)
         elif why.check(WorkerTimeoutError):
-            log.msg("""
+            print("""
 The worker took more than 10 seconds to start and/or connect to the
 buildslave, so we were unable to confirm that it started and connected
 correctly. Please 'tail twistd.log' and look for a line that says 'message
@@ -64,21 +65,21 @@ then your worker might be using the wrong botname or password. Please
 correct these problems and then restart the worker.
 """)
         elif why.check(ReconfigError):
-            log.msg("""
+            print("""
 The buildslave appears to have encountered an error in the master.cfg config
 file during startup. It is probably running with an empty configuration right
 now. Please inspect and fix master.cfg, then restart the buildslave.
 """)
         elif why.check(WorkerDetectedError):
-            log.msg("""
+            print("""
 Buildslave is starting up, not following logfile.
 """)
         else:
-            log.msg("""
+            print("""
 Unable to confirm that the worker started correctly. You may need to
 stop it, fix the config file, and restart.
 """)
-            log.msg(why)
+            print(why)
         self.rc = 1
         reactor.stop()
 

--- a/worker/buildbot_worker/scripts/stop.py
+++ b/worker/buildbot_worker/scripts/stop.py
@@ -13,10 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import print_function
+
 import os
 import time
-
-from twisted.python import log
 
 from buildbot_worker.scripts import base
 
@@ -65,12 +65,12 @@ def stopWorker(basedir, quiet, signame="TERM"):
             os.kill(pid, 0)
         except OSError:
             if not quiet:
-                log.msg("worker process %d is dead" % pid)
+                print("worker process %d is dead" % pid)
             return
         timer += 1
         time.sleep(1)
     if not quiet:
-        log.msg("never saw process go away")
+        print("never saw process go away")
 
 
 def stop(config, signame="TERM"):
@@ -84,6 +84,6 @@ def stop(config, signame="TERM"):
         stopWorker(basedir, quiet, signame)
     except WorkerNotRunning:
         if not quiet:
-            log.msg("worker not running")
+            print("worker not running")
 
     return 0

--- a/worker/buildbot_worker/test/unit/test_scripts_restart.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_restart.py
@@ -23,7 +23,7 @@ from twisted.trial import unittest
 
 
 class TestRestart(misc.IsWorkerDirMixin,
-                  misc.LoggingMixin,
+                  misc.StdoutAssertionsMixin,
                   unittest.TestCase):
 
     """
@@ -32,7 +32,7 @@ class TestRestart(misc.IsWorkerDirMixin,
     config = {"basedir": "dummy", "nodaemon": False, "quiet": False}
 
     def setUp(self):
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
         # patch start.startWorker() to do nothing
         self.startWorker = mock.Mock()
@@ -70,8 +70,8 @@ class TestRestart(misc.IsWorkerDirMixin,
                                                  self.config["quiet"],
                                                  self.config["nodaemon"])
 
-        self.assertLogged("no old worker process found to stop")
-        self.assertLogged("now restarting worker process..")
+        self.assertStdoutEqual("no old worker process found to stop\n"
+                               "now restarting worker process..\n")
 
     def test_restart(self):
         """
@@ -89,4 +89,4 @@ class TestRestart(misc.IsWorkerDirMixin,
         self.startWorker.assert_called_once_with(self.config["basedir"],
                                                  self.config["quiet"],
                                                  self.config["nodaemon"])
-        self.assertLogged("now restarting worker process..")
+        self.assertStdoutEqual("now restarting worker process..\n")

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -325,15 +325,13 @@ class TestOptions(misc.LoggingMixin, unittest.TestCase):
 functionPlaceholder = None
 
 
-class TestRun(misc.LoggingMixin, misc.StdoutAssertionsMixin,
-              unittest.TestCase):
+class TestRun(misc.StdoutAssertionsMixin, unittest.TestCase):
 
     """
     Test buildbot_worker.scripts.runner.run()
     """
 
     def setUp(self):
-        self.setUpLogging()
         self.setUpStdoutAssertions()
 
     class TestSubCommand(usage.Options):
@@ -390,10 +388,9 @@ class TestRun(misc.LoggingMixin, misc.StdoutAssertionsMixin,
 
         exception = self.assertRaises(SystemExit, runner.run)
         self.assertEqual(exception.code, 1, "unexpected exit code")
-        self.assertLogged("command:  usage-error-message",
-                          "GeneralUsage",
-                          "unexpected error message on stdout")
-        self.assertInStdout("command:  usage-error-message")
+        self.assertStdoutEqual("command:  usage-error-message\n\n"
+                               "GeneralUsage\n",
+                               "unexpected error message on stdout")
 
     def test_run_bad_suboption(self):
         """
@@ -409,7 +406,6 @@ class TestRun(misc.LoggingMixin, misc.StdoutAssertionsMixin,
         self.assertEqual(exception.code, 1, "unexpected exit code")
 
         # check that we get error message for a sub-option
-        self.assertLogged("command:  usage-error-message",
-                          "SubOptionUsage",
-                          "unexpected error message on stdout")
-        self.assertInStdout("command:  usage-error-message")
+        self.assertStdoutEqual("command:  usage-error-message\n\n"
+                               "SubOptionUsage\n",
+                               "unexpected error message on stdout")

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -291,14 +291,14 @@ class TestCreateWorkerOptions(OptionsMixin, unittest.TestCase):
                          "incorrect master host and/or port")
 
 
-class TestOptions(misc.LoggingMixin, unittest.TestCase):
+class TestOptions(misc.StdoutAssertionsMixin, unittest.TestCase):
 
     """
     Test buildbot_worker.scripts.runner.Options class.
     """
 
     def setUp(self):
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
     def parse(self, *args):
         opts = runner.Options()
@@ -313,7 +313,7 @@ class TestOptions(misc.LoggingMixin, unittest.TestCase):
     def test_version(self):
         exception = self.assertRaises(SystemExit, self.parse, '--version')
         self.assertEqual(exception.code, 0, "unexpected exit code")
-        self.assertLogged('worker version:')
+        self.assertInStdout('worker version:')
 
     def test_verbose(self):
         self.patch(log, 'startLogging', mock.Mock())

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -325,7 +325,8 @@ class TestOptions(misc.LoggingMixin, unittest.TestCase):
 functionPlaceholder = None
 
 
-class TestRun(misc.LoggingMixin, unittest.TestCase):
+class TestRun(misc.LoggingMixin, misc.StdoutAssertionsMixin,
+              unittest.TestCase):
 
     """
     Test buildbot_worker.scripts.runner.run()
@@ -333,6 +334,7 @@ class TestRun(misc.LoggingMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpLogging()
+        self.setUpStdoutAssertions()
 
     class TestSubCommand(usage.Options):
         subcommandFunction = __name__ + ".functionPlaceholder"
@@ -391,6 +393,7 @@ class TestRun(misc.LoggingMixin, unittest.TestCase):
         self.assertLogged("command:  usage-error-message",
                           "GeneralUsage",
                           "unexpected error message on stdout")
+        self.assertInStdout("command:  usage-error-message")
 
     def test_run_bad_suboption(self):
         """
@@ -409,3 +412,4 @@ class TestRun(misc.LoggingMixin, unittest.TestCase):
         self.assertLogged("command:  usage-error-message",
                           "SubOptionUsage",
                           "unexpected error message on stdout")
+        self.assertInStdout("command:  usage-error-message")

--- a/worker/buildbot_worker/test/unit/test_scripts_stop.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_stop.py
@@ -26,7 +26,7 @@ from twisted.trial import unittest
 
 
 class TestStopWorker(misc.FileIOMixin,
-                     misc.LoggingMixin,
+                     misc.StdoutAssertionsMixin,
                      unittest.TestCase):
 
     """
@@ -35,7 +35,7 @@ class TestStopWorker(misc.FileIOMixin,
     PID = 9876
 
     def setUp(self):
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
         # patch os.chdir() to do nothing
         self.patch(os, "chdir", mock.Mock())
@@ -75,16 +75,16 @@ class TestStopWorker(misc.FileIOMixin,
         self.patch(time, "sleep", mock.Mock())
 
         # check that stopWorker() sends expected signal to right PID
-        # and print correct message to the log
+        # and print correct message to stdout
         stop.stopWorker(None, False)
         mocked_kill.assert_has_calls([mock.call(self.PID, signal.SIGTERM),
                                       mock.call(self.PID, 0)])
 
-        self.assertLogged("worker process %s is dead" % self.PID)
+        self.assertStdoutEqual("worker process %s is dead\n" % self.PID)
 
 
 class TestStop(misc.IsWorkerDirMixin,
-               misc.LoggingMixin,
+               misc.StdoutAssertionsMixin,
                unittest.TestCase):
 
     """
@@ -110,7 +110,7 @@ class TestStop(misc.IsWorkerDirMixin,
         """
         test calling stop() when no worker is running
         """
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
         # patch basedir check to always succeed
         self.setupUpIsWorkerDir(True)
@@ -121,7 +121,7 @@ class TestStop(misc.IsWorkerDirMixin,
 
         stop.stop(self.config)
 
-        self.assertLogged("worker not running")
+        self.assertStdoutEqual("worker not running\n")
 
     def test_successful_stop(self):
         """
@@ -137,5 +137,5 @@ class TestStop(misc.IsWorkerDirMixin,
 
         stop.stop(self.config)
         mock_stopWorker.assert_called_once_with(self.config["basedir"],
-                                               self.config["quiet"],
-                                               "TERM")
+                                                self.config["quiet"],
+                                                "TERM")

--- a/worker/buildbot_worker/test/util/misc.py
+++ b/worker/buildbot_worker/test/util/misc.py
@@ -14,11 +14,13 @@
 # Copyright Buildbot Team Members
 
 import __builtin__
+import cStringIO
 import errno
 import mock
 import os
-import shutil
 import re
+import shutil
+import sys
 
 from twisted.python import log
 
@@ -165,3 +167,26 @@ class LoggingMixin(object):
 
     def assertWasQuiet(self):
         self.assertEqual(self._logEvents, [])
+
+
+class StdoutAssertionsMixin(object):
+
+    """
+    Mix this in to be able to assert on stdout during the test
+    """
+
+    def setUpStdoutAssertions(self):
+        self.stdout = cStringIO.StringIO()
+        self.patch(sys, 'stdout', self.stdout)
+
+    def assertWasQuiet(self):
+        self.assertEqual(self.stdout.getvalue(), '')
+
+    def assertInStdout(self, exp):
+        self.assertIn(exp, self.stdout.getvalue())
+
+    def assertStdoutEqual(self, exp, msg=None):
+        self.assertEqual(exp, self.stdout.getvalue(), msg)
+
+    def getStdout(self):
+        return self.stdout.getvalue().strip()


### PR DESCRIPTION
As alternative we can revert changes from 4d733e6 commit by @jvlomax
(in buildbot-worker copy).

By default Twisted log is not written anywhere so we don't see any
errors from buildbot-worker invocations, e.g.

```
$ buildbot-worker create-worker w
$ echo $?
1
$
```