### PR TITLE
Fix project info line

### DIFF
--- a/www/base/src/app/about/about.tpl.jade
+++ b/www/base/src/app/about/about.tpl.jade
@@ -5,7 +5,7 @@
         .row
           .col-sm-4
             ul
-              li Project Infos:
+              li Project Info:&nbsp;
                 a(ng-href="{{config.titleURL}}") {{config.title}}
               li(ng-repeat="v in config.versions") {{v[0]}} version: {{v[1]}}
         .row


### PR DESCRIPTION
Correct "Infos" to "Info", use <strike>tag interpolation</strike> `&nbsp;` to preserve space after colon.