### PR TITLE
switch setup.py[bundle] to buildbot_worker instead of slave

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -465,7 +465,7 @@ else:
         ] + test_deps,
         'bundle': [
             "buildbot-www=={0}".format(bundle_version),
-            "buildbot-slave=={0}".format(bundle_version),
+            "buildbot-worker=={0}".format(bundle_version),
             "buildbot-waterfall-view=={0}".format(bundle_version),
             "buildbot-console-view=={0}".format(bundle_version),
         ],


### PR DESCRIPTION
The release for buildot 0.9.0b9 included buildbot_slave in the [bundle]
