### PR TITLE
fix typo `BuilderFactory()` in example

### DIFF
--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -803,10 +803,11 @@ GitHubStatus
                              context=context,
                              startDescription='Build started.',
                              endDescription='Build done.')
+    factory = util.BuildFactory()
     buildbot_bbtools = util.BuilderConfig(
         name='builder-name',
         workernames=['worker1'],
-        factory=BuilderFactory())
+        factory=factory)
     c['builders'].append(buildbot_bbtools)
     c['services'].append(gs)
 


### PR DESCRIPTION
Actually I don't see any implementation of `GitHubStatus` in Nine.

@tardyp what is with `GitHubStatus`? Is it removed in favor of `GithubStatusPush`?
We need to update docs if it is.

P.S. Same typo in eight branch. @sa2ajj is it you who maintains eight branch?