### PR TITLE
rename "slavedest" to "workerdest" in buildbot-worker's downloadFile command

### DIFF
--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -226,13 +226,18 @@ class Source(LoggingBuildStep, CompositeStepMixin):
         def _downloadFile(buf, filename):
             filereader = remotetransfer.StringFileReader(buf)
             args = {
-                'slavedest': filename,
                 'maxsize': None,
                 'reader': filereader,
                 'blocksize': 16 * 1024,
                 'workdir': self.workdir,
                 'mode': None
             }
+
+            if self.workerVersionIsOlderThan('downloadFile', '3.0'):
+                args['slavedest'] = filename
+            else:
+                args['workerdest'] = filename
+
             cmd = remotecommand.RemoteCommand('downloadFile', args)
             cmd.useLog(self.stdio_log, False)
             log.msg("Downloading file: %s" % (filename))

--- a/master/buildbot/steps/source/darcs.py
+++ b/master/buildbot/steps/source/darcs.py
@@ -253,13 +253,18 @@ class Darcs(Source):
     def _downloadFile(self, buf, filename):
         filereader = remotetransfer.StringFileReader(buf)
         args = {
-            'slavedest': filename,
             'maxsize': None,
             'reader': filereader,
             'blocksize': 16 * 1024,
             'workdir': self.workdir,
             'mode': None
         }
+
+        if self.workerVersionIsOlderThan('downloadFile', '3.0'):
+            args['slavedest'] = filename
+        else:
+            args['workerdest'] = filename
+
         cmd = remotecommand.RemoteCommand('downloadFile', args)
         cmd.useLog(self.stdio_log, False)
         log.msg("Downloading file: %s" % (filename))

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -471,13 +471,17 @@ class FileDownload(_TransferBuildStep, WorkerAPICompatMixin):
 
         # default arguments
         args = {
-            'slavedest': workerdest,
             'maxsize': self.maxsize,
             'reader': fileReader,
             'blocksize': self.blocksize,
             'workdir': self.workdir,
             'mode': self.mode,
         }
+
+        if self.workerVersionIsOlderThan('downloadFile', '3.0'):
+            args['slavedest'] = workerdest
+        else:
+            args['workerdest'] = workerdest
 
         cmd = makeStatusRemoteCommand(self, 'downloadFile', args)
         d = self.runTransferCommand(cmd)
@@ -537,13 +541,17 @@ class StringDownload(_TransferBuildStep, WorkerAPICompatMixin):
 
         # default arguments
         args = {
-            'slavedest': workerdest,
             'maxsize': self.maxsize,
             'reader': fileReader,
             'blocksize': self.blocksize,
             'workdir': self.workdir,
             'mode': self.mode,
         }
+
+        if self.workerVersionIsOlderThan('downloadFile', '3.0'):
+            args['slavedest'] = workerdest
+        else:
+            args['workerdest'] = workerdest
 
         cmd = makeStatusRemoteCommand(self, 'downloadFile', args)
         d = self.runTransferCommand(cmd)

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -196,6 +196,73 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
+                                        workerdest='.buildbot-diff', workdir='wkdir',
+                                        mode=None))
+            + 0,
+            Expect('downloadFile', dict(blocksize=16384, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='.buildbot-patched', workdir='wkdir',
+                                        mode=None))
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'update-index', '--refresh'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'apply', '--index', '-p', '1'],
+                        initialStdin='patch')
+            + 0,
+            Expect('rmdir', dict(dir='wkdir/.buildbot-diff',
+                                 logEnviron=True))
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', 'Git')
+        return self.runStep()
+
+    def test_mode_full_clean_patch_worker_2_16(self):
+        self.setupStep(
+            git.Git(repourl='http://github.com/buildbot/buildbot.git',
+                    mode='full', method='clean'),
+            patch=(1, 'patch'),
+            worker_version={'*': '2.16'})
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d', '-x'],
+                        logEnviron=True)
+            + 0,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            Expect('downloadFile', dict(blocksize=16384, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
@@ -258,13 +325,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        slavedest='.buildbot-diff', workdir='wkdir',
+                                        workerdest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        slavedest='.buildbot-patched', workdir='wkdir',
+                                        workerdest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,
             ExpectShell(workdir='wkdir',

--- a/master/buildbot/test/unit/test_steps_source_mercurial.py
+++ b/master/buildbot/test/unit/test_steps_source_mercurial.py
@@ -241,6 +241,73 @@ class TestMercurial(sourcesteps.SourceStepMixin, unittest.TestCase):
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
+                                        workerdest='.buildbot-diff', workdir='wkdir',
+                                        mode=None))
+            + 0,
+            Expect('downloadFile', dict(blocksize=16384, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='.buildbot-patched', workdir='wkdir',
+                                        mode=None))
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=[
+                            'hg', '--verbose', 'import', '--no-commit', '-p', '1', '-'],
+                        initialStdin='patch')
+            + 0,
+            Expect('rmdir', dict(dir='wkdir/.buildbot-diff',
+                                 logEnviron=True))
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['hg', '--verbose', 'parents',
+                                 '--template', '{node}\\n'])
+            + ExpectShell.log('stdio', stdout='\n')
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
+    def test_mode_full_clean_patch_worker_2_16(self):
+        self.setupStep(
+            mercurial.Mercurial(repourl='http://hg.mozilla.org',
+                                mode='full', method='clean', branchType='inrepo'),
+            patch=(1, 'patch'),
+            worker_version={'*': '2.16'})
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['hg', '--verbose', '--version'])
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 0,
+            Expect('stat', dict(file='wkdir/.hg',
+                                logEnviron=True))
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['hg', '--verbose', '--config',
+                                 'extensions.purge=', 'purge'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['hg', '--verbose', 'pull',
+                                 'http://hg.mozilla.org', '--rev', 'default'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['hg', '--verbose', 'identify', '--branch'])
+            + ExpectShell.log('stdio',
+                              stdout='default')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['hg', '--verbose', 'locate', 'set:added()'])
+            + 1,
+            ExpectShell(workdir='wkdir',
+                        command=['hg', '--verbose', 'update',
+                                 '--clean', '--rev', 'default'])
+            + 0,
+            Expect('downloadFile', dict(blocksize=16384, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
                                         slavedest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
@@ -307,13 +374,13 @@ class TestMercurial(sourcesteps.SourceStepMixin, unittest.TestCase):
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        slavedest='.buildbot-diff', workdir='wkdir',
+                                        workerdest='.buildbot-diff', workdir='wkdir',
                                         mode=None))
             + 0,
             Expect('downloadFile', dict(blocksize=16384, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        slavedest='.buildbot-patched', workdir='wkdir',
+                                        workerdest='.buildbot-patched', workdir='wkdir',
                                         mode=None))
             + 0,
             ExpectShell(workdir='wkdir',

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -252,18 +252,18 @@ class WorkerFileDownloadCommand(TransferCommand):
     Arguments:
 
         - ['workdir']:   base directory to use
-        - ['slavedest']: name of the worker-side file to be created
+        - ['workerdest']: name of the worker-side file to be created
         - ['reader']:    RemoteReference to a buildbot_worker.protocols.base.FileReaderProxy object
         - ['maxsize']:   max size (in bytes) of file to write
         - ['blocksize']: max size for each data block
         - ['mode']:      access mode for the new file
     """
     debug = False
-    requiredArgs = ['workdir', 'slavedest', 'reader', 'blocksize']
+    requiredArgs = ['workdir', 'workerdest', 'reader', 'blocksize']
 
     def setup(self, args):
         self.workdir = args['workdir']
-        self.filename = args['slavedest']
+        self.filename = args['workerdest']
         self.reader = args['reader']
         self.bytes_remaining = args['maxsize']
         self.blocksize = args['blocksize']

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -406,7 +406,7 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
 
         self.make_command(transfer.WorkerFileDownloadCommand, dict(
             workdir='.',
-            slavedest='data',
+            workerdest='data',
             reader=FakeRemote(self.fakemaster),
             maxsize=None,
             blocksize=32,
@@ -433,7 +433,7 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
 
         self.make_command(transfer.WorkerFileDownloadCommand, dict(
             workdir='workdir',
-            slavedest=os.path.join('subdir', 'data'),
+            workerdest=os.path.join('subdir', 'data'),
             reader=FakeRemote(self.fakemaster),
             maxsize=None,
             blocksize=32,
@@ -459,7 +459,7 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
         os.makedirs(os.path.join(self.basedir, 'dir'))
         self.make_command(transfer.WorkerFileDownloadCommand, dict(
             workdir='.',
-            slavedest='dir',  # but that's a directory!
+            workerdest='dir',  # but that's a directory!
             reader=FakeRemote(self.fakemaster),
             maxsize=None,
             blocksize=32,
@@ -483,7 +483,7 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
 
         self.make_command(transfer.WorkerFileDownloadCommand, dict(
             workdir='.',
-            slavedest='data',
+            workerdest='data',
             reader=FakeRemote(self.fakemaster),
             maxsize=50,
             blocksize=32,
@@ -511,7 +511,7 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
 
         self.make_command(transfer.WorkerFileDownloadCommand, dict(
             workdir='.',
-            slavedest='data',
+            workerdest='data',
             reader=FakeRemote(self.fakemaster),
             maxsize=100,
             blocksize=2,


### PR DESCRIPTION
This is expected backward incompatible master/worker API change.

Based on PR #2239.

Release notes are in WIP branch: https://github.com/rutsky/buildbot/blob/simple-e2e-test/master/docs/index.rst
I'll cherry-pick them when dependent PRs will be merged.
