### PR TITLE
Replace basestring with future.utils.string_types.

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -21,6 +21,7 @@ from types import MethodType
 
 from future.utils import iteritems
 from future.utils import itervalues
+from future.utils import string_types
 from future.utils import text_type
 from twisted.python import failure
 from twisted.python import log
@@ -338,7 +339,7 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
 
         def copy_str_param(name, alt_key=None):
             copy_param(name, alt_key=alt_key,
-                       check_type=basestring, check_type_name='a string')
+                       check_type=string_types, check_type_name='a string')
 
         copy_str_param('title', alt_key='projectName')
         copy_str_param('titleURL', alt_key='projectURL')

--- a/master/buildbot/monkeypatches/testcase_assert.py
+++ b/master/buildbot/monkeypatches/testcase_assert.py
@@ -16,6 +16,7 @@
 
 import re
 import unittest
+from future.utils import string_types
 
 
 def _assertRaisesRegexp(self, expected_exception, expected_regexp,
@@ -36,7 +37,7 @@ def _assertRaisesRegexp(self, expected_exception, expected_regexp,
     if exception is None:
         self.fail("%s not raised" % str(expected_exception.__name__))
 
-    if isinstance(expected_regexp, basestring):
+    if isinstance(expected_regexp, string_types):
         expected_regexp = re.compile(expected_regexp)
 
     if not expected_regexp.search(str(exception)):

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -15,6 +15,8 @@
 import warnings
 import weakref
 
+from future.utils import string_types
+
 from twisted.application import internet
 from twisted.application import service
 from twisted.internet import defer
@@ -38,7 +40,7 @@ from buildbot.worker_transition import deprecatedWorkerModuleAttribute
 def enforceChosenWorker(bldr, workerforbuilder, breq):
     if 'workername' in breq.properties:
         workername = breq.properties['workername']
-        if isinstance(workername, basestring):
+        if isinstance(workername, string_types):
             return workername == workerforbuilder.worker.workername
 
     return True

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -16,7 +16,9 @@ import re
 
 from future.utils import iteritems
 from future.utils import itervalues
+from future.utils import string_types
 from future.utils import text_type
+
 from twisted.internet import defer
 from twisted.internet import error
 from twisted.python import util as twutil
@@ -1229,7 +1231,7 @@ def regex_log_evaluator(cmd, _, regexes):
         # we won't be changing "worst" unless possible_status is worse than it,
         # so we don't even need to check the log if that's the case
         if worst_status(worst, possible_status) == possible_status:
-            if isinstance(err, (basestring)):
+            if isinstance(err, (string_types)):
                 err = re.compile(".*%s.*" % err, re.DOTALL)
             for l in itervalues(cmd.logs):
                 if err.search(l.getText()):

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -1231,7 +1231,7 @@ def regex_log_evaluator(cmd, _, regexes):
         # we won't be changing "worst" unless possible_status is worse than it,
         # so we don't even need to check the log if that's the case
         if worst_status(worst, possible_status) == possible_status:
-            if isinstance(err, (string_types)):
+            if isinstance(err, string_types):
                 err = re.compile(".*%s.*" % err, re.DOTALL)
             for l in itervalues(cmd.logs):
                 if err.search(l.getText()):

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -15,6 +15,7 @@
 import re
 
 from future.utils import itervalues
+from future.utils import string_types
 from future.utils import text_type
 from twisted.internet import defer
 from twisted.python import log
@@ -41,7 +42,7 @@ class Log(object):
 
     @staticmethod
     def _decoderFromString(cfg):
-        if isinstance(cfg, basestring):
+        if isinstance(cfg, string_types):
             return lambda s: s.decode(cfg, 'replace')
         else:
             return cfg

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import iteritems
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.internet import error
 from twisted.python import log
@@ -348,7 +349,7 @@ class RemoteShellCommand(RemoteCommand):
         if decodeRC is None:
             decodeRC = {0: SUCCESS}
         self.command = command  # stash .command, set it later
-        if isinstance(self.command, basestring):
+        if isinstance(self.command, string_types):
             # Single string command doesn't support obfuscation.
             self.fake_command = command
         else:

--- a/master/buildbot/process/users/manual.py
+++ b/master/buildbot/process/users/manual.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.python import log
 
@@ -52,7 +53,7 @@ class CommandlineUserManagerPerspective(pbutil.NewCredPerspective):
             # list, alternating ident, uid
             formatted_results += "user(s) added:\n"
             for user in results:
-                if isinstance(user, basestring):
+                if isinstance(user, string_types):
                     formatted_results += "identifier: %s\n" % user
                 else:
                     formatted_results += "uid: %d\n\n" % user

--- a/master/buildbot/reporters/hipchat.py
+++ b/master/buildbot/reporters/hipchat.py
@@ -1,3 +1,4 @@
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.python import log
 
@@ -13,9 +14,9 @@ class HipChatStatusPush(HttpStatusPushBase):
     def checkConfig(self, auth_token, endpoint="https://api.hipchat.com",
                     builder_room_map=None, builder_user_map=None,
                     event_messages=None, **kwargs):
-        if not isinstance(auth_token, basestring):
+        if not isinstance(auth_token, string_types):
             config.error('auth_token must be a string')
-        if not isinstance(endpoint, basestring):
+        if not isinstance(endpoint, string_types):
             config.error('endpoint must be a string')
         if builder_room_map and not isinstance(builder_room_map, dict):
             config.error('builder_room_map must be a dict')

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -23,6 +23,7 @@ from email.utils import formatdate
 from StringIO import StringIO
 
 from future.utils import iteritems
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log as twlog
@@ -91,7 +92,7 @@ class MailNotifier(service.BuildbotService):
                       "exception", "cancelled")
 
     def computeShortcutModes(self, mode):
-        if isinstance(mode, basestring):
+        if isinstance(mode, string_types):
             if mode == "all":
                 mode = ("failing", "passing", "warnings",
                         "exception", "cancelled")
@@ -148,7 +149,7 @@ class MailNotifier(service.BuildbotService):
                 'Newlines are not allowed in email subjects')
 
         if lookup is not None:
-            if not isinstance(lookup, basestring):
+            if not isinstance(lookup, string_types):
                 assert interfaces.IEmailLookup.providedBy(lookup)
 
         if extraHeaders:
@@ -186,7 +187,7 @@ class MailNotifier(service.BuildbotService):
         self.relayhost = relayhost
         self.subject = subject
         if lookup is not None:
-            if isinstance(lookup, basestring):
+            if isinstance(lookup, string_types):
                 lookup = Domain(str(lookup))
 
         self.lookup = lookup

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.moves.collections import UserList
 from future.utils import lrange
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.python import log
 
@@ -165,7 +166,7 @@ def getResponsibleUsersForBuild(master, buildid):
     # add owner from properties
     if 'owner' in properties:
         owner = properties['owner'][0]
-        if isinstance(owner, basestring):
+        if isinstance(owner, string_types):
             blamelist.add(owner)
         else:
             blamelist.update(owner)

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import iteritems
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log
@@ -43,7 +44,7 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
             ok = False
         else:
             for b in builderNames:
-                if not isinstance(b, basestring):
+                if not isinstance(b, string_types):
                     ok = False
         if not ok:
             config.error(

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -17,6 +17,7 @@ import traceback
 
 from future.utils import iteritems
 from future.utils import itervalues
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.python.reflect import accumulateClassList
 
@@ -536,7 +537,7 @@ class CodebaseParameter(NestedParameter):
         for k, v in iteritems(fields_dict):
             if v is DefaultField:
                 v = StringParameter(name=k, label=k.capitalize() + ":")
-            elif isinstance(v, basestring):
+            elif isinstance(v, string_types):
                 v = FixedParameter(name=k, default=v)
             fields_dict[k] = v
 
@@ -671,7 +672,7 @@ class ForceScheduler(base.BaseScheduler):
 
         codebase_dict = {}
         for codebase in codebases:
-            if isinstance(codebase, basestring):
+            if isinstance(codebase, string_types):
                 codebase = CodebaseParameter(codebase=codebase)
             elif not isinstance(codebase, CodebaseParameter):
                 config.error("ForceScheduler '%s': 'codebases' must be a list of strings or CodebaseParameter objects: %r" % (

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import itervalues
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log
@@ -286,7 +287,7 @@ class NightlyBase(Timed):
                 time = (time + 1) % 7
             return time
 
-        if isinstance(time, basestring):
+        if isinstance(time, string_types):
             if isDayOfWeek:
                 # time could be a comma separated list of values, e.g. "5,sun"
                 time_array = str(time).split(',')

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -19,6 +19,7 @@ from builtins import bytes
 from builtins import str
 
 from future.utils import iteritems
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.internet import error
 from twisted.internet import reactor
@@ -133,7 +134,7 @@ class MasterShellCommand(BuildStep):
             newenv = {}
             for key, v in iteritems(env):
                 if v is not None:
-                    if not isinstance(v, basestring):
+                    if not isinstance(v, string_types):
                         raise RuntimeError("'env' values must be strings or "
                                            "lists; key '%s' is incorrect" % (key,))
                     newenv[key] = p.sub(subst, env[key])

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -16,6 +16,7 @@ import inspect
 import re
 
 from future.utils import iteritems
+from future.utils import string_types
 from twisted.python import failure
 from twisted.python import log
 from twisted.python.deprecate import deprecatedModuleAttribute
@@ -454,9 +455,9 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
         is no upper bound."""
 
         for fileRe, warnRe, start, end in suppressionList:
-            if fileRe is not None and isinstance(fileRe, basestring):
+            if fileRe is not None and isinstance(fileRe, string_types):
                 fileRe = re.compile(fileRe)
-            if warnRe is not None and isinstance(warnRe, basestring):
+            if warnRe is not None and isinstance(warnRe, string_types):
                 warnRe = re.compile(warnRe)
             self.suppressions.append((fileRe, warnRe, start, end))
 
@@ -486,12 +487,12 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
 
         directoryEnterRe = self.directoryEnterPattern
         if (directoryEnterRe is not None
-                and isinstance(directoryEnterRe, basestring)):
+                and isinstance(directoryEnterRe, string_types)):
             directoryEnterRe = re.compile(directoryEnterRe)
 
         directoryLeaveRe = self.directoryLeavePattern
         if (directoryLeaveRe is not None
-                and isinstance(directoryLeaveRe, basestring)):
+                and isinstance(directoryLeaveRe, string_types)):
             directoryLeaveRe = re.compile(directoryLeaveRe)
 
         # Check if each line in the output from this command matched our

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -15,6 +15,7 @@
 from distutils.version import LooseVersion
 
 from future.utils import iteritems
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log
@@ -141,11 +142,11 @@ class Git(Source):
 
         if not self.repourl:
             bbconfig.error("Git: must provide repourl.")
-        if isinstance(self.mode, basestring):
+        if isinstance(self.mode, string_types):
             if not self._hasAttrGroupMember('mode', self.mode):
                 bbconfig.error("Git: mode must be %s" %
                                (' or '.join(self._listAttrGroupMembers('mode'))))
-            if isinstance(self.method, basestring):
+            if isinstance(self.method, string_types):
                 if (self.mode == 'full' and self.method not in ['clean', 'fresh', 'clobber', 'copy', None]):
                     bbconfig.error("Git: invalid method for mode 'full'.")
                 if self.shallow and (self.mode != 'full' or self.method != 'clobber'):

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -16,6 +16,7 @@
 import re
 from types import StringType
 
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.python import log
 
@@ -230,7 +231,7 @@ class P4(Source):
         command.extend(doCommand)
 
         def encodeArg(arg):
-            if isinstance(arg, basestring):
+            if isinstance(arg, string_types):
                 return arg.encode('utf-8')
             elif isinstance(arg, tuple):
                 # If a tuple, then the second element is the argument that will

--- a/master/buildbot/test/integration/test_hyper.py
+++ b/master/buildbot/test/integration/test_hyper.py
@@ -16,6 +16,7 @@ import json
 import os
 from unittest.case import SkipTest
 
+from future.utils import string_types
 from twisted.internet import defer
 
 from buildbot.process.results import SUCCESS
@@ -90,7 +91,7 @@ def masterConfig():
                       workernames=["hyper1"],
                       factory=f2)]
     hyperconfig = workerhyper.Hyper.guess_config()
-    if isinstance(hyperconfig, basestring):
+    if isinstance(hyperconfig, string_types):
         hyperconfig = json.load(open(hyperconfig))
     hyperhost, hyperconfig = hyperconfig['clouds'].items()[0]
     masterFQDN = os.environ.get('masterFQDN')

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -16,6 +16,7 @@ import os
 import re
 
 import mock
+from future.utils import string_types
 from future.utils import text_type
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -106,7 +107,7 @@ class GitOutputParsing(gpo.GetProcessOutputMixin, unittest.TestCase):
         def cb_desired(r):
             self.assertEquals(r, desiredGoodResult)
             # check types
-            if isinstance(r, basestring):
+            if isinstance(r, string_types):
                 self.assertIsInstance(r, text_type)
             elif isinstance(r, list):
                 [self.assertIsInstance(e, text_type) for e in r]

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -18,6 +18,7 @@ import mock
 from future.builtins import range
 from future.utils import iteritems
 from future.utils import itervalues
+from future.utils import string_types
 from future.utils import text_type
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -615,7 +616,7 @@ class V2RootResource_JSONRPC2(www.WwwTestMixin, unittest.TestCase):
         exp['error'] = {'code': jsonrpccode, 'message': message}
 
         # process a regular expression for message, if given
-        if not isinstance(message, basestring):
+        if not isinstance(message, string_types):
             if message.match(got['error']['message']):
                 exp['error']['message'] = got['error']['message']
             else:

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.moves.urllib.parse import urlsplit
 from future.moves.urllib.parse import urlunsplit
+from future.utils import string_types
 
 import calendar
 import datetime
@@ -261,7 +262,7 @@ def human_readable_delta(start, end):
 
 
 def makeList(input):
-    if isinstance(input, basestring):
+    if isinstance(input, string_types):
         return [input]
     elif input is None:
         return []

--- a/master/buildbot/util/identifiers.py
+++ b/master/buildbot/util/identifiers.py
@@ -15,6 +15,7 @@
 
 import re
 
+from future.utils import string_types
 from future.utils import text_type
 from buildbot import util
 
@@ -35,7 +36,7 @@ def isIdentifier(maxLength, object):
 
 
 def forceIdentifier(maxLength, str):
-    if not isinstance(str, basestring):
+    if not isinstance(str, string_types):
         raise TypeError("%r cannot be coerced to an identifier" % (str,))
 
     # usually ascii2unicode can handle it

--- a/master/buildbot/util/misc.py
+++ b/master/buildbot/util/misc.py
@@ -16,6 +16,7 @@
 Miscellaneous utilities; these should be imported from C{buildbot.util}, not
 directly from this module.
 """
+from future.utils import string_types
 from twisted.internet import reactor
 
 
@@ -23,7 +24,7 @@ def deferredLocked(lock_or_attr):
     def decorator(fn):
         def wrapper(*args, **kwargs):
             lock = lock_or_attr
-            if isinstance(lock, basestring):
+            if isinstance(lock, string_types):
                 lock = getattr(args[0], lock)
             return lock.run(fn, *args, **kwargs)
         return wrapper

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -25,6 +25,7 @@ import time
 
 from future.utils import integer_types
 from future.utils import iteritems
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.internet import threads
 from twisted.python import log
@@ -113,7 +114,7 @@ class EC2LatentWorker(AbstractLatentWorker):
                             'valid_ami_owners should be int or iterable '
                             'of ints', element)
         if valid_ami_location_regex is not None:
-            if not isinstance(valid_ami_location_regex, basestring):
+            if not isinstance(valid_ami_location_regex, string_types):
                 raise ValueError(
                     'valid_ami_location_regex should be a string')
             else:

--- a/master/buildbot/www/authz/endpointmatchers.py
+++ b/master/buildbot/www/authz/endpointmatchers.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 import inspect
 
+from future.utils import string_types
 from twisted.internet import defer
 
 from buildbot.data.exceptions import InvalidPathError
@@ -51,7 +52,7 @@ class EndpointMatcherBase(object):
         # a repr for debugging. displays the class, and string attributes
         args = []
         for k, v in self.__dict__.items():
-            if isinstance(v, basestring):
+            if isinstance(v, string_types):
                 args.append("%s='%s'" % (k, v))
         return "%s(%s)" % (self.__class__.__name__, ", ".join(args))
 

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -18,6 +18,7 @@ import requests
 from future.moves.urllib.parse import parse_qs
 from future.moves.urllib.parse import urlencode
 from future.utils import iteritems
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.internet import threads
 
@@ -130,7 +131,7 @@ class OAuth2Auth(auth.AuthBase):
             response = requests.post(
                 url, data=data, auth=auth, verify=self.sslVerify)
             response.raise_for_status()
-            if isinstance(response.content, basestring):
+            if isinstance(response.content, string_types):
                 try:
                     content = json.loads(response.content)
                 except ValueError:

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -16,6 +16,7 @@ from autobahn.twisted.resource import WebSocketResource
 from autobahn.twisted.websocket import WebSocketServerFactory
 from autobahn.twisted.websocket import WebSocketServerProtocol
 from future.utils import itervalues
+from future.utils import string_types
 from twisted.internet import defer
 from twisted.python import log
 
@@ -66,7 +67,7 @@ class WsProtocol(WebSocketServerProtocol):
         return tuple([str(p) if p != "*" else None for p in path])
 
     def isPath(self, path):
-        if not isinstance(path, basestring):
+        if not isinstance(path, string_types):
             return False
         return True
 

--- a/master/contrib/buildbot_json.py
+++ b/master/contrib/buildbot_json.py
@@ -44,6 +44,7 @@ import urllib2
 
 from future.builtins import range
 from future.utils import lrange
+from future.utils import string_types
 from future.utils import text_type
 
 """Queries buildbot through the json interface.
@@ -685,7 +686,7 @@ class BuildSteps(NonAddressableNodeList):
 
     def __getitem__(self, key):
         """Accept step name in addition to index number."""
-        if isinstance(key, basestring):
+        if isinstance(key, string_types):
             # It's a string, try to find the corresponding index.
             for i, step in enumerate(self.data):
                 if step['name'] == key:

--- a/master/contrib/webhook_status.py
+++ b/master/contrib/webhook_status.py
@@ -1,5 +1,6 @@
 import urllib
 
+from future.utils import string_types
 from twisted.internet import reactor
 from twisted.python import log
 from twisted.web import client
@@ -49,7 +50,7 @@ class WebHookTransmitter(status.base.StatusReceiverMultiService):
     def __init__(self, url, categories=None, extra_params=None,
                  max_attempts=MAX_ATTEMPTS, retry_multiplier=RETRY_MULTIPLIER):
         status.base.StatusReceiverMultiService.__init__(self)
-        if isinstance(url, basestring):
+        if isinstance(url, string_types):
             self.urls = [url]
         else:
             self.urls = url

--- a/worker/buildbot_worker/monkeypatches/testcase_assert.py
+++ b/worker/buildbot_worker/monkeypatches/testcase_assert.py
@@ -16,6 +16,7 @@
 
 import re
 import unittest
+from future.utils import string_types
 
 
 def _assertRaisesRegexp(self, expected_exception, expected_regexp,
@@ -36,7 +37,7 @@ def _assertRaisesRegexp(self, expected_exception, expected_regexp,
     if exception is None:
         self.fail("%s not raised" % str(expected_exception.__name__))
 
-    if isinstance(expected_regexp, basestring):
+    if isinstance(expected_regexp, string_types):
         expected_regexp = re.compile(expected_regexp)
 
     if not expected_regexp.search(str(exception)):

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -30,6 +30,7 @@ from tempfile import NamedTemporaryFile
 
 from future.builtins import range
 from future.utils import iteritems
+from future.utils import string_types
 from future.utils import text_type
 from twisted.internet import defer
 from twisted.internet import error
@@ -347,7 +348,7 @@ class RunProcess(object):
                     newenv[key] = os.environ[key]
             for key, v in iteritems(environ):
                 if v is not None:
-                    if not isinstance(v, basestring):
+                    if not isinstance(v, string_types):
                         raise RuntimeError("'env' values must be strings or "
                                            "lists; key '%s' is incorrect" % (key,))
                     newenv[key] = p.sub(subst, v)
@@ -449,7 +450,7 @@ class RunProcess(object):
         self.pp = RunProcessPP(self)
 
         self.using_comspec = False
-        if isinstance(self.command, basestring):
+        if isinstance(self.command, string_types):
             if runtime.platformType == 'win32':
                 # allow %COMSPEC% to have args
                 argv = os.environ['COMSPEC'].split()
@@ -592,7 +593,7 @@ class RunProcess(object):
         tf = NamedTemporaryFile(dir='.', suffix=".bat", delete=False)
         # echo off hides this cheat from the log files.
         tf.write("@echo off\n")
-        if isinstance(self.command, basestring):
+        if isinstance(self.command, string_types):
             tf.write(self.command)
         else:
             tf.write(win32_batch_quote(self.command))

--- a/worker/buildbot_worker/test/util/misc.py
+++ b/worker/buildbot_worker/test/util/misc.py
@@ -31,6 +31,7 @@ import shutil
 import sys
 
 import mock
+from future.utils import string_types
 from twisted.python import log
 
 from buildbot_worker.scripts import base
@@ -40,7 +41,7 @@ def nl(s):
     """Convert the given string to the native newline format, assuming it is
     already in normal UNIX newline format (\n).  Use this to create the
     appropriate expectation in a failUnlessEqual"""
-    if not isinstance(s, basestring):
+    if not isinstance(s, string_types):
         return s
     return s.replace('\n', os.linesep)
 

--- a/worker/buildbot_worker/util.py
+++ b/worker/buildbot_worker/util.py
@@ -16,6 +16,7 @@
 import itertools
 import textwrap
 import time
+from future.utils import string_types
 
 
 def remove_userpassword(url):
@@ -59,7 +60,7 @@ class Obfuscated(object):
 
     @staticmethod
     def to_text(s):
-        if isinstance(s, basestring):
+        if isinstance(s, string_types):
             return s
         else:
             return str(s)


### PR DESCRIPTION
basestring is gone on Python 3.
On Python 2, future.utils.string_types expands to basestring.
On Python 3, future.utils.string_types expands to str.