### PR TITLE
Fix spelling.

### DIFF
--- a/master/docs/developer/config.rst
+++ b/master/docs/developer/config.rst
@@ -181,7 +181,7 @@ described in :ref:`developer-Reconfiguration`.
 
     .. py:classmethod:: loadFromDict(config_dict, filename)
 
-        :param dict config_dict: The dictionary containg the configuration to load.
+        :param dict config_dict: The dictionary containing the configuration to load.
         :param string filename: The filename to use when reporting errors.
         :returns: new :py:class:`MasterConfig` instance
 


### PR DESCRIPTION
This showed up as a build failure when #2139 and #2148 both landed.