### PR TITLE
Move to a ChangeHook in hgbuildbot.py (closes #2227)

### DIFF
--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -67,10 +67,11 @@ def getChanges(request, options=None):
     revlink = firstOrNothing(args.get('revlink'))
     repository = firstOrNothing(args.get('repository'))
     project = firstOrNothing(args.get('project'))
+    codebase = firstOrNothing(args.get('codebase'))
 
     chdict = dict(author=author, files=files, comments=comments,
                   revision=revision, when=when,
                   branch=branch, category=category, revlink=revlink,
                   properties=properties, repository=repository,
-                  project=project)
+                  project=project, codebase=codebase)
     return ([chdict], None)

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -45,8 +45,7 @@ Darcs
  * :bb:chsrc:`Change Hooks` in WebStatus
 
 Mercurial
- * :bb:chsrc:`PBChangeSource` (listening for connections from :file:`contrib/hgbuildbot.py` run in an ``changegroup`` hook)
- * :bb:chsrc:`Change Hooks` in WebStatus
+ * :bb:chsrc:`Change Hooks` in WebStatus (including :file:`contrib/hgbuildbot.py`, configurable in a ``changegroup`` hook)
  * `BitBucket change hook <BitBucket hook>`_ (specifically designed for BitBucket notifications, but requiring a publicly-accessible WebStatus)
  * :bb:chsrc:`HgPoller` (polling a remote Mercurial repository)
  * :bb:chsrc:`GoogleCodeAtomPoller` (polling the commit feed for a GoogleCode Git repository)

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -25,6 +25,27 @@ The :file:`post_build_request.py` script in :file:`master/contrib` allows for th
 Run :command:`post_build_request.py --help` for more information.
 The ``base`` dialect must be enabled for this to work.
 
+Mercurial hook
+++++++++++++++
+
+The Mercurial hook uses the base dialect:
+
+.. code-block:: python
+
+    c['www'] = dict(
+        ...,
+        change_hook_dialects={'base': True},
+    )
+
+Once this is configured on your buildmaster add the following hook on your server-side Mercurial repository's ``hgrc``:
+
+.. code-block:: ini
+
+    [hooks]
+    changegroup.buildbot = python:/path/to/hgbuildbot.py:hook
+
+You'll find ``hgbuildbot.py``, and its inline documentation, in the ``contrib`` directory of Buildbot's repository.
+
 GitHub hook
 +++++++++++
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -388,6 +388,7 @@ initialzed
 initliazation
 Initlized
 initscripts
+inline
 inlineCallbacks
 inrepo
 inrepos


### PR DESCRIPTION
Starting a Twisted reactor within a Mercurial hook is problematic
because a hook can get called multiple times (from the same Mercurial
process) which conflicts with the one-time only nature of the Twisted
reactor start/stop calls.

By moving to HTTP requests the hook is now re-entrant which fixes
ReactorNotRestartable exceptions being raised all the time.

The requests library is used to make the calls, since it has a
functional TLS implementation (unlike urllib/httplib in Python 2 until
recently).

Additionally, the codebase argument is added to the base ChangeHook, so
it can properly be used with a codebaseGenerator.

Finally, if a venv argument is used, it is now properly used to activate
the environment [1].

Possible improvements to this changeset are:

- send requests in parallel;
- switch back to urllib2 so the hook doesn't depend on anything;
- a few more cleanups.

[1] https://github.com/pypa/virtualenv/blob/master/virtualenv_embedded/activate_this.py