### PR TITLE
Enhance buildrequest summary so that it look more like a buildsummary

### DIFF
--- a/master/buildbot/schedulers/triggerable.py
+++ b/master/buildbot/schedulers/triggerable.py
@@ -32,8 +32,6 @@ class Triggerable(base.BaseScheduler):
         base.BaseScheduler.__init__(self, name, builderNames, **kwargs)
         self._waiters = {}
         self._buildset_complete_consumer = None
-        if reason is None:
-            reason = u"The Triggerable scheduler named '%s' triggered this build" % name
         self.reason = reason
 
     def trigger(self, waited_for, sourcestamps=None, set_props=None,
@@ -46,14 +44,20 @@ class Triggerable(base.BaseScheduler):
         # potentially overridden by anything from the triggering build
         props = Properties()
         props.updateFromProperties(self.properties)
+
+        reason = self.reason
         if set_props:
             props.updateFromProperties(set_props)
+            reason = set_props.getProperty('reason')
+
+        if reason is None:
+            reason = u"The Triggerable scheduler named '%s' triggered this build" % self.name
 
         # note that this does not use the buildset subscriptions mechanism, as
         # the duration of interest to the caller is bounded by the lifetime of
         # this process.
         idsDeferred = self.addBuildsetForSourceStampsWithDefaults(
-            self.reason,
+            reason,
             sourcestamps, waited_for,
             properties=props,
             parent_buildid=parent_buildid,

--- a/master/buildbot/test/unit/test_schedulers_triggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_triggerable.py
@@ -158,7 +158,7 @@ class Triggerable(scheduler.SchedulerMixin, unittest.TestCase):
     def test_constructor_no_reason(self):
         sched = self.makeScheduler()
         self.assertEqual(
-            sched.reason, "The Triggerable scheduler named 'n' triggered this build")
+            sched.reason, None)  # default reason is dynamic
 
     def test_constructor_explicit_reason(self):
         sched = self.makeScheduler(reason="Because I said so")
@@ -329,6 +329,27 @@ class Triggerable(scheduler.SchedulerMixin, unittest.TestCase):
                 'properties': {'scheduler': ('n', 'Scheduler')},
                 'reason': "The Triggerable scheduler named 'n' triggered "
                           "this build",
+                'sourcestamps': [],
+                'waited_for': True}),
+        ])
+
+    @defer.inlineCallbacks
+    def test_trigger_with_reason(self):
+        # Test triggering with a reason, and make sure the buildset's reason is updated accordingly
+        # (and not the default)
+        waited_for = True
+        sched = self.makeScheduler(overrideBuildsetMethods=True)
+        set_props = properties.Properties()
+        set_props.setProperty('reason', 'test1', 'test')
+        idsDeferred, d = sched.trigger(
+            waited_for, sourcestamps=[], set_props=set_props)
+        yield idsDeferred
+
+        self.assertEqual(self.addBuildsetCalls, [
+            ('addBuildsetForSourceStampsWithDefaults', {
+                'builderNames': None,
+                'properties': {'scheduler': ('n', 'Scheduler'), 'reason': ('test1', 'test')},
+                'reason': "test1",
                 'sourcestamps': [],
                 'waited_for': True}),
         ])

--- a/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.coffee
@@ -11,12 +11,17 @@ class Buildrequestsummary extends Directive('common')
 
 
 class _buildrequestsummary extends Controller('common')
-    constructor: ($scope, dataService, findBuilds) ->
+    constructor: ($scope, dataService, findBuilds, resultsService) ->
+        _.mixin($scope, resultsService)
         $scope.$watch "buildrequest.claimed", (n, o) ->
             if n  # if it is unclaimed, then claimed, we need to try again
                 findBuilds $scope,
                     $scope.buildrequest.buildrequestid
 
         data = dataService.open().closeOnDestroy($scope)
-        data.getBuildrequests($scope.buildrequestid).then (buildrequests) ->
-            $scope.buildrequest = buildrequests[0]
+        data.getBuildrequests($scope.buildrequestid).onNew = (buildrequest) ->
+            $scope.buildrequest = buildrequest
+            data.getBuildsets(buildrequest.buildsetid).onNew = (buildset) ->
+                $scope.buildset = buildset
+            data.getBuilders(buildrequest.builderid).onNew = (builder) ->
+                $scope.builder = builder

--- a/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.tpl.jade
@@ -1,8 +1,25 @@
 div
-  div(ng-if="buildrequest.claimed")
-    div(ng-repeat="build in builds")
+  div(ng-repeat="build in builds")
       buildsummary(buildid="build.buildid", condensed="true")
-  div(ng-if="!buildrequest.claimed")
-    span.badge-status.status_pending.pulse
-        | &nbsp;
-    | waiting for available worker
+  div(ng-if="!builds")
+    .panel.panel-default.results_PENDING(style="margin-bottom:0px;opacity:.7")
+      .panel-heading.no-select
+          .flex-row
+              .flex-grow-1
+                a(ui-sref="builder({builder:builder.builderid})")
+                    | {{builder.name}}
+                | #{' '}/ buildrequests /#{' '}
+                a(ui-sref="buildrequest({buildrequest:buildrequest.buildrequestid})")
+                    | {{buildrequest.buildrequestid}}
+                | #{' '}| {{buildset.reason}}
+              .flex-grow-1.text-right
+                  div(ng-if="!buildrequest.claimed")
+                      span
+                        | waiting for available worker#{' '}
+                      .label.results_PENDING
+                        | ...
+                  div(ng-if="buildrequest.claimed")
+                    span
+                      | #{' '}{{buildrequest.state_string}}#{' '}
+                    .label(ng-class="results2class(buildrequest)")
+                      | {{results2text(buildrequest)}}

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -1,59 +1,60 @@
-.panel.panel-default(ng-class="results2class(buildsummary.build)")
-  .panel-heading.no-select
-    .row
-      .col-sm-6
-        .btn.btn-xs.btn-default(ng-click="buildsummary.toggleFullDisplay()", title="Expand all step logs")
-            i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':buildsummary.fulldisplay}")
-        .btn.btn-xs.btn-default(ng-click="buildsummary.toggleDetails()", title="Show steps according to their importance")
-            i.fa.fa-expand
-            | {{buildsummary.levelOfDetails()}}
-        | &nbsp;
-        span(ng-if="buildsummary.prefix") {{buildsummary.prefix}}&nbsp;
-        a(ui-sref="build({builder:buildsummary.builder.builderid, build:buildsummary.build.number})")
-          | {{buildsummary.builder.name}}/{{buildsummary.build.number}}&nbsp;
-        span(ng-if="buildsummary.reason") |&nbsp;{{buildsummary.reason}}
-      .col-sm-6.text-right
-          span(ng-show="buildsummary.build.complete")
-              | {{(buildsummary.build.complete_at - buildsummary.build.started_at)| durationformat:'LLL' }}
-          span(ng-show="!buildsummary.build.complete")
-              | {{(buildsummary.now - buildsummary.build.started_at)| durationformat:'LLL' }}
-          span
-            | &nbsp;{{buildsummary.build.state_string}}&nbsp;
-          .label(ng-class="results2class(buildsummary.build)")
-            | {{results2text(buildsummary.build)}}
-          span(ng-if="buildsummary.parentbuild")
-              | &nbsp;
-              a.label(ng-class="results2class(buildsummary.parentbuild)",
-              ui-sref="build({builder:buildsummary.parentbuilder.builderid, build:buildsummary.parentbuild.number})")
-                    | {{buildsummary.parentrelationship}}:
-                    | {{buildsummary.parentbuilder.name}}/{{buildsummary.parentbuild.number}}
-  ul.list-group.no-select
-    li.list-group-item(ng-if="buildsummary.isStepDisplayed(step)"
-                       ng-repeat="step in buildsummary.steps | orderBy: ['stepid']")
-      div(ng-click="step.fulldisplay=!step.fulldisplay")
-          span.pull-right(ng-if="step.started_at")
-            span(ng-show="step.complete")
-                | {{ step.duration| durationformat:'LLL' }}
-            span(ng-show="!step.complete")
-                | {{ buildsummary.now - step.started_at| durationformat:'LLL' }}
-            | &nbsp;{{step.state_string}}
-          span.badge-status(ng-class="results2class(step, 'pulse')")
-            | {{step.number}}
-          | &nbsp;
-          i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':step.fulldisplay}", ng-if="step.logs.length")
-          | &nbsp; {{step.name}}
-      div.anim-stepdetails(ng-show="step.fulldisplay")
+.panel.panel-default(ng-class="results2class(buildsummary.build)", style="margin-bottom:0px")
+    .panel-heading.no-select
+        .flex-row
+            .flex-grow-1
+                .btn.btn-xs.btn-default(ng-click="buildsummary.toggleFullDisplay()", title="Expand all step logs")
+                    i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':buildsummary.fulldisplay}")
+                .btn.btn-xs.btn-default(ng-click="buildsummary.toggleDetails()", title="Show steps according to their importance")
+                    i.fa.fa-expand
+                    | {{buildsummary.levelOfDetails()}}
+                | #{' '}
+                span(ng-if="buildsummary.prefix") {{buildsummary.prefix}}#{' '}
+                a(ui-sref="build({builder:buildsummary.builder.builderid, build:buildsummary.build.number})")
+                  | {{buildsummary.builder.name}}/{{buildsummary.build.number}}#{' '}
+                span(ng-if="buildsummary.reason") | {{buildsummary.reason}}
+            .flex-grow-1
+                .pull-right
+                    span(ng-show="buildsummary.build.complete")
+                        | {{(buildsummary.build.complete_at - buildsummary.build.started_at)| durationformat:'LLL' }}
+                    span(ng-show="!buildsummary.build.complete")
+                        | {{(buildsummary.now - buildsummary.build.started_at)| durationformat:'LLL' }}
+                    span
+                      | #{' '}{{buildsummary.build.state_string}}#{' '}
+                    .label(ng-class="results2class(buildsummary.build)")
+                      | {{results2text(buildsummary.build)}}
+                    span(ng-if="buildsummary.parentbuild")
+                        | #{' '}
+                        a.label(ng-class="results2class(buildsummary.parentbuild)",
+                        ui-sref="build({builder:buildsummary.parentbuilder.builderid, build:buildsummary.parentbuild.number})")
+                              | {{buildsummary.parentrelationship}}:
+                              | {{buildsummary.parentbuilder.name}}/{{buildsummary.parentbuild.number}}
+    ul.list-group.no-select
+      li.list-group-item(ng-if="buildsummary.isStepDisplayed(step)"
+                         ng-repeat="step in buildsummary.steps | orderBy: ['stepid']")
+        div(ng-click="step.fulldisplay=!step.fulldisplay")
+            span.pull-right(ng-if="step.started_at")
+              span(ng-show="step.complete")
+                  | {{ step.duration| durationformat:'LLL' }}
+              span(ng-show="!step.complete")
+                  | {{ buildsummary.now - step.started_at| durationformat:'LLL' }}
+              | #{' '}{{step.state_string}}
+            span.badge-status(ng-class="results2class(step, 'pulse')")
+              | {{step.number}}
+            | #{' '}
+            i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':step.fulldisplay}", ng-if="step.logs.length")
+            | #{' '} {{step.name}}
+        div.anim-stepdetails(ng-show="step.fulldisplay")
+          ul
+            li(ng-repeat="log in step.logs")
+              a(ng-href="api/v2/logs/{{log.logid}}/raw")
+                  i.fa.fa-download
+              | #{' '}
+              a(ui-sref="log({builder:buildsummary.builder.builderid, build:buildsummary.build.number, step: step.number, log:log.slug})")
+                  | {{log.name}}
+              | #{' '}({{log.num_lines}} line{{log.num_lines > 1?'s':''}})
         ul
-          li(ng-repeat="log in step.logs")
-            a(ng-href="api/v2/logs/{{log.logid}}/raw")
-                i.fa.fa-download
-            | &nbsp;
-            a(ui-sref="log({builder:buildsummary.builder.builderid, build:buildsummary.build.number, step: step.number, log:log.slug})")
-                | {{log.name}}
-            | &nbsp;({{log.num_lines}} line{{log.num_lines > 1?'s':''}})
-      ul
-        li(ng-if='!(buildsummary.isBuildRequestURL(url.url) || buildsummary.isBuildURL(url.url))', ng-repeat="url in step.urls")
-          a(target="_blank", ng-href="{{url.url}}") {{url.name}}
-      ul.list-unstyled
-        li(ng-if='buildsummary.isBuildRequestURL(url.url)', ng-repeat="url in step.urls")
-          buildrequestsummary(style="margin-left:30px;margin-top:8px",buildrequestid='buildsummary.getBuildRequestIDFromURL(url.url)')
+          li(ng-if='!(buildsummary.isBuildRequestURL(url.url) || buildsummary.isBuildURL(url.url))', ng-repeat="url in step.urls")
+            a(target="_blank", ng-href="{{url.url}}") {{url.name}}
+        ul.list-unstyled
+          li(ng-if='buildsummary.isBuildRequestURL(url.url)', ng-repeat="url in step.urls")
+            buildrequestsummary(style="margin-left:30px;margin-top:8px",buildrequestid='buildsummary.getBuildRequestIDFromURL(url.url)')

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -12,22 +12,21 @@
                 a(ui-sref="build({builder:buildsummary.builder.builderid, build:buildsummary.build.number})")
                   | {{buildsummary.builder.name}}/{{buildsummary.build.number}}#{' '}
                 span(ng-if="buildsummary.reason") | {{buildsummary.reason}}
-            .flex-grow-1
-                .pull-right
-                    span(ng-show="buildsummary.build.complete")
-                        | {{(buildsummary.build.complete_at - buildsummary.build.started_at)| durationformat:'LLL' }}
-                    span(ng-show="!buildsummary.build.complete")
-                        | {{(buildsummary.now - buildsummary.build.started_at)| durationformat:'LLL' }}
-                    span
-                      | #{' '}{{buildsummary.build.state_string}}#{' '}
-                    .label(ng-class="results2class(buildsummary.build)")
-                      | {{results2text(buildsummary.build)}}
-                    span(ng-if="buildsummary.parentbuild")
-                        | #{' '}
-                        a.label(ng-class="results2class(buildsummary.parentbuild)",
-                        ui-sref="build({builder:buildsummary.parentbuilder.builderid, build:buildsummary.parentbuild.number})")
-                              | {{buildsummary.parentrelationship}}:
-                              | {{buildsummary.parentbuilder.name}}/{{buildsummary.parentbuild.number}}
+            .flex-grow-1.text-right
+                span(ng-show="buildsummary.build.complete")
+                    | {{(buildsummary.build.complete_at - buildsummary.build.started_at)| durationformat:'LLL' }}
+                span(ng-show="!buildsummary.build.complete")
+                    | {{(buildsummary.now - buildsummary.build.started_at)| durationformat:'LLL' }}
+                span
+                  | #{' '}{{buildsummary.build.state_string}}#{' '}
+                .label(ng-class="results2class(buildsummary.build)")
+                  | {{results2text(buildsummary.build)}}
+                span(ng-if="buildsummary.parentbuild")
+                    | #{' '}
+                    a.label(ng-class="results2class(buildsummary.parentbuild)",
+                    ui-sref="build({builder:buildsummary.parentbuilder.builderid, build:buildsummary.parentbuild.number})")
+                          | {{buildsummary.parentrelationship}}:
+                          | {{buildsummary.parentbuilder.name}}/{{buildsummary.parentbuild.number}}
     ul.list-group.no-select
       li.list-group-item(ng-if="buildsummary.isStepDisplayed(step)"
                          ng-repeat="step in buildsummary.steps | orderBy: ['stepid']")

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -118,3 +118,38 @@
 li.unstyled{
   list-style: none;
 }
+.no-margin{
+  margin: 0px !important;
+}
+
+/* flex row will make the row grow automatically given the size of the content
+   This will make sure all the inside div will fill all content.
+   This is useful when you want to create a row with one left and one right
+   the level of grow give the importance of the div. The more it has grow the more it will win
+   space when fighting against the other divs
+   You can use it with following jade code:
+   .flex-row
+      .flex-grow-1  left content
+      .flex-grow-1
+          .pull-right right content
+
+*/
+.flex-row {
+  display: flex;
+  flex-flow: row;
+
+  /* Then we define how is distributed the remaining space */
+  justify-content: space-around;
+    .flex-grow-1 {
+        flex-grow: 1
+    }
+    .flex-grow-2 {
+        flex-grow: 2
+    }
+    .flex-grow-3 {
+        flex-grow: 3
+    }
+    .flex-grow-4 {
+        flex-grow: 4
+    }
+}


### PR DESCRIPTION
When there are a lot of triggered builds, and no slave available
there are few information to the user on the buildrequest

This commit also enhances the display of the buildsumary by:

- use flexbox to automatically fill the space wether reason or status is the larger

- stop using &nbsp; for trailing space which will not wrap properly

- fix triggerable so that it properly set the reason of the buildset

![image](https://cloud.githubusercontent.com/assets/109859/17221483/4e54c0d4-54f4-11e6-9641-fd70f76bac7c.png)

previous version:
![image](https://cloud.githubusercontent.com/assets/109859/17221527/73f754aa-54f4-11e6-8e51-112dd03c3a20.png)
