### PR TITLE
rename "slavesrc" to "workersrc" in buildbot-worker's uploadFile and uploadDirectory commands

### DIFF
--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -302,8 +302,16 @@ class CVS(Source):
             'blocksize': 32 * 1024,
         }
 
+        def uploadFileArgs(source):
+            full_args = dict(args)
+            if self.workerVersionIsOlderThan('uploadFile', '3.0'):
+                full_args['slavesrc'] = source
+            else:
+                full_args['workersrc'] = source
+            return full_args
+
         cmd = remotecommand.RemoteCommand('uploadFile',
-                                          dict(slavesrc='Root', **args),
+                                          uploadFileArgs('Root'),
                                           ignore_updates=True)
         yield self.runCommand(cmd)
         if cmd.rc is not None and cmd.rc != 0:
@@ -321,7 +329,7 @@ class CVS(Source):
 
         myFileWriter.buffer = ""
         cmd = remotecommand.RemoteCommand('uploadFile',
-                                          dict(slavesrc='Repository', **args),
+                                          uploadFileArgs('Repository'),
                                           ignore_updates=True)
         yield self.runCommand(cmd)
         if cmd.rc is not None and cmd.rc != 0:
@@ -335,7 +343,7 @@ class CVS(Source):
         # we can't update (unless we remove those tags with cvs update -A)
         myFileWriter.buffer = ""
         cmd = buildstep.RemoteCommand('uploadFile',
-                                      dict(slavesrc='Entries', **args),
+                                      uploadFileArgs('Entries'),
                                       ignore_updates=True)
         yield self.runCommand(cmd)
         if cmd.rc is not None and cmd.rc != 0:

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -149,13 +149,17 @@ class FileUpload(_TransferBuildStep, WorkerAPICompatMixin):
 
         # default arguments
         args = {
-            'slavesrc': source,
             'workdir': self.workdir,
             'writer': fileWriter,
             'maxsize': self.maxsize,
             'blocksize': self.blocksize,
             'keepstamp': self.keepstamp,
         }
+
+        if self.workerVersionIsOlderThan('uploadFile', '3.0'):
+            args['slavesrc'] = source
+        else:
+            args['workersrc'] = source
 
         cmd = makeStatusRemoteCommand(self, 'uploadFile', args)
         d = self.runTransferCommand(cmd, fileWriter)
@@ -223,13 +227,17 @@ class DirectoryUpload(_TransferBuildStep, WorkerAPICompatMixin):
 
         # default arguments
         args = {
-            'slavesrc': source,
             'workdir': self.workdir,
             'writer': dirWriter,
             'maxsize': self.maxsize,
             'blocksize': self.blocksize,
             'compress': self.compress
         }
+
+        if self.workerVersionIsOlderThan('uploadDirectory', '3.0'):
+            args['slavesrc'] = source
+        else:
+            args['workersrc'] = source
 
         cmd = makeStatusRemoteCommand(self, 'uploadDirectory', args)
         d = self.runTransferCommand(cmd, dirWriter)
@@ -282,13 +290,17 @@ class MultipleFileUpload(_TransferBuildStep, WorkerAPICompatMixin):
             masterdest, self.maxsize, self.mode)
 
         args = {
-            'slavesrc': source,
             'workdir': self.workdir,
             'writer': fileWriter,
             'maxsize': self.maxsize,
             'blocksize': self.blocksize,
             'keepstamp': self.keepstamp,
         }
+
+        if self.workerVersionIsOlderThan('uploadFile', '3.0'):
+            args['slavesrc'] = source
+        else:
+            args['workersrc'] = source
 
         cmd = makeStatusRemoteCommand(self, 'uploadFile', args)
         return self.runTransferCommand(cmd, fileWriter)
@@ -298,13 +310,17 @@ class MultipleFileUpload(_TransferBuildStep, WorkerAPICompatMixin):
             masterdest, self.maxsize, self.compress, 0o600)
 
         args = {
-            'slavesrc': source,
             'workdir': self.workdir,
             'writer': dirWriter,
             'maxsize': self.maxsize,
             'blocksize': self.blocksize,
             'compress': self.compress
         }
+
+        if self.workerVersionIsOlderThan('uploadDirectory', '3.0'):
+            args['slavesrc'] = source
+        else:
+            args['workersrc'] = source
 
         cmd = makeStatusRemoteCommand(self, 'uploadDirectory', args)
         return self.runTransferCommand(cmd, dirWriter)

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -293,12 +293,16 @@ class CompositeStepMixin():
         fileWriter = remotetransfer.StringFileWriter()
         # default arguments
         args = {
-            'slavesrc': filename,
             'workdir': self.workdir,
             'writer': fileWriter,
             'maxsize': None,
             'blocksize': 32 * 1024,
         }
+
+        if self.workerVersionIsOlderThan('uploadFile', '3.0'):
+            args['slavesrc'] = filename
+        else:
+            args['workersrc'] = filename
 
         def commandComplete(cmd):
             if cmd.didFail():

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -754,7 +754,7 @@ class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase,
         self.expectCommands(
             # step will first get the remote suppressions file
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='supps', workdir='wkdir',
+                                      workersrc='supps', workdir='wkdir',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(upload_behavior),
 

--- a/master/buildbot/test/unit/test_steps_source_cvs.py
+++ b/master/buildbot/test/unit/test_steps_source_cvs.py
@@ -101,6 +101,57 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
+                                      workersrc='Root', workdir='wkdir/CVS',
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
+            +
+            Expect.behavior(
+                uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
+            + 0,
+            Expect('uploadFile', dict(blocksize=32768, maxsize=None,
+                                      workersrc='Repository', workdir='wkdir/CVS',
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
+            + Expect.behavior(uploadString('mozilla/browser/'))
+            + 0,
+            Expect('uploadFile', dict(blocksize=32768, maxsize=None,
+                                      workersrc='Entries', workdir='wkdir/CVS',
+                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
+            +
+            Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['cvsdiscard'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['cvs', '-z3', 'update', '-dP'])
+            + 0,
+        )
+
+        self.expectOutcome(result=SUCCESS, state_string="update")
+        self.expectProperty('got_revision', '2012-09-09 12:00:39 +0000', 'CVS')
+        return self.runStep()
+
+    def test_mode_full_clean_and_login_worker_2_16(self):
+        self.setupStep(
+            cvs.CVS(cvsroot=":pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot",
+                    cvsmodule="mozilla/browser/", mode='full', method='clean',
+                    login="a password"),
+            worker_version={'*': '2.16'})
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['cvs', '--version'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['cvs',
+                                 '-d',
+                                 ':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot',
+                                 'login'],
+                        initialStdin="a password\n")
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('uploadFile', dict(blocksize=32768, maxsize=None,
                                       slavesrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
@@ -146,19 +197,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                         command=['cvsdiscard'])
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -207,19 +258,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -251,19 +302,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -293,19 +344,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -334,19 +385,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -454,19 +505,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                  timeout=step.timeout))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='source/CVS',
+                                      workersrc='Root', workdir='source/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='source/CVS',
+                                      workersrc='Repository', workdir='source/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='source/CVS',
+                                      workersrc='Entries', workdir='source/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -499,7 +550,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                  timeout=step.timeout))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='source/CVS',
+                                      workersrc='Root', workdir='source/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('the-end-of-the-universe'))
             + 0,
@@ -534,19 +585,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -572,19 +623,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
@@ -618,7 +669,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             # on Windows, this file does not contain the password, per
             # http://trac.buildbot.net/ticket/2355
@@ -626,12 +677,12 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                 uploadString(':pserver:dustin@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
             + 0,
@@ -656,19 +707,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -696,19 +747,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -737,19 +788,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -775,19 +826,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -813,7 +864,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
@@ -844,7 +895,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
@@ -884,7 +935,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('the-end-of-the-universe'))
             + 0,
@@ -915,14 +966,14 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('the-end-of-the-universe'))
             + 0,
@@ -953,7 +1004,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + 1,
             ExpectShell(workdir='',
@@ -979,7 +1030,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('the-end-of-the-universe'))
             + 0,
@@ -1006,19 +1057,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -1048,7 +1099,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
@@ -1080,19 +1131,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=False))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))
@@ -1133,19 +1184,19 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Root', workdir='wkdir/CVS',
+                                      workersrc='Root', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(
                 uploadString(':pserver:anonymous@cvs-mirror.mozilla.org:/cvsroot'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Repository', workdir='wkdir/CVS',
+                                      workersrc='Repository', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             + Expect.behavior(uploadString('mozilla/browser/'))
             + 0,
             Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      slavesrc='Entries', workdir='wkdir/CVS',
+                                      workersrc='Entries', workdir='wkdir/CVS',
                                       writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
             +
             Expect.behavior(uploadString('/file/1.1/Fri May 17 23:20:00//\nD'))

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -55,18 +55,18 @@ class WorkerFileUploadCommand(TransferCommand):
     Arguments:
 
         - ['workdir']:   base directory to use
-        - ['slavesrc']:  name of the worker-side file to read from
+        - ['workersrc']:  name of the worker-side file to read from
         - ['writer']:    RemoteReference to a buildbot_worker.protocols.base.FileWriterProxy object
         - ['maxsize']:   max size (in bytes) of file to write
         - ['blocksize']: max size for each data block
         - ['keepstamp']: whether to preserve file modified and accessed times
     """
     debug = False
-    requiredArgs = ['workdir', 'slavesrc', 'writer', 'blocksize']
+    requiredArgs = ['workdir', 'workersrc', 'writer', 'blocksize']
 
     def setup(self, args):
         self.workdir = args['workdir']
-        self.filename = args['slavesrc']
+        self.filename = args['workersrc']
         self.writer = args['writer']
         self.remaining = args['maxsize']
         self.blocksize = args['blocksize']
@@ -182,11 +182,11 @@ class WorkerFileUploadCommand(TransferCommand):
 
 class WorkerDirectoryUploadCommand(WorkerFileUploadCommand):
     debug = False
-    requiredArgs = ['workdir', 'slavesrc', 'writer', 'blocksize']
+    requiredArgs = ['workdir', 'workersrc', 'writer', 'blocksize']
 
     def setup(self, args):
         self.workdir = args['workdir']
-        self.dirname = args['slavesrc']
+        self.dirname = args['workersrc']
         self.writer = args['writer']
         self.remaining = args['maxsize']
         self.blocksize = args['blocksize']

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -132,7 +132,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
 
         self.make_command(transfer.WorkerFileUploadCommand, dict(
             workdir='workdir',
-            slavesrc='data',
+            workersrc='data',
             writer=FakeRemote(self.fakemaster),
             maxsize=1000,
             blocksize=64,
@@ -155,7 +155,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
 
         self.make_command(transfer.WorkerFileUploadCommand, dict(
             workdir='workdir',
-            slavesrc='data',
+            workersrc='data',
             writer=FakeRemote(self.fakemaster),
             maxsize=100,
             blocksize=64,
@@ -177,7 +177,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
     def test_missing(self):
         self.make_command(transfer.WorkerFileUploadCommand, dict(
             workdir='workdir',
-            slavesrc='data-nosuch',
+            workersrc='data-nosuch',
             writer=FakeRemote(self.fakemaster),
             maxsize=100,
             blocksize=64,
@@ -203,7 +203,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
 
         self.make_command(transfer.WorkerFileUploadCommand, dict(
             workdir='workdir',
-            slavesrc='data',
+            workersrc='data',
             writer=FakeRemote(self.fakemaster),
             maxsize=1000,
             blocksize=64,
@@ -227,7 +227,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
 
         self.make_command(transfer.WorkerFileUploadCommand, dict(
             workdir='workdir',
-            slavesrc='data',
+            workersrc='data',
             writer=FakeRemote(self.fakemaster),
             maxsize=100,
             blocksize=2,
@@ -262,7 +262,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
 
         self.make_command(transfer.WorkerFileUploadCommand, dict(
             workdir='workdir',
-            slavesrc='data',
+            workersrc='data',
             writer=FakeRemote(self.fakemaster),
             maxsize=1000,
             blocksize=64,
@@ -309,7 +309,7 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
 
         self.make_command(transfer.WorkerDirectoryUploadCommand, dict(
             workdir='workdir',
-            slavesrc='data',
+            workersrc='data',
             writer=FakeRemote(self.fakemaster),
             maxsize=None,
             blocksize=512,
@@ -357,7 +357,7 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
 
         self.make_command(transfer.WorkerDirectoryUploadCommand, dict(
             workdir='workdir',
-            slavesrc='data',
+            workersrc='data',
             writer=FakeRemote(self.fakemaster),
             maxsize=None,
             blocksize=512,


### PR DESCRIPTION
This is expected backward incompatible master/worker API change.

Release notes are in WIP branch: https://github.com/rutsky/buildbot/blob/simple-e2e-test/master/docs/index.rst
I'll cherry-pick them as soon as dependent pull requests (#2234, #2237) will be merged.
