### PR TITLE
remote templates creation in upgrade-master

### DIFF
--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -65,12 +65,6 @@ def upgradeFiles(config):
         print("        consider using third party HTTP server for serving "
               "static files")
 
-    templdir = os.path.join(config['basedir'], "templates")
-    if not os.path.exists(templdir):
-        if not config['quiet']:
-            print("creating templates")
-        os.mkdir(templdir)
-
     installFile(config, os.path.join(config['basedir'], "master.cfg.sample"),
                 util.sibpath(__file__, "sample.cfg"), overwrite=True)
 

--- a/master/buildbot/test/unit/test_scripts_upgrade_master.py
+++ b/master/buildbot/test/unit/test_scripts_upgrade_master.py
@@ -172,7 +172,6 @@ class TestUpgradeMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
     def test_upgradeFiles(self):
         upgrade_master.upgradeFiles(mkconfig())
         for f in [
-                'test/templates',
                 'test/master.cfg.sample',
         ]:
             self.assertTrue(os.path.exists(f), "%s not found" % f)


### PR DESCRIPTION
they are now not used in nine