### PR TITLE
trigger: initialize brids

### DIFF
--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -222,6 +222,7 @@ class Trigger(BuildStep):
             )
             # we are not in a hurry of starting all in parallel and managing
             # the deferred lists, just let the db writes be serial.
+            brids = {}
             try:
                 bsid, brids = yield idsDeferred
             except Exception as e:


### PR DESCRIPTION
When an exception occurs brids is not initalized
and the step fails on the line
self.brids.extend(itervalues(brids))

Change-Id: Ifd7dab2fb0ee27e773ffb3d629ffd42c139c9867