### PR TITLE
Log a message on the worker when buildbot-slave is detected.

### DIFF
--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -157,9 +157,12 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(info, r)
         calls = [
             mock.call('getWorkerInfo'),
+            mock.call('print',
+                      message='buildbot-slave detected, failing back to deprecated buildslave API. '
+                              '(Ignoring missing getWorkerInfo method.)'),
             mock.call('getSlaveInfo'),
             mock.call('getCommands'),
-            mock.call('getVersion')
+            mock.call('getVersion'),
         ]
         self.mind.callRemote.assert_has_calls(calls)
 
@@ -191,6 +194,9 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(info, r)
         calls = [
             mock.call('getWorkerInfo'),
+            mock.call('print',
+                      message='buildbot-slave detected, failing back to deprecated buildslave API. '
+                              '(Ignoring missing getWorkerInfo method.)'),
             mock.call('getSlaveInfo'),
         ]
         self.mind.callRemote.assert_has_calls(calls)
@@ -253,6 +259,8 @@ class TestConnection(unittest.TestCase):
         # All remote commands tried in remoteGetWorkerInfo are unavailable.
         # This should be real old worker...
         def side_effect(*args, **kwargs):
+            if args[0] == 'print':
+                return
             return defer.fail(twisted_pb.RemoteError(
                 'twisted.spread.flavors.NoSuchMethod', None, None))
 
@@ -264,6 +272,9 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(info, r)
         calls = [
             mock.call('getWorkerInfo'),
+            mock.call('print',
+                      message='buildbot-slave detected, failing back to deprecated buildslave API. '
+                              '(Ignoring missing getWorkerInfo method.)'),
             mock.call('getSlaveInfo'),
             mock.call('getCommands'),
             mock.call('getVersion'),

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -198,6 +198,9 @@ class Connection(base.Connection, pb.Avatar):
                 info = yield self.mind.callRemote('getWorkerInfo')
             defer.returnValue(info)
         except _NoSuchMethod:
+            yield self.remotePrint(
+                "buildbot-slave detected, failing back to deprecated buildslave API. "
+                "(Ignoring missing getWorkerInfo method.)")
             info = {}
 
             # Probably this is deprecated buildslave.


### PR DESCRIPTION
Rather than try to get rid of the exception, just print a log message explaining it.

Supersedes #2287.

```
2016-06-26T15:27:15-0600 [Broker,client] Peer will receive following PB traceback:
2016-06-26T15:27:15-0600 [Broker,client] Unhandled Error
	Traceback (most recent call last):
	  File ".../lib/python2.7/site-packages/twisted/spread/banana.py", line 167, in gotItem
	    self.callExpressionReceived(item)
	  File ".../lib/python2.7/site-packages/twisted/spread/banana.py", line 130, in callExpressionReceived
	    self.expressionReceived(obj)
	  File ".../lib/python2.7/site-packages/twisted/spread/pb.py", line 563, in expressionReceived
	    method(*sexp[1:])
	  File ".../lib/python2.7/site-packages/twisted/spread/pb.py", line 875, in proto_message
	    self._recvMessage(self.localObjectForID, requestID, objectID, message, answerRequired, netArgs, netKw)
	--- <exception caught here> ---
	  File ".../lib/python2.7/site-packages/twisted/spread/pb.py", line 889, in _recvMessage
	    netResult = object.remoteMessageReceived(self, message, netArgs, netKw)
	  File ".../lib/python2.7/site-packages/twisted/spread/flavors.py", line 112, in remoteMessageReceived
	    raise NoSuchMethod("No such method: remote_%s" % (message,))
	twisted.spread.flavors.NoSuchMethod: No such method: remote_getWorkerInfo
	
2016-06-26T15:27:15-0600 [Broker,client] message from master: buildbot-slave detected, failing to deprecated buildslave API. (Ignoring missing getWorkerInfo method.)
```