### PR TITLE
enable e2e tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,7 @@ script:
   - "[ $TESTS != setuppy_test ] || (cd worker; python setup.py test)"
 
   - "[ $TESTS != smokes ] || ./common/maketarballs.sh"
-#  - "[ $TESTS != smokes ] || ./common/smokedist.sh"
+  - "[ $TESTS != smokes ] || ./common/smokedist.sh"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,36 +21,7 @@ python:
   - "2.7"
 
 env:
-  # lint, docs and coverage first as they're more likely to find issues
-  - TWISTED=latest SQLALCHEMY=latest TESTS=lint
-  - TWISTED=latest SQLALCHEMY=latest TESTS=docs
-  - TWISTED=latest SQLALCHEMY=latest TESTS=coverage
-
-  # add js tests in separate job. Start it early because it is quite long
-  - TWISTED=latest SQLALCHEMY=latest TESTS=js
   - TWISTED=latest SQLALCHEMY=latest TESTS=smokes
-
-  - TWISTED=14.0.2 SQLALCHEMY=latest TESTS=trial
-  - TWISTED=15.4.0 SQLALCHEMY=latest TESTS=trial
-  - TWISTED=latest SQLALCHEMY=latest TESTS=trial
-  # Configuration when SQLite database is persistent between running tests
-  # (by default in other tests in-memory SQLite database is used which is
-  # recreated for each test).
-  # Helps to detect issues with incorrect database setup/cleanup in tests.
-  - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=sqlite:////tmp/test_db.sqlite
-  # Configuration that runs tests with real MySQL database
-  - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest
-  - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest&storage_engine=InnoDB
-  # Configuration that runs tests with real PostgreSQL database with pg8000 and psycopg2 drivers
-  - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=postgresql+psycopg2:///bbtest?user=postgres
-  - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=postgresql+pg8000:///bbtest?user=postgres
-
-  # Test different versions of SQLAlchemy
-  - TWISTED=15.5.0 SQLALCHEMY=0.8.0 TESTS=trial
-  - TWISTED=15.5.0 SQLALCHEMY=latest TESTS=trial
-
-  # Configuration to run `python setup.py test` to check this test runner.
-  # - TWISTED=latest SQLALCHEMY=latest TESTS=setuppy_test
 
 cache:
   directories:

--- a/smokes/protractor.conf.js
+++ b/smokes/protractor.conf.js
@@ -6,7 +6,7 @@ exports.config = {
     ],
 
     capabilities: {
-        'browserName': 'chrome'
+        'browserName': 'phantomjs'
     },
 
     baseUrl: 'http://localhost:8010',


### PR DESCRIPTION
Only phantomjs is supported in travis, which is sufficient for our needs

- temporarily for testing, we enable on TESTS=smokes