### PR TITLE
Providing Apache2 sample conf

### DIFF
--- a/master/docs/developer/www-server.rst
+++ b/master/docs/developer/www-server.rst
@@ -173,6 +173,8 @@ Client will receive events as websocket frames encoded in json with following fo
 
    {"k":key,"m":message}
 
+.. _SSE:
+
 Server Sent Events
 ~~~~~~~~~~~~~~~~~~
 

--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -434,6 +434,40 @@ Here is an nginx configuration that is known to work (nginx 1.6.2):
             }
     }
 
+To run with Apache2, you'll need `mod_proxy_wstunnel <https://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html>`_ in addition to `mod_proxy_http <https://httpd.apache.org/docs/2.4/mod/mod_proxy_http.html>`_. Serving HTTPS (`mod_ssl <https://httpd.apache.org/docs/2.4/mod/mod_ssl.html>`_) is advised to prevent issues with enterprise proxies (see :ref:`SSE`), even if you don't need the encryption itself.
+
+Here is a configuration that is known to work (Apache 2.4.10 / Debian 8), directly at the top of the domain.
+
+.. code-block:: none
+
+
+    <VirtualHost *:443>
+        ServerName buildbot.example
+        ServerAdmin webmaster@buildbot.example
+
+        <Location /ws>
+          ProxyPass ws://localhost:8020/ws
+          ProxyPassReverse ws://localhost:8020/ws
+        </Location>
+
+        ProxyPass /ws !
+        ProxyPass / http://localhost:8020/
+        ProxyPassReverse / http://localhost:8020/
+
+        SetEnvIf X-Url-Scheme https HTTPS=1
+        ProxyPreserveHost On
+
+        SSLEngine on
+        SSLCertificateFile /path/to/cert.pem
+        SSLCertificateKeyFile /path/to/cert.key
+
+        # check Apache2 documentation for current safe SSL settings
+        # This is actually the Debian 8 default at the time of this writing:
+        SSLProtocol all -SSLv3
+
+    </VirtualHost>
+
+
 .. _Web-Authorization:
 
 Authorization rules


### PR DESCRIPTION
I'm actually not sure about SSE: I think the exclusion in Nginx conf is specific to the way Nginx works, but I'm not sure. My Apache2 setups seem to work well. 

If some can tell me effortlessly how it'd look if SSE was broken,  that'd spare me installing a broken Nginx config just for the sake of comparison ? (I'd include relevant testing info in the PR itself)
