### PR TITLE
Fix the MsBuild steps

### DIFF
--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -415,7 +415,7 @@ VS2013 = VC12
 
 class MsBuild4(VisualStudio):
     platform = None
-    vcenv_bat = "\"${VS110COMNTOOLS}..\\..\\VC\\vcvarsall.bat\""
+    vcenv_bat = r"${VS110COMNTOOLS}..\..\VC\vcvarsall.bat"
     renderables = ['platform']
 
     def __init__(self, platform, **kwargs):
@@ -444,21 +444,17 @@ class MsBuild4(VisualStudio):
             config.error(
                 'platform is mandatory. Please specify a string such as "Win32"')
 
-        command = ["%VCENV_BAT%",
-                   "x86",
-                   "&&",
-                   "msbuild",
-                   self.projectfile,
-                   "/p:Configuration=%s" % (self.config),
-                   "/p:Platform=%s" % (self.platform)]
+        command = ('"%%VCENV_BAT%%" x86 && msbuild "%s" /p:Configuration="%s" /p:Platform="%s"'
+                   % (self.projectfile, self.config, self.platform))
+
         if self.project is not None:
-            command.append("/t:%s" % (self.project))
+            command += ' /t:"%s"' % (self.project)
         elif self.mode == "build":
-            command.append("/t:Build")
+            command += ' /t:Build'
         elif self.mode == "clean":
-            command.append("/t:Clean")
+            command += ' /t:Clean'
         elif self.mode == "rebuild":
-            command.append("/t:Rebuild")
+            command += ' /t:Rebuild'
 
         self.setCommand(command)
 
@@ -468,4 +464,4 @@ MsBuild = MsBuild4
 
 
 class MsBuild12(MsBuild4):
-    vcenv_bat = "\"${VS120COMNTOOLS}..\\..\\VC\\vcvarsall.bat\""
+    vcenv_bat = r"${VS120COMNTOOLS}..\..\VC\vcvarsall.bat"

--- a/master/buildbot/test/unit/test_steps_vstudio.py
+++ b/master/buildbot/test/unit/test_steps_vstudio.py
@@ -795,10 +795,8 @@ class TestMsBuild(steps.BuildStepMixin, unittest.TestCase):
 
         self.expectCommands(
             ExpectShell(workdir='wkdir', usePTY='slave-config',
-                        command=['%VCENV_BAT%', 'x86', '&&',
-                                 'msbuild', 'pf', '/p:Configuration=cfg', '/p:Platform=Win32',
-                                 '/t:pj'],
-                        env={'VCENV_BAT': '"${VS110COMNTOOLS}..\\..\\VC\\vcvarsall.bat"'})
+                        command='"%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="Win32" /t:"pj"',
+                        env={'VCENV_BAT': r'${VS110COMNTOOLS}..\..\VC\vcvarsall.bat'})
             + 0
         )
         self.expectOutcome(result=SUCCESS,
@@ -811,10 +809,8 @@ class TestMsBuild(steps.BuildStepMixin, unittest.TestCase):
 
         self.expectCommands(
             ExpectShell(workdir='wkdir', usePTY='slave-config',
-                        command=['%VCENV_BAT%', 'x86', '&&',
-                                 'msbuild', 'pf', '/p:Configuration=cfg', '/p:Platform=x64',
-                                 '/t:Rebuild'],
-                        env={'VCENV_BAT': '"${VS110COMNTOOLS}..\\..\\VC\\vcvarsall.bat"'})
+                        command='"%VCENV_BAT%" x86 && msbuild "pf" /p:Configuration="cfg" /p:Platform="x64" /t:Rebuild',
+                        env={'VCENV_BAT': r'${VS110COMNTOOLS}..\..\VC\vcvarsall.bat'})
             + 0
         )
         self.expectOutcome(result=SUCCESS,

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -45,6 +45,8 @@ Features
 Fixes
 ~~~~~
 
+* The :bb:step:`MsBuild4` and :bb:step:`MsBuild12` steps work again (:bug:`2878`).
+
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
These steps use a list as a command, despite needing shell processing. This broke after Windows argument escaping was made more strict in 693a2cb. Make them use a single string instead.

Fixes <http://trac.buildbot.net/ticket/2878>.