### PR TITLE
Issue3562

### DIFF
--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -284,7 +284,7 @@ class HgPoller(base.PollingChangeSource):
                 revision=unicode(node),
                 files=files,
                 comments=comments,
-                when_timestamp=int(timestamp),
+                when_timestamp=int(timestamp) if timestamp else None,
                 branch=ascii2unicode(self.branch),
                 category=ascii2unicode(self.category),
                 project=ascii2unicode(self.project),

--- a/master/buildbot/test/unit/test_changes_hgpoller.py
+++ b/master/buildbot/test/unit/test_changes_hgpoller.py
@@ -27,6 +27,7 @@ ENVIRON_2116_KEY = 'TEST_THAT_ENVIRONMENT_GETS_PASSED_TO_SUBPROCESSES'
 class TestHgPoller(gpo.GetProcessOutputMixin,
                    changesource.ChangeSourceMixin,
                    unittest.TestCase):
+    usetimestamps = True
 
     def setUp(self):
         # To test that environment variables get propagated to subprocesses
@@ -43,6 +44,7 @@ class TestHgPoller(gpo.GetProcessOutputMixin,
 
         def create_poller(_):
             self.poller = hgpoller.HgPoller(self.remote_repo,
+                                            usetimestamps=self.usetimestamps,
                                             workdir='/some/dir')
             self.poller.setServiceParent(self.master)
             self.poller._isRepositoryReady = _isRepositoryReady
@@ -122,7 +124,10 @@ class TestHgPoller(gpo.GetProcessOutputMixin,
             self.assertEqual(change['revision'], '4423cdb')
             self.assertEqual(change['author'],
                              'Bob Test <bobtest@example.org>')
-            self.assertEqual(change['when_timestamp'], 1273258100),
+            if self.usetimestamps:
+                self.assertEqual(change['when_timestamp'], 1273258100)
+            else:
+                self.assertEqual(change['when_timestamp'], None)
             self.assertEqual(
                 change['files'], ['file1 with spaces', os.path.join('dir with spaces', 'file2')])
             self.assertEqual(change['src'], 'hg')
@@ -193,3 +198,9 @@ class TestHgPoller(gpo.GetProcessOutputMixin,
             self.assertEqual(change['revision'], u'784bd')
             self.assertEqual(change['comments'], u'Comment for rev 5')
         d.addCallback(check_changes)
+
+
+class HgPollerNoTimestamp(TestHgPoller):
+    """ Test HgPoller() without parsing revision commit timestamp """
+
+    usetimestamps=False

--- a/master/buildbot/test/unit/test_changes_hgpoller.py
+++ b/master/buildbot/test/unit/test_changes_hgpoller.py
@@ -203,4 +203,4 @@ class TestHgPoller(gpo.GetProcessOutputMixin,
 class HgPollerNoTimestamp(TestHgPoller):
     """ Test HgPoller() without parsing revision commit timestamp """
 
-    usetimestamps=False
+    usetimestamps = False

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -36,6 +36,7 @@ Fixes
 ~~~~~
 
 * :bb:reporter:`GerritStatusPush` now includes build properties in the ``startCB`` and ``reviewCB`` functions. ``startCB`` now must return a dictionary.
+* Fix TypeError exception with :py:class:`~buildbot.changes.HgPoller` if ``usetimestamps=False`` is used (:bug:`3562`)
 
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/master/setup.py
+++ b/master/setup.py
@@ -482,7 +482,7 @@ else:
             'idna >= 0.6',
         ],
         'docs': [
-            'sphinx',
+            'sphinx==1.4.3',
             'sphinxcontrib-blockdiag',
             'sphinxcontrib-spelling',
             'pyenchant',


### PR DESCRIPTION
- Fix TypeError with HgPoller() if usetimestamps=False (fixes #3562)
- Test HgPoller() without parsing revision commit timestamp (refs #3562)