### PR TITLE
Fix consistency in scheduler_changes table usage #3532

### DIFF
--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -244,6 +244,9 @@ class FakeUpdates(service.AsyncService):
         return defer.succeed(None)
 
     def findSchedulerId(self, name):
+        return self.master.db.schedulers.findSchedulerId(name)
+
+    def forget_about_it(self, name):
         validation.verifyType(self.testcase, 'scheduler name', name,
                               validation.StringValidator())
         if name not in self.schedulerIds:

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -222,7 +222,7 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
         sched.deactivate = mock.Mock(return_value=defer.succeed(None))
 
         # set the schedulerid, and claim the scheduler on another master
-        self.setSchedulerToMaster(self.OTHER_MASTER_ID)
+        yield self.setSchedulerToMaster(self.OTHER_MASTER_ID)
 
         yield sched.startService()
         sched.clock.advance(sched.POLL_INTERVAL_SEC / 2)
@@ -232,7 +232,7 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
         self.assertFalse(sched.deactivate.called)
         self.assertFalse(sched.isActive())
         # objectid is attached by the test helper
-        self.assertEqual(sched.serviceid, sched.objectid)
+        self.assertEqual(sched.serviceid, self.SCHEDULERID)
 
         # clear that masterid
         yield sched.stopService()

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -29,6 +29,7 @@ from twisted.trial import unittest
 class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
 
     OBJECTID = 19
+    SCHEDULERID = 9
     exp_bsid_brids = (123, {'b': 456})
 
     def setUp(self):
@@ -50,7 +51,7 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
         sched = self.attachScheduler(
             base.BaseScheduler(name=name, builderNames=builderNames,
                                properties=properties, codebases=codebases),
-            self.OBJECTID)
+            self.OBJECTID, self.SCHEDULERID)
         self.master.data.updates.addBuildset = mock.Mock(
             name='data.addBuildset',
             side_effect=lambda *args, **kwargs:

--- a/master/buildbot/test/unit/test_schedulers_basic.py
+++ b/master/buildbot/test/unit/test_schedulers_basic.py
@@ -33,7 +33,7 @@ class CommonStuffMixin(object):
 
         self.master.db.insertTestData(
             [fakedb.Builder(name=builderName) for builderName in kwargs['builderNames']])
-        sched = self.attachScheduler(klass(**kwargs), self.SCHEDULERID)
+        sched = self.attachScheduler(klass(**kwargs), self.OBJECTID, self.SCHEDULERID)
 
         # add a Clock to help checking timing issues
         self.clock = sched._reactor = task.Clock()
@@ -69,7 +69,8 @@ class CommonStuffMixin(object):
 class BaseBasicScheduler(CommonStuffMixin,
                          scheduler.SchedulerMixin, unittest.TestCase):
 
-    SCHEDULERID = 244
+    OBJECTID = 244
+    SCHEDULERID = 4
 
     # a custom subclass since we're testing the base class.  This basically
     # re-implements SingleBranchScheduler, but with more asserts
@@ -296,7 +297,7 @@ class SingleBranchScheduler(CommonStuffMixin,
         self.master.db.insertTestData(
             [fakedb.Builder(name=builderName) for builderName in kwargs['builderNames']])
         sched = self.attachScheduler(basic.SingleBranchScheduler(**kwargs),
-                                     self.SCHEDULERID,
+                                     self.OBJECTID, self.SCHEDULERID,
                                      overrideBuildsetMethods=True)
 
         # add a Clock to help checking timing issues
@@ -452,7 +453,8 @@ class SingleBranchScheduler(CommonStuffMixin,
 class AnyBranchScheduler(CommonStuffMixin,
                          scheduler.SchedulerMixin, unittest.TestCase):
 
-    SCHEDULERID = 246
+    SCHEDULERID = 6
+    OBJECTID = 246
 
     def setUp(self):
         self.setUpScheduler()

--- a/master/buildbot/test/unit/test_schedulers_dependent.py
+++ b/master/buildbot/test/unit/test_schedulers_dependent.py
@@ -27,6 +27,7 @@ from twisted.trial import unittest
 SUBMITTED_AT_TIME = 111111111
 COMPLETE_AT_TIME = 222222222
 OBJECTID = 33
+SCHEDULERID = 133
 UPSTREAM_NAME = u'uppy'
 
 
@@ -49,7 +50,7 @@ class Dependent(scheduler.SchedulerMixin, unittest.TestCase):
 
         sched = dependent.Dependent(name='n', builderNames=['b'],
                                     upstream=upstream)
-        self.attachScheduler(sched, OBJECTID,
+        self.attachScheduler(sched, OBJECTID, SCHEDULERID,
                              overrideBuildsetMethods=True,
                              createBuilderDB=True)
 

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -43,6 +43,7 @@ from twisted.trial import unittest
 class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.TestCase):
 
     OBJECTID = 19
+    SCHEDULERID = 9
 
     def setUp(self):
         self.setUpScheduler()
@@ -54,7 +55,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                       **kw):
         sched = self.attachScheduler(
             ForceScheduler(name=name, builderNames=builderNames, **kw),
-            self.OBJECTID,
+            self.OBJECTID, self.SCHEDULERID,
             overrideBuildsetMethods=True,
             createBuilderDB=True)
         sched.master.config = config.MasterConfig()

--- a/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
@@ -30,6 +30,7 @@ from twisted.trial import unittest
 class Nightly(scheduler.SchedulerMixin, unittest.TestCase):
 
     OBJECTID = 132
+    SCHEDULERID = 32
 
     # not all timezones are even multiples of 1h from GMT.  This variable
     # holds the number of seconds ahead of the hour for the current timezone.
@@ -39,7 +40,8 @@ class Nightly(scheduler.SchedulerMixin, unittest.TestCase):
 
     def makeScheduler(self, **kwargs):
         sched = self.attachScheduler(timed.Nightly(**kwargs),
-                                     self.OBJECTID, overrideBuildsetMethods=True)
+                                     self.OBJECTID, self.SCHEDULERID,
+                                     overrideBuildsetMethods=True)
 
         self.master.db.insertTestData(
             [fakedb.Builder(name=bname) for bname in kwargs.get("builderNames", [])])

--- a/master/buildbot/test/unit/test_schedulers_timed_NightlyBase.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_NightlyBase.py
@@ -32,13 +32,14 @@ class NightlyBase(scheduler.SchedulerMixin, unittest.TestCase):
     """detailed getNextBuildTime tests"""
 
     OBJECTID = 133
+    SCHEDULERID = 33
 
     def setUp(self):
         self.setUpScheduler()
 
     def makeScheduler(self, firstBuildDuration=0, **kwargs):
         return self.attachScheduler(timed.NightlyBase(**kwargs),
-                                    self.OBJECTID)
+                                    self.OBJECTID, self.SCHEDULERID)
 
     @defer.inlineCallbacks
     def do_getNextBuildTime_test(self, sched, *expectations):

--- a/master/buildbot/test/unit/test_schedulers_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_NightlyTriggerable.py
@@ -23,11 +23,12 @@ from twisted.trial import unittest
 
 class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
 
-    SCHEDULERID = 1327
+    SCHEDULERID = 327
+    OBJECTID = 1327
 
     def makeScheduler(self, firstBuildDuration=0, **kwargs):
         sched = self.attachScheduler(timed.NightlyTriggerable(**kwargs),
-                                     self.SCHEDULERID,
+                                     self.OBJECTID, self.SCHEDULERID,
                                      overrideBuildsetMethods=True,
                                      createBuilderDB=True)
 

--- a/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
@@ -24,13 +24,14 @@ from twisted.trial import unittest
 class Periodic(scheduler.SchedulerMixin, unittest.TestCase):
 
     OBJECTID = 23
+    SCHEDULERID = 3
 
     def setUp(self):
         self.setUpScheduler()
 
     def makeScheduler(self, firstBuildDuration=0, exp_branch=None, **kwargs):
         self.sched = sched = timed.Periodic(**kwargs)
-        self.attachScheduler(self.sched, self.OBJECTID)
+        self.attachScheduler(self.sched, self.OBJECTID, self.SCHEDULERID)
 
         # add a Clock to help checking timing issues
         self.clock = sched._reactor = task.Clock()

--- a/master/buildbot/test/unit/test_schedulers_triggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_triggerable.py
@@ -37,6 +37,7 @@ class TriggerableInterfaceTest(unittest.TestCase, interfaces.InterfaceTests):
 class Triggerable(scheduler.SchedulerMixin, unittest.TestCase):
 
     OBJECTID = 33
+    SCHEDULERID = 13
 
     def setUp(self):
         # Necessary to get an assertable submitted_at time.
@@ -59,7 +60,8 @@ class Triggerable(scheduler.SchedulerMixin, unittest.TestCase):
 
         sched = self.attachScheduler(
             triggerable.Triggerable(name='n', builderNames=['b'], **kwargs),
-            self.OBJECTID, overrideBuildsetMethods=overrideBuildsetMethods)
+            self.OBJECTID, self.SCHEDULERID,
+            overrideBuildsetMethods=overrideBuildsetMethods)
         sched._updateWaiters._reactor = self.clock
 
         return sched

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -84,6 +84,7 @@ class JobdirService(dirs.DirsMixin, unittest.TestCase):
 class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
 
     OBJECTID = 23
+    SCHEDULERID = 3
 
     def setUp(self):
         self.setUpScheduler()
@@ -106,7 +107,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
         # build scheduler
         kwargs = dict(name="tsched", builderNames=['a'], jobdir=self.jobdir)
         sched = self.attachScheduler(
-            trysched.Try_Jobdir(**kwargs), self.OBJECTID,
+            trysched.Try_Jobdir(**kwargs), self.OBJECTID, self.SCHEDULERID,
             overrideBuildsetMethods=True)
 
         # watch interaction with the watcher service
@@ -508,7 +509,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
         sched = self.attachScheduler(
             trysched.Try_Jobdir(
                 name='tsched', builderNames=['buildera', 'builderb'],
-                jobdir='foo'), self.OBJECTID,
+                jobdir='foo'), self.OBJECTID, self.SCHEDULERID,
             overrideBuildsetMethods=True,
             createBuilderDB=True)
         fakefile = mock.Mock()
@@ -645,6 +646,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
 class Try_Userpass_Perspective(scheduler.SchedulerMixin, unittest.TestCase):
 
     OBJECTID = 26
+    SCHEDULERID = 6
 
     def setUp(self):
         self.setUpScheduler()
@@ -654,7 +656,7 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, unittest.TestCase):
 
     def makeScheduler(self, **kwargs):
         sched = self.attachScheduler(trysched.Try_Userpass(**kwargs),
-                                     self.OBJECTID,
+                                     self.OBJECTID, self.SCHEDULERID,
                                      overrideBuildsetMethods=True,
                                      createBuilderDB=True)
         # Try will return a remote version of master.status, so give it
@@ -764,6 +766,7 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, unittest.TestCase):
 class Try_Userpass(scheduler.SchedulerMixin, unittest.TestCase):
 
     OBJECTID = 25
+    SCHEDULERID = 5
 
     def setUp(self):
         self.setUpScheduler()
@@ -773,7 +776,7 @@ class Try_Userpass(scheduler.SchedulerMixin, unittest.TestCase):
 
     def makeScheduler(self, **kwargs):
         sched = self.attachScheduler(trysched.Try_Userpass(**kwargs),
-                                     self.OBJECTID)
+                                     self.OBJECTID, self.SCHEDULERID)
         return sched
 
     def test_service(self):

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -47,7 +47,7 @@ class SchedulerMixin(interfaces.InterfaceTests):
     def tearDownScheduler(self):
         pass
 
-    def attachScheduler(self, scheduler, objectid,
+    def attachScheduler(self, scheduler, objectid, schedulerid,
                         overrideBuildsetMethods=False,
                         createBuilderDB=False):
         """Set up a scheduler with a fake master and db; sets self.sched, and
@@ -74,7 +74,9 @@ class SchedulerMixin(interfaces.InterfaceTests):
         scheduler.setServiceParent(self.master)
 
         rows = [fakedb.Object(id=objectid, name=scheduler.name,
-                              class_name='SomeScheduler')]
+                              class_name='SomeScheduler'),
+                fakedb.Scheduler(id=schedulerid, name=scheduler.name),
+                ]
         if createBuilderDB is True:
             rows.extend([fakedb.Builder(name=bname)
                          for bname in scheduler.builderNames])

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -144,14 +144,13 @@ class SchedulerMixin(interfaces.InterfaceTests):
         self.sched = scheduler
         return scheduler
 
+    @defer.inlineCallbacks
     def setSchedulerToMaster(self, otherMaster):
-        self.master.data.updates.schedulerIds[
-            self.sched.name] = self.sched.objectid
+        sched_id = yield self.master.data.updates.findSchedulerId(self.sched.name)
         if otherMaster:
-            self.master.data.updates.schedulerMasters[
-                self.sched.objectid] = otherMaster
+            self.master.data.updates.schedulerMasters[sched_id] = otherMaster
         else:
-            del self.master.data.updates.schedulerMasters[self.sched.objectid]
+            del self.master.data.updates.schedulerMasters[sched_id]
 
     class FakeChange:
         who = ''


### PR DESCRIPTION
The ids referred to in scheduler_changes should be those from the
schedulers table, instead of the objectid (used for object_states)

For now, this PR is work-in-progress, as it doesn't take @djmitche remark that scheduler id could be take from `_getServiceId`, which itself could implement caching.

That being said, untangling OBJECTID and SCHEDULERID in the tests has been somewhat easier than I expected.