### PR TITLE
move comments about installed deps for docs to setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,14 +90,8 @@ install:
   - "[ $TWISTED = latest ] || pip install Twisted==$TWISTED"
   - "[ $SQLALCHEMY = latest ] || pip install sqlalchemy==$SQLALCHEMY"
 
-  # mock is preinstalled on Travis
-  # Install lz4 for log compression utest
-  # Install python-future for py2/3 compatability
-  # Install pyjade for custom templates tests
   # Install MySQL-python for tests that uses real MySQL
   # Install psycopg2 and pg8000 for tests that uses real PostgreSQL
-  # Install boto and moto for running EC2 tests
-  # Install txgithub to run buildbot.status.github module tests
   - |
       [ $TESTS != trial -a $TESTS != coverage -a $TESTS != lint -a $TESTS != js ] || \
       pip install -e pkg \

--- a/master/setup.py
+++ b/master/setup.py
@@ -426,6 +426,7 @@ else:
         'Jinja2 >= 2.1',
         # required for tests, but Twisted requires this anyway
         'zope.interface >= 4.1.1',
+        # python-future required for py2/3 compatibility
         'future',
         'sqlalchemy>=0.8.0',
         'sqlalchemy-migrate>=0.9',
@@ -437,10 +438,12 @@ else:
     # Unit test dependencies.
     test_deps = [
         'txrequests',
-        'future',
+        # pyjade required for custom templates tests
         'pyjade',
+        # boto3 and moto required for running EC2 tests
         'boto3',
         'moto',
+        # txgithub required to run buildbot.status.github module tests
         'txgithub',
         'ramlfications',
         'mock',
@@ -449,6 +452,7 @@ else:
         test_deps += [
             # LZ4 fails to build on Windows:
             # https://github.com/steeve/python-lz4/issues/27
+            # lz4 required for log compression tests.
             'lz4',
         ]
 


### PR DESCRIPTION
Also removes `future` package from list of tests requirements, since
`install_requires` includes it.

Probably will conflict with #2247 