### PR TITLE
Fix: Custom templates aren't rendered

### DIFF
--- a/www/base/src/app/layout.jade
+++ b/www/base/src/app/layout.jade
@@ -22,3 +22,11 @@ html.no-js(xmlns:ng='http://angularjs.org', xmlns:app='ignored')
     | {% endfor %}
     script
       | angular.module("app").constant("config", {{configjson|safe}})
+    | {% if custom_templates %}
+    script
+      | angular.module("app").run(function ($templateCache) {
+      | {% for name, html in custom_templates.items() %}
+      |  $templateCache.put("{{ name }}", {{ html|safe }});
+      | {% endfor %}
+      | })
+    | {% endif %}

--- a/www/md_base/src/app/index.jade
+++ b/www/md_base/src/app/index.jade
@@ -33,3 +33,11 @@ html(ng-app="app", ng-controller="appController as app")
       | {% endfor %}
       script
         | angular.module("app").constant("config", {{configjson|safe}})
+      | {% if custom_templates %}
+      script
+         |angular.module('app').run(function ($templateCache) {
+         | {% for name, html in custom_templates.items() %}
+         |   $templateCache.put("{{ name }}", {{ html|safe }});
+         | {% endfor %}
+         |});
+      | {% endif %}


### PR DESCRIPTION
Custom templates are [passed](https://github.com/buildbot/buildbot/blob/master/master/buildbot/www/config.py#L147) to the index template scope but aren't rendered in the index template.