### PR TITLE
Use a specified reactor for debouncing.

### DIFF
--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -345,9 +345,9 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
         self.patch(NewStyleStep, 'getResultSummary',
                    lambda self: defer.succeed({'step': u'CS', 'build': u'CB'}))
         step = NewStyleStep()
-        step.updateSummary._reactor = self.clock
         step.master = fakemaster.make_master(testcase=self,
                                              wantData=True, wantDb=True)
+        step.master.reactor = self.clock
         step.stepid = 13
         step.step_status = mock.Mock()
         return step

--- a/master/buildbot/test/unit/test_schedulers_triggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_triggerable.py
@@ -48,6 +48,8 @@ class Triggerable(scheduler.SchedulerMixin, unittest.TestCase):
         self.clock_patch.start()
 
         self.setUpScheduler()
+        # Patch reactor for sched._updateWaiters debounce
+        self.master.reactor = self.clock
         self.subscription = None
 
     def tearDown(self):
@@ -61,7 +63,6 @@ class Triggerable(scheduler.SchedulerMixin, unittest.TestCase):
             triggerable.Triggerable(name='n', builderNames=['b'], **kwargs),
             self.OBJECTID, self.SCHEDULERID,
             overrideBuildsetMethods=overrideBuildsetMethods)
-        sched._updateWaiters._reactor = self.clock
 
         return sched
 

--- a/master/buildbot/test/unit/test_util_debounce.py
+++ b/master/buildbot/test/unit/test_util_debounce.py
@@ -24,13 +24,14 @@ from buildbot.util import debounce
 
 class DebouncedClass(object):
 
-    def __init__(self):
+    def __init__(self, reactor):
         self.callDeferred = None
         self.calls = 0
         self.expCalls = 0
         self.stopDeferreds = []
+        self.reactor = reactor
 
-    @debounce.method(wait=4.0)
+    @debounce.method(wait=4.0, get_reactor=lambda self: self.reactor)
     def maybe(self):
         assert not self.callDeferred
         self.calls += 1
@@ -51,10 +52,8 @@ class DebounceTest(unittest.TestCase):
         self.clock = task.Clock()
 
     def scenario(self, events):
-        dbs = dict((k, DebouncedClass())
+        dbs = dict((k, DebouncedClass(self.clock))
                    for k in set([n for n, _, _ in events]))
-        for db in itervalues(dbs):
-            db.maybe._reactor = self.clock
         while events:
             n, t, e = events.pop(0)
             db = dbs[n]

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -170,6 +170,10 @@ class BuildStepMixin(object):
         self.master = fakemaster.make_master(wantData=wantData, wantDb=wantDb,
                                              wantMq=wantMq, testcase=self)
 
+        # mock out the reactor for updateSummary's debouncing
+        self.debounceClock = task.Clock()
+        self.master.reactor = self.debounceClock
+
         # set defaults
         if wantDefaultWorkdir:
             step.workdir = step._workdir or 'wkdir'
@@ -246,10 +250,6 @@ class BuildStepMixin(object):
 
         # check that the step's name is not None
         self.assertNotEqual(step.name, None)
-
-        # mock out the reactor for updateSummary's debouncing
-        self.debounceClock = task.Clock()
-        step.updateSummary._reactor = self.debounceClock
 
         return step
 

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -404,6 +404,7 @@ The ``debounce.method(wait)`` decorator is the tool for the job.
 .. py:function:: method(wait)
 
     :param wait: time to wait before invoking, in seconds
+    :param get_reactor: A callable that takes the underlying instance and returns the reactor to use. Defaults to ``instance.master.reactor``.
 
     Returns a decorator that debounces the underlying method.
     The underlying method must take no arguments (except ``self``).


### PR DESCRIPTION
This fixes the test error in #2212 (caused by `buildbot.test.integration.test_worker.Tests.test_local_worker_max_builds` leaking `DelayedCalls`.).