### PR TITLE
builder: _defaultCollapseRequest is a staticmethod

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -534,7 +534,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
         if collapseRequests_fn is False:
             collapseRequests_fn = None
         elif collapseRequests_fn is True:
-            collapseRequests_fn = Builder._defaultCollapseRequestFn
+            collapseRequests_fn = self._defaultCollapseRequestFn
 
         return collapseRequests_fn
 

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -538,7 +538,8 @@ class Builder(util_service.ReconfigurableServiceMixin,
 
         return collapseRequests_fn
 
-    def _defaultCollapseRequestFn(self, master, builder, brdict1, brdict2):
+    @staticmethod
+    def _defaultCollapseRequestFn(master, builder, brdict1, brdict2):
         return buildrequest.BuildRequest.canBeCollapsed(master, brdict1, brdict2)
 
 

--- a/master/buildbot/test/unit/test_process_buildrequest.py
+++ b/master/buildbot/test/unit/test_process_buildrequest.py
@@ -18,6 +18,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process import buildrequest
+from buildbot.process.builder import Builder
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
 
@@ -77,7 +78,7 @@ class TestBuildRequestCollapser(unittest.TestCase):
             fakedb.BuildRequest(id=19, buildsetid=30, builderid=77,
                                 priority=13, submitted_at=1300305712, results=-1),
         ]
-        self.do_request_collapse(rows, [19], [])
+        return self.do_request_collapse(rows, [19], [])
 
     def test_collapseRequests_no_collapse(self):
 
@@ -108,7 +109,7 @@ class TestBuildRequestCollapser(unittest.TestCase):
         ]
 
         self.bldr.getCollapseRequestsFn = lambda: collapseRequests_fn
-        self.do_request_collapse(rows, [21], [])
+        return self.do_request_collapse(rows, [21], [])
 
     def test_collapseRequests_collapse_all(self):
 
@@ -139,8 +140,9 @@ class TestBuildRequestCollapser(unittest.TestCase):
         ]
 
         self.bldr.getCollapseRequestsFn = lambda: collapseRequests_fn
-        self.do_request_collapse(rows, [21], [19, 20])
+        return self.do_request_collapse(rows, [21], [19, 20])
 
+    @defer.inlineCallbacks
     def test_collapseRequests_collapse_default(self):
 
         def collapseRequests_fn(master, builder, brdict1, brdict2):
@@ -174,9 +176,9 @@ class TestBuildRequestCollapser(unittest.TestCase):
                                 priority=13, submitted_at=1300305712, results=-1),
         ]
 
-        self.bldr.getCollapseRequestsFn = lambda: collapseRequests_fn
-        self.do_request_collapse(rows, [22], [])
-        self.do_request_collapse(rows, [21], [19, 20])
+        self.bldr.getCollapseRequestsFn = lambda: Builder._defaultCollapseRequestFn
+        yield self.do_request_collapse(rows, [22], [])
+        yield self.do_request_collapse(rows, [21], [19, 20])
 
 
 class TestBuildRequest(unittest.TestCase):


### PR DESCRIPTION
The collapse related unit tests in test_process_buildrequest
had two issues:
1. the deferred in the test_* method calling self.do_request_collapse,
   were not returned
2. the mock of getCollapseRequestsFn in *_collapse_default did not
   permit to catch the following bug (
   Exceptions.TypeError: unbound method _defaultCollapseRequestFn()
must be called with Builder instance as first argument
(got FakeMaster instance instead))

This commit fixes the bug (_defaultCollapseRequest should be put
as a staticmethod) and reproduces/validates it modifying related
unit tests.

Change-Id: Iec10a70e5f2d8b96c1f4a6bdb184be6638b88818