### PR TITLE
put the JS test earlier to optimize overall time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ env:
   - TWISTED=latest SQLALCHEMY=latest TESTS=docs
   - TWISTED=latest SQLALCHEMY=latest TESTS=coverage
 
+  # add js tests in separate job. Start it early because it is quite long
+  - TWISTED=latest SQLALCHEMY=latest TESTS=js
+
   - TWISTED=14.0.2 SQLALCHEMY=latest TESTS=trial
   - TWISTED=15.4.0 SQLALCHEMY=latest TESTS=trial
   - TWISTED=latest SQLALCHEMY=latest TESTS=trial
@@ -44,9 +47,6 @@ env:
   # Test different versions of SQLAlchemy
   - TWISTED=15.5.0 SQLALCHEMY=0.8.0 TESTS=trial
   - TWISTED=15.5.0 SQLALCHEMY=latest TESTS=trial
-
-  # add extra tests in separate jobs
-  - TWISTED=latest SQLALCHEMY=latest TESTS=js
 
   # Configuration to run `python setup.py test` to check this test runner.
   # - TWISTED=latest SQLALCHEMY=latest TESTS=setuppy_test
@@ -138,7 +138,10 @@ before_script:
 
 # Tests running commands
 script:
-  - "[ $TESTS != js ] || make frontend_install_tests"
+  # make frontend_install_tests takes 17 min, so we only do it post submit
+  - "[ $TESTS != js -o ${TRAVIS_PULL_REQUEST} = false ] || make frontend"
+  - "[ $TESTS != js -o ${TRAVIS_PULL_REQUEST} != false ] || make frontend_install_tests"
+
   - "[ $TESTS != trial ]   || trial  --reporter=text --rterrors buildbot.test buildbot_worker.test"
   - "[ $TESTS != trial_worker ] || trial  --reporter=text --rterrors buildbot_worker.test"
   # run tests under coverage for latest only (it's slower..)


### PR DESCRIPTION
with current way, travis tests finish with a single job slowly building the JS
better start the JS job earlier to make sure we use parallelism as much as possible