### PR TITLE
rewrap outputted to the console text

### DIFF
--- a/master/buildbot/scripts/reconfig.py
+++ b/master/buildbot/scripts/reconfig.py
@@ -20,6 +20,7 @@ from buildbot.scripts.logwatcher import BuildmasterTimeoutError
 from buildbot.scripts.logwatcher import LogWatcher
 from buildbot.scripts.logwatcher import ReconfigError
 from buildbot.util import in_reactor
+from buildbot.util import rewrap
 
 from twisted.internet import reactor
 
@@ -62,19 +63,17 @@ class Reconfigurator:
         os.kill(self.pid, signal.SIGHUP)
 
     def success(self, res):
-        print("""
-Reconfiguration appears to have completed successfully.
-""")
+        print("Reconfiguration appears to have completed successfully")
 
     def failure(self, why):
         self.rc = 1
         if why.check(BuildmasterTimeoutError):
             print("Never saw reconfiguration finish.")
         elif why.check(ReconfigError):
-            print("""
-Reconfiguration failed. Please inspect the master.cfg file for errors,
-correct them, then try 'buildbot reconfig' again.
-""")
+            print(rewrap("""\
+                Reconfiguration failed. Please inspect the master.cfg file for
+                errors, correct them, then try 'buildbot reconfig' again.
+                """))
         elif why.check(IOError):
             # we were probably unable to open the file in the first place
             self.sighup()

--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -22,6 +22,7 @@ from buildbot.scripts.logwatcher import BuildmasterStartupError
 from buildbot.scripts.logwatcher import BuildmasterTimeoutError
 from buildbot.scripts.logwatcher import LogWatcher
 from buildbot.scripts.logwatcher import ReconfigError
+from buildbot.util import rewrap
 
 from twisted.internet import protocol
 from twisted.internet import reactor
@@ -46,26 +47,29 @@ class Follower:
 
     def _failure(self, why):
         if why.check(BuildmasterTimeoutError):
-            print("""
-The buildmaster took more than 10 seconds to start, so we were unable to
-confirm that it started correctly. Please 'tail twistd.log' and look for a
-line that says 'BuildMaster is running' to verify correct startup.
-""")
+            print(rewrap("""\
+                The buildmaster took more than 10 seconds to start, so we were
+                unable to confirm that it started correctly.
+                Please 'tail twistd.log' and look for a line that says
+                'BuildMaster is running' to verify correct startup.
+                """))
         elif why.check(ReconfigError):
-            print("""
-The buildmaster appears to have encountered an error in the master.cfg config
-file during startup. Please inspect and fix master.cfg, then restart the
-buildmaster.
-""")
+            print(rewrap("""\
+                The buildmaster appears to have encountered an error in the
+                master.cfg config file during startup.
+                Please inspect and fix master.cfg, then restart the
+                buildmaster.
+                """))
         elif why.check(BuildmasterStartupError):
-            print("""
-The buildmaster startup failed. Please see 'twistd.log' for possible reason.
-""")
+            print(rewrap("""\
+                The buildmaster startup failed. Please see 'twistd.log' for
+                possible reason.
+                """))
         else:
-            print("""
-Unable to confirm that the buildmaster started correctly. You may need to
-stop it, fix the config file, and restart.
-""")
+            print(rewrap("""\
+                Unable to confirm that the buildmaster started correctly.
+                You may need to stop it, fix the config file, and restart.
+                """))
             print(why)
         self.rc = 1
         reactor.stop()

--- a/master/buildbot/test/unit/test_util.py
+++ b/master/buildbot/test/unit/test_util.py
@@ -403,3 +403,62 @@ class CommandToString(unittest.TestCase):
 
     def test_invalid_ascii(self):
         self.assertEqual(util.command_to_string('a\xffc'), u"'a\ufffdc'")
+
+
+class TestRewrap(unittest.TestCase):
+
+    def test_main(self):
+        tests = [
+            ("", "", None),
+            ("\n", "\n", None),
+            ("\n  ", "\n", None),
+            ("  \n", "\n", None),
+            ("  \n  ", "\n", None),
+            ("""
+                multiline
+                with
+                indent
+                """,
+             "\nmultiline with indent",
+             None),
+            ("""\
+                multiline
+                with
+                indent
+
+                """,
+             "multiline with indent\n",
+             None),
+            ("""\
+                 multiline
+                 with
+                 indent
+
+                 """,
+             "multiline with indent\n",
+             None),
+            ("""\
+                multiline
+                with
+                indent
+
+                  and
+                   formatting
+                """,
+             "multiline with indent\n  and\n   formatting\n",
+             None),
+            ("""\
+                multiline
+                with
+                indent
+                and wrapping
+
+                  and
+                   formatting
+                """,
+             "multiline with\nindent and\nwrapping\n  and\n   formatting\n",
+             15),
+        ]
+
+        for text, expected, width in tests:
+            self.assertEqual(util.rewrap(text, width=width), expected)

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -18,9 +18,11 @@ from future.moves.urllib.parse import urlunsplit
 import calendar
 import datetime
 import dateutil.tz
+import itertools
 import locale
 import re
 import string
+import textwrap
 import time
 
 from twisted.python import reflect
@@ -371,9 +373,47 @@ def command_to_string(command):
     return rv
 
 
+def rewrap(text, width=None):
+    """
+    Rewrap text for output to the console.
+
+    Removes common indentation and rewraps paragraphs according to the console
+    width.
+
+    Line feeds between paragraphs preserved.
+    Formatting of paragraphs that starts with additional indentation
+    preserved.
+    """
+
+    if width is None:
+        width = 80
+
+    # Remove common indentation.
+    text = textwrap.dedent(text)
+
+    def needs_wrapping(line):
+        # Line always non-empty.
+        return not line[0].isspace()
+
+    # Split text by lines and group lines that comprise paragraphs.
+    wrapped_text = ""
+    for do_wrap, lines in itertools.groupby(text.splitlines(True),
+                                            key=needs_wrapping):
+        paragraph = ''.join(lines)
+
+        if do_wrap:
+            paragraph = textwrap.fill(paragraph, width)
+
+        wrapped_text += paragraph
+
+    return wrapped_text
+
+
 __all__ = [
     'naturalSort', 'now', 'formatInterval', 'ComparableMixin', 'json',
     'safeTranslate', 'none_or_str',
     'NotABranch', 'deferredLocked', 'UTC',
     'diffSets', 'makeList', 'in_reactor', 'string2boolean',
-    'check_functional_environment', 'human_readable_delta']
+    'check_functional_environment', 'human_readable_delta',
+    'rewrap',
+]

--- a/worker/buildbot_worker/scripts/start.py
+++ b/worker/buildbot_worker/scripts/start.py
@@ -20,6 +20,7 @@ import sys
 import time
 
 from buildbot_worker.scripts import base
+from buildbot_worker.util import rewrap
 
 
 class Follower(object):
@@ -45,23 +46,25 @@ class Follower(object):
         from twisted.internet import reactor
         from buildbot_worker.scripts.logwatcher import WorkerTimeoutError
         if why.check(WorkerTimeoutError):
-            print("""
-The worker took more than 10 seconds to start and/or connect to the
-buildmaster, so we were unable to confirm that it started and connected
-correctly. Please 'tail twistd.log' and look for a line that says 'message
-from master: attached' to verify correct startup. If you see a bunch of
-messages like 'will retry in 6 seconds', your worker might not have the
-correct hostname or portnumber for the buildmaster, or the buildmaster might
-not be running. If you see messages like
-   'Failure: twisted.cred.error.UnauthorizedLogin'
-then your worker might be using the wrong botname or password. Please
-correct these problems and then restart the worker.
-""")
+            print(rewrap("""\
+                The worker took more than 10 seconds to start and/or connect
+                to the buildmaster, so we were unable to confirm that it
+                started and connected correctly.
+                Please 'tail twistd.log' and look for a line that says
+                'message from master: attached' to verify correct startup.
+                If you see a bunch of messages like 'will retry in 6 seconds',
+                your worker might not have the correct hostname or portnumber
+                for the buildmaster, or the buildmaster might not be running.
+                If you see messages like
+                   'Failure: twisted.cred.error.UnauthorizedLogin'
+                then your worker might be using the wrong botname or password.
+                Please correct these problems and then restart the worker.
+                """))
         else:
-            print("""
-Unable to confirm that the worker started correctly. You may need to
-stop it, fix the config file, and restart.
-""")
+            print(rewrap("""\
+                Unable to confirm that the worker started correctly.
+                You may need to stop it, fix the config file, and restart.
+                """))
             print(why)
         self.rc = 1
         reactor.stop()

--- a/worker/buildbot_worker/test/unit/test_util.py
+++ b/worker/buildbot_worker/test/unit/test_util.py
@@ -80,3 +80,62 @@ class TestObfuscated(unittest.TestCase):
         cmd = 1
         self.failUnlessEqual(1, util.Obfuscated.get_real(cmd))
         self.failUnlessEqual(1, util.Obfuscated.get_fake(cmd))
+
+
+class TestRewrap(unittest.TestCase):
+
+    def test_main(self):
+        tests = [
+            ("", "", None),
+            ("\n", "\n", None),
+            ("\n  ", "\n", None),
+            ("  \n", "\n", None),
+            ("  \n  ", "\n", None),
+            ("""
+                multiline
+                with
+                indent
+                """,
+             "\nmultiline with indent",
+             None),
+            ("""\
+                multiline
+                with
+                indent
+
+                """,
+             "multiline with indent\n",
+             None),
+            ("""\
+                 multiline
+                 with
+                 indent
+
+                 """,
+             "multiline with indent\n",
+             None),
+            ("""\
+                multiline
+                with
+                indent
+
+                  and
+                   formatting
+                """,
+             "multiline with indent\n  and\n   formatting\n",
+             None),
+            ("""\
+                multiline
+                with
+                indent
+                and wrapping
+
+                  and
+                   formatting
+                """,
+             "multiline with\nindent and\nwrapping\n  and\n   formatting\n",
+             15),
+        ]
+
+        for text, expected, width in tests:
+            self.assertEqual(util.rewrap(text, width=width), expected)

--- a/worker/buildbot_worker/util.py
+++ b/worker/buildbot_worker/util.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+import itertools
+import textwrap
 import time
 
 
@@ -85,3 +87,39 @@ class Obfuscated(object):
                 else:
                     rv.append(Obfuscated.to_text(elt))
         return rv
+
+
+def rewrap(text, width=None):
+    """
+    Rewrap text for output to the console.
+
+    Removes common indentation and rewraps paragraphs according to the console
+    width.
+
+    Line feeds between paragraphs preserved.
+    Formatting of paragraphs that starts with additional indentation
+    preserved.
+    """
+
+    if width is None:
+        width = 80
+
+    # Remove common indentation.
+    text = textwrap.dedent(text)
+
+    def needs_wrapping(line):
+        # Line always non-empty.
+        return not line[0].isspace()
+
+    # Split text by lines and group lines that comprise paragraphs.
+    wrapped_text = ""
+    for do_wrap, lines in itertools.groupby(text.splitlines(True),
+                                            key=needs_wrapping):
+        paragraph = ''.join(lines)
+
+        if do_wrap:
+            paragraph = textwrap.fill(paragraph, width)
+
+        wrapped_text += paragraph
+
+    return wrapped_text


### PR DESCRIPTION
This PR based on #2160, lets deal with that one first.
<hr>

We want:

1. to have strings properly formatted in the source code;

2. to have outputted to the terminal strings properly wrapped;

3. to preserve formatting of some parts of outputted to the terminal strings.

Currently strings are not well formatted in the source code:

```python
        if why.check(WorkerTimeoutError):
            print("""
The worker took more than 10 seconds to start and/or connect to the
buildmaster, so we were unable to confirm that it started and connected
correctly. Please 'tail twistd.log' and look for a line that says 'message
from master: attached' to verify correct startup. If you see a bunch of
messages like 'will retry in 6 seconds', your worker might not have the
correct hostname or portnumber for the buildmaster, or the buildmaster might
not be running. If you see messages like
   'Failure: twisted.cred.error.UnauthorizedLogin'
then your worker might be using the wrong botname or password. Please
correct these problems and then restart the worker.
""")
```

If we use `textwrap.dedent` here strings will not be properly wrapped,
instead of being wrapped by 80 column, they will be wrapped by 62 column in the console:

```python
        if why.check(WorkerTimeoutError):
            print(textwrap.dedent("""\
                The worker took more than 10 seconds to start and/or connect
                to the buildmaster, so we were unable to confirm that it
                started and connected correctly.
                Please 'tail twistd.log' and look for a line that says
                'message from master: attached' to verify correct startup.
                If you see a bunch of messages like 'will retry in 6 seconds',
                your worker might not have the correct hostname or portnumber
                for the buildmaster, or the buildmaster might not be running.
                If you see messages like
                   'Failure: twisted.cred.error.UnauthorizedLogin'
                then your worker might be using the wrong botname or password.
                Please correct these problems and then restart the worker.
                """))
```

If we use `textwrap.fill` to rewrap paragraphs we will get properly filled
by width strings, but will loose formatting (e.g. of
`  'Failure: twisted.cred.error.UnauthorizedLogin'` in the example above).

`rewrap` function combines `textwrap.dedent` with rewrapping with
`textwrap.fill` paragraphs that doesn't contain raw code blocks
(denoted by spaces at the begin of a line).