### PR TITLE
Start using a non-global reactor.

### DIFF
--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -116,7 +116,7 @@ class DBConnector(WorkerAPICompatMixin, service.ReconfigurableServiceMixin,
         # set up the engine and pool
         self._engine = enginestrategy.create_engine(db_url,
                                                     basedir=self.basedir)
-        self.pool = pool.DBThreadPool(self._engine, verbose=verbose)
+        self.pool = pool.DBThreadPool(self._engine, reactor=self.master.reactor, verbose=verbose)
 
         # make sure the db is up to date, unless specifically asked not to
         if check_version:

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -18,6 +18,7 @@ import weakref
 import mock
 
 from twisted.internet import defer
+from twisted.internet import reactor
 
 from zope.interface import implements
 
@@ -169,6 +170,7 @@ class FakeMaster(service.MasterService):
     def __init__(self, master_id=fakedb.FakeBuildRequestsComponent.MASTER_ID):
         service.MasterService.__init__(self)
         self._master_id = master_id
+        self.reactor = reactor
         self.objectids = []
         self.config = config.MasterConfig()
         self.caches = FakeCaches()

--- a/master/buildbot/test/integration/test_worker_transition.py
+++ b/master/buildbot/test/integration/test_worker_transition.py
@@ -145,8 +145,15 @@ class RunMaster(dirs.DirsMixin, www.RequiresWwwMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def _run_master(self, loaded_config):
+        # mock reactor.stop (which trial *really* doesn't
+        # like test code to call!)
+        mock_reactor = mock.Mock(spec=reactor)
+        mock_reactor.callWhenRunning = reactor.callWhenRunning
+        mock_reactor.getThreadPool = reactor.getThreadPool
+        mock_reactor.callFromThread = reactor.callFromThread
+
         # create the master
-        m = BuildMaster(self.basedir, self.configfile)
+        m = BuildMaster(self.basedir, self.configfile, reactor=mock_reactor)
 
         # update the DB
         yield m.db.setup(check_version=False)
@@ -155,13 +162,6 @@ class RunMaster(dirs.DirsMixin, www.RequiresWwwMixin, unittest.TestCase):
         # stub out m.db.setup since it was already called above
         m.db.setup = lambda: None
 
-        # mock reactor.stop (which trial *really* doesn't
-        # like test code to call!)
-        mock_reactor = mock.Mock(spec=reactor)
-        mock_reactor.callWhenRunning = reactor.callWhenRunning
-        mock_reactor.getThreadPool = reactor.getThreadPool
-        mock_reactor.callFromThread = reactor.callFromThread
-
         # mock configuration loading
         @classmethod
         def loadConfig(cls, basedir, filename):
@@ -169,7 +169,7 @@ class RunMaster(dirs.DirsMixin, www.RequiresWwwMixin, unittest.TestCase):
 
         with mock.patch('buildbot.config.MasterConfig.loadConfig', loadConfig):
             # start the service
-            yield m.startService(_reactor=mock_reactor)
+            yield m.startService()
         self.failIf(mock_reactor.stop.called,
                     "startService tried to stop the reactor; check logs")
 

--- a/master/buildbot/test/unit/test_db_pool.py
+++ b/master/buildbot/test/unit/test_db_pool.py
@@ -33,7 +33,7 @@ class Basic(unittest.TestCase):
     def setUp(self):
         self.engine = sa.create_engine('sqlite://')
         self.engine.optimal_thread_pool_size = 1
-        self.pool = pool.DBThreadPool(self.engine)
+        self.pool = pool.DBThreadPool(self.engine, reactor=reactor)
 
     def tearDown(self):
         self.pool.shutdown()
@@ -108,7 +108,7 @@ class Stress(unittest.TestCase):
 
         self.engine = sa.create_engine('sqlite:///test.sqlite')
         self.engine.optimal_thread_pool_size = 2
-        self.pool = pool.DBThreadPool(self.engine)
+        self.pool = pool.DBThreadPool(self.engine, reactor=reactor)
 
     def tearDown(self):
         self.pool.shutdown()
@@ -159,7 +159,7 @@ class Native(unittest.TestCase, db.RealDatabaseMixin):
         d = self.setUpRealDatabase(want_pool=False)
 
         def make_pool(_):
-            self.pool = pool.DBThreadPool(self.db_engine)
+            self.pool = pool.DBThreadPool(self.db_engine, reactor=reactor)
         d.addCallback(make_pool)
         return d
 

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -17,6 +17,7 @@ import os
 from sqlalchemy.schema import MetaData
 
 from twisted.internet import defer
+from twisted.internet import reactor
 from twisted.python import log
 from twisted.trial import unittest
 
@@ -194,7 +195,7 @@ class RealDatabaseMixin(object):
         if not want_pool:
             return defer.succeed(None)
 
-        self.db_pool = pool.DBThreadPool(self.db_engine)
+        self.db_pool = pool.DBThreadPool(self.db_engine, reactor=reactor)
 
         log.msg("cleaning database %s" % self.db_url)
         d = self.db_pool.do(self.__thd_clean_database)


### PR DESCRIPTION
It is much easier to test code that doesn't use the global reactor.

Change `BuildMaster` to take an optional reactor as a first step.