### PR TITLE
upgrade guanlecoja to ~0.7.0

### DIFF
--- a/www/codeparameter/package.json
+++ b/www/codeparameter/package.json
@@ -5,7 +5,7 @@
         "npm": ">=1.4.0"
     },
     "dependencies": {
-        "gulp": "3.9.0",
-        "guanlecoja": "~0.6.0"
+        "guanlecoja": "~0.7.0",
+        "gulp": "3.9.0"
     }
 }

--- a/www/console_view/package.json
+++ b/www/console_view/package.json
@@ -5,7 +5,7 @@
         "npm": ">=1.4.0"
     },
     "dependencies": {
-        "gulp": "3.9.0",
-        "guanlecoja": "~0.6.0"
+        "guanlecoja": "~0.7.0",
+        "gulp": "3.9.0"
     }
 }

--- a/www/data_module/package.json
+++ b/www/data_module/package.json
@@ -9,8 +9,8 @@
     "url": "git://github.com/buildbot/buildbot-data-js.git"
   },
   "dependencies": {
-    "guanlecoja": "~0.6.0",
-    "gulp": "^3.9.0",
+    "guanlecoja": "~0.7.0",
+    "gulp": "3.9.0",
     "shelljs": "~0.5.3"
   },
   "dependencies": {},

--- a/www/md_base/package.json
+++ b/www/md_base/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "dependencies": {
-    "guanlecoja": "~0.6.0",
+    "guanlecoja": "~0.7.0",
     "gulp": "3.9.0",
     "gulp-shell": "^0.4.0",
     "gulp-svg-symbols": "^0.3.1",

--- a/www/nestedexample/package.json
+++ b/www/nestedexample/package.json
@@ -5,7 +5,7 @@
         "npm": ">=1.4.0"
     },
     "dependencies": {
-        "gulp": "3.9.0",
-        "guanlecoja": "~0.6.0"
+        "guanlecoja": "~0.7.0",
+        "gulp": "3.9.0"
     }
 }

--- a/www/waterfall_view/package.json
+++ b/www/waterfall_view/package.json
@@ -5,7 +5,7 @@
         "npm": ">=1.4.10"
     },
     "dependencies": {
-        "gulp": "3.9.0",
-        "guanlecoja": "~0.6.0"
+        "guanlecoja": "~0.7.0",
+        "gulp": "3.9.0"
     }
 }


### PR DESCRIPTION
this version has support for latest version of node (6)

prevents errors such as:

[14:57:28] gulp-ng-classify:SyntaxError
[14:57:28] regular expressions cannot begin with *