### PR TITLE
Added Bitbucket build status reporter and documentation

### DIFF
--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -55,18 +55,18 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
                     'url': build['url']
                     }
             owner, repo = self.get_owner_and_repo(sourcestamp['repository'])
-            if repo is not None and owner is not None:
-                token = ''
-                oauth_request = yield self.session.post(self.oauth_url, auth=self.auth,
-                                                       data={'grant_type': 'client_credentials'})
-                if oauth_request.status_code == 200:
-                    token = json.loads(oauth_request.content)['access_token']
-                self.session.headers.update({'Authorization': 'Bearer ' + token})
-                bitbucket_uri = '/'.join([self.base_url, owner, repo, 'commit', sha, 'statuses', 'build'])
-                response = yield self.session.post(bitbucket_uri, json=body)
-                if response.status_code != 201:
-                    log.msg("%s: unable to upload Bitbucket status: %s" %
-                            (response.status_code, response.content))
+            token = ''
+            oauth_request = yield self.session.post(self.oauth_url, auth=self.auth,
+                                                   data={'grant_type': 'client_credentials'})
+            if oauth_request.status_code == 200:
+                token = json.loads(oauth_request.content)['access_token']
+            self.session.headers.update({'Authorization': 'Bearer ' + token})
+            print "HERE"
+            bitbucket_uri = '/'.join([self.base_url, owner, repo, 'commit', sha, 'statuses', 'build'])
+            response = yield self.session.post(bitbucket_uri, json=body)
+            if response.status_code != 201:
+                log.msg("%s: unable to upload Bitbucket status: %s" %
+                        (response.status_code, response.content))
             else:
                 log.msg("Unable to determine owner or repository name: (owner: %s, repo: %s)" %
                         (str(owner), str(repo)))
@@ -79,8 +79,8 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
                     https://bitbucket.com/OWNER/REPONAME.git
         :return: owner, repo: The owner of the repository and the repository name
         """
-        owner = None
-        repo = None
+        owner = 'repo'
+        repo = 'repo'
         if repourl.startswith('git@'):
             tail = repourl.split(':')[-1]
             owner = tail.split('/')[-2]

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -61,7 +61,6 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
             if oauth_request.status_code == 200:
                 token = json.loads(oauth_request.content)['access_token']
             self.session.headers.update({'Authorization': 'Bearer ' + token})
-            print "HERE"
             bitbucket_uri = '/'.join([self.base_url, owner, repo, 'commit', sha, 'statuses', 'build'])
             response = yield self.session.post(bitbucket_uri, json=body)
             if response.status_code != 201:
@@ -75,8 +74,9 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
         """
         Takes a git repository URL from Bitbucket and tries to determine the owner and repository name
         :param repourl: Bitbucket git repo in the form of
-                    git@bitbucket.com/OWNER/REPONAME.git
+                    git@bitbucket.com:OWNER/REPONAME.git
                     https://bitbucket.com/OWNER/REPONAME.git
+                    ssh://git@bitbucket.com/OWNER/REPONAME.git
         :return: owner, repo: The owner of the repository and the repository name
         """
         owner = 'repo'
@@ -85,7 +85,7 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
             tail = repourl.split(':')[-1]
             owner = tail.split('/')[-2]
             repo = tail.split('/')[-1]
-        elif repourl.startswith('http'):
+        elif repourl.startswith('http') or repourl.startswith('ssh://git@'):
             repo = repourl.split('/')[-1]
             owner = repourl.split('/')[-2]
         if repo is not None and repo.endswith('.git'):

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -60,7 +60,7 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
                 oauth_request = yield self.session.post(self.oauth_url, auth=self.auth,
                                                        data={'grant_type': 'client_credentials'})
                 if oauth_request.status_code == 200:
-                    token =  json.loads(oauth_request.content)['access_token']
+                    token = json.loads(oauth_request.content)['access_token']
                 self.session.headers.update({'Authorization': 'Bearer ' + token})
                 bitbucket_uri = '/'.join([self.base_url, owner, repo, 'commit', sha, 'statuses', 'build'])
                 response = yield self.session.post(bitbucket_uri, json=body)
@@ -91,4 +91,3 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
         if repo is not None and repo.endswith('.git'):
             repo = repo[:-4]
         return owner, repo
-

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -1,0 +1,94 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import json
+
+from twisted.internet import defer
+from twisted.python import log
+
+from buildbot.process.results import SUCCESS
+from buildbot.reporters import http
+
+# Magic words understood by Butbucket REST API
+BITBUCKET_INPROGRESS = 'INPROGRESS'
+BITBUCKET_SUCCESSFUL = 'SUCCESSFUL'
+BITBUCKET_FAILED = 'FAILED'
+
+
+class BitbucketStatusPush(http.HttpStatusPushBase):
+    name = "BitbucketStatusPush"
+
+    @defer.inlineCallbacks
+    def reconfigService(self, oauth_key, oauth_secret, base_url='https://api.bitbucket.org/2.0/repositories',
+                        oauth_url='https://bitbucket.org/site/oauth2/access_token', **kwargs):
+        yield http.HttpStatusPushBase.reconfigService(self, **kwargs)
+        if base_url.endswith('/'):
+            base_url = base_url[:-1]
+        self.base_url = base_url
+        self.oauth_url = oauth_url
+        self.auth = (oauth_key, oauth_secret)
+
+    @defer.inlineCallbacks
+    def send(self, build):
+        results = build['results']
+        if build['complete']:
+            status = BITBUCKET_SUCCESSFUL if results == SUCCESS else BITBUCKET_FAILED
+        else:
+            status = BITBUCKET_INPROGRESS
+        for sourcestamp in build['buildset']['sourcestamps']:
+            sha = sourcestamp['revision']
+            body = {'state': status,
+                    'key': build['builder']['name'],
+                    'name': build['builder']['name'],
+                    'url': build['url']
+                    }
+            owner, repo = self.get_owner_and_repo(sourcestamp['repository'])
+            if repo is not None and owner is not None:
+                token = ''
+                oauth_request = yield self.session.post(self.oauth_url, auth=self.auth,
+                                                       data={'grant_type': 'client_credentials'})
+                if oauth_request.status_code == 200:
+                    token =  json.loads(oauth_request.content)['access_token']
+                self.session.headers.update({'Authorization': 'Bearer ' + token})
+                bitbucket_uri = '/'.join([self.base_url, owner, repo, 'commit', sha, 'statuses', 'build'])
+                response = yield self.session.post(bitbucket_uri, json=body)
+                if response.status_code != 201:
+                    log.msg("%s: unable to upload Bitbucket status: %s" %
+                            (response.status_code, response.content))
+            else:
+                log.msg("Unable to determine owner or repository name: (owner: %s, repo: %s)" %
+                        (str(owner), str(repo)))
+
+    def get_owner_and_repo(self, repourl):
+        """
+        Takes a git repository URL from Bitbucket and tries to determine the owner and repository name
+        :param repourl: Bitbucket git repo in the form of
+                    git@bitbucket.com/OWNER/REPONAME.git
+                    https://bitbucket.com/OWNER/REPONAME.git
+        :return: owner, repo: The owner of the repository and the repository name
+        """
+        owner = None
+        repo = None
+        if repourl.startswith('git@'):
+            tail = repourl.split(':')[-1]
+            owner = tail.split('/')[-2]
+            repo = tail.split('/')[-1]
+        elif repourl.startswith('http'):
+            repo = repourl.split('/')[-1]
+            owner = repourl.split('/')[-2]
+        if repo is not None and repo.endswith('.git'):
+            repo = repo[:-4]
+        return owner, repo
+

--- a/master/buildbot/test/unit/test_reporter_bitbucket.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucket.py
@@ -1,0 +1,81 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+from mock import Mock
+from mock import call
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot import config
+from buildbot.process.results import FAILURE
+from buildbot.process.results import SUCCESS
+from buildbot.reporters.bitbucket import BitbucketStatusPush
+from buildbot.test.fake import fakemaster
+from buildbot.test.util.reporter import ReporterTestMixin
+
+
+class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        # ignore config error if txrequests is not installed
+        config._errors = Mock()
+        self.master = fakemaster.make_master(testcase=self,
+                                             wantData=True, wantDb=True, wantMq=True)
+
+        self.sp = sp = BitbucketStatusPush("key", "secret")
+        sp.sessionFactory = Mock(return_value=Mock())
+        yield sp.setServiceParent(self.master)
+        yield sp.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.sp.stopService()
+        self.assertEqual(self.sp.session.close.call_count, 1)
+        config._errors = None
+
+    @defer.inlineCallbacks
+    def setupBuildResults(self, buildResults):
+        self.insertTestData([buildResults], buildResults)
+        build = yield self.master.data.get(("builds", 20))
+        defer.returnValue(build)
+
+    @defer.inlineCallbacks
+    def test_basic(self):
+        build = yield self.setupBuildResults(SUCCESS)
+        build['complete'] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        build['complete'] = True
+        self.sp.buildFinished(("build", 20, "finished"), build)
+        build['results'] = FAILURE
+        self.sp.buildFinished(("build", 20, "finished"), build)
+        # we make sure proper calls to txrequests have been made
+        self.assertEqual(
+            self.sp.session.post.mock_calls, [
+            call('https://bitbucket.org/site/oauth2/access_token', auth=('key', 'secret'),
+                 data={'grant_type': 'client_credentials'}),
+            call(u'https://api.bitbucket.org/2.0/repositories/repo/repo/commit/d34db33fd43db33f/statuses/build',
+                 json={'url': 'http://localhost:8080/#builders/79/builds/0',
+                  'state': 'INPROGRESS', 'key': u'Builder0', 'name': u'Builder0'}),
+            call('https://bitbucket.org/site/oauth2/access_token', auth=('key', 'secret'),
+                  data={'grant_type': 'client_credentials'}),
+            call(u'https://api.bitbucket.org/2.0/repositories/repo/repo/commit/d34db33fd43db33f/statuses/build',
+                  json={'url': 'http://localhost:8080/#builders/79/builds/0',
+                   'state': 'SUCCESSFUL', 'key': u'Builder0', 'name': u'Builder0'}),
+            call('https://bitbucket.org/site/oauth2/access_token', auth=('key', 'secret'),
+                  data={'grant_type': 'client_credentials'}),
+            call(u'https://api.bitbucket.org/2.0/repositories/repo/repo/commit/d34db33fd43db33f/statuses/build',
+                  json={'url': 'http://localhost:8080/#builders/79/builds/0',
+                   'state': 'FAILED', 'key': u'Builder0', 'name': u'Builder0'})
+        ])

--- a/master/buildbot/test/unit/test_reporter_bitbucket.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucket.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from mock import Mock
 from mock import call
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -67,15 +68,15 @@ class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin):
                  data={'grant_type': 'client_credentials'}),
             call(u'https://api.bitbucket.org/2.0/repositories/repo/repo/commit/d34db33fd43db33f/statuses/build',
                  json={'url': 'http://localhost:8080/#builders/79/builds/0',
-                  'state': 'INPROGRESS', 'key': u'Builder0', 'name': u'Builder0'}),
+                       'state': 'INPROGRESS', 'key': u'Builder0', 'name': u'Builder0'}),
             call('https://bitbucket.org/site/oauth2/access_token', auth=('key', 'secret'),
-                  data={'grant_type': 'client_credentials'}),
+                 data={'grant_type': 'client_credentials'}),
             call(u'https://api.bitbucket.org/2.0/repositories/repo/repo/commit/d34db33fd43db33f/statuses/build',
-                  json={'url': 'http://localhost:8080/#builders/79/builds/0',
-                   'state': 'SUCCESSFUL', 'key': u'Builder0', 'name': u'Builder0'}),
+                 json={'url': 'http://localhost:8080/#builders/79/builds/0',
+                       'state': 'SUCCESSFUL', 'key': u'Builder0', 'name': u'Builder0'}),
             call('https://bitbucket.org/site/oauth2/access_token', auth=('key', 'secret'),
-                  data={'grant_type': 'client_credentials'}),
+                 data={'grant_type': 'client_credentials'}),
             call(u'https://api.bitbucket.org/2.0/repositories/repo/repo/commit/d34db33fd43db33f/statuses/build',
-                  json={'url': 'http://localhost:8080/#builders/79/builds/0',
-                   'state': 'FAILED', 'key': u'Builder0', 'name': u'Builder0'})
+                 json={'url': 'http://localhost:8080/#builders/79/builds/0',
+                       'state': 'FAILED', 'key': u'Builder0', 'name': u'Builder0'})
         ])

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -879,7 +879,7 @@ As a result, we recommend you use https in your base_url rather than http.
     :param string password: the stash user's password
     :param list builders: only send update for specified builders
 
-.. bb:reporter::BitbucketStatusPush
+.. bb:reporter:: BitbucketStatusPush
 
 BitbucketStatusPush
 ~~~~~~~~~~~~~~~~~~~

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -884,7 +884,6 @@ As a result, we recommend you use https in your base_url rather than http.
 BitbucketStatusPush
 ~~~~~~~~~~~~~~~~~~~
 
-.. @cindex BitbucketStatusPush
 .. py:class:: buildbot.reporters.bitbucket.BitbucketStatusPush
 
 ::
@@ -899,11 +898,12 @@ It tracks the last build for each builderName for each commit built.
 
 It requires `txrequests`_ package to allow interaction with the Bitbucket REST and OAuth APIs.
 
-It uses OAuth 2.x to authenticate with Bitbucket. To enable this, you need to go to your
-Bitbucket Settings -> OAuth page. Click "Add consumer". Give the new consumer a name, eg 'buildbot',
-and put in any URL as the callback (this is needed for Oauth 2.x but is not used by this reporter,
-eg 'https://localhost:8010/callback'). Give the consumer Repositories:Write access. After creating the consumer,
-you will then be able to see the OAuth key and secret.
+It uses OAuth 2.x to authenticate with Bitbucket.
+To enable this, you need to go to your Bitbucket Settings -> OAuth page.
+Click "Add consumer".
+Give the new consumer a name, eg 'buildbot', and put in any URL as the callback (this is needed for Oauth 2.x but is not used by this reporter, eg 'https://localhost:8010/callback').
+Give the consumer Repositories:Write access.
+After creating the consumer, you will then be able to see the OAuth key and secret.
 
 .. py:class:: BitbucketStatusPush(oauth_key, oauth_secret, base_url='https://api.bitbucket.org/2.0/repositories', oauth_url='https://bitbucket.org/site/oauth2/access_token', builders=None)
 

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -899,9 +899,9 @@ It tracks the last build for each builderName for each commit built.
 
 It requires `txrequests`_ package to allow interaction with the Bitbucket REST and OAuth APIs.
 
-It uses OAUTH 2.x to authenticate with Bitbucket. To enable this, you need to go to your
+It uses OAuth 2.x to authenticate with Bitbucket. To enable this, you need to go to your
 Bitbucket Settings -> OAuth page. Click "Add consumer". Give the new consumer a name, eg 'buildbot',
-and put in any URL as the callback (this is needed for Oauth2 but is not used by this reporter,
+and put in any URL as the callback (this is needed for Oauth 2.x but is not used by this reporter,
 eg 'https://localhost:8010/callback'). Give the consumer Repositories:Write access. After creating the consumer,
 you will then be able to see the OAuth key and secret.
 
@@ -1067,3 +1067,6 @@ Here's a complete example:
                 result['notify'] = (build['results'] != 0)
             return result
 
+.. spelling::
+
+    OAuth

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -879,6 +879,39 @@ As a result, we recommend you use https in your base_url rather than http.
     :param string password: the stash user's password
     :param list builders: only send update for specified builders
 
+.. bb:reporter::BitbucketStatusPush
+
+BitbucketStatusPush
+~~~~~~~~~~~~~~~~~~~
+
+.. @cindex BitbucketStatusPush
+.. py:class:: buildbot.reporters.bitbucket.BitbucketStatusPush
+
+::
+
+    from buildbot.plugins import reporters
+    bs = reporters.BitbucketStatusPush('oauth_key', 'oauth_secret')
+    c['services'].append(bs)
+
+:class:`BitbucketStatusPush` publishes build status using `Bitbucket Build Status API <https://confluence.atlassian.com/bitbucket/buildstatus-resource-779295267.html>`_.
+The build status is published to a specific commit SHA in Bitbucket.
+It tracks the last build for each builderName for each commit built.
+
+It requires `txrequests`_ package to allow interaction with the Bitbucket REST and OAuth APIs.
+
+It uses OAUTH 2.x to authenticate with Bitbucket. To enable this, you need to go to your
+Bitbucket Settings -> OAuth page. Click "Add consumer". Give the new consumer a name, eg 'buildbot',
+and put in any URL as the callback (this is needed for Oauth2 but is not used by this reporter,
+eg 'https://localhost:8010/callback'). Give the consumer Repositories:Write access. After creating the consumer,
+you will then be able to see the OAuth key and secret.
+
+.. py:class:: BitbucketStatusPush(oauth_key, oauth_secret, base_url='https://api.bitbucket.org/2.0/repositories', oauth_url='https://bitbucket.org/site/oauth2/access_token', builders=None)
+
+    :param string oauth_key: The OAuth consumer key
+    :param string oauth_secret: The OAuth consumer secret
+    :param string base_url: Bitbucket's Build Status API URL
+    :param string oauth_url: Bitbucket's OAuth API URL
+    :param list builders: only send update for specified builders
 
 .. bb:reporter:: GitLabStatusPush
 

--- a/master/docs/relnotes/0.9.0rc1.rst
+++ b/master/docs/relnotes/0.9.0rc1.rst
@@ -23,6 +23,8 @@ Features
 
 * The ``dist`` parameter in :bb:step:`RpmBuild` is now renderable.
 
+* new :bb:reporter:`BitbucketStatusPush` to report build results to a Bitbucket Cloud repository.
+
 Fixes
 ~~~~~
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -301,6 +301,7 @@ setup_args = {
             ('buildbot.reporters.http', ['HttpStatusPush']),
             ('buildbot.reporters.github', ['GitHubStatusPush']),
             ('buildbot.reporters.stash', ['StashStatusPush']),
+            ('buildbot.reporters.bitbucket', ['BitbucketStatusPush']),
             ('buildbot.reporters.irc', ['IRC']),
 
         ]),


### PR DESCRIPTION
Bitbucket's build status API is introduced here: 
https://blog.bitbucket.org/2015/11/18/introducing-the-build-status-api-for-bitbucket-cloud/

It seems quite different with respect to the URLs for the Stash build status API, and also used OAuth, so I made this reporter instead. Since I do not use stash

The docs page has been updated to show how to create and OAuth key for this reporter.

For testing I used a test Bitbucket repo here
https://bitbucket.org/scottbragg_aq1/testbb/commits/all