### PR TITLE
Update flake8 to version 2.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ install:
 
   # Note pylint version is pinned because newer versions can't import zope.interface - http://www.logilab.org/92792
   # astroid > 1.4 is incompatible with pylint 1.1.0
-  - "[ $TESTS != lint ] || pip install pylint==1.1.0 pep8==1.5.7 flake8==2.5.5  astroid==1.3.8"
+  - "[ $TESTS != lint ] || pip install pylint==1.1.0 'flake8~=2.6.0'  astroid==1.3.8"
   # Install sphinx so that pylint will be able to import it
   - "[ $TESTS != lint ] || pip install sphinx"
   # Install docs dependencies for running the tests

--- a/common/flake8rc
+++ b/common/flake8rc
@@ -18,5 +18,8 @@ max-line-length = 100
 # E711 comparison to None should be 'if cond is None:'
 # E712 comparison to False should be 'if cond is False:' or 'if not cond:'
 # E721 do not compare types, use 'isinstance()'
+# W503 line break before binary operator
+# E731 do not assign a lambda expression, use a def
+# E402 module level import not at top of file
 
-ignore = E122,E123,E126,E128,E211,E501,E711,E712,E721
+ignore = E122,E123,E126,E128,E211,E501,E711,E712,E721,E731,W503,E402

--- a/common/flake8rc
+++ b/common/flake8rc
@@ -20,6 +20,5 @@ max-line-length = 100
 # E721 do not compare types, use 'isinstance()'
 # W503 line break before binary operator
 # E731 do not assign a lambda expression, use a def
-# E402 module level import not at top of file
 
-ignore = E122,E123,E126,E128,E211,E501,E711,E712,E721,E731,W503,E402
+ignore = E122,E123,E126,E128,E211,E501,E711,E712,E721,E731,W503

--- a/master/buildbot/buildslave/__init__.py
+++ b/master/buildbot/buildslave/__init__.py
@@ -16,16 +16,15 @@
 # This module is left for backward compatibility of old-named worker API.
 # It should never be imported by Buildbot.
 
+from buildbot.worker import AbstractLatentWorker as _AbstractLatentWorker
+from buildbot.worker import AbstractWorker as _AbstractWorker
+from buildbot.worker import Worker as _Worker
 from buildbot.worker_transition import deprecatedWorkerModuleAttribute
 from buildbot.worker_transition import reportDeprecatedWorkerModuleUsage
 
 reportDeprecatedWorkerModuleUsage(
     "'{old}' module is deprecated, use "
     "'buildbot.worker' module instead".format(old=__name__))
-
-from buildbot.worker import AbstractLatentWorker as _AbstractLatentWorker
-from buildbot.worker import AbstractWorker as _AbstractWorker
-from buildbot.worker import Worker as _Worker
 
 deprecatedWorkerModuleAttribute(locals(), _AbstractWorker,
                                 compat_name="AbstractBuildSlave",

--- a/master/buildbot/steps/slave.py
+++ b/master/buildbot/steps/slave.py
@@ -17,12 +17,25 @@
 # It should never be imported by Buildbot.
 
 
-# pylint: disable=wildcard-import
-# pylint: disable=unused-wildcard-import
-from buildbot.steps.worker import *  # noqa
+from buildbot.steps.worker import CompositeStepMixin
+from buildbot.steps.worker import CopyDirectory
+from buildbot.steps.worker import FileExists
+from buildbot.steps.worker import MakeDirectory
+from buildbot.steps.worker import RemoveDirectory
+from buildbot.steps.worker import SetPropertiesFromEnv
+from buildbot.steps.worker import WorkerBuildStep
 # pylint: disable=unused-import
 from buildbot.worker_transition import deprecatedWorkerModuleAttribute
 from buildbot.worker_transition import reportDeprecatedWorkerModuleUsage
+
+__all__ = [
+    'CompositeStepMixin',
+    'CopyDirectory',
+    'FileExists',
+    'MakeDirectory',
+    'RemoveDirectory',
+    'SetPropertiesFromEnv',
+]
 
 reportDeprecatedWorkerModuleUsage(
     "'{old}' module is deprecated, use "

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -13,17 +13,19 @@
 #
 # Copyright Buildbot Team Members
 
+import sys
+import warnings
+
 from distutils.version import LooseVersion
 
-# apply the same patches the buildmaster does when it starts
 from buildbot import monkeypatches
+
+# apply the same patches the buildmaster does when it starts
 monkeypatches.patch_all(for_tests=True)
 
 # enable deprecation warnings
-import warnings
 warnings.filterwarnings('always', category=DeprecationWarning)
 
-import sys
 if sys.version_info[:2] < (3, 2):
     # Setup logging unhandled messages to stderr.
     # Since Python 3.2 similar functionality implemented through
@@ -65,9 +67,9 @@ if LooseVersion(mock.__version__) < LooseVersion("0.8"):
 # were emitted.
 # Without explicit load of deprecated modules it's hard to predict when
 # they will be imported and when warning should be catched.
-from buildbot.test.util.warnings import assertProducesWarning
-from buildbot.worker_transition import DeprecatedWorkerAPIWarning
-from buildbot.worker_transition import DeprecatedWorkerModuleWarning
+from buildbot.test.util.warnings import assertProducesWarning  # noqa
+from buildbot.worker_transition import DeprecatedWorkerAPIWarning  # noqa
+from buildbot.worker_transition import DeprecatedWorkerModuleWarning  # noqa
 
 with assertProducesWarning(
         DeprecatedWorkerModuleWarning,

--- a/master/buildbot/test/test_extra_coverage.py
+++ b/master/buildbot/test/test_extra_coverage.py
@@ -17,8 +17,6 @@
 # included in the coverage because none of the tests import
 # them; this results in a more accurate total coverage percent.
 
-modules = []  # for the benefit of pyflakes
-
 from buildbot import worker
 from buildbot.changes import p4poller
 from buildbot.changes import svnpoller
@@ -43,6 +41,7 @@ from buildbot.steps.package.rpm import rpmlint
 from buildbot.steps.package.rpm import rpmspec
 from buildbot.util import eventual
 
+modules = []  # for the benefit of pyflakes
 modules.extend([worker])
 modules.extend([p4poller, svnpoller])
 modules.extend([base, sendchange, tryclient])

--- a/master/setup.py
+++ b/master/setup.py
@@ -464,7 +464,6 @@ else:
     setup_args['extras_require'] = {
         'test': [
             'setuptools_trial',
-            'pep8',
             'isort',
             'pylint==1.1.0',
             'pyflakes',

--- a/slave/buildslave/test/test_extra_coverage.py
+++ b/slave/buildslave/test/test_extra_coverage.py
@@ -17,8 +17,7 @@
 # included in the coverage because none of the tests import
 # them; this results in a more accurate total coverage percent.
 
-modules = []  # for the benefit of pyflakes
-
 from buildslave.scripts import logwatcher
 
+modules = []  # for the benefit of pyflakes
 modules.extend([logwatcher])

--- a/worker/buildbot_worker/test/test_extra_coverage.py
+++ b/worker/buildbot_worker/test/test_extra_coverage.py
@@ -17,8 +17,7 @@
 # included in the coverage because none of the tests import
 # them; this results in a more accurate total coverage percent.
 
-modules = []  # for the benefit of pyflakes
-
 from buildbot_worker.scripts import logwatcher
 
+modules = []  # for the benefit of pyflakes
 modules.extend([logwatcher])


### PR DESCRIPTION
This introduces a few new errors:

- `W503` line break before binary operator

   I don't think this is a sensible choice and the codebase doesn't follow this convention.
- `E731` do not assign a lambda expression, use a def

   This is used often in tests for functions that return canned values. I think turning them into `def`s obscures that.
- `E402` module level import not at top of file

  I've fixed most of the occurrences of this, as they are fairly trivial.