### PR TITLE
Don't return deferreds twice when substantiating.

### DIFF
--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 from buildbot.config import BuilderConfig
+from buildbot.process.results import SUCCESS
 from buildbot.process.factory import BuildFactory
 from buildbot.test.fake.reactor import NonThreadPool
 from buildbot.test.fake.reactor import TestReactor
@@ -23,7 +24,13 @@ from buildbot.worker.base import AbstractLatentWorker
 from twisted.internet.defer import Deferred
 from twisted.python import threadpool
 from twisted.python.failure import Failure
+from twisted.python.filepath import FilePath
 from twisted.trial.unittest import SynchronousTestCase
+
+try:
+    from buildbot_worker.bot import LocalWorker
+except ImportError:
+    LocalWorker = None
 
 
 class LatentController(object):
@@ -42,6 +49,9 @@ class LatentController(object):
         self.started = False
         d, self._start_deferred = self._start_deferred, None
         d.callback(result)
+
+    def connect_worker(self, workdir):
+        LocalWorker(self.worker.name, workdir.path, False).setServiceParent(self.worker)
 
 
 class ControllableLatentWorker(AbstractLatentWorker):
@@ -229,3 +239,65 @@ class Tests(SynchronousTestCase):
         # already kicked in to start a new build on this (the only) worker. We check that
         # a new instance was requested, which indicates that the worker accepted the build.
         self.assertEqual(controller.started, True)
+
+    def test_worker_multiple_substantiations_succeed(self):
+        """
+        If multiple builders trigger try to substantiate a worker at
+        the same time, if the substantiation succeeds then all of
+        the builds proceeed.
+        """
+        controller = LatentController('local')
+        config_dict = {
+            'builders': [
+                BuilderConfig(name="testy-1",
+                              workernames=["local"],
+                              factory=BuildFactory(),
+                              ),
+                BuilderConfig(name="testy-2",
+                              workernames=["local"],
+                              factory=BuildFactory(),
+                              ),
+            ],
+            'workers': [controller.worker],
+            'protocols': {'null': {}},
+            'multiMaster': True,
+        }
+        master = self.successResultOf(getMaster(self, self.reactor, config_dict))
+        builder_ids = [
+            self.successResultOf(master.data.updates.findBuilderId('testy-1')),
+            self.successResultOf(master.data.updates.findBuilderId('testy-2')),
+        ]
+
+        finished_builds = []
+        self.successResultOf(master.mq.startConsuming(
+            lambda key, build: finished_builds.append(build),
+            ('builds', None, 'finished')))
+
+        # Trigger a buildrequest
+        bsid, brids = self.successResultOf(
+            master.data.updates.addBuildset(
+                waited_for=False,
+                builderids=builder_ids,
+                sourcestamps=[
+                    {'codebase': '',
+                     'repository': '',
+                     'branch': None,
+                     'revision': None,
+                     'project': ''},
+                ],
+            )
+        )
+
+        # The worker fails to substantiate.
+        controller.start_instance(True)
+
+        local_workdir = FilePath(self.mktemp())
+        local_workdir.createDirectory()
+        controller.connect_worker(local_workdir)
+
+        # We check that there were two builds that finished, and
+        # that they both finished with success
+        self.assertEqual([build['results'] for build in finished_builds], [SUCCESS] * 2)
+
+    if LocalWorker is None:
+        test_worker_multiple_substantiations_succeed.skip = "buildbot-slave package is not installed"

--- a/master/buildbot/test/unit/test_util_notifier.py
+++ b/master/buildbot/test/unit/test_util_notifier.py
@@ -1,0 +1,117 @@
+# Copyright Buildbot Team Members
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from buildbot.util import Notifier
+
+from twisted.python.failure import Failure
+from twisted.trial.unittest import SynchronousTestCase
+
+
+class TestException(Exception):
+    """
+    An exception thrown in tests.
+    """
+
+
+class Tests(SynchronousTestCase):
+    def test_wait(self):
+        """
+        Calling `Notifier.wait` returns a deferred that hasn't fired.
+        """
+        n = Notifier()
+        self.assertNoResult(n.wait())
+
+    def test_notify_no_waiters(self):
+        """
+        Calling `Notifier.notify` when there are no waiters does not
+        raise.
+        """
+        n = Notifier()
+        n.notify(object())
+        # Does not raise.
+
+    def test_notify_multiple_waiters(self):
+        """
+        If there all multiple waiters, `Notifier.notify` fires all
+        the deferreds with the same value.
+        """
+        value = object()
+        n = Notifier()
+        ds = [n.wait(), n.wait()]
+        n.notify(value)
+        self.assertEqual(
+            [self.successResultOf(d) for d in ds],
+            [value] * 2,
+        )
+
+    def test_new_waiters_not_notified(self):
+        """
+        If a new waiter is added while notifying, it won't be
+        notified until the next notification.
+        """
+        value = object()
+        n = Notifier()
+        box = []
+
+        def add_new_waiter(_):
+            box.append(n.wait())
+        n.wait().addCallback(add_new_waiter)
+        n.notify(object())
+        self.assertNoResult(box[0])
+        n.notify(value)
+        self.assertEqual(
+            self.successResultOf(box[0]),
+            value,
+        )
+
+    def test_notify_failure(self):
+        """
+        If a failure is passed to `Notifier.notify` then the waiters
+        are errback'd.
+        """
+        n = Notifier()
+        d = n.wait()
+        n.notify(Failure(TestException()))
+        self.failureResultOf(d, TestException)
+
+    def test_nonzero_waiters(self):
+        """
+        If there are waiters, ``Notifier`` evaluates as `True`.
+        """
+        n = Notifier()
+        n.wait()
+        self.assertTrue(n)
+
+    def test_nonzero_no_waiters(self):
+        """
+        If there no waiters, ``Notifier`` evaluates as `False`.
+        """
+        n = Notifier()
+        self.assertFalse(n)
+
+    def test_nonzero_cleared_waiters(self):
+        """
+        After notifying waiters, ``Notifier`` evaluates as `False`.
+        """
+        n = Notifier()
+        n.wait()
+        n.notify(object())
+        self.assertFalse(n)

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -31,6 +31,7 @@ from zope.interface import implements
 
 from buildbot.interfaces import IConfigured
 from buildbot.util.misc import deferredLocked
+from ._notifier import Notifier
 
 
 def naturalSort(l):
@@ -416,4 +417,5 @@ __all__ = [
     'diffSets', 'makeList', 'in_reactor', 'string2boolean',
     'check_functional_environment', 'human_readable_delta',
     'rewrap',
+    'Notifier',
 ]

--- a/master/buildbot/util/_notifier.py
+++ b/master/buildbot/util/_notifier.py
@@ -1,0 +1,40 @@
+# Copyright Buildbot Team Members
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from twisted.internet.defer import Deferred
+
+
+class Notifier(object):
+    def __init__(self):
+        self._waiters = []
+
+    def wait(self):
+        d = Deferred()
+        self._waiters.append(d)
+        return d
+
+    def notify(self, result):
+        waiters, self._waiters = self._waiters, []
+        for waiter in waiters:
+            waiter.callback(result)
+
+    def __nonzero__(self):
+        return bool(self._waiters)

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -208,6 +208,19 @@ Several small utilities are available at the top-level :mod:`buildbot.util` pack
     If ``maybe_list`` is a list or tuple, join it with spaces, casting any strings into unicode using :py:func:`ascii2unicode`.
     This is useful for configuration parameters that may be strings or lists of strings.
 
+.. py:class:: Notifier():
+
+    This is a helper for firing mulitple deferreds with the same result.
+
+    .. py:method:: wait()
+
+        Return a deferred that will fire when when the notifier is notified.
+
+    .. py:method:: notify(value)
+
+        Fire all the outstanding deferreds with the given value.
+
+
 :py:mod:`buildbot.util.lru`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Adding callbacks to a deferred mutates the deferred, and change the result that will be passed to new callbacks. Thus, returning the same deferred to multiple callers doesn't behave sanely. Change the place we do in the latent worker to instead return a fresh deferred every time. (Note: https://github.com/buildbot/buildbot/compare/master...tomprince:latent-with-a-Build appears to be necessary to expose the issue here, since we happen to have only ever called this serially).