### PR TITLE
check that builder tags do not contain duplicates

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -991,6 +991,11 @@ class BuilderConfig(util_config.ConfiguredMixin, WorkerAPICompatMixin):
             if bad_tags:
                 error(
                     "builder '%s': tags list contains something that is not a string" % (name,))
+
+            if len(tags) != len(set(tags)):
+                dupes = " ".join(set([x for x in tags if tags.count(x) > 1]))
+                error(
+                    "builder '%s': tags list contains duplicate tags: %s" % (name, dupes))
         else:
             tags = []
 

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1325,6 +1325,12 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
             lambda: config.BuilderConfig(tags=['abc', 13],
                                          name='a', workernames=['a'], factory=self.factory))
 
+    def test_tags_no_tag_dupes(self):
+        self.assertRaisesConfigError(
+            "builder 'a': tags list contains duplicate tags: abc",
+            lambda: config.BuilderConfig(tags=['abc', 'bca', 'abc'],
+                                         name='a', workernames=['a'], factory=self.factory))
+
     def test_tags_no_categories_too(self):
         self.assertRaisesConfigError(
             "categories are deprecated and replaced by tags; you should only specify tags",


### PR DESCRIPTION
duplicates are rejected by the db api but not by config,
which will lead to half reconfigured master

http://trac.buildbot.net/ticket/3588