### PR TITLE
Start latent workers as part of the build, rather than before the build.

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -273,14 +273,7 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         try:
             self.setupBuild()  # create .steps
         except Exception:
-            # the build hasn't started yet, so log the exception as a point
-            # event instead of flunking the build.
-            # TODO: associate this failure with the build instead.
-            # this involves doing
-            # self.build_status.buildStarted() from within the exception
-            # handler
-            log.msg("Build.setupBuild failed")
-            log.err(Failure())
+            log.err(Failure(), "Build.setupBuild failed")
             self.buildFinished(['Build.setupBuild', 'failed'], EXCEPTION)
             return
 

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -214,8 +214,6 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
             props.setProperty("project", source.project, "Build")
 
     def setupWorkerForBuilder(self, workerforbuilder):
-        self.workerforbuilder = workerforbuilder
-
         self.path_module = workerforbuilder.worker.path_module
 
         # navigate our way back to the L{buildbot.worker.Worker}
@@ -237,12 +235,10 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         """This method sets up the build, then starts it by invoking the
         first Step. It returns a Deferred which will fire when the build
         finishes. This Deferred is guaranteed to never errback."""
-        worker = workerforbuilder.worker
+        self.workerforbuilder = workerforbuilder
+        self.conn = None
 
-        # we are taking responsibility for watching the connection to the
-        # remote. This responsibility was held by the Builder until our
-        # startBuild was called, and will not return to them until we fire
-        # the Deferred returned by this method.
+        worker = workerforbuilder.worker
 
         log.msg("%s.startBuild" % self)
 
@@ -261,14 +257,10 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
                                                                       str(self.buildid),
                                                                       "stop"))
         self.setupOwnProperties()
-        self.setupWorkerForBuilder(workerforbuilder)
 
         # then narrow WorkerLocks down to the right worker
-        self.locks = [(l.getLock(self.workerforbuilder.worker), a)
+        self.locks = [(l.getLock(workerforbuilder.worker), a)
                       for l, a in self.locks]
-        self.conn = workerforbuilder.worker.conn
-        self.subs = self.conn.notifyOnDisconnect(self.lostRemote)
-
         metrics.MetricCountEvent.log('active_builds', 1)
 
         # make sure properties are available to people listening on 'new'
@@ -291,8 +283,59 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
             log.err(Failure())
             self.buildFinished(['Build.setupBuild', 'failed'], EXCEPTION)
             return
+
         # flush properties in the beginning of the build
         yield self._flushProperties(None)
+
+        try:
+            ready = yield workerforbuilder.prepare(self)
+        except Exception:
+            log.err(Failure(), 'while preparing workerforbuilder:')
+            self.buildFinished(["worker", "not", "available"], RETRY)
+            return
+
+        # If prepare returns True then it is ready and we start a build
+        # If it returns false then we don't start a new build.
+        if not ready:
+            log.msg("worker %s can't build %s after all; retrying the "
+                    "build" % (self, workerforbuilder))
+            self.stopped = True
+            self.buildFinished(["worker", "not", "available"], RETRY)
+            return
+
+        # ping the worker to make sure they're still there. If they've
+        # fallen off the map (due to a NAT timeout or something), this
+        # will fail in a couple of minutes, depending upon the TCP
+        # timeout.
+        #
+        # TODO: This can unnecessarily suspend the starting of a build, in
+        # situations where the worker is live but is pushing lots of data to
+        # us in a build.
+        log.msg("starting build %s.. pinging the worker %s"
+                % (self, workerforbuilder))
+        try:
+            ping_success = yield workerforbuilder.ping()
+        except Exception:
+            log.err(Failure(), 'while pinging worker before build:')
+            ping_success = False
+
+        if not ping_success:
+            log.msg("worker ping failed; retrying the build")
+            self.buildFinished(["worker", "not", "pinged"], RETRY)
+            return
+
+        self.conn = workerforbuilder.worker.conn
+        self.setupWorkerForBuilder(workerforbuilder)
+        self.subs = self.conn.notifyOnDisconnect(self.lostRemote)
+
+        # tell the remote that it's starting a build, too
+        try:
+            yield self.conn.remoteStartBuild(self.builder.name)
+        except Exception:
+            log.err(Failure(), 'while calling remote startBuild:')
+            self.buildFinished(["worker", "not", "building"], RETRY)
+            return
+
         yield self.acquireLocks()
 
         # start the sequence of steps

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -21,11 +21,12 @@ from buildbot.worker_transition import WorkerAPICompatMixin
 
 
 class States(Names):
-    ATTACHING = NamedConstant()  # worker attached, still checking hostinfo/etc
-    IDLE = NamedConstant()  # idle, available for use
-    BUILDING = NamedConstant()  # build is running
-    LATENT = NamedConstant()  # latent worker is not substantiated; similar to idle
-    SUBSTANTIATING = NamedConstant()
+    # The worker isn't attached, or is in the process of attaching.
+    DETACHED = NamedConstant()
+    # The worker is available to build: either attached, or a latent worker.
+    AVAILABLE = NamedConstant()
+    # The worker is building.
+    BUILDING = NamedConstant()
 
 
 class AbstractWorkerForBuilder(WorkerAPICompatMixin, object):
@@ -70,7 +71,7 @@ class AbstractWorkerForBuilder(WorkerAPICompatMixin, object):
         return False
 
     def isBusy(self):
-        return self.state not in (States.IDLE, States.LATENT)
+        return self.state != States.AVAILABLE
 
     def buildStarted(self):
         self.state = States.BUILDING
@@ -84,7 +85,7 @@ class AbstractWorkerForBuilder(WorkerAPICompatMixin, object):
             worker_buildStarted(self)
 
     def buildFinished(self):
-        self.state = States.IDLE
+        self.state = States.AVAILABLE
         if self.worker:
             self.worker.buildFinished(self)
 
@@ -95,7 +96,6 @@ class AbstractWorkerForBuilder(WorkerAPICompatMixin, object):
         @type  commands: dict: string -> string, or None
         @param commands: provides the worker's version of each RemoteCommand
         """
-        self.state = States.ATTACHING
         self.remoteCommands = commands  # maps command name to version
         if self.worker is None:
             self.worker = worker
@@ -109,10 +109,7 @@ class AbstractWorkerForBuilder(WorkerAPICompatMixin, object):
         d.addCallback(lambda _:
                       self.worker.conn.remotePrint(message="attached"))
 
-        @d.addCallback
-        def setIdle(res):
-            self.state = States.IDLE
-            return self
+        d.addCallback(lambda _: self)
 
         return d
 
@@ -199,14 +196,25 @@ class WorkerForBuilder(AbstractWorkerForBuilder):
 
     def __init__(self):
         AbstractWorkerForBuilder.__init__(self)
-        self.state = States.ATTACHING
+        self.state = States.DETACHED
+
+    def attached(self, worker, commands):
+        d = AbstractWorkerForBuilder.attached(self, worker, commands)
+
+        @d.addCallback
+        def setAvailable(res):
+            # Only set available on non-latent workers, since latent workers
+            # only attach while a build is in progress.
+            self.state = States.AVAILABLE
+            return res
+        return d
 
     def detached(self):
         AbstractWorkerForBuilder.detached(self)
         if self.worker:
             self.worker.removeWorkerForBuilder(self)
         self.worker = None
-        self.state = States.ATTACHING
+        self.state = States.DETACHED
 
 
 class LatentWorkerForBuilder(AbstractWorkerForBuilder):
@@ -214,7 +222,7 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
     def __init__(self, worker, builder):
         AbstractWorkerForBuilder.__init__(self)
         self.worker = worker
-        self.state = States.LATENT
+        self.state = States.AVAILABLE
         self.setBuilder(builder)
         self.worker.addWorkerForBuilder(self)
         log.msg("Latent worker %s attached to %s" % (worker.workername,
@@ -227,17 +235,9 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
 
         log.msg("substantiating worker %s" % (self,))
         d = self.substantiate(build)
-
-        @d.addCallback
-        def substantiation_cancelled(res):
-            # if res is False, latent worker cancelled subtantiation
-            if not res:
-                self.state = States.LATENT
-            return res
         return d
 
     def substantiate(self, build):
-        self.state = States.SUBSTANTIATING
         d = self.worker.substantiate(self, build)
         if not self.worker.substantiated:
             event = self.builder.builder_status.addEvent(
@@ -254,17 +254,12 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
                 return res
 
             def substantiation_failed(res):
-                self.state = States.LATENT
                 event.text = ["substantiate", "failed"]
                 # TODO add log of traceback to event
                 event.finish()
                 return res
             d.addCallbacks(substantiated, substantiation_failed)
         return d
-
-    def detached(self):
-        AbstractWorkerForBuilder.detached(self)
-        self.state = States.LATENT
 
     def ping(self, status=None):
         if not self.worker.substantiated:

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -116,7 +116,7 @@ class AbstractWorkerForBuilder(WorkerAPICompatMixin, object):
 
         return d
 
-    def prepare(self, builder_status, build):
+    def prepare(self, build):
         if not self.worker or not self.worker.acquireLocks():
             return defer.succeed(False)
         return defer.succeed(True)
@@ -220,7 +220,7 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
         log.msg("Latent worker %s attached to %s" % (worker.workername,
                                                      self.builder_name))
 
-    def prepare(self, builder_status, build):
+    def prepare(self, build):
         # If we can't lock, then don't bother trying to substantiate
         if not self.worker or not self.worker.acquireLocks():
             return defer.succeed(False)
@@ -234,12 +234,6 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
             if not res:
                 self.state = States.LATENT
             return res
-
-        @d.addErrback
-        def substantiation_failed(f):
-            builder_status.addPointEvent(['removing', 'latent',
-                                          self.worker.workername])
-            return f
         return d
 
     def substantiate(self, build):

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -1,0 +1,84 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet.defer import Deferred
+from twisted.trial.unittest import SkipTest
+
+from buildbot.worker.base import AbstractLatentWorker
+
+try:
+    from buildbot_worker.bot import LocalWorker as RemoteWorker
+except ImportError:
+    RemoteWorker = None
+
+
+class LatentController(object):
+    """
+    A controller for ``ControllableLatentWorker``.
+
+    https://glyph.twistedmatrix.com/2015/05/separate-your-fakes-and-your-inspectors.html
+    """
+
+    def __init__(self, name, **kwargs):
+        self.worker = ControllableLatentWorker(name, self, **kwargs)
+        self.started = False
+        self.stopped = False
+
+    def start_instance(self, result):
+        assert self.started
+        self.started = False
+        d, self._start_deferred = self._start_deferred, None
+        d.callback(result)
+
+    def stop_instance(self, result):
+        assert self.stopped
+        self.stoped = False
+        d, self._stop_deferred = self._stop_deferred, None
+        d.callback(result)
+
+    def connect_worker(self, workdir):
+        if RemoteWorker is None:
+            raise SkipTest("buildbot-worker package is not installed")
+        self.remote_worker = RemoteWorker(self.worker.name, workdir.path, False)
+        self.remote_worker.setServiceParent(self.worker)
+
+    def disconnect_worker(self, workdir):
+        return self.remote_worker.disownServiceParent()
+
+
+class ControllableLatentWorker(AbstractLatentWorker):
+    """
+    A latent worker that can be contolled by tests.
+    """
+
+    def __init__(self, name, controller, **kwargs):
+        AbstractLatentWorker.__init__(self, name, None, **kwargs)
+        self._controller = controller
+
+    def checkConfig(self, name, _, **kwargs):
+        AbstractLatentWorker.checkConfig(self, name, None, **kwargs)
+
+    def reconfigService(self, name, _, **kwargs):
+        AbstractLatentWorker.reconfigService(self, name, None, **kwargs)
+
+    def start_instance(self, build):
+        self._controller.started = True
+        self._controller._start_deferred = Deferred()
+        return self._controller._start_deferred
+
+    def stop_instance(self, build):
+        self._controller.stopped = True
+        self._controller._stop_deferred = Deferred()
+        return self._controller._stop_deferred

--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -18,8 +18,11 @@ from twisted.python import threadpool
 from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import SynchronousTestCase
+from zope.interface import implementer
 
 from buildbot.config import BuilderConfig
+from buildbot.interfaces import IBuildStepFactory
+from buildbot.process.buildstep import BuildStep
 from buildbot.process.factory import BuildFactory
 from buildbot.process.results import SUCCESS
 from buildbot.test.fake.reactor import NonThreadPool
@@ -79,6 +82,29 @@ class ControllableLatentWorker(AbstractLatentWorker):
 
     def stop_instance(self, build):
         return Deferred()
+
+
+@implementer(IBuildStepFactory)
+class StepController(object):
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.steps = []
+
+    def buildStep(self):
+        step_deferred = Deferred()
+        step = ControllableStep(step_deferred, **self.kwargs)
+        self.steps.append((step, step_deferred))
+        return step
+
+
+class ControllableStep(BuildStep):
+
+    def run(self):
+        return self._step_deferred
+
+    def __init__(self, step_deferred, **kwargs):
+        BuildStep.__init__(self, **kwargs)
+        self._step_deferred = step_deferred
 
 
 class TestException(Exception):
@@ -357,5 +383,66 @@ class Tests(SynchronousTestCase):
         self.assertEqual([build['results']
                           for build in finished_builds], [SUCCESS] * 2)
 
+    def test_worker_max_builds_honored(self):
+        """
+        If max_builds is set, only one build is started on a worker
+        at a time.
+        """
+        controller = LatentController(
+            'local',
+            max_builds=1,
+        )
+        step_controller = StepController()
+        config_dict = {
+            'builders': [
+                BuilderConfig(name="testy-1",
+                              workernames=["local"],
+                              factory=BuildFactory([step_controller]),
+                              ),
+                BuilderConfig(name="testy-2",
+                              workernames=["local"],
+                              factory=BuildFactory([step_controller]),
+                              ),
+            ],
+            'workers': [controller.worker],
+            'protocols': {'null': {}},
+            'multiMaster': True,
+        }
+        master = self.successResultOf(getMaster(self, self.reactor, config_dict))
+        builder_ids = [
+            self.successResultOf(master.data.updates.findBuilderId('testy-1')),
+            self.successResultOf(master.data.updates.findBuilderId('testy-2')),
+        ]
+
+        started_builds = []
+        self.successResultOf(master.mq.startConsuming(
+            lambda key, build: started_builds.append(build),
+            ('builds', None, 'new')))
+
+        # Trigger a buildrequest
+        bsid, brids = self.successResultOf(
+            master.data.updates.addBuildset(
+                waited_for=False,
+                builderids=builder_ids,
+                sourcestamps=[
+                    {'codebase': '',
+                     'repository': '',
+                     'branch': None,
+                     'revision': None,
+                     'project': ''},
+                ],
+            )
+        )
+
+        # The worker fails to substantiate.
+        controller.start_instance(True)
+
+        local_workdir = FilePath(self.mktemp())
+        local_workdir.createDirectory()
+        controller.connect_worker(local_workdir)
+
+        self.assertEqual(len(started_builds), 1)
+
     if LocalWorker is None:
         test_worker_multiple_substantiations_succeed.skip = "buildbot-slave package is not installed"
+        test_worker_max_builds_honored.skip = "buildbot-slave package is not installed"

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -1,0 +1,177 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet.defer import Deferred
+from twisted.python import threadpool
+from twisted.python.filepath import FilePath
+from twisted.trial.unittest import SynchronousTestCase
+from zope.interface import implementer
+
+from buildbot.config import BuilderConfig
+from buildbot.interfaces import IBuildStepFactory
+from buildbot.process.buildstep import BuildStep
+from buildbot.process.factory import BuildFactory
+from buildbot.test.fake.latent import LatentController
+from buildbot.test.fake.reactor import NonThreadPool
+from buildbot.test.fake.reactor import TestReactor
+from buildbot.test.util.integration import getMaster
+from buildbot.worker.local import LocalWorker
+
+try:
+    from buildbot_worker.bot import LocalWorker as RemoteWorker
+except ImportError:
+    RemoteWorker = None
+
+
+@implementer(IBuildStepFactory)
+class StepController(object):
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.steps = []
+
+    def buildStep(self):
+        step_deferred = Deferred()
+        step = ControllableStep(step_deferred, **self.kwargs)
+        self.steps.append((step, step_deferred))
+        return step
+
+
+class ControllableStep(BuildStep):
+
+    def run(self):
+        return self._step_deferred
+
+    def __init__(self, step_deferred, **kwargs):
+        BuildStep.__init__(self, **kwargs)
+        self._step_deferred = step_deferred
+
+
+class Tests(SynchronousTestCase):
+
+    def setUp(self):
+        self.patch(threadpool, 'ThreadPool', NonThreadPool)
+        self.reactor = TestReactor()
+
+    def test_latent_max_builds(self):
+        """
+        If max_builds is set, only one build is started on a latent
+        worker at a time.
+        """
+        controller = LatentController(
+            'local',
+            max_builds=1,
+        )
+        step_controller = StepController()
+        config_dict = {
+            'builders': [
+                BuilderConfig(name="testy-1",
+                              workernames=["local"],
+                              factory=BuildFactory([step_controller]),
+                              ),
+                BuilderConfig(name="testy-2",
+                              workernames=["local"],
+                              factory=BuildFactory([step_controller]),
+                              ),
+            ],
+            'workers': [controller.worker],
+            'protocols': {'null': {}},
+            'multiMaster': True,
+        }
+        master = self.successResultOf(getMaster(self, self.reactor, config_dict))
+        builder_ids = [
+            self.successResultOf(master.data.updates.findBuilderId('testy-1')),
+            self.successResultOf(master.data.updates.findBuilderId('testy-2')),
+        ]
+
+        started_builds = []
+        self.successResultOf(master.mq.startConsuming(
+            lambda key, build: started_builds.append(build),
+            ('builds', None, 'new')))
+
+        # Trigger a buildrequest
+        bsid, brids = self.successResultOf(
+            master.data.updates.addBuildset(
+                waited_for=False,
+                builderids=builder_ids,
+                sourcestamps=[
+                    {'codebase': '',
+                     'repository': '',
+                     'branch': None,
+                     'revision': None,
+                     'project': ''},
+                ],
+            )
+        )
+
+        # The worker fails to substantiate.
+        controller.start_instance(True)
+
+        local_workdir = FilePath(self.mktemp())
+        local_workdir.createDirectory()
+        controller.connect_worker(local_workdir)
+
+        self.assertEqual(len(started_builds), 1)
+
+    def test_local_worker_max_builds(self):
+        """
+        If max_builds is set, only one build is started on a worker
+        at a time.
+        """
+        step_controller = StepController()
+        config_dict = {
+            'builders': [
+                BuilderConfig(name="testy-1",
+                              workernames=["local"],
+                              factory=BuildFactory([step_controller]),
+                              ),
+                BuilderConfig(name="testy-2",
+                              workernames=["local"],
+                              factory=BuildFactory([step_controller]),
+                              ),
+            ],
+            'workers': [LocalWorker('local', max_builds=1)],
+            'protocols': {'null': {}},
+            'multiMaster': True,
+        }
+        master = self.successResultOf(getMaster(self, self.reactor, config_dict))
+        builder_ids = [
+            self.successResultOf(master.data.updates.findBuilderId('testy-1')),
+            self.successResultOf(master.data.updates.findBuilderId('testy-2')),
+        ]
+
+        started_builds = []
+        self.successResultOf(master.mq.startConsuming(
+            lambda key, build: started_builds.append(build),
+            ('builds', None, 'new')))
+
+        # Trigger a buildrequest
+        bsid, brids = self.successResultOf(
+            master.data.updates.addBuildset(
+                waited_for=False,
+                builderids=builder_ids,
+                sourcestamps=[
+                    {'codebase': '',
+                     'repository': '',
+                     'branch': None,
+                     'revision': None,
+                     'project': ''},
+                ],
+            )
+        )
+
+        self.assertEqual(len(started_builds), 1)
+
+    if RemoteWorker is None:
+        skip = "buildbot-worker package is not installed"

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -1130,7 +1130,7 @@ class TestBuildProperties(unittest.TestCase):
         workerforbuilder = Mock(name='workerforbuilder')
         workerforbuilder.worker = w
 
-        build.setupWorkerForBuilder(workerforbuilder)
+        build.workerforbuilder = workerforbuilder
 
         with assertNotProducesWarnings(DeprecatedWorkerAPIWarning):
             new = build.getWorkerName()

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -766,7 +766,6 @@ class AbstractLatentWorker(AbstractWorker):
         return AbstractWorker.canStartBuild(self)
 
     def buildStarted(self, sb):
-        assert self.substantiated
         self._clearBuildWaitTimer()
         self.building.add(sb.builder_name)
 

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -646,7 +646,6 @@ class AbstractLatentWorker(AbstractWorker):
                     build_wait_timeout=60 * 10,
                     **kwargs):
         AbstractWorker.checkConfig(self, name, password, **kwargs)
-        self.building = set()
         self.build_wait_timeout = build_wait_timeout
         self._substantiation_notifier = Notifier()
 
@@ -655,6 +654,12 @@ class AbstractLatentWorker(AbstractWorker):
                         **kwargs):
         self.build_wait_timeout = build_wait_timeout
         return AbstractWorker.reconfigService(self, name, password, **kwargs)
+
+    @property
+    def building(self):
+        # A LatentWorkerForBuilder will only be busy if it is building.
+        return {wfb for wfb in itervalues(self.workerforbuilders)
+                if wfb.isBusy()}
 
     def failed_to_start(self, instance_id, instance_state):
         log.msg('%s %s failed to start instance %s (%s)' %
@@ -767,12 +772,10 @@ class AbstractLatentWorker(AbstractWorker):
 
     def buildStarted(self, sb):
         self._clearBuildWaitTimer()
-        self.building.add(sb.builder_name)
 
     def buildFinished(self, sb):
         AbstractWorker.buildFinished(self, sb)
 
-        self.building.remove(sb.builder_name)
         if not self.building:
             if self.build_wait_timeout == 0:
                 d = self.insubstantiate()
@@ -807,7 +810,6 @@ class AbstractLatentWorker(AbstractWorker):
             del self._shutdown_callback_handle
             self.master.reactor.removeSystemEventTrigger(handle)
         self.substantiated = False
-        self.building.clear()  # just to be sure
         yield d
         self.insubstantiating = False
         self.botmaster.maybeStartBuildsForWorker(self.name)


### PR DESCRIPTION
- This makes the claimed buildrequest visible as a build .
- This makes it so that starting workers isn't serialized as part of the BRD's activity loop.