### PR TITLE
Fix missing VS2015 entry_points

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -294,7 +294,7 @@ setup_args = {
             ('buildbot.steps.vstudio', [
                 'VC6', 'VC7', 'VS2003', 'VC8', 'VS2005', 'VCExpress9', 'VC9',
                 'VS2008', 'VC10', 'VS2010', 'VC11', 'VS2012', 'VC12', 'VS2013',
-                'MsBuild4', 'MsBuild', 'MsBuild12'])
+                'VC14', 'VS2015', 'MsBuild4', 'MsBuild', 'MsBuild12', 'MsBuild14'])
         ]),
         ('buildbot.reporters', [
             ('buildbot.reporters.mail', ['MailNotifier']),


### PR DESCRIPTION
Fix missing VS2015 entry_points in 'buildbot.steps'