### PR TITLE
Allow JSONStringDownload to work on renderables

### DIFF
--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -562,6 +562,8 @@ class JSONStringDownload(StringDownload, WorkerAPICompatMixin):
 
     name = "json_download"
 
+    renderables = ['o']
+
     def __init__(self, o, workerdest=None,
                  slavedest=None,  # deprecated, use `workerdest` instead
                  **buildstep_kwargs):
@@ -577,11 +579,16 @@ class JSONStringDownload(StringDownload, WorkerAPICompatMixin):
         if workerdest is None:
             raise TypeError("__init__() takes at least 3 arguments")
 
+        self.super_class = StringDownload
         if 's' in buildstep_kwargs:
             del buildstep_kwargs['s']
-        s = json.dumps(o)
+        self.o = o
         StringDownload.__init__(
-            self, s=s, workerdest=workerdest, **buildstep_kwargs)
+            self, s=None, workerdest=workerdest, **buildstep_kwargs)
+
+    def start(self):
+        self.s = json.dumps(self.o)
+        return self.super_class.start(self)
 
 
 class JSONPropertiesDownload(StringDownload, WorkerAPICompatMixin):


### PR DESCRIPTION
Currently the `json.dumps` call is in the `__init__` method, where it does not have access to property values or other renderable content. I move it to the `start` method and add the object to dump to the `renderables` list.

I do not convert it or any of the other steps in the file to new-style build steps.
