### PR TITLE
fix link on Mercurial notify extension

### DIFF
--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -225,7 +225,7 @@ Bzr
 
 Mercurial
     NotifyExtension
-        http://mercurial.selenic.com/wiki/NotifyExtension
+        https://www.mercurial-scm.org/wiki/NotifyExtension
 
 Git
     post-receive-email


### PR DESCRIPTION
Looks like Mercurial completely moved to it's own domain.