### PR TITLE
Make more use of a non-global reactor.

### DIFF
--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -105,6 +105,7 @@ class DBConnector(WorkerAPICompatMixin, service.ReconfigurableServiceMixin,
 
         self.cleanup_timer = internet.TimerService(self.CLEANUP_PERIOD,
                                                    self._doCleanup)
+        self.cleanup_timer.clock = self.master.reactor
         self.cleanup_timer.setServiceParent(self)
         return d
 

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -501,7 +501,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
 
     # Build Creation
 
-    def maybeStartBuild(self, workerforbuilder, breqs, _reactor=reactor):
+    def maybeStartBuild(self, workerforbuilder, breqs):
         # This method is called by the botmaster whenever this builder should
         # start a set of buildrequests on a worker. Do not call this method
         # directly - use master.botmaster.maybeStartBuildsForBuilder, or one of


### PR DESCRIPTION
This is in preparation for synchronous integration tests.