### PR TITLE
Master shutdown

### DIFF
--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -134,7 +134,7 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
                     for id in brids])
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                 transaction.rollback()
-                raise AlreadyClaimedError
+                raise AlreadyClaimedError()
 
             transaction.commit()
 
@@ -163,7 +163,7 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
                 # went wrong
                 if res.rowcount != len(batch):
                     transaction.rollback()
-                    raise AlreadyClaimedError
+                    raise AlreadyClaimedError()
 
             transaction.commit()
         return self.db.pool.do(thd)

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -271,7 +271,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
 
             if hasattr(signal, "SIGUSR1"):
                 def sigusr1(*args):
-                    self.reactor.callLater(0, self.botmaster.cleanShutdown)
+                    eventually(self.botmaster.cleanShutdown)
                 signal.signal(signal.SIGUSR1, sigusr1)
 
             # get the masterid so other services can use it in
@@ -323,6 +323,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
             yield self.data.updates.masterStopped(
                 name=self.name, masterid=self.masterid)
         if self.running:
+            yield self.botmaster.cleanShutdown(quickMode=True, stopReactor=False)
             yield service.AsyncMultiService.stopService(self)
 
         log.msg("BuildMaster is stopped")

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -795,7 +795,6 @@ class BuildStep(results.ResultComputingConfigMixin,
     @defer.inlineCallbacks
     def addLogWithFailure(self, why, logprefix=""):
         # helper for showing exceptions to the users
-        print why.getTraceback()
         try:
             yield self.addCompleteLog(logprefix + "err.text", why.getTraceback())
             yield self.addHTMLLog(logprefix + "err.html", formatFailure(why))

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -775,7 +775,6 @@ class BuildStep(results.ResultComputingConfigMixin,
     @_maybeUnhandled
     @defer.inlineCallbacks
     def addCompleteLog(self, name, text):
-        log.msg("addCompleteLog(%s)" % name)
         logid = yield self.master.data.updates.addLog(self.stepid,
                                                       util.ascii2unicode(name), u't')
         l = self._newLog(name, u't', logid)
@@ -785,7 +784,6 @@ class BuildStep(results.ResultComputingConfigMixin,
     @_maybeUnhandled
     @defer.inlineCallbacks
     def addHTMLLog(self, name, html):
-        log.msg("addHTMLLog(%s)" % name)
         logid = yield self.master.data.updates.addLog(self.stepid,
                                                       util.ascii2unicode(name), u'h')
         l = self._newLog(name, u'h', logid)

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -219,9 +219,14 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
         if not self.worker or not self.worker.acquireLocks():
             return defer.succeed(False)
 
+        self.state = States.DETACHED
         log.msg("substantiating worker %s" % (self,))
         d = self.substantiate(build)
         return d
+
+    def attached(self, worker, commands):
+        self.state = States.BUILDING
+        return AbstractWorkerForBuilder.attached(self, worker, commands)
 
     def substantiate(self, build):
         return self.worker.substantiate(self, build)

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -225,7 +225,7 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
         return d
 
     def attached(self, worker, commands):
-        self.state = States.BUILDING
+        self.state = States.AVAILABLE
         return AbstractWorkerForBuilder.attached(self, worker, commands)
 
     def substantiate(self, build):

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -225,7 +225,10 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
         return d
 
     def attached(self, worker, commands):
-        self.state = States.AVAILABLE
+        # When a latent worker is attached, it is actually because it prepared for a build
+        # thus building and not available like for normal worker
+        if self.state == States.DETACHED:
+            self.state = States.BUILDING
         return AbstractWorkerForBuilder.attached(self, worker, commands)
 
     def substantiate(self, build):

--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -115,6 +115,10 @@ types:
                                         type: string
                                         required: false
                                         description: The reason why the build was stopped
+                                    results:
+                                        type: integer
+                                        required: false
+                                        description: optionally results value override (default CANCELLED)
                 /actions/rebuild:
                     post:
                         description: |

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
+
 from buildbot.util import service
 
 
@@ -24,6 +26,7 @@ class FakeBotMaster(service.AsyncMultiService):
         self.locks = {}
         self.builders = {}
         self.buildsStartedForWorkers = []
+        self.delayShutdown = False
 
     def getLockByID(self, lockid):
         if lockid not in self.locks:
@@ -45,3 +48,9 @@ class FakeBotMaster(service.AsyncMultiService):
 
     def workerLost(self, bot):
         pass
+
+    def cleanShutdown(self, quickMode=False, stopReactor=True):
+        self.shuttingDown = True
+        if self.delayShutdown:
+            self.shutdownDeferred = defer.Deferred()
+            return self.shutdownDeferred

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -39,12 +39,16 @@ class LatentController(object):
         self.worker = ControllableLatentWorker(name, self, **kwargs)
         self.started = False
         self.stopped = False
+        self.auto_stop_flag = False
 
     def start_instance(self, result):
         assert self.started
         self.started = False
         d, self._start_deferred = self._start_deferred, None
         d.callback(result)
+
+    def auto_stop(self, result):
+        self.auto_stop_flag = result
 
     def stop_instance(self, result):
         assert self.stopped
@@ -90,6 +94,8 @@ class ControllableLatentWorker(AbstractLatentWorker):
 
     def stop_instance(self, build):
         self._controller.stopped = True
+        if self._controller.auto_stop_flag:
+            return succeed(True)
         self._controller._stop_deferred = Deferred()
         return self._controller._stop_deferred
 

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -82,10 +82,10 @@ class OldStyleCustomBuildStep(buildstep.BuildStep):
                 self.failed(failure.Failure(RuntimeError('oh noes')))
             else:
                 self.finished(results.SUCCESS)
-        except Exception as e:
+        except Exception:
             import traceback
             traceback.print_exc()
-            self.failed(failure.Failure(e))
+            self.failed(failure.Failure())
 
 
 class Latin1ProducingCustomBuildStep(buildstep.BuildStep):

--- a/master/buildbot/test/integration/test_hyper.py
+++ b/master/buildbot/test/integration/test_hyper.py
@@ -1,0 +1,103 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+import json
+import os
+from unittest.case import SkipTest
+
+from twisted.internet import defer
+
+from buildbot.process.results import SUCCESS
+from buildbot.test.util.integration import RunMasterBase
+from buildbot.worker import hyper as workerhyper
+from buildbot.worker.hyper import HyperLatentWorker
+
+
+# This integration test creates a master and hyper worker environment,
+# it requires hyper creds to be configured locally with 'hyper config'
+# masterFQDN environment can be used in order to define your internet visible address
+
+class HyperMaster(RunMasterBase):
+
+    def setUp(self):
+        if workerhyper.Hyper is None:
+            raise SkipTest("hyper is not installed")
+        try:
+            workerhyper.Hyper.guess_config()
+        except RuntimeError:
+            raise SkipTest("no default config is detected")
+
+    @defer.inlineCallbacks
+    def test_trigger(self):
+        yield self.setupConfig(masterConfig(), startWorker=False)
+
+        change = dict(branch="master",
+                      files=["foo.c"],
+                      author="me@foo.com",
+                      comments="good stuff",
+                      revision="HEAD",
+                      project="none"
+                      )
+        yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
+        builds = yield self.master.data.get(("builds",))
+        self.assertEqual(len(builds), 2)
+        for b in builds:
+            self.assertEqual(b['results'], SUCCESS)
+
+
+# master configuration
+def masterConfig():
+    c = {}
+    from buildbot.config import BuilderConfig
+    from buildbot.process.factory import BuildFactory
+    from buildbot.plugins import steps, schedulers
+
+    c['schedulers'] = [
+        schedulers.Triggerable(
+            name="trigsched",
+            builderNames=["build"]),
+        schedulers.AnyBranchScheduler(
+            name="sched",
+            builderNames=["testy"])]
+
+    f = BuildFactory()
+    f.addStep(steps.ShellCommand(command='echo hello'))
+    f.addStep(steps.Trigger(schedulerNames=['trigsched'],
+                            waitForFinish=True,
+                            updateSourceStamp=True))
+    f.addStep(steps.ShellCommand(command='echo world'))
+    f2 = BuildFactory()
+    f2.addStep(steps.ShellCommand(command='echo ola'))
+    c['builders'] = [
+        BuilderConfig(name="testy",
+                      workernames=["hyper1"],
+                      factory=f),
+        BuilderConfig(name="build",
+                      workernames=["hyper1"],
+                      factory=f2)]
+    hyperconfig = workerhyper.Hyper.guess_config()
+    if isinstance(hyperconfig, basestring):
+        hyperconfig = json.load(open(hyperconfig))
+    hyperhost, hyperconfig = hyperconfig['clouds'].items()[0]
+    masterFQDN = os.environ.get('masterFQDN')
+    # FIXME: tardyp/buildbot-worker has workaround bug for hyper's init which disable SIGCHILD signal
+    # http://trac.buildbot.net/ticket/3592
+    c['workers'] = [
+        HyperLatentWorker('hyper1', 'passwd', hyperhost, hyperconfig['accesskey'],
+            hyperconfig['secretkey'], 'tardyp/buildbot-worker',
+            masterFQDN=masterFQDN)
+    ]
+    c['protocols'] = {"pb": {"port": "tcp:0"}}
+
+    return c

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -31,6 +31,7 @@ from buildbot.interfaces import IConfigLoader
 from buildbot.test.fake import fakedata
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemq
+from buildbot.test.fake.botmaster import FakeBotMaster
 from buildbot.test.util import dirs
 from buildbot.test.util import logging
 
@@ -176,6 +177,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
             self.reactor = self.make_reactor()
             self.master = master.BuildMaster(
                 self.basedir, reactor=self.reactor, config_loader=DefaultLoader())
+            self.master.botmaster = FakeBotMaster()
             self.db = self.master.db = fakedb.FakeDBConnector(self)
             self.db.setServiceParent(self.master)
             self.mq = self.master.mq = fakemq.FakeMQConnector(self)
@@ -238,22 +240,37 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
             self.assertLogged("BuildMaster startup failed")
         return d
 
+    @defer.inlineCallbacks
     def test_startup_ok(self):
-        d = self.master.startService()
+        yield self.master.startService()
 
-        @d.addCallback
-        def check_started(_):
-            self.assertTrue(self.master.data.updates.thisMasterActive)
-        d.addCallback(lambda _: self.master.stopService())
+        self.assertTrue(self.master.data.updates.thisMasterActive)
+        d = self.master.stopService()
+        self.assertTrue(d.called)
+        self.failIf(self.reactor.stop.called)
+        self.assertLogged("BuildMaster is running")
 
-        @d.addCallback
-        def check(_):
-            self.failIf(self.reactor.stop.called)
-            self.assertLogged("BuildMaster is running")
+        # check started/stopped messages
+        self.assertFalse(self.master.data.updates.thisMasterActive)
 
-            # check started/stopped messages
-            self.assertFalse(self.master.data.updates.thisMasterActive)
-        return d
+    @defer.inlineCallbacks
+    def test_startup_ok_waitforshutdown(self):
+        yield self.master.startService()
+
+        self.assertTrue(self.master.data.updates.thisMasterActive)
+        # use fakebotmaster shutdown delaying
+        self.master.botmaster.delayShutdown = True
+        d = self.master.stopService()
+
+        self.assertFalse(d.called)
+        self.master.botmaster.shutdownDeferred.callback(None)
+        self.assertTrue(d.called)
+
+        self.failIf(self.reactor.stop.called)
+        self.assertLogged("BuildMaster is running")
+
+        # check started/stopped messages
+        self.assertFalse(self.master.data.updates.thisMasterActive)
 
     @defer.inlineCallbacks
     def test_reconfig(self):

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -19,13 +19,15 @@ from twisted.trial import unittest
 from buildbot import config
 from buildbot.process import factory
 from buildbot.process.botmaster import BotMaster
+from buildbot.process.results import CANCELLED
+from buildbot.process.results import RETRY
 from buildbot.test.fake import fakemaster
 
 
 class TestCleanShutdown(unittest.TestCase):
 
     def setUp(self):
-        master = fakemaster.make_master(testcase=self, wantData=True)
+        self.master = master = fakemaster.make_master(testcase=self, wantData=True)
         self.botmaster = BotMaster()
         self.botmaster.setServiceParent(master)
         self.reactor = mock.Mock()
@@ -37,19 +39,30 @@ class TestCleanShutdown(unittest.TestCase):
     def assertReactorNotStopped(self, _=None):
         self.assertFalse(self.reactor.stop.called)
 
-    def makeFakeBuild(self):
+    def makeFakeBuild(self, waitedFor=False):
         self.fake_builder = builder = mock.Mock()
-        build = mock.Mock()
-        builder.builder_status.getCurrentBuilds.return_value = [build]
-
+        build_status = mock.Mock()
+        builder.builder_status.getCurrentBuilds.return_value = [build_status]
         self.build_deferred = defer.Deferred()
+
+        request = mock.Mock()
+        request.waitedFor = waitedFor
+        build = mock.Mock()
+        build.stopBuild = self.stopFakeBuild
         build.waitUntilFinished.return_value = self.build_deferred
+        build.requests = [request]
+        builder.building = [build]
 
         self.botmaster.builders = mock.Mock()
         self.botmaster.builders.values.return_value = [builder]
 
+    def stopFakeBuild(self, reason, results):
+        self.reason = reason
+        self.results = results
+        self.finishFakeBuild()
+
     def finishFakeBuild(self):
-        self.fake_builder.builder_status.getCurrentBuilds.return_value = []
+        self.fake_builder.building = []
         self.build_deferred.callback(None)
 
     # tests
@@ -76,6 +89,26 @@ class TestCleanShutdown(unittest.TestCase):
 
         # And now we should be stopped
         self.assertReactorStopped()
+
+    def test_shutdown_busy_quick(self):
+        """Test that the master shuts down after builds finish"""
+        self.makeFakeBuild()
+
+        self.botmaster.cleanShutdown(quickMode=True, _reactor=self.reactor)
+
+        # And now we should be stopped
+        self.assertReactorStopped()
+        self.assertEqual(self.results, RETRY)
+
+    def test_shutdown_busy_quick_cancelled(self):
+        """Test that the master shuts down after builds finish"""
+        self.makeFakeBuild(waitedFor=True)
+
+        self.botmaster.cleanShutdown(quickMode=True, _reactor=self.reactor)
+
+        # And now we should be stopped
+        self.assertReactorStopped()
+        self.assertEqual(self.results, CANCELLED)
 
     def test_shutdown_cancel_not_shutting_down(self):
         """Test that calling cancelCleanShutdown when none is in progress

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -814,7 +814,7 @@ class AbstractLatentWorker(AbstractWorker):
         yield d
         self.insubstantiating = False
         if self._substantiation_notifier:
-            # notify waiters that substanciation was cancelled
+            # notify waiters that substantiation was cancelled
             self._substantiation_notifier.notify(failure.Failure(Exception("cancelled")))
         self.botmaster.maybeStartBuildsForWorker(self.name)
 

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -810,6 +810,9 @@ class AbstractLatentWorker(AbstractWorker):
 
     @defer.inlineCallbacks
     def _soft_disconnect(self, fast=False):
+        if self.building:
+            # wait until build finished
+            return
         # a negative build_wait_timeout means the worker should never be shut
         # down, so just disconnect.
         if self.build_wait_timeout < 0:

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -466,9 +466,12 @@ class AbstractWorker(service.BuildbotService, object):
             # use get() since we might have changed our mind since then
             b = self.botmaster.builders.get(name)
             if b:
-                d1 = b.attached(self, self.worker_commands)
+                d1 = self.attachBuilder(b)
                 dl.append(d1)
         yield defer.DeferredList(dl)
+
+    def attachBuilder(self, builder):
+        return builder.attached(self, self.worker_commands)
 
     def shutdownRequested(self):
         log.msg("worker %s wants to shut down" % (self.name,))
@@ -729,6 +732,10 @@ class AbstractLatentWorker(AbstractWorker):
                 "Firing %s substantiation deferred with success" % (self.name,))
             self.substantiation_build = None
             self._substantiation_notifier.notify(True)
+
+    def attachBuilder(self, builder):
+        sb = self.workerforbuilders.get(builder.name)
+        return sb.attached(self, self.worker_commands)
 
     def detached(self):
         AbstractWorker.detached(self)

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -806,6 +806,9 @@ class AbstractLatentWorker(AbstractWorker):
         self.substantiated = False
         yield d
         self.insubstantiating = False
+        if self._substantiation_notifier:
+            # notify waiters that substanciation was cancelled
+            self._substantiation_notifier.notify(failure.Failure(Exception("cancelled")))
         self.botmaster.maybeStartBuildsForWorker(self.name)
 
     @defer.inlineCallbacks

--- a/master/buildbot/worker/hyper.py
+++ b/master/buildbot/worker/hyper.py
@@ -63,7 +63,7 @@ class HyperLatentWorker(AbstractLatentWorker):
             config.error("Size is not valid %s vs %r".format(hyper_size, self.ALLOWED_SIZES))
 
     def reconfigService(self, name, password, hyper_host,
-                        hyper_accesskey, hyper_secretkey, image, hyper_size="xs", masterFQDN=None, **kwargs):
+                        hyper_accesskey, hyper_secretkey, image, hyper_size="s3", masterFQDN=None, **kwargs):
 
         AbstractLatentWorker.reconfigService(self, name, password, **kwargs)
         self.size = hyper_size
@@ -124,8 +124,11 @@ class HyperLatentWorker(AbstractLatentWorker):
     def _thd_start_instance(self, image):
         instance = self.client.create_container(
             image,
-            name=('%s%s' % (self.workername, id(self))).replace("_", "-"),
             environment=self.createEnvironment(),
+            labels={
+                'sh_hyper_instancetype': self.size
+            },
+            name=('%s%s' % (self.workername, id(self))).replace("_", "-")
         )
 
         if instance.get('Id') is None:

--- a/master/buildbot/worker/hyper.py
+++ b/master/buildbot/worker/hyper.py
@@ -100,6 +100,8 @@ class HyperLatentWorker(AbstractLatentWorker):
         }
         if self.registration is not None:
             result["BUILDMASTER_PORT"] = str(self.registration.getPBPort())
+        if ":" in self.masterFQDN:
+            result["BUILDMASTER"], result["BUILDMASTER_PORT"] = self.masterFQDN.split(":")
         return result
 
     @defer.inlineCallbacks

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -274,6 +274,18 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Hy
     Address of the master the worker should connect to. Use if you master machine does not have proper fqdn.
     This value is passed to the docker image via environment variable ``BUILDMASTER``
 
+    If the value contains a colon (``:``), then BUILDMASTER and BUILDMASTER_PORT environment variables will be passed, following scheme: ``masterFQDN="$BUILDMASTER:$BUILDMASTER_PORT"``
+
+    This feature is useful for testing behind a proxy using ngrok command like: ``ngrok tcp 9989``
+    ngrok config can the be retrieved with following snippet:
+
+.. code-block:: python
+
+    import requests, urlparse
+    r = requests.get("http://localhost:4040/api/tunnels/command_line").json()
+    masterFQDN = urlparse.urlparse(r['public_url']).netloc
+
+
 ``hyper_accesskey``
     (mandatory)
     Access key to use as part of the creds to access hyper.

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -276,8 +276,8 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Hy
 
     If the value contains a colon (``:``), then BUILDMASTER and BUILDMASTER_PORT environment variables will be passed, following scheme: ``masterFQDN="$BUILDMASTER:$BUILDMASTER_PORT"``
 
-    This feature is useful for testing behind a proxy using ngrok command like: ``ngrok tcp 9989``
-    ngrok config can the be retrieved with following snippet:
+    This feature is useful for testing behind a proxy using ``ngrok`` command like: ``ngrok tcp 9989``
+    ``ngrok`` config can the be retrieved with following snippet:
 
 .. code-block:: python
 


### PR DESCRIPTION
Based on #2327 and #2328 

    master shutdown: stop all builds at master shutdown

    Previously when master shutdown, all the builds where marked RETRY
    because the workers were forcefully disconnected.

    This has bad impact like not putting correct reason why the build has been stopped.
    User sees slave disconnected, while the reason is master shutdown.
