### PR TITLE
Revert "Replace print with log.msg()"

### DIFF
--- a/master/contrib/coverage2text.py
+++ b/master/contrib/coverage2text.py
@@ -2,10 +2,11 @@
 
 import sys
 
+from twisted.python import usage
+
 from coverage import coverage
 from coverage.results import Numbers
 from coverage.summary import SummaryReporter
-from twisted.python import usage
 
 
 # this is an adaptation of the code behind "coverage report", modified to

--- a/master/contrib/coverage2text.py
+++ b/master/contrib/coverage2text.py
@@ -2,11 +2,10 @@
 
 import sys
 
-from twisted.python import usage
-
 from coverage import coverage
 from coverage.results import Numbers
 from coverage.summary import SummaryReporter
+from twisted.python import usage
 
 
 # this is an adaptation of the code behind "coverage report", modified to

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -42,6 +42,15 @@ Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
+Buildslave
+----------
+
+Fixes
+~~~~~
+
+* ``buildslave`` script now outputs messages to the terminal.
+
+
 Worker
 ------
 

--- a/slave/buildslave/commands/repo.py
+++ b/slave/buildslave/commands/repo.py
@@ -18,7 +18,6 @@ import re
 import textwrap
 
 from twisted.internet import defer
-from twisted.python import log
 
 from buildslave import runprocess
 from buildslave.commands.base import AbandonChain
@@ -69,8 +68,8 @@ class Repo(SourceBaseCommand):
         return os.path.join(self.builder.basedir, self.srcdir)
 
     def sourcedirIsUpdateable(self):
-        log.msg(os.path.join(self._fullSrcdir(), ".repo"))
-        log.msg(os.path.isdir(os.path.join(self._fullSrcdir(), ".repo")))
+        print os.path.join(self._fullSrcdir(), ".repo")
+        print os.path.isdir(os.path.join(self._fullSrcdir(), ".repo"))
         return os.path.isdir(os.path.join(self._fullSrcdir(), ".repo"))
 
     def _repoCmd(self, command, cb=None, abandonOnFailure=True, **kwargs):

--- a/slave/buildslave/commands/repo.py
+++ b/slave/buildslave/commands/repo.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import print_function
+
 import os
 import re
 import textwrap
@@ -68,8 +70,8 @@ class Repo(SourceBaseCommand):
         return os.path.join(self.builder.basedir, self.srcdir)
 
     def sourcedirIsUpdateable(self):
-        print os.path.join(self._fullSrcdir(), ".repo")
-        print os.path.isdir(os.path.join(self._fullSrcdir(), ".repo"))
+        print(os.path.join(self._fullSrcdir(), ".repo"))
+        print(os.path.isdir(os.path.join(self._fullSrcdir(), ".repo")))
         return os.path.isdir(os.path.join(self._fullSrcdir(), ".repo"))
 
     def _repoCmd(self, command, cb=None, abandonOnFailure=True, **kwargs):

--- a/slave/buildslave/scripts/base.py
+++ b/slave/buildslave/scripts/base.py
@@ -13,14 +13,14 @@
 #
 # Copyright Buildbot Team Members
 
-import os
+from __future__ import print_function
 
-from twisted.python import log
+import os
 
 
 def isBuildslaveDir(dir):
     def print_error(error_message):
-        log.msg("%s\ninvalid buildslave directory '%s'" % (error_message, dir))
+        print("%s\ninvalid buildslave directory '%s'" % (error_message, dir))
 
     buildbot_tac = os.path.join(dir, "buildbot.tac")
     try:

--- a/slave/buildslave/scripts/create_slave.py
+++ b/slave/buildslave/scripts/create_slave.py
@@ -13,9 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
-import os
+from __future__ import print_function
 
-from twisted.python import log
+import os
 
 
 slaveTACTemplate = ["""
@@ -88,11 +88,11 @@ def _makeBaseDir(basedir, quiet):
     """
     if os.path.exists(basedir):
         if not quiet:
-            log.msg("updating existing installation")
+            print("updating existing installation")
         return
 
     if not quiet:
-        log.msg("mkdir", basedir)
+        print("mkdir", basedir)
 
     try:
         os.mkdir(basedir)
@@ -123,12 +123,12 @@ def _makeBuildbotTac(basedir, tac_file_contents, quiet):
 
         if oldcontents == tac_file_contents:
             if not quiet:
-                log.msg("buildbot.tac already exists and is correct")
+                print("buildbot.tac already exists and is correct")
             return
 
         if not quiet:
-            log.msg("not touching existing buildbot.tac")
-            log.msg("creating buildbot.tac.new instead")
+            print("not touching existing buildbot.tac")
+            print("creating buildbot.tac.new instead")
 
         tacfile = os.path.join(basedir, "buildbot.tac.new")
 
@@ -159,8 +159,8 @@ def _makeInfoFiles(basedir, quiet):
             return False
 
         if not quiet:
-            log.msg("Creating %s, you need to edit it appropriately." %
-                    os.path.join("info", file))
+            print("Creating %s, you need to edit it appropriately." %
+                  os.path.join("info", file))
 
         try:
             open(filepath, "wt").write(contents)
@@ -172,7 +172,7 @@ def _makeInfoFiles(basedir, quiet):
     path = os.path.join(basedir, "info")
     if not os.path.exists(path):
         if not quiet:
-            log.msg("mkdir", path)
+            print("mkdir", path)
         try:
             os.mkdir(path)
         except OSError as exception:
@@ -191,11 +191,11 @@ def _makeInfoFiles(basedir, quiet):
 
     if not os.path.exists(access_uri):
         if not quiet:
-            log.msg("Not creating %s - add it if you wish" %
-                    os.path.join("info", "access_uri"))
+            print("Not creating %s - add it if you wish" %
+                  os.path.join("info", "access_uri"))
 
     if created and not quiet:
-        log.msg("Please edit the files in %s appropriately." % path)
+        print("Please edit the files in %s appropriately." % path)
 
 
 def createSlave(config):
@@ -220,11 +220,11 @@ def createSlave(config):
         _makeBuildbotTac(basedir, contents, quiet)
         _makeInfoFiles(basedir, quiet)
     except CreateSlaveError as exception:
-        log.msg("%s\nfailed to configure buildslave in %s" %
-                (exception, config['basedir']))
+        print("%s\nfailed to configure buildslave in %s" %
+              (exception, config['basedir']))
         return 1
 
     if not quiet:
-        log.msg("buildslave configured in %s" % basedir)
+        print("buildslave configured in %s" % basedir)
 
     return 0

--- a/slave/buildslave/scripts/logwatcher.py
+++ b/slave/buildslave/scripts/logwatcher.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import print_function
+
 import os
 import platform
 
@@ -21,7 +23,6 @@ from twisted.internet import error
 from twisted.internet import protocol
 from twisted.internet import reactor
 from twisted.protocols.basic import LineOnlyReceiver
-from twisted.python import log
 from twisted.python.failure import Failure
 
 
@@ -51,7 +52,7 @@ class TailProcess(protocol.ProcessProtocol):
         self.lw.dataReceived(data)
 
     def errReceived(self, data):
-        log.msg("ERR: '%s'" % (data,))
+        print("ERR: '%s'" % (data,))
 
 
 class LogWatcher(LineOnlyReceiver):
@@ -126,7 +127,7 @@ class LogWatcher(LineOnlyReceiver):
             self.processtype = "buildslave"
 
         if self.in_reconfig:
-            log.msg(line)
+            print(line)
 
         if "message from master: attached" in line:
             return self.finished("buildslave")

--- a/slave/buildslave/scripts/restart.py
+++ b/slave/buildslave/scripts/restart.py
@@ -13,7 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.python import log
+from __future__ import print_function
 
 from buildslave.scripts import base
 from buildslave.scripts import start
@@ -31,8 +31,8 @@ def restart(config):
         stop.stopSlave(basedir, quiet)
     except stop.SlaveNotRunning:
         if not quiet:
-            log.msg("no old buildslave process found to stop")
+            print("no old buildslave process found to stop")
     if not quiet:
-        log.msg("now restarting buildslave process..")
+        print("now restarting buildslave process..")
 
     return start.startSlave(basedir, quiet, config['nodaemon'])

--- a/slave/buildslave/scripts/runner.py
+++ b/slave/buildslave/scripts/runner.py
@@ -16,11 +16,12 @@
 # N.B.: don't import anything that might pull in a reactor yet. Some of our
 # subcommands want to load modules that need the gtk reactor.
 
+from __future__ import print_function
+
 import os
 import re
 import sys
 
-from twisted.python import log
 from twisted.python import reflect
 from twisted.python import usage
 
@@ -244,10 +245,11 @@ class Options(usage.Options):
 
     def opt_version(self):
         import buildslave
-        log.msg("Buildslave version: %s" % buildslave.version)
+        print("Buildslave version: %s" % buildslave.version)
         usage.Options.opt_version(self)
 
     def opt_verbose(self):
+        from twisted.python import log
         log.startLogging(sys.stderr)
 
     def postOptions(self):
@@ -260,10 +262,10 @@ def run():
     try:
         config.parseOptions()
     except usage.error as e:
-        log.msg("%s:  %s" % (sys.argv[0], e))
-        log.msg()
+        print("%s:  %s" % (sys.argv[0], e))
+        print()
         c = getattr(config, 'subOptions', config)
-        log.msg(str(c))
+        print(str(c))
         sys.exit(1)
 
     subconfig = config.subOptions

--- a/slave/buildslave/scripts/start.py
+++ b/slave/buildslave/scripts/start.py
@@ -13,11 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+
 import os
 import sys
 import time
-
-from twisted.python import log
 
 from buildslave.scripts import base
 
@@ -28,7 +27,7 @@ class Follower(object):
         from twisted.internet import reactor
         from buildslave.scripts.logwatcher import LogWatcher
         self.rc = 0
-        log.msg("Following twistd.log until startup finished..")
+        print("Following twistd.log until startup finished..")
         lw = LogWatcher("twistd.log")
         d = lw.start()
         d.addCallbacks(self._success, self._failure)
@@ -37,7 +36,7 @@ class Follower(object):
 
     def _success(self, processtype):
         from twisted.internet import reactor
-        log.msg("The %s appears to have (re)started correctly." % processtype)
+        print("The %s appears to have (re)started correctly." % processtype)
         self.rc = 0
         reactor.stop()
 
@@ -46,13 +45,13 @@ class Follower(object):
         from buildslave.scripts.logwatcher import BuildmasterTimeoutError, \
             ReconfigError, BuildslaveTimeoutError, BuildSlaveDetectedError
         if why.check(BuildmasterTimeoutError):
-            log.msg("""
+            print("""
 The buildslave took more than 10 seconds to start, so we were unable to
 confirm that it started correctly. Please 'tail twistd.log' and look for a
 line that says 'configuration update complete' to verify correct startup.
 """)
         elif why.check(BuildslaveTimeoutError):
-            log.msg("""
+            print("""
 The buildslave took more than 10 seconds to start and/or connect to the
 buildslave, so we were unable to confirm that it started and connected
 correctly. Please 'tail twistd.log' and look for a line that says 'message
@@ -65,21 +64,21 @@ then your buildslave might be using the wrong botname or password. Please
 correct these problems and then restart the buildslave.
 """)
         elif why.check(ReconfigError):
-            log.msg("""
+            print("""
 The buildslave appears to have encountered an error in the master.cfg config
 file during startup. It is probably running with an empty configuration right
 now. Please inspect and fix master.cfg, then restart the buildslave.
 """)
         elif why.check(BuildSlaveDetectedError):
-            log.msg("""
+            print("""
 Buildslave is starting up, not following logfile.
 """)
         else:
-            log.msg("""
+            print("""
 Unable to confirm that the buildslave started correctly. You may need to
 stop it, fix the config file, and restart.
 """)
-            log.msg(why)
+            print(why)
         self.rc = 1
         reactor.stop()
 

--- a/slave/buildslave/scripts/stop.py
+++ b/slave/buildslave/scripts/stop.py
@@ -13,10 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import print_function
+
 import os
 import time
-
-from twisted.python import log
 
 from buildslave.scripts import base
 
@@ -65,12 +65,12 @@ def stopSlave(basedir, quiet, signame="TERM"):
             os.kill(pid, 0)
         except OSError:
             if not quiet:
-                log.msg("buildslave process %d is dead" % pid)
+                print("buildslave process %d is dead" % pid)
             return
         timer += 1
         time.sleep(1)
     if not quiet:
-        log.msg("never saw process go away")
+        print("never saw process go away")
 
 
 def stop(config, signame="TERM"):
@@ -84,6 +84,6 @@ def stop(config, signame="TERM"):
         stopSlave(basedir, quiet, signame)
     except SlaveNotRunning:
         if not quiet:
-            log.msg("buildslave not running")
+            print("buildslave not running")
 
     return 0

--- a/slave/buildslave/scripts/upgrade_slave.py
+++ b/slave/buildslave/scripts/upgrade_slave.py
@@ -13,9 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
-import os
+from __future__ import print_function
 
-from twisted.python import log
+import os
 
 from buildslave.scripts import base
 
@@ -31,10 +31,9 @@ def upgradeSlave(config):
         "from buildbot.slave.bot import BuildSlave",
         "from buildslave.bot import BuildSlave")
     if new_buildbot_tac != buildbot_tac:
-        open(os.path.join(basedir, "buildbot.tac"), "w").write(
-            new_buildbot_tac)
-        log.msg("buildbot.tac updated")
+        open(os.path.join(basedir, "buildbot.tac"), "w").write(new_buildbot_tac)
+        print("buildbot.tac updated")
     else:
-        log.msg("No changes made")
+        print("No changes made")
 
     return 0

--- a/slave/buildslave/test/fake/slavebuilder.py
+++ b/slave/buildslave/test/fake/slavebuilder.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 from __future__ import print_function
 
 import pprint

--- a/slave/buildslave/test/unit/test_commands_utils.py
+++ b/slave/buildslave/test/unit/test_commands_utils.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 from __future__ import print_function
 
 import os
@@ -110,8 +111,10 @@ class RmdirRecursive(unittest.TestCase):
             if os.path.exists(self.target):
                 shutil.rmtree(self.target)
         except Exception:
-            print(
-                "\n(target directory was not removed by test, and cleanup failed too)\n")
+            print("\n"
+                  "(target directory was not removed by test, and cleanup "
+                  "failed too)"
+                  "\n")
             raise
 
     def test_rmdirRecursive_easy(self):

--- a/slave/buildslave/test/unit/test_scripts_create_slave.py
+++ b/slave/buildslave/test/unit/test_scripts_create_slave.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 
 import os
-import re
 
 import mock
 from twisted.trial import unittest
@@ -31,7 +30,7 @@ def _regexp_path(name, *names):
     return os.path.join(name, *names).replace("\\", "\\\\")
 
 
-class TestMakeBaseDir(misc.LoggingMixin, unittest.TestCase):
+class TestMakeBaseDir(misc.StdoutAssertionsMixin, unittest.TestCase):
 
     """
     Test buildslave.scripts.create_slave._makeBaseDir()
@@ -39,7 +38,7 @@ class TestMakeBaseDir(misc.LoggingMixin, unittest.TestCase):
 
     def setUp(self):
         # capture stdout
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
         # patch os.mkdir() to do nothing
         self.mkdir = mock.Mock()
@@ -54,8 +53,8 @@ class TestMakeBaseDir(misc.LoggingMixin, unittest.TestCase):
         # call _makeBaseDir()
         create_slave._makeBaseDir("dummy", False)
 
-        # check that correct message was printed to the log
-        self.assertLogged("updating existing installation")
+        # check that correct message was printed to stdout
+        self.assertStdoutEqual("updating existing installation\n")
         # check that os.mkdir was not called
         self.assertFalse(self.mkdir.called,
                          "unexpected call to os.mkdir()")
@@ -87,8 +86,8 @@ class TestMakeBaseDir(misc.LoggingMixin, unittest.TestCase):
 
         # check that os.mkdir() was called with correct path
         self.mkdir.assert_called_once_with("dummy")
-        # check that correct message was printed to the log
-        self.assertLogged("mkdir dummy")
+        # check that correct message was printed to stdout
+        self.assertStdoutEqual("mkdir dummy\n")
 
     def testBasedirCreatedQuiet(self):
         """
@@ -121,7 +120,7 @@ class TestMakeBaseDir(misc.LoggingMixin, unittest.TestCase):
                                 create_slave._makeBaseDir, "dummy", False)
 
 
-class TestMakeBuildbotTac(misc.LoggingMixin,
+class TestMakeBuildbotTac(misc.StdoutAssertionsMixin,
                           misc.FileIOMixin,
                           unittest.TestCase):
 
@@ -131,7 +130,7 @@ class TestMakeBuildbotTac(misc.LoggingMixin,
 
     def setUp(self):
         # capture stdout
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
         # patch os.chmod() to do nothing
         self.chmod = mock.Mock()
@@ -203,12 +202,12 @@ class TestMakeBuildbotTac(misc.LoggingMixin,
         self.assertFalse(self.fileobj.write.called,
                          "unexpected write() call")
 
-        # check output to the log
+        # check output to stdout
         if quiet:
             self.assertWasQuiet()
         else:
-            self.assertLogged(
-                "buildbot.tac already exists and is correct")
+            self.assertStdoutEqual(
+                "buildbot.tac already exists and is correct\n")
 
     def testTacFileCorrect(self):
         """
@@ -245,12 +244,12 @@ class TestMakeBuildbotTac(misc.LoggingMixin,
         self.fileobj.write.assert_called_once_with("new-tac-contents")
         self.chmod.assert_called_once_with(tac_file_path + ".new", 0o600)
 
-        # check output to the log
+        # check output to stdout
         if quiet:
             self.assertWasQuiet()
         else:
-            self.assertLogged("not touching existing buildbot.tac",
-                              "creating buildbot.tac.new instead")
+            self.assertStdoutEqual("not touching existing buildbot.tac\n"
+                                   "creating buildbot.tac.new instead\n")
 
     def testDiffTacFile(self):
         """
@@ -284,7 +283,7 @@ class TestMakeBuildbotTac(misc.LoggingMixin,
         self.chmod.assert_called_once_with(tac_file_path, 0o600)
 
 
-class TestMakeInfoFiles(misc.LoggingMixin,
+class TestMakeInfoFiles(misc.StdoutAssertionsMixin,
                         misc.FileIOMixin,
                         unittest.TestCase):
 
@@ -294,7 +293,7 @@ class TestMakeInfoFiles(misc.LoggingMixin,
 
     def setUp(self):
         # capture stdout
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
     def checkMkdirError(self, quiet):
         """
@@ -316,12 +315,11 @@ class TestMakeInfoFiles(misc.LoggingMixin,
                                 create_slave._makeInfoFiles,
                                 "bdir", quiet)
 
-        # check output to the log
+        # check output to stdout
         if quiet:
             self.assertWasQuiet()
         else:
-            self.assertLogged(
-                re.escape("mkdir %s" % os.path.join("bdir", "info")))
+            self.assertStdoutEqual("mkdir %s\n" % os.path.join("bdir", "info"))
 
     def testMkdirError(self):
         """
@@ -366,13 +364,13 @@ class TestMakeInfoFiles(misc.LoggingMixin,
                                 create_slave._makeInfoFiles,
                                 "bdir", quiet)
 
-        # check output to the log
+        # check output to stdout
         if quiet:
             self.assertWasQuiet()
         else:
-            self.assertLogged(
-                re.escape("Creating %s, you need to edit it appropriately." %
-                          os.path.join("info", "admin")))
+            self.assertStdoutEqual(
+                "Creating %s, you need to edit it appropriately.\n" %
+                os.path.join("info", "admin"))
 
     def testOpenError(self):
         """
@@ -430,21 +428,20 @@ class TestMakeInfoFiles(misc.LoggingMixin,
             [mock.call("Your Name Here <admin@youraddress.invalid>\n"),
              mock.call("Please put a description of this build host here\n")])
 
-        # check output to the log
+        # check output to stdout
         if quiet:
             self.assertWasQuiet()
         else:
-            self.assertLogged(
-                re.escape("mkdir %s" % info_path),
-                re.escape("Creating %s, you need to edit it appropriately." %
-                          os.path.join("info", "admin")),
-                re.escape("Creating %s, you need to edit it appropriately." %
-                          os.path.join("info", "host")),
-                re.escape("Not creating %s - add it if you wish" %
-                          os.path.join("info", "access_ur")),
-                re.escape("Please edit the files in %s appropriately." %
-                          info_path)
-            )
+            self.assertStdoutEqual(
+                "mkdir %s\n"
+                "Creating %s, you need to edit it appropriately.\n"
+                "Creating %s, you need to edit it appropriately.\n"
+                "Not creating %s - add it if you wish\n"
+                "Please edit the files in %s appropriately.\n" %
+                (info_path, os.path.join("info", "admin"),
+                 os.path.join("info", "host"),
+                 os.path.join("info", "access_uri"),
+                 info_path))
 
     def testCreatedSuccessfully(self):
         """
@@ -472,7 +469,7 @@ class TestMakeInfoFiles(misc.LoggingMixin,
         self.assertWasQuiet()
 
 
-class TestCreateSlave(misc.LoggingMixin, unittest.TestCase):
+class TestCreateSlave(misc.StdoutAssertionsMixin, unittest.TestCase):
 
     """
     Test buildslave.scripts.create_slave.createSlave()
@@ -503,7 +500,7 @@ class TestCreateSlave(misc.LoggingMixin, unittest.TestCase):
 
     def setUp(self):
         # capture stdout
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
     def setUpMakeFunctions(self, exception=None):
         """
@@ -548,9 +545,9 @@ class TestCreateSlave(misc.LoggingMixin, unittest.TestCase):
         self.assertEquals(create_slave.createSlave(self.options), 1,
                           "unexpected exit code")
 
-        # check that correct error message was printed the the log
-        self.assertLogged("err-msg",
-                          "failed to configure buildslave in bdir")
+        # check that correct error message was printed on stdout
+        self.assertStdoutEqual("err-msg\n"
+                               "failed to configure buildslave in bdir\n")
 
     def testMinArgs(self):
         """
@@ -570,8 +567,8 @@ class TestCreateSlave(misc.LoggingMixin, unittest.TestCase):
                                       expected_tac_contents,
                                       self.options["quiet"])
 
-        # check that correct info message was printed to the log
-        self.assertLogged("buildslave configured in bdir")
+        # check that correct info message was printed
+        self.assertStdoutEqual("buildslave configured in bdir\n")
 
     def assertTACFileContents(self, options):
         """
@@ -724,8 +721,8 @@ class TestCreateSlave(misc.LoggingMixin, unittest.TestCase):
                                       expected_tac_contents,
                                       self.options["quiet"])
 
-        # check that correct info message was printed to the log
-        self.assertLogged("buildslave configured in bdir")
+        # check that correct info message was printed
+        self.assertStdoutEqual("buildslave configured in bdir\n")
 
     def testWithOpts(self):
         """
@@ -751,8 +748,8 @@ class TestCreateSlave(misc.LoggingMixin, unittest.TestCase):
                                       expected_tac_contents,
                                       options["quiet"])
 
-        # check that correct info message was printed to the log
-        self.assertLogged("buildslave configured in bdir")
+        # check that correct info message was printed
+        self.assertStdoutEqual("buildslave configured in bdir\n")
 
     def testQuiet(self):
         """

--- a/slave/buildslave/test/unit/test_scripts_restart.py
+++ b/slave/buildslave/test/unit/test_scripts_restart.py
@@ -23,7 +23,7 @@ from buildslave.test.util import misc
 
 
 class TestRestart(misc.IsBuildslaveDirMixin,
-                  misc.LoggingMixin,
+                  misc.StdoutAssertionsMixin,
                   unittest.TestCase):
 
     """
@@ -32,7 +32,7 @@ class TestRestart(misc.IsBuildslaveDirMixin,
     config = {"basedir": "dummy", "nodaemon": False, "quiet": False}
 
     def setUp(self):
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
         # patch start.startSlave() to do nothing
         self.startSlave = mock.Mock()
@@ -64,14 +64,13 @@ class TestRestart(misc.IsBuildslaveDirMixin,
         mock_stopSlave = mock.Mock(side_effect=stop.SlaveNotRunning())
         self.patch(stop, "stopSlave", mock_stopSlave)
 
-        # check that restart() calls startSlave() and outputs correct messages
+        # check that restart() calls startSlave() and prints correct messages
         restart.restart(self.config)
         self.startSlave.assert_called_once_with(self.config["basedir"],
                                                 self.config["quiet"],
                                                 self.config["nodaemon"])
-
-        self.assertLogged("no old buildslave process found to stop")
-        self.assertLogged("now restarting buildslave process..")
+        self.assertStdoutEqual("no old buildslave process found to stop\n"
+                               "now restarting buildslave process..\n")
 
     def test_restart(self):
         """
@@ -84,9 +83,9 @@ class TestRestart(misc.IsBuildslaveDirMixin,
         mock_stopSlave = mock.Mock()
         self.patch(stop, "stopSlave", mock_stopSlave)
 
-        # check that restart() calls startSlave() and outputs correct messages
+        # check that restart() calls startSlave() and prints correct messages
         restart.restart(self.config)
         self.startSlave.assert_called_once_with(self.config["basedir"],
                                                 self.config["quiet"],
                                                 self.config["nodaemon"])
-        self.assertLogged("now restarting buildslave process..")
+        self.assertStdoutEqual("now restarting buildslave process..\n")

--- a/slave/buildslave/test/unit/test_scripts_runner.py
+++ b/slave/buildslave/test/unit/test_scripts_runner.py
@@ -304,14 +304,14 @@ class TestCreateSlaveOptions(OptionsMixin, unittest.TestCase):
                          "incorrect master host and/or port")
 
 
-class TestOptions(misc.LoggingMixin, unittest.TestCase):
+class TestOptions(misc.StdoutAssertionsMixin, unittest.TestCase):
 
     """
     Test buildslave.scripts.runner.Options class.
     """
 
     def setUp(self):
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
     def parse(self, *args):
         opts = runner.Options()
@@ -326,7 +326,7 @@ class TestOptions(misc.LoggingMixin, unittest.TestCase):
     def test_version(self):
         exception = self.assertRaises(SystemExit, self.parse, '--version')
         self.assertEqual(exception.code, 0, "unexpected exit code")
-        self.assertLogged('Buildslave version:')
+        self.assertInStdout('Buildslave version:')
 
     def test_verbose(self):
         self.patch(log, 'startLogging', mock.Mock())
@@ -338,14 +338,14 @@ class TestOptions(misc.LoggingMixin, unittest.TestCase):
 functionPlaceholder = None
 
 
-class TestRun(misc.LoggingMixin, unittest.TestCase):
+class TestRun(misc.StdoutAssertionsMixin, unittest.TestCase):
 
     """
     Test buildslave.scripts.runner.run()
     """
 
     def setUp(self):
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
     class TestSubCommand(usage.Options):
         subcommandFunction = __name__ + ".functionPlaceholder"
@@ -401,9 +401,9 @@ class TestRun(misc.LoggingMixin, unittest.TestCase):
 
         exception = self.assertRaises(SystemExit, runner.run)
         self.assertEqual(exception.code, 1, "unexpected exit code")
-        self.assertLogged("command:  usage-error-message",
-                          "GeneralUsage",
-                          "unexpected error message on stdout")
+        self.assertStdoutEqual("command:  usage-error-message\n\n"
+                               "GeneralUsage\n",
+                               "unexpected error message on stdout")
 
     def test_run_bad_suboption(self):
         """
@@ -419,6 +419,6 @@ class TestRun(misc.LoggingMixin, unittest.TestCase):
         self.assertEqual(exception.code, 1, "unexpected exit code")
 
         # check that we get error message for a sub-option
-        self.assertLogged("command:  usage-error-message",
-                          "SubOptionUsage",
-                          "unexpected error message on stdout")
+        self.assertStdoutEqual("command:  usage-error-message\n\n"
+                               "SubOptionUsage\n",
+                               "unexpected error message on stdout")

--- a/slave/buildslave/test/unit/test_scripts_stop.py
+++ b/slave/buildslave/test/unit/test_scripts_stop.py
@@ -27,7 +27,7 @@ from buildslave.test.util import misc
 
 
 class TestStopSlave(misc.FileIOMixin,
-                    misc.LoggingMixin,
+                    misc.StdoutAssertionsMixin,
                     unittest.TestCase):
 
     """
@@ -36,7 +36,7 @@ class TestStopSlave(misc.FileIOMixin,
     PID = 9876
 
     def setUp(self):
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
         # patch os.chdir() to do nothing
         self.patch(os, "chdir", mock.Mock())
@@ -76,16 +76,15 @@ class TestStopSlave(misc.FileIOMixin,
         self.patch(time, "sleep", mock.Mock())
 
         # check that stopSlave() sends expected signal to right PID
-        # and print correct message to the log
+        # and print correct message to stdout
         stop.stopSlave(None, False)
         mocked_kill.assert_has_calls([mock.call(self.PID, signal.SIGTERM),
                                       mock.call(self.PID, 0)])
-
-        self.assertLogged("buildslave process %s is dead" % self.PID)
+        self.assertStdoutEqual("buildslave process %s is dead\n" % self.PID)
 
 
 class TestStop(misc.IsBuildslaveDirMixin,
-               misc.LoggingMixin,
+               misc.StdoutAssertionsMixin,
                unittest.TestCase):
 
     """
@@ -111,7 +110,7 @@ class TestStop(misc.IsBuildslaveDirMixin,
         """
         test calling stop() when no slave is running
         """
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
         # patch basedir check to always succeed
         self.setupUpIsBuildslaveDir(True)
@@ -121,8 +120,7 @@ class TestStop(misc.IsBuildslaveDirMixin,
         self.patch(stop, "stopSlave", mock_stopSlave)
 
         stop.stop(self.config)
-
-        self.assertLogged("buildslave not running")
+        self.assertStdoutEqual("buildslave not running\n")
 
     def test_successful_stop(self):
         """

--- a/slave/buildslave/test/unit/test_scripts_upgrade_slave.py
+++ b/slave/buildslave/test/unit/test_scripts_upgrade_slave.py
@@ -37,8 +37,8 @@ from buildbot.slave.bot import BuildSlave
 
 
 class TestUpgradeSlave(misc.IsBuildslaveDirMixin,
+                       misc.StdoutAssertionsMixin,
                        misc.FileIOMixin,
-                       misc.LoggingMixin,
                        unittest.TestCase):
 
     """
@@ -47,7 +47,7 @@ class TestUpgradeSlave(misc.IsBuildslaveDirMixin,
     config = {"basedir": "dummy"}
 
     def setUp(self):
-        self.setUpLogging()
+        self.setUpStdoutAssertions()
 
         # expected buildbot.tac relative path
         self.buildbot_tac = os.path.join(self.config["basedir"],
@@ -82,8 +82,8 @@ class TestUpgradeSlave(misc.IsBuildslaveDirMixin,
         self.assertEqual(upgrade_slave.upgradeSlave(self.config), 0,
                          "unexpected exit code")
 
-        # check message to the log
-        self.assertLogged("No changes made")
+        # check message to stdout
+        self.assertStdoutEqual("No changes made\n")
 
         # check that open() was called with correct path
         self.open.assert_called_once_with(self.buildbot_tac)
@@ -107,8 +107,8 @@ class TestUpgradeSlave(misc.IsBuildslaveDirMixin,
         self.assertEqual(upgrade_slave.upgradeSlave(self.config), 0,
                          "unexpected exit code")
 
-        # check message to the log
-        self.assertLogged("buildbot.tac updated")
+        # check message to stdout
+        self.assertStdoutEqual("buildbot.tac updated\n")
 
         # check calls to open()
         self.open.assert_has_calls([mock.call(self.buildbot_tac),

--- a/slave/buildslave/test/util/misc.py
+++ b/slave/buildslave/test/util/misc.py
@@ -14,12 +14,13 @@
 # Copyright Buildbot Team Members
 
 import __builtin__
-import io
 import errno
-import mock
+import io
 import os
 import shutil
 import sys
+
+import mock
 
 from buildslave.scripts import base
 


### PR DESCRIPTION
This reverts commit 4d733e62d5570fdb9e603ebfeb333899bdb1f710.

Use of log was removed since it doesn't work for command line utility.
Fixes missing *all* output from `buildslave` command.

`print` function is used instead of `print` statement (in changed places, there is still use of `print` statement in other places).
Change to new-style exceptions handling left intact.
`fn.__name__` is still used instead of `fn.func_name` (works in Pythin 2.6, 2.7 and 3).