### PR TITLE
Make sample.cfg more declarative

### DIFF
--- a/master/buildbot/scripts/sample.cfg
+++ b/master/buildbot/scripts/sample.cfg
@@ -6,99 +6,100 @@ from buildbot.plugins import *
 # This is a sample buildmaster config file. It must be installed as
 # 'master.cfg' in your buildmaster's base directory.
 
-# This is the dictionary that the buildmaster pays attention to. We also use
-# a shorter alias to save typing.
-c = BuildmasterConfig = {}
+# This is the dictionary that the buildmaster pays attention to.
+BuildmasterConfig = {
+    ####### WORKERS
 
-####### WORKERS
+    # The 'workers' list defines the set of recognized workers. Each element is
+    # a Worker object, specifying a unique worker name and password.  The same
+    # worker name and password must be configured on the worker.
+    'workers': [worker.Worker("example-worker", "pass")],
 
-# The 'workers' list defines the set of recognized workers. Each element is
-# a Worker object, specifying a unique worker name and password.  The same
-# worker name and password must be configured on the worker.
-c['workers'] = [worker.Worker("example-worker", "pass")]
+    # 'protocols' contains information about protocols which master will use for
+    # communicating with workers. You must define at least 'port' option that workers
+    # could connect to your master with this protocol.
+    # 'port' must match the value configured into the workers (with their
+    # --master option)
+    'protocols': {'pb': {'port': 9989}},
 
-# 'protocols' contains information about protocols which master will use for
-# communicating with workers. You must define at least 'port' option that workers
-# could connect to your master with this protocol.
-# 'port' must match the value configured into the workers (with their
-# --master option)
-c['protocols'] = {'pb': {'port': 9989}}
+    ####### CHANGESOURCES
 
-####### CHANGESOURCES
+    # the 'change_source' setting tells the buildmaster how it should find out
+    # about source code changes.  Here we point to the buildbot clone of pyflakes.
+    'change_source': [
+        changes.GitPoller(
+            'git://github.com/buildbot/pyflakes.git',
+            workdir='gitpoller-workdir', branch='master',
+            pollinterval=300),
+    ],
 
-# the 'change_source' setting tells the buildmaster how it should find out
-# about source code changes.  Here we point to the buildbot clone of pyflakes.
+    ####### SCHEDULERS
 
-c['change_source'] = []
-c['change_source'].append(changes.GitPoller(
-        'git://github.com/buildbot/pyflakes.git',
-        workdir='gitpoller-workdir', branch='master',
-        pollinterval=300))
+    # Configure the Schedulers, which decide how to react to incoming changes.  In this
+    # case, just kick off a 'runtests' build
 
-####### SCHEDULERS
+    'schedulers': [
+        schedulers.SingleBranchScheduler(
+            name="all",
+            change_filter=util.ChangeFilter(branch='master'),
+            treeStableTimer=None,
+            builderNames=["runtests"]),
+        schedulers.ForceScheduler(
+            name="force",
+            builderNames=["runtests"]),
+    ],
 
-# Configure the Schedulers, which decide how to react to incoming changes.  In this
-# case, just kick off a 'runtests' build
+    ####### BUILDERS
 
-c['schedulers'] = []
-c['schedulers'].append(schedulers.SingleBranchScheduler(
-                            name="all",
-                            change_filter=util.ChangeFilter(branch='master'),
-                            treeStableTimer=None,
-                            builderNames=["runtests"]))
-c['schedulers'].append(schedulers.ForceScheduler(
-                            name="force",
-                            builderNames=["runtests"]))
+    # The 'builders' list defines the Builders, which tell Buildbot how to perform a build:
+    # what steps, and which workers can execute them.  Note that any particular build will
+    # only take place on one worker.
 
-####### BUILDERS
+    'builders': [
+        util.BuilderConfig(
+            name="runtests",
+            workernames=["example-worker"],
+            factory=util.BuildFactory([
+                # check out the source
+                steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'),
+                # run the tests (note that this will require that 'trial' is installed)
+                steps.ShellCommand(command=["trial", "pyflakes"]),
+            ]),
+        ),
+    ],
 
-# The 'builders' list defines the Builders, which tell Buildbot how to perform a build:
-# what steps, and which workers can execute them.  Note that any particular build will
-# only take place on one worker.
+    ####### STATUS TARGETS
 
-factory = util.BuildFactory()
-# check out the source
-factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
-# run the tests (note that this will require that 'trial' is installed)
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"]))
+    # 'status' is a list of Status Targets. The results of each build will be
+    # pushed to these targets. buildbot/status/*.py has a variety to choose from,
+    # like IRC bots.
 
-c['builders'] = []
-c['builders'].append(
-    util.BuilderConfig(name="runtests",
-      workernames=["example-worker"],
-      factory=factory))
+    'status': [],
 
-####### STATUS TARGETS
+    ####### PROJECT IDENTITY
 
-# 'status' is a list of Status Targets. The results of each build will be
-# pushed to these targets. buildbot/status/*.py has a variety to choose from,
-# like IRC bots.
+    # the 'title' string will appear at the top of this buildbot installation's
+    # home pages (linked to the 'titleURL').
 
-c['status'] = []
+    'title': "Pyflakes",
+    'titleURL': "https://launchpad.net/pyflakes",
 
-####### PROJECT IDENTITY
+    # the 'buildbotURL' string should point to the location where the buildbot's
+    # internal web server is visible. This typically uses the port number set in
+    # the 'www' entry below, but with an externally-visible host name which the
+    # buildbot cannot figure out without some help.
 
-# the 'title' string will appear at the top of this buildbot installation's
-# home pages (linked to the 'titleURL').
+    'buildbotURL': "http://localhost:8010/",
 
-c['title'] = "Pyflakes"
-c['titleURL'] = "https://launchpad.net/pyflakes"
+    # minimalistic config to activate new web UI
+    'www': dict(port=8010,
+                plugins=dict(waterfall_view={}, console_view={})),
 
-# the 'buildbotURL' string should point to the location where the buildbot's
-# internal web server is visible. This typically uses the port number set in 
-# the 'www' entry below, but with an externally-visible host name which the 
-# buildbot cannot figure out without some help.
+    ####### DB URL
 
-c['buildbotURL'] = "http://localhost:8010/"
-
-# minimalistic config to activate new web UI
-c['www'] = dict(port=8010,
-                plugins=dict(waterfall_view={}, console_view={}))
-
-####### DB URL
-
-c['db'] = {
-    # This specifies what database buildbot uses to store its state.  You can leave
-    # this at its default for all but the largest installations.
-    'db_url' : "sqlite:///state.sqlite",
+    'db': {
+        # This specifies what database buildbot uses to store its state.  You can leave
+        # this at its default for all but the largest installations.
+        'db_url' : "sqlite:///state.sqlite",
+    }
 }


### PR DESCRIPTION
This patch changes the sample.cfg to just define a dictionary, rather than building one up piecemeal over several instructions.

It's partly a matter of personal taste, but I think this style makes the structure more clear. In particular, it makes it very obvious that none of the keys bare any relationship to the others. It also shifts it closer to the 'data' end of the spectrum than the 'code' end of the spectrum, which makes it simpler.

I've taken care not to reflow lines or make any other changes. 