### PR TITLE
Make EC2 spot instance tests use spot instances

### DIFF
--- a/master/buildbot/test/unit/test_worker_ec2.py
+++ b/master/buildbot/test/unit/test_worker_ec2.py
@@ -396,9 +396,11 @@ class TestEC2LatentWorker(unittest.TestCase):
                                  max_spot_price=1.5,
                                  security_group_ids=[sg.id],
                                  subnet_id=subnet.id,
+                                 region='us-east-1',
+                                 placement='a'
                                  )
 
-        instance_id, _, _ = bs._start_instance()
+        instance_id, _, _ = bs._request_spot_instance()
         instances = r.instances.filter(
             Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
         instances = list(instances)
@@ -428,9 +430,11 @@ class TestEC2LatentWorker(unittest.TestCase):
                                      secret_identifier='privatekey',
                                      ami=amis[0].id, spot_instance=True,
                                      max_spot_price=1.5,
-                                     product_description=product_description
+                                     product_description=product_description,
+                                     region='us-east-1',
+                                     placement='a'
                                      )
-        instance_id, _, _ = bs._start_instance()
+        instance_id, _, _ = bs._request_spot_instance()
         instances = r.instances.filter(
             Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
         instances = list(instances)


### PR DESCRIPTION
Repair the spot instance tests to actually attempt to use
spot instances.  EC2LatentWorker()'s internal method _start_instance()
starts a normal EC2 On-Demand instance, not a Spot Instance.  It
is the _request_spot_instance() method that requests a spot instance,
so change the tests to use that.

This is expected to fail in testing on the step that requests the
spot instance historical data.
