### PR TITLE
remove worker's WorkerForBuilder.remote_shutdown()

### DIFF
--- a/master/docs/developer/master-worker.rst
+++ b/master/docs/developer/master-worker.rst
@@ -68,6 +68,9 @@ The worker-side Bot object has the following remote methods:
 :meth:`~buildbot_worker.pb.BotPb.remote_getVersion`
     Returns the worker's version.
 
+:meth:`~buildbot_worker.pb.BotPb.remote_shutdown`
+    Shuts down the worker cleanly.
+
 Worker methods
 ~~~~~~~~~~~~~~
 
@@ -135,9 +138,6 @@ Worker-Side :class:`~buildbot_worker.pb.WorkerForBuilderPb` Methods
 
 :meth:`~buildbot_worker.pb.WorkerForBuilderPb.remote_interruptCommand`
     Interrupts the currently-running command
-
-:meth:`~buildbot_worker.pb.WorkerForBuilderPb.remote_shutdown`
-    Shuts down the worker cleanly
 
 Master-side :class:`~buildbot.process.workerforbuilder.WorkerForBuilder` Methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -225,12 +225,6 @@ class WorkerForBuilderBase(service.Service):
             d.addErrback(self._ackFailed, "sendComplete")
             self.remoteStep = None
 
-    def remote_shutdown(self):
-        log.msg("worker shutting down on command from master")
-        log.msg(
-            "NOTE: master is using deprecated WorkerForBuilder.shutdown method")
-        reactor.stop()
-
 
 class BotBase(service.MultiService):
 

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -264,17 +264,6 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         # little)
         return self.sb.callRemote("setMaster", mock.Mock())
 
-    def test_shutdown(self):
-        # don't *actually* shut down the reactor - that would be silly
-        stop = mock.Mock()
-        self.patch(reactor, "stop", stop)
-        d = self.sb.callRemote("shutdown")
-
-        def check(_):
-            self.assertTrue(stop.called)
-        d.addCallback(check)
-        return d
-
     def test_startBuild(self):
         return self.sb.callRemote("startBuild")
 


### PR DESCRIPTION
`WorkerForBuilder.remote_shutdown()` marked as obsolete and looks like not used by recent versions of master.