### PR TITLE
Skip test on machine which can't read the dump sqlite3 database

### DIFF
--- a/master/buildbot/db/migrate/versions/047_cascading_deletes.py
+++ b/master/buildbot/db/migrate/versions/047_cascading_deletes.py
@@ -15,6 +15,7 @@
 
 import sqlalchemy as sa
 from migrate.changeset.constraint import ForeignKeyConstraint
+
 from buildbot.util import sautils
 
 
@@ -38,5 +39,6 @@ def upgrade(migrate_engine):
                ForeignKeyConstraint([configured_workers.c.workerid],
                                     [workers.c.id], ondelete='CASCADE'),
                ):
-        fk.drop()
+        if migrate_engine.dialect.name != 'sqlite':
+            fk.drop()
         fk.create()

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 import os
 import shutil
+import sqlite3
 import tarfile
 
 import migrate
@@ -179,7 +180,13 @@ class UpgradeTestMixin(db.RealDatabaseMixin):
                 self.fail("\n" + str(diff))
         return d
 
-    def gotError(e):
+    def gotError(self, e):
+        e.trap(sqlite3.DatabaseError)
+        if "file is encrypted or is not a database" in str(e):
+            self.flushLoggedErrors(sqlite3.DatabaseError)
+            raise unittest.SkipTest(
+                "sqlite dump not readable on this machine %s"
+                % str(e))
         return e
 
     def do_test_upgrade(self, pre_callbacks=[]):

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -222,8 +222,7 @@ class UpgradeTestV090b4(UpgradeTestMixin, unittest.TestCase):
 
     def test_gotError(self):
         def upgrade():
-            raise sqlite3.DatabaseError('file is encrypted or is not a database')
-
+            return defer.fail(sqlite3.DatabaseError('file is encrypted or is not a database'))
         self.db.model.upgrade = upgrade
         self.failureResultOf(self.do_test_upgrade(), unittest.SkipTest)
 

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -220,6 +220,13 @@ class UpgradeTestV090b4(UpgradeTestMixin, unittest.TestCase):
     def verify_thd(self, conn):
         pass
 
+    def test_gotError(self):
+        def upgrade():
+            raise sqlite3.DatabaseError('file is encrypted or is not a database')
+
+        self.db.model.upgrade = upgrade
+        self.failureResultOf(self.do_test_upgrade(), unittest.SkipTest)
+
 
 class UpgradeTestV087p1(UpgradeTestMixin, unittest.TestCase):
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -466,6 +466,7 @@ else:
             'setuptools_trial',
             'isort',
             'pylint==1.1.0',
+            'astroid==1.3.8',
             'pyflakes',
         ] + test_deps,
         'bundle': [


### PR DESCRIPTION
It looks like sqlite3 is not binary compatible between OS, so the upgrade tests will fail
on freebsd test slaves

with this error:

This code mark the test as skipped if it founds error like this.

[ERROR]
Traceback (most recent call last):
Failure: sqlalchemy.exc.DatabaseError: (sqlite3.DatabaseError) file is encrypted or is not a database [SQL: u'\nCREATE TABLE test_unicode (\n\tu VARCHAR(100), \n\tb BLOB\n)\n\n']

buildbot.test.integration.test_upgrade.UpgradeTestV090b4.test_upgrade