### PR TITLE
Quickfixed poller change_hook broken by site API change

### DIFF
--- a/master/buildbot/www/hooks/poller.py
+++ b/master/buildbot/www/hooks/poller.py
@@ -18,9 +18,9 @@
 
 from buildbot.changes.base import PollingChangeSource
 
-
 def getChanges(req, options=None):
-    change_svc = req.site.master.change_svc
+    master = req.site.resource.children['change_hook'].master
+    change_svc = master.change_svc
     poll_all = "poller" not in req.args
 
     allow_all = True
@@ -28,9 +28,7 @@ def getChanges(req, options=None):
     if isinstance(options, dict) and "allowed" in options:
         allow_all = False
         allowed = options["allowed"]
-
     pollers = []
-
     for source in change_svc:
         if not isinstance(source, PollingChangeSource):
             continue


### PR DESCRIPTION
This PR is a work in progress:

- I didn't look at unit or integration tests yet, but I suppose they don't exist at all, otherwise the breaking change would have not been unnoticed
- I don't know if change hooks are even supposed to be able to grab the master object (thee code structure suggests they aren't but this one really needs it). If they are, then a more streamlined way of doing it would be preferable

I can confirm it solves http://trac.buildbot.net/ticket/3559