### PR TITLE
Bump angularjs dependencies

### DIFF
--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -86,6 +86,11 @@ class BuildsetsEndpoint(Db2DataMixin, base.Endpoint):
 
         @d.addCallback
         def db2data(buildsets):
+            # buildset db2data is pretty heavy. for the sake of console_view prefilter the data
+            # should fix it properly in http://trac.buildbot.net/ticket/3537
+            if (resultSpec.order == ['-submitted_at'] and resultSpec.limit and resultSpec.offset is None):
+                buildsets.sort(key=lambda x: x['submitted_at'], reverse=True)
+                buildsets = buildsets[:resultSpec.limit]
             d = defer.DeferredList([self.db2data(bs) for bs in buildsets],
                                    fireOnOneErrback=True, consumeErrors=True)
 

--- a/www/base/guanlecoja/config.coffee
+++ b/www/base/guanlecoja/config.coffee
@@ -3,7 +3,7 @@
 #   This module contains all configuration for the build process
 #
 ### ###############################################################################################
-ANGULAR_TAG = "~1.4.6"
+ANGULAR_TAG = "~1.5.3"
 gulp = require("gulp")
 path = require("path")
 shell = require("gulp-shell")

--- a/www/base/guanlecoja/config.coffee
+++ b/www/base/guanlecoja/config.coffee
@@ -30,7 +30,7 @@ config =
         # JavaScript libraries (order matters)
         deps:
             "guanlecoja-ui":
-                version: '~1.5.0'
+                version: '~1.6.0'
                 files: ['vendors.js', 'scripts.js']
             moment:
                 version: "~2.6.0"

--- a/www/base/src/app/builders/buildrequest/buildrequest.tpl.jade
+++ b/www/base/src/app/builders/buildrequest/buildrequest.tpl.jade
@@ -1,11 +1,11 @@
 .container
   .row
-      tabset(justified="left")
-          tab(heading="build {{build.number}}", active="build.active", ng-repeat="build in builds")
+      uib-tabset(justified="left")
+          uib-tab(heading="build {{build.number}}", active="build.active", ng-repeat="build in builds")
               buildsummary(build="build")
-          tab(heading="properties")
+          uib-tab(heading="properties")
               properties(properties="properties")
-          tab(heading="Debug")
+          uib-tab(heading="Debug")
               h4 Buildrequest
               rawdata(data="buildrequest")
               h4 Buildset

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.config.coffee
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.config.coffee
@@ -3,9 +3,9 @@ class State extends Config
         $stateProvider.state "builder.forcebuilder",
             url: "/force/:scheduler",
             ### @ngInject ###
-            onEnter: ($stateParams, $state, $modal) ->
+            onEnter: ($stateParams, $state, $uibModal) ->
                 modal = {}
-                modal.modal = $modal.open
+                modal.modal = $uibModal.open
                     templateUrl: "views/forcedialog.html"
                     controller: 'forceDialogController'
                     windowClass: 'modal-xlg'

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.controller.coffee
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.controller.coffee
@@ -32,6 +32,7 @@ class forceDialog extends Controller
                     gatherFields = (fields) ->
                         for field in fields
                             field.errors = ''
+                            field.haserrors = false
                             if field.fields?
                                 gatherFields(field.fields)
                             else
@@ -46,6 +47,7 @@ class forceDialog extends Controller
                         if err.error.code == -32602
                             for k, v of err.error.message
                                 fields_ref[k].errors = v
+                                fields_ref[k].haserrors = true
                         else
                             $scope.error = err.error.message
                 cancel: ->

--- a/www/base/src/app/builders/builds/build.tpl.jade
+++ b/www/base/src/app/builders/builds/build.tpl.jade
@@ -13,13 +13,13 @@
             span.badge-status(ng-class="results2class(nextbuild, 'pulse')") &rarr;
         span(ng-if="last_build") Next &rarr;
   .row
-      tabset
-          tab(heading="Build steps")
+      uib-tabset
+          uib-tab(heading="Build steps")
               buildsummary(ng-if="build", build="build", parentbuild="parent_build",
                            parentrelationship="buildset.parent_relationship")
-          tab(heading="Build Properties")
+          uib-tab(heading="Build Properties")
               properties(properties="properties")
-          tab(heading="Worker: {{worker.name}}")
+          uib-tab(heading="Worker: {{worker.name}}")
             table.table.table-hover.table-striped.table-condensed
               tbody
                   tr
@@ -28,16 +28,16 @@
                 tr(ng-repeat="(name, value) in worker.workerinfo")
                   td.text-left {{ name }}
                   td.text-right {{ value }}
-          tab(heading="Responsible Users")
+          uib-tab(heading="Responsible Users")
             ul.list-group
                 li.list-group-item(ng-repeat="(author, email) in responsibles")
                     .change-avatar
                         img(ng-src="avatar?email={{email}}")
                     a(ng-href="mailto:{{email}}")
                         | {{ author }}
-          tab(heading="Changes")
+          uib-tab(heading="Changes")
               changelist(changes="changes")
-          tab(heading="Debug")
+          uib-tab(heading="Debug")
               h4
                   a(ui-sref="buildrequest({buildrequest:buildrequest.buildrequestid})")
                      | Buildrequest:

--- a/www/base/src/app/builders/log/logviewer/scrollviewport.directive.coffee
+++ b/www/base/src/app/builders/log/logviewer/scrollviewport.directive.coffee
@@ -92,7 +92,7 @@ class Scroll extends Directive
                         # Replace angularjs linker by _.template, which is much faster
                         rowTemplate = "<#{repeaterType} style='height:#{rowHeight}px;'>" +
                             "#{template[0].innerHTML}</#{repeaterType}>"
-                        rowTemplate = _.template(rowTemplate,null, interpolate: /\{\{::(.+?)\}\}/g )
+                        rowTemplate = _.template(rowTemplate, interpolate: /\{\{::(.+?)\}\}/g )
                         linker = (scope, cb) ->
                             cb(angular.element(rowTemplate(scope)))
 

--- a/www/base/src/app/builders/log/logviewer/scrollviewport.spec.coffee
+++ b/www/base/src/app/builders/log/logviewer/scrollviewport.spec.coffee
@@ -1,8 +1,8 @@
 describe 'page with sidebar', ->
     beforeEach (module("app"))
     elmBody = scope = rootScope = queries = timeout = null
-    padding = (pix) -> type:"padding", height:pix
-    elements = (start, end) -> type:"elements", start:start, end:end
+    padding = (pix) -> type: "padding", height: pix
+    elements = (start, end) -> type: "elements", start: start, end: end
 
     assertDOM = (l) ->
         childs = []
@@ -55,7 +55,7 @@ describe 'page with sidebar', ->
                 d = $q.defer()
                 $timeout ->
                     ret = []
-                    ret.push(v:(index + i)) for i in [0..num - 1]
+                    ret.push(v: (index + i)) for i in [0..num - 1]
                     d.resolve(ret)
                 return d.promise
         $compile(elmBody)(scope)[0]

--- a/www/base/src/app/common/directives/basefield/basefield.directive.coffee
+++ b/www/base/src/app/common/directives/basefield/basefield.directive.coffee
@@ -10,8 +10,9 @@ class Basefield extends Directive('common')
             controller: '_basefieldController'
         }
 
+
 class _basefield extends Controller('common')
     constructor: ($scope) ->
         # clear error on value change
         $scope.$watch "field.value", (o,n) ->
-            $scope.field.errors = ""
+            $scope.field.haserrors = false

--- a/www/base/src/app/common/directives/basefield/basefield.tpl.jade
+++ b/www/base/src/app/common/directives/basefield/basefield.tpl.jade
@@ -1,9 +1,5 @@
 div
-    div.form-group(ng-class="{'has-warning': field.warnings,'has-error': field.errors}")
-        div(ng-transclude)
-        .popover.bottom.anim-popover(ng-if="field.errors", style="display:block;top:40px")
-            h5.popover-title
-                | {{field.label}}:
-            .popover-content
-                p {{field.errors}}
-            .arrow
+    div.form-group(ng-class="{'has-warning': field.warnings,'has-error': field.haserrors}")
+        div(ng-transclude,
+            uib-popover="{{field.errors}}", popover-title="{{field.label}}",
+            popover-is-open="field.haserrors", popover-trigger="none")

--- a/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.coffee
@@ -3,7 +3,7 @@ class Buildrequestsummary extends Directive('common')
         return {
             replace: true
             restrict: 'E'
-            scope: {buildrequestid: '='}
+            scope: {buildrequestid: '=?'}
             templateUrl: 'views/buildrequestsummary.html'
             compile: RecursionHelper.compile
             controller: '_buildrequestsummaryController'

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.coffee
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.coffee
@@ -3,7 +3,7 @@ class Buildsticker extends Directive('common')
         return {
             replace: true
             restrict: 'E'
-            scope: {build: '=', builder:'='}
+            scope: {build: '=?', builder: '=?'}
             templateUrl: 'views/buildsticker.html'
             controller: '_buildstickerController'
         }
@@ -17,6 +17,6 @@ class _buildsticker extends Controller('common')
 
         data = dataService.open().closeOnDestroy($scope)
         $scope.$watch 'build', (build) ->
-            if not $scope.builder?
-                data.getBuilders(build.builderid).then (builders) ->
-                    $scope.builder = builders[0]
+            if not $scope.builder
+                data.getBuilders(build.builderid).onNew = (builder) ->
+                    $scope.builder = builder

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.coffee
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.coffee
@@ -1,7 +1,7 @@
 beforeEach module 'app'
 
 describe 'buildsticker controller', ->
-    dataService = scope = $compile = results = $timeout = null
+    dataService = scope = $compile = results = $timeout = $rootScope = null
 
     injected = ($injector) ->
         $compile = $injector.get('$compile')
@@ -19,10 +19,12 @@ describe 'buildsticker controller', ->
         build = buildid: 3, builderid: 2, number: 1
         dataService.when('builds/3', [build])
         dataService.when('builders/2', [{builderid: 2}])
-        dataService.getBuilds(build.buildid).then (builds) ->
-            scope.build = builds[0]
+        data = dataService.open()
+        data.getBuilds(build.buildid).onNew = (build) ->
+            scope.build = build
         element = $compile("<buildsticker build='build'></buildsticker>")(scope)
         $timeout.flush()
+        $rootScope.$digest()
 
         sticker = element.children().eq(0)
 

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
@@ -4,7 +4,7 @@ class Buildsummary extends Directive('common')
             replace: true
             restrict: 'E'
             scope: {}
-            bindToController: {buildid: '=', build: '=', condensed: '=', parentbuild: '=', parentrelationship: '='}
+            bindToController: {buildid: '=?', build: '=?', condensed: '=?', parentbuild: '=?', parentrelationship: '=?'}
             templateUrl: 'views/buildsummary.html'
             compile: RecursionHelper.compile
             controller: '_buildsummaryController'

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -6,7 +6,7 @@
             i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':buildsummary.fulldisplay}")
         .btn.btn-xs.btn-default(ng-click="buildsummary.toggleDetails()", title="Show steps according to their importance")
             i.fa.fa-expand
-            {{buildsummary.levelOfDetails()}}
+            | {{buildsummary.levelOfDetails()}}
         | &nbsp;
         span(ng-if="buildsummary.prefix") {{buildsummary.prefix}}&nbsp;
         a(ui-sref="build({builder:buildsummary.builder.builderid, build:buildsummary.build.number})")
@@ -28,7 +28,8 @@
                     | {{buildsummary.parentrelationship}}:
                     | {{buildsummary.parentbuilder.name}}/{{buildsummary.parentbuild.number}}
   ul.list-group.no-select
-    li.list-group-item(ng-if="buildsummary.isStepDisplayed(step)", ng-repeat="step in buildsummary.steps")
+    li.list-group-item(ng-if="buildsummary.isStepDisplayed(step)"
+                       ng-repeat="step in buildsummary.steps | orderBy: ['stepid']")
       div(ng-click="step.fulldisplay=!step.fulldisplay")
           span.pull-right(ng-if="step.started_at")
             span(ng-show="step.complete")

--- a/www/base/src/app/common/directives/changelist/changelist.directive.coffee
+++ b/www/base/src/app/common/directives/changelist/changelist.directive.coffee
@@ -3,7 +3,7 @@ class Changelist extends Directive('common')
         return {
             replace: true
             restrict: 'E'
-            scope: {changes: '='}
+            scope: {changes: '=?'}
             templateUrl: 'views/changelist.html'
             controller: '_changeListController'
         }

--- a/www/base/src/app/common/directives/connectionstatus/connectionstatus.directive.coffee
+++ b/www/base/src/app/common/directives/connectionstatus/connectionstatus.directive.coffee
@@ -3,7 +3,7 @@ class connectionstatus extends Directive('common')
         return {
             replace: true
             restrict: 'E'
-            scope: {data:'='}
+            scope: {}
             templateUrl: 'views/connectionstatus.html'
             compile: RecursionHelper.compile
             controller: '_connectionstatusController'

--- a/www/base/src/app/common/directives/forcefields/tabslayout.tpl.jade
+++ b/www/base/src/app/common/directives/forcefields/tabslayout.tpl.jade
@@ -1,6 +1,6 @@
 div
-    tabset(justified="true")
-        tab(ng-repeat='field in field.fields | filter:{hide:false}',
+    uib-tabset(justified="true")
+        uib-tab(ng-repeat='field in field.fields | filter:{hide:false}',
             heading="{{field.tablabel}}",
             class="{{column_class}}")
             forcefield(recursive,

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -3,7 +3,6 @@
 @import "../../libs/font-awesome/less/font-awesome.less";
 @import (inline) "../../libs/guanlecoja-ui/styles.css";
 @fa-font-path: "./fonts";
-
 /* base css for angular, dont display anything until angular is running */
 [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
   display: none !important;
@@ -29,9 +28,9 @@
   }
 }
 
-/* make the sidebar be on the back when dialog is open */
-.modal-open .sidebar {
-    z-index: 0;
+/* make the sidebar be on the back of the modals dialog */
+.sidebar {
+    z-index: (@zindex-modal - 1) !important;
 }
 
 /* button bar inside the breadcrum, used for forcesched buttons */

--- a/www/codeparameter/guanlecoja/config.coffee
+++ b/www/codeparameter/guanlecoja/config.coffee
@@ -3,7 +3,7 @@
 #   This module contains all configuration for the build process
 #
 ### ###############################################################################################
-ANGULAR_TAG = "~1.3.0"
+ANGULAR_TAG = "~1.5.3"
 gulp = require("gulp")
 
 gulp.task "copyace", ->

--- a/www/codeparameter/package.json
+++ b/www/codeparameter/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "gulp": "3.9.0",
-        "guanlecoja": "~0.5.3"
+        "guanlecoja": "~0.6.0"
     }
 }

--- a/www/console_view/guanlecoja/config.coffee
+++ b/www/console_view/guanlecoja/config.coffee
@@ -3,7 +3,7 @@
 #   This module contains all configuration for the build process
 #
 ### ###############################################################################################
-ANGULAR_TAG = "~1.4.6"
+ANGULAR_TAG = "~1.5.3"
 module.exports =
 
     ### ###########################################################################################
@@ -14,13 +14,13 @@ module.exports =
     bower:
         testdeps:
             "guanlecoja-ui":
-                version: '~1.5.0'
+                version: '~1.6.0'
                 files: ['vendors.js', 'scripts.js']
             "angular-mocks":
                 version: ANGULAR_TAG
                 files: "angular-mocks.js"
             'buildbot-data':
-                version: '~1.0.14'
+                version: '~2.0.0'
                 files: 'dist/buildbot-data.js'
 
     karma:

--- a/www/console_view/package.json
+++ b/www/console_view/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "gulp": "3.9.0",
-        "guanlecoja": "~0.5.3"
+        "guanlecoja": "~0.6.0"
     }
 }

--- a/www/console_view/src/module/console.tpl.jade
+++ b/www/console_view/src/module/console.tpl.jade
@@ -15,8 +15,7 @@
                 builders-header(builders='c.builders' width='c.width' cell-width='c.cellWidth')
     .content
         .change-rows(ng-style='{width: c.width}')
-            change-row(ng-repeat="change in c.changes | filter: search | orderBy: 'changeid':true track by change.changeid"
+            change-row(ng-repeat="change in c.changes | filter: search | orderBy: ['changeid'] track by change.changeid"
                        change='change'
-                       builders='builders'
                        width='c.width'
                        cell-width='c.cellWidth')

--- a/www/console_view/src/module/console.tpl.jade
+++ b/www/console_view/src/module/console.tpl.jade
@@ -7,8 +7,8 @@
         .header-content(ng-style='{width: c.width}')
             .col-15
                 .buttons
-                    i.fa.fa-plus-circle(ng-click='c.openAll()' tooltip='Open information for all changes' tooltip-placement='right')
-                    i.fa.fa-minus-circle(ng-click='c.closeAll()' tooltip='Close information for all changes' tooltip-placement='right')
+                    i.fa.fa-plus-circle(ng-click='c.openAll()' uib-tooltip='Open information for all changes' uib-tooltip-placement='right')
+                    i.fa.fa-minus-circle(ng-click='c.closeAll()' uib-tooltip='Close information for all changes' uib-tooltip-placement='right')
                 .search-field
                     input(type='text' name='search' ng-model='search' placeholder='search')
             .col-85

--- a/www/console_view/src/module/main.module.coffee
+++ b/www/console_view/src/module/main.module.coffee
@@ -51,7 +51,7 @@ class Console extends Controller
             return not v.masterids? or v.masterids.length > 0
 
         @$scope.builds = @builds = @dataAccessor.getBuilds({limit: @buildLimit, order: '-complete_at'})
-        @changes = @dataAccessor.getChanges({limit: @changeLimit, order: '-when_timestamp'})
+        @changes = @dataAccessor.getChanges({limit: @changeLimit, order: '-changeid'})
         @buildrequests = @dataAccessor.getBuildrequests({limit: @buildLimit, order: '-submitted_at'})
         @buildsets = @dataAccessor.getBuildsets({limit: @buildLimit, order: '-submitted_at'})
 

--- a/www/console_view/src/module/main.module.coffee
+++ b/www/console_view/src/module/main.module.coffee
@@ -62,13 +62,24 @@ class Console extends Controller
         # @todo: no way to know if there are no builds, or if its not yet loaded
         if @builds.length == 0 or @builders.length == 0 or @changes.length == 0 or @buildsets.length == 0 or @buildrequests == 0
             return
-        @loading = false
+
+        @changesBySSID = {}
+        for change in @changes
+            @changesBySSID[change.sourcestamp.ssid] = change
+            change.builders = []
+            change.buildersById = {}
+            for builder in @builders
+                builder = builderid:builder.builderid, name:builder.name, builds: []
+                change.builders.push(builder)
+                change.buildersById[builder.builderid] = builder
 
         for build in @builds
             @matchBuildWithChange(build)
+
         for change in @changes
             change.maxbuilds = 1
-            for k, b of change.buildsPerBuilder
+            for builder in change.builders
+                b = builder.builds
                 if b.length > change.maxbuilds
                     change.maxbuilds = b.length
 
@@ -76,6 +87,8 @@ class Console extends Controller
         angular.element(@$window).bind 'resize', =>
             @setWidth(@$window.innerWidth)
             @$scope.$apply()
+
+        @loading = false
 
     ###
     # Match builds with a change
@@ -88,12 +101,9 @@ class Console extends Controller
         if not buildset? or not buildset.sourcestamps?
             return
         for sourcestamp in buildset.sourcestamps
-            for change in @changes
-                if change.sourcestamp.ssid == sourcestamp.ssid
-                    change.buildsPerBuilder ?= {}
-                    change.buildsPerBuilder[build.builderid] ?= []
-                    if build not in change.buildsPerBuilder[build.builderid]
-                        change.buildsPerBuilder[build.builderid].push(build)
+            change = @changesBySSID[sourcestamp.ssid]
+            if change?
+                change.buildersById[build.builderid].builds.push(build)
     ###
     # Set the content width
     ###

--- a/www/console_view/src/module/main.module.spec.coffee
+++ b/www/console_view/src/module/main.module.spec.coffee
@@ -145,9 +145,9 @@ describe 'Console view controller', ->
         createController()
         $timeout.flush()
         expect(scope.c.changes[0]).toBeDefined()
-        expect(scope.c.changes[0].buildsPerBuilder).toBeDefined()
-        builds = scope.c.changes[0].buildsPerBuilder
-        expect(builds[1][0].buildid).toBe(1)
-        expect(builds[2][0].buildid).toBe(2)
-        expect(builds[3][0].buildid).toBe(4)
-        expect(builds[4][0].buildid).toBe(3)
+        expect(scope.c.changes[0].builders).toBeDefined()
+        builders = scope.c.changes[0].builders
+        expect(builders[0].builds[0].buildid).toBe(1)
+        expect(builders[1].builds[0].buildid).toBe(2)
+        expect(builders[2].builds[0].buildid).toBe(4)
+        expect(builders[3].builds[0].buildid).toBe(3)

--- a/www/console_view/src/module/view/builders-header/buildersheader.directive.coffee
+++ b/www/console_view/src/module/view/builders-header/buildersheader.directive.coffee
@@ -6,7 +6,7 @@ class BuildersHeader extends Directive
             scope: {
                 width: '='
                 cellWidth: '='
-                builders: '='
+                builders: '=?'
             }
             templateUrl: 'console_view/views/buildersheader.html'
             controller: '_buildersHeaderController'

--- a/www/console_view/src/module/view/change-row/changerow.directive.coffee
+++ b/www/console_view/src/module/view/change-row/changerow.directive.coffee
@@ -16,7 +16,7 @@ class ChangeRow extends Directive
 
 
 class _changeRow extends Controller
-    constructor: ($scope, resultsService, @$modal) ->
+    constructor: ($scope, resultsService, @$uibModal) ->
         angular.extend this, resultsService
         @infoIsCollapsed = true
 
@@ -36,7 +36,7 @@ class _changeRow extends Controller
         @change.link = "#{repository}/commit/#{@change.revision}"
 
     selectBuild: (build) ->
-        modal = @$modal.open
+        modal = @$uibModal.open
             templateUrl: 'console_view/views/modal.html'
             controller: 'consoleModalController as modal'
             windowClass: 'modal-small'

--- a/www/console_view/src/module/view/change-row/changerow.directive.coffee
+++ b/www/console_view/src/module/view/change-row/changerow.directive.coffee
@@ -6,8 +6,7 @@ class ChangeRow extends Directive
             scope: {
                 width: '='
                 cellWidth: '='
-                change: '='
-                builders: '='
+                change: '=?'
             }
             templateUrl: 'console_view/views/changerow.html'
             controller: '_changeRowController'
@@ -29,7 +28,6 @@ class _changeRow extends Controller
             if @change
                 if angular.isString(@change.repository)
                     @createLink()
-        $scope.$watch 'builders', (@builders) ->
 
     createLink: ->
         repository = @change.repository.replace('.git', '')

--- a/www/console_view/src/module/view/change-row/changerow.directive.spec.coffee
+++ b/www/console_view/src/module/view/change-row/changerow.directive.spec.coffee
@@ -3,7 +3,7 @@ beforeEach ->
     # Mock resultsService
     module ($provide) ->
         $provide.service 'resultsService', ->
-        $provide.service '$modal', ->
+        $provide.service '$uibModal', ->
         null
 
 describe 'Change row directive controller', ->

--- a/www/console_view/src/module/view/change-row/changerow.tpl.jade
+++ b/www/console_view/src/module/view/change-row/changerow.tpl.jade
@@ -12,9 +12,9 @@
                 span(ng-if='!cr.change.author_email')  {{ cr.change.author }}
     .col-85
         .builds
-            span.build(ng-repeat="builder in builders | orderBy: 'name' track by builder.builderid"
-                 ng-style="{'width': cr.cellWidth}", title="{{builder.name}}")
-                a(ng-repeat="build in cr.change.buildsPerBuilder[builder.builderid] track by $index| orderBy:'started_at'")
+            span.build(ng-repeat="builder in change.builders | orderBy: ['name'] track by builder.builderid"
+                       ng-style="{'width': cr.cellWidth}", title="{{builder.name}}")
+                a(ng-repeat="build in builder.builds | orderBy: ['started_at']")
                     .badge-status(ng-if='build.buildid'
                                   ng-class="cr.results2class(build, 'pulse')"
                                   ng-click='cr.selectBuild(build)')

--- a/www/console_view/src/module/view/change-row/changerow.tpl.jade
+++ b/www/console_view/src/module/view/change-row/changerow.tpl.jade
@@ -4,7 +4,7 @@
             .change-avatar
                 img(ng-src="avatar?email={{cr.change.author_email}}")
             i.fa.fa-chevron-circle-right(ng-click='cr.toggleInfo()' ng-class="{'fa-rotate-90': !cr.infoIsCollapsed}")
-            span(tooltip='{{ cr.change.comments }}' tooltip-placement='top')
+            span(uib-tooltip='{{ cr.change.comments }}' uib-tooltip-placement='top')
                 a(ng-if='cr.change.author_email'
                   ng-href='mailto: {{cr.change.author_email}}'
                   target='_blank')

--- a/www/console_view/src/module/view/change-row/modal/modal.controller.coffee
+++ b/www/console_view/src/module/view/change-row/modal/modal.controller.coffee
@@ -1,7 +1,7 @@
 class ConsoleModal extends Controller
-    constructor: ($scope, @$modalInstance, @selectedBuild) ->
+    constructor: ($scope, @$uibModalInstance, @selectedBuild) ->
         $scope.$on '$stateChangeStart', =>
             @close()
 
     close: ->
-        @$modalInstance.close()
+        @$uibModalInstance.close()

--- a/www/data_module/guanlecoja/config.coffee
+++ b/www/data_module/guanlecoja/config.coffee
@@ -3,7 +3,7 @@
 #   This module contains all configuration for the build process
 #
 ### ###############################################################################################
-ANGULAR_TAG = '~1.4.1'
+ANGULAR_TAG = "~1.5.3"
 
 gulp = require('gulp')
 require("shelljs/global")

--- a/www/data_module/package.json
+++ b/www/data_module/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/buildbot/buildbot-data-js.git"
   },
   "dependencies": {
-    "guanlecoja": "latest",
+    "guanlecoja": "~0.6.0",
     "gulp": "^3.9.0",
     "shelljs": "~0.5.3"
   },

--- a/www/md_base/guanlecoja/config.coffee
+++ b/www/md_base/guanlecoja/config.coffee
@@ -3,7 +3,7 @@
 #   This module contains all configuration for the build process
 #
 ### ###############################################################################################
-ANGULAR_TAG = '~1.4.1'
+ANGULAR_TAG = "~1.5.3"
 ANGULAR_MATERIAL_TAG = '~0.10.0'
 
 path = require('path')

--- a/www/md_base/guanlecoja/config.coffee
+++ b/www/md_base/guanlecoja/config.coffee
@@ -3,7 +3,7 @@
 #   This module contains all configuration for the build process
 #
 ### ###############################################################################################
-ANGULAR_TAG = "~1.5.3"
+ANGULAR_TAG = "~1.4.1"
 ANGULAR_MATERIAL_TAG = '~0.10.0'
 
 path = require('path')

--- a/www/md_base/package.json
+++ b/www/md_base/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "dependencies": {
-    "guanlecoja": "~0.5.3",
+    "guanlecoja": "~0.6.0",
     "gulp": "3.9.0",
     "gulp-shell": "^0.4.0",
     "gulp-svg-symbols": "^0.3.1",

--- a/www/nestedexample/guanlecoja/config.coffee
+++ b/www/nestedexample/guanlecoja/config.coffee
@@ -3,7 +3,7 @@
 #   This module contains all configuration for the build process
 #
 ### ###############################################################################################
-ANGULAR_TAG = "~1.3.0"
+ANGULAR_TAG = "~1.5.3"
 
 config =
 

--- a/www/nestedexample/package.json
+++ b/www/nestedexample/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "gulp": "3.9.0",
-        "guanlecoja": "~0.5.3"
+        "guanlecoja": "~0.6.0"
     }
 }

--- a/www/waterfall_view/guanlecoja/config.coffee
+++ b/www/waterfall_view/guanlecoja/config.coffee
@@ -3,7 +3,7 @@
 #   This module contains all configuration for the build process
 #
 ### ###############################################################################################
-ANGULAR_TAG = "~1.4.6"
+ANGULAR_TAG = "~1.5.3"
 module.exports =
 
     ### ###########################################################################################
@@ -15,7 +15,7 @@ module.exports =
         testdeps:
             # vendors.js includes jquery, angularjs, etc in the right order
             "guanlecoja-ui":
-                version: '~1.5.0'
+                version: '~1.6.0'
                 files: ['vendors.js', 'scripts.js']
             "angular-mocks":
                 version: ANGULAR_TAG
@@ -24,7 +24,7 @@ module.exports =
                 version: "3.4.11"
                 files: "d3.js"
             'buildbot-data':
-                version: '~1.0.14'
+                version: '~2.0.0'
                 files: 'dist/buildbot-data.js'
     karma:
         # we put tests first, so that we have angular, and fake app defined

--- a/www/waterfall_view/package.json
+++ b/www/waterfall_view/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "gulp": "3.9.0",
-        "guanlecoja": "~0.5.3"
+        "guanlecoja": "~0.6.0"
     }
 }

--- a/www/waterfall_view/src/module/main.module.coffee
+++ b/www/waterfall_view/src/module/main.module.coffee
@@ -11,7 +11,7 @@ class WaterfallView extends App
 class Waterfall extends Controller
     self = null
     constructor: (@$scope, $q, $timeout, @$window, @$log,
-                  @$modal, dataService, d3Service, @dataProcessorService,
+                  @$uibModal, dataService, d3Service, @dataProcessorService,
                   scaleService, @bbSettingsService) ->
         self = this
 
@@ -491,7 +491,7 @@ class Waterfall extends Controller
 
     click: (build) ->
         # Open modal on click
-        modal = self.$modal.open
+        modal = self.$uibModal.open
             templateUrl: 'waterfall_view/views/modal.html'
             controller: 'waterfallModalController as modal'
             windowClass: 'modal-small'

--- a/www/waterfall_view/src/module/main.module.spec.coffee
+++ b/www/waterfall_view/src/module/main.module.spec.coffee
@@ -1,6 +1,6 @@
 beforeEach ->
     module ($provide) ->
-        $provide.service '$modal', -> open: ->
+        $provide.service '$uibModal', -> open: ->
         null
 
     # Mock bbSettingsProvider
@@ -20,7 +20,7 @@ beforeEach ->
     module 'waterfall_view'
 
 describe 'Waterfall view controller', ->
-    $rootScope = $state = elem = w = $document = $window = $modal = $timeout =
+    $rootScope = $state = elem = w = $document = $window = $uibModal = $timeout =
         bbSettingsService = dataService = null
 
     builders = [
@@ -95,7 +95,7 @@ describe 'Waterfall view controller', ->
         $state = $injector.get('$state')
         $document = $injector.get('$document')
         $window = $injector.get('$window')
-        $modal = $injector.get('$modal')
+        $uibModal = $injector.get('$uibModal')
         $timeout = $injector.get('$timeout')
         bbSettingsService = $injector.get('bbSettingsService')
         dataService = $injector.get('dataService')

--- a/www/waterfall_view/src/module/modal/modal.controller.coffee
+++ b/www/waterfall_view/src/module/modal/modal.controller.coffee
@@ -1,7 +1,7 @@
 class WaterfallModal extends Controller
-    constructor: ($scope, @$modalInstance, @selectedBuild) ->
+    constructor: ($scope, @$uibModalInstance, @selectedBuild) ->
         $scope.$on '$stateChangeStart', =>
             @close()
 
     close: ->
-        @$modalInstance.close()
+        @$uibModalInstance.close()

--- a/www/waterfall_view/src/module/modal/modal.controller.spec.coffee
+++ b/www/waterfall_view/src/module/modal/modal.controller.spec.coffee
@@ -1,16 +1,16 @@
 beforeEach ->
     # Mock modalService
     module ($provide) ->
-        $provide.service '$modalInstance', -> close: ->
+        $provide.service '$uibModalInstance', -> close: ->
         null
 
 describe 'Waterfall modal controller', ->
-    createController = $rootScope = $modalInstance = scope = null
+    createController = $rootScope = $uibModalInstance = scope = null
 
     injected = ($injector) ->
         $controller = $injector.get('$controller')
         $rootScope = $injector.get('$rootScope')
-        $modalInstance = $injector.get('$modalInstance')
+        $uibModalInstance = $injector.get('$uibModalInstance')
         scope = $rootScope.$new()
 
         createController = ->
@@ -35,10 +35,10 @@ describe 'Waterfall modal controller', ->
         $rootScope.$broadcast('$stateChangeStart')
         expect(m.close).toHaveBeenCalled()
 
-    it 'should call $modalInstance.close on close()', ->
+    it 'should call $uibModalInstance.close on close()', ->
         createController()
         m = scope.m
-        spyOn($modalInstance, 'close')
-        expect($modalInstance.close).not.toHaveBeenCalled()
+        spyOn($uibModalInstance, 'close')
+        expect($uibModalInstance.close).not.toHaveBeenCalled()
         m.close()
-        expect($modalInstance.close).toHaveBeenCalled()
+        expect($uibModalInstance.close).toHaveBeenCalled()


### PR DESCRIPTION
As we are very near the release, we won't be able to upgrade that much our JS dependencies, as people will start to create code against it.

I upgraded guanlecoja-ui to latest version of its dependencies, and here is the needed code in bb in order to have it working under those new deps

https://github.com/buildbot/guanlecoja-ui#changelog

* 1.6.0: Massive upgrade of dependencies:
  - jquery 2.1 -> 2.2.
  - Angular 1.4 -> 1.5.
  - Lodash -> 4.11.
  - Drop underscore.string as lodash got most important string utils.
  - angular-ui-bootstrap 0.11 -> 1.3.2: Most important change is that ui-bootstrap directives are now prefixed with "uib-" e.g: in jade: ".dropdown-toggle" -> ".dropdown-toggle(uib-dropdown-toggle)" This makes the markup more complicated, but the old 0.11 documentation is not even available anymore, so its best to upgrade.

I still need to test that heavily beyond unit tests as we are far from 100% coverage.
