### PR TITLE
Publish build started events

### DIFF
--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -216,6 +216,10 @@ class Build(base.ResourceType):
         defer.returnValue(res)
 
     @base.updateMethod
+    def startBuild(self, buildid):
+        return self.generateEvent(buildid, "started")
+
+    @base.updateMethod
     @defer.inlineCallbacks
     def finishBuild(self, buildid, results):
         res = yield self.master.db.builds.finishBuild(

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -276,6 +276,7 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
 
         yield self.master.data.updates.setBuildStateString(self.buildid,
                                                            u'starting')
+        yield self.master.data.updates.startBuild(self.buildid)
         self.build_status.buildStarted(self)
 
         try:


### PR DESCRIPTION
Lots of reporters (http, gerrit, etc) are listening to the ("build", None, "started") tuple, which is no longer being published. This brings that functionality back.