### PR TITLE
Fix issue in buildstep class

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -167,7 +167,9 @@ class SyncLogFileWrapper(logobserver.LogObserver):
         def next(x):
             self._catchup()
             return x
-        self.step._start_unhandled_deferreds.append(d)
+
+        if self.step._start_unhandled_deferreds is not None:
+            self.step._start_unhandled_deferreds.append(d)
 
     def _delay(self, op):
         self.delayedOperations.append(op)
@@ -739,7 +741,8 @@ class BuildStep(results.ResultComputingConfigMixin,
         # create a logfile instance that acts like old-style status logfiles
         # begin to create a new-style logfile
         loog_d = self.addLog_newStyle(name, type, logEncoding)
-        self._start_unhandled_deferreds.append(loog_d)
+        if self._start_unhandled_deferreds is not None:
+            self._start_unhandled_deferreds.append(loog_d)
         # and wrap the deferred that will eventually fire with that logfile
         # into a write-only logfile instance
         wrapper = SyncLogFileWrapper(self, name, loog_d)


### PR DESCRIPTION
Fix following issue raised during step execution:

File "/home/lab/dev_buildbot/src/buildbot-nine/master/buildbot/process/buildstep.py", line 170, in _catchup
    self.step._start_unhandled_deferreds.append(d)
  exceptions.AttributeError: 'NoneType' object has no attribute 'append'

Change-Id: I1abd303f3fa89f6a8d0409b79e4edfeb70144d29