### PR TITLE
Replace Exception.message with str(Exception)

### DIFF
--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -210,8 +210,8 @@ class EC2LatentWorker(AbstractLatentWorker):
             self.ec2.KeyPair(self.keypair_name).load()
             # key_pair.delete() # would be used to recreate
         except ClientError as e:
-            if 'InvalidKeyPair.NotFound' not in e.message:
-                if 'AuthFailure' in e.message:
+            if 'InvalidKeyPair.NotFound' not in str(e):
+                if 'AuthFailure' in str(e):
                     log.msg('POSSIBLE CAUSES OF ERROR:\n'
                             '  Did you supply your AWS credentials?\n'
                             '  Did you sign up for EC2?\n'
@@ -229,7 +229,7 @@ class EC2LatentWorker(AbstractLatentWorker):
             try:
                 self.ec2.SecurityGroup(security_name).load()
             except ClientError as e:
-                if 'InvalidGroup.NotFound' in e.message:
+                if 'InvalidGroup.NotFound' in str(e):
                     self.security_group = self.ec2.create_security_group(
                         GroupName=security_name,
                         Description='Authorization to access the buildbot instance.')

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -124,7 +124,7 @@ class V2RootResource(resource.Resource):
         try:
             yield
         except exceptions.InvalidPathError as e:
-            writeError(str(e) or "invalid path", errcode=404,
+            writeError(e.args[0] or "invalid path", errcode=404,
                        jsonrpccode=JSONRPC_CODES['invalid_request'])
             return
         except exceptions.InvalidControlException as e:
@@ -132,7 +132,7 @@ class V2RootResource(resource.Resource):
                        jsonrpccode=JSONRPC_CODES["method_not_found"])
             return
         except BadRequest as e:
-            writeError(str(e) or "invalid request", errcode=400,
+            writeError(e.args[0] or "invalid request", errcode=400,
                        jsonrpccode=JSONRPC_CODES["method_not_found"])
             return
         except BadJsonRpc2 as e:

--- a/master/contrib/github_buildbot.py
+++ b/master/contrib/github_buildbot.py
@@ -134,7 +134,7 @@ class GitHubBuildBot(resource.Resource):
         except Exception as e:
             logging.exception(e)
             request.setResponseCode(INTERNAL_SERVER_ERROR)
-            return json.dumps({"error": e.message})
+            return json.dumps({"error": str(e)})
 
     def process_change(self, change, branch, repo, repo_url):
         files = change['added'] + change['removed'] + change['modified']


### PR DESCRIPTION
BaseException.message is deprecated in Python 2.6 and gone in Python 3.

See:
https://docs.python.org/2/whatsnew/2.6.html#deprecations-and-removals