### PR TITLE
use local path for postgres dir to work outside of linux hosts also.

### DIFF
--- a/master/contrib/docker/docker-compose.yml
+++ b/master/contrib/docker/docker-compose.yml
@@ -2,7 +2,7 @@ postgres:
     env_file: db.env
     image: "postgres:9.4"
     volumes:
-        - /var/lib/buildbot_db:/var/lib/postgresql/data
+        - ./buildbot_db:/var/lib/postgresql/data
     expose:
         - 5432
 


### PR DESCRIPTION
OSX with docker 1.12.0-a reports:

```
docker: Error response from daemon: Mounts denied:
The path /var/lib/buildbot_db
is not shared from OS X and is not known to Docker.
You can configure shared paths from Docker -> Preferences... -> File Sharing.
See https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.
```

This PR moves the postgres dir mountpoint to the <pwd>/buildbot_db as that should always be permitted.