### PR TITLE
Allow slaves to substantiate in parallel

### DIFF
--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -505,12 +505,15 @@ class BuildRequestDistributor(service.AsyncMultiService):
                 bc = self.createBuildChooser(bldr, self.master)
                 continue
 
-            buildStarted = yield bldr.maybeStartBuild(worker, breqs)
-            if not buildStarted:
-                yield self.master.data.updates.unclaimBuildRequests(brids)
-                # try starting builds again.  If we still have a working worker,
-                # then this may re-claim the same buildrequests
-                self.botmaster.maybeStartBuildsForBuilder(self.name)
+            d = bldr.maybeStartBuild(worker, breqs)
+            @defer.inlineCallbacks
+            def checkBuildStart(buildStarted, brids, builderName):
+                if not buildStarted:
+                    yield self.master.data.updates.unclaimBuildRequests(brids)
+                    # try starting builds again.  If we still have a working
+                    # worker, then this may re-claim the same buildrequests
+                    self.botmaster.maybeStartBuildsForBuilder(builderName)
+            d.addCallback(checkBuildStart, brids, bldr.name)
 
     def createBuildChooser(self, bldr, master):
         # just instantiate the build chooser requested


### PR DESCRIPTION
BuildRequestDistributor's _maybeStartBuildsOnBuilder() method is
decorated with @defer.inlineCallbacks.  This means that when it
uses "yield bldr.maybeStartBuild", the entire slave substantiation
process is sequentialized at that point.

slave substantiation can take considerable time, especially with
something like EC2 latent slaves.  Even without anything substantial
happening in the cloud init (user-data) script, it can easily take
a couple of minutes.  If any substantial configuration of the
OS takes place ins the user-data script, maybeStartBuild() can
easily take many minutes.

To enable parallel slave substantiation, we need to stop waiting on
bldr.maybeStartBuild() inline.  Instead we move the error
handling code into a callback function that can be added to the
Deferred that is returned by bldr.maybeStartBuild().

At least for for the EC2LatentBuildSlave class, everything else down
the chain is properly event based and/or threaded.  This small
code change allows slaves to substantiate in parallel.
