### PR TITLE
fix pb.NoSuchMethod checking

### DIFF
--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -277,3 +277,11 @@ class Test_wrapRemoteException(unittest.TestCase):
                 raise Error()
 
         self.assertRaises(Error, f)
+
+    def test_raises_RemoteError(self):
+        def f():
+            with pb._wrapRemoteException():
+                raise twisted_pb.RemoteError(
+                    'twisted.spread.flavors.ProtocolError', None, None)
+
+        self.assertRaises(Error, twisted_pb.RemoteError)

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -160,7 +160,8 @@ class TestConnection(unittest.TestCase):
     def test_remoteGetWorkerInfo_getSlaveInfo_fails(self):
         def side_effect(*args, **kwargs):
             if 'getSlaveInfo' in args:
-                return defer.fail(twisted_pb.NoSuchMethod())
+                return defer.fail(twisted_pb.RemoteError(
+                    'twisted.spread.flavors.NoSuchMethod', None, None))
             if 'getCommands' in args:
                 return defer.succeed({'x': 1, 'y': 2})
             if 'getVersion' in args:

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -284,4 +284,4 @@ class Test_wrapRemoteException(unittest.TestCase):
                 raise twisted_pb.RemoteError(
                     'twisted.spread.flavors.ProtocolError', None, None)
 
-        self.assertRaises(Error, twisted_pb.RemoteError)
+        self.assertRaises(twisted_pb.RemoteError, f)

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -256,3 +256,24 @@ class TestConnection(unittest.TestCase):
         conn.perspective_keepalive()
 
         conn.worker.messageReceivedFromWorker.assert_called_with()
+
+
+class Test_wrapRemoteException(unittest.TestCase):
+
+    def test_raises_NoSuchMethod(self):
+        def f():
+            with pb._wrapRemoteException():
+                raise twisted_pb.RemoteError(
+                    'twisted.spread.flavors.NoSuchMethod', None, None)
+
+        self.assertRaises(pb._NoSuchMethod, f)
+
+    def test_raises_unknown(self):
+        class Error(Exception):
+            pass
+
+        def f():
+            with pb._wrapRemoteException():
+                raise Error()
+
+        self.assertRaises(Error, f)


### PR DESCRIPTION
My testing shows, that in case of remote `pb.NoSuchMethod` error, caller site received pb.RemoteError with information about remote exception, and NOT `pb.NoSuchMethod` exception.

`remoteGetWorkerInfo()` tested with WIP e2e tests in context of transition to new worker protocol.

`remoteShutdown()` is not tested.