### PR TITLE
fix TestCase.assertRegexpMatches() Python 2.6 backport

### DIFF
--- a/master/buildbot/monkeypatches/testcase_assert.py
+++ b/master/buildbot/monkeypatches/testcase_assert.py
@@ -52,7 +52,7 @@ def _assertRegexpMatches(self, text, regexp, msg=None):
     introduced in python 2.7. The goal for this function is to behave exactly
     as assertRegexpMatches() in standard library.
     """
-    if not re.search(text, regexp):
+    if not re.search(regexp, text):
         if msg is not None:
             self.fail(msg)
         else:


### PR DESCRIPTION
Nobody used assertRegexpMatches() in Buildbot by the way,
maybe because of this error :)

Reference: https://docs.python.org/2.6/library/re.html#re.search