### PR TITLE
Dockerfiles are broken, fix and upgrade ubuntu container to 16.04

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -31,4 +31,4 @@ RUN \
 
 WORKDIR /var/lib/buildbot
 VOLUME /var/lib/buildbot
-CMD ["/usr/src/buildbot/docker/master/start_buildbot.sh"]
+CMD ["/usr/src/buildbot/contrib/docker/master/start_buildbot.sh"]

--- a/master/Dockerfile.ubuntu
+++ b/master/Dockerfile.ubuntu
@@ -1,14 +1,14 @@
 # buildbot/buildbot-master-ubuntu
 
-# Provides a base Ubuntu (14.04) image with latest buildbot master installed
+# Provides a base Ubuntu (16.04) image with latest buildbot master installed
 # (based on twisted dockerfile https://github.com/cyli/docker-twisted)
 
-FROM        ubuntu:14.04
+FROM        ubuntu:16.04
 MAINTAINER  Buildbot maintainers
 
 # Last build date - this can be updated whenever there are security updates so
 # that everything is rebuilt
-ENV         security_updates_as_of 2016-06-20
+ENV         security_updates_as_of 2016-07-30
 
 ADD . /usr/src/buildbot
 # Install security updates and required packages
@@ -20,11 +20,12 @@ RUN         apt-get update && \
                 python-psycopg2
 
 # Install required python packages, and twisted
-RUN         pip install service_identity pycrypto && \
+RUN         pip install --upgrade pip setuptools && \
+            pip install service_identity pycrypto && \
             pip install twisted && \
             pip install  --pre "buildbot[bundle]" && \
             pip install  "/usr/src/buildbot"
 
 WORKDIR /var/lib/buildbot
 VOLUME /var/lib/buildbot
-CMD ["/usr/src/contrib/docker/master/start_buildbot.sh"]
+CMD ["/usr/src/buildbot/contrib/docker/master/start_buildbot.sh"]

--- a/master/contrib/docker/master/start_buildbot.sh
+++ b/master/contrib/docker/master/start_buildbot.sh
@@ -3,7 +3,7 @@ B=`pwd`
 if [ ! -f $B/buildbot.tac ]
 then
     buildbot create-master --db="postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres/$POSTGRES_DB" $B
-    mv $B/master.cfg.sample $B/master.cfg
+    mv /usr/src/buildbot/buildbot/scripts/sample.cfg $B/master.cfg
     cp /usr/src/buildbot/contrib/docker/master/buildbot.tac $B
 
     echo


### PR DESCRIPTION
Fixes issues like
```
docker: Error response from daemon: Container command '/usr/src/contrib/docker/master/start_buildbot.sh' not found or does not exist..
```