### PR TITLE
don't remove SLAVEPASS from environment by default in buildbot-worker

### DIFF
--- a/worker/buildbot_worker/scripts/create_worker.py
+++ b/worker/buildbot_worker/scripts/create_worker.py
@@ -52,8 +52,6 @@ buildmaster_host = %(host)r
 port = %(port)d
 workername = %(name)r
 passwd = %(passwd)r
-if "SLAVEPASS" in os.environ:
-    del os.environ['SLAVEPASS']
 keepalive = %(keepalive)d
 usepty = %(usepty)d
 umask = %(umask)s


### PR DESCRIPTION
These lines were introduced in 75f9ad7fc1dc by @pieterlexis.
I don't think these changes are required anymore.

Worker configuration created with `buildbot-worker create ...` doesn't
use environment variables to set password.

Worker configuration created with
master/contrib/docker/worker/Dockerfile optionally  uses environment
variable to specify password, but also has it's own code that clears
environment.

So I don't see any supported configuration that requires clearing of the
environment variables.

If *user* created configuration that uses environment variable to set
password, *he* must clear environment variables.

@pieterlexis please comment if you think I'm missing something.