### PR TITLE
Added user toggle to schedulers.

### DIFF
--- a/master/buildbot/data/forceschedulers.py
+++ b/master/buildbot/data/forceschedulers.py
@@ -32,7 +32,8 @@ def forceScheduler2Data(sched):
                button_name=text_type(sched.buttonName),
                label=text_type(sched.label),
                builder_names=[text_type(name)
-                              for name in sched.builderNames])
+                              for name in sched.builderNames],
+               enabled=sched.enabled)
     ret["all_fields"] = [field.getSpec() for field in sched.all_fields]
     return ret
 
@@ -105,5 +106,6 @@ class ForceScheduler(base.ResourceType):
         button_name = types.String()
         label = types.String()
         builder_names = types.List(of=types.Identifier(50))
+        enabled = types.Boolean()
         all_fields = types.List(of=types.JsonObject())
     entityType = EntityType(name)

--- a/master/buildbot/db/migrate/versions/049_add_schedulers_enabled.py
+++ b/master/buildbot/db/migrate/versions/049_add_schedulers_enabled.py
@@ -1,0 +1,28 @@
+# This file is part of Buildbot. Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import sqlalchemy as sa
+from buildbot.util import sautils
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+    schedulers_table = sautils.Table('schedulers', metadata, autoload=True)
+    enabled = sa.Column('enabled', sa.SmallInteger, nullable=False, server_default="1")
+    enabled.create(schedulers_table)

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -473,6 +473,8 @@ class Model(base.DBConnectorComponent):
         # of that name used for a unique index
         sa.Column('name', sa.Text, nullable=False),
         sa.Column('name_hash', sa.String(40), nullable=False),
+        sa.Column('enabled', sa.SmallInteger,
+                  server_default=sa.DefaultClause("1")),
     )
 
     # This links schedulers to the master where they are running.  A scheduler

--- a/master/buildbot/newsfragments/scheduler_toggle.feature
+++ b/master/buildbot/newsfragments/scheduler_toggle.feature
@@ -1,0 +1,1 @@
+Schedulers can now be toggled on and off from the UI. Useful for temporarily disabling periodic timers.

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -92,10 +92,9 @@ class BaseBasicScheduler(base.BaseScheduler):
     @defer.inlineCallbacks
     def activate(self):
         yield base.BaseScheduler.activate(self)
-        # even if we aren't called via _activityPoll(), at this point we
-        # need to ensure the service id is set correctly
-        if self.serviceid is None:
-            self.serviceid = yield self._getServiceId()
+
+        if not self.enabled:
+            return
 
         yield self.startConsumingChanges(fileIsImportant=self.fileIsImportant,
                                          change_filter=self.change_filter,
@@ -116,6 +115,9 @@ class BaseBasicScheduler(base.BaseScheduler):
     def deactivate(self):
         # the base deactivate will unsubscribe from new changes
         yield base.BaseScheduler.deactivate(self)
+
+        if not self.enabled:
+            return
 
         @util.deferredLocked(self._stable_timers_lock)
         def cancel_timers():

--- a/master/buildbot/schedulers/dependent.py
+++ b/master/buildbot/schedulers/dependent.py
@@ -49,6 +49,9 @@ class Dependent(base.BaseScheduler):
     def activate(self):
         yield base.BaseScheduler.deactivate(self)
 
+        if not self.enabled:
+            return
+
         self._buildset_new_consumer = yield self.master.mq.startConsuming(
             self._buildset_new_cb,
             ('buildsets', None, 'new'))
@@ -65,6 +68,9 @@ class Dependent(base.BaseScheduler):
     def deactivate(self):
         # the base deactivate will unsubscribe from new changes
         yield base.BaseScheduler.deactivate(self)
+
+        if not self.enabled:
+            return
 
         if self._buildset_new_consumer:
             self._buildset_new_consumer.stopConsuming()

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -105,6 +105,9 @@ class Try_Jobdir(TryBase):
     def activate(self):
         yield TryBase.activate(self)
 
+        if not self.enabled:
+            return
+
         # set the watcher's basedir now that we have a master
         jobdir = os.path.join(self.master.basedir, self.jobdir)
         self.watcher.setBasedir(jobdir)
@@ -119,6 +122,10 @@ class Try_Jobdir(TryBase):
     @defer.inlineCallbacks
     def deactivate(self):
         yield TryBase.deactivate(self)
+
+        if not self.enabled:
+            return
+
         # bridge the activate/deactivate to a startService/stopService on the
         # child service
         self.watcher.stopService()
@@ -436,6 +443,9 @@ class Try_Userpass(TryBase):
     def activate(self):
         yield TryBase.activate(self)
 
+        if not self.enabled:
+            return
+
         # register each user/passwd with the pbmanager
         def factory(mind, username):
             return Try_Userpass_Perspective(self, username)
@@ -447,5 +457,9 @@ class Try_Userpass(TryBase):
     @defer.inlineCallbacks
     def deactivate(self):
         yield TryBase.deactivate(self)
+
+        if not self.enabled:
+            return
+
         yield defer.gatherResults(
             [reg.unregister() for reg in self.registrations])

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -442,6 +442,9 @@ class FakeUpdates(service.AsyncService):
     def workerMissing(self, workerid, masterid, last_connection, notify):
         self.missingWorkers.append((workerid, masterid, last_connection, notify))
 
+    def schedulerEnable(self, schedulerid, v):
+        return self.master.db.schedulers.enable(schedulerid, v)
+
 
 class FakeDataConnector(service.AsyncMultiService):
     # FakeDataConnector delegates to the real DataConnector so it can get all

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -361,6 +361,7 @@ class Scheduler(Row):
         id=None,
         name='schname',
         name_hash=None,
+        enabled=1,
     )
 
     id_column = 'id'
@@ -1002,6 +1003,7 @@ class FakeSchedulersComponent(FakeDBComponent):
         self.scheduler_masters = {}
         self.states = {}
         self.classifications = {}
+        self.enabled = {}
 
     def insertTestData(self, rows):
         for row in rows:
@@ -1010,6 +1012,7 @@ class FakeSchedulersComponent(FakeDBComponent):
                 cls[row.changeid] = row.important
             if isinstance(row, Scheduler):
                 self.schedulers[row.id] = row.name
+                self.enabled[row.id] = True
             if isinstance(row, SchedulerMaster):
                 self.scheduler_masters[row.schedulerid] = row.masterid
 
@@ -1076,6 +1079,7 @@ class FakeSchedulersComponent(FakeDBComponent):
             rv = dict(
                 id=schedulerid,
                 name=self.schedulers[schedulerid],
+                enabled=self.enabled.get(schedulerid, True),
                 masterid=None)
             # only set masterid if the relevant scheduler master exists and
             # is active
@@ -1139,6 +1143,11 @@ class FakeSchedulersComponent(FakeDBComponent):
     def assertSchedulerMaster(self, schedulerid, masterid):
         self.t.assertEqual(self.scheduler_masters.get(schedulerid),
                            masterid)
+
+    def enable(self, schedulerid, v):
+        assert schedulerid in self.schedulers
+        self.enabled[schedulerid] = v
+        return defer.succeed((('control', 'schedulers', schedulerid, 'enable'), {'enabled': v}))
 
 
 class FakeSourceStampsComponent(FakeDBComponent):

--- a/master/buildbot/test/unit/test_data_forceschedulers.py
+++ b/master/buildbot/test/unit/test_data_forceschedulers.py
@@ -118,7 +118,8 @@ expected_default = {
     'builder_names': [u'builder'],
     'button_name': u'defaultforce',
     'label': u'defaultforce',
-    'name': u'defaultforce'}
+    'name': u'defaultforce',
+    'enabled': True}
 
 
 class ForceschedulerEndpoint(endpoint.EndpointMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_data_schedulers.py
+++ b/master/buildbot/test/unit/test_data_schedulers.py
@@ -101,6 +101,11 @@ class SchedulerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             self.assertEqual(scheduler, None)
         return d
 
+    @defer.inlineCallbacks
+    def test_action_enable(self):
+        r = yield self.callControl("enable", {'enabled': False}, ('schedulers', 13))
+        self.assertEqual(r, None)
+
 
 class SchedulersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
@@ -160,6 +165,42 @@ class Scheduler(interfaces.InterfaceTests, unittest.TestCase):
         self.master = fakemaster.make_master(wantMq=True, wantDb=True,
                                              wantData=True, testcase=self)
         self.rtype = schedulers.Scheduler(self.master)
+
+    def test_signature_schedulerEnable(self):
+        @self.assertArgSpecMatches(
+            self.master.data.updates.schedulerEnable,
+            self.rtype.schedulerEnable)
+        def schedulerEnable(self, schedulerid, v):
+            pass
+
+    @defer.inlineCallbacks
+    def test_schedulerEnable(self):
+        SOMETIME = 1348971992
+        yield self.master.db.insertTestData([
+            fakedb.Master(id=22, active=0, last_active=SOMETIME),
+            fakedb.Scheduler(id=13, name='some:scheduler'),
+            fakedb.SchedulerMaster(schedulerid=13, masterid=22),
+        ])
+        yield self.rtype.schedulerEnable(13, False)
+        self.master.mq.assertProductions(
+            [(('schedulers', '13', 'updated'),
+              {'enabled': False,
+               'master': {'active': False,
+                          'last_active': fakedb._mkdt(SOMETIME),
+                          'masterid': 22,
+                          'name': u'some:master'},
+               'name': u'some:scheduler',
+               'schedulerid': 13})])
+        yield self.rtype.schedulerEnable(13, True)
+        self.master.mq.assertProductions(
+            [(('schedulers', '13', 'updated'),
+              {'enabled': True,
+               'master': {'active': False,
+                          'last_active': fakedb._mkdt(SOMETIME),
+                          'masterid': 22,
+                          'name': u'some:master'},
+               'name': u'some:scheduler',
+               'schedulerid': 13})])
 
     def test_signature_findSchedulerId(self):
         @self.assertArgSpecMatches(

--- a/master/buildbot/test/unit/test_db_migrate_versions_049_add_schedulers_enabled.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_049_add_schedulers_enabled.py
@@ -1,0 +1,72 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import sqlalchemy as sa
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_thd(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        schedulers = sautils.Table(
+            'schedulers', metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+
+            # name for this scheduler, as given in the configuration, plus a hash
+            # of that name used for a unique index
+            sa.Column('name', sa.Text, nullable=False),
+            sa.Column('name_hash', sa.String(40), nullable=False, server_default='')
+        )
+
+        schedulers.create()
+
+        conn.execute(schedulers.insert(), [
+            dict(number=3, name='echo', urls_json='[]')])
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            schedulers = sautils.Table('schedulers', metadata, autoload=True)
+            self.assertIsInstance(schedulers.c.enabled.type, sa.SmallInteger)
+
+            q = sa.select([schedulers.c.name, schedulers.c.enabled])
+            num_rows = 0
+            for row in conn.execute(q):
+                # verify that the default value was set correctly
+                self.assertEqual(row.enabled, True)
+                num_rows += 1
+            self.assertEqual(num_rows, 1)
+
+        return self.do_test_migration(48, 49, setup_thd, verify_thd)

--- a/master/buildbot/test/unit/test_db_schedulers.py
+++ b/master/buildbot/test/unit/test_db_schedulers.py
@@ -48,6 +48,41 @@ class Tests(interfaces.InterfaceTests):
 
     # tests
 
+    def test_signature_enable(self):
+        @self.assertArgSpecMatches(self.db.schedulers.enable)
+        def enable(self, schedulerid, v):
+            pass
+
+    @defer.inlineCallbacks
+    def test_enable(self):
+        yield self.insertTestData([self.scheduler24, self.master13,
+                                   self.scheduler24master])
+        sch = yield self.db.schedulers.getScheduler(24)
+        validation.verifyDbDict(self, 'schedulerdict', sch)
+        self.assertEqual(sch, dict(
+            id=24,
+            name='schname',
+            enabled=True,
+            masterid=13))
+
+        yield self.db.schedulers.enable(24, False)
+        sch = yield self.db.schedulers.getScheduler(24)
+        validation.verifyDbDict(self, 'schedulerdict', sch)
+        self.assertEqual(sch, dict(
+            id=24,
+            name='schname',
+            enabled=False,
+            masterid=13))
+
+        yield self.db.schedulers.enable(24, True)
+        sch = yield self.db.schedulers.getScheduler(24)
+        validation.verifyDbDict(self, 'schedulerdict', sch)
+        self.assertEqual(sch, dict(
+            id=24,
+            name='schname',
+            enabled=True,
+            masterid=13))
+
     def test_signature_classifyChanges(self):
         @self.assertArgSpecMatches(self.db.schedulers.classifyChanges)
         def classifyChanges(self, schedulerid, classifications):
@@ -219,6 +254,7 @@ class Tests(interfaces.InterfaceTests):
         self.assertEqual(sch, dict(
             id=24,
             name='schname',
+            enabled=True,
             masterid=None))
 
     @defer.inlineCallbacks
@@ -235,6 +271,7 @@ class Tests(interfaces.InterfaceTests):
         self.assertEqual(sch, dict(
             id=24,
             name='schname',
+            enabled=True,
             masterid=13))
 
     @defer.inlineCallbacks
@@ -246,6 +283,7 @@ class Tests(interfaces.InterfaceTests):
         self.assertEqual(sch, dict(
             id=25,
             name='schname2',
+            enabled=True,
             masterid=14))  # row exists, but marked inactive
 
     def test_signature_getSchedulers(self):
@@ -267,8 +305,8 @@ class Tests(interfaces.InterfaceTests):
         [validation.verifyDbDict(self, 'schedulerdict', sch)
          for sch in schlist]
         self.assertEqual(sorted(schlist, key=schKey), sorted([
-            dict(id=24, name='schname', masterid=13),
-            dict(id=25, name='schname2', masterid=None),
+            dict(id=24, name='schname', enabled=True, masterid=13),
+            dict(id=25, name='schname2', enabled=True, masterid=None),
         ], key=schKey))
 
     @defer.inlineCallbacks
@@ -281,7 +319,7 @@ class Tests(interfaces.InterfaceTests):
         [validation.verifyDbDict(self, 'schedulerdict', sch)
          for sch in schlist]
         self.assertEqual(sorted(schlist), sorted([
-            dict(id=24, name='schname', masterid=13),
+            dict(id=24, name='schname', enabled=True, masterid=13),
         ]))
 
     @defer.inlineCallbacks
@@ -294,7 +332,7 @@ class Tests(interfaces.InterfaceTests):
         [validation.verifyDbDict(self, 'schedulerdict', sch)
          for sch in schlist]
         self.assertEqual(sorted(schlist), sorted([
-            dict(id=24, name='schname', masterid=13),
+            dict(id=24, name='schname', enabled=True, masterid=13),
         ]))
 
     @defer.inlineCallbacks
@@ -308,7 +346,7 @@ class Tests(interfaces.InterfaceTests):
         [validation.verifyDbDict(self, 'schedulerdict', sch)
          for sch in schlist]
         self.assertEqual(sorted(schlist), sorted([
-            dict(id=24, name='schname', masterid=13),
+            dict(id=24, name='schname', enabled=True, masterid=13),
         ]))
 
         schlist = yield self.db.schedulers.getSchedulers(
@@ -327,7 +365,7 @@ class Tests(interfaces.InterfaceTests):
         [validation.verifyDbDict(self, 'schedulerdict', sch)
          for sch in schlist]
         self.assertEqual(sorted(schlist), sorted([
-            dict(id=25, name='schname2', masterid=None),
+            dict(id=25, name='schname2', enabled=True, masterid=None),
         ]))
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -120,6 +120,16 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
         else:
             self.fail("didn't assert")
 
+    @defer.inlineCallbacks
+    def test_enabled_callback(self):
+        sched = self.makeScheduler()
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+
     def do_test_change_consumption(self, kwargs, expected_result):
         # (expected_result should be True (important), False (unimportant), or
         # None (ignore the change))
@@ -158,9 +168,10 @@ class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
         d = sched.startConsumingChanges(**kwargs)
 
         def test(_):
-            # check that it registered a callback
-            self.assertEqual(len(self.mq.qrefs), 1)
-            qref = self.mq.qrefs[0]
+            # check that it registered callbacks
+            self.assertEqual(len(self.mq.qrefs), 2)
+
+            qref = self.mq.qrefs[1]
             self.assertEqual(qref.filter, ('changes', None, 'new'))
 
             # invoke the callback with the change, and check the result

--- a/master/buildbot/test/unit/test_schedulers_basic.py
+++ b/master/buildbot/test/unit/test_schedulers_basic.py
@@ -288,6 +288,32 @@ class BaseBasicScheduler(CommonStuffMixin,
 
         yield sched.deactivate()
 
+    @defer.inlineCallbacks
+    def test_enabled_callback(self):
+        sched = self.makeScheduler(self.Subclass)
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+
+    @defer.inlineCallbacks
+    def test_disabled_activate(self):
+        sched = self.makeScheduler(self.Subclass)
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, False)
+        r = yield sched.activate()
+        self.assertEqual(r, None)
+
+    @defer.inlineCallbacks
+    def test_disabled_deactivate(self):
+        sched = self.makeScheduler(self.Subclass)
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, False)
+        r = yield sched.deactivate()
+        self.assertEqual(r, None)
+
 
 class SingleBranchScheduler(CommonStuffMixin,
                             scheduler.SchedulerMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_schedulers_dependent.py
+++ b/master/buildbot/test/unit/test_schedulers_dependent.py
@@ -202,3 +202,29 @@ class Dependent(scheduler.SchedulerMixin, unittest.TestCase):
 
         # and check that it wrote the correct value back to the state
         self.db.state.assertState(OBJECTID, upstream_bsids=[11, 13])
+
+    @defer.inlineCallbacks
+    def test_enabled_callback(self):
+        sched = self.makeScheduler()
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+
+    @defer.inlineCallbacks
+    def test_disabled_activate(self):
+        sched = self.makeScheduler()
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, False)
+        r = yield sched.activate()
+        self.assertEqual(r, None)
+
+    @defer.inlineCallbacks
+    def test_disabled_deactivate(self):
+        sched = self.makeScheduler()
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, False)
+        r = yield sched.deactivate()
+        self.assertEqual(r, None)

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -44,6 +44,11 @@ class SchedulerManager(unittest.TestCase):
             return defer.succeed(rv)
         self.master.db.state.getObjectId = getObjectId
 
+        def getScheduler(sched_id):
+            return defer.succeed(dict(enabled=True))
+
+        self.master.db.schedulers.getScheduler = getScheduler
+
         self.new_config = mock.Mock()
 
         self.sm = manager.SchedulerManager()

--- a/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
@@ -136,6 +136,44 @@ class Nightly(scheduler.SchedulerMixin, unittest.TestCase):
             name='test', builderNames=['test'], branch='default', month='1')
         self.assertEqual(sched.month, "1")
 
+    @defer.inlineCallbacks
+    def test_enabled_callback(self):
+        sched = self.makeScheduler(
+            name='test', builderNames=['test'], branch='default')
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+
+    @defer.inlineCallbacks
+    def test_disabled_activate(self):
+        sched = self.makeScheduler(
+            name='test', builderNames=['test'], branch='default')
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, False)
+        r = yield sched.activate()
+        self.assertEqual(r, None)
+
+    @defer.inlineCallbacks
+    def test_disabled_deactivate(self):
+        sched = self.makeScheduler(
+            name='test', builderNames=['test'], branch='default')
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, False)
+        r = yield sched.deactivate()
+        self.assertEqual(r, None)
+
+    @defer.inlineCallbacks
+    def test_disabled_start_build(self):
+        sched = self.makeScheduler(
+            name='test', builderNames=['test'], branch='default')
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, False)
+        r = yield sched.startBuild()
+        self.assertEqual(r, None)
+
     # end-to-end tests: let's see the scheduler in action
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
@@ -189,3 +189,41 @@ class Periodic(scheduler.SchedulerMixin, unittest.TestCase):
         d = sched.getNextBuildTime(20)
         d.addCallback(lambda t: self.assertEqual(t, 33))
         return d
+
+    @defer.inlineCallbacks
+    def test_enabled_callback(self):
+        sched = self.makeScheduler(name='test', builderNames=['test'],
+                                   periodicBuildTimer=13)
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+        expectedValue = not sched.enabled
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, expectedValue)
+
+    @defer.inlineCallbacks
+    def test_disabled_activate(self):
+        sched = self.makeScheduler(name='test', builderNames=['test'],
+                                   periodicBuildTimer=13)
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, False)
+        r = yield sched.activate()
+        self.assertEqual(r, None)
+
+    @defer.inlineCallbacks
+    def test_disabled_deactivate(self):
+        sched = self.makeScheduler(name='test', builderNames=['test'],
+                                   periodicBuildTimer=13)
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, False)
+        r = yield sched.deactivate()
+        self.assertEqual(r, None)
+
+    @defer.inlineCallbacks
+    def test_disabled_start_build(self):
+        sched = self.makeScheduler(name='test', builderNames=['test'],
+                                   periodicBuildTimer=13)
+        yield sched._enabledCallback(None, {'enabled': not sched.enabled})
+        self.assertEqual(sched.enabled, False)
+        r = yield sched.startBuild()
+        self.assertEqual(r, None)

--- a/master/buildbot/test/unit/test_schedulers_timed_Timed.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Timed.py
@@ -48,7 +48,6 @@ class Timed(scheduler.SchedulerMixin, unittest.TestCase):
         sched = self.attachScheduler(self.Subclass(**kwargs), self.OBJECTID)
         self.clock = sched._reactor = task.Clock()
         return sched
-
     # tests
 
     # note that most of the heavy-lifting for testing this class is handled by

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -529,6 +529,7 @@ dbdict['schedulerdict'] = DictValidator(
     id=IntValidator(),
     name=StringValidator(),
     masterid=NoneOk(IntValidator()),
+    enabled=BooleanValidator(),
 )
 
 # builds

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.tpl.jade
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.tpl.jade
@@ -5,7 +5,8 @@
         hr
         div.form-horizontal
             .alert.alert-danger(ng-show="error") {{error}}
+            .alert.alert-danger(ng-show="!sch.enabled") SCHEDULER DISABLED
             forcefield(field="rootfield" ng-if="rootfield")
     .modal-footer
       button.btn.btn-default(ng-click="cancel()") Cancel
-      button.btn.btn-primary(ng-click="ok()") Start Build
+      button.btn.btn-primary(ng-click="ok()", ng-disabled="!sch.enabled") Start Build

--- a/www/base/src/app/schedulers/schedulers.controller.coffee
+++ b/www/base/src/app/schedulers/schedulers.controller.coffee
@@ -2,3 +2,9 @@ class schedulers extends Controller
     constructor: ($log, $scope, $location, dataService) ->
         data = dataService.open().closeOnDestroy($scope)
         $scope.schedulers = data.getSchedulers()
+
+        $scope.change = (s) ->
+            newValue = s.enabled
+            param = enabled: newValue
+            dataService.control 'schedulers', s.schedulerid, 'enable', param
+                

--- a/www/base/src/app/schedulers/schedulers.tpl.jade
+++ b/www/base/src/app/schedulers/schedulers.tpl.jade
@@ -3,16 +3,22 @@
       uib-tab(heading="All schedulers")
         table.table.table-hover.table-striped.table-condensed
           tr
+              td Enabled
               td Scheduler Name
               td Master
           tr(ng-repeat='scheduler in schedulers | orderBy: ["name"]')
+              td
+                input(type="checkbox", ng-model="scheduler.enabled", ng-change="change(scheduler)")
               td {{ scheduler.name }}
               td {{ scheduler.master.name }}
       uib-tab(heading="All schedulers by master")
         table.table.table-hover.table-striped.table-condensed
           tr
+              td Enabled
               td Scheduler Name
               td Master
           tr(ng-repeat='scheduler in schedulers | orderBy: ["master.name", "name"]')
+              td
+                input(type="checkbox", ng-model="scheduler.enabled", ng-change="change(scheduler)")
               td {{ scheduler.name }}
               td {{ scheduler.master.name }}


### PR DESCRIPTION
Hello!

I have added the ability for the user to toggle a scheduler.

In the schedulers UI there's now a new column with checkboxes to enable or disable a scheduler. Periodic schedulers will print a log message if a build is being skipped. Force schedulers will have their build button disabled and display a red warning banner reminding the user the scheduler is disabled.

To do this I've added an enabled column to the schedulers table in the database. I've added unit tests by mirroring what was done for the step.hidden attribute which was similarly added. I couldn't see where to add docs. Let me know if you need me to add some.

![force_sched](https://cloud.githubusercontent.com/assets/3230260/16250808/48bad032-37d5-11e6-9b1e-7f599d580a70.png)

![scheduler](https://cloud.githubusercontent.com/assets/3230260/16250812/4b467f86-37d5-11e6-91bc-1ba39a8fe31f.png)

Please let me know if you need anything. :) Thx!
