### PR TITLE
fix sqlite maxconn to 1

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -234,8 +234,7 @@ class GerritChangeSource(base.ChangeSource):
         self.process = None
 
         # if the service is stopped, don't try to restart the process
-        if not self.wantProcess:
-            log.msg("service is not running; not reconnecting")
+        if not self.wantProcess or reactor._stopped:
             return
 
         now = util.now()

--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -53,16 +53,16 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
 
             q = builders_tbl.update(
                 whereclause=(builders_tbl.c.id == builderid))
-            conn.execute(q, description=description)
+            conn.execute(q, description=description).close()
             # remove previous builders_tags
             conn.execute(builders_tags_tbl.delete(
-                whereclause=((builders_tags_tbl.c.builderid == builderid))))
+                whereclause=((builders_tags_tbl.c.builderid == builderid)))).close()
 
             # add tag ids
             if tagsids:
                 conn.execute(builders_tags_tbl.insert(),
                              [dict(builderid=builderid, tagid=tagid)
-                              for tagid in tagsids])
+                              for tagid in tagsids]).close()
 
             transaction.commit()
 

--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -46,6 +46,7 @@ class ReconnectingListener(object):
 
 
 class Strategy(object):
+
     def set_up(self, u, engine):
         pass
 
@@ -163,7 +164,7 @@ class BuildbotEngineStrategy(strategies.ThreadLocalEngineStrategy):
         """For sqlite, percent-substitute %(basedir)s and use a full
         path to the basedir.  If using a memory database, force the
         pool size to be 1."""
-        max_conns = None
+        max_conns = 1
 
         # when given a database path, stick the basedir in there
         if u.database:
@@ -189,15 +190,9 @@ class BuildbotEngineStrategy(strategies.ThreadLocalEngineStrategy):
             # Silence that warning.
             kwargs.setdefault('connect_args', {})['check_same_thread'] = False
 
-        # in-memory databases need exactly one connection
-        if not u.database:
-            kwargs['pool_size'] = 1
-            max_conns = 1
-
-        # allow serializing access to the db
+        # ignore serializing access to the db
         if 'serialize_access' in u.query:
             u.query.pop('serialize_access')
-            max_conns = 1
 
         return u, kwargs, max_conns
 

--- a/master/buildbot/db/masters.py
+++ b/master/buildbot/db/masters.py
@@ -48,6 +48,7 @@ class MastersConnectorComponent(base.DBConnectorComponent):
             r = conn.execute(sa.select([tbl.c.active],
                                        whereclause=whereclause))
             rows = r.fetchall()
+            r.close()
             if not rows:
                 return False  # can't change a row that doesn't exist..
             was_active = bool(rows[0].active)

--- a/master/buildbot/db/pool.py
+++ b/master/buildbot/db/pool.py
@@ -191,6 +191,7 @@ class DBThreadPool(object):
                     time.sleep(backoff)
                     backoff *= self.BACKOFF_MULT
                     # and re-try
+                    log.err(e, 'retrying {} after sql error {}'.format(callable, e))
                     continue
                 except Exception as e:
                     log.err(e, 'Got fatal Exception on DB')

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -44,7 +44,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                     conn.execute(ins_q,
                                  schedulerid=schedulerid,
                                  changeid=changeid,
-                                 important=imp_int)
+                                 important=imp_int).close()
                 except (sqlalchemy.exc.ProgrammingError,
                         sqlalchemy.exc.IntegrityError):
                     transaction.rollback()
@@ -52,7 +52,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                     # insert failed, so try an update
                     conn.execute(upd_q,
                                  wc_changeid=changeid,
-                                 important=imp_int)
+                                 important=imp_int).close()
 
                 transaction.commit()
         return self.db.pool.do(thd)
@@ -64,7 +64,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
             if less_than is not None:
                 wc = wc & (sch_ch_tbl.c.changeid < less_than)
             q = sch_ch_tbl.delete(whereclause=wc)
-            conn.execute(q)
+            conn.execute(q).close()
         return self.db.pool.do(thd)
 
     def getChangeClassifications(self, schedulerid, branch=-1,
@@ -122,14 +122,14 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
             if masterid is None:
                 q = sch_mst_tbl.delete(
                     whereclause=(sch_mst_tbl.c.schedulerid == schedulerid))
-                conn.execute(q)
+                conn.execute(q).close()
                 return
 
             # try a blind insert..
             try:
                 q = sch_mst_tbl.insert()
                 conn.execute(q,
-                             dict(schedulerid=schedulerid, masterid=masterid))
+                             dict(schedulerid=schedulerid, masterid=masterid)).close()
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                 # someone already owns this scheduler.
                 raise SchedulerAlreadyClaimedError

--- a/master/buildbot/test/unit/test_db_enginestrategy.py
+++ b/master/buildbot/test/unit/test_db_enginestrategy.py
@@ -50,7 +50,7 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
         kwargs = dict(basedir='/my-base-dir')
         u, kwargs, max_conns = self.strat.special_case_sqlite(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
-                         ["sqlite:////my-base-dir/x/state.sqlite", None,
+                         ["sqlite:////my-base-dir/x/state.sqlite", 1,
                           self.sqlite_kwargs])
 
     def test_sqlite_relpath(self):
@@ -71,14 +71,14 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
         kwargs = dict(basedir=basedir)
         u, kwargs, max_conns = self.strat.special_case_sqlite(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
-                         [expected_url, None, exp_kwargs])
+                         [expected_url, 1, exp_kwargs])
 
     def test_sqlite_abspath(self):
         u = url.make_url("sqlite:////x/state.sqlite")
         kwargs = dict(basedir='/my-base-dir')
         u, kwargs, max_conns = self.strat.special_case_sqlite(u, kwargs)
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
-                         ["sqlite:////x/state.sqlite", None, self.sqlite_kwargs])
+                         ["sqlite:////x/state.sqlite", 1, self.sqlite_kwargs])
 
     def test_sqlite_memory(self):
         u = url.make_url("sqlite://")
@@ -87,9 +87,6 @@ class BuildbotEngineStrategy_special_cases(unittest.TestCase):
         self.assertEqual([str(u), max_conns, self.filter_kwargs(kwargs)],
                          ["sqlite://", 1,  # only one conn at a time
                           dict(basedir='my-base-dir',
-                               # note: no poolclass= argument
-                               # extra in-memory args
-                               pool_size=1,
                                connect_args=dict(check_same_thread=False))])
 
     def test_mysql_simple(self):

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -47,11 +47,6 @@ Examples::
 
 SQLite requires no special configuration.
 
-If Buildbot produces "database is locked" exceptions, try adding ``serialize_access=1`` to the DB URL as a workaround::
-
-    c['db_url'] = "sqlite:///state.sqlite?serialize_access=1"
-
-and please file a bug at http://trac.buildbot.net.
 
 .. index:: MySQL
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -40,6 +40,8 @@ Fixes
 * :bb:reporter:`GerritStatusPush` now includes build properties in the ``startCB`` and ``reviewCB`` functions. ``startCB`` now must return a dictionary.
 * Fix TypeError exception with :py:class:`~buildbot.changes.HgPoller` if ``usetimestamps=False`` is used (:bug:`3562`)
 
+* sqlite access is serialized in order to improve stability (:bug:`3565`)
+
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
PR #2270, shows lots of issues related to sqlite multiprocessing.

I think this not really related to this PR, but rather related to sqlite not working well with threads.

After investigating a couple of hours, I wasn't really able to fix the issue.

I added a bunch of connection close(), but those are not really sufficient (this removes some operational errors, but not all)

putting max_conn to 1 to sqlite as default to secure 0.9.0 release, and filling this bug
http://trac.buildbot.net/ticket/3565

