### PR TITLE
fix change hook integration

### DIFF
--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -216,6 +216,8 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
         self.site.sessionFactory = BuildbotSession
 
+        # Make sure site.master is set. It is required for poller change_hook
+        self.site.master = self.master
         # convert this to a tuple so it can't be appended anymore (in
         # case some dynamically created resources try to get reconfigs)
         self.reconfigurableResources = tuple(self.reconfigurableResources)


### PR DESCRIPTION

This overrides #2263 
We keep the same api as before. Maybe other people have dependencies on request.site.master being valid.

This is untested. @gracinet could you test it on your env?
This would deserve an integration test, but that would be a bit complicated
