### PR TITLE
 eat unhandled_callbacks recursively

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -634,19 +634,20 @@ class BuildStep(results.ResultComputingConfigMixin,
                                      consumeErrors=True)
             self._start_deferred = None
             unhandled = self._start_unhandled_deferreds
-            self._start_unhandled_deferreds = None
             self.realUpdateSummary()
 
-        # Wait for any possibly-unhandled deferreds.  If any fail, change the
-        # result to EXCEPTION and log.
-        if unhandled:
-            unhandled_results = yield defer.DeferredList(unhandled,
-                                                         consumeErrors=True)
-            for success, res in unhandled_results:
-                if not success:
-                    log.err(
-                        res, "from an asynchronous method executed in an old-style step")
-                    results = EXCEPTION
+            # Wait for any possibly-unhandled deferreds.  If any fail, change the
+            # result to EXCEPTION and log.
+            while unhandled:
+                self._start_unhandled_deferreds = []
+                unhandled_results = yield defer.DeferredList(unhandled,
+                                                             consumeErrors=True)
+                for success, res in unhandled_results:
+                    if not success:
+                        log.err(
+                            res, "from an asynchronous method executed in an old-style step")
+                        results = EXCEPTION
+                unhandled = self._start_unhandled_deferreds
 
         defer.returnValue(results)
 

--- a/master/buildbot/test/integration/test_integration_mastershell.py
+++ b/master/buildbot/test/integration/test_integration_mastershell.py
@@ -1,0 +1,58 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+from twisted.internet import defer
+
+from buildbot.test.util.integration import RunMasterBase
+
+
+# This integration test creates a master and worker environment,
+# with one builders and a shellcommand step
+# meant to be a template for integration steps
+class ShellMaster(RunMasterBase):
+
+    @defer.inlineCallbacks
+    def test_shell(self):
+        yield self.setupConfig(masterConfig())
+
+        change = dict(branch="master",
+                      files=["foo.c"],
+                      author="me@foo.com",
+                      comments="good stuff",
+                      revision="HEAD",
+                      project="none"
+                      )
+        build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
+        self.assertEqual(build['buildid'], 1)
+
+
+# master configuration
+def masterConfig():
+    c = {}
+    from buildbot.config import BuilderConfig
+    from buildbot.process.factory import BuildFactory
+    from buildbot.plugins import steps, schedulers
+
+    c['schedulers'] = [
+        schedulers.AnyBranchScheduler(
+            name="sched",
+            builderNames=["testy"])]
+
+    f = BuildFactory()
+    f.addStep(steps.MasterShellCommand(command='echo hello'))
+    c['builders'] = [
+        BuilderConfig(name="testy",
+                      workernames=["local1"],
+                      factory=f)]
+    return c


### PR DESCRIPTION
 Unhandled_callbacks can also generate more deferred in SyncLogFileWrapper._wrapup

 Then we should eat the callback list until they do not generate more