### PR TITLE
Fix the MsBuild steps

### DIFF
--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -388,7 +388,7 @@ VS2013 = VC12
 
 class MsBuild4(VisualStudio):
     platform = None
-    vcenv_bat = "\"${VS110COMNTOOLS}..\\..\\VC\\vcvarsall.bat\""
+    vcenv_bat = r"${VS110COMNTOOLS}..\..\VC\vcvarsall.bat"
 
     def __init__(self, platform, **kwargs):
         self.platform = platform
@@ -415,15 +415,11 @@ class MsBuild4(VisualStudio):
         if self.platform is None:
             config.error('platform is mandatory. Please specify a string such as "Win32"')
 
-        command = ["%VCENV_BAT%",
-                   "x86",
-                   "&&",
-                   "msbuild",
-                   self.projectfile,
-                   "/p:Configuration=%s" % (self.config),
-                   "/p:Platform=%s" % (self.platform)]
+        command = ('"%%VCENV_BAT%%" x86 && msbuild "%s" /p:Configuration="%s" /p:Platform="%s"'
+                   % (self.projectfile, self.config, self.platform))
+
         if self.project is not None:
-            command.append("/t:%s" % (self.project))
+            command += ' /t:"%s"' % (self.project)
 
         self.setCommand(command)
 
@@ -433,4 +429,4 @@ MsBuild = MsBuild4
 
 
 class MsBuild12(MsBuild4):
-    vcenv_bat = "\"${VS120COMNTOOLS}..\\..\\VC\\vcvarsall.bat\""
+    vcenv_bat = r"${VS120COMNTOOLS}..\..\VC\vcvarsall.bat"

--- a/master/buildbot/test/unit/test_steps_vstudio.py
+++ b/master/buildbot/test/unit/test_steps_vstudio.py
@@ -792,10 +792,8 @@ class TestMsBuild(steps.BuildStepMixin, unittest.TestCase):
 
         self.expectCommands(
             ExpectShell(workdir='wkdir', usePTY='slave-config',
-                        command=['%VCENV_BAT%', 'x86', '&&',
-                                 'msbuild', 'pf', '/p:Configuration=cfg', '/p:Platform=Win32',
-                                 '/t:pj'],
-                        env={'VCENV_BAT': '"${VS110COMNTOOLS}..\\..\\VC\\vcvarsall.bat"'})
+                        command='"%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /t:"pj"',
+                        env={'VCENV_BAT': r'${VS110COMNTOOLS}..\..\VC\vcvarsall.bat'})
             + 0
         )
         self.expectOutcome(result=SUCCESS,
@@ -807,9 +805,8 @@ class TestMsBuild(steps.BuildStepMixin, unittest.TestCase):
 
         self.expectCommands(
             ExpectShell(workdir='wkdir', usePTY='slave-config',
-                        command=['%VCENV_BAT%', 'x86', '&&',
-                                 'msbuild', 'pf', '/p:Configuration=cfg', '/p:Platform=x64'],
-                        env={'VCENV_BAT': '"${VS110COMNTOOLS}..\\..\\VC\\vcvarsall.bat"'})
+                        command='"%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="x64"',
+                        env={'VCENV_BAT': r'${VS110COMNTOOLS}..\..\VC\vcvarsall.bat'})
             + 0
         )
         self.expectOutcome(result=SUCCESS,


### PR DESCRIPTION
These steps use a list as a command, despite needing shell processing. This broke after Windows argument escaping was made more strict in 693a2cb. Make them use a single string instead.

I also added quoting for the various user-supplied parameters, so that e.g. project paths with spaces in them are processed correctly.

Fixes <http://trac.buildbot.net/ticket/2878>.