### PR TITLE
Allow independant EC2 price_multiplier or max_spot_price usage

### DIFF
--- a/master/buildbot/test/unit/test_worker_ec2.py
+++ b/master/buildbot/test/unit/test_worker_ec2.py
@@ -501,6 +501,28 @@ class TestEC2LatentWorker(unittest.TestCase):
 
         self.assertRaises(ValueError, create_worker)
 
+    @mock_ec2
+    def test_fail_multiplier_and_max_are_none(self):
+        '''
+        price_multiplier and max_spot_price may not be None at the same time.
+        '''
+        c, r = self.botoSetup()
+        amis = list(r.images.all())
+
+        def create_worker():
+            ec2.EC2LatentWorker('bot1', 'sekrit', 'm1.large',
+                                identifier='publickey',
+                                secret_identifier='privatekey',
+                                keypair_name="latent_buildbot_worker",
+                                security_name='latent_buildbot_worker',
+                                ami=amis[0].id,
+                                region='us-west-1',
+                                spot_instance=True,
+                                price_multiplier=None,
+                                max_spot_price=None
+                                )
+        self.assertRaises(ValueError, create_worker)
+
 
 class TestEC2LatentWorkerDefaultKeyairSecurityGroup(unittest.TestCase):
     ec2_connection = None

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -448,7 +448,7 @@ class EC2LatentWorker(AbstractLatentWorker):
                 (self.__class__.__name__, self.workername,
                  instance.id, goal, duration // 60, duration % 60))
 
-    def _request_spot_instance(self):
+    def _bid_price_from_spot_price_history(self):
         timestamp_yesterday = time.gmtime(int(time.time() - 86400))
         spot_history_starttime = time.strftime(
             '%Y-%m-%dT%H:%M:%SZ', timestamp_yesterday)
@@ -466,6 +466,10 @@ class EC2LatentWorker(AbstractLatentWorker):
             bid_price = 0.02
         else:
             bid_price = (price_sum / price_count) * self.price_multiplier
+        return bid_price
+
+    def _request_spot_instance(self):
+        bid_price = self._bid_price_from_spot_price_history()
         if bid_price > self.max_spot_price:
             log.msg('%s %s calculated spot price %0.3f exceeds '
                     'configured maximum of %0.3f' %

--- a/master/docs/manual/cfg-workers-ec2.rst
+++ b/master/docs/manual/cfg-workers-ec2.rst
@@ -338,3 +338,9 @@ Additionally, you may want to specify ``max_spot_price`` and ``price_multiplier`
 
 This example would attempt to create a m1.large spot instance in the us-west-2b region costing no more than $0.09/hour.
 The spot prices for 'Linux/UNIX' spot instances in that region over the last 24 hours will be averaged and multiplied by the ``price_multiplier`` parameter, then a spot request will be sent to Amazon with the above details.
+If the multiple exceeds the ``max_spot_price``, the bid price will be the ``max_spot_price``.
+
+Either ``max_spot_price`` or ``price_multiplier``, but not both, may be None.
+If ``price_multiplier`` is None, then no historical price information is retrieved; the bid price is simply the specified ``max_spot_price``.
+If the ``max_spot_price`` is None, then the multiple of the historical average spot prices is used as the bid price with no limit.
+

--- a/master/docs/manual/cfg-workers-ec2.rst
+++ b/master/docs/manual/cfg-workers-ec2.rst
@@ -338,32 +338,3 @@ Additionally, you may want to specify ``max_spot_price`` and ``price_multiplier`
 
 This example would attempt to create a m1.large spot instance in the us-west-2b region costing no more than $0.09/hour.
 The spot prices for 'Linux/UNIX' spot instances in that region over the last 24 hours will be averaged and multiplied by the ``price_multiplier`` parameter, then a spot request will be sent to Amazon with the above details.
-
-When a spot request fails
--------------------------
-
-In some cases Amazon may reject a spot request because the spot price, determined by taking the 24-hour average of that availability zone's spot prices for the given product description, is lower than the current price.
-The optional parameters ``retry`` and ``retry_price_adjustment`` allow for resubmitting the spot request with an adjusted price.
-If the spot request continues to fail, and the number of attempts exceeds the value of the ``retry`` parameter, an error message will be logged.
-
-::
-
-    from buildbot.plugins import worker
-    c['workers'] = [
-        worker.EC2LatentWorker('bot1', 'sekrit', 'm1.large',
-                               'ami-12345', region='us-west-2',
-                               identifier='publickey',
-                               secret_identifier='privatekey',
-                               elastic_ip='208.77.188.166',
-                               keypair_name='latent_buildbot_worker',
-                               security_name='latent_buildbot_worker',
-                               placement='b', spot_instance=True,
-                               max_spot_price=0.09,
-                               price_multiplier=1.15,
-                               retry=3,
-                               retry_price_adjustment=1.1)
-    ]
-
-In this example, a spot request will be sent with a bid price of 15% above the 24-hour average.
-If the request fails with the status **price-too-low**, the request will be resubmitted up to twice, each time with a 10% increase in the bid price.
-If the request succeeds, the worker will substantiate as normal and run any pending builds.


### PR DESCRIPTION
Change the EC2LatentBuildSlave to allow the use of just one
of either max_spot_price or price_multiplier.  In other words,
either value can be set to None so that only the other value
is used.  When spot instances are used, at least one of those two
parameters must be set.

If only max_spot_price is set, that is the value that is used
as the bid price.  There is not need to look up the historical
bid prices in that case.  It seems likely that in the real world
most people will want to set the maximum price they are willing
to pay.  Artificially bidding lower than one is willing to pay
based on historical information is probably not a very common use
case.

Also, change the logic to use as the bid price the minumum of either
the multiple of the historical average or the max_spot_price.  The
previous behavior was to raise an exception if the multiple was in
excess of the max_spot_price.  That doesn't make much sense.  The
historical average tells us little about the price _now_, so it probably
never makes sense to abort early without at least making an attempt
to substantiate with the max_spot_price.

Fixes #2898 problems 1 and 3.
