### PR TITLE
fix documentation for collapseBuildRequest callback

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -538,8 +538,8 @@ class Builder(util_service.ReconfigurableServiceMixin,
 
         return collapseRequests_fn
 
-    def _defaultCollapseRequestFn(self, brdict1, brdict2):
-        return buildrequest.BuildRequest.canBeCollapsed(self.master, brdict1, brdict2)
+    def _defaultCollapseRequestFn(self, master, builder, brdict1, brdict2):
+        return buildrequest.BuildRequest.canBeCollapsed(master, brdict1, brdict2)
 
 
 class BuilderControl:

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -80,7 +80,7 @@ class BuildRequestCollapser(object):
                 if unclaim_br['buildrequestid'] == br['buildrequestid']:
                     continue
 
-                canCollapse = yield collapseRequestsFn(bldr, br, unclaim_br)
+                canCollapse = yield collapseRequestsFn(self.master, bldr, br, unclaim_br)
                 if canCollapse is True:
                     collapseBRs.append(unclaim_br)
 

--- a/master/buildbot/test/unit/test_process_buildrequest.py
+++ b/master/buildbot/test/unit/test_process_buildrequest.py
@@ -62,7 +62,7 @@ class TestBuildRequestCollapser(unittest.TestCase):
 
     def test_collapseRequests_no_other_request(self):
 
-        def collapseRequests_fn(builder, brdict1, brdict2):
+        def collapseRequests_fn(master, builder, brdict1, brdict2):
             # Allow all requests
             self.fail("Should never be called")
             return True
@@ -82,7 +82,7 @@ class TestBuildRequestCollapser(unittest.TestCase):
 
     def test_collapseRequests_no_collapse(self):
 
-        def collapseRequests_fn(builder, brdict1, brdict2):
+        def collapseRequests_fn(master, builder, brdict1, brdict2):
             # Fail all collapse attempts
             return False
 
@@ -113,7 +113,7 @@ class TestBuildRequestCollapser(unittest.TestCase):
 
     def test_collapseRequests_collapse_all(self):
 
-        def collapseRequests_fn(builder, brdict1, brdict2):
+        def collapseRequests_fn(master, builder, brdict1, brdict2):
             # collapse all attempts
             return True
 
@@ -144,7 +144,7 @@ class TestBuildRequestCollapser(unittest.TestCase):
 
     def test_collapseRequests_collapse_default(self):
 
-        def collapseRequests_fn(builder, brdict1, brdict2):
+        def collapseRequests_fn(master, builder, brdict1, brdict2):
             return buildrequest.BuildRequest.canBeCollapsed(builder.master, brdict1, brdict2)
 
         rows = [

--- a/master/docs/manual/cfg-builders.rst
+++ b/master/docs/manual/cfg-builders.rst
@@ -136,17 +136,23 @@ Requests are only candidated for a merge if both requests have exactly the same 
 This behavior can be controlled globally, using the :bb:cfg:`collapseRequests` parameter, and on a per-:class:`Builder` basis, using the ``collapseRequests`` argument to the :class:`Builder` configuration.
 If ``collapseRequests`` is given, it completely overrides the global configuration.
 
-For either configuration parameter, a value of ``True`` (the default) causes buildbot to merge BuildRequests that have "compatible" source stamps.
-Source stamps are compatible if:
+Possible values for both ``collapseRequests`` configurations are:
 
-* their codebase, branch, project, and repository attributes match exactly;
-* neither source stamp has a patch (e.g., from a try scheduler); and
-* either both source stamps are associated with changes, or neither ar associated with changes but they have matching revisions.
+``True``
+    Requests will be collapsed if their sourcestamp are compatible (see below for definition of compatible).
 
-A configuration value of ``False`` indicates that requests should never be merged.
+``False``
+    Requests will never be collapsed.
 
-The configuration value can also be a callable, specifying a custom merging function.
-See :ref:`Collapse-Request-Functions` for details.
+``callable(builder, req1, req2)``
+    Requests will be collapsed if the callable returns true.
+    See :ref:`Collapse-Request-Functions` for detailed example.
+
+Sourcestamps are compatible if all of the below conditions are met:
+
+* Their codebase, branch, project, and repository attributes match exactly
+* Neither source stamp has a patch (e.g., from a try scheduler)
+* Either both source stamps are associated with changes, or neither are associated with changes but they have matching revisions.
 
 .. index:: Builds; priority
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -63,6 +63,9 @@ Deprecations, Removals, and Non-Compatible Changes
 * html is not permitted anymore in 'label' attributes of forcescheduler parameters.
 
 * ``LocalWorker`` now requires ``buildbot-worker`` package, instead of ``buildbot-slave``.
+* :ref:`Collapse-Request-Functions` now takes master as first argument.
+  The previous callable contained too few data in order to be really usable.
+  As collapseRequests has never been released outside of beta, backward compatibility with previous release has **not** been implemented.
 
 Worker
 ------

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -388,6 +388,7 @@ inrepo
 inrepos
 interCaps
 internet
+ini
 intialization
 intialized
 ip
@@ -900,5 +901,6 @@ xda
 Xen
 xf
 xvfb
+yaml
 Zope
 zsh


### PR DESCRIPTION
While doing the documentation, I figured out it wasn't possible to write the same logic as before without a master reference.
So I added it in the API (right about time)

Note that the examples are indeed a bit more complicated :-/