### PR TITLE
Replace unicode() with future.utils.text_type()

### DIFF
--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -123,7 +123,7 @@ class DateTime(Instance):
 class String(Instance):
 
     name = "string"
-    types = (unicode,)
+    types = (text_type,)
     ramlType = "string"
 
     def valueFromString(self, arg):

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -16,6 +16,7 @@ import calendar
 
 from future.utils import iteritems
 from future.utils import itervalues
+from future.utils import text_type
 from twisted.internet import defer
 
 from buildbot.data import resultspec
@@ -113,7 +114,7 @@ class TempSourceStamp(object):
             'patch_comment'] = result.pop('patch_info')
 
         assert all(
-            isinstance(val, (unicode, type(None), int))
+            isinstance(val, (text_type, type(None), int))
             for attr, val in iteritems(result)
         ), result
         return result

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -70,7 +70,7 @@ class BooleanValidator(InstanceValidator):
 
 class StringValidator(InstanceValidator):
     # strings must be unicode
-    types = (unicode,)
+    types = (text_type,)
     name = 'string'
 
 
@@ -91,7 +91,7 @@ class DateTimeValidator(Validator):
 
 
 class IdentifierValidator(Validator):
-    types = (unicode,)
+    types = (text_type,)
     name = 'identifier'
     hasArgs = True
 

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -132,6 +132,7 @@ For example, if only short emails are desired (e.g., for delivery to phones)::
 
 Another example of a function delivering a customized html email containing the last 80 log lines of logs of the last build step is given below::
 
+    from future.utils import text_type
     from buildbot.plugins import util, reporters
 
     import cgi, datetime
@@ -223,7 +224,7 @@ Another example of a function delivering a customized html email containing the 
             text.append(u'<h4>Last %d lines of "%s"</h4>' % (limit_lines, name))
             unilist = list()
             for line in content[len(content)-limit_lines:]:
-                unilist.append(cgi.escape(unicode(line,'utf-8')))
+                unilist.append(cgi.escape(text_type(line,'utf-8')))
             text.append(u'<pre>')
             text.extend(unilist)
             text.append(u'</pre>')


### PR DESCRIPTION
unicode() is gone in Python 3