### PR TITLE
Add cascading deletes on foreign keys for builder_masters

### DIFF
--- a/master/buildbot/db/migrate/versions/047_cascading_deletes.py
+++ b/master/buildbot/db/migrate/versions/047_cascading_deletes.py
@@ -1,0 +1,42 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+from migrate.changeset.constraint import ForeignKeyConstraint
+from buildbot.util import sautils
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+
+    builders = sautils.Table('builders', metadata, autoload=True)
+    masters = sautils.Table('masters', metadata, autoload=True)
+    workers = sautils.Table('workers', metadata, autoload=True)
+    builder_masters = sautils.Table('builder_masters', metadata, autoload=True)
+    configured_workers = sautils.Table('configured_workers', metadata,
+                                       autoload=True)
+
+    for fk in (ForeignKeyConstraint([builder_masters.c.builderid],
+                                    [builders.c.id], ondelete='CASCADE'),
+               ForeignKeyConstraint([builder_masters.c.masterid],
+                                    [masters.c.id], ondelete='CASCADE'),
+               ForeignKeyConstraint([configured_workers.c.buildermasterid],
+                                    [builder_masters.c.id], ondelete='CASCADE'),
+               ForeignKeyConstraint([configured_workers.c.workerid],
+                                    [workers.c.id], ondelete='CASCADE'),
+               ):
+        fk.drop()
+        fk.create()

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -270,8 +270,10 @@ class Model(base.DBConnectorComponent):
         'configured_workers', metadata,
         sa.Column('id', sa.Integer, primary_key=True, nullable=False),
         sa.Column('buildermasterid', sa.Integer,
-                  sa.ForeignKey('builder_masters.id'), nullable=False),
-        sa.Column('workerid', sa.Integer, sa.ForeignKey('workers.id'),
+                  sa.ForeignKey('builder_masters.id', ondelete='CASCADE'),
+                  nullable=False),
+        sa.Column('workerid', sa.Integer,
+                  sa.ForeignKey('workers.id', ondelete='CASCADE'),
                   nullable=False),
     )
 
@@ -507,9 +509,11 @@ class Model(base.DBConnectorComponent):
     builder_masters = sautils.Table(
         'builder_masters', metadata,
         sa.Column('id', sa.Integer, primary_key=True, nullable=False),
-        sa.Column('builderid', sa.Integer, sa.ForeignKey('builders.id'),
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
                   nullable=False),
-        sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
+        sa.Column('masterid', sa.Integer,
+                  sa.ForeignKey('masters.id', ondelete='CASCADE'),
                   nullable=False),
     )
 

--- a/master/buildbot/test/unit/test_db_migrate_versions_047_cascading_deleletes.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_047_cascading_deleletes.py
@@ -12,7 +12,6 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-from contextlib import contextmanager
 import sqlalchemy as sa
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_migrate_versions_047_cascading_deleletes.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_047_cascading_deleletes.py
@@ -1,0 +1,125 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+from contextlib import contextmanager
+import sqlalchemy as sa
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_thd(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        builders = sautils.Table(
+            'builders', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('name', sa.String(50), nullable=False),
+        )
+        builders.create()
+
+        masters = sautils.Table(
+            'masters', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('name', sa.String(50), nullable=False),
+        )
+        masters.create()
+
+        workers = sautils.Table(
+            'workers', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('name', sa.String(50), nullable=False),
+        )
+        workers.create()
+
+        builder_masters = sautils.Table(
+            'builder_masters', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('builderid', sa.Integer, sa.ForeignKey('builders.id'),
+                      nullable=False),
+            sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
+                      nullable=False),
+        )
+        builder_masters.create()
+
+        configured_workers = sautils.Table(
+            'configured_workers', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('workerid', sa.Integer, sa.ForeignKey('workers.id'),
+                      nullable=False),
+            sa.Column('buildermasterid', sa.Integer,
+                      sa.ForeignKey('builder_masters.id'),
+                      nullable=False),
+        )
+        configured_workers.create()
+
+        conn.execute(builders.insert(), [
+            dict(id=3, name='echo'),
+            dict(id=4, name='tests'),
+        ])
+
+        conn.execute(masters.insert(), [
+            dict(id=1, name='bm1'),
+            dict(id=2, name='bm2'),
+        ])
+
+        conn.execute(builder_masters.insert(), [
+            dict(id=1, builderid=4, masterid=1),
+            dict(id=2, builderid=3, masterid=2),
+        ])
+
+        conn.execute(workers.insert(), [
+            dict(id=1, name="powerful"),
+            dict(id=2, name="limited"),
+        ])
+
+        conn.execute(configured_workers.insert(), [
+            dict(id=1, buildermasterid=1, workerid=2),
+        ])
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+
+        def verify_thd(conn):
+            """Can't verify much under SQLite
+
+            Even with PRAGMA foreign_keys=ON, the cascading deletes are
+            actually ignored with SQLite, so we can't really test the behaviour
+            in that environment.
+
+            On the other hand, SQLite's FKs apparently don't prevent removals.
+            The cascading behaviour is really needed for other DBs right now,
+            and only in reconfigs.
+            """
+            metadata = sa.MetaData()
+            metadata.bind = conn
+            masters = sautils.Table('masters', metadata,
+                                    autoload=True)
+            conn.execute(masters.delete().where(masters.c.name == 'bm1'))
+            q = sa.select([masters.c.id, masters.c.name])
+            self.assertEqual(conn.execute(q).fetchall(),
+                             [(2, 'bm2')])
+
+        return self.do_test_migration(46, 47, setup_thd, verify_thd)


### PR DESCRIPTION
This solves http://trac.buildbot.net/ticket/3504

ondelete is supported by SQLA 0.8.0.
Apparently [SQLA 0.9.2](http://docs.sqlalchemy.org/en/rel_0_9/changelog/changelog_09.html#change-0.9.2) brings dialect-dependent validation of such arguments,
but the syntax is uniform between SQLite, MySQL and PostgreSQL anyway.

(SQLite3 has had CASCADE since it got FKs in the first place in version 3.6.19)

Caveats / TODOs:

- upgrade-master does not add the ondelete option
- should do most of the other many2many relationships as well

I'm a bit concerned that we'll find corner cases where deletion of data is actually unwanted (e.g, because it's temporary / should be an update / should be a disabling), but that's beyond the scope of this PR.