### PR TITLE
Fix issue builds and buildrequest display

### DIFF
--- a/www/base/src/app/builders/builder/builder.controller.coffee
+++ b/www/base/src/app/builders/builder/builder.controller.coffee
@@ -38,4 +38,4 @@ class Builder extends Controller
                     glTopbarContextualActionsService.setContextualActions(actions)
 
             $scope.builds = builder.getBuilds(limit:20, order:'-number')
-            $scope.buildrequests = builder.getBuildrequests(claimed:0)
+            $scope.buildrequests = builder.getBuildrequests(claimed:false)

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -22,11 +22,11 @@
           | &nbsp;
           a.label(ng-class="results2class(buildsummary.parentbuild)",
           ui-sref="build({builder:buildsummary.parentbuilder.builderid, build:buildsummary.parentbuild.number})")
-                | {{buildsummary.parentrelationship}}: 
+                | {{buildsummary.parentrelationship}}:
                 | {{buildsummary.parentbuilder.name}}/{{buildsummary.parentbuild.number}}
   ul.list-group.no-select
     li.list-group-item(ng-if="buildsummary.isStepDisplayed(step)", ng-repeat="step in buildsummary.steps")
-                       
+
       div(ng-click="step.fulldisplay=!step.fulldisplay")
           span.pull-right(ng-if="step.started_at")
             span(ng-show="step.complete")
@@ -49,7 +49,7 @@
                 | {{log.name}}
             | &nbsp;({{log.num_lines}} line{{log.num_lines > 1?'s':''}})
       ul
-        li(ng-if='!(isBuildRequestURL(url.url) || isBuildURL(url.url))', ng-repeat="url in step.urls")
+        li(ng-if='!(buildsummary.isBuildRequestURL(url.url) || buildsummary.isBuildURL(url.url))', ng-repeat="url in step.urls")
           a(target="_blank", ng-href="{{url.url}}") {{url.name}}
       ul.list-unstyled
         li(ng-if='buildsummary.isBuildRequestURL(url.url)', ng-repeat="url in step.urls")


### PR DESCRIPTION
When urls of builds are buildbot ones, the url was displayed twice
(as raw and as buildrequestsummary)
This patch allow to display raw url for external urls only
and as buildrequestsummary for buildbot urls only.

Fix issue to display correctly the list of build requests on the builder page