### PR TITLE
Replace zope.interface.implements() with @zope.interface.implementer

### DIFF
--- a/master/buildbot/changes/base.py
+++ b/master/buildbot/changes/base.py
@@ -15,15 +15,15 @@
 
 from twisted.internet import defer
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot.interfaces import IChangeSource
 from buildbot.util import service
 from buildbot.util.poll import method as poll_method
 
 
+@implementer(IChangeSource)
 class ChangeSource(service.ClusteredBuildbotService):
-    implements(IChangeSource)
 
     def describe(self):
         pass

--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -18,7 +18,7 @@ from future.utils import iteritems
 from twisted.internet import defer
 from twisted.python import log
 from twisted.web import html
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot import util
@@ -26,13 +26,12 @@ from buildbot.process.properties import Properties
 from buildbot.util import datetime2epoch
 
 
+@implementer(interfaces.IStatusEvent)
 class Change:
 
     """I represent a single change to the source tree. This may involve several
     files, but they are all changed by the same person, and there is a change
     comment for the group as a whole."""
-
-    implements(interfaces.IStatusEvent)
 
     number = None
     branch = None

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -28,17 +28,17 @@ from email.utils import parsedate_tz
 
 from twisted.internet import defer
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import util
 from buildbot.interfaces import IChangeSource
 from buildbot.util.maildir import MaildirService
 
 
+@implementer(IChangeSource)
 class MaildirSource(MaildirService, util.ComparableMixin):
 
     """Generic base class for Maildir-based change sources"""
-    implements(IChangeSource)
 
     compare_attrs = ("basedir", "pollinterval", "prefix")
 

--- a/master/buildbot/changes/manager.py
+++ b/master/buildbot/changes/manager.py
@@ -15,7 +15,7 @@
 
 from twisted.internet import defer
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot import util
@@ -23,6 +23,7 @@ from buildbot.process import metrics
 from buildbot.util import service
 
 
+@implementer(interfaces.IEventSource)
 class ChangeManager(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
     """
@@ -33,8 +34,6 @@ class ChangeManager(service.ReconfigurableServiceMixin, service.AsyncMultiServic
     L{buildbot.interfaces.IChangeSource} as child services. These are added by
     the master with C{addSource}.
     """
-
-    implements(interfaces.IEventSource)
 
     name = "change_manager"
 

--- a/master/buildbot/manhole.py
+++ b/master/buildbot/manhole.py
@@ -28,7 +28,7 @@ from twisted.cred import checkers
 from twisted.cred import portal
 from twisted.internet import protocol
 from twisted.python import log
-from zope.interface import implements  # requires Twisted-2.0 or later
+from zope.interface import implementer  # requires Twisted-2.0 or later
 
 from buildbot import config
 from buildbot.util import ComparableMixin
@@ -58,8 +58,8 @@ class makeTelnetProtocol:
         return telnet.TelnetTransport(auth, self.portal)
 
 
+@implementer(portal.IRealm)
 class _TelnetRealm:
-    implements(portal.IRealm)
 
     def __init__(self, namespace_maker):
         self.namespace_maker = namespace_maker

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -25,7 +25,7 @@ from twisted.internet import threads
 from twisted.python import components
 from twisted.python import failure
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 
 import buildbot
 import buildbot.pbmanager
@@ -531,8 +531,8 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
         return d
 
 
+@implementer(interfaces.IControl)
 class Control:
-    implements(interfaces.IControl)
 
     def __init__(self, master):
         self.master = master

--- a/master/buildbot/pbmanager.py
+++ b/master/buildbot/pbmanager.py
@@ -22,7 +22,7 @@ from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log
 from twisted.spread import pb
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot.util import service
 
@@ -107,8 +107,8 @@ class Registration(object):
         return disp.port.getHost().port
 
 
+@implementer(portal.IRealm, checkers.ICredentialsChecker)
 class Dispatcher(service.AsyncService):
-    implements(portal.IRealm, checkers.ICredentialsChecker)
 
     credentialInterfaces = [credentials.IUsernamePassword,
                             credentials.IUsernameHashedPassword]

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -23,7 +23,7 @@ from twisted.python import components
 from twisted.python import failure
 from twisted.python import log
 from twisted.python.failure import Failure
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.process import buildstep
@@ -44,6 +44,7 @@ from buildbot.worker_transition import WorkerAPICompatMixin
 from buildbot.worker_transition import deprecatedWorkerClassMethod
 
 
+@implementer(interfaces.IBuildControl)
 class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
 
     """I represent a single build by a single worker. Specialized Builders can
@@ -67,8 +68,6 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
     @ivar build_status: the L{buildbot.status.build.BuildStatus} that
                         collects our status
     """
-
-    implements(interfaces.IBuildControl)
 
     workdir = "build"
     build_status = None

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -19,7 +19,7 @@ from twisted.application import internet
 from twisted.application import service
 from twisted.internet import defer
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.data import resultspec
@@ -455,8 +455,8 @@ class Builder(util_service.ReconfigurableServiceMixin,
         return buildrequest.BuildRequest.canBeCollapsed(master, brdict1, brdict2)
 
 
+@implementer(interfaces.IBuilderControl)
 class BuilderControl:
-    implements(interfaces.IBuilderControl)
 
     def __init__(self, builder, control):
         self.original = builder

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -27,7 +27,7 @@ from twisted.python import versions
 from twisted.python.failure import Failure
 from twisted.python.reflect import accumulateClassList
 from twisted.web.util import formatFailure
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import config
 from buildbot import interfaces
@@ -81,6 +81,7 @@ _hush_pyflakes = [
     LogObserver, LogLineObserver, OutputProgressObserver]
 
 
+@implementer(interfaces.IBuildStepFactory)
 class _BuildStepFactory(util.ComparableMixin):
 
     """
@@ -89,7 +90,6 @@ class _BuildStepFactory(util.ComparableMixin):
     easier to test that the right factories are getting created.
     """
     compare_attrs = ('factory', 'args', 'kwargs')
-    implements(interfaces.IBuildStepFactory)
 
     def __init__(self, factory, *args, **kwargs):
         self.factory = factory
@@ -241,11 +241,10 @@ class BuildStepStatus(object):
     pass
 
 
+@implementer(interfaces.IBuildStep)
 class BuildStep(results.ResultComputingConfigMixin,
                 properties.PropertiesMixin,
                 WorkerAPICompatMixin):
-
-    implements(interfaces.IBuildStep)
 
     alwaysRun = False
     doStepIf = True

--- a/master/buildbot/process/logobserver.py
+++ b/master/buildbot/process/logobserver.py
@@ -13,13 +13,13 @@
 #
 # Copyright Buildbot Team Members
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 
 
+@implementer(interfaces.ILogObserver)
 class LogObserver(object):
-    implements(interfaces.ILogObserver)
 
     def setStep(self, step):
         self.step = step

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -20,7 +20,7 @@ from future.builtins import range
 from future.utils import iteritems
 from twisted.internet import defer
 from twisted.python.components import registerAdapter
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import config
 from buildbot import util
@@ -31,6 +31,7 @@ from buildbot.util import json
 from buildbot.worker_transition import reportDeprecatedWorkerNameUsage
 
 
+@implementer(IProperties)
 class Properties(util.ComparableMixin):
 
     """
@@ -49,7 +50,6 @@ class Properties(util.ComparableMixin):
     """
 
     compare_attrs = ('properties',)
-    implements(IProperties)
 
     def __init__(self, **kwargs):
         """
@@ -275,6 +275,7 @@ class _PropertyMap(object):
         self.temp_vals[key] = val
 
 
+@implementer(IRenderable)
 class WithProperties(util.ComparableMixin):
 
     """
@@ -282,7 +283,6 @@ class WithProperties(util.ComparableMixin):
     want to interpolate build properties.
     """
 
-    implements(IRenderable)
     compare_attrs = ('fmtstring', 'args', 'lambda_subs')
 
     def __init__(self, fmtstring, *args, **lambda_subs):
@@ -343,8 +343,8 @@ class _NotHasKey(util.ComparableMixin):
 _notHasKey = _NotHasKey()
 
 
+@implementer(IRenderable)
 class _Lookup(util.ComparableMixin, object):
-    implements(IRenderable)
 
     compare_attrs = (
         'value', 'index', 'default', 'defaultWhenFalse', 'hasKey', 'elideNoneAs')
@@ -402,16 +402,16 @@ def _getInterpolationList(fmtstring):
     return list(dd)
 
 
+@implementer(IRenderable)
 class _PropertyDict(object):
-    implements(IRenderable)
 
     def getRenderingFor(self, build):
         return build.getProperties()
 _thePropertyDict = _PropertyDict()
 
 
+@implementer(IRenderable)
 class _SourceStampDict(util.ComparableMixin, object):
-    implements(IRenderable)
 
     compare_attrs = ('codebase',)
 
@@ -426,8 +426,8 @@ class _SourceStampDict(util.ComparableMixin, object):
             return {}
 
 
+@implementer(IRenderable)
 class _Lazy(util.ComparableMixin, object):
-    implements(IRenderable)
 
     compare_attrs = ('value',)
 
@@ -462,6 +462,7 @@ def _on_property_usage(prop_name, stacklevel):
             stacklevel=stacklevel)
 
 
+@implementer(IRenderable)
 class Interpolate(util.ComparableMixin, object):
 
     """
@@ -469,7 +470,6 @@ class Interpolate(util.ComparableMixin, object):
     want to interpolate build properties.
     """
 
-    implements(IRenderable)
     compare_attrs = ('fmtstring', 'args', 'kwargs')
 
     identifier_re = re.compile(r'^[\w._-]*$')
@@ -649,13 +649,12 @@ class Interpolate(util.ComparableMixin, object):
             return d
 
 
+@implementer(IRenderable)
 class Property(util.ComparableMixin):
 
     """
     An instance of this class renders a property of a build.
     """
-
-    implements(IRenderable)
 
     compare_attrs = ('key', 'default', 'defaultWhenFalse')
 
@@ -692,12 +691,12 @@ class Property(util.ComparableMixin):
                 return props.render(self.default)
 
 
+@implementer(IRenderable)
 class FlattenList(util.ComparableMixin):
 
     """
     An instance of this class flattens all nested lists in a list
     """
-    implements(IRenderable)
 
     compare_attrs = ('nestedlist')
 
@@ -723,8 +722,8 @@ class FlattenList(util.ComparableMixin):
         return FlattenList(self.nestedlist + b, self.types)
 
 
+@implementer(IRenderable)
 class _Renderer(util.ComparableMixin, object):
-    implements(IRenderable)
 
     compare_attrs = ('getRenderingFor',)
 
@@ -739,14 +738,13 @@ def renderer(fn):
     return _Renderer(fn)
 
 
+@implementer(IRenderable)
 class _DefaultRenderer(object):
 
     """
     Default IRenderable adaptor. Calls .getRenderingFor if available, otherwise
     returns argument unchanged.
     """
-
-    implements(IRenderable)
 
     def __init__(self, value):
         try:
@@ -760,13 +758,12 @@ class _DefaultRenderer(object):
 registerAdapter(_DefaultRenderer, object, IRenderable)
 
 
+@implementer(IRenderable)
 class _ListRenderer(object):
 
     """
     List IRenderable adaptor. Maps Build.render over the list.
     """
-
-    implements(IRenderable)
 
     def __init__(self, value):
         self.value = value
@@ -777,13 +774,12 @@ class _ListRenderer(object):
 registerAdapter(_ListRenderer, list, IRenderable)
 
 
+@implementer(IRenderable)
 class _TupleRenderer(object):
 
     """
     Tuple IRenderable adaptor. Maps Build.render over the tuple.
     """
-
-    implements(IRenderable)
 
     def __init__(self, value):
         self.value = value
@@ -796,13 +792,12 @@ class _TupleRenderer(object):
 registerAdapter(_TupleRenderer, tuple, IRenderable)
 
 
+@implementer(IRenderable)
 class _DictRenderer(object):
 
     """
     Dict IRenderable adaptor. Maps Build.render over the keya and values in the dict.
     """
-
-    implements(IRenderable)
 
     def __init__(self, value):
         self.value = _ListRenderer(
@@ -816,13 +811,12 @@ class _DictRenderer(object):
 registerAdapter(_DictRenderer, dict, IRenderable)
 
 
+@implementer(IRenderable)
 class Transform(object):
 
     """
     A renderable that combines other renderables' results using an arbitrary function.
     """
-
-    implements(IRenderable)
 
     def __init__(self, function, *args, **kwargs):
         if not callable(function) and not IRenderable.providedBy(function):

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -26,7 +26,7 @@ from future.utils import iteritems
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log as twlog
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import config
 from buildbot import interfaces
@@ -69,8 +69,8 @@ VALID_EMAIL_ADDR = re.compile(VALID_EMAIL_ADDR)
 ENCODING = 'utf8'
 
 
+@implementer(interfaces.IEmailLookup)
 class Domain(util.ComparableMixin):
-    implements(interfaces.IEmailLookup)
     compare_attrs = ("domain")
 
     def __init__(self, domain):
@@ -84,9 +84,8 @@ class Domain(util.ComparableMixin):
         return name + "@" + self.domain
 
 
+@implementer(interfaces.IEmailSender)
 class MailNotifier(service.BuildbotService):
-
-    implements(interfaces.IEmailSender)
 
     possible_modes = ("change", "failing", "passing", "problem", "warnings",
                       "exception", "cancelled")

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -16,7 +16,7 @@ from future.utils import iteritems
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import config
 from buildbot import interfaces
@@ -26,9 +26,8 @@ from buildbot.util.service import ClusteredBuildbotService
 from buildbot.util.state import StateMixin
 
 
+@implementer(interfaces.IScheduler)
 class BaseScheduler(ClusteredBuildbotService, StateMixin):
-
-    implements(interfaces.IScheduler)
 
     DEFAULT_CODEBASES = {'': {}}
 

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -16,7 +16,7 @@ from future.utils import itervalues
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import config
 from buildbot import util
@@ -333,8 +333,8 @@ class Nightly(NightlyBase):
                              **kwargs)
 
 
+@implementer(ITriggerableScheduler)
 class NightlyTriggerable(NightlyBase):
-    implements(ITriggerableScheduler)
 
     def __init__(self, name, builderNames, minute=0, hour='*',
                  dayOfMonth='*', month='*', dayOfWeek='*',

--- a/master/buildbot/schedulers/triggerable.py
+++ b/master/buildbot/schedulers/triggerable.py
@@ -15,7 +15,7 @@
 from future.utils import itervalues
 from twisted.internet import defer
 from twisted.python import failure
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot.interfaces import ITriggerableScheduler
 from buildbot.process.properties import Properties
@@ -23,8 +23,8 @@ from buildbot.schedulers import base
 from buildbot.util import debounce
 
 
+@implementer(ITriggerableScheduler)
 class Triggerable(base.BaseScheduler):
-    implements(ITriggerableScheduler)
 
     compare_attrs = base.BaseScheduler.compare_attrs + ('reason',)
 

--- a/master/buildbot/status/base.py
+++ b/master/buildbot/status/base.py
@@ -14,7 +14,7 @@
 # Copyright Buildbot Team Members
 
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import pbutil
 from buildbot import util
@@ -22,8 +22,8 @@ from buildbot.interfaces import IStatusReceiver
 from buildbot.util import service
 
 
+@implementer(IStatusReceiver)
 class StatusReceiverBase:
-    implements(IStatusReceiver)
 
     def requestSubmitted(self, request):
         pass
@@ -109,5 +109,6 @@ class StatusReceiverService(StatusReceiverBase, service.AsyncService,
 StatusReceiver = StatusReceiverService
 
 
+@implementer(IStatusReceiver)
 class StatusReceiverPerspective(StatusReceiver, pbutil.NewCredPerspective):
-    implements(IStatusReceiver)
+    pass

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -15,14 +15,14 @@
 
 from twisted.internet import defer
 from twisted.internet import reactor
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot import util
 
 
+@implementer(interfaces.IBuildStatus, interfaces.IStatusEvent)
 class BuildStatus():
-    implements(interfaces.IBuildStatus, interfaces.IStatusEvent)
 
     sources = None
     reason = None

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -17,7 +17,7 @@ import os
 
 from twisted.persisted import styles
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot import util
@@ -40,6 +40,7 @@ _hush_pyflakes = [SUCCESS, WARNINGS, FAILURE, SKIPPED,
                   EXCEPTION, RETRY, CANCELLED, Results, worst_status]
 
 
+@implementer(interfaces.IBuilderStatus, interfaces.IEventSource)
 class BuilderStatus(styles.Versioned):
 
     """I handle status information for a single process.build.Builder object.
@@ -59,8 +60,6 @@ class BuilderStatus(styles.Versioned):
     @ivar  tags: user-defined "tag" this builder has; can be
                      used to filter on in status clients
     """
-
-    implements(interfaces.IBuilderStatus, interfaces.IEventSource)
 
     persistenceVersion = 2
     persistenceForgets = ('wasUpgraded', )

--- a/master/buildbot/status/buildrequest.py
+++ b/master/buildbot/status/buildrequest.py
@@ -14,14 +14,14 @@
 # Copyright Buildbot Team Members
 from twisted.internet import defer
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.util.eventual import eventually
 
 
+@implementer(interfaces.IBuildRequestStatus)
 class BuildRequestStatus:
-    implements(interfaces.IBuildRequestStatus)
 
     def __init__(self, buildername, brid, status, brdict=None):
         self.buildername = buildername

--- a/master/buildbot/status/buildset.py
+++ b/master/buildbot/status/buildset.py
@@ -13,15 +13,15 @@
 #
 # Copyright Buildbot Team Members
 from twisted.internet import defer
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.data import resultspec
 from buildbot.status.buildrequest import BuildRequestStatus
 
 
+@implementer(interfaces.IBuildSetStatus)
 class BuildSetStatus:
-    implements(interfaces.IBuildSetStatus)
 
     def __init__(self, bsdict, status):
         self.id = bsdict['bsid']

--- a/master/buildbot/status/event.py
+++ b/master/buildbot/status/event.py
@@ -13,14 +13,14 @@
 #
 # Copyright Buildbot Team Members
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot import util
 
 
+@implementer(interfaces.IStatusEvent)
 class Event:
-    implements(interfaces.IStatusEvent)
 
     started = None
     finished = None

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -19,7 +19,7 @@ from future.utils import iteritems
 from future.utils import itervalues
 from twisted.internet import defer
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot import util
@@ -32,8 +32,8 @@ from buildbot.util import service
 from buildbot.util.eventual import eventually
 
 
+@implementer(interfaces.IStatus)
 class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
-    implements(interfaces.IStatus)
 
     def __init__(self):
         service.AsyncMultiService.__init__(self)

--- a/master/buildbot/status/worker.py
+++ b/master/buildbot/status/worker.py
@@ -15,15 +15,15 @@
 
 import time
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.util import ascii2unicode
 from buildbot.util.eventual import eventually
 
 
+@implementer(interfaces.IWorkerStatus)
 class WorkerStatus:
-    implements(interfaces.IWorkerStatus)
 
     admin = None
     host = None

--- a/master/buildbot/steps/source/repo.py
+++ b/master/buildbot/steps/source/repo.py
@@ -17,7 +17,7 @@ import textwrap
 
 from twisted.internet import defer
 from twisted.internet import reactor
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import util
 from buildbot.interfaces import IRenderable
@@ -25,8 +25,8 @@ from buildbot.process import buildstep
 from buildbot.steps.source.base import Source
 
 
+@implementer(IRenderable)
 class RepoDownloadsFromProperties(util.ComparableMixin, object):
-    implements(IRenderable)
     parse_download_re = (re.compile(r"repo download ([^ ]+) ([0-9]+/[0-9]+)"),
                          re.compile(r"([^ ]+) ([0-9]+/[0-9]+)"),
                          re.compile(r"([^ ]+)/([0-9]+/[0-9]+)"),
@@ -65,8 +65,8 @@ class RepoDownloadsFromProperties(util.ComparableMixin, object):
         return ret
 
 
+@implementer(IRenderable)
 class RepoDownloadsFromChangeSource(util.ComparableMixin, object):
-    implements(IRenderable)
     compare_attrs = ('codebase',)
 
     def __init__(self, codebase=None):

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -18,7 +18,7 @@ import weakref
 import mock
 from twisted.internet import defer
 from twisted.internet import reactor
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import config
 from buildbot import interfaces
@@ -102,9 +102,8 @@ class FakeStatus(service.BuildbotService):
         return "h://bb.me"
 
 
+@implementer(interfaces.IBuilderStatus)
 class FakeBuilderStatus(object):
-
-    implements(interfaces.IBuilderStatus)
 
     def __init__(self, master=None, buildername="Builder"):
         if master:

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -22,7 +22,7 @@ from future.builtins import range
 from future.utils import iteritems
 from twisted.internet import defer
 from twisted.trial import unittest
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import config
 from buildbot import interfaces
@@ -77,8 +77,8 @@ class FakeStatusReceiver(status_base.StatusReceiver):
     pass
 
 
+@implementer(interfaces.IScheduler)
 class FakeScheduler(object):
-    implements(interfaces.IScheduler)
 
     def __init__(self, name):
         self.name = name

--- a/master/buildbot/test/unit/test_data_buildsets.py
+++ b/master/buildbot/test/unit/test_data_buildsets.py
@@ -15,7 +15,7 @@
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.data import buildsets
@@ -246,8 +246,8 @@ class Buildset(util_interfaces.InterfaceTests, unittest.TestCase):
                  sourcestamps=[ssmap[ssid] for ssid in sourcestampids]))
 
     def test_addBuildset_two_builderNames(self):
+        @implementer(interfaces.IScheduler)
         class FakeSched(object):
-            implements(interfaces.IScheduler)
             name = 'fakesched'
 
         kwargs = dict(scheduler=u'fakesched', reason=u'because',
@@ -270,8 +270,8 @@ class Buildset(util_interfaces.InterfaceTests, unittest.TestCase):
                                         expectedReturn, expectedMessages, expectedBuildset)
 
     def test_addBuildset_no_builderNames(self):
+        @implementer(interfaces.IScheduler)
         class FakeSched(object):
-            implements(interfaces.IScheduler)
             name = 'fakesched'
 
         kwargs = dict(scheduler=u'fakesched', reason=u'because',

--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -19,7 +19,7 @@ import re
 
 import mock
 from twisted.trial import unittest
-from zope.interface import implements
+from zope.interface import implementer
 
 import buildbot.plugins.db
 from buildbot.errors import PluginDBError
@@ -81,12 +81,12 @@ class ITestInterface(IPlugin):
         "Greets by :param:`name`"
 
 
+@implementer(ITestInterface)
 class ClassWithInterface(object):
 
     """
     a class to implement a simple interface
     """
-    implements(ITestInterface)
 
     def __init__(self, name=None):
         self._name = name

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -19,7 +19,6 @@ from mock import call
 from twisted.internet import defer
 from twisted.trial import unittest
 from zope.interface import implementer
-from zope.interface import implements
 
 from buildbot import interfaces
 from buildbot.locks import WorkerLock
@@ -115,10 +114,10 @@ class FakeBuilder:
         pass
 
 
+@implementer(interfaces.IBuildStepFactory)
 class FakeStepFactory(object):
 
     """Fake step factory that just returns a fixed step object."""
-    implements(interfaces.IBuildStepFactory)
 
     def __init__(self, step):
         self.step = step
@@ -1060,8 +1059,9 @@ class TestBuildProperties(unittest.TestCase):
     """
 
     def setUp(self):
+        @implementer(interfaces.IProperties)
         class FakeProperties(Mock):
-            implements(interfaces.IProperties)
+            pass
 
         class FakeBuildStatus(Mock):
             pass
@@ -1114,8 +1114,9 @@ class TestBuildProperties(unittest.TestCase):
         self.properties.render.assert_called_with("xyz")
 
     def test_getWorkerName_old_api(self):
+        @implementer(interfaces.IProperties)
         class FakeProperties(Mock):
-            implements(interfaces.IProperties)
+            pass
 
         import posixpath
 
@@ -1148,8 +1149,9 @@ class TestBuildProperties(unittest.TestCase):
         self.assertIdentical(new, old)
 
     def test_workername_old_api(self):
+        @implementer(interfaces.IProperties)
         class FakeProperties(Mock):
-            implements(interfaces.IProperties)
+            pass
 
         import posixpath
 

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -18,7 +18,7 @@ import mock
 from twisted.internet import defer
 from twisted.python import components
 from twisted.trial import unittest
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot.interfaces import IProperties
 from buildbot.interfaces import IRenderable
@@ -60,8 +60,8 @@ class FakeSource:
         return ds
 
 
+@implementer(IRenderable)
 class DeferredRenderable:
-    implements(IRenderable)
 
     def __init__(self):
         self.d = defer.Deferred()
@@ -1033,8 +1033,8 @@ class TestProperties(unittest.TestCase):
         self.assertIdentical(self.props.getBuild(), self.props.build)
 
     def test_render(self):
+        @implementer(IRenderable)
         class Renderable(object):
-            implements(IRenderable)
 
             def getRenderingFor(self, props):
                 return props.getProperty('x') + 'z'

--- a/master/buildbot/test/unit/test_steps_subunit.py
+++ b/master/buildbot/test/unit/test_steps_subunit.py
@@ -16,7 +16,7 @@ import StringIO
 
 import mock
 from twisted.trial import unittest
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.process.results import FAILURE
@@ -26,8 +26,9 @@ from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
 
 
+@implementer(interfaces.ILogObserver)
 class StubLogObserver(mock.Mock):
-    implements(interfaces.ILogObserver)
+    pass
 
 
 class TestSetPropertiesFromEnv(steps.BuildStepMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -17,7 +17,7 @@ from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import failure
 from twisted.trial import unittest
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import config
 from buildbot import interfaces
@@ -33,8 +33,8 @@ from buildbot.test.util import steps
 from buildbot.test.util.interfaces import InterfaceTests
 
 
+@implementer(interfaces.ITriggerableScheduler)
 class FakeTriggerable(object):
-    implements(interfaces.ITriggerableScheduler)
 
     triggered_with = None
     result = SUCCESS

--- a/master/buildbot/test/unit/test_worker_manager.py
+++ b/master/buildbot/test/unit/test_worker_manager.py
@@ -15,7 +15,7 @@
 import mock
 from twisted.internet import defer
 from twisted.trial import unittest
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.process import botmaster
@@ -24,9 +24,8 @@ from buildbot.util import service
 from buildbot.worker import manager as workermanager
 
 
+@implementer(interfaces.IWorker)
 class FakeWorker(service.BuildbotService):
-
-    implements(interfaces.IWorker)
 
     reconfig_count = 0
 

--- a/master/buildbot/test/util/properties.py
+++ b/master/buildbot/test/util/properties.py
@@ -13,13 +13,13 @@
 #
 # Copyright Buildbot Team Members
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot.interfaces import IRenderable
 
 
+@implementer(IRenderable)
 class ConstantRenderable(object):
-    implements(IRenderable)
 
     def __init__(self, value):
         self.value = value

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -27,7 +27,7 @@ import time
 
 from twisted.python import reflect
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot.interfaces import IConfigured
 from buildbot.util.misc import deferredLocked
@@ -102,8 +102,8 @@ def formatInterval(eta):
     return ", ".join(eta_parts)
 
 
+@implementer(IConfigured)
 class ComparableMixin(object):
-    implements(IConfigured)
     compare_attrs = ()
 
     class _None:

--- a/master/buildbot/util/config.py
+++ b/master/buildbot/util/config.py
@@ -16,13 +16,13 @@ import re
 
 from future.utils import iteritems
 from twisted.python.components import registerAdapter
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot.interfaces import IConfigured
 
 
+@implementer(IConfigured)
 class _DefaultConfigured(object):
-    implements(IConfigured)
 
     def __init__(self, value):
         self.value = value
@@ -33,8 +33,8 @@ class _DefaultConfigured(object):
 registerAdapter(_DefaultConfigured, object, IConfigured)
 
 
+@implementer(IConfigured)
 class _ListConfigured(object):
-    implements(IConfigured)
 
     def __init__(self, value):
         self.value = value
@@ -45,8 +45,8 @@ class _ListConfigured(object):
 registerAdapter(_ListConfigured, list, IConfigured)
 
 
+@implementer(IConfigured)
 class _DictConfigured(object):
-    implements(IConfigured)
 
     def __init__(self, value):
         self.value = value
@@ -57,8 +57,8 @@ class _DictConfigured(object):
 registerAdapter(_DictConfigured, dict, IConfigured)
 
 
+@implementer(IConfigured)
 class _SREPatternConfigured(object):
-    implements(IConfigured)
 
     def __init__(self, value):
         self.value = value
@@ -69,8 +69,8 @@ class _SREPatternConfigured(object):
 registerAdapter(_SREPatternConfigured, type(re.compile("")), IConfigured)
 
 
+@implementer(IConfigured)
 class ConfiguredMixin(object):
-    implements(IConfigured)
 
     def getConfigDict(self):
         return {'name': self.name}

--- a/master/buildbot/util/netstrings.py
+++ b/master/buildbot/util/netstrings.py
@@ -15,19 +15,19 @@
 from twisted.internet.interfaces import IAddress
 from twisted.internet.interfaces import ITransport
 from twisted.protocols import basic
-from zope.interface import implements
+from zope.interface import implementer
 
 
+@implementer(IAddress)
 class NullAddress(object):
 
     "an address for NullTransport"
-    implements(IAddress)
 
 
+@implementer(ITransport)
 class NullTransport(object):
 
     "a do-nothing transport to make NetstringReceiver happy"
-    implements(ITransport)
 
     def write(self, data):
         raise NotImplementedError

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -22,7 +22,7 @@ from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log
 from twisted.python.reflect import namedModule
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot import config
 from buildbot.interfaces import ILatentWorker
@@ -39,6 +39,7 @@ from buildbot.util.eventual import eventually
 from buildbot.worker_transition import deprecatedWorkerClassProperty
 
 
+@implementer(IWorker)
 class AbstractWorker(service.BuildbotService, object):
 
     """This is the master-side representative for a remote buildbot worker.
@@ -50,8 +51,6 @@ class AbstractWorker(service.BuildbotService, object):
     I represent a worker -- a remote machine capable of
     running builds.  I am instantiated by the configuration file, and can be
     subclassed to add extra functionality."""
-
-    implements(IWorker)
 
     # reconfig workers after builders
     reconfig_priority = 64
@@ -613,6 +612,7 @@ class Worker(AbstractWorker):
         self.maybeShutdown()
 
 
+@implementer(ILatentWorker)
 class AbstractLatentWorker(AbstractWorker):
 
     """A worker that will start up a worker instance when needed.
@@ -622,8 +622,6 @@ class AbstractLatentWorker(AbstractWorker):
     See ec2buildslave.py for a concrete example.  Also see the stub example in
     test/test_slaves.py.
     """
-
-    implements(ILatentWorker)
 
     substantiated = False
     substantiation_build = None

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -24,7 +24,7 @@ from twisted.web.guard import BasicCredentialFactory
 from twisted.web.guard import DigestCredentialFactory
 from twisted.web.guard import HTTPAuthSessionWrapper
 from twisted.web.resource import IResource
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot.util import config
 from buildbot.www import resource
@@ -120,8 +120,8 @@ class RemoteUserAuth(AuthBase):
             yield self.updateUserInfo(request)
 
 
+@implementer(IRealm)
 class AuthRealm(object):
-    implements(IRealm)
 
     def __init__(self, master, auth):
         self.auth = auth

--- a/master/buildbot/www/authz/authz.py
+++ b/master/buildbot/www/authz/authz.py
@@ -17,7 +17,7 @@ import re
 
 from twisted.internet import defer
 from twisted.web.error import Error
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot.interfaces import IConfigured
 from buildbot.www.authz.roles import RolesFromOwner
@@ -38,8 +38,8 @@ def reStrMatcher(value, match):
     return re.match(match, value)
 
 
+@implementer(IConfigured)
 class Authz(object):
-    implements(IConfigured)
 
     def getConfigDict(self):
         return {}

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -23,7 +23,7 @@ from twisted.python import log
 from twisted.web import guard
 from twisted.web import resource
 from twisted.web import server
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot.plugins.db import get_plugins
 from buildbot.util import service
@@ -232,13 +232,13 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             rsrc.reconfigResource(new_config)
 
     def setupProtectedResource(self, resource_obj, checkers):
+        @implementer(IRealm)
         class SimpleRealm(object):
 
             """
             A realm which gives out L{ChangeHookResource} instances for authenticated
             users.
             """
-            implements(IRealm)
 
             def requestAvatar(self, avatarId, mind, *interfaces):
                 if resource.IResource in interfaces:

--- a/master/contrib/fakemaster.py
+++ b/master/contrib/fakemaster.py
@@ -23,14 +23,14 @@ from twisted.internet import reactor
 from twisted.internet import stdio
 from twisted.protocols import basic
 from twisted.spread import pb
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot.process.buildstep import RemoteShellCommand
 from buildbot.util import service
 
 
+@implementer(portal.IRealm)
 class Dispatcher:
-    implements(portal.IRealm)
 
     def __init__(self):
         self.names = {}

--- a/master/docs/manual/cfg-properties.rst
+++ b/master/docs/manual/cfg-properties.rst
@@ -390,8 +390,8 @@ The method should take one argument - an :class:`~buildbot.interfaces.IPropertie
 Pass instances of the class anywhere other renderables are accepted.
 For example::
 
+    @implementer(IRenderable)
     class DetermineFoo(object):
-        implements(IRenderable)
         def getRenderingFor(self, props):
             if props.hasProperty('bar'):
                 return props['bar']
@@ -404,8 +404,8 @@ or, more practically,
 
 ::
 
+    @implementer(IRenderable)
     class Now(object):
-        implements(IRenderable)
         def getRenderingFor(self, props):
             return time.clock()
     ShellCommand(command=['make', Interpolate('TIME=%(kw:now)s', now=Now())])

--- a/worker/buildbot_worker/commands/base.py
+++ b/worker/buildbot_worker/commands/base.py
@@ -25,7 +25,7 @@ from twisted.internet import threads
 from twisted.python import failure
 from twisted.python import log
 from twisted.python import runtime
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot_worker import runprocess
 from buildbot_worker import util
@@ -81,8 +81,8 @@ command_version = "3.0"
 #      command.
 
 
+@implementer(IWorkerCommand)
 class Command(object):
-    implements(IWorkerCommand)
 
     """This class defines one command that can be invoked by the build master.
     The command is executed on the worker side, and always sends back a

--- a/worker/buildbot_worker/test/unit/test_bot_Worker.py
+++ b/worker/buildbot_worker/test/unit/test_bot_Worker.py
@@ -24,7 +24,7 @@ from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.spread import pb
 from twisted.trial import unittest
-from zope.interface import implements
+from zope.interface import implementer
 
 from buildbot_worker import bot
 from buildbot_worker.test.util import misc
@@ -47,13 +47,12 @@ class MasterPerspective(pb.Avatar):
             on_keepalive()
 
 
+@implementer(portal.IRealm)
 class MasterRealm(object):
 
     def __init__(self, perspective, on_attachment):
         self.perspective = perspective
         self.on_attachment = on_attachment
-
-    implements(portal.IRealm)
 
     def requestAvatar(self, avatarId, mind, *interfaces):
         assert pb.IPerspective in interfaces


### PR DESCRIPTION
On Python 3, zope.interface.implements() fails with:

builtins.TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.