### PR TITLE
Change default value for networking_config

### DIFF
--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -59,7 +59,7 @@ class DockerLatentWorker(AbstractLatentWorker):
 
     def __init__(self, name, password, docker_host, image=None, command=None,
                  volumes=None, dockerfile=None, version=None, tls=None, followStartupLogs=False,
-                 masterFQDN=None, hostconfig=None, networking_config='bridge', **kwargs):
+                 masterFQDN=None, hostconfig=None, networking_config=None, **kwargs):
 
         if not client:
             config.error("The python module 'docker-py>=1.4' is needed to use a"

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -221,7 +221,8 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     Extra host configuration parameters passed as a dictionary used to create HostConfig object. See `docker-py's HostConfig documentation <http://docker-py.readthedocs.org/en/latest/hostconfig/>`_ for all the supported options.
 
 ``networking_config``
-  Set the network configuration for the docker container. It can be one the following: 'bridge', 'host', container:<NAME or ID>, none. The default is bridge. This option is equivalent to using the ``--net=`` command line parameter in docker. 
+  (optional)
+  Extra network configuration settings passed as a dictionary used to create NetworkConfig object. See this docker-py `test <https://github.com/docker/docker-py/blob/81edb398ebf7ce5c7ef14aa0739de5329589aabe/tests/unit/container_test.py#L988>`_ for usage example.
 
 Setting up Volumes
 ..................


### PR DESCRIPTION
The current default value for networking config cannot be read by docker and causes the DockerLatentWorker to error. If the `networking_config` option is not set, it should default to None and if specified, should take a dictionary of values. The original implementation was supposed to pass network_config to the docker client's `start()` method in order to set the `network_mode`, but I inadvertently added it to the client's `create_container` call in PR https://github.com/buildbot/buildbot/pull/2039. If a DockerLatentWorker is used, the current workaround is to set networking_config to None in the constructor, defeating the spirit of being optional. Since the host_config parameter sets the network mode, no need to bother with the docker client's `start()` method.