### PR TITLE
LatentWorker do not insubstantiate at shutdown

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,6 @@
 [settings]
 line_length=110
-known_third_party=twisted,migrate,sqlalchemy,ldap3,klein
+known_third_party=twisted,migrate,sqlalchemy,ldap3,klein,future,requests,MySQLdb,zope,coverage,autobahn,pkg_resources,jinja2,mock,dateutil,sphinx,setuptools
+known_first_party=buildbot,buildbot_worker
 force_single_line=1
 

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -17,6 +17,7 @@ import time
 from email.message import Message
 from email.utils import formatdate
 
+from future.utils import itervalues
 from twisted.internet import defer
 from twisted.python import log
 from twisted.python.reflect import namedModule
@@ -35,7 +36,6 @@ from buildbot.util import ascii2unicode
 from buildbot.util import service
 from buildbot.util.eventual import eventually
 from buildbot.worker_transition import deprecatedWorkerClassProperty
-from future.utils import itervalues
 
 
 class AbstractWorker(service.BuildbotService, object):


### PR DESCRIPTION
we already stop the workers at stopService, which is called by the Application's hierarchy stop

Doing the complicated SystemEventTrigger is just uneeded duplication