### PR TITLE
flake8 2.6.0 makes the build fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ install:
 
   # Note pylint version is pinned because newer versions can't import zope.interface - http://www.logilab.org/92792
   # astroid > 1.4 is incompatible with pylint 1.1.0
-  - "[ $TESTS != lint ] || pip install pylint==1.1.0 pep8==1.5.7 flake8  astroid==1.3.8"
+  - "[ $TESTS != lint ] || pip install pylint==1.1.0 pep8==1.5.7 flake8==2.5.5  astroid==1.3.8"
   # Install sphinx so that pylint will be able to import it
   - "[ $TESTS != lint ] || pip install sphinx"
   # Install docs dependencies for running the tests


### PR DESCRIPTION
Fixing the flake8 to 2.5.5 to make time for a real fix

to fix in 3566