### PR TITLE
replace readthedocs.org with readthedocs.io

### DIFF
--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -131,8 +131,8 @@ pygments_style = 'trac'
 # modindex_common_prefix = []
 
 intersphinx_mapping = {
-    'python': ('http://python.readthedocs.org/en/latest/', None),
-    'sqlalchemy': ('http://sqlalchemy.readthedocs.org/en/latest/', None),
+    'python': ('https://python.readthedocs.io/en/latest/', None),
+    'sqlalchemy': ('https://sqlalchemy.readthedocs.io/en/latest/', None),
 }
 
 extlinks = {

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -205,7 +205,7 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     (optional)
     This allow to use TLS when connecting with the Docker socket.
     This should be a ``docker.tls.TLSConfig`` object.
-    See `docker-py's own documentation <http://docker-py.readthedocs.org/en/latest/tls/>`_ for more details on how to initialise this object.
+    See `docker-py's own documentation <https://docker-py.readthedocs.io/en/latest/tls/>`_ for more details on how to initialise this object.
 
 ``followStartupLogs``
     (optional, defaults to false)
@@ -218,7 +218,7 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
 
 ``hostconfig``
     (optional)
-    Extra host configuration parameters passed as a dictionary used to create HostConfig object. See `docker-py's HostConfig documentation <http://docker-py.readthedocs.org/en/latest/hostconfig/>`_ for all the supported options.
+    Extra host configuration parameters passed as a dictionary used to create HostConfig object. See `docker-py's HostConfig documentation <https://docker-py.readthedocs.io/en/latest/hostconfig/>`_ for all the supported options.
 
 ``networking_config``
   Set the network configuration for the docker container. It can be one the following: 'bridge', 'host', container:<NAME or ID>, none. The default is bridge. This option is equivalent to using the ``--net=`` command line parameter in docker. 

--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -76,7 +76,7 @@ SQLAlchemy: http://www.sqlalchemy.org/
   Buildbot requires SQLAlchemy version 0.8.0 or higher.
   SQLAlchemy allows Buildbot to build database schemas and queries for a wide variety of database systems.
 
-SQLAlchemy-Migrate: https://sqlalchemy-migrate.readthedocs.org/en/latest/
+SQLAlchemy-Migrate: https://sqlalchemy-migrate.readthedocs.io/en/latest/
 
   Buildbot requires SQLAlchemy-Migrate version 0.9.0 or higher.
   Buildbot uses SQLAlchemy-Migrate to manage schema upgrades from version to version.


### PR DESCRIPTION
All user generated content on ReadTheDocs are stored on .io domain now
to overcome some security issues.
Old links works for now, but ReadTheDocs recommend to update them.
See https://blog.readthedocs.com/securing-subdomains/ for details.

Also use HTTPS instead of HTTP.