### PR TITLE
simplify remoteGetWorkerInfo logic

### DIFF
--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -171,7 +171,8 @@ class TestConnection(unittest.TestCase):
                     'info': 'test',
                     'slave_commands': {
                         'y': 2, 'x': 1
-                    }
+                    },
+                    'version': 'TheVersion',
                 })
             if 'getSlaveInfo' in args:
                 return defer.fail(twisted_pb.RemoteError(
@@ -188,7 +189,7 @@ class TestConnection(unittest.TestCase):
         r = {'info': 'test', 'slave_commands': {
             'y': 2, 'x': 1}, 'version': 'TheVersion'}
         self.assertEqual(info, r)
-        calls = [mock.call('getWorkerInfo'), mock.call('getVersion')]
+        calls = [mock.call('getWorkerInfo')]
         self.mind.callRemote.assert_has_calls(calls)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
retrieve "slave_commands" and "version" only when old buildslave is
detected.