### PR TITLE
Fix the cancel and stop story

### DIFF
--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -25,8 +25,12 @@ Master
 Features
 ~~~~~~~~
 
+* add a UI button to allow to cancel the whole queue for a builder
+
 Fixes
 ~~~~~
+
+* fix the UI to allow to cancel a buildrequest (:bug:`3582`)
 
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/www/base/src/app/builders/builder/builder.controller.coffee
+++ b/www/base/src/app/builders/builder/builder.controller.coffee
@@ -1,10 +1,13 @@
 class Builder extends Controller
     constructor: ($rootScope, $scope, dataService, $stateParams, resultsService, recentStorage,
-        glBreadcrumbService, $state, glTopbarContextualActionsService) ->
+        glBreadcrumbService, $state, glTopbarContextualActionsService, $q) ->
         # make resultsService utilities available in the template
         _.mixin($scope, resultsService)
         data = dataService.open().closeOnDestroy($scope)
         builderid = $stateParams.builder
+        $scope.forceschedulers = []
+        $scope.is_cancelling = false
+
         data.getBuilders(builderid).onNew = (builder) ->
             $scope.builder = builder
             breadcrumb = [
@@ -23,19 +26,74 @@ class Builder extends Controller
                 glBreadcrumbService.setBreadcrumb(breadcrumb)
             glBreadcrumbService.setBreadcrumb(breadcrumb)
 
-            builder.getForceschedulers().onChange = (forceschedulers) ->
-                $scope.forceschedulers = forceschedulers
-                actions = []
-                _.forEach forceschedulers, (sch) ->
+            doCancel = ->
+                if $scope.is_cancelling
+                    return
+                if not window.confirm("Are you sure you want to cancel all builds?")
+                    return
+                $scope.is_cancelling = true
+                refreshContextMenu()
+
+                success = (res) ->
+                    $scope.is_cancelling = false
+                    refreshContextMenu()
+
+                failure = (why) ->
+                    $scope.is_cancelling = false
+                    $scope.error = "Cannot cancel: " + why.error.message
+                    refreshContextMenu()
+
+                dl = []
+                $scope.buildrequests.forEach (buildrequest) ->
+                    if not buildrequest.claimed
+                        dl.push buildrequest.control('cancel')
+                $scope.builds.forEach (build) ->
+                    if not build.complete
+                        dl.push build.control('stop')
+                $q.when(dl).then(success, failure)
+
+            refreshContextMenu = ->
+                if $scope.$$destroyed
+                    return
+                actions = [
+                ]
+                canStop = false
+                $scope.builds.forEach (build) ->
+                    if not build.complete
+                        canStop = true
+                $scope.buildrequests.forEach (buildrequest) ->
+                    if not buildrequest.claimed
+                        canStop = true
+
+                if canStop
+                    if $scope.is_cancelling
+                        actions.push
+                            caption: "Cancelling..."
+                            icon: "spinner fa-spin"
+                            action: doCancel
+                    else
+                        actions.push
+                            caption: "Cancel whole queue"
+                            extra_class: "btn-danger"
+                            icon: "stop"
+                            action: doCancel
+                _.forEach $scope.forceschedulers, (sch) ->
                     actions.push
                         caption: sch.button_name
                         extra_class: "btn-primary"
-                        action: -> $state.go("builder.forcebuilder", scheduler:sch.name)
+                        action: ->
+                            $state.go("builder.forcebuilder",
+                                scheduler:sch.name)
 
-                # reinstall contextual actions when coming back from forcesched
                 glTopbarContextualActionsService.setContextualActions(actions)
-                $scope.$on '$stateChangeSuccess', ->
-                    glTopbarContextualActionsService.setContextualActions(actions)
 
+            builder.getForceschedulers().onChange = (forceschedulers) ->
+                $scope.forceschedulers = forceschedulers
+                refreshContextMenu()
+                # reinstall contextual actions when coming back from forcesched
+                $scope.$on '$stateChangeSuccess', ->
+                    refreshContextMenu()
             $scope.builds = builder.getBuilds(limit:20, order:'-number')
             $scope.buildrequests = builder.getBuildrequests(claimed:false)
+            $scope.builds.onChange=refreshContextMenu
+            $scope.buildrequests.onChange=refreshContextMenu

--- a/www/base/src/app/builders/buildrequest/buildrequest.controller.coffee
+++ b/www/base/src/app/builders/buildrequest/buildrequest.controller.coffee
@@ -17,8 +17,7 @@ class Buildrequest extends Controller
             refreshContextMenu()
 
             success = (res) ->
-                $state.go 'builder',
-                    builder: $scope.buildrequest.builderid
+                # refresh is done via complete event
 
             failure = (why) ->
                 $scope.is_cancelling = false
@@ -48,7 +47,8 @@ class Buildrequest extends Controller
 
         data = dataService.open().closeOnDestroy($scope)
         data.getBuildrequests($stateParams.buildrequest).onNew = (buildrequest) ->
-            $scope.buildrequest = publicFieldsFilter(buildrequest)
+            $scope.buildrequest = buildrequest
+            $scope.raw_buildrequest = publicFieldsFilter(buildrequest)
             data.getBuilders(buildrequest.builderid).onNew = (builder) ->
                 $scope.builder = builder
                 breadcrumb = [

--- a/www/base/src/app/builders/buildrequest/buildrequest.tpl.jade
+++ b/www/base/src/app/builders/buildrequest/buildrequest.tpl.jade
@@ -7,7 +7,7 @@
               properties(properties="properties")
           uib-tab(heading="Debug")
               h4 Buildrequest
-              rawdata(data="buildrequest")
+              rawdata(data="raw_buildrequest")
               h4 Buildset
               rawdata(data="buildset")
               h4 Builder


### PR DESCRIPTION
Cancel of a buildrequest was not working in the buildrequest page.

(pushing to release branch for that reason http://trac.buildbot.net/ticket/3582)

When there are tons of buildrequests in the queue this is very painful to stop them all manually

So we also add a feature that was in buildbot eight cancel whole queue. Unlike in eight the whole queue means buildrequests *and* running builds for the sake of simplicity

We can still change the code to add a separate button to avoid killing running builds.