### PR TITLE
Trivial mail fixes.

### DIFF
--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -30,7 +30,7 @@ def getPreviousBuild(master, build):
     n = build['number'] - 1
     while n >= 0:
         prev = yield master.data.get(("builders", build['builderid'], "builds", n))
-        if prev['results'] != RETRY:
+        if prev and prev['results'] != RETRY:
             defer.returnValue(prev)
         n -= 1
     defer.returnValue(None)
@@ -163,7 +163,7 @@ def getResponsibleUsersForBuild(master, buildid):
 
     # add owner from properties
     if 'owner' in properties:
-        blamelist.add(properties['owner'][0])
+        blamelist.update(properties['owner'][0])
 
     blamelist = list(blamelist)
     blamelist.sort()


### PR DESCRIPTION
I had to make these changes in order to get mail notification to work. This came about from stack traces in twistd.log where there was a an unexpected value. I'm not sure if this is a proper fix or a side effect from some other confusion over owners vs owner in the code somewhere. There was also an unexpected None value.

My mail reporter was over the form:

mn = reporters.MailNotifier(fromaddr=twn.fromEmailAddress,
                             relayhost=twn.emailServer,
                             sendToInterestedUsers=True,
                             mode=['change', 'failing'],
                             extraRecipients=[twn.buildAdminEmail, 'xxx@trionworlds.com', 'xxx@trionworlds.com', 'xxx@trionworlds.com'],
                             lookup='trionworlds.com',
                             messageFormatter=MessageFormatter(template_name='trion_mail.txt', template_dir=r'C:\TrionBuildbot\templates'),
                             tags=['compile_check', 'checks'],
                             )