### PR TITLE
Fix test_contrib_buildbot_cvs_mail on Python 3

### DIFF
--- a/master/buildbot/test/unit/test_contrib_buildbot_cvs_mail.py
+++ b/master/buildbot/test/unit/test_contrib_buildbot_cvs_mail.py
@@ -13,16 +13,20 @@
 #
 # Copyright Buildbot Team Members
 from __future__ import unicode_literals
+
 import os
 import re
 import sys
 
+from future.utils import text_type
 from twisted.internet import defer
 from twisted.internet import protocol
 from twisted.internet import reactor
 from twisted.internet import utils
 from twisted.python import log
 from twisted.trial import unittest
+
+from buildbot.test.util.misc import encodeExecutableAndArgs
 
 test = '''
 Update of /cvsroot/test
@@ -87,9 +91,11 @@ golden_1_12_regex = [
 class _SubprocessProtocol(protocol.ProcessProtocol):
 
     def __init__(self, input, deferred):
+        if isinstance(input, text_type):
+            input = input.encode('utf-8')
         self.input = input
         self.deferred = deferred
-        self.output = ''
+        self.output = b''
 
     def outReceived(self, s):
         self.output += s
@@ -108,6 +114,8 @@ def getProcessOutputAndValueWithInput(executable, args, input):
     "similar to getProcessOutputAndValue, but also allows injection of input on stdin"
     d = defer.Deferred()
     p = _SubprocessProtocol(input, d)
+
+    (executable, args) = encodeExecutableAndArgs(executable, args)
     reactor.spawnProcess(p, executable, (executable,) + tuple(args))
     return d
 
@@ -119,9 +127,11 @@ class TestBuildbotCvsMail(unittest.TestCase):
         skip = ("'%s' does not exist (normal unless run from git)"
                 % buildbot_cvs_mail_path)
 
-    def assertOutputOk(self, xxx_todo_changeme4, regexList):
+    def assertOutputOk(self, result, regexList):
         "assert that the output from getProcessOutputAndValueWithInput matches expectations"
-        (output, code) = xxx_todo_changeme4
+        (output, code) = result
+        if isinstance(output, bytes):
+            output = output.decode("utf-8")
         try:
             self.failUnlessEqual(code, 0, "subprocess exited uncleanly")
             lines = output.splitlines()
@@ -140,70 +150,86 @@ class TestBuildbotCvsMail(unittest.TestCase):
 
     def test_buildbot_cvs_mail_from_cvs1_11(self):
         # Simulate CVS 1.11
-        d = getProcessOutputAndValueWithInput(sys.executable,
-                                              [self.buildbot_cvs_mail_path, '--cvsroot=\"ext:example:/cvsroot\"',
-                                               '--email=buildbot@example.com', '-P', 'test', '-R', 'noreply@example.com', '-t',
-                                               'test', 'README', '1.1,1.2', 'hello.c', '2.2,2.3'],
+        executable = sys.executable
+        args = [self.buildbot_cvs_mail_path, '--cvsroot=\"ext:example:/cvsroot\"',
+                '--email=buildbot@example.com', '-P', 'test', '-R', 'noreply@example.com', '-t',
+                'test', 'README', '1.1,1.2', 'hello.c', '2.2,2.3']
+        (executable, args) = encodeExecutableAndArgs(executable, args)
+        d = getProcessOutputAndValueWithInput(executable,
+                                              args,
                                               input=test)
         d.addCallback(self.assertOutputOk, golden_1_11_regex)
         return d
 
     def test_buildbot_cvs_mail_from_cvs1_12(self):
         # Simulate CVS 1.12, with --path option
-        d = getProcessOutputAndValueWithInput(sys.executable,
-                                              [self.buildbot_cvs_mail_path, '--cvsroot=\"ext:example.com:/cvsroot\"',
-                                               '--email=buildbot@example.com', '-P', 'test', '--path', 'test',
-                                               '-R', 'noreply@example.com', '-t',
-                                               'README', '1.1', '1.2', 'hello.c', '2.2', '2.3'],
+        executable = sys.executable
+        args = [self.buildbot_cvs_mail_path, '--cvsroot=\"ext:example.com:/cvsroot\"',
+                '--email=buildbot@example.com', '-P', 'test', '--path', 'test',
+                '-R', 'noreply@example.com', '-t',
+                'README', '1.1', '1.2', 'hello.c', '2.2', '2.3']
+        (executable, args) = encodeExecutableAndArgs(executable, args)
+        d = getProcessOutputAndValueWithInput(executable,
+                                              args,
                                               input=test)
         d.addCallback(self.assertOutputOk, golden_1_12_regex)
         return d
 
     def test_buildbot_cvs_mail_no_args_exits_with_error(self):
-        d = utils.getProcessOutputAndValue(
-            sys.executable, [self.buildbot_cvs_mail_path])
+        executable = sys.executable
+        args = [self.buildbot_cvs_mail_path]
+        (executable, args) = encodeExecutableAndArgs(executable, args)
+        d = utils.getProcessOutputAndValue(executable, args)
 
-        def check(xxx_todo_changeme):
-            (stdout, stderr, code) = xxx_todo_changeme
+        def check(result):
+            (stdout, stderr, code) = result
             self.assertEqual(code, 2)
         d.addCallback(check)
         return d
 
     def test_buildbot_cvs_mail_without_email_opt_exits_with_error(self):
-        d = utils.getProcessOutputAndValue(sys.executable, [self.buildbot_cvs_mail_path,
-                                                            '--cvsroot=\"ext:example.com:/cvsroot\"',
-                                                            '-P', 'test', '--path', 'test',
-                                                            '-R', 'noreply@example.com', '-t',
-                                                            'README', '1.1', '1.2', 'hello.c', '2.2', '2.3'])
+        executable = sys.executable
+        args = [self.buildbot_cvs_mail_path,
+                '--cvsroot=\"ext:example.com:/cvsroot\"',
+                '-P', 'test', '--path', 'test',
+                '-R', 'noreply@example.com', '-t',
+                'README', '1.1', '1.2', 'hello.c', '2.2', '2.3']
+        (executable, args) = encodeExecutableAndArgs(executable, args)
+        d = utils.getProcessOutputAndValue(executable, args)
 
-        def check(xxx_todo_changeme1):
-            (stdout, stderr, code) = xxx_todo_changeme1
+        def check(result):
+            (stdout, stderr, code) = result
             self.assertEqual(code, 2)
         d.addCallback(check)
         return d
 
     def test_buildbot_cvs_mail_without_cvsroot_opt_exits_with_error(self):
-        d = utils.getProcessOutputAndValue(sys.executable, [self.buildbot_cvs_mail_path,
-                                                            '--complete-garbage-opt=gomi',
-                                                            '--cvsroot=\"ext:example.com:/cvsroot\"',
-                                                            '--email=buildbot@example.com', '-P', 'test', '--path',
-                                                            'test', '-R', 'noreply@example.com', '-t',
-                                                            'README', '1.1', '1.2', 'hello.c', '2.2', '2.3'])
+        executable = sys.executable
+        args = [self.buildbot_cvs_mail_path, '--complete-garbage-opt=gomi',
+                '--cvsroot=\"ext:example.com:/cvsroot\"',
+                '--email=buildbot@example.com', '-P', 'test', '--path',
+                'test', '-R', 'noreply@example.com', '-t',
+                'README', '1.1', '1.2', 'hello.c', '2.2', '2.3']
+        (executable, args) = encodeExecutableAndArgs(executable, args)
+        d = utils.getProcessOutputAndValue(executable, args)
 
-        def check(xxx_todo_changeme2):
-            (stdout, stderr, code) = xxx_todo_changeme2
+        def check(result):
+            (stdout, stderr, code) = result
             self.assertEqual(code, 2)
         d.addCallback(check)
         return d
 
     def test_buildbot_cvs_mail_with_unknown_opt_exits_with_error(self):
-        d = utils.getProcessOutputAndValue(sys.executable, [self.buildbot_cvs_mail_path,
-                                                            '--email=buildbot@example.com', '-P', 'test', '--path',
-                                                            'test', '-R', 'noreply@example.com', '-t',
-                                                            'README', '1.1', '1.2', 'hello.c', '2.2', '2.3'])
+        executable = sys.executable
+        args = [self.buildbot_cvs_mail_path,
+                '--email=buildbot@example.com', '-P', 'test', '--path',
+                'test', '-R', 'noreply@example.com', '-t',
+                'README', '1.1', '1.2', 'hello.c', '2.2', '2.3']
+        (executable, args) = encodeExecutableAndArgs(executable, args)
+        d = utils.getProcessOutputAndValue(executable, args)
 
-        def check(xxx_todo_changeme3):
-            (stdout, stderr, code) = xxx_todo_changeme3
+        def check(result):
+            (stdout, stderr, code) = result
             self.assertEqual(code, 2)
         d.addCallback(check)
         return d

--- a/master/buildbot/test/unit/test_contrib_buildbot_cvs_mail.py
+++ b/master/buildbot/test/unit/test_contrib_buildbot_cvs_mail.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import unicode_literals
 import os
 import re
 import sys

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -56,7 +56,7 @@ class StdoutAssertionsMixin(object):
         return self.stdout.getvalue().strip()
 
 
-def _encodeExecutableAndArgs(executable, args, encoding="utf-8"):
+def encodeExecutableAndArgs(executable, args, encoding="utf-8"):
     """
     Encode executable and arguments from unicode to bytes.
     This avoids a deprecation warning when calling reactor.spawnProcess()

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -15,6 +15,7 @@
 import cStringIO
 import os
 import sys
+from future.utils import text_type
 
 
 class PatcherMixin(object):
@@ -53,3 +54,20 @@ class StdoutAssertionsMixin(object):
 
     def getStdout(self):
         return self.stdout.getvalue().strip()
+
+
+def _encodeExecutableAndArgs(executable, args, encoding="utf-8"):
+    """
+    Encode executable and arguments from unicode to bytes.
+    This avoids a deprecation warning when calling reactor.spawnProcess()
+    """
+    if isinstance(executable, text_type):
+        executable = executable.encode(encoding)
+
+    argsBytes = []
+    for arg in args:
+        if isinstance(arg, text_type):
+            arg = arg.encode(encoding)
+        argsBytes.append(arg)
+
+    return (executable, argsBytes)

--- a/master/contrib/buildbot_cvs_mail.py
+++ b/master/contrib/buildbot_cvs_mail.py
@@ -13,6 +13,7 @@
 # Options handling done right by djmitche
 
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import optparse
 import os

--- a/master/contrib/buildbot_cvs_mail.py
+++ b/master/contrib/buildbot_cvs_mail.py
@@ -23,8 +23,8 @@ import socket
 import sys
 import textwrap
 import time
-from cStringIO import StringIO
 from email.utils import formataddr
+from io import StringIO
 
 """
     -t
@@ -130,8 +130,15 @@ X-Mailer: Python buildbot-cvs-mail %(version)s
     if options.path:
         print('Path: %s' % options.path, file=s)
     print('Project: %s' % options.project, file=s)
-    s.write(sys.stdin.read())
-    print(file=s)
+    cvs_input = sys.stdin.read()
+
+    # On Python 2, sys.stdin.read() returns bytes, but
+    # on Python 3, it returns unicode str.
+    if isinstance(cvs_input, bytes):
+        cvs_input = cvs_input.decode("utf-8")
+
+    s.write(cvs_input)
+    print('', file=s)
     conn.sendmail(address, options.email, s.getvalue())
     conn.close()
 


### PR DESCRIPTION
This mainly addresses unicode issues.

I highly recommend that anyone doing Python 2 -> Python 3
porting work which involves unicode should watch Ned Batchelder's presentation:

http://nedbatchelder.com/text/unipain.html

Specifically, he talks about the **Unicode sandwich**, where
as much as possible, within the confines of your application, you should
try to maintain your data as unicode,
but when you _send the data somewhere else_ such as *writing to a file* or
*sending to a socket*, you should encode the data to bytes, and treat it as bytes.
