### PR TITLE
fix: GerritStatusPush startCB callback is never called

### DIFF
--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -265,7 +265,7 @@ class GerritStatusPush(service.BuildbotService):
 
         self._buildStartedConsumer = yield startConsuming(
             self.buildStarted,
-            ('builds', None, 'started'))
+            ('builds', None, 'new'))
 
     def stopService(self):
         self._buildsetCompleteConsumer.stopConsuming()


### PR DESCRIPTION
I found out that startCB callback is never called because startConsuming called with the wrong routing key.