### PR TITLE
Change map() to list comprehension

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -731,7 +731,7 @@ class BuildStep(results.ResultComputingConfigMixin,
         sv = self.build.getWorkerCommandVersion(command, None)
         if sv is None:
             return True
-        if list(map(int, sv.split("."))) < list(map(int, minversion.split("."))):
+        if [int(s) for s in sv.split(".")] < [int(m) for m in minversion.split(".")]:
             return True
         return False
     deprecatedWorkerClassMethod(locals(), workerVersionIsOlderThan)

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -731,7 +731,7 @@ class BuildStep(results.ResultComputingConfigMixin,
         sv = self.build.getWorkerCommandVersion(command, None)
         if sv is None:
             return True
-        if map(int, sv.split(".")) < map(int, minversion.split(".")):
+        if list(map(int, sv.split("."))) < list(map(int, minversion.split("."))):
             return True
         return False
     deprecatedWorkerClassMethod(locals(), workerVersionIsOlderThan)


### PR DESCRIPTION
On Python 2, map() returns a list, and on Python 3 it returns a generator.
We really need a list here.