### PR TITLE
log is master startup fails + handling in `buildbot start`

### DIFF
--- a/master/buildbot/scripts/logwatcher.py
+++ b/master/buildbot/scripts/logwatcher.py
@@ -33,6 +33,10 @@ class BuildmasterTimeoutError(Exception):
     pass
 
 
+class BuildmasterStartupError(Exception):
+    pass
+
+
 class ReconfigError(Exception):
     pass
 
@@ -141,3 +145,5 @@ class LogWatcher(LineOnlyReceiver):
             return self.finished("buildmaster")
         if "BuildMaster is running" in line:
             return self.finished("buildmaster")
+        if "BuildMaster startup failed" in line:
+            return self.finished(Failure(BuildmasterStartupError()))

--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -18,6 +18,7 @@ import os
 import sys
 
 from buildbot.scripts import base
+from buildbot.scripts.logwatcher import BuildmasterStartupError
 from buildbot.scripts.logwatcher import BuildmasterTimeoutError
 from buildbot.scripts.logwatcher import LogWatcher
 from buildbot.scripts.logwatcher import ReconfigError
@@ -55,6 +56,10 @@ line that says 'BuildMaster is running' to verify correct startup.
 The buildmaster appears to have encountered an error in the master.cfg config
 file during startup. Please inspect and fix master.cfg, then restart the
 buildmaster.
+""")
+        elif why.check(BuildmasterStartupError):
+            print("""
+The buildmaster startup failed. Please see 'twistd.log' for possible reason.
 """)
         else:
             print("""

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -206,6 +206,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
         def check(_):
             self.reactor.stop.assert_called_with()
             self.assertLogged("oh noes")
+            self.assertLogged("BuildMaster startup failed")
         return d
 
     def test_startup_db_not_ready(self):
@@ -220,6 +221,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
         def check(_):
             self.reactor.stop.assert_called_with()
             self.assertLogged("GOT HERE")
+            self.assertLogged("BuildMaster startup failed")
         return d
 
     def test_startup_error(self):
@@ -233,6 +235,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
         def check(_):
             self.reactor.stop.assert_called_with()
             self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1)
+            self.assertLogged("BuildMaster startup failed")
         return d
 
     def test_startup_ok(self):


### PR DESCRIPTION
Now `buildbot start` handles cases when master startup failed and explicitly say that something failed.

By the way, how about I remove `_master_initialized` from BuildMaster?
It's not used anywhere and previously has incorrect value if master startup failed.