### PR TITLE
set docker network mode when starting container

### DIFF
--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -185,8 +185,7 @@ class DockerLatentWorker(AbstractLatentWorker):
             name='%s_%s' % (self.workername, id(self)),
             volumes=self.volumes,
             environment=self.createEnvironment(),
-            host_config=host_conf,
-            networking_config=self.networking_config
+            host_config=host_conf
         )
 
         if instance.get('Id') is None:
@@ -198,7 +197,7 @@ class DockerLatentWorker(AbstractLatentWorker):
         log.msg('Container created, Id: %s...' % (shortid,))
         instance['image'] = image
         self.instance = instance
-        docker_client.start(instance)
+        docker_client.start(instance, network_mode=self.networking_config)
         log.msg('Container started')
         if self.followStartupLogs:
             logs = docker_client.attach(


### PR DESCRIPTION
This [commit](https://github.com/buildbot/buildbot/commit/0c5fa88184562d634b9f43efaf1aae9846321c60) added the networking_config to the wrong place. This fixes it. It should use the networking_config when starting the container instance, not when creating it. In the current version, passing networking_config as a string to the `create_container` call in docker.py results in a 500 error as the docker client is unable to properly deserialize the `create_container` parameters. 