### PR TITLE
db: remove unwanted specialization

### DIFF
--- a/master/buildbot/test/regressions/test_import_unicode_changes.py
+++ b/master/buildbot/test/regressions/test_import_unicode_changes.py
@@ -12,14 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-from twisted.trial import unittest
-
 from buildbot.db.connector import DBConnector
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import change_import
+from buildbot.test.util import db
 
 
-class TestUnicodeChanges(change_import.ChangeImportMixin, unittest.TestCase):
+class TestUnicodeChanges(change_import.ChangeImportMixin, db.TestCase):
 
     def setUp(self):
         d = self.setUpChangeImport()

--- a/master/buildbot/test/unit/test_db_buildrequests.py
+++ b/master/buildbot/test/unit/test_db_buildrequests.py
@@ -346,6 +346,14 @@ class Tests(interfaces.InterfaceTests):
     def test_getBuildRequests_no_repository_nor_branch(self):
         return self.do_test_getBuildRequests_branch_arg(expected=[70, 80, 90])
 
+    def failWithExpFailure(self, expfailure=None):
+        def fail(f):
+            if not expfailure:
+                raise f
+            self.flushLoggedErrors(expfailure)
+            f.trap(expfailure)
+        return fail
+
     def do_test_claimBuildRequests(self, rows, now, brids, expected=None,
                                    expfailure=None, claimed_at=None):
         clock = task.Clock()
@@ -368,11 +376,7 @@ class Tests(interfaces.InterfaceTests):
                         for r in results]),
                 sorted(expected))
 
-        @d.addErrback
-        def fail(f):
-            if not expfailure:
-                raise f
-            f.trap(expfailure)
+        d.addErrback(self.failWithExpFailure(expfailure))
         return d
 
     def test_claimBuildRequests_single(self):
@@ -509,11 +513,7 @@ class Tests(interfaces.InterfaceTests):
                 sorted(expected)
             )
 
-        @d.addErrback
-        def fail(f):
-            if not expfailure:
-                raise f
-            f.trap(expfailure)
+        d.addErrback(self.failWithExpFailure(expfailure))
         return d
 
     def test_reclaimBuildRequests(self):
@@ -584,11 +584,7 @@ class Tests(interfaces.InterfaceTests):
                 for r in results
             ), sorted(expected))
 
-        @d.addErrback
-        def fail(f):
-            if not expfailure:
-                raise f
-            f.trap(expfailure)
+        d.addErrback(self.failWithExpFailure(expfailure))
         return d
 
     def test_completeBuildRequests(self):

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -23,6 +23,7 @@ from buildbot.db import buildsets
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
+from buildbot.test.util import db
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
 from buildbot.util import UTC
@@ -566,7 +567,7 @@ class TestFakeDB(unittest.TestCase, Tests):
         self.assertFailure(d, AssertionError)
 
 
-class TestRealDB(unittest.TestCase,
+class TestRealDB(db.TestCase,
                  connector_component.ConnectorComponentMixin,
                  RealTests):
 

--- a/master/buildbot/test/unit/test_db_changesources.py
+++ b/master/buildbot/test/unit/test_db_changesources.py
@@ -19,6 +19,7 @@ from buildbot.db import changesources
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
+from buildbot.test.util import db
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
 
@@ -278,7 +279,7 @@ class TestFakeDB(unittest.TestCase, Tests):
         self.insertTestData = self.db.insertTestData
 
 
-class TestRealDB(unittest.TestCase,
+class TestRealDB(db.TestCase,
                  connector_component.ConnectorComponentMixin,
                  RealTests):
 

--- a/master/buildbot/test/unit/test_db_schedulers.py
+++ b/master/buildbot/test/unit/test_db_schedulers.py
@@ -19,6 +19,7 @@ from buildbot.db import schedulers
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
+from buildbot.test.util import db
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
 
@@ -352,7 +353,7 @@ class TestFakeDB(unittest.TestCase, Tests):
         return defer.succeed(None)
 
 
-class TestRealDB(unittest.TestCase,
+class TestRealDB(db.TestCase,
                  connector_component.ConnectorComponentMixin,
                  RealTests):
 

--- a/master/buildbot/test/unit/test_db_state.py
+++ b/master/buildbot/test/unit/test_db_state.py
@@ -12,16 +12,15 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-from twisted.trial import unittest
-
 from buildbot.db import state
 from buildbot.test.fake import fakedb
 from buildbot.test.util import connector_component
+from buildbot.test.util import db
 
 
 class TestStateConnectorComponent(
     connector_component.ConnectorComponentMixin,
-        unittest.TestCase):
+        db.TestCase):
 
     def setUp(self):
         d = self.setUpConnectorComponent(

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -232,3 +232,16 @@ class RealDatabaseMixin(object):
                         log.msg("while inserting %s - %s" % (row, row.values))
                         raise
         return self.db_pool.do(thd)
+
+
+class TestCase(unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def assertFailure(self, d, excp):
+        exception = None
+        try:
+            yield d
+        except Exception as e:
+            exception = e
+        self.assertIsInstance(exception, excp)
+        self.flushLoggedErrors(excp)


### PR DESCRIPTION
The previous version had messages related to
MySQL database only, in the code to handle
all connection pools: db/pool.py.

This commit puts that logic in the enginestrategy
instead.

MySQL database connection issues were handled
before checkouting connections from the pool.
However, similar issues were observed when executing queries,
as per the test scenarios related to a builder implementing
a ETL use case. The refactoring implemented above
permits to implement related retries when executing
queries too.

Signed-off-by: Ion Alberdi <ion.alberdi@intel.com>