### PR TITLE
worker: fix invalid DockerLatent volumes name

### DIFF
--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -86,14 +86,14 @@ class TestDockerLatentWorker(unittest.TestCase):
         bs = self.ConcreteWorker('bot', 'pass', 'tcp://1234:2375', 'worker', ['bin/bash'],
                                  volumes=[Interpolate('/data:/buildslave/%(kw:builder)s/build', builder=Property('builder'))])
         id, name = yield bs.start_instance(self.build)
-        self.assertEqual(bs.volumes, ['/data:/buildslave/docker_worker/build'])
+        self.assertEqual(bs.volumes, ['/buildslave/docker_worker/build'])
 
     @defer.inlineCallbacks
     def test_volume_no_suffix(self):
         bs = self.ConcreteWorker(
             'bot', 'pass', 'tcp://1234:2375', 'worker', ['bin/bash'], volumes=['/src/webapp:/opt/webapp'])
         yield bs.start_instance(self.build)
-        self.assertEqual(bs.volumes, ['/src/webapp:/opt/webapp'])
+        self.assertEqual(bs.volumes, ['/opt/webapp'])
         self.assertEqual(
             bs.binds, {'/src/webapp': {'bind': '/opt/webapp', 'ro': False}})
 
@@ -104,7 +104,7 @@ class TestDockerLatentWorker(unittest.TestCase):
                                           '~:/backup:rw'])
         yield bs.start_instance(self.build)
         self.assertEqual(
-            bs.volumes, ['/src/webapp:/opt/webapp:ro', '~:/backup:rw'])
+            bs.volumes, ['/opt/webapp', '/backup'])
         self.assertEqual(bs.binds, {'/src/webapp': {'bind': '/opt/webapp', 'ro': True},
                                     '~': {'bind': '/backup', 'ro': False}})
 

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -80,7 +80,7 @@ class DockerLatentWorker(AbstractLatentWorker):
                 if not isinstance(volume_string, str):
                     continue
                 try:
-                    volume, bind = volume_string.split(":", 1)
+                    bind, volume = volume_string.split(":", 1)
                 except ValueError:
                     config.error("Invalid volume definition for docker "
                                  "%s. Skipping..." % volume_string)
@@ -110,18 +110,19 @@ class DockerLatentWorker(AbstractLatentWorker):
         self.volumes = []
         for volume_string in (volumes or []):
             try:
-                volume, bind = volume_string.split(":", 1)
+                bind, volume = volume_string.split(":", 1)
             except ValueError:
                 config.error("Invalid volume definition for docker "
                              "%s. Skipping..." % volume_string)
                 continue
-            self.volumes.append(volume_string)
 
             ro = False
-            if bind.endswith(':ro') or bind.endswith(':rw'):
-                ro = bind[-2:] == 'ro'
-                bind = bind[:-3]
-            self.binds[volume] = {'bind': bind, 'ro': ro}
+            if volume.endswith(':ro') or volume.endswith(':rw'):
+                ro = volume[-2:] == 'ro'
+                volume = volume[:-3]
+
+            self.volumes.append(volume)
+            self.binds[bind] = {'bind': volume, 'ro': ro}
 
     def createEnvironment(self):
         result = {


### PR DESCRIPTION
Volumes from DockerLatentWorker were named against the 'bind:volume'
string instead of the 'volume' part only.

According to docker-py documentation[1], `volumes` parameter from
create_container() must only contain volumes name (ie. '/mnt/vol1') and
not the complete definition (ie. '/home/user1:/mnt/vol1').

This lead to unwanted entry in the container filesystem (ie.
'/home/user1:/mnt/vol1/' folder was created inside the container).

[1] https://docker-py.readthedocs.io/en/latest/volumes/