### PR TITLE
worker.openstack: Support novaclient 3.x

### DIFF
--- a/master/buildbot/test/fake/openstack.py
+++ b/master/buildbot/test/fake/openstack.py
@@ -23,10 +23,10 @@ ERROR = 'ERROR'
 UNKNOWN = 'UNKNOWN'
 
 
-# Parts used from novaclient.v1_1.
+# Parts used from novaclient
 class Client():
 
-    def __init__(self, username, password, tenant_name, auth_url):
+    def __init__(self, version, username, password, tenant_name, auth_url):
         self.images = Images()
         self.servers = Servers()
 

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -91,7 +91,7 @@ class TestOpenStackWorker(unittest.TestCase):
 
         bs = openstack.OpenStackLatentWorker('bot', 'pass', flavor=1,
                                              image=image_callable, **self.os_auth)
-        os_client = novaclient.Client('user', 'pass', 'tenant', 'auth')
+        os_client = novaclient.Client('1.1', 'user', 'pass', 'tenant', 'auth')
         os_client.images.images = ['uuid1', 'uuid2', 'uuid2']
         self.assertEqual('uuid1', bs._getImage(os_client, image_callable))
 

--- a/master/docs/manual/cfg-workers-openstack.rst
+++ b/master/docs/manual/cfg-workers-openstack.rst
@@ -15,7 +15,7 @@ This document will guide you through setup of an OpenStack latent worker:
 Install dependencies
 --------------------
 
-OpenStackLatentWorker requires python-novaclient v3.0 or newer to work, you can install it with pip install python-novaclient.
+OpenStackLatentWorker requires python-novaclient to work, you can install it with pip install python-novaclient.
 
 Get an Account in an OpenStack cloud
 ------------------------------------

--- a/master/docs/manual/cfg-workers-openstack.rst
+++ b/master/docs/manual/cfg-workers-openstack.rst
@@ -12,6 +12,11 @@ This document will guide you through setup of an OpenStack latent worker:
    :depth: 1
    :local:
 
+Install dependencies
+--------------------
+
+OpenStackLatentWorker requires python-novaclient v3.0 or newer to work, you can install it with pip install python-novaclient.
+
 Get an Account in an OpenStack cloud
 ------------------------------------
 
@@ -94,7 +99,12 @@ These are the same details set in either environment variables or passed as opti
 ``nova_args``
     (optional)
     A dict that will be appended to the arguments when creating a VM.
-    Buildbot uses the OpenStack Nova version 1.1 API.
+    Buildbot uses the OpenStack Nova version 1.1 API by default (see client_version).
+
+``client_version``
+    (optional)
+    Nova client version to use. Defaults to 1.1 (deprecated). Use 2 or 2.minor for
+    version 2 API.
 
 Here is the simplest example of configuring an OpenStack latent worker.
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -28,6 +28,7 @@ Features
 Fixes
 ~~~~~
 
+* OpenStackLatentWorker uses the novaclient API correctly now.
 
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Adds client_version support, which is required for python-novaclient 3.x.