### PR TITLE
buildstep: finish unfinished logs

### DIFF
--- a/master/buildbot/test/fake/logfile.py
+++ b/master/buildbot/test/fake/logfile.py
@@ -82,6 +82,7 @@ class FakeLogFile(object):
     def finish(self):
         self.flushFakeLogfile()
         self.finished = True
+        return defer.succeed(None)
 
     def fakeData(self, header='', stdout='', stderr=''):
         if header:

--- a/master/buildbot/test/integration/test_log_finish.py
+++ b/master/buildbot/test/integration/test_log_finish.py
@@ -14,10 +14,10 @@
 # Copyright Buildbot Team Members
 from twisted.internet import defer
 
-from buildbot.test.util.integration import RunMasterBase
 from buildbot.plugins import steps
 from buildbot.process.results import EXCEPTION
 from buildbot.process.results import SUCCESS
+from buildbot.test.util.integration import RunMasterBase
 
 
 class TestLog(RunMasterBase):

--- a/master/buildbot/test/integration/test_log_finish.py
+++ b/master/buildbot/test/integration/test_log_finish.py
@@ -47,7 +47,7 @@ class TestLog(RunMasterBase):
 
         class MyStep(steps.ShellCommand):
             def _newLog(obj, name, type, logid, logEncoding):
-                r = super(MyStep, obj)._newLog(name, type, logid, logEncoding)
+                r = steps.ShellCommand._newLog(obj, name, type, logid, logEncoding)
                 self.curr_log = r
                 return self.curr_log
 
@@ -60,8 +60,7 @@ class TestLog(RunMasterBase):
                       author="me@foo.com",
                       comments="good stuff",
                       revision="HEAD",
-                      project="none"
-                      )
+                      project="none")
         build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         self.assertEqual(build['results'], SUCCESS)
@@ -72,7 +71,7 @@ class TestLog(RunMasterBase):
 
         class MyStep(steps.MasterShellCommand):
             def _newLog(obj, name, type, logid, logEncoding):
-                r = super(MyStep, obj)._newLog(name, type, logid, logEncoding)
+                r = steps.MasterShellCommand._newLog(obj, name, type, logid, logEncoding)
                 self.curr_log = r
                 return self.curr_log
 
@@ -85,8 +84,7 @@ class TestLog(RunMasterBase):
                       author="me@foo.com",
                       comments="good stuff",
                       revision="HEAD",
-                      project="none"
-                      )
+                      project="none")
         build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         self.assertEqual(build['results'], SUCCESS)
@@ -97,7 +95,7 @@ class TestLog(RunMasterBase):
 
         class MyStep(steps.MasterShellCommand):
             def _newLog(obj, name, type, logid, logEncoding):
-                r = super(MyStep, obj)._newLog(name, type, logid, logEncoding)
+                r = steps.MasterShellCommand._newLog(obj, name, type, logid, logEncoding)
                 self.curr_log = r
                 self.patch(r, "finish", lambda: defer.fail(RuntimeError('Could not finish')))
                 return self.curr_log
@@ -111,8 +109,7 @@ class TestLog(RunMasterBase):
                       author="me@foo.com",
                       comments="good stuff",
                       revision="HEAD",
-                      project="none"
-                      )
+                      project="none")
         build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         self.assertFalse(self.curr_log.finished)

--- a/master/buildbot/test/integration/test_log_finish.py
+++ b/master/buildbot/test/integration/test_log_finish.py
@@ -1,0 +1,123 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+from twisted.internet import defer
+
+from buildbot.test.util.integration import RunMasterBase
+from buildbot.plugins import steps
+from buildbot.process.results import EXCEPTION
+from buildbot.process.results import SUCCESS
+
+
+class TestLog(RunMasterBase):
+
+    # master configuration
+    def masterConfig(self, step):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import schedulers
+
+        c['schedulers'] = [
+            schedulers.AnyBranchScheduler(
+                name="sched",
+                builderNames=["testy"])]
+
+        f = BuildFactory()
+        f.addStep(step)
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["local1"],
+                          factory=f)]
+        return c
+
+    @defer.inlineCallbacks
+    def test_shellcommand(self):
+
+        class MyStep(steps.ShellCommand):
+            def _newLog(obj, name, type, logid, logEncoding):
+                r = super(MyStep, obj)._newLog(name, type, logid, logEncoding)
+                self.curr_log = r
+                return self.curr_log
+
+        step = MyStep(command='echo hello')
+
+        yield self.setupConfig(self.masterConfig(step))
+
+        change = dict(branch="master",
+                      files=["foo.c"],
+                      author="me@foo.com",
+                      comments="good stuff",
+                      revision="HEAD",
+                      project="none"
+                      )
+        build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
+        self.assertEqual(build['buildid'], 1)
+        self.assertEqual(build['results'], SUCCESS)
+        self.assertTrue(self.curr_log.finished)
+
+    @defer.inlineCallbacks
+    def test_mastershellcommand(self):
+
+        class MyStep(steps.MasterShellCommand):
+            def _newLog(obj, name, type, logid, logEncoding):
+                r = super(MyStep, obj)._newLog(name, type, logid, logEncoding)
+                self.curr_log = r
+                return self.curr_log
+
+        step = MyStep(command='echo hello')
+
+        yield self.setupConfig(self.masterConfig(step))
+
+        change = dict(branch="master",
+                      files=["foo.c"],
+                      author="me@foo.com",
+                      comments="good stuff",
+                      revision="HEAD",
+                      project="none"
+                      )
+        build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
+        self.assertEqual(build['buildid'], 1)
+        self.assertEqual(build['results'], SUCCESS)
+        self.assertTrue(self.curr_log.finished)
+
+    @defer.inlineCallbacks
+    def test_mastershellcommand_issue(self):
+
+        class MyStep(steps.MasterShellCommand):
+            def _newLog(obj, name, type, logid, logEncoding):
+                r = super(MyStep, obj)._newLog(name, type, logid, logEncoding)
+                self.curr_log = r
+                self.patch(r, "finish", lambda: defer.fail(RuntimeError('Could not finish')))
+                return self.curr_log
+
+        step = MyStep(command='echo hello')
+
+        yield self.setupConfig(self.masterConfig(step))
+
+        change = dict(branch="master",
+                      files=["foo.c"],
+                      author="me@foo.com",
+                      comments="good stuff",
+                      revision="HEAD",
+                      project="none"
+                      )
+        build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
+        self.assertEqual(build['buildid'], 1)
+        self.assertFalse(self.curr_log.finished)
+        self.assertEqual(build['results'], EXCEPTION)
+        errors = self.flushLoggedErrors()
+        self.assertEquals(len(errors), 1)
+        error = errors[0]
+        self.assertEquals(error.getErrorMessage(), 'Could not finish')


### PR DESCRIPTION
The previous version did not call finish on
unfinished (log.finished == False) logs. Such
situations happened among others with logs not attached to
a RemoteCommand, like for example stdio on
a MasterShellCommand.

Not calling finish had at least, two side effects:
- the 'complete' of related log lines attribute was not set to 1
  in the database,
- master.data.updates.compressLog was not called on the final
  state of the log.

For these reasons, this commit calls 'finish' on unfinised
logs before ending the step. The result of the step is set
to EXCEPTION if an error occured during that operation.

Change-Id: I30ebfc51ffac12cab22f4864494b3a334a202dac