### PR TITLE
add download attribute to workaround firefox retriction

### DIFF
--- a/www/base/src/app/builders/log/logviewer/logviewer.tpl.jade
+++ b/www/base/src/app/builders/log/logviewer/logviewer.tpl.jade
@@ -1,6 +1,6 @@
 .container.logcontainer
   .row.logoptions
-    a.btn.btn-default(title="download log as file", ng-href="{{raw_url}}")
+    a.btn.btn-default(download="{{log.name}}", title="download log as file", ng-href="{{raw_url}}")
         i.fa.fa-download
     a.btn.btn-default(title="load all data for use with browser search tool",
                            aria-pressed="loadAll", ng-class="{active: loadAll}", ng-click="loadAll = !loadAll")


### PR DESCRIPTION

    Firefox stops all network activity when user click on a link
    including websockets.

    you have to set a download attribute to avoid this:

    https://bugzilla.mozilla.org/show_bug.cgi?id=858538
