### PR TITLE
Replace list.sort(cmp=) with list.sort(key=)

### DIFF
--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -162,7 +162,7 @@ class Change:
     def asDict(self):
         '''returns a dictonary with suitable info for html/mail rendering'''
         files = [dict(name=f) for f in self.files]
-        files.sort(cmp=lambda a, b: a['name'] < b['name'])
+        files.sort(key=lambda a: a['name'])
 
         result = {
             # Constant

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -307,7 +307,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             candidates = [(i, b, b.getTimes()[1])
                           for i, b in enumerate(next_build)
                           if b is not None]
-            candidates.sort(lambda x, y: cmp(x[2], y[2]))
+            candidates.sort(key=lambda x: x[2])
             if not candidates:
                 return
 

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -35,7 +35,7 @@ def nth_worker(n):
         if workers is None:
             workers = builder
         workers = workers[:]
-        workers.sort(cmp=lambda a, b: cmp(a.name, b.name))
+        workers.sort(key=lambda a: a.name)
         return workers[n]
     return pick_nth_by_name
 
@@ -210,7 +210,7 @@ class Test(TestBRDBase):
         builders = ['bldr%02d' % i for i in range(15)]
 
         def slow_sorter(master, bldrs):
-            bldrs.sort(lambda b1, b2: cmp(b1.name, b2.name))
+            bldrs.sort(key=lambda b1: b1.name)
             d = defer.Deferred()
             reactor.callLater(0, d.callback, bldrs)
 

--- a/master/buildbot/test/unit/test_process_results.py
+++ b/master/buildbot/test/unit/test_process_results.py
@@ -27,9 +27,15 @@ class TestResults(unittest.TestCase):
             self.assertEqual(results.Results[i], r)
 
     def test_worst_status(self):
+        self.assertEqual(results.WARNINGS,
+            results.worst_status(results.SUCCESS, results.WARNINGS))
+        self.assertEqual(results.CANCELLED,
+            results.worst_status(results.SKIPPED, results.CANCELLED))
+
+    def test_sort_worst_status(self):
         res = lrange(len(results.Results))
         res.sort(
-            cmp=lambda a, b: 1 if (results.worst_status(a, b) == a) else -1)
+            key=lambda a: a if a != results.SKIPPED else -1)
         self.assertEqual(res, [
             results.SKIPPED,
             results.SUCCESS,


### PR DESCRIPTION
The cmp= keyword argument to list.sort() is gone in Python 3.

See:
http://python3porting.com/problems.html#sorting