### PR TITLE
LatentWorker better handling of substanciation failure cases

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -449,9 +449,7 @@ class BuildStep(results.ResultComputingConfigMixin,
     realUpdateSummary = updateSummary
 
     @defer.inlineCallbacks
-    def startStep(self, remote):
-        self.remote = remote
-
+    def addStep(self):
         # create and start the step, noting that the name may be altered to
         # ensure uniqueness
         self.stepid, self.number, self.name = yield self.master.data.updates.addStep(
@@ -459,6 +457,11 @@ class BuildStep(results.ResultComputingConfigMixin,
             name=util.ascii2unicode(self.name))
         yield self.master.data.updates.startStep(self.stepid)
 
+    @defer.inlineCallbacks
+    def startStep(self, remote):
+        self.remote = remote
+
+        yield self.addStep()
         self.locks = yield self.build.render(self.locks)
 
         # convert all locks into their real form
@@ -792,6 +795,7 @@ class BuildStep(results.ResultComputingConfigMixin,
     @defer.inlineCallbacks
     def addLogWithFailure(self, why, logprefix=""):
         # helper for showing exceptions to the users
+        print why.getTraceback()
         try:
             yield self.addCompleteLog(logprefix + "err.text", why.getTraceback())
             yield self.addHTMLLog(logprefix + "err.html", formatFailure(why))

--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+import os
+
 from twisted.python import threadpool
 from twisted.python.failure import Failure
 from twisted.trial.unittest import SynchronousTestCase
@@ -353,4 +355,4 @@ class Tests(SynchronousTestCase):
         for i in ["err_text", "err_html"]:
             self.assertIn("can't create dir", logs_by_name[i])
             # make sure stacktrace is present in html
-            self.assertIn("test/integration/test_latent.py", logs_by_name[i])
+            self.assertIn(os.path.join("integration", "test_latent.py"), logs_by_name[i])

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -15,7 +15,6 @@
 
 from twisted.internet.defer import Deferred
 from twisted.python import threadpool
-from twisted.python.filepath import FilePath
 from twisted.trial.unittest import SynchronousTestCase
 from zope.interface import implementer
 
@@ -118,9 +117,7 @@ class Tests(SynchronousTestCase):
         # The worker fails to substantiate.
         controller.start_instance(True)
 
-        local_workdir = FilePath(self.mktemp())
-        local_workdir.createDirectory()
-        controller.connect_worker(local_workdir)
+        controller.connect_worker(self)
 
         self.assertEqual(len(started_builds), 1)
 

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -184,6 +184,8 @@ class TestBuild(unittest.TestCase):
 
         self.workerforbuilder = Mock(name='workerforbuilder')
         self.workerforbuilder.worker = self.worker
+        self.workerforbuilder.prepare = lambda _: True
+        self.workerforbuilder.ping = lambda: True
 
         self.build.setBuilder(self.builder)
 
@@ -375,6 +377,8 @@ class TestBuild(unittest.TestCase):
 
         eWorker.worker = self.worker
         cWorker.worker = self.worker
+        eWorker.prepare = cWorker.prepare = lambda _: True
+        eWorker.ping = cWorker.ping = lambda: True
 
         l = WorkerLock('lock', 2)
         claimLog = []

--- a/master/buildbot/test/unit/test_worker_hyper.py
+++ b/master/buildbot/test/unit/test_worker_hyper.py
@@ -123,7 +123,7 @@ class TestHyperLatentWorker(unittest.SynchronousTestCase):
     def test_start_worker_but_error(self):
         worker = self.makeWorker(image="buggy")
         d = worker.substantiate(None, FakeBuild())
-        self.reactor.pump([.1])
+        self.reactor.advance(.1)
         self.failureResultOf(d)
         self.assertIsNotNone(worker.client)
         self.assertEqual(worker.instance, None)

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -419,7 +419,6 @@ class AbstractWorker(service.BuildbotService, object):
         when we wind up with two connections for the same worker, in which
         case we disconnect the older connection.
         """
-
         if self.conn is None:
             return defer.succeed(None)
         log.msg("disconnecting old worker %s now" % (self.name,))
@@ -728,7 +727,7 @@ class AbstractLatentWorker(AbstractWorker):
         self.missing_timer = None
         if self.substantiation_build:
             self.substantiation_build = None
-            self._substantiation_notifier.notify(failure)
+            self._substantiation_notifier.notify(False)
         d = self.insubstantiate()
         d.addErrback(log.err, 'while insubstantiating')
         # notify people, but only if we're still in the config
@@ -877,7 +876,7 @@ class AbstractLatentWorker(AbstractWorker):
             # them
             if self._substantiation_notifier:
                 self.substantiation_build = None
-                self._substantiation_notifier.notify(why)
+                self._substantiation_notifier.notify(False)
             if self.missing_timer:
                 self.missing_timer.cancel()
                 self.missing_timer = None


### PR DESCRIPTION
2 cases are handled here:

- substanciation timeout
- cannot create the build directories

integration test those cases, and refactor to simplify the code
