### PR TITLE
Update docs for buildbot-worker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Buildbot is based on original work from `Brian Warner
 Buildbot consists of several components:
 
 * master
-* slave
+* worker
 * www/base
 * www/console_view
 * www/waterfall_view

--- a/master/docs/developer/cls-buildsteps.rst
+++ b/master/docs/developer/cls-buildsteps.rst
@@ -162,7 +162,7 @@ BuildStep
     .. py:method:: startStep(remote)
 
         :param remote: a remote reference to the worker-side
-            :class:`~buildslave.bot.SlaveBuilder` instance
+            :class:`~buildbot_worker.pb.WorkerForBuilderPb` instance
         :returns: Deferred
 
         Begin the step.

--- a/master/docs/developer/tests.rst
+++ b/master/docs/developer/tests.rst
@@ -1,10 +1,8 @@
 Buildbot's Test Suite
 =====================
 
-Buildbot's tests are under ``buildbot.test`` and, for the buildslave,
-``buildslave.test``.  Tests for the slave are similar to the master, although
-in some cases helpful functionality on the master is not re-implemented on the
-slave.
+Buildbot's master tests are under ``buildbot.test``, ``buildbot-worker`` package tests are under ``buildbot_worker.test``, and ``buildbot-slave`` package tests are under ``buildslave.test``.
+Tests for the workers are similar to the master, although in some cases helpful functionality on the master is not re-implemented on the worker.
 
 Suites
 ------

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -1035,7 +1035,7 @@ The :bb:step:`ShellCommand` arguments are:
 
 ``workdir``
     All ShellCommands are run by default in the ``workdir``, which defaults to the :file:`build` subdirectory of the worker builder's base directory.
-    The absolute path of the workdir will thus be the worker's basedir (set as an option to ``buildslave create-slave``, :ref:`Creating-a-worker`) plus the builder's basedir (set in the builder's ``builddir`` key in :file:`master.cfg`) plus the workdir itself (a class-level attribute of the BuildFactory, defaults to :file:`build`).
+    The absolute path of the workdir will thus be the worker's basedir (set as an option to ``buildbot-worker create-worker``, :ref:`Creating-a-worker`) plus the builder's basedir (set in the builder's ``builddir`` key in :file:`master.cfg`) plus the workdir itself (a class-level attribute of the BuildFactory, defaults to :file:`build`).
 
     For example::
 
@@ -2136,7 +2136,7 @@ The optional ``compress`` argument can be given as ``'gz'`` or ``'bz2'`` to comp
 
 .. note::
 
-   The permissions on the copied files will be the same on the master as originally on the worker, see option `buildslave create-slave --umask` to change the default one.
+   The permissions on the copied files will be the same on the master as originally on the worker, see option ``buildbot-worker create-worker --umask`` to change the default one.
 
 .. bb:step:: MultipleFileUpload
 
@@ -2400,7 +2400,7 @@ If, for example, you use ``variables=['Tmp']``, the result will be a property na
                                       "-cp",
                                       util.Interpolate("%(prop:SOME_JAVA_LIB_HOME)s")]))
 
-Note that this step requires that the Buildslave be at least version 0.8.3.
+Note that this step requires that the worker be at least version 0.8.3.
 For previous versions, no environment variables are available (the worker environment will appear to be empty).
 
 .. index:: Properties; triggering schedulers

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -91,14 +91,14 @@ Don't forget to add your dependencies in there to get a succesfull build !
     RUN apt-get update && apt-get install -y \
        python-dev \
        python-pip
-    RUN pip install buildbot-slave
+    RUN pip install buildbot-worker
     RUN groupadd -r buildbot && useradd -r -g buildbot buildbot
     RUN mkdir /worker && chown buildbot:buildbot /worker
     # Install your build-dependencies here ...
     USER buildbot
     WORKDIR /worker
-    RUN buildslave create-slave . <master-hostname> <workername> <workerpassword>
-    ENTRYPOINT ["/usr/local/bin/buildslave"]
+    RUN buildbot-worker create-worker . <master-hostname> <workername> <workerpassword>
+    ENTRYPOINT ["/usr/local/bin/buildbot-worker"]
     CMD ["start", "--nodaemon"]
 
 On line 11, the hostname for your master instance, as well as the worker name and password is setup.

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -4,7 +4,7 @@ Command-line Tool
 =================
 
 This section describes command-line tools available after buildbot installation.
-Since version 0.8 the one-for-all :command:`buildbot` command-line tool was divided into two parts namely :command:`buildbot` and :command:`buildslave`.
+Since version 0.8 the one-for-all :command:`buildbot` command-line tool was divided into two parts namely :command:`buildbot` and :command:`buildslave`, starting from version 0.9 :command:`buildslave` command was replaced with :command:`buildbot-worker` command.
 The last one was separated from main command-line tool to minimize dependencies required for running a worker while leaving all other functions to :command:`buildbot` tool.
 
 Every command-line tool has a list of global options and a set of commands which have their own options.
@@ -13,9 +13,9 @@ One can run these tools in the following way:
 .. code-block:: none
 
    buildbot [global options] command [command options]
-   buildslave [global options] command [command options]
+   buildbot-worker [global options] command [command options]
 
-The ``buildbot`` command is used on the master, while ``buildslave`` is used on the worker.
+The ``buildbot`` command is used on the master, while ``buildbot-worker`` is used on the worker.
 Global options are the same for both tools which perform the following actions:
 
 --help
@@ -35,7 +35,7 @@ You can get help on any command by specifying ``--help`` as a command option:
 
    buildbot @var{command} --help
 
-You can also use manual pages for :command:`buildbot` and :command:`buildslave` for quick reference on command-line options.
+You can also use manual pages for :command:`buildbot` and :command:`buildbot-worker` for quick reference on command-line options.
 
 The remainder of this section describes each buildbot command.
 See :bb:index:`cmdline` for a full list.
@@ -636,13 +636,13 @@ Note carefully that the names in the :file:`options` file usually do not match t
 worker
 ------
 
-:command:`buildslave` command-line tool is used for worker management only and does not provide any additional functionality.
+:command:`buildbot-worker` command-line tool is used for worker management only and does not provide any additional functionality.
 One can create, start, stop and restart the worker.
 
-.. bb:cmdline:: create-slave
+.. bb:cmdline:: create-worker
 
-create-slave
-~~~~~~~~~~~~
+create-worker
+~~~~~~~~~~~~~
 
 This creates a new directory and populates it with files that let it be used as a worker's base directory.
 You must provide several arguments, which are used to create the initial :file:`buildbot.tac` file.
@@ -651,9 +651,9 @@ The option `-r` option is advisable here, just like for ``create-master``.
 
 .. code-block:: none
 
-    buildslave create-slave -r {BASEDIR} {MASTERHOST}:{PORT} {WORKERNAME} {PASSWORD}
+    buildbot-worker create-worker -r {BASEDIR} {MASTERHOST}:{PORT} {WORKERNAME} {PASSWORD}
 
-The create-slave options are described in :ref:`Worker-Options`.
+The create-worker options are described in :ref:`Worker-Options`.
 
 .. bb:cmdline:: start (worker)
 
@@ -665,7 +665,7 @@ The daemon is launched in the background, with events logged to a file named :fi
 
 .. code-block:: none
 
-    buildslave start [--nodaemon] BASEDIR
+    buildbot-worker start [--nodaemon] BASEDIR
 
 The option `--nodaemon` option instructs Buildbot to skip daemonizing.
 The process will start in the foreground.
@@ -678,7 +678,7 @@ restart
 
 .. code-block:: none
 
-    buildslave restart [--nodaemon] BASEDIR
+    buildbot-worker restart [--nodaemon] BASEDIR
 
 This restarts a worker which is already running.
 It is equivalent to a ``stop`` followed by a ``start``.

--- a/master/docs/manual/deploy.rst
+++ b/master/docs/manual/deploy.rst
@@ -60,7 +60,7 @@ You can use something like the following:
         -prune -o -type f -mtime +14 -exec rm {} \;
     @weekly cd BASEDIR && find twistd.log* -mtime +14 -exec rm {} \;
 
-Alternatively, you can configure a maximum number of old logs to be kept using the ``--log-count`` command line option when running ``buildslave create-slave`` or ``buildbot create-master``.
+Alternatively, you can configure a maximum number of old logs to be kept using the ``--log-count`` command line option when running ``buildbot-worker create-worker`` or ``buildbot create-master``.
 
 .. _Troubleshooting:
 
@@ -100,7 +100,7 @@ If you get impatient, just manually stop and re-start the worker.
 
 When the buildmaster is restarted, all workers will be disconnected, and will attempt to reconnect as usual.
 The reconnect time will depend upon how long the buildmaster is offline (i.e. how far up the exponential backoff curve the workers have travelled).
-Again, :samp:`buildslave restart {BASEDIR}` will speed up the process.
+Again, :samp:`buildbot-worker restart {BASEDIR}` will speed up the process.
 
 .. _Contrib-Scripts:
 

--- a/master/docs/manual/installation/installation.rst
+++ b/master/docs/manual/installation/installation.rst
@@ -6,7 +6,7 @@ Installing the code
 The Buildbot Packages
 ~~~~~~~~~~~~~~~~~~~~~
 
-Buildbot comes in several parts: ``buildbot`` (the buildmaster), ``buildbot-slave`` (the worker), ``buildbot-www``, and several web plugins such as ``buildbot-waterfall-view``.
+Buildbot comes in several parts: ``buildbot`` (the buildmaster), ``buildbot-worker`` (the worker), ``buildbot-www``, and several web plugins such as ``buildbot-waterfall-view``.
 
 The worker and buildmaster can be installed individually or together.
 The base web (``buildbot.www``) and web plugins are required to run a master with a web interface (the common configuration).
@@ -25,7 +25,7 @@ and for the worker:
 
 .. code-block:: bash
 
-    pip install buildbot-slave
+    pip install buildbot-worker
 
 When using ``pip`` to install instead of distribution specific package manangers, e.g. via `apt-get` or `ports`, it is simpler to choose exactly which version one wants to use.
 It may however be easier to install via distribution specific package mangers but note that they may provide an earlier version than what is available via ``pip``.
@@ -39,7 +39,7 @@ If you plan to use TLS or SSL in master configuration (e.g. to fetch resources o
 Installation From Tarballs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Buildbot and Buildslave are installed using the standard Python `distutils <http://docs.python.org/library/distutils.html>`_ process.
+Buildbot master and ``buildbot-worker`` are installed using the standard Python `distutils <http://docs.python.org/library/distutils.html>`_ process.
 For either component, after unpacking the tarball, the process is:
 
 .. code-block:: bash
@@ -60,7 +60,7 @@ To test this, shift to a different directory (like :file:`/tmp`), and run:
 
     buildbot --version
     # or
-    buildslave --version
+    buildbot-worker --version
 
 If it shows you the versions of Buildbot and Twisted, the install went ok.
 If it says "no such command" or it gets an ``ImportError`` when it tries to load the libraries, then something went wrong.
@@ -100,7 +100,7 @@ Then, run the tests:
 
     PYTHONPATH=. trial buildbot.test
     # or
-    PYTHONPATH=. trial buildslave.test
+    PYTHONPATH=. trial buildbot_worker.test
 
 Nothing should fail, although a few might be skipped.
 

--- a/master/docs/manual/installation/misc.rst
+++ b/master/docs/manual/installation/misc.rst
@@ -14,7 +14,7 @@ To launch them, pass the working directory to the :command:`buildbot` and :comma
     # start a master
     buildbot start [ BASEDIR ]
     # start a worker
-    buildslave start [ WORKER_BASEDIR ]
+    buildbot-worker start [ WORKER_BASEDIR ]
 
 The *BASEDIR* is option and can be omitted if the current directory contains the buildbot configuration (the :file:`buildbot.tac` file).
 
@@ -95,7 +95,7 @@ To stop a buildmaster or worker manually, use:
 
     buildbot stop [ BASEDIR ]
     # or
-    buildslave stop [ WORKER_BASEDIR ]
+    buildbot-worker stop [ WORKER_BASEDIR ]
 
 This simply looks for the :file:`twistd.pid` file and kills whatever process is identified within.
 
@@ -121,7 +121,7 @@ Workers can similarly be restarted with:
 
 .. code-block:: bash
 
-    buildslave restart [ BASEDIR ]
+    buildbot-worker restart [ BASEDIR ]
 
 There are certain configuration changes that are not handled cleanly by ``buildbot reconfig``.
 If this occurs, ``buildbot restart`` is a more robust tool to fully switch over to the new configuration.

--- a/master/docs/manual/installation/misc.rst
+++ b/master/docs/manual/installation/misc.rst
@@ -7,7 +7,7 @@ Launching the daemons
 ---------------------
 
 Both the buildmaster and the worker run as daemon programs.
-To launch them, pass the working directory to the :command:`buildbot` and :command:`buildworker` commands, as appropriate:
+To launch them, pass the working directory to the :command:`buildbot` and :command:`buildbot-worker` commands, as appropriate:
 
 .. code-block:: bash
 

--- a/master/docs/manual/installation/misc.rst
+++ b/master/docs/manual/installation/misc.rst
@@ -54,19 +54,19 @@ With a little modification these scripts can be used both on Debian and RHEL-bas
 
 .. code-block:: bash
 
-    # install as /etc/default/buildslave
-    #         or /etc/sysconfig/buildslave
-    master/contrib/init-scripts/buildslave.default
+    # install as /etc/default/buildbot-worker
+    #         or /etc/sysconfig/buildbot-worker
+    worker/contrib/init-scripts/buildbot-worker.default
 
     # install as /etc/default/buildmaster
     #         or /etc/sysconfig/buildmaster
     master/contrib/init-scripts/buildmaster.default
 
-    # install as /etc/init.d/buildslave
-    slave/contrib/init-scripts/buildslave.init.sh
+    # install as /etc/init.d/buildbot-worker
+    worker/contrib/init-scripts/buildbot-worker.init.sh
 
     # install as /etc/init.d/buildmaster
-    slave/contrib/init-scripts/buildmaster.init.sh
+    master/contrib/init-scripts/buildmaster.init.sh
 
     # ... and tell sysvinit about them
     chkconfig buildmaster reset

--- a/master/docs/manual/worker-transition.rst
+++ b/master/docs/manual/worker-transition.rst
@@ -527,6 +527,9 @@ List of database-related changes in API (fallback for old API is provided):
    * - :py:attr:`buildbot.db.connector.DBConnector.buildslaves`
      - :py:attr:`buildbot.db.connector.DBConnector.workers`
 
+
+.. _Worker-Transition-Buildbot-Worker:
+
 ``buildbot-worker``
 -------------------
 

--- a/master/docs/manual/worker-transition.rst
+++ b/master/docs/manual/worker-transition.rst
@@ -550,3 +550,5 @@ List of database-related changes in API (fallback for old API is provided):
      - yes
 
 ``buildbot-worker`` doesn't support worker-side specification of ``usePTY`` (with ``--usepty`` command line switch of ``buildbot-worker create-worker``), you need to specify this option on master side.
+
+``getSlaveInfo`` remote command was renamed to ``getWorkerInfo`` in ``buildbot-worker``.

--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -117,17 +117,17 @@ It would however be completely ok to do this on another computer - as long as th
   virtualenv --no-site-packages bb-worker
   cd bb-worker
 
-Install the ``buildslave`` command:
+Install the ``buildbot-worker`` command:
 
 .. code-block:: bash
 
-   ./bin/pip install buildbot-slave
+   ./bin/pip install buildbot-worker
 
 Now, create the worker:
 
 .. code-block:: bash
 
-  ./bin/buildslave create-slave worker localhost example-worker pass
+  ./bin/buildbot-worker create-worker worker localhost example-worker pass
 
 .. note:: If you decided to create this from another computer, you should replace ``localhost`` with the name of the computer where your master is running.
 
@@ -141,7 +141,7 @@ And finally, start the worker:
 
 .. code-block:: bash
 
-  ./bin/buildslave start worker
+  ./bin/buildbot-worker start worker
 
 Check the worker's output.
 It should end with lines like these:


### PR DESCRIPTION
`master-worker.rst` was updated to meet my expectations from master/worker protocol — please review it carefully.

Some steps in documentation will not work immediately (e.g. `pip install buildbot-worker`), since `buildbot-worker` is not released yet (only as beta, which is not installed by default by pip).
I think this is OK for latest documentation.
