### PR TITLE
Update buildsummary directive to display reason of the build.

### DIFF
--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
@@ -64,6 +64,10 @@ class _buildsummary extends Controller('common')
         @isBuildURL = (url) ->
             return buildURLMatcher.exec(url) != null
 
+        @getBuildProperty = (property) ->
+            hasProperty = self.properties && self.properties.hasOwnProperty(property)
+            return  if hasProperty then self.properties[property][0] else null
+
         @toggleFullDisplay = ->
             @fulldisplay = !@fulldisplay
             if @fullDisplay
@@ -83,6 +87,10 @@ class _buildsummary extends Controller('common')
 
             data.getBuilders(build.builderid).onNew = (builder) ->
                 self.builder = builder
+
+            build.getProperties().onNew = (properties) ->
+                self.properties = properties
+                self.reason = self.getBuildProperty('reason')
 
             self.steps = build.getSteps()
 

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -1,7 +1,7 @@
 .panel.panel-default(ng-class="results2class(buildsummary.build)")
   .panel-heading.no-select
     .row
-      .col-sm-5
+      .col-sm-6
         .btn.btn-xs.btn-default(ng-click="buildsummary.toggleFullDisplay()", title="Expand all step logs")
             i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':buildsummary.fulldisplay}")
         .btn.btn-xs.btn-default(ng-click="buildsummary.toggleDetails()", title="Show steps according to their importance")
@@ -10,11 +10,9 @@
         | &nbsp;
         span(ng-if="buildsummary.prefix") {{buildsummary.prefix}}&nbsp;
         a(ui-sref="build({builder:buildsummary.builder.builderid, build:buildsummary.build.number})")
-          | {{buildsummary.builder.name}}/{{buildsummary.build.number}}
-      .col-sm-4
-        span
-          | {{buildsummary.reason}}
-      .col-sm-3.text-right
+          | {{buildsummary.builder.name}}/{{buildsummary.build.number}}&nbsp;
+        span(ng-if="buildsummary.reason") |&nbsp;{{buildsummary.reason}}
+      .col-sm-6.text-right
           span(ng-show="buildsummary.build.complete")
               | {{(buildsummary.build.complete_at - buildsummary.build.started_at)| durationformat:'LLL' }}
           span(ng-show="!buildsummary.build.complete")

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -1,32 +1,36 @@
 .panel.panel-default(ng-class="results2class(buildsummary.build)")
   .panel-heading.no-select
-    .btn.btn-xs.btn-default(ng-click="buildsummary.toggleFullDisplay()", title="Expand all step logs")
-        i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':buildsummary.fulldisplay}")
-    .btn.btn-xs.btn-default(ng-click="buildsummary.toggleDetails()", title="Show steps according to their importance")
-        i.fa.fa-expand
-        {{buildsummary.levelOfDetails()}}
-    | &nbsp;
-    span(ng-if="buildsummary.prefix") {{buildsummary.prefix}}&nbsp;
-    a(ui-sref="build({builder:buildsummary.builder.builderid, build:buildsummary.build.number})")
-      | {{buildsummary.builder.name}}/{{buildsummary.build.number}}
-    .pull-right
-      span(ng-show="buildsummary.build.complete")
-          | {{(buildsummary.build.complete_at - buildsummary.build.started_at)| durationformat:'LLL' }}
-      span(ng-show="!buildsummary.build.complete")
-          | {{(buildsummary.now - buildsummary.build.started_at)| durationformat:'LLL' }}
-      span
-        | &nbsp;{{buildsummary.build.state_string}}&nbsp;
-      .label(ng-class="results2class(buildsummary.build)")
-        | {{results2text(buildsummary.build)}}
-      span(ng-if="buildsummary.parentbuild")
-          | &nbsp;
-          a.label(ng-class="results2class(buildsummary.parentbuild)",
-          ui-sref="build({builder:buildsummary.parentbuilder.builderid, build:buildsummary.parentbuild.number})")
-                | {{buildsummary.parentrelationship}}:
-                | {{buildsummary.parentbuilder.name}}/{{buildsummary.parentbuild.number}}
+    .row
+      .col-sm-5
+        .btn.btn-xs.btn-default(ng-click="buildsummary.toggleFullDisplay()", title="Expand all step logs")
+            i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':buildsummary.fulldisplay}")
+        .btn.btn-xs.btn-default(ng-click="buildsummary.toggleDetails()", title="Show steps according to their importance")
+            i.fa.fa-expand
+            {{buildsummary.levelOfDetails()}}
+        | &nbsp;
+        span(ng-if="buildsummary.prefix") {{buildsummary.prefix}}&nbsp;
+        a(ui-sref="build({builder:buildsummary.builder.builderid, build:buildsummary.build.number})")
+          | {{buildsummary.builder.name}}/{{buildsummary.build.number}}
+      .col-sm-4
+        span
+          | {{buildsummary.reason}}
+      .col-sm-3.text-right
+          span(ng-show="buildsummary.build.complete")
+              | {{(buildsummary.build.complete_at - buildsummary.build.started_at)| durationformat:'LLL' }}
+          span(ng-show="!buildsummary.build.complete")
+              | {{(buildsummary.now - buildsummary.build.started_at)| durationformat:'LLL' }}
+          span
+            | &nbsp;{{buildsummary.build.state_string}}&nbsp;
+          .label(ng-class="results2class(buildsummary.build)")
+            | {{results2text(buildsummary.build)}}
+          span(ng-if="buildsummary.parentbuild")
+              | &nbsp;
+              a.label(ng-class="results2class(buildsummary.parentbuild)",
+              ui-sref="build({builder:buildsummary.parentbuilder.builderid, build:buildsummary.parentbuild.number})")
+                    | {{buildsummary.parentrelationship}}:
+                    | {{buildsummary.parentbuilder.name}}/{{buildsummary.parentbuild.number}}
   ul.list-group.no-select
     li.list-group-item(ng-if="buildsummary.isStepDisplayed(step)", ng-repeat="step in buildsummary.steps")
-
       div(ng-click="step.fulldisplay=!step.fulldisplay")
           span.pull-right(ng-if="step.started_at")
             span(ng-show="step.complete")


### PR DESCRIPTION
Some users need to have the reason of the build directly in the buildsummary
view.
This patch get the 'reason' property of the build then display it in the
buildsummary view.
Use bootstrap grid to display panel containing: build/build#, reason ...
Refer to screenshot
<img width="960" alt="display_reason" src="https://cloud.githubusercontent.com/assets/12556701/14565822/2eba92f8-032d-11e6-975f-60ea1c51b08a.png">


Change-Id: I4502eefff63b58b7a6d88ec4aa51ee4bba504d82