### PR TITLE
run isort only if there are changed Python files

### DIFF
--- a/common/validate.sh
+++ b/common/validate.sh
@@ -176,12 +176,18 @@ check_sa_Table || warning "use (buildbot.util.)sautils.Table instead of sa.Table
 status "checking for release notes"
 check_relnotes || warning "$REVRANGE does not add release notes"
 
-status "checking import module convention in modified files"
-if [[ -z `command -v isort` ]]; then
-    warning "isort is not installed"
-else
-    if ! isort ${py_files[@]}; then
-        warning "unable to run isort on modified files"
+if [ ${#py_files[@]} -ne 0 ]; then
+    status "checking import module convention in modified files"
+    if [[ -z `command -v isort` ]]; then
+        warning "isort is not installed"
+    else
+        if ! isort ${py_files[@]}; then
+            warning "unable to run isort on modified files"
+        else
+            if ! git diff --quiet --exit-code ${py_files[@]}; then
+                not_ok "isort made changes"
+            fi
+        fi
     fi
 fi
 


### PR DESCRIPTION
otherwise isort is being run without argument which leads to recursive fixing of all `*.py` files.

Also adds reporting if isort changed files.

BTW, `setup.py` is not included in list of Python files which looks strange to me. 

/cc: @tardyp 