### PR TITLE
output list of installed python packages at the end of install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,8 +147,6 @@ install:
   # https://github.com/pypa/setuptools/issues/500
   - "[ $TESTS != setuppy_test ] || pip install autobahn Twisted"
 
-  - "pip list"
-
 before_script:
   # create real MySQL database for tests
   - mysql -e 'create database bbtest;'
@@ -186,6 +184,11 @@ notifications:
 
 after_success:
   - "[ $TESTS != coverage ] || codecov"
+
+after_script:
+  # List installed packages along with their versions.
+  - "pip list"
+
 sudo: false
 git:
   depth: 300

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,6 +147,8 @@ install:
   # https://github.com/pypa/setuptools/issues/500
   - "[ $TESTS != setuppy_test ] || pip install autobahn Twisted"
 
+  - "pip list"
+
 before_script:
   # create real MySQL database for tests
   - mysql -e 'create database bbtest;'
@@ -178,8 +180,6 @@ script:
   - "[ $TESTS != setuppy_test ] || (cd worker; python setup.py test)"
 
   - "[ $TESTS != trial_worker_only ] || trial --reporter=text --rterrors buildbot.test buildbot_worker.test"
-
-  - "echo 'travis_fold:start:piplist'; pip list; echo 'travis_fold:end:piplist'"
 
 notifications:
   email: false


### PR DESCRIPTION
Output will be collapsed for the same reason as in PR #2227.
Previously if some of testing steps failed `pip list` command is not issued at all.