### PR TITLE
reraise error if remoteGetWorkerInfo() fails

### DIFF
--- a/master/buildbot/test/unit/test_worker_manager.py
+++ b/master/buildbot/test/unit/test_worker_manager.py
@@ -108,3 +108,14 @@ class TestWorkerManager(unittest.TestCase):
 
         # worker *was* replaced (different class)
         self.assertIdentical(self.workers.workers['worker1'], worker_new)
+
+    @defer.inlineCallbacks
+    def test_newConnection_remoteGetWorkerInfo_failure(self):
+        class Error(RuntimeError):
+            pass
+
+        conn = mock.Mock()
+        conn.remoteGetWorkerInfo = mock.Mock(
+            return_value=defer.fail(Error()))
+        yield self.assertFailure(
+            self.workers.newConnection(conn, "worker"), Error)

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -110,9 +110,7 @@ class WorkerManager(MeasuredBuildbotServiceManager):
                                        old_conn.remotePrint("master got a duplicate connection"))
                 # if we get here then old connection is still alive, and new
                 # should be rejected
-                defer.returnValue(
-                    Failure(RuntimeError("rejecting duplicate worker"))
-                )
+                raise RuntimeError("rejecting duplicate worker")
             except defer.CancelledError:
                 old_conn.loseConnection()
                 log.msg("Connected worker '%s' ping timed out after %d seconds"
@@ -131,7 +129,7 @@ class WorkerManager(MeasuredBuildbotServiceManager):
         except Exception as e:
             log.msg("Failed to communicate with worker '%s'\n"
                     "%s" % (workerName, e))
-            defer.returnValue(Failure(e))
+            raise
 
         conn.info = info
         self.connections[workerName] = conn

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 from twisted.internet import defer
 from twisted.python import log
-from twisted.python.failure import Failure
 
 from buildbot.process.measured_service import MeasuredBuildbotServiceManager
 from buildbot.util import misc

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -131,7 +131,7 @@ class WorkerManager(MeasuredBuildbotServiceManager):
         except Exception as e:
             log.msg("Failed to communicate with worker '%s'\n"
                     "%s" % (workerName, e))
-            defer.returnValue(False)
+            defer.returnValue(Failure(e))
 
         conn.info = info
         self.connections[workerName] = conn


### PR DESCRIPTION
otherwise we'll see in log "rejecting duplicate worker" error