### PR TITLE
use buildbot-worker instead buildbot-slave in epydoc API reference generation script

### DIFF
--- a/apidocs/Makefile
+++ b/apidocs/Makefile
@@ -3,13 +3,13 @@
 all: reference.tgz
 
 cleanpyc:
-	cd .. && find master slave -name '*.pyc' -exec rm \{} \; || exit 1
+	cd .. && find master worker -name '*.pyc' -exec rm \{} \; || exit 1
 
 reference: cleanpyc
 	rm -rf reference
 	cd .. && python apidocs/epyrun -o apidocs/reference \
-			--exclude="buildbot\\.test" --exclude="buildslave\\.test" \
-			buildbot buildslave
+			--exclude="buildbot\\.test" --exclude="buildbot_worker\\.test" \
+			buildbot buildbot_worker
 
 reference.tgz: reference
 	tar -zcf reference.tgz reference


### PR DESCRIPTION
I even managed to build reference docs with patched Epydoc:
common/generate_buildbot_api_documentation.sh has good starting point to
get list of required patches, unfortunately these patches are no longer
available by those URLs.

Looks like Epydoc should be dropped in favor of other tools, like
pydoctor or pdoc.