### PR TITLE
Remove class variables interfering with __slots__ in ListResult

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -134,21 +134,18 @@ class ListResult(UserList):
 
     __slots__ = ['offset', 'total', 'limit']
 
-    # if set, this is the index in the overall results of the first element of
-    # this list
-    offset = None
-
-    # if set, this is the total number of results
-    total = None
-
-    # if set, this is the limit, either from the user or the implementation
-    limit = None
-
     def __init__(self, values,
                  offset=None, total=None, limit=None):
         UserList.__init__(self, values)
+
+        # if set, this is the index in the overall results of the first element of
+        # this list
         self.offset = offset
+
+        # if set, this is the total number of results
         self.total = total
+
+        # if set, this is the limit, either from the user or the implementation
         self.limit = limit
 
     def __repr__(self):


### PR DESCRIPTION
In Python 3, this was triggering this error:

builtins.ValueError: 'offset' in __slots__ conflicts with class variable

In Python 2, if you defined slots and after that defined a property
with the same name the slots descriptor was replaced silently. In
Python 3 this isn't allowed anymore.

See:
https://github.com/paramiko/paramiko/issues/103#issuecomment-15127799
http://bugs.python.org/issue12766