### PR TITLE
Fix invocation of trial on Windows with Twisted 16.4.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
 build: false
 
 test_script:
-  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\\trial.py --reporter=text --rterrors buildbot.test buildbot_worker.test"
+  - "%PYTHON%\\python.exe -m twisted.trial --reporter=text --rterrors buildbot.test buildbot_worker.test"
 
 on_failure:
   # Store _trial_temp directory as artifact on build failure.


### PR DESCRIPTION
In Twisted 16.4.0, trial was converted to a Python console
script.  It must be invoked as "trial" or "python -m twisted.trial".
%PYTHON%\\Scripts\trial.py is gone in Twisted 16.4.0.