### PR TITLE
Use syntax in PEP 3110 for catching exceptions.

### DIFF
--- a/master/contrib/bk_buildbot.py
+++ b/master/contrib/bk_buildbot.py
@@ -128,7 +128,7 @@ class ChangeSender:
                 print "You must supply a branch with -b or --branch."
                 sys.exit(1)
 
-        except usage.error, ue:
+        except usage.error as ue:
             print opts
             print "%s: %s" % (sys.argv[0], ue)
             sys.exit()

--- a/master/contrib/darcs_buildbot.py
+++ b/master/contrib/darcs_buildbot.py
@@ -84,7 +84,7 @@ def getChangesFromCommand(cmd, count):
     out = commands.getoutput(cmd)
     try:
         doc = minidom.parseString(out)
-    except xml.parsers.expat.ExpatError, e:
+    except xml.parsers.expat.ExpatError as e:
         print "failed to parse XML"
         print str(e)
         print "purported XML is:"

--- a/master/contrib/github_buildbot.py
+++ b/master/contrib/github_buildbot.py
@@ -130,7 +130,7 @@ class GitHubBuildBot(resource.Resource):
             self.send_changes(changes, request)
             return server.NOT_DONE_YET
 
-        except Exception, e:
+        except Exception as e:
             logging.exception(e)
             request.setResponseCode(INTERNAL_SERVER_ERROR)
             return json.dumps({"error": e.message})

--- a/master/contrib/svn_buildbot.py
+++ b/master/contrib/svn_buildbot.py
@@ -246,7 +246,7 @@ class ChangeSender:
         opts = Options()
         try:
             opts.parseOptions()
-        except usage.error, ue:
+        except usage.error as ue:
             print opts
             print "%s: %s" % (sys.argv[0], ue)
             sys.exit()

--- a/master/contrib/svnpoller.py
+++ b/master/contrib/svnpoller.py
@@ -48,7 +48,7 @@ try:
         paths.append("".join([t.data for t in p.childNodes]))
     # print "PATHS"
     # print paths
-except xml.parsers.expat.ExpatError, e:
+except xml.parsers.expat.ExpatError as e:
     print "FAILED TO PARSE 'svn log' XML:"
     print str(e)
     print "----"

--- a/master/contrib/trac/bbwatcher/api.py
+++ b/master/contrib/trac/bbwatcher/api.py
@@ -12,7 +12,7 @@ class BuildBotSystem(object):
             scheme, loc, _, _, _ = urlparse.urlsplit(url, scheme='http')
             url = '%s://%s/xmlrpc' % (scheme, loc)
             self.server = xmlrpclib.ServerProxy(url)
-        except Exception, e:
+        except Exception as e:
             raise ValueError('Invalid BuildBot XML-RPC server %s: %s' % (url, e))
 
     def getAllBuildsInInterval(self, start, stop):
@@ -23,7 +23,7 @@ class BuildBotSystem(object):
         for i in range(1, 5 + 1):
             try:
                 builds.append(Build(self.server.getBuild(name, -i)))
-            except Exception, e:
+            except Exception as e:
                 self.env.log.debug('Cannot fetch build-info: %s' % (e))
                 break
         return Builder(name, builds, [])

--- a/master/contrib/trac/bbwatcher/web_ui.py
+++ b/master/contrib/trac/bbwatcher/web_ui.py
@@ -48,7 +48,7 @@ class TracBuildBotWatcher(Component):
     def get_timeline_events(self, req, start, stop, filters):
         try:
             master = BuildBotSystem(self.buildbot_url)
-        except Exception, e:
+        except Exception as e:
             print 'Error hitting BuildBot', e
             return
         # This was a comprehension: the loop is clearer
@@ -73,7 +73,7 @@ class TracBuildBotWatcher(Component):
         m = self.BUILDER_RE.match(req.path_info)
         try:
             builder = m.group(1) or None
-        except Exception, e:
+        except Exception as e:
             builder = None
         master = BuildBotSystem(self.buildbot_url)
         if builder is None:
@@ -91,7 +91,7 @@ class TracBuildBotWatcher(Component):
             try:
                 master = BuildBotSystem(self.buildbot_url)
                 data = {'builder': master.getBuilder(builder)}
-            except Exception, e:
+            except Exception as e:
                 print 'Error fetching builder stats', e
             data['context'] = Context.from_request(req, ('buildbot', builder))
             return 'bbw_builder.html', data, 'text/html'

--- a/master/contrib/windows/buildbot_service.py
+++ b/master/contrib/windows/buildbot_service.py
@@ -314,7 +314,7 @@ class BBService(win32serviceutil.ServiceFramework):
                                   event,
                                   (self._svc_name_,
                                    " (%s)" % self._svc_display_name_))
-        except win32api.error, details:
+        except win32api.error as details:
             # Failed to write a log entry - most likely problem is
             # that the event log is full.  We don't want this to kill us
             try:
@@ -326,7 +326,7 @@ class BBService(win32serviceutil.ServiceFramework):
     def _dolog(self, func, msg):
         try:
             func(msg)
-        except win32api.error, details:
+        except win32api.error as details:
             # Failed to write a log entry - most likely problem is
             # that the event log is full.  We don't want this to kill us
             try:
@@ -400,7 +400,7 @@ class BBService(win32serviceutil.ServiceFramework):
         while True:
             try:
                 ec, data = win32file.ReadFile(handle, CHILDCAPTURE_BLOCK_SIZE)
-            except pywintypes.error, err:
+            except pywintypes.error as err:
                 # ERROR_BROKEN_PIPE means the child process closed the
                 # handle - ie, it terminated.
                 if err[0] != winerror.ERROR_BROKEN_PIPE:
@@ -471,7 +471,7 @@ def CustomInstall(opts):
     import pythoncom
     try:
         RegisterWithFirewall(sys.executable, "BuildBot")
-    except pythoncom.com_error, why:
+    except pythoncom.com_error as why:
         print "FAILED to register with the Windows firewall"
         print why
 

--- a/master/docs/bbdocs/highlighterrors.py
+++ b/master/docs/bbdocs/highlighterrors.py
@@ -70,7 +70,7 @@ def patched_unhighlighted(self, source):
 def patched_highlight_block(self, *args, **kwargs):
     try:
         return orig_highlight_block(self, *args, **kwargs)
-    except UnhighlightedError, ex:
+    except UnhighlightedError as ex:
         msg = ex.args[0]
         if 'warn' in kwargs:
             kwargs['warn'](msg)

--- a/worker/contrib/windows/buildbot_service.py
+++ b/worker/contrib/windows/buildbot_service.py
@@ -314,7 +314,7 @@ class BBService(win32serviceutil.ServiceFramework):
                                   event,
                                   (self._svc_name_,
                                    " (%s)" % self._svc_display_name_))
-        except win32api.error, details:
+        except win32api.error as details:
             # Failed to write a log entry - most likely problem is
             # that the event log is full.  We don't want this to kill us
             try:
@@ -326,7 +326,7 @@ class BBService(win32serviceutil.ServiceFramework):
     def _dolog(self, func, msg):
         try:
             func(msg)
-        except win32api.error, details:
+        except win32api.error as details:
             # Failed to write a log entry - most likely problem is
             # that the event log is full.  We don't want this to kill us
             try:
@@ -400,7 +400,7 @@ class BBService(win32serviceutil.ServiceFramework):
         while True:
             try:
                 ec, data = win32file.ReadFile(handle, CHILDCAPTURE_BLOCK_SIZE)
-            except pywintypes.error, err:
+            except pywintypes.error as err:
                 # ERROR_BROKEN_PIPE means the child process closed the
                 # handle - ie, it terminated.
                 if err[0] != winerror.ERROR_BROKEN_PIPE:
@@ -471,7 +471,7 @@ def CustomInstall(opts):
     import pythoncom
     try:
         RegisterWithFirewall(sys.executable, "BuildBot")
-    except pythoncom.com_error, why:
+    except pythoncom.com_error as why:
         print "FAILED to register with the Windows firewall"
         print why
 


### PR DESCRIPTION
This works in 2.6 and higher.  In Python 3, this is mandatory.