### PR TITLE
Fix the document for GerritStatusPush callback

### DIFF
--- a/master/docs/examples/git_gerrit.cfg
+++ b/master/docs/examples/git_gerrit.cfg
@@ -178,7 +178,7 @@ def gerritSummaryCB(buildInfoList, results, status, arg):
     else:
         verified = -1
 
-    return dict(message=msg = '\n\n'.join(msgs),
+    return dict(message='\n\n'.join(msgs),
                 labels={
                     'Verified': verified
                 })


### PR DESCRIPTION
This commit removes the redundant `msg=` from gerritSummaryCB because it
will result in SyntaxError.  This error is not in master branch.  It
seems to be introduced while backporting the patch to **eight** branch.