### PR TITLE
specify existing docker image tag 'master' to prevent failure when do…

### DIFF
--- a/master/contrib/docker/docker-compose.yml
+++ b/master/contrib/docker/docker-compose.yml
@@ -10,7 +10,7 @@ buildbot:
 # switch between local build and dockerhub image
 #    build: ../../Dockerfile
 #    build: ../../Dockerfile.ubuntu
-    image: "buildbot/buildbot-master"
+    image: "buildbot/buildbot-master:master"
     env_file: db.env
     ports:
         - "8010:8010"
@@ -26,7 +26,7 @@ buildbot:
 worker:
     # switch between local build and dockerhub image
 #    build: ../../../worker/Dockerfile
-    image: "buildbot/buildbot-worker"
+    image: "buildbot/buildbot-worker:master"
     environment:
         BUILDMASTER: buildbot
         BUILDMASTER_PORT: 9989


### PR DESCRIPTION
…cker expects 'latest' to exist, but doesn't.

This change is required to enable docker to find the relevant image. Without a tag specified, docker defaults to looking for 'latest' which doesn't exist.