### PR TITLE
Use future.utils.integer_types instead of (int, long)

### DIFF
--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -17,6 +17,7 @@ import datetime
 import re
 
 # See "Type Validation" in master/docs/developer/tests.rst
+from future.utils import integer_types
 from future.utils import iteritems
 
 from buildbot import util
@@ -105,7 +106,7 @@ class Instance(Type):
 class Integer(Instance):
 
     name = "integer"
-    types = (int, long)
+    types = integer_types
     ramlType = "integer"
 
     def valueFromString(self, arg):

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -16,6 +16,7 @@
 Support for buildsets in the database
 """
 import sqlalchemy as sa
+from future.utils import integer_types
 from future.utils import iteritems
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -50,7 +51,7 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
 
         # convert to sourcestamp IDs first, as necessary
         def toSsid(sourcestamp):
-            if isinstance(sourcestamp, (int, long)):
+            if isinstance(sourcestamp, integer_types):
                 return defer.succeed(sourcestamp)
             else:
                 ssConnector = self.master.db.sourcestamps

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -17,6 +17,7 @@ import datetime
 import re
 
 # See "Type Validation" in master/docs/developer/tests.rst
+from future.utils import integer_types
 from future.utils import iteritems
 
 from buildbot.util import UTC
@@ -57,7 +58,7 @@ class InstanceValidator(Validator):
 
 
 class IntValidator(InstanceValidator):
-    types = (int, long)
+    types = integer_types
     name = 'integer'
 
 

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -20,6 +20,7 @@ from uuid import uuid1
 import mock
 import pkg_resources
 from future.moves.urllib.parse import unquote as urlunquote
+from future.utils import integer_types
 from future.utils import iteritems
 from twisted.internet import defer
 from twisted.web import server
@@ -79,7 +80,7 @@ class FakeRequest(object):
 
     def setResponseCode(self, code):
         # twisted > 16 started to assert this
-        assert isinstance(code, (int, long))
+        assert isinstance(code, integer_types)
         self.responseCode = code
 
     def setHeader(self, hdr, value):

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -23,6 +23,7 @@ import os
 import re
 import time
 
+from future.utils import integer_types
 from future.utils import iteritems
 from twisted.internet import defer
 from twisted.internet import threads
@@ -103,11 +104,11 @@ class EC2LatentWorker(AbstractLatentWorker):
                 'valid_ami_location_regex and valid_ami_owners')
         self.ami = ami
         if valid_ami_owners is not None:
-            if isinstance(valid_ami_owners, (int, long)):
+            if isinstance(valid_ami_owners, integer_types):
                 valid_ami_owners = (valid_ami_owners,)
             else:
                 for element in valid_ami_owners:
-                    if not isinstance(element, (int, long)):
+                    if not isinstance(element, integer_types):
                         raise ValueError(
                             'valid_ami_owners should be int or iterable '
                             'of ints', element)


### PR DESCRIPTION
long is gone in Python 3