### PR TITLE
Small worker renaming in contrib scripts, man pages

### DIFF
--- a/common/merge_and_pep8.sh
+++ b/common/merge_and_pep8.sh
@@ -21,7 +21,7 @@ function unittests()
 {
     status run the whole test suite as a double check
     find . -name \*.pyc -exec rm {} \;
-    trial --reporter=text buildslave buildbot
+    trial --reporter=text buildslave buildbot_worker buildbot
     if [[ $? != 0 ]]
     then
         echo "Oups.. the tests are failing, better resolve them now before the big autopep8 work"

--- a/common/validate.sh
+++ b/common/validate.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-TEST='buildbot.test buildslave.test'
+TEST='buildbot.test buildslave.test buildbot_worker.test'
 
 # if stdout is a terminal define some colors
 # validate.sh can be run as hook from GUI git clients, such as git-gui
@@ -162,7 +162,7 @@ if ! $quick; then
 elif [ -z `command -v cctrial` ]; then
     warning "Skipping Python Tests ('pip install cctrial' for quick tests)"
 else
-    cctrial -H buildbot buildslave || not_ok "Python tests failed"
+    cctrial -H buildbot buildslave buildbot_worker || not_ok "Python tests failed"
 fi
 
 status "checking formatting"

--- a/master/contrib/README.txt
+++ b/master/contrib/README.txt
@@ -48,10 +48,10 @@ zsh/_buildbot: zsh tab-completion file for 'buildbot' command. Put it in one
                of the directories appearing in $fpath to enable tab-completion
                in zsh.
 
-bash/buildslave: bash tab-completion file for 'buildbot' command. Source this
-                 file to enable completions in your bash session. This is
-                 typically accomplished by placing the file into the
-                 appropriate 'bash_completion.d' directory.
+bash/buildbot: bash tab-completion file for 'buildbot' command. Source this
+               file to enable completions in your bash session. This is
+               typically accomplished by placing the file into the
+               appropriate 'bash_completion.d' directory.
 
 SimpleConfig.py: an example of how to configure buildbot using a declarative
                  json file plus one buildshim script per project

--- a/master/docs/buildbot.1
+++ b/master/docs/buildbot.1
@@ -299,7 +299,7 @@ Print the list of available commands and global options.
 All subsequent commands are ignored.
 .TP
 .BR --version
-Print twistd and buildslave version.
+Print Buildbot and Twisted versions.
 All subsequent commands are ignored.
 .TP
 .BR --verbose
@@ -503,7 +503,7 @@ The jobdir (maildir) for submitting jobs
 master.cfg
 Buildbot master configuration file
 .SH "SEE ALSO"
-.BR buildslave (1),
+.BR buildbot-worker (1),
 .BR patch (1)
 .PP
 The complete documentation is available in texinfo format. To use it, run

--- a/pkg/README
+++ b/pkg/README
@@ -19,10 +19,10 @@ developers are inconvenienced by the failure.  Features
   before committing, will know shortly afterwards whether they have broken the
   build or not.
 
-* Buildbot has minimal requirements for slaves: using virtualenv, only a
+* Buildbot has minimal requirements for workers: using virtualenv, only a
   Python installation is required.
 
-* Slaves can be run behind a NAT firewall and communicate with the master
+* Workers can be run behind a NAT firewall and communicate with the master
 
 * Buildbot has a variety of status-reporting tools to get information about
   builds in front of developers in a timely manner.

--- a/worker/contrib/bash/buildbot-worker
+++ b/worker/contrib/bash/buildbot-worker
@@ -5,7 +5,7 @@
 _buildbot_worker()
 {
     local buildbot_worker_subcommands="
-        create-slave upgrade-slave start stop restart"
+        create-worker start stop restart"
 
     local cur=${COMP_WORDS[COMP_CWORD]}
     local subcommand=

--- a/worker/contrib/os-x/README
+++ b/worker/contrib/os-x/README
@@ -15,7 +15,7 @@ His email message is as follows:
   Hi guys,
   	I've had these kicking around for a while and thought that maybe
   someone would like to see them.  Installing either of these two to /
-  Library/LaunchDaemons will cause the bulidbot slave or master to auto-
+  Library/LaunchDaemons will cause the Buildbot worker or master to auto-
   start as whatever user you like on launch.  This is the "right way to
   do this" going forward, startupitems are deprecated.  Please note that
   this means any tests that require a windowserver connection on os x

--- a/worker/docs/buildbot-worker.1
+++ b/worker/docs/buildbot-worker.1
@@ -28,7 +28,7 @@ buildbot-worker \- a tool for managing buildbot worker instances
 ]
 .PP
 .B buildbot-worker
-create-slave
+create-worker
 [
 .BR \-q | \-\-quiet
 ]
@@ -98,7 +98,7 @@ Buildbot worker or create a new worker instance.
 .SH OPTIONS
 .SS Commands
 .TP
-.BR create-slave
+.BR create-worker
 Create and populate a directory for a new worker
 .TP
 .BR start
@@ -121,7 +121,7 @@ All subsequent commands are ignored.
 .TP
 .BR --verbose
 Verbose output.
-.SS create-slave command options
+.SS create-worker command options
 .TP
 .BR \-f | \-\-force
 Re-use an existing directory.


### PR DESCRIPTION
Master contrib scripts mainly not touched (I see that some files in master contrib directory looks similar to files in worker contrib directory --- probably they need to be synced, or removed).
