### PR TITLE
Only build main-line branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -187,5 +187,10 @@ notifications:
 after_success:
   - "[ $TESTS != coverage ] || codecov"
 sudo: false
+branches:
+  # Only build main-line branches.
+  only:
+    - master
+    - eight
 git:
   depth: 300


### PR DESCRIPTION
There is no reason to build branches like [this](https://travis-ci.org/buildbot/buildbot/builds/129810705), since they also get built as a PRs ([here](https://travis-ci.org/buildbot/buildbot/builds/129810761)).