### PR TITLE
Error class stores status in strings

### DIFF
--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -170,6 +170,12 @@ class V2RootResource_CORS(www.WwwTestMixin, unittest.TestCase):
         self.assertNotOk('invalid origin')
 
     @defer.inlineCallbacks
+    def test_cors_origin_mismatch_post(self):
+        yield self.render_resource(self.rsrc, '/', method='POST', origin='h://bad')
+        self.assertRequest(content=json.dumps({'error': {'message': 'invalid origin'}}),
+                           responseCode=400)
+
+    @defer.inlineCallbacks
     def test_cors_origin_preflight_match_GET(self):
         yield self.render_resource(self.rsrc, '/',
                                    method='OPTIONS', origin='h://good',

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -78,6 +78,8 @@ class FakeRequest(object):
             self.deferred.callback(self.written)
 
     def setResponseCode(self, code):
+        # twisted > 16 started to assert this
+        assert isinstance(code, (int, long))
         self.responseCode = code
 
     def setHeader(self, hdr, value):

--- a/master/buildbot/www/resource.py
+++ b/master/buildbot/www/resource.py
@@ -84,7 +84,7 @@ class Resource(resource.Resource):
         def failHttpError(f):
             f.trap(Error)
             e = f.value
-            writeError(e.message, errcode=e.status)
+            writeError(e.message, errcode=int(e.status))
 
         @d.addErrback
         def fail(f):

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -426,7 +426,11 @@ class V2RootResource(resource.Resource):
                 log.msg("HTTP error: %s" % (msg,))
             request.setResponseCode(errcode)
             request.setHeader('content-type', 'text/plain; charset=utf-8')
-            request.write(json.dumps(dict(error=msg)))
+            if request.method == 'POST':
+                # jsonRPC callers want the error message in error.message
+                request.write(json.dumps(dict(error=dict(message=msg))))
+            else:
+                request.write(json.dumps(dict(error=msg)))
             request.finish()
         return self.asyncRenderHelper(request, self.asyncRender, writeError)
 


### PR DESCRIPTION
but setResponseCode wants an int.
tw16 started to enforce Error's status  to be string, while before we always sent an int.

http://trac.buildbot.net/ticket/3580