### PR TITLE
Use an in-memory db for integration tests.

### DIFF
--- a/master/buildbot/test/integration/test_master.py
+++ b/master/buildbot/test/integration/test_master.py
@@ -81,6 +81,3 @@ c['status'] = []
 c['title'] = "test"
 c['titleURL'] = "test"
 c['buildbotURL'] = "http://localhost:8010/"
-c['db'] = {
-    'db_url': "sqlite:///state.sqlite"
-}

--- a/master/buildbot/test/integration/test_try_client.py
+++ b/master/buildbot/test/integration/test_try_client.py
@@ -298,7 +298,6 @@ def masterConfig(extra_config):
     c['title'] = "test"
     c['titleURL'] = "test"
     c['buildbotURL'] = "http://localhost:8010/"
-    c['db'] = {'db_url': "sqlite:///state.sqlite"}
     c['mq'] = {'debug': True}
     # test wants to influence the config, but we still return a new config each time
     c.update(extra_config)

--- a/master/buildbot/test/integration/test_worker_transition.py
+++ b/master/buildbot/test/integration/test_worker_transition.py
@@ -76,10 +76,6 @@ c['title'] = "Pyflakes"
 c['titleURL'] = "https://launchpad.net/pyflakes"
 
 c['buildbotURL'] = "http://localhost:8010/"
-
-c['db'] = {
-    'db_url' : "sqlite:///state.sqlite",
-}
 """
 
 # Template for master configuration after renaming.
@@ -124,10 +120,6 @@ c['title'] = "Pyflakes"
 c['titleURL'] = "https://launchpad.net/pyflakes"
 
 c['buildbotURL'] = "http://localhost:8010/"
-
-c['db'] = {
-    'db_url' : "sqlite:///state.sqlite",
-}
 """
 
 

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -58,7 +58,11 @@ def getMaster(case, reactor, config_dict):
     basedir.createDirectory()
     master = BuildMaster(basedir.path, reactor=reactor, config_loader=DictLoader(config_dict))
 
+    if 'db_url' not in config_dict:
+        config_dict['db_url'] = 'sqlite://'
+
     # TODO: Allow BuildMaster to transparently upgrade the database, at least for tests.
+    master.config.db['db_url'] = config_dict['db_url']
     yield master.db.setup(check_version=False)
     yield master.db.model.upgrade()
     master.db.setup = lambda: None


### PR DESCRIPTION
This is based on #2187, but doesn't support `BUILDBOT_TEST_DB_URL`, since that needs more work.