### PR TITLE
Replace xrange() with range() for Python 3 compatibility

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -49,7 +49,7 @@ class ResourceType(object):
 
     def getEndpoints(self):
         endpoints = self.endpoints[:]
-        for i in xrange(len(endpoints)):
+        for i in range(len(endpoints)):
             ep = endpoints[i]
             if not issubclass(ep, Endpoint):
                 raise TypeError("Not an Endpoint subclass")

--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -17,6 +17,7 @@ import copy
 import re
 import UserList
 
+from future.builtins import range
 from twisted.internet import defer
 
 from buildbot.data import exceptions

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -114,13 +114,13 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                 if row.first_line < first_line:
                     idx = -1
                     count = first_line - row.first_line
-                    for _ in xrange(count):
+                    for _ in range(count):
                         idx = content.index('\n', idx + 1)
                     content = content[idx + 1:]
                 if row.last_line > last_line:
                     idx = len(content) + 1
                     count = row.last_line - last_line
-                    for _ in xrange(count):
+                    for _ in range(count):
                         idx = content.rindex('\n', 0, idx)
                     content = content[:idx]
                 rv.append(content)

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
+from future.builtins import range
 from future.utils import itervalues
 from twisted.internet import defer
 from twisted.python import log

--- a/master/buildbot/process/metrics.py
+++ b/master/buildbot/process/metrics.py
@@ -38,6 +38,7 @@ from collections import defaultdict
 from collections import deque
 
 from future.utils import iteritems
+from future.utils import lrange
 from twisted.application import service
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
@@ -75,7 +76,7 @@ class MetricTimeEvent(MetricEvent):
         self.timer = timer
         self.elapsed = elapsed
 
-ALARM_OK, ALARM_WARN, ALARM_CRIT = range(3)
+ALARM_OK, ALARM_WARN, ALARM_CRIT = lrange(3)
 ALARM_TEXT = ["OK", "WARN", "CRIT"]
 
 

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -16,6 +16,7 @@ import collections
 import re
 import weakref
 
+from future.builtins import range
 from future.utils import iteritems
 from twisted.internet import defer
 from twisted.python.components import registerAdapter

--- a/master/buildbot/process/results.py
+++ b/master/buildbot/process/results.py
@@ -13,7 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
-SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY, CANCELLED = range(7)
+from future.utils import lrange
+
+SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY, CANCELLED = lrange(7)
 Results = ["success", "warnings", "failure", "skipped", "exception", "retry", "cancelled"]
 
 

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -19,6 +19,7 @@ import time
 import warnings
 from distutils.version import LooseVersion
 
+from future.builtins import range
 from future.utils import iteritems
 from twisted.internet import defer
 from twisted.internet import reactor

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from UserList import UserList
 
+from future.utils import lrange
 from twisted.internet import defer
 from twisted.python import log
 
@@ -92,13 +93,13 @@ def getDetailsForBuilds(master, buildset, builds, wantProperties=False, wantStep
             [master.data.get(("builds", build['buildid'], 'properties'))
              for build in builds])
     else:  # we still need a list for the big zip
-        buildproperties = range(len(builds))
+        buildproperties = lrange(len(builds))
 
     if wantPreviousBuild:
         prev_builds = yield defer.gatherResults(
             [getPreviousBuild(master, build) for build in builds])
     else:  # we still need a list for the big zip
-        prev_builds = range(len(builds))
+        prev_builds = lrange(len(builds))
 
     if wantSteps:
         buildsteps = yield defer.gatherResults(
@@ -111,7 +112,7 @@ def getDetailsForBuilds(master, buildset, builds, wantProperties=False, wantStep
                     l['content'] = yield master.data.get(("logs", l['logid'], 'contents'))
 
     else:  # we still need a list for the big zip
-        buildsteps = range(len(builds))
+        buildsteps = lrange(len(builds))
 
     # a big zip to connect everything together
     for build, properties, steps, prev in zip(builds, buildproperties, buildsteps, prev_builds):

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -20,6 +20,7 @@ from string import capitalize
 from string import join
 from string import lower
 
+from future.builtins import range
 from twisted.internet import defer
 from twisted.internet import protocol
 from twisted.internet import reactor

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -21,6 +21,7 @@ import sys
 import traceback
 from contextlib import contextmanager
 
+from future.builtins import range
 from twisted.internet import defer
 from twisted.python import runtime
 from twisted.python import usage

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -24,6 +24,7 @@ import sys
 import textwrap
 
 import sqlalchemy as sa
+from future.builtins import range
 from twisted.python import reflect
 from twisted.python import usage
 

--- a/master/buildbot/steps/mtrlogobserver.py
+++ b/master/buildbot/steps/mtrlogobserver.py
@@ -15,6 +15,7 @@
 import re
 import sys
 
+from future.builtins import range
 from twisted.enterprise import adbapi
 from twisted.internet import defer
 from twisted.python import log

--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -397,7 +397,7 @@ class Trial(ShellCommand):
 
             # using -j/--jobs flag produces more than one test log.
             self.logfiles = {}
-            for i in xrange(self.jobs):
+            for i in range(self.jobs):
                 self.logfiles['test.%d.log' %
                               i] = '_trial_temp/%d/test.log' % i
                 self.logfiles['err.%d.log' % i] = '_trial_temp/%d/err.log' % i

--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -17,6 +17,7 @@ BuildSteps that are specific to the Twisted source tree
 """
 import re
 
+from future.builtins import range
 from twisted.python import log
 
 from buildbot.process import logobserver

--- a/master/buildbot/test/fuzz/test_lru.py
+++ b/master/buildbot/test/fuzz/test_lru.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 import random
 
+from future.utils import lrange
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log
@@ -63,7 +64,7 @@ class LRUCacheFuzzer(fuzz.FuzzTestCase):
                                    set([key + 1000]))
         self.lru = lru.AsyncLRUCache(delayed_miss_fn, 50)
 
-        keys = range(250)
+        keys = lrange(250)
         errors = []  # bail out early in the event of an error
         results = []  # keep references to (most) results
 

--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -15,6 +15,7 @@
 
 import os
 
+from future.builtins import range
 from twisted.python import threadpool
 from twisted.python.failure import Failure
 from twisted.trial.unittest import SynchronousTestCase

--- a/master/buildbot/test/unit/test_changes_manager.py
+++ b/master/buildbot/test/unit/test_changes_manager.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
+from future.builtins import range
 from twisted.trial import unittest
 
 from buildbot.changes import manager

--- a/master/buildbot/test/unit/test_changes_svnpoller.py
+++ b/master/buildbot/test/unit/test_changes_svnpoller.py
@@ -370,7 +370,7 @@ class TestSVNPoller(gpo.GetProcessOutputMixin,
         s._prefix = "sample"
 
         logentries = dict(
-            zip(xrange(1, 7), reversed(make_logentry_elements(6))))
+            zip(range(1, 7), reversed(make_logentry_elements(6))))
         changes = s.create_changes(reversed([logentries[3], logentries[2]]))
         self.failUnlessEqual(len(changes), 2)
         # note that parsing occurs in reverse
@@ -431,7 +431,7 @@ class TestSVNPoller(gpo.GetProcessOutputMixin,
         s._prefix = "sample"
 
         logentries = dict(
-            zip(xrange(1, 7), reversed(make_logentry_elements(6))))
+            zip(range(1, 7), reversed(make_logentry_elements(6))))
         changes = s.create_changes(reversed([logentries[3], logentries[2]]))
         self.failUnlessEqual(len(changes), 2)
 

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -18,6 +18,7 @@ import re
 import textwrap
 
 import mock
+from future.builtins import range
 from future.utils import iteritems
 from twisted.internet import defer
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_connector.py
+++ b/master/buildbot/test/unit/test_data_connector.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+from future.builtins import range
 from twisted.internet import defer
 from twisted.python import reflect
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_logchunks.py
+++ b/master/buildbot/test/unit/test_data_logchunks.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 import textwrap
 
+from future.builtins import range
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_data_resultspec.py
+++ b/master/buildbot/test/unit/test_data_resultspec.py
@@ -15,6 +15,7 @@
 import datetime
 import random
 
+from future.utils import lrange
 from twisted.trial import unittest
 
 from buildbot.data import base
@@ -171,7 +172,7 @@ class ResultSpec(unittest.TestCase):
             base.ListResult(exp, total=2))
 
     def do_test_pagination(self, bareList):
-        data = mklist('x', *range(101, 131))
+        data = mklist('x', *lrange(101, 131))
         if not bareList:
             data = base.ListResult(data)
             data.offset = None
@@ -179,19 +180,19 @@ class ResultSpec(unittest.TestCase):
             data.limit = None
         self.assertListResultEqual(
             resultspec.ResultSpec(offset=0).apply(data),
-            base.ListResult(mklist('x', *range(101, 131)),
+            base.ListResult(mklist('x', *lrange(101, 131)),
                             offset=0, total=30))
         self.assertListResultEqual(
             resultspec.ResultSpec(offset=10).apply(data),
-            base.ListResult(mklist('x', *range(111, 131)),
+            base.ListResult(mklist('x', *lrange(111, 131)),
                             offset=10, total=30))
         self.assertListResultEqual(
             resultspec.ResultSpec(offset=10, limit=10).apply(data),
-            base.ListResult(mklist('x', *range(111, 121)),
+            base.ListResult(mklist('x', *lrange(111, 121)),
                             offset=10, total=30, limit=10))
         self.assertListResultEqual(
             resultspec.ResultSpec(offset=20, limit=15).apply(data),
-            base.ListResult(mklist('x', *range(121, 131)),
+            base.ListResult(mklist('x', *lrange(121, 131)),
                             offset=20, total=30, limit=15))  # off the end
 
     def test_pagination_bare_list(self):
@@ -201,18 +202,18 @@ class ResultSpec(unittest.TestCase):
         return self.do_test_pagination(bareList=False)
 
     def test_pagination_prepaginated(self):
-        data = base.ListResult(mklist('x', *range(10, 20)))
+        data = base.ListResult(mklist('x', *lrange(10, 20)))
         data.offset = 10
         data.total = 30
         data.limit = 10
         self.assertListResultEqual(
             # ResultSpec has its offset/limit fields cleared
             resultspec.ResultSpec().apply(data),
-            base.ListResult(mklist('x', *range(10, 20)),
+            base.ListResult(mklist('x', *lrange(10, 20)),
                             offset=10, total=30, limit=10))
 
     def test_pagination_prepaginated_without_clearing_resultspec(self):
-        data = base.ListResult(mklist('x', *range(10, 20)))
+        data = base.ListResult(mklist('x', *lrange(10, 20)))
         data.offset = 10
         data.limit = 10
         # ResultSpec does not have its offset/limit fields cleared - this is
@@ -221,7 +222,7 @@ class ResultSpec(unittest.TestCase):
                           resultspec.ResultSpec(offset=10, limit=20).apply(data))
 
     def test_endpoint_returns_total_without_applying_filters(self):
-        data = base.ListResult(mklist('x', *range(10, 20)))
+        data = base.ListResult(mklist('x', *lrange(10, 20)))
         data.total = 99
         # apply doesn't want to get a total with filters still outstanding
         f = resultspec.Filter(field='x', op='gt', values=[23])

--- a/master/buildbot/test/unit/test_db_buildrequests.py
+++ b/master/buildbot/test/unit/test_db_buildrequests.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 import datetime
 
+from future.builtins import range
 from future.utils import lrange
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_buildrequests.py
+++ b/master/buildbot/test/unit/test_db_buildrequests.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 import datetime
 
+from future.utils import lrange
 from twisted.internet import task
 from twisted.trial import unittest
 
@@ -416,12 +417,12 @@ class Tests(interfaces.InterfaceTests):
             [
                 fakedb.BuildRequest(
                     id=id, buildsetid=self.BSID, builderid=self.BLDRID1)
-                for id in xrange(1, 1000)
+                for id in range(1, 1000)
             ],
-            1300305713, range(1, 1000),
+            1300305713, lrange(1, 1000),
             [
                 (id, epoch2datetime(1300305713), self.MASTER_ID)
-                for id in xrange(1, 1000)
+                for id in range(1, 1000)
             ]
         )
 
@@ -446,7 +447,7 @@ class Tests(interfaces.InterfaceTests):
                 # the fly in the ointment..
                 fakedb.BuildRequestClaim(brid=1000,
                                          masterid=self.OTHER_MASTER_ID, claimed_at=1300103810),
-            ], 1300305712, range(1, 1001),
+            ], 1300305712, lrange(1, 1001),
             expfailure=buildrequests.AlreadyClaimedError)
         d.addCallback(lambda _:
                       self.db.buildrequests.getBuildRequests(claimed=True))
@@ -638,7 +639,7 @@ class Tests(interfaces.InterfaceTests):
         ], 1300305712,
             [(id, True, 7, epoch2datetime(1300305712))
                 for id in range(1, 280)
-             ], brids=range(1, 280))
+             ], brids=lrange(1, 280))
 
     def test_completeBuildRequests_multiple_notmine(self):
         # note that the requests are completed even though they are not mine!

--- a/master/buildbot/test/unit/test_db_builds.py
+++ b/master/buildbot/test/unit/test_db_builds.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import lrange
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest
@@ -299,7 +300,7 @@ class RealTests(Tests):
         yield self.insertTestData(self.backgroundData)
 
         # add new builds at *just* the wrong time, repeatedly
-        numbers = range(1, 8)
+        numbers = lrange(1, 8)
 
         def raceHook(conn):
             if not numbers:

--- a/master/buildbot/test/unit/test_db_changes.py
+++ b/master/buildbot/test/unit/test_db_changes.py
@@ -318,7 +318,7 @@ class Tests(interfaces.InterfaceTests):
         d = self.insertTestData([
             fakedb.SourceStamp(id=92),
         ] + [
-            fakedb.Change(changeid=i) for i in xrange(2, 102)])
+            fakedb.Change(changeid=i) for i in range(2, 102)])
         d.addCallback(lambda _:
                       self.db.changes.getChangesCount())
 
@@ -671,7 +671,7 @@ class RealTests(Tests):
             fakedb.SourceStamp(id=29),
         ] + [
             fakedb.Change(changeid=n, sourcestampid=29)
-            for n in xrange(1, 151)
+            for n in range(1, 151)
         ])
 
         d.addCallback(lambda _: self.db.changes.pruneChanges(1))

--- a/master/buildbot/test/unit/test_db_changes.py
+++ b/master/buildbot/test/unit/test_db_changes.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
+
+from future.builtins import range
 from future.utils import iteritems
 from twisted.internet import defer
 from twisted.internet import task

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -15,6 +15,7 @@
 import base64
 import textwrap
 
+from future.builtins import range
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_steps.py
+++ b/master/buildbot/test/unit/test_db_steps.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 import time
 
+from future.builtins import range
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_workers.py
+++ b/master/buildbot/test/unit/test_db_workers.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
+from future.builtins import range
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -18,6 +18,7 @@ import textwrap
 import mock
 from autobahn.wamp.types import EventDetails
 from autobahn.wamp.types import SubscribeOptions
+from future.builtins import range
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -45,7 +45,7 @@ class FakeWampConnector(object):
         owntopic = self.topic.split(".")
         if len(topic) != len(owntopic):
             return False
-        for i in xrange(len(topic)):
+        for i in range(len(topic)):
             if owntopic[i] != "" and topic[i] != owntopic[i]:
                 return False
         return True

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -206,7 +206,7 @@ class Test(TestBRDBase):
         # test 15 "parallel" invocations of maybeStartBuildsOn, with a
         # _sortBuilders that takes a while.  This is a regression test for bug
         # 1979.
-        builders = ['bldr%02d' % i for i in xrange(15)]
+        builders = ['bldr%02d' % i for i in range(15)]
 
         def slow_sorter(master, bldrs):
             bldrs.sort(lambda b1, b2: cmp(b1.name, b2.name))

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+from future.builtins import range
 from future.utils import iteritems
 from twisted.internet import defer
 from twisted.internet import reactor

--- a/master/buildbot/test/unit/test_process_factory.py
+++ b/master/buildbot/test/unit/test_process_factory.py
@@ -15,6 +15,7 @@
 from random import choice
 from string import ascii_uppercase
 
+from future.builtins import range
 from twisted.trial import unittest
 
 from buildbot.process.buildstep import BuildStep

--- a/master/buildbot/test/unit/test_process_metrics.py
+++ b/master/buildbot/test/unit/test_process_metrics.py
@@ -15,6 +15,7 @@
 import gc
 import sys
 
+from future.utils import lrange
 from twisted.internet import task
 from twisted.trial import unittest
 
@@ -125,7 +126,7 @@ class TestMetricTimeEvent(TestMetricBase):
         self.assertEquals(report['timers']['foo_time'], 5)
 
     def testAverages(self):
-        data = range(10)
+        data = lrange(10)
         for i in data:
             metrics.MetricTimeEvent.log('foo_time', i)
         report = self.observer.asDict()

--- a/master/buildbot/test/unit/test_process_metrics.py
+++ b/master/buildbot/test/unit/test_process_metrics.py
@@ -15,6 +15,7 @@
 import gc
 import sys
 
+from future.builtins import range
 from future.utils import lrange
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_process_results.py
+++ b/master/buildbot/test/unit/test_process_results.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import lrange
 from twisted.python import log
 from twisted.trial import unittest
 
@@ -26,7 +27,7 @@ class TestResults(unittest.TestCase):
             self.assertEqual(results.Results[i], r)
 
     def test_worst_status(self):
-        res = range(len(results.Results))
+        res = lrange(len(results.Results))
         res.sort(
             cmp=lambda a, b: 1 if (results.worst_status(a, b) == a) else -1)
         self.assertEqual(res, [

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -15,6 +15,7 @@
 
 import warnings
 
+from future.builtins import range
 from mock import Mock
 from mock import call
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -170,7 +170,7 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
 
     def makeBuildInfo(self, buildResults, resultText, builds):
         info = []
-        for i in xrange(len(buildResults)):
+        for i in range(len(buildResults)):
             info.append({'name': u"Builder%d" % i, 'result': buildResults[i],
                          'resultText': resultText[i], 'text': u'buildText',
                          'url': "http://localhost:8080/#builders/%d/builds/%d" % (79 + i, i),

--- a/master/buildbot/test/unit/test_steps_mswin.py
+++ b/master/buildbot/test/unit/test_steps_mswin.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_steps_source_repo.py
+++ b/master/buildbot/test/unit/test_steps_source_repo.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+
 from twisted.trial import unittest
 
 from buildbot.changes.changes import Change

--- a/master/buildbot/test/unit/test_steps_source_repo.py
+++ b/master/buildbot/test/unit/test_steps_source_repo.py
@@ -127,7 +127,7 @@ class TestRepo(sourcesteps.SourceStepMixin, unittest.TestCase):
             self.ExpectShell(
                 command=['repo', 'manifest', '-r', '-o', 'manifest-original.xml'])
         ]
-        for i in xrange(len(commands)):
+        for i in range(len(commands)):
             self.expectCommands(commands[i] + (which_fail == i and 1 or 0))
             if which_fail == i and breakatfail:
                 break

--- a/master/buildbot/test/unit/test_util_lineboundaries.py
+++ b/master/buildbot/test/unit/test_util_lineboundaries.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/test/unit/test_util_lru.py
+++ b/master/buildbot/test/unit/test_util_lru.py
@@ -172,7 +172,7 @@ class LRUCacheTest(unittest.TestCase):
         self.check_result(res, short('a'), 0, 1)
 
         self.lru.miss_fn = long
-        for i in xrange(100):
+        for i in range(100):
             res = self.lru.get('a')
             self.check_result(res, short('a'), i + 1, 1)
 
@@ -433,7 +433,7 @@ class AsyncLRUCacheTest(unittest.TestCase):
         self.check_result(res, short('a'), 0, 1)
 
         self.lru.miss_fn = self.long_miss_fn
-        for i in xrange(100):
+        for i in range(100):
             res = yield self.lru.get('a')
             self.check_result(res, short('a'), i + 1, 1)
 

--- a/master/buildbot/test/unit/test_util_lru.py
+++ b/master/buildbot/test/unit/test_util_lru.py
@@ -16,6 +16,7 @@ import gc
 import random
 import string
 
+from future.builtins import range
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import failure

--- a/master/buildbot/test/unit/test_util_service.py
+++ b/master/buildbot/test/unit/test_util_service.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+from future.builtins import range
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_www_ldapuserinfo.py
+++ b/master/buildbot/test/unit/test_www_ldapuserinfo.py
@@ -17,6 +17,7 @@ import new
 import sys
 
 import mock
+from future.builtins import range
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_www_ldapuserinfo.py
+++ b/master/buildbot/test/unit/test_www_ldapuserinfo.py
@@ -63,7 +63,7 @@ class CommonTestCase(unittest.TestCase):
     def assertSearchCalledWith(self, exp):
         got = self.userInfoProvider.search.call_args_list
         self.assertEqual(len(exp), len(got))
-        for i in xrange(len(exp)):
+        for i in range(len(exp)):
             self.assertEqual(exp[i][0][0], got[i][0][1])
             self.assertEqual(exp[i][0][1], got[i][0][2])
             self.assertEqual(exp[i][0][2], got[i][1]['attributes'])

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -15,6 +15,7 @@
 import re
 
 import mock
+from future.builtins import range
 from future.utils import iteritems
 from future.utils import itervalues
 from twisted.internet import defer

--- a/master/buildbot/test/util/interfaces.py
+++ b/master/buildbot/test/util/interfaces.py
@@ -15,6 +15,7 @@
 import inspect
 
 import pkg_resources
+from future.builtins import range
 from twisted.trial import unittest
 
 

--- a/master/buildbot/test/util/interfaces.py
+++ b/master/buildbot/test/util/interfaces.py
@@ -41,7 +41,7 @@ class InterfaceTests(object):
             args = spec[0]
             defaults = list(spec[3] if spec[3] is not None else [])
             di = -1
-            for ai in xrange(len(args) - 1, -1, -1):
+            for ai in range(len(args) - 1, -1, -1):
                 arg = args[ai]
                 if arg.startswith('_') or (arg == 'self' and ai == 0):
                     del args[ai]

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -94,8 +94,8 @@ class SchedulerMixin(interfaces.InterfaceTests):
                 self.assertArgSpecMatches(actual, fake)
                 setattr(scheduler, method, fake)
             self.addBuildsetCalls = []
-            self._bsidGenerator = iter(xrange(500, 999))
-            self._bridGenerator = iter(xrange(100, 999))
+            self._bsidGenerator = iter(range(500, 999))
+            self._bridGenerator = iter(range(100, 999))
 
             # temporarily override the sourcestamp and sourcestampset methods
             self.addedSourceStamps = []

--- a/master/buildbot/util/croniter.py
+++ b/master/buildbot/util/croniter.py
@@ -94,7 +94,7 @@ class croniter(object):
                         raise ValueError(
                             "[%s] is not acceptable" % expr_format)
 
-                    for j in xrange(int(low), int(high) + 1):
+                    for j in range(int(low), int(high) + 1):
                         if j % int(step) == 0:
                             e_list.append(j)
                 else:

--- a/master/buildbot/util/croniter.py
+++ b/master/buildbot/util/croniter.py
@@ -13,6 +13,7 @@ from time import mktime
 from time import time
 
 from dateutil.relativedelta import relativedelta
+from future.builtins import range
 
 search_re = re.compile(r'^([^-]+)-([^-/]+)(/(.*))?$')
 only_int_re = re.compile(r'^\d+$')

--- a/master/contrib/buildbot_json.py
+++ b/master/contrib/buildbot_json.py
@@ -41,6 +41,8 @@ import sys
 import time
 import urllib
 import urllib2
+
+from future.builtins import range
 from future.utils import lrange
 
 """Queries buildbot through the json interface.

--- a/master/contrib/buildbot_json.py
+++ b/master/contrib/buildbot_json.py
@@ -41,6 +41,7 @@ import sys
 import time
 import urllib
 import urllib2
+from future.utils import lrange
 
 """Queries buildbot through the json interface.
 """
@@ -59,7 +60,7 @@ except ImportError:
 
 # These values are buildbot constants used for Build and BuildStep.
 # This line was copied from master/buildbot/status/builder.py.
-SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY = range(6)
+SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY = lrange(6)
 
 
 # Generic node caching code.
@@ -321,7 +322,7 @@ class NonAddressableNodeList(VirtualNodeList):  # pylint: disable=W0223
     @property
     def cached_children(self):
         if self.parent.cached_data is not None:
-            for i in xrange(len(self.parent.cached_data[self.subkey])):
+            for i in range(len(self.parent.cached_data[self.subkey])):
                 yield self[i]
 
     @property
@@ -334,7 +335,7 @@ class NonAddressableNodeList(VirtualNodeList):  # pylint: disable=W0223
     def cached_keys(self):
         if self.parent.cached_data is None:
             return None
-        return range(len(self.parent.data.get(self.subkey, [])))
+        return lrange(len(self.parent.data.get(self.subkey, [])))
 
     @property
     def data(self):
@@ -355,7 +356,7 @@ class NonAddressableNodeList(VirtualNodeList):  # pylint: disable=W0223
     def __iter__(self):
         """Enables 'for i in obj:'. It returns children."""
         if self.data:
-            for i in xrange(len(self.data)):
+            for i in range(len(self.data)):
                 yield self[i]
 
     def __getitem__(self, key):
@@ -859,7 +860,7 @@ class Builds(AddressableNodeList):
         # Only cache keys here.
         self.cache_keys()
         if self._keys:
-            for i in xrange(max(self._keys), -1, -1):
+            for i in range(max(self._keys), -1, -1):
                 yield self[i]
 
     def cache_keys(self):

--- a/master/contrib/check_buildbot.py
+++ b/master/contrib/check_buildbot.py
@@ -5,6 +5,9 @@ from __future__ import print_function
 import sys
 import urllib
 
+from future.utils import lrange
+
+
 """check_buildbot.py -H hostname -p httpport [options]
 
 nagios check for buildbot.
@@ -19,7 +22,7 @@ except ImportError:
     import json
 
 
-OK, WARNING, CRITICAL, UNKNOWN = range(4)
+OK, WARNING, CRITICAL, UNKNOWN = lrange(4)
 STATUS_TEXT = ["OK", "Warning", "Critical", "Unknown"]
 STATUS_CODES = dict(OK=OK, WARNING=WARNING, CRIT=CRITICAL)
 

--- a/master/contrib/hgbuildbot.py
+++ b/master/contrib/hgbuildbot.py
@@ -146,6 +146,7 @@ import os.path
 
 import requests
 
+from future.builtins import range
 from mercurial.encoding import fromlocal
 from mercurial.node import hex
 from mercurial.node import nullid

--- a/master/contrib/trac/bbwatcher/api.py
+++ b/master/contrib/trac/bbwatcher/api.py
@@ -1,6 +1,7 @@
 import urlparse
 import xmlrpclib
 
+from future.builtins import range
 from model import Build
 from model import Builder
 

--- a/master/contrib/windows/buildbot_service.py
+++ b/master/contrib/windows/buildbot_service.py
@@ -69,6 +69,8 @@ import os
 import sys
 import threading
 
+from future.builtins import range
+
 import pywintypes
 import servicemanager
 import win32api

--- a/worker/buildbot_worker/monkeypatches/bug4881.py
+++ b/worker/buildbot_worker/monkeypatches/bug4881.py
@@ -15,7 +15,7 @@
 # Copyright Buildbot Team Members
 
 import os
-from builtins import range
+from future.utils import lrange
 
 from twisted.internet import process
 from twisted.python import log
@@ -190,7 +190,7 @@ class _FDDetector(object):
         # to close
         if maxfds > 1024:
             maxfds = 1024
-        return range(maxfds)
+        return lrange(maxfds)
 
     def _fallbackFDImplementation(self):
         """
@@ -198,7 +198,7 @@ class _FDDetector(object):
         close 256 FDs.
         """
         maxfds = 256
-        return range(maxfds)
+        return lrange(maxfds)
 
 
 detector = _FDDetector()

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -28,6 +28,7 @@ import traceback
 from collections import deque
 from tempfile import NamedTemporaryFile
 
+from future.builtins import range
 from future.utils import iteritems
 from twisted.internet import defer
 from twisted.internet import error

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -16,9 +16,9 @@
 import multiprocessing
 import os
 import shutil
-from builtins import range
 
 import mock
+from future.builtins import range
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import task

--- a/worker/contrib/windows/buildbot_service.py
+++ b/worker/contrib/windows/buildbot_service.py
@@ -69,6 +69,8 @@ import os
 import sys
 import threading
 
+from future.builtins import range
+
 import pywintypes
 import servicemanager
 import win32api


### PR DESCRIPTION
xrange() is gone in Python 3.
In Python 3, range() returns a view, not a list,
so in a few places where we really need a list, we
need to wrap it with list().

See:
http://python3porting.com/differences.html#range-and-xrange