### PR TITLE
.travis.yml: put lint tests first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,13 @@ cache:
 
 matrix:
   include:
-    # lint first as they're more likely to find issues
+    # lint, docs and coverage first as they're more likely to find issues
     - python: "2.7"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=lint
+    - python: "2.7"
+      env: TWISTED=latest SQLALCHEMY=latest TESTS=docs
+    - python: "2.7"
+      env: TWISTED=latest SQLALCHEMY=latest TESTS=coverage
 
     # Test different versions of SQLAlchemy
     - python: "2.7"
@@ -74,11 +78,7 @@ matrix:
 
     # add extra tests in separate jobs
     - python: "2.7"
-      env: TWISTED=latest SQLALCHEMY=latest TESTS=coverage
-    - python: "2.7"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=js
-    - python: "2.7"
-      env: TWISTED=latest SQLALCHEMY=latest TESTS=docs
 
     # python 3 tests
 #    - python: "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,10 @@ cache:
 
 matrix:
   include:
+    # lint first as they're more likely to find issues
+    - python: "2.7"
+      env: TWISTED=latest SQLALCHEMY=latest TESTS=lint
+
     # Test different versions of SQLAlchemy
     - python: "2.7"
       env: TWISTED=15.5.0 SQLALCHEMY=0.6.0 TESTS=trial
@@ -71,8 +75,6 @@ matrix:
     # add extra tests in separate jobs
     - python: "2.7"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=coverage
-    - python: "2.7"
-      env: TWISTED=latest SQLALCHEMY=latest TESTS=lint
     - python: "2.7"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=js
     - python: "2.7"


### PR DESCRIPTION
More than 20 travis jobs are currently
executed to validate a pull request. Travis
however doesn't start the 20 builds in parallel.

The link tests are therefore executed after
previous ones are finished.
To avoid situations where all the unit tests are ok,
but one needs to wait 20 minutes to be aware
of a lint issue (incorrect order of import), which is quite likely
to happen, this commit puts the lint test first.

Change-Id: Id57d6d9fec4742cc7ea768d888e058835ebb2113