### PR TITLE
Decode bytes output from process using utf-8 encoding for Python 3

### DIFF
--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -57,7 +57,7 @@ def getVersion(init_file):
         out = p.communicate()[0]
 
         if (not p.returncode) and out:
-            v = VERSION_MATCH.search(out)
+            v = VERSION_MATCH.search(out.decode('utf-8'))
             if v is not None:
                 return v.group(1)
     except OSError:

--- a/worker/buildbot_worker/__init__.py
+++ b/worker/buildbot_worker/__init__.py
@@ -55,7 +55,7 @@ def getVersion(init_file):
         out = p.communicate()[0]
 
         if (not p.returncode) and out:
-            v = VERSION_MATCH.search(out)
+            v = VERSION_MATCH.search(out.decode('utf-8'))
             if v:
                 return v.group(1)
     except OSError:


### PR DESCRIPTION
On Python 3, the output of a process is bytes, not str.
However, we need str, not bytes when generating
the version string.

This fixes the following on Python 3:

pip install -e pkg
pip install -e worker

Without this fix,

**pip install -e pkg** fails with:

```
Obtaining file:///Users/crodrigues/b1/pkg
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/crodrigues/b1/pkg/setup.py", line 24, in <module>
        version=buildbot_pkg.getVersion("."),
      File "/Users/crodrigues/b1/pkg/buildbot_pkg.py", line 60, in getVersion
        v = VERSION_MATCH.search(out)
    TypeError: cannot use a string pattern on a bytes-like object

```

and 

**pip install -e worker** fails with:

```
Obtaining file:///Users/crodrigues/b1/worker
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/crodrigues/b1/worker/setup.py", line 28, in <module>
        from buildbot_worker import version
      File "/Users/crodrigues/b1/worker/buildbot_worker/__init__.py", line 67, in <module>
        version = getVersion(__file__)
      File "/Users/crodrigues/b1/worker/buildbot_worker/__init__.py", line 58, in getVersion
        v = VERSION_MATCH.search(out)
    TypeError: cannot use a string pattern on a bytes-like object    
```