### PR TITLE
update about page to correctly show dependencies version

### DIFF
--- a/www/base/guanlecoja/config.coffee
+++ b/www/base/guanlecoja/config.coffee
@@ -30,7 +30,7 @@ config =
         # JavaScript libraries (order matters)
         deps:
             "guanlecoja-ui":
-                version: '~1.6.0'
+                version: '~1.6.1'
                 files: ['vendors.js', 'scripts.js']
             moment:
                 version: "~2.6.0"

--- a/www/base/package.json
+++ b/www/base/package.json
@@ -5,7 +5,7 @@
     "npm": ">=1.4.10"
   },
   "dependencies": {
-    "guanlecoja": "~0.6.0",
+    "guanlecoja": "~0.7.0",
     "gulp": "3.9.0",
     "gulp-shell": "^0.4.1",
     "http-proxy": "^1.11.1",

--- a/www/base/src/app/about/about.controller.coffee
+++ b/www/base/src/app/about/about.controller.coffee
@@ -2,7 +2,8 @@ class About extends Controller
     constructor: ($scope, config, restService) ->
 
         $scope.config = config
+        $scope.bower_configs = BOWERDEPS
 
         #$scope.bower_configs = bower_configs
         restService.get('application.spec').then (specs) ->
-            $scope.specs = specs
+            $scope.specs = specs['specs']

--- a/www/base/src/app/about/about.tpl.jade
+++ b/www/base/src/app/about/about.tpl.jade
@@ -1,25 +1,39 @@
 .container
   .row
     .well
-        h2 About this buildbot
+        h2 About this&nbsp;
+          a(href="http://buildbot.net") buildbot
+          | &nbsp;running for&nbsp;
+          a(ng-href="{{config.titleURL}}") {{config.title}}
         .row
-          .col-sm-4
+          .col-sm-12
             ul
-              li Project Info:&nbsp;
-                a(ng-href="{{config.titleURL}}") {{config.title}}
               li(ng-repeat="v in config.versions") {{v[0]}} version: {{v[1]}}
-        .row
-          small
 
-            | buildbot-www is configured using:
-            rawdata(data='config')
-            | buildbot-www is using the following open-source JavaScript libraries:
-            dl.dl-horizontal
-              div(ng-repeat='module in bower_configs')
-                dt
-                  a(ng-show='module.http_url', ng-href='{{module.http_url}}') {{module.name}}
-                  span(ng-hide='module.http_url') {{module.name}}
-                dd {{module.version}}
+  .row
+    .well
+        h2 Configuration
+        | buildbot-www is configured using
+        rawdata(data='config')
+  .row
+    .well
+        h2 Javascript dependencies
+        |  buildbot-www is using the following open-source JavaScript libraries
+        | (according to their bower manifest):
+        dl.dl-horizontal
+          table.table.table-stripped.table-condensed
+            tr
+                th name
+                th version
+                th license
+                th description
+            tr(ng-repeat='module in bower_configs', title="{{module}}")
+              td
+                a(ng-show='module.homepage', ng-href='{{module.homepage}}') {{module.name}}
+                span(ng-hide='module.homepage') {{module.name}}
+              td {{module.version}}
+              td {{ module.license.join ? module.license.join(", ") : module.license}}
+              td {{ module.description }}
   .row
     .well
       h2 API description


### PR DESCRIPTION
This one is mostly dependent on guanlecoja work I did separatly

https://github.com/buildbot/guanlecoja/pull/4
https://github.com/buildbot/guanlecoja-ui/pull/5
https://github.com/tardyp/gulp-bower-deps/commit/43563c1bca9f1a561e355c685414ed57c7a367c2

This is the last unwired element I am aware of, and shall be fixing http://trac.buildbot.net/ticket/2995

![image](https://cloud.githubusercontent.com/assets/109859/16425533/764b1828-3d65-11e6-96a8-bc920b041657.png)
