### PR TITLE
log.py: Get deferred errors on addStd*/addContent

### DIFF
--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -125,7 +125,7 @@ class PlainLog(Log):
 
     def addContent(self, text):
         # add some text in the log's default stream
-        self.lbf.append(text)
+        return self.lbf.append(text)
 
     @defer.inlineCallbacks
     def finish(self):
@@ -166,7 +166,7 @@ class StreamLog(Log):
                 self.subPoint.deliver(stream, lines)
                 # strip the last character, as the regexp will add a
                 # prefix character after the trailing newline
-                self.addRawLines(self.pat.sub(stream, lines)[:-1])
+                return self.addRawLines(self.pat.sub(stream, lines)[:-1])
             lbf = self.lbfs[stream] = \
                 lineboundaries.LineBoundaryFinder(wholeLines)
             return lbf

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -72,9 +72,7 @@ class Log(object):
         # formatted for the log type, and newline-terminated
         assert lines[-1] == '\n'
         assert not self.finished
-        yield self.lock.acquire()
-        yield self.master.data.updates.appendLog(self.logid, lines)
-        yield self.lock.release()
+        yield self.lock.run(lambda: self.master.data.updates.appendLog(self.logid, lines))
 
     # completion
 
@@ -92,11 +90,11 @@ class Log(object):
     @defer.inlineCallbacks
     def finish(self):
         assert not self.finished
-        yield self.lock.acquire()
-        self.finished = True
-        yield self.master.data.updates.finishLog(self.logid)
-        yield self.lock.release()
 
+        def fToRun():
+            self.finished = True
+            return self.master.data.updates.finishLog(self.logid)
+        yield self.lock.run(fToRun)
         # notify subscribers *after* finishing the log
         self.subPoint.deliver(None, None)
 

--- a/master/buildbot/util/lineboundaries.py
+++ b/master/buildbot/util/lineboundaries.py
@@ -44,9 +44,9 @@ class LineBoundaryFinder(object):
                     self.partialLine = text
                     return defer.succeed(None)
             return self.callback(text)
+        return defer.succeed(None)
 
     def flush(self):
         if self.partialLine:
             return self.append('\n')
-        else:
-            return defer.succeed(None)
+        return defer.succeed(None)


### PR DESCRIPTION
The previous version chose not to return deferreds
on some situations. When errors happened on
those lost deferreds, buildbot:
- reported "Unhandled error in Deferred"
- did not signal the error to the caller.

For this reason, this commit makes
- PlainLog.addContent
- StreamLog.addStdout/addStderr/addHeader

return a deferred instead.

Change-Id: I2dfae20b47e50e41d32b7c0366564580ad839767
Signed-off-by: Ion Alberdi <ion.alberdi@intel.com>