### PR TITLE
rename getSlaveInfo to getWorkerInfo in new master-worker protocol

### DIFF
--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -81,8 +81,13 @@ class FakeWorkerWorker(pb.Referenceable):
     def remote_print(self, message):
         log.msg("WORKER-SIDE: remote_print(%r)" % (message,))
 
-    def remote_getSlaveInfo(self):
-        return {'info': 'here'}
+    def remote_getWorkerInfo(self):
+        return {
+            'info': 'here',
+            'slave_commands': {
+                'x': 1,
+            }
+        }
 
     def remote_getVersion(self):
         return buildbot.version

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -160,7 +160,8 @@ class TestConnection(unittest.TestCase):
     def test_remoteGetWorkerInfo_getSlaveInfo_fails(self):
         def side_effect(*args, **kwargs):
             if 'getSlaveInfo' in args:
-                return defer.fail(twisted_pb.NoSuchMethod())
+                return defer.fail(twisted_pb.RemoteError(
+                    'twisted.spread.flavors.NoSuchMethod', None, None))
             if 'getCommands' in args:
                 return defer.succeed({'x': 1, 'y': 2})
             if 'getVersion' in args:

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -216,6 +216,28 @@ class TestConnection(unittest.TestCase):
         self.mind.callRemote.assert_has_calls(calls)
 
     @defer.inlineCallbacks
+    def test_remoteGetWorkerInfo_no_info(self):
+        # All remote commands tried in remoteGetWorkerInfo are unavailable.
+        # This should be real old worker...
+        def side_effect(*args, **kwargs):
+            return defer.fail(twisted_pb.RemoteError(
+                'twisted.spread.flavors.NoSuchMethod', None, None))
+
+        self.mind.callRemote.side_effect = side_effect
+        conn = pb.Connection(self.master, self.worker, self.mind)
+        info = yield conn.remoteGetWorkerInfo()
+
+        r = {}
+        self.assertEqual(info, r)
+        calls = [
+            mock.call('getWorkerInfo'),
+            mock.call('getSlaveInfo'),
+            mock.call('getCommands'),
+            mock.call('getVersion'),
+        ]
+        self.mind.callRemote.assert_has_calls(calls)
+
+    @defer.inlineCallbacks
     def test_remoteSetBuilderList(self):
         builders = ['builder1', 'builder2']
         self.mind.callRemote.return_value = defer.succeed(builders)

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -256,3 +256,24 @@ class TestConnection(unittest.TestCase):
         conn.perspective_keepalive()
 
         conn.worker.messageReceivedFromWorker.assert_called_with()
+
+
+class Test_wrapRemoteException(unittest.TestCase):
+
+    def test_raises_NoSuchMethod(self):
+        def f():
+            with pb._wrapRemoteException():
+                raise twisted_pb.RemoteError(
+                    'twisted.spread.flavors.NoSuchMethod', None, None)
+
+        self.assertRaises(pb._NoSuchMethod, f)
+
+    def test_raises_unknown(self):
+        class Error(Exception):
+            pass
+
+        def f():
+            with pb._wrapRemoteException():
+                raise Error()
+
+        self.assertRaises(Error, f)

--- a/master/buildbot/worker/protocols/null.py
+++ b/master/buildbot/worker/protocols/null.py
@@ -70,7 +70,7 @@ class Connection(base.Connection):
         return defer.maybeDeferred(self.worker.bot.remote_print, message)
 
     def remoteGetWorkerInfo(self):
-        return defer.maybeDeferred(self.worker.bot.remote_getSlaveInfo)
+        return defer.maybeDeferred(self.worker.bot.remote_getWorkerInfo)
 
     def remoteSetBuilderList(self, builders):
         return defer.maybeDeferred(self.worker.bot.remote_setBuilderList, builders)

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -73,6 +73,14 @@ Changes for Developers
 
 * EC2 Latent Worker upgraded from ``boto2`` to ``boto3``.
 
+Deprecations, Removals, and Non-Compatible Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Master/worker protocol has been changed:
+
+  * ``getSlaveInfo`` remote method was renamed to ``getWorkerInfo``.
+
+
 Details
 -------
 

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -302,7 +302,7 @@ class BotBase(service.MultiService):
     def remote_print(self, message):
         log.msg("message from master:", message)
 
-    def remote_getSlaveInfo(self):
+    def remote_getWorkerInfo(self):
         """This command retrieves data from the files in WORKERDIR/info/* and
         sends the contents to the buildmaster. These are used to describe
         the worker and its configuration, and should be created and

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -73,14 +73,14 @@ class TestBot(unittest.TestCase):
         d.addCallback(check)
         return d
 
-    def test_getSlaveInfo(self):
+    def test_getWorkerInfo(self):
         infodir = os.path.join(self.basedir, "info")
         os.makedirs(infodir)
         open(os.path.join(infodir, "admin"), "w").write("testy!")
         open(os.path.join(infodir, "foo"), "w").write("bar")
         open(os.path.join(infodir, "environ"), "w").write("something else")
 
-        d = self.bot.callRemote("getSlaveInfo")
+        d = self.bot.callRemote("getWorkerInfo")
 
         def check(info):
             self.assertEqual(info, dict(
@@ -92,8 +92,8 @@ class TestBot(unittest.TestCase):
         d.addCallback(check)
         return d
 
-    def test_getSlaveInfo_nodir(self):
-        d = self.bot.callRemote("getSlaveInfo")
+    def test_getWorkerInfo_nodir(self):
+        d = self.bot.callRemote("getWorkerInfo")
 
         def check(info):
             self.assertEqual(set(info.keys()), set(

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -285,9 +285,11 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         # patch runprocess to handle the 'echo', below
         self.patch_runprocess(
             Expect(['echo', 'hello'], os.path.join(
-                self.basedir, 'sb', 'workdir'))
-            + {'hdr': 'headers'} + {'stdout': 'hello\n'} + {'rc': 0}
-            + 0,
+                self.basedir, 'sb', 'workdir')) +
+            {'hdr': 'headers'} +
+            {'stdout': 'hello\n'} +
+            {'rc': 0} +
+            0,
         )
 
         d = defer.succeed(None)
@@ -319,9 +321,9 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         # except that we interrupt it)
         self.patch_runprocess(
             Expect(['sleep', '10'], os.path.join(
-                self.basedir, 'sb', 'workdir'))
-            + {'hdr': 'headers'}
-            + {'wait': True}
+                self.basedir, 'sb', 'workdir')) +
+            {'hdr': 'headers'} +
+            {'wait': True}
         )
 
         d = defer.succeed(None)
@@ -364,8 +366,8 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         # patch runprocess to generate a failure
         self.patch_runprocess(
             Expect(['sleep', '10'], os.path.join(
-                self.basedir, 'sb', 'workdir'))
-            + failure.Failure(Exception("Oops"))
+                self.basedir, 'sb', 'workdir')) +
+            failure.Failure(Exception("Oops"))
         )
         # patch the log.err, otherwise trial will think something *actually*
         # failed


### PR DESCRIPTION
Based on PR #2220.

This is (expected) backward incompatible change in master-worker protocol. New worker now will work only with new master (which is expected too).
Few more similar (and incompatible) change are upcoming for [bug 2340](http://trac.buildbot.net/ticket/2340).

Tested in WIP e2e tests in PR #2136 
