### PR TITLE
forcesched: fix owner parameter when no authentication is used

### DIFF
--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -441,26 +441,25 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                               '"label": "Your name:", "tablabel": "Your name:", "hide": false, '
                               '"fullName": "username", "type": "username", "size": 30}')
 
-    def test_UserNameParameterErrorTestIsInvalidMail(self):
-        self.do_ParameterTest(value="test",
-                              expect=CollectedValidationError,
-                              expectKind=Exception,
-                              klass=UserNameParameter(debug=False),
-                              name="username", label="Your name:")
+    def test_UserNameParameterIsValidMail(self):
+        email = "test@buildbot.net"
+        self.do_ParameterTest(value=email, expect=email,
+                              klass=UserNameParameter(),
+                              name="username", label="Your name:",
+                              expectJson='{"regex": null, "need_email": true, "multiple": false, '
+                              '"name": "username", "default": "", "required": false, '
+                              '"label": "Your name:", "tablabel": "Your name:", "hide": false, '
+                              '"fullName": "username", "type": "username", "size": 30}')
 
-    def test_UserNameParameterErrorTestAtBuildbotInvalidMail(self):
-        self.do_ParameterTest(value="test@buildbot.net",
-                              expect=CollectedValidationError,
-                              expectKind=Exception,
-                              klass=UserNameParameter(debug=False),
-                              name="username", label="Your name:")
-
-    def test_UserNameParameterErrorTestAtBuildbotBisInvalidMail(self):
-        self.do_ParameterTest(value="<test@buildbot.net>",
-                              expect=CollectedValidationError,
-                              expectKind=Exception,
-                              klass=UserNameParameter(debug=False),
-                              name="username", label="Your name:")
+    def test_UserNameParameterIsValidMailBis(self):
+        email = "<test@buildbot.net>"
+        self.do_ParameterTest(value=email, expect=email,
+                              klass=UserNameParameter(),
+                              name="username", label="Your name:",
+                              expectJson='{"regex": null, "need_email": true, "multiple": false, '
+                              '"name": "username", "default": "", "required": false, '
+                              '"label": "Your name:", "tablabel": "Your name:", "hide": false, '
+                              '"fullName": "username", "type": "username", "size": 30}')
 
     def test_ChoiceParameter(self):
         self.do_ParameterTest(value='t1', expect='t1',

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.tpl.jade
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.tpl.jade
@@ -1,7 +1,8 @@
 .modal-content
-    .modal-header
-        h4 {{sch.label}}
     .modal-body
+        // put the header in the body in order to correctly display error popup
+        h4 {{sch.label}}
+        hr
         div.form-horizontal
             .alert.alert-danger(ng-show="error") {{error}}
             forcefield(field="rootfield" ng-if="rootfield")


### PR DESCRIPTION
- if 'anonymous' user is send in owner parameter, then we use the username parameter from forcesched
- fix username validation so that it uses the same regex as the mail reporter
- fix forcesched to correctly display the validation error message

fixes http://trac.buildbot.net/ticket/3587
