### PR TITLE
include raml files onto Buildbot distribution

### DIFF
--- a/master/MANIFEST.in
+++ b/master/MANIFEST.in
@@ -25,6 +25,9 @@ include buildbot/scripts/buildbot_tac.tmpl
 include buildbot/buildbot.png
 include buildbot/reporters/templates/*.txt
 
+include buildbot/spec/api.raml
+include buildbot/spec/types/*.raml
+
 include buildbot/db/migrate/README buildbot/db/migrate/migrate.cfg
 
 include contrib/* contrib/windows/* contrib/os-x/* contrib/css/* contrib/libvirt/*

--- a/master/setup.py
+++ b/master/setup.py
@@ -203,6 +203,8 @@ setup_args = {
             "buildbot/scripts/sample.cfg",
             "buildbot/scripts/buildbot_tac.tmpl",
         ]),
+        include("buildbot/spec", "*.raml"),
+        include("buildbot/spec/types", "*.raml"),
     ] + include_statics("buildbot/www/static"),
     'scripts': scripts,
     'cmdclass': {'install_data': install_data_twisted,


### PR DESCRIPTION
@tardyp I haven't included `indent.py` in Buildbot distribution. Do we need it?
