### PR TITLE
fix for sphinx > 1.4.3

### DIFF
--- a/master/docs/bbdocs/ext.py
+++ b/master/docs/bbdocs/ext.py
@@ -71,7 +71,7 @@ class BBRefTargetDirective(Directive):
             else:
                 indextype = 'single'
                 indexentry = tpl % (fullname,)
-            entries.append((indextype, indexentry, targetname, targetname))
+            entries.append((indextype, indexentry, targetname, targetname, None))
 
         if entries:
             inode = addnodes.index(entries=entries)

--- a/master/setup.py
+++ b/master/setup.py
@@ -488,7 +488,7 @@ else:
             'idna >= 0.6',
         ],
         'docs': [
-            'sphinx==1.4.3',
+            'sphinx>1.4.0',
             'sphinxcontrib-blockdiag',
             'sphinxcontrib-spelling',
             'pyenchant',


### PR DESCRIPTION
sphinx now wants 5 columns in its index description...
here you go.. I am not sure what is the last item, but None works (and is what sphinx is doing in the warning code)

https://github.com/sphinx-doc/sphinx/issues/2673