### PR TITLE
rename "slave_commands" key in worker info to "worker_commands"

### DIFF
--- a/master/buildbot/test/fake/fakeprotocol.py
+++ b/master/buildbot/test/fake/fakeprotocol.py
@@ -27,7 +27,7 @@ class FakeConnection(base.Connection):
 
         # users of the fake can add to this as desired
         self.info = {
-            'slave_commands': [],
+            'worker_commands': [],
             'version': '0.8.2',
             'basedir': '/sl',
             'system': 'nt',

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -84,7 +84,7 @@ class FakeWorkerWorker(pb.Referenceable):
     def remote_getWorkerInfo(self):
         return {
             'info': 'here',
-            'slave_commands': {
+            'worker_commands': {
                 'x': 1,
             }
         }

--- a/master/buildbot/test/unit/test_worker_base.py
+++ b/master/buildbot/test/unit/test_worker_base.py
@@ -384,7 +384,7 @@ class TestAbstractWorker(unittest.TestCase):
             'basedir': 'TheBaseDir',
             'system': 'TheWorkerSystem',
             'version': 'version',
-            'slave_commands': COMMANDS,
+            'worker_commands': COMMANDS,
         }
         yield worker.attached(conn)
 

--- a/master/buildbot/test/unit/test_worker_local.py
+++ b/master/buildbot/test/unit/test_worker_local.py
@@ -81,4 +81,4 @@ class TestLocalWorker(unittest.TestCase):
                                properties={'a': 'b'})
         yield sl.startService()
         info = yield sl.conn.remoteGetWorkerInfo()
-        self.assertIn("slave_commands", info)
+        self.assertIn("worker_commands", info)

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -152,7 +152,7 @@ class TestConnection(unittest.TestCase):
         conn = pb.Connection(self.master, self.worker, self.mind)
         info = yield conn.remoteGetWorkerInfo()
 
-        r = {'info': 'test', 'slave_commands': {
+        r = {'info': 'test', 'worker_commands': {
             'y': 2, 'x': 1}, 'version': 'TheVersion'}
         self.assertEqual(info, r)
         calls = [
@@ -169,7 +169,7 @@ class TestConnection(unittest.TestCase):
             if 'getWorkerInfo' in args:
                 return defer.succeed({
                     'info': 'test',
-                    'slave_commands': {
+                    'worker_commands': {
                         'y': 2, 'x': 1
                     }
                 })
@@ -185,7 +185,7 @@ class TestConnection(unittest.TestCase):
         conn = pb.Connection(self.master, self.worker, self.mind)
         info = yield conn.remoteGetWorkerInfo()
 
-        r = {'info': 'test', 'slave_commands': {
+        r = {'info': 'test', 'worker_commands': {
             'y': 2, 'x': 1}, 'version': 'TheVersion'}
         self.assertEqual(info, r)
         calls = [mock.call('getWorkerInfo'), mock.call('getVersion')]
@@ -209,7 +209,7 @@ class TestConnection(unittest.TestCase):
         conn = pb.Connection(self.master, self.worker, self.mind)
         info = yield conn.remoteGetWorkerInfo()
 
-        r = {'slave_commands': {'y': 2, 'x': 1}, 'version': 'TheVersion'}
+        r = {'worker_commands': {'y': 2, 'x': 1}, 'version': 'TheVersion'}
         self.assertEqual(info, r)
         calls = [mock.call('getSlaveInfo'), mock.call(
             'getCommands'), mock.call('getVersion')]

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -164,6 +164,38 @@ class TestConnection(unittest.TestCase):
         self.mind.callRemote.assert_has_calls(calls)
 
     @defer.inlineCallbacks
+    def test_remoteGetWorkerInfo_slave_2_16(self):
+        """In buildslave 2.16 all information about worker is retrieved in
+        a single getSlaveInfo() call."""
+        def side_effect(*args, **kwargs):
+            if 'getWorkerInfo' in args:
+                return defer.fail(twisted_pb.RemoteError(
+                    'twisted.spread.flavors.NoSuchMethod', None, None))
+            if 'getSlaveInfo' in args:
+                return defer.succeed({
+                    'info': 'test',
+                    'slave_commands': {'x': 1, 'y': 2},
+                    'version': 'TheVersion',
+                })
+            if 'getCommands' in args:
+                return defer.succeed({'x': 1, 'y': 2})
+            if 'getVersion' in args:
+                return defer.succeed('TheVersion')
+
+        self.mind.callRemote.side_effect = side_effect
+        conn = pb.Connection(self.master, self.worker, self.mind)
+        info = yield conn.remoteGetWorkerInfo()
+
+        r = {'info': 'test', 'worker_commands': {
+            'y': 2, 'x': 1}, 'version': 'TheVersion'}
+        self.assertEqual(info, r)
+        calls = [
+            mock.call('getWorkerInfo'),
+            mock.call('getSlaveInfo'),
+        ]
+        self.mind.callRemote.assert_has_calls(calls)
+
+    @defer.inlineCallbacks
     def test_remoteGetWorkerInfo_worker(self):
         def side_effect(*args, **kwargs):
             if 'getWorkerInfo' in args:

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -354,7 +354,7 @@ class AbstractWorker(service.BuildbotService, object):
         self.worker_status.setConnected(True)
 
         self._applyWorkerInfo(conn.info)
-        self.worker_commands = conn.info.get("slave_commands", {})
+        self.worker_commands = conn.info.get("worker_commands", {})
         self.worker_environ = conn.info.get("environ", {})
         self.worker_basedir = conn.info.get("basedir", None)
         self.worker_system = conn.info.get("system", None)

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -211,10 +211,12 @@ class Connection(base.Connection, pb.Avatar):
 
             # newer workers send all info in one command
             if "slave_commands" in info:
+                assert "worker_commands" not in info
+                info["worker_commands"] = info.pop("slave_commands")
                 defer.returnValue(info)
             try:
                 with _wrapRemoteException():
-                    info["slave_commands"] = yield self.mind.callRemote(
+                    info["worker_commands"] = yield self.mind.callRemote(
                         'getCommands')
             except _NoSuchMethod:
                 log.msg("Worker.getCommands is unavailable - ignoring")

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -72,6 +72,8 @@ Deprecations, Removals, and Non-Compatible Changes
 
 * Master/worker protocol has been changed:
 
+  * ``slave_commands`` key in worker information was renamed to ``worker_commands``.
+
   * ``getSlaveInfo`` remote method was renamed to ``getWorkerInfo``.
 
 

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -325,7 +325,7 @@ class BotBase(service.MultiService):
         files['numcpus'] = self.numcpus
 
         files['version'] = self.remote_getVersion()
-        files['slave_commands'] = self.remote_getCommands()
+        files['worker_commands'] = self.remote_getCommands()
         return files
 
     def remote_getVersion(self):

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -86,7 +86,7 @@ class TestBot(unittest.TestCase):
             self.assertEqual(info, dict(
                 admin='testy!', foo='bar',
                 environ=os.environ, system=os.name, basedir=self.basedir,
-                slave_commands=self.real_bot.remote_getCommands(),
+                worker_commands=self.real_bot.remote_getCommands(),
                 version=self.real_bot.remote_getVersion(),
                 numcpus=multiprocessing.cpu_count()))
         d.addCallback(check)
@@ -97,7 +97,7 @@ class TestBot(unittest.TestCase):
 
         def check(info):
             self.assertEqual(set(info.keys()), set(
-                ['environ', 'system', 'numcpus', 'basedir', 'slave_commands', 'version']))
+                ['environ', 'system', 'numcpus', 'basedir', 'worker_commands', 'version']))
         d.addCallback(check)
         return d
 


### PR DESCRIPTION
This is expected backward incompatible change in master-worker protocol.
Users of beta versions of buildbot-worker will need to update worker at the same time as master.
