### PR TITLE
Fix BitbucketPullrequestPoller change detection

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -102,7 +102,8 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
             if not self.branch or branch in self.branch:
                 current = yield self._getCurrentRev(nr)
 
-                if not current or current != revision:
+                # compare _short_ hashes to check if the PR has been updated
+                if not current or current[0:12] != revision[0:12]:
                     # parse pull request api page (required for the filter)
                     page = yield client.getPage(str(pr['links']['self']['href']))
                     pr_json = json.loads(page, encoding=self.encoding)

--- a/master/buildbot/test/unit/test_changes_bitbucket.py
+++ b/master/buildbot/test/unit/test_changes_bitbucket.py
@@ -26,13 +26,14 @@ from buildbot.test.util import changesource
 
 
 class SourceRest():
+    """https://bitbucket.org/!api/2.0/repositories/{owner}/{slug}"""
     template = """\
 {
 
     "hash": "%(hash)s",
     "links": {
         "html": {
-            "href": "https://bitbucket.org/%(owner)s/%(slug)s/commits/%(hash)s"
+            "href": "https://bitbucket.org/%(owner)s/%(slug)s/commits/%(short_hash)s"
         }
     },
     "repository": {
@@ -67,6 +68,7 @@ class SourceRest():
             "owner": self.owner,
             "slug": self.slug,
             "hash": self.hash,
+            "short_hash": self.hash[0:12],
             "date": self.date,
         }
 
@@ -78,6 +80,7 @@ class SourceRest():
 
 
 class PullRequestRest():
+    """https://bitbucket.org/!api/2.0/repositories/{owner}/{slug}/pullrequests/{pull_request_id}"""
     template = """\
 {
 
@@ -124,6 +127,7 @@ class PullRequestRest():
             "description": self.description,
             "title": self.title,
             "hash": self.source.hash,
+            "short_hash": self.source.hash[0:12],
             "owner": self.source.owner,
             "slug": self.source.slug,
             "display_name": self.display_name,
@@ -134,6 +138,7 @@ class PullRequestRest():
 
 
 class PullRequestListRest():
+    """https://bitbucket.org/api/2.0/repositories/{owner}/{slug}/pullrequests"""
     template = """\
         {
             "description": "%(description)s",
@@ -151,10 +156,10 @@ class PullRequestListRest():
             "title": "%(title)s",
             "source": {
                 "commit": {
-                    "hash": "%(hash)s",
+                    "hash": "%(short_hash)s",
                     "links": {
                         "self": {
-                            "href": "https://bitbucket.org/!api/2.0/repositories/%(src_owner)s/%(src_slug)s/commit/%(hash)s"
+                            "href": "https://bitbucket.org/!api/2.0/repositories/%(src_owner)s/%(src_slug)s/commit/%(short_hash)s"
                         }
                     }
                 },
@@ -200,6 +205,7 @@ class PullRequestListRest():
                 "display_name": pr.display_name,
                 "title": pr.title,
                 "hash": pr.source.hash,
+                "short_hash": pr.source.hash[0:12],
                 "src_owner": pr.source.owner,
                 "src_slug": pr.source.slug,
                 "created_on": pr.created_on,
@@ -260,7 +266,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
         src = SourceRest(
             owner="contributor",
             slug="slug",
-            hash="000000000000000000000000000001",
+            hash="1111111111111111111111111111111111111111",
             date=self.date,
         )
         pr = PullRequestRest(
@@ -280,7 +286,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
         src = SourceRest(
             owner="contributor",
             slug="slug",
-            hash="000000000000000000000000000002",
+            hash="2222222222222222222222222222222222222222",
             date=self.date,
         )
         pr = PullRequestRest(
@@ -367,8 +373,8 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
             'project': u'',
             'properties': {},
             'repository': u'https://bitbucket.org/contributor/slug',
-            'revision': u'000000000000000000000000000001',
-            'revlink': u'https://bitbucket.org/contributor/slug/commits/000000000000000000000000000001',
+            'revision': u'1111111111111111111111111111111111111111',
+            'revlink': u'https://bitbucket.org/contributor/slug/commits/111111111111',
             'src': u'bitbucket',
             'when_timestamp': 1381869500,
         }])
@@ -392,8 +398,8 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
             'project': u'',
             'properties': {},
             'repository': u'https://bitbucket.org/contributor/slug',
-            'revision': u'000000000000000000000000000001',
-            'revlink': u'https://bitbucket.org/contributor/slug/commits/000000000000000000000000000001',
+            'revision': u'1111111111111111111111111111111111111111',
+            'revlink': u'https://bitbucket.org/contributor/slug/commits/111111111111',
             'src': u'bitbucket',
             'when_timestamp': 1381869500,
         }])
@@ -420,8 +426,9 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
             'project': u'',
             'properties': {},
             'repository': u'https://bitbucket.org/contributor/slug',
-            'revision': u'000000000000000000000000000001',
-            'revlink': u'https://bitbucket.org/contributor/slug/commits/000000000000000000000000000001',
+
+            'revision': u'1111111111111111111111111111111111111111',
+            'revlink': u'https://bitbucket.org/contributor/slug/commits/111111111111',
             'src': u'bitbucket',
             'when_timestamp': 1381869500,
         }])
@@ -439,8 +446,8 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
                 'project': u'',
                 'properties': {},
                 'repository': u'https://bitbucket.org/contributor/slug',
-                'revision': u'000000000000000000000000000001',
-                'revlink': u'https://bitbucket.org/contributor/slug/commits/000000000000000000000000000001',
+                'revision': u'1111111111111111111111111111111111111111',
+                'revlink': u'https://bitbucket.org/contributor/slug/commits/111111111111',
                 'src': u'bitbucket',
                 'when_timestamp': 1381869500,
             },
@@ -454,8 +461,8 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
                 'project': u'',
                 'properties': {},
                 'repository': u'https://bitbucket.org/contributor/slug',
-                'revision': u'000000000000000000000000000002',
-                'revlink': u'https://bitbucket.org/contributor/slug/commits/000000000000000000000000000002',
+                'revision': u'2222222222222222222222222222222222222222',
+                'revlink': u'https://bitbucket.org/contributor/slug/commits/222222222222',
                 'src': u'bitbucket',
                 'when_timestamp': 1381869500,
             }
@@ -499,8 +506,8 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
             'project': u'',
             'properties': {},
             'repository': u'https://bitbucket.org/contributor/slug',
-            'revision': u'000000000000000000000000000001',
-            'revlink': u'https://bitbucket.org/contributor/slug/commits/000000000000000000000000000001',
+            'revision': u'1111111111111111111111111111111111111111',
+            'revlink': u'https://bitbucket.org/contributor/slug/commits/111111111111',
             'src': u'bitbucket',
             'when_timestamp': 1381869500,
         }])
@@ -528,8 +535,8 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
             'project': u'',
             'properties': {},
             'repository': u'https://bitbucket.org/contributor/slug',
-            'revision': u'000000000000000000000000000001',
-            'revlink': u'https://bitbucket.org/contributor/slug/commits/000000000000000000000000000001',
+            'revision': u'1111111111111111111111111111111111111111',
+            'revlink': u'https://bitbucket.org/contributor/slug/commits/111111111111',
             'src': u'bitbucket',
             'when_timestamp': 1396825656,
         }])


### PR DESCRIPTION
Currently the BitbucketPullrequestPoller treats all pull requests as
if they have been updated, rather than filtering them properly. This is
because the existing check compares the short hash of the incoming
changeset with the full hash of the current revision.

This patch changes the behaviour to compart the short hashes of the
incoming and current revisions.

The Bitbucket API returns short hashes for a number of queries. The
test data has been updated to reflect this.

fixes #3597

Signed-off-by: Sam Bristow <sam.bristow@gmail.com>