### PR TITLE
Expose builder.tags to web templates.

### DIFF
--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -634,6 +634,7 @@ class BuildersResource(HtmlResource):
         base_builders_url = path_to_root(req) + "builders/"
         for bn in builders:
             bld = {'link': base_builders_url + urllib.quote(bn, safe=''),
+                   'tags': status.getBuilder(bn).tags,
                    'name': bn}
             bs.append(bld)
 

--- a/master/buildbot/status/web/grid.py
+++ b/master/buildbot/status/web/grid.py
@@ -90,6 +90,7 @@ class GridStatusMixin(object):
 
         cxt = {'url': path_to_builder(request, builder),
                'name': builder.getName(),
+               'tags': builder.tags,
                'state': state,
                'n_pending': n_pending}
 


### PR DESCRIPTION
This tiny PR exposes the builders' "tags" attribute to the templates, allowing me to customize the templates using that feature.