### PR TITLE
Upgrade test_worker_ec2 from boto2 -> boto3

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -439,7 +439,6 @@ else:
         'txrequests',
         'future',
         'pyjade',
-        'boto',
         'boto3',
         'moto',
         'txgithub',


### PR DESCRIPTION
This is the third and last change for the boto3 upgrade, it was broken up into three parts:
1) Increase boto2 test coverage to ensure boto3 changes are correct (#2164) 
2) Upgrade ec2.py implementation from boto2 to boto3 (#2181)
3) Upgrade the test suite to boto3 (this pr)