### PR TITLE
Nova same client

### DIFF
--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -55,10 +55,7 @@ class TestOpenStackWorker(unittest.TestCase):
         self.assertEqual(bs.flavor, 1)
         self.assertEqual(bs.image, 'image-uuid')
         self.assertEqual(bs.block_devices, None)
-        self.assertEqual(bs.os_username, 'user')
-        self.assertEqual(bs.os_password, 'pass')
-        self.assertEqual(bs.os_tenant_name, 'tenant')
-        self.assertEqual(bs.os_auth_url, 'auth')
+        self.assertIsInstance(bs.novaclient, novaclient.Client)
 
     def test_constructor_block_devices_default(self):
         block_devices = [{'uuid': 'uuid', 'volume_size': 10}]

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -53,7 +53,7 @@ class OpenStackLatentWorker(AbstractLatentWorker):
                  image=None,
                  meta=None,
                  # Have a nova_args parameter to allow passing things directly
-                 # to novaclient v1.1.
+                 # to novaclient.
                  nova_args=None,
                  client_version='1.1',
                  **kwargs):
@@ -68,11 +68,10 @@ class OpenStackLatentWorker(AbstractLatentWorker):
         AbstractLatentWorker.__init__(self, name, password, **kwargs)
 
         self.flavor = flavor
-        self.os_username = os_username
-        self.os_password = os_password
-        self.os_tenant_name = os_tenant_name
-        self.os_auth_url = os_auth_url
         self.client_version = client_version
+        self.novaclient = client.Client(client_version, os_username,
+                                        os_password, os_tenant_name,
+                                        os_auth_url)
 
         if block_devices is not None:
             self.block_devices = [
@@ -127,16 +126,13 @@ class OpenStackLatentWorker(AbstractLatentWorker):
         return threads.deferToThread(self._start_instance)
 
     def _start_instance(self):
-        # Authenticate to OpenStack.
-        os_client = client.Client(self.client_version, self.os_username, self.os_password,
-                                  self.os_tenant_name, self.os_auth_url)
-        image_uuid = self._getImage(os_client, self.image)
+        image_uuid = self._getImage(self.novaclient, self.image)
         boot_args = [self.workername, image_uuid, self.flavor]
         boot_kwargs = dict(
             meta=self.meta,
             block_device_mapping_v2=self.block_devices,
             **self.nova_args)
-        instance = os_client.servers.create(*boot_args, **boot_kwargs)
+        instance = self.novaclient.servers.create(*boot_args, **boot_kwargs)
         self.instance = instance
         log.msg('%s %s starting instance %s (image %s)' %
                 (self.__class__.__name__, self.workername, instance.id,
@@ -152,7 +148,7 @@ class OpenStackLatentWorker(AbstractLatentWorker):
                         (self.__class__.__name__, self.workername, duration // 60,
                          instance.id))
             try:
-                inst = os_client.servers.get(instance.id)
+                inst = self.novaclient.servers.get(instance.id)
             except nce.NotFound:
                 log.msg('%s %s instance %s (%s) went missing' %
                         (self.__class__.__name__, self.workername,
@@ -182,14 +178,10 @@ class OpenStackLatentWorker(AbstractLatentWorker):
         self._stop_instance(instance, fast)
 
     def _stop_instance(self, instance, fast):
-        # Authenticate to OpenStack. This is needed since it seems the update
-        # method doesn't do a whole lot of updating right now.
-        os_client = client.Client(self.client_version, self.os_username, self.os_password,
-                                  self.os_tenant_name, self.os_auth_url)
         # When the update method does work, replace the lines like below with
         # instance.update().
         try:
-            inst = os_client.servers.get(instance.id)
+            inst = self.novaclient.servers.get(instance.id)
         except nce.NotFound:
             # If can't find the instance, then it's already gone.
             log.msg('%s %s instance %s (%s) already terminated' %

--- a/master/docs/bbdocs/ext.py
+++ b/master/docs/bbdocs/ext.py
@@ -185,6 +185,7 @@ class BBDomain(Domain):
         'chsrc': ObjType('chsrc', 'chsrc'),
         'step': ObjType('step', 'step'),
         'reporter': ObjType('reporter', 'reporter'),
+        'worker': ObjType('worker', 'worker'),
         'cmdline': ObjType('cmdline', 'cmdline'),
         'msg': ObjType('msg', 'msg'),
         'event': ObjType('event', 'event'),
@@ -217,6 +218,11 @@ class BBDomain(Domain):
                                             indextemplates=[
                                                 'single: Reporter Targets; %s',
                                                 'single: %s Reporter Target',
+                                            ]),
+        'worker': make_ref_target_directive('worker',
+                                            indextemplates=[
+                                                'single: Build Workers; %s',
+                                                'single: %s Build Worker',
                                             ]),
         'cmdline': make_ref_target_directive('cmdline',
                                              indextemplates=[
@@ -271,6 +277,7 @@ class BBDomain(Domain):
         'chsrc': XRefRole(),
         'step': XRefRole(),
         'reporter': XRefRole(),
+        'worker': XRefRole(),
         'cmdline': XRefRole(),
         'msg': XRefRole(),
         'event': XRefRole(),
@@ -289,6 +296,7 @@ class BBDomain(Domain):
         make_index("chsrc", "Change Source Index"),
         make_index("step", "Build Step Index"),
         make_index("reporter", "Reporter Target Index"),
+        make_index("worker", "Build Worker Index"),
         make_index("cmdline", "Command Line Index"),
         make_index("msg", "MQ Routing Key Index"),
         make_index("event", "Data API Event Index"),

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -2,8 +2,13 @@
     Docker
     Workers; Docker
 
+.. bb:worker:: DockerLatentWorker
+
 Docker latent worker
 ====================
+
+.. @cindex DockerLatentWorker
+.. py:class:: buildbot.worker.docker.DockerLatentWorker
 
 Docker_ is an open-source project that automates the deployment of applications inside software containers.
 Using the Docker latent worker, an attempt is made at instantiating a fresh image upon each build, assuring consistency of the environment between builds.

--- a/master/docs/manual/cfg-workers-ec2.rst
+++ b/master/docs/manual/cfg-workers-ec2.rst
@@ -4,8 +4,13 @@
    AWS EC2
    Workers; AWS EC2
 
+.. bb:worker:: EC2LatentWorker
+
 Amazon Web Services Elastic Compute Cloud ("AWS EC2")
 =====================================================
+
+.. @cindex EC2LatentWorker
+.. py:class:: buildbot.worker.ec2.EC2LatentWorker
 
 `EC2 <http://aws.amazon.com/ec2/>`_ is a web service that allows you to start virtual machines in an Amazon data center.
 Please see their website for details, including costs.

--- a/master/docs/manual/cfg-workers-libvirt.rst
+++ b/master/docs/manual/cfg-workers-libvirt.rst
@@ -4,8 +4,13 @@
    libvirt
    Workers; libvirt
 
+.. bb:worker:: LibVirtWorker
+
 Libvirt
 =======
+
+.. @cindex LibVirtWorker
+.. py:class:: buildbot.worker.libvirt.LibVirtWorker
 
 `libvirt <http://www.libvirt.org/>`_ is a virtualization API for interacting with the virtualization capabilities of recent versions of Linux and other OSes.
 It is LGPL and comes with a stable C API, and Python bindings.

--- a/master/docs/manual/cfg-workers-openstack.rst
+++ b/master/docs/manual/cfg-workers-openstack.rst
@@ -1,7 +1,12 @@
 .. -*- rst -*-
 
+.. bb:worker:: OpenStackLatentWorker
+
 OpenStack
 =========
+
+.. @cindex OpenStackLatentWorker
+.. py:class:: buildbot.worker.openstack.OpenStackLatentWorker
 
 `OpenStack <http://openstack.org/>`_ is a series of interconnected components that facilitates managing compute, storage, and network resources in a data center.
 It is available under the Apache License and has a REST interface along with a Python client.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -32,6 +32,8 @@ Features
 
 * Added support for specifying the depth of a shallow clone in :bb:step:`Git`.
 
+* :bb:worker:`OpenStackLatentWorker` now uses a single novaclient instance to not require re-authentication when starting or stopping instances.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
Use the same client for all interactions with Nova. This allows not having to store the auth details in the class and caching the connection to OpenStack across that worker's life cycle.