### PR TITLE
Tweak build change retrieval to not error for 'None' change

### DIFF
--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -195,7 +195,9 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
 
         # For each codebase, append changes until we match the parent
         for cb, change in iteritems(fromChanges):
-            if change and change['changeid'] != toChanges.get(cb, {}).get('changeid'):
+            # Careful; toChanges[cb] may be None from getChangeFromSSid
+            toCbChange = toChanges.get(cb) or {}
+            if change and change['changeid'] != toCbChange.get('changeid'):
                 changes.append(change)
                 while ((toChanges.get(cb, {}).get('changeid') not in change['parent_changeids']) and
                        change['parent_changeids']):


### PR DESCRIPTION
getChangeFromSSid() can return None, but the change retrieval for a build did
not work properly in that scenario.

---

I took a look at adding a unit test case, but I can't figure out how to recreate this problem in a controlled environment (specifically, the environment of `test_db_changes` / `test_getChangesForBuild`). All my attempts to recreate lead to database integrity issues or don't reproduce.

If someone has pointers on unit tests, I can take another look at adding them.