### PR TITLE
Increased size of builder identifier from 20 to 50 

### DIFF
--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -77,7 +77,7 @@ class Builder(base.ResourceType):
 
     class EntityType(types.Entity):
         builderid = types.Integer()
-        name = types.Identifier(20)
+        name = types.Identifier(50)
         masterids = types.List(of=types.Integer())
         description = types.NoneOk(types.String())
         tags = types.List(of=types.String())

--- a/master/buildbot/data/forceschedulers.py
+++ b/master/buildbot/data/forceschedulers.py
@@ -96,9 +96,9 @@ class ForceScheduler(base.ResourceType):
     keyFields = []
 
     class EntityType(types.Entity):
-        name = types.Identifier(20)
+        name = types.Identifier(50)
         button_name = types.String()
         label = types.String()
-        builder_names = types.List(of=types.Identifier(20))
+        builder_names = types.List(of=types.Identifier(50))
         all_fields = types.List(of=types.JsonObject())
     entityType = EntityType(name)


### PR DESCRIPTION
Fixes #3430

The DB schema has these fields of type TEXT which doesn't have an upper size limit. The builder identifier was only 20 while steps' and workers' names in the data module had size 50.

Going to a URL such as 
http://10.100.200.25:8010/api/v2/builders?name=runtestswithareallylongnamethatshouldnotbreak
no longer produces an error with this minor patch.