### PR TITLE
Fix glob() and runGlob() calls to remote 

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -1062,9 +1062,9 @@ class CommandMixin(object):
         return self._runRemoteCommand('mkdir', abandonOnFailure,
                                       {'dir': dir, 'logEnviron': False})
 
-    def glob(self, glob):
+    def runGlob(self, path):
         return self._runRemoteCommand(
-            'glob', True, {'glob': glob, 'logEnviron': False},
+            'glob', True, {'path': path, 'logEnviron': False},
             makeResult=lambda cmd: cmd.updates['files'][0])
 
 

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -279,12 +279,12 @@ class CompositeStepMixin():
                                                'logEnviron': self.logEnviron, },
                                      **kwargs)
 
-    def runGlob(self, glob):
+    def runGlob(self, path):
         """ find files matching a shell-style pattern"""
         def commandComplete(cmd):
             return cmd.updates['files'][-1]
 
-        return self.runRemoteCommand('glob', {'glob': glob,
+        return self.runRemoteCommand('glob', {'path': path,
                                               'logEnviron': self.logEnviron, },
                                      evaluateCommand=commandComplete)
 

--- a/master/buildbot/test/integration/test_commandmixin.py
+++ b/master/buildbot/test/integration/test_commandmixin.py
@@ -1,0 +1,96 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+from twisted.internet import defer
+
+from buildbot.process import results
+from buildbot.process.buildstep import BuildStep
+from buildbot.process.buildstep import CommandMixin
+from buildbot.test.util.integration import RunMasterBase
+
+
+# This integration test creates a master and worker environment,
+# and makes sure the command mixin is working.
+class CommandMixinMaster(RunMasterBase):
+
+    @defer.inlineCallbacks
+    def test_commandmixin(self):
+        yield self.setupConfig(masterConfig())
+
+        change = dict(branch="master",
+                      files=["foo.c"],
+                      author="me@foo.com",
+                      comments="good stuff",
+                      revision="HEAD",
+                      project="none"
+                      )
+        build = yield self.doForceBuild(wantSteps=True, useChange=change,
+                                        wantLogs=True)
+        self.assertEqual(build['buildid'], 1)
+        self.assertEqual(build['results'], results.SUCCESS)
+
+
+class TestCommandMixinStep(BuildStep, CommandMixin):
+
+    def __init__(self, *args, **kwargs):
+        BuildStep.__init__(self, *args, **kwargs)
+
+    @defer.inlineCallbacks
+    def run(self):
+        contents = yield self.runGlob('*')
+        if contents != []:
+            defer.returnValue(results.FAILURE)
+
+        hasPath = yield self.pathExists('composite_mixin_test')
+        if hasPath:
+            defer.returnValue(results.FAILURE)
+
+        yield self.runMkdir('composite_mixin_test')
+
+        hasPath = yield self.pathExists('composite_mixin_test')
+        if not hasPath:
+            defer.returnValue(results.FAILURE)
+
+        contents = yield self.runGlob('*')
+        if not contents[0].endswith('composite_mixin_test'):
+            defer.returnValue(results.FAILURE)
+
+        yield self.runRmdir('composite_mixin_test')
+
+        hasPath = yield self.pathExists('composite_mixin_test')
+        if hasPath:
+            defer.returnValue(results.FAILURE)
+
+        defer.returnValue(results.SUCCESS)
+
+
+# master configuration
+def masterConfig():
+    c = {}
+    from buildbot.config import BuilderConfig
+    from buildbot.process.factory import BuildFactory
+    from buildbot.plugins import schedulers
+
+    c['schedulers'] = [
+        schedulers.AnyBranchScheduler(
+            name="sched",
+            builderNames=["testy"])]
+
+    f = BuildFactory()
+    f.addStep(TestCommandMixinStep())
+    c['builders'] = [
+        BuilderConfig(name="testy",
+                      workernames=["local1"],
+                      factory=f)]
+    return c

--- a/master/buildbot/test/integration/test_compositestepmixin.py
+++ b/master/buildbot/test/integration/test_compositestepmixin.py
@@ -1,0 +1,97 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+from twisted.internet import defer
+
+from buildbot.process import results
+from buildbot.process.buildstep import BuildStep
+from buildbot.steps.worker import CompositeStepMixin
+from buildbot.test.util.integration import RunMasterBase
+
+
+# This integration test creates a master and worker environment,
+# and makes sure the composite step mixin is working.
+class CompositeStepMixinMaster(RunMasterBase):
+
+    @defer.inlineCallbacks
+    def test_compositemixin(self):
+        yield self.setupConfig(masterConfig())
+
+        change = dict(branch="master",
+                      files=["foo.c"],
+                      author="me@foo.com",
+                      comments="good stuff",
+                      revision="HEAD",
+                      project="none"
+                      )
+        build = yield self.doForceBuild(wantSteps=True, useChange=change,
+                                        wantLogs=True)
+        self.assertEqual(build['buildid'], 1)
+        self.assertEqual(build['results'], results.SUCCESS)
+
+
+class TestCompositeMixinStep(BuildStep, CompositeStepMixin):
+
+    def __init__(self, *args, **kwargs):
+        BuildStep.__init__(self, *args, **kwargs)
+        self.logEnviron = False
+
+    @defer.inlineCallbacks
+    def run(self):
+        contents = yield self.runGlob('*')
+        if contents != []:
+            defer.returnValue(results.FAILURE)
+
+        hasPath = yield self.pathExists('composite_mixin_test')
+        if hasPath:
+            defer.returnValue(results.FAILURE)
+
+        yield self.runMkdir('composite_mixin_test')
+
+        hasPath = yield self.pathExists('composite_mixin_test')
+        if not hasPath:
+            defer.returnValue(results.FAILURE)
+
+        contents = yield self.runGlob('*')
+        if not contents[0].endswith('composite_mixin_test'):
+            defer.returnValue(results.FAILURE)
+
+        yield self.runRmdir('composite_mixin_test')
+
+        hasPath = yield self.pathExists('composite_mixin_test')
+        if hasPath:
+            defer.returnValue(results.FAILURE)
+
+        defer.returnValue(results.SUCCESS)
+
+
+# master configuration
+def masterConfig():
+    c = {}
+    from buildbot.config import BuilderConfig
+    from buildbot.process.factory import BuildFactory
+    from buildbot.plugins import schedulers
+
+    c['schedulers'] = [
+        schedulers.AnyBranchScheduler(
+            name="sched",
+            builderNames=["testy"])]
+
+    f = BuildFactory()
+    f.addStep(TestCompositeMixinStep())
+    c['builders'] = [
+        BuilderConfig(name="testy",
+                      workernames=["local1"],
+                      factory=f)]
+    return c

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -810,11 +810,11 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
     def test_glob(self):
         @defer.inlineCallbacks
         def testFunc():
-            res = yield self.step.glob("*.pyc")
+            res = yield self.step.runGlob("*.pyc")
             self.assertEqual(res, ["one.pyc", "two.pyc"])
         self.step.testMethod = testFunc
         self.expectCommands(
-            Expect('glob', {'glob': '*.pyc', 'logEnviron': False})
+            Expect('glob', {'path': '*.pyc', 'logEnviron': False})
             + Expect.update('files', ["one.pyc", "two.pyc"])
             + 0
         )
@@ -822,9 +822,9 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
     def test_glob_empty(self):
-        self.step.testMethod = lambda: self.step.glob("*.pyc")
+        self.step.testMethod = lambda: self.step.runGlob("*.pyc")
         self.expectCommands(
-            Expect('glob', {'glob': '*.pyc', 'logEnviron': False})
+            Expect('glob', {'path': '*.pyc', 'logEnviron': False})
             + Expect.update('files', [])
             + 0
         )
@@ -832,9 +832,9 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
     def test_glob_fail(self):
-        self.step.testMethod = lambda: self.step.glob("*.pyc")
+        self.step.testMethod = lambda: self.step.runGlob("*.pyc")
         self.expectCommands(
-            Expect('glob', {'glob': '*.pyc', 'logEnviron': False})
+            Expect('glob', {'path': '*.pyc', 'logEnviron': False})
             + 1
         )
         self.expectOutcome(result=FAILURE)

--- a/master/buildbot/test/unit/test_steps_worker.py
+++ b/master/buildbot/test/unit/test_steps_worker.py
@@ -364,7 +364,7 @@ class TestCompositeStepMixin(steps.BuildStepMixin, unittest.TestCase):
 
         self.setupStep(CompositeUser(testFunc))
         self.expectCommands(
-            Expect('glob', {'glob': '*.pyc', 'logEnviron': False})
+            Expect('glob', {'path': '*.pyc', 'logEnviron': False})
             + Expect.update('files', ["one.pyc", "two.pyc"])
             + 0
         )
@@ -374,7 +374,7 @@ class TestCompositeStepMixin(steps.BuildStepMixin, unittest.TestCase):
     def test_glob_fail(self):
         self.setupStep(CompositeUser(lambda x: x.runGlob("*.pyc")))
         self.expectCommands(
-            Expect('glob', {'glob': '*.pyc', 'logEnviron': False})
+            Expect('glob', {'path': '*.pyc', 'logEnviron': False})
             + 1
         )
         self.expectOutcome(result=FAILURE)

--- a/master/docs/developer/cls-buildsteps.rst
+++ b/master/docs/developer/cls-buildsteps.rst
@@ -584,14 +584,14 @@ This class can only be used in new-style steps.
         Determine if the given path exists on the worker (in any form - file, directory, or otherwise).
         This uses the ``stat`` command.
 
-    .. py:method:: runGlob(glob)
+    .. py:method:: runGlob(path)
 
         :param path: path to test
         :returns: list of filenames
 
         Get the list of files matching the given path pattern on the worker.
         This uses Python's ``glob`` module.
-        If the ``glob`` method fails, it aborts the step.
+        If the ``runGlob`` method fails, it aborts the step.
 
     .. py:method:: getFileContentFromWorker(path, abandonOnFailure=False)
 

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -897,7 +897,7 @@ If the path does not exist (or anything fails) we mark the step as failed; if th
                 self.finished(util.WARNINGS)
                 return
 
-            cmd = buildstep.RemoteCommand('glob', {'glob': self.dirname + '/*.pyc'})
+            cmd = buildstep.RemoteCommand('glob', {'path': self.dirname + '/*.pyc'})
 
             d = self.runCommand(cmd)
             d.addCallback(lambda res: self.evaluateGlob(cmd))

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -62,6 +62,10 @@ Worker
 Fixes
 ~~~~~
 
+* ``runGlob()`` uses the correct remote protocol for both :py:class:`~buildbot.process.buildstep.CommandMixin` and :py:class:`~buildbot.steps.worker.ComposititeStepMixin`.
+
+* Rename ``glob()`` to ``runGlob()`` in :py:class:`~buildbot.process.buildstep.CommandMixin`
+
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
There is a disconnect between the way the master calls glob in both the CommandMixin and CompositeMixin classes and the way the worker expects the command, which is defined as:

```
class GlobPath(base.Command):

    header = "glob"

    # args['path'] is relative to Builder directory, and is required.
    requiredArgs = ['path']

    def start(self):
        pathname = os.path.join(self.builder.basedir, self.args['path'])
```

This updates both components to pass the expected `path` arg instead of the `glob` for the glob command. Since the worker and master protocol tests are isolated, though, there isn't any additional verification that this change is correct. However, it did make glob work correctly on my local setup using CommandMixin.

I also updated the documentation on a couple minor points to be consistent with code.

There are a couple bigger questions raised here such as:
  - Should CommandMixin use `runGlob()` instead of `glob()` as the documentation claimed?
  - Should we pass `glob` via the remote protocol instead of `path`?

Both of these seemed like bigger questions with likely painful transitions, so I decided to fix the code as is and not worry about the rest.