### PR TITLE
Update remote error handling to relay remote errors

### DIFF
--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -209,8 +209,15 @@ class WorkerForBuilderBase(service.Service):
             log.err(failure)
             # failure, if present, is a failure.Failure. To send it across
             # the wire, we must turn it into a pb.CopyableFailure.
-            failure = pb.CopyableFailure(failure)
-            failure.unsafeTracebacks = True
+            if isinstance(failure, pb.CopiedFailure):
+                # copiedFailures from other remotes don't construct normally
+                # into CopyableFailure. This won't fully send the traceback,
+                # but is better than failing and hanging the command.
+                failure = pb.CopyableFailure(failure.value, failure.type,
+                                             failure.getTracebackObject())
+            else:
+                failure = pb.CopyableFailure(failure)
+                failure.unsafeTracebacks = True
         else:
             # failure is None
             log.msg("WorkerForBuilder.commandComplete", self.command)


### PR DESCRIPTION
Previously, when a remote's remote (e.g. master) failed during an operation
(such as uploading a file), the remote received a CopiedFailure. The remote
would not not properly reconstruct the failure to pass onto master. This led
the remote raising additional exceptions rather than properly terminating the
current command.

With this approach, the traceback is not passed (although a copy exists in the
original remote's logs, but the error is properly passed through the remote back
to master.

---

I ran into this problem working on a file uploader when I passed in an invalid `masterdest` argument that caused os.unlink to fail. 

I suspect there's a unit test that needs to be written, but I'm not sure how/where to put it, especially since the failure scenario seems to cause the build step in question to run indefinitely since the master never gets notification of the command completing by failing. Thoughts on the best approach to testing? 