### PR TITLE
Use future.utils.iterkeys() and future.utils.itervalues() for Python 3.

### DIFF
--- a/master/buildbot/worker_transition.py
+++ b/master/buildbot/worker_transition.py
@@ -199,7 +199,9 @@ def deprecatedWorkerModuleAttribute(scope, attribute, compat_name=None,
         "scope must be module, i.e. locals()"
 
     if new_name is None:
-        attribute_name = scope.keys()[scope.values().index(attribute)]
+        scope_keys = list(scope.keys())
+        scope_values = list(scope.values())
+        attribute_name = scope_keys[scope_values.index(attribute)]
     else:
         attribute_name = new_name
 
@@ -235,7 +237,9 @@ def deprecatedWorkerClassProperty(scope, prop, compat_name=None,
     """
 
     if new_name is None:
-        attribute_name = scope.keys()[scope.values().index(prop)]
+        scope_keys = list(scope.keys())
+        scope_values = list(scope.values())
+        attribute_name = scope_keys[scope_values.index(prop)]
     else:
         attribute_name = new_name
 


### PR DESCRIPTION
dict.keys() / dict.values() returns list on Python 2, and
a generator on Python 3.  We need a list.

Without this fix, we get this error on Python 3:

```
 File "/Users/crodrigues/uio/buildbot/master/buildbot/worker_transition.py", line 202, in deprecatedWorkerModuleAttribute
    attribute_name = scope.keys()[scope.values().index(attribute)]
AttributeError: 'dict_values' object has no attribute 'index'
```