### PR TITLE
get rid of `public_html` directory

### DIFF
--- a/master/buildbot/scripts/create_master.py
+++ b/master/buildbot/scripts/create_master.py
@@ -77,18 +77,6 @@ def makeSampleConfig(config):
     os.chmod(target, 0o600)
 
 
-def makePublicHtml(config):
-    webdir = os.path.join(config['basedir'], "public_html")
-    if os.path.exists(webdir):
-        if not config['quiet']:
-            print("public_html/ already exists: not replacing")
-        return
-    else:
-        os.mkdir(webdir)
-    if not config['quiet']:
-        print("populating public_html/")
-
-
 @defer.inlineCallbacks
 def createDB(config, _noMonkey=False):
     # apply the db monkeypatches (and others - no harm)
@@ -114,7 +102,6 @@ def createMaster(config):
     makeBasedir(config)
     makeTAC(config)
     makeSampleConfig(config)
-    makePublicHtml(config)
     yield createDB(config)
 
     if not config['quiet']:

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -60,10 +60,10 @@ def upgradeFiles(config):
         print("upgrading basedir")
 
     webdir = os.path.join(config['basedir'], "public_html")
-    if not os.path.exists(webdir):
-        if not config['quiet']:
-            print("creating public_html")
-        os.mkdir(webdir)
+    if os.path.exists(webdir):
+        print("Notice: public_html is not used starting from Buildbot 0.9.0")
+        print("        consider using third party HTTP server for serving "
+              "static files")
 
     templdir = os.path.join(config['basedir'], "templates")
     if not os.path.exists(templdir):
@@ -73,24 +73,6 @@ def upgradeFiles(config):
 
     installFile(config, os.path.join(config['basedir'], "master.cfg.sample"),
                 util.sibpath(__file__, "sample.cfg"), overwrite=True)
-
-    # if index.html exists, use it to override the root page tempalte
-    index_html = os.path.join(webdir, "index.html")
-    root_html = os.path.join(templdir, "root.html")
-    if os.path.exists(index_html):
-        if os.path.exists(root_html):
-            print("Notice: %s now overrides %s" % (root_html, index_html))
-            print("        as the latter is not used by buildbot anymore.")
-            print("        Decide which one you want to keep.")
-        else:
-            try:
-                print("Notice: Moving %s to %s." % (index_html, root_html))
-                print("        You can (and probably want to) remove it if "
-                      "you haven't modified this file.")
-                os.renames(index_html, root_html)
-            except Exception as e:
-                print("Error moving %s to %s: %s" % (index_html, root_html,
-                                                     str(e)))
 
 
 @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_scripts_create_master.py
+++ b/master/buildbot/test/unit/test_scripts_create_master.py
@@ -51,7 +51,7 @@ class TestCreateMaster(misc.StdoutAssertionsMixin, unittest.TestCase):
         # mock out everything that createMaster calls, then check that
         # they are called, in order
         functions = ['makeBasedir', 'makeTAC', 'makeSampleConfig',
-                     'makePublicHtml', 'createDB']
+                     'createDB']
         repls = {}
         calls = []
         for fn in functions:
@@ -221,12 +221,6 @@ class TestCreateMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
                                                 quiet=True))
         with open(os.path.join('test', 'master.cfg.sample'), 'rt') as f:
             self.assertIn("XXYYZZ", f.read())
-        self.assertWasQuiet()
-
-    def test_makePublicHtml(self):
-        create_master.makePublicHtml(mkconfig(basedir='test', quiet=True))
-        self.assertTrue(os.path.exists(
-            os.path.join('test', 'public_html')))
         self.assertWasQuiet()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_scripts_upgrade_master.py
+++ b/master/buildbot/test/unit/test_scripts_upgrade_master.py
@@ -172,30 +172,17 @@ class TestUpgradeMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
     def test_upgradeFiles(self):
         upgrade_master.upgradeFiles(mkconfig())
         for f in [
-                'test/public_html',
                 'test/templates',
                 'test/master.cfg.sample',
         ]:
             self.assertTrue(os.path.exists(f), "%s not found" % f)
         self.assertInStdout('upgrading basedir')
 
-    def test_upgradeFiles_rename_index_html(self):
+    def test_upgradeFiles_notice_about_unused_public_html(self):
         os.mkdir('test/public_html')
         self.writeFile('test/public_html/index.html', 'INDEX')
         upgrade_master.upgradeFiles(mkconfig())
-        self.assertFalse(os.path.exists("test/public_html/index.html"))
-        self.assertEqual(self.readFile("test/templates/root.html"), 'INDEX')
-        self.assertInStdout('Moving ')
-
-    def test_upgradeFiles_index_html_collision(self):
-        os.mkdir('test/public_html')
-        self.writeFile('test/public_html/index.html', 'INDEX')
-        os.mkdir('test/templates')
-        self.writeFile('test/templates/root.html', 'ROOT')
-        upgrade_master.upgradeFiles(mkconfig())
-        self.assertTrue(os.path.exists("test/public_html/index.html"))
-        self.assertEqual(self.readFile("test/templates/root.html"), 'ROOT')
-        self.assertInStdout('Decide')
+        self.assertInStdout('public_html is not used')
 
     @defer.inlineCallbacks
     def test_upgradeDatabase(self):

--- a/master/buildbot/test/unit/test_www_service.py
+++ b/master/buildbot/test/unit/test_www_service.py
@@ -12,7 +12,6 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import os
 
 import mock
 from twisted.cred.checkers import InMemoryUsernamePasswordDatabaseDontUse
@@ -46,9 +45,7 @@ class Test(www.WwwTestMixin, unittest.TestCase):
         self.svc.setServiceParent(self.master)
 
     def makeConfig(self, **kwargs):
-        pwd = os.getcwd()
-        w = dict(
-            port=None, public_html=pwd, auth=auth.NoAuth(), logfileName='l')
+        w = dict(port=None, auth=auth.NoAuth(), logfileName='l')
         w.update(kwargs)
         new_config = mock.Mock()
         new_config.www = w

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -1871,7 +1871,7 @@ You might also want to add option `--pdf` to generate a PDF file instead of a la
 
 The API docs are generated in-place in the build tree (under the workdir, in the subdirectory controlled by the option `-o` argument).
 To make them useful, you will probably have to copy them to somewhere they can be read.
-A command like ``rsync -ad apiref/ dev.example.com:~public_html/current-apiref/`` might be useful.
+For example if you have server with configured nginx web server, you can place generated docs to it's public folder with command like ``rsync -ad apiref/ dev.example.com:~/usr/share/nginx/www/current-apiref/``.
 You might instead want to bundle them into a tarball and publish it in the same place where the generated install tarball is placed.
 
 ::
@@ -2061,9 +2061,10 @@ There are a pair of steps named :bb:step:`FileUpload` and :bb:step:`FileDownload
 :bb:step:`FileUpload` moves a file *up to* the master, while :bb:step:`FileDownload` moves a file *down from* the master.
 
 As an example, let's assume that there is a step which produces an HTML file within the source tree that contains some sort of generated project documentation.
-We want to move this file to the buildmaster, into a :file:`~/public_html` directory, so it can be visible to developers.
+And let's assume that we run nginx web server on buildmaster host for serving static files.
+We want to move this file to the buildmaster, into a :file:`/usr/share/nginx/www/` directory, so it can be visible to developers.
 This file will wind up in the worker-side working directory under the name :file:`docs/reference.html`.
-We want to put it into the master-side :file:`~/public_html/ref.html`, and add a link to the HTML status to the uploaded file.
+We want to put it into the master-side :file:`/usr/share/nginx/www/ref.html`, and add a link to the HTML status to the uploaded file.
 
 ::
 
@@ -2071,7 +2072,7 @@ We want to put it into the master-side :file:`~/public_html/ref.html`, and add a
 
     f.addStep(steps.ShellCommand(command=["make", "docs"]))
     f.addStep(steps.FileUpload(workersrc="docs/reference.html",
-                               masterdest="/home/bb/public_html/ref.html",
+                               masterdest="/usr/share/nginx/www/ref.html",
                                url="http://somesite/~buildbot/ref.html"))
 
 The ``masterdest=`` argument will be passed to :meth:`os.path.expanduser`, so things like ``~`` will be expanded properly.
@@ -2125,14 +2126,15 @@ To transfer complete directories from the worker to the master, there is a :clas
 It works like :bb:step:`FileUpload`, just for directories.
 However it does not support the ``maxsize``, ``blocksize`` and ``mode`` arguments.
 As an example, let's assume an generated project documentation, which consists of many files (like the output of :command:`doxygen` or :command:`epydoc`).
-We want to move the entire documentation to the buildmaster, into a :file:`~/public_html/docs` directory, and add a link to the uploaded documentation on the HTML status page.
+And let's assume that we run nginx web server on buildmaster host for serving static files.
+We want to move the entire documentation to the buildmaster, into a :file:`/usr/share/nginx/www/docs` directory, and add a link to the uploaded documentation on the HTML status page.
 On the worker-side the directory can be found under :file:`docs`::
 
     from buildbot.plugins import steps
 
     f.addStep(steps.ShellCommand(command=["make", "docs"]))
     f.addStep(steps.DirectoryUpload(workersrc="docs",
-                                    masterdest="~/public_html/docs",
+                                    masterdest="/usr/share/nginx/www/docs",
                                     url="~buildbot/docs"))
 
 The :bb:step:`DirectoryUpload` step will create all necessary directories and transfers empty directories, too.
@@ -2161,7 +2163,7 @@ This parameter should either be a list, or something that can be rendered as a l
     f.addStep(steps.ShellCommand(command=["make", "test"]))
     f.addStep(steps.ShellCommand(command=["make", "docs"]))
     f.addStep(steps.MultipleFileUpload(workersrcs=["docs", "test-results.html"],
-                                       masterdest="~/public_html",
+                                       masterdest="/usr/share/nginx/www/",
                                        url="~buildbot"))
 
 The ``url=`` parameter, can be used to specify a link to be displayed in the HTML status of the step.

--- a/master/docs/manual/deploy.rst
+++ b/master/docs/manual/deploy.rst
@@ -52,11 +52,11 @@ Each build and log are recorded in a separate file, arranged hierarchically unde
 To prevent these files from growing without bound, you should periodically delete old build logs.
 A simple cron job to delete anything older than, say, two weeks should do the job.
 The only trick is to leave the :file:`buildbot.tac` and other support files alone, for which :command:`find`'s ``-mindepth`` argument helps skip everything in the top directory.
-You can use something like the following:
+You can use something like the following (assuming builds are stored in :file:`./builds/` directory):
 
 .. code-block:: none
 
-    @weekly cd BASEDIR && find . -mindepth 2 i-path './public_html/*' \
+    @weekly cd BASEDIR && find . -mindepth 2 i-path './builds/*' \
         -prune -o -type f -mtime +14 -exec rm {} \;
     @weekly cd BASEDIR && find twistd.log* -mtime +14 -exec rm {} \;
 

--- a/master/docs/manual/installation/nine-upgrade.rst
+++ b/master/docs/manual/installation/nine-upgrade.rst
@@ -152,6 +152,12 @@ The following fields are identifiers:
 * builder name (20-character)
 * step name (50-character)
 
+Serving static files
+--------------------
+
+Since version 0.9.0 Buildbot doesn't use and don't serve master's ``public_html`` directory.
+You need to use third-party HTTP server for serving static files.
+
 Transition to "worker" terminology
 ----------------------------------
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -52,6 +52,9 @@ Deprecations, Removals, and Non-Compatible Changes
 
 * Support for python 2.6 was dropped from the master.
 
+* ``public_html`` directory is not created anymore in ``buildbot create-master`` (it's not used for some time already).
+  Documentation was updated with suggestions to use third party web server for serving static file.
+
 * ``usePTY`` default value has been changed from ``slave-config`` to ``None`` (use of ``slave-config`` will still work).
 
 Buildslave


### PR DESCRIPTION
It is not used and not supported for some time.

Use of third-party web server suggested.
`public_html` directory in examples were replaces with
`/usr/share/nginx/www/` (so examples assume use of nginx).

Fixes http://trac.buildbot.net/ticket/3547