### PR TITLE
make github hook record even non-distinct commits

### DIFF
--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -173,11 +173,6 @@ class GitHubEventHandler(object):
             return changes
 
         for commit in payload['commits']:
-            if not commit.get('distinct', True):
-                log.msg('Commit `%s` is a non-distinct commit, ignoring...' %
-                        (commit['id'],))
-                continue
-
             files = []
             for kind in ('added', 'modified', 'removed'):
                 files.extend(commit.get(kind, []))
@@ -196,7 +191,8 @@ class GitHubEventHandler(object):
                 'branch': branch,
                 'revlink': commit['url'],
                 'repository': repo_url,
-                'project': project
+                'project': project,
+                'properties': {'github_distinct': commit.get('distinct', True)}
             }
 
             if callable(self._codebase):

--- a/master/docs/manual/cfg-schedulers.rst
+++ b/master/docs/manual/cfg-schedulers.rst
@@ -160,6 +160,16 @@ or apply a regular expression, using the attribute name with a "``_re``" suffix:
     import re
     my_filter = util.ChangeFilter(category_re=re.compile('.*deve.*', re.I))
 
+:class:`buildbot.status.web.hooks.github.GitHubEventHandler` has a special
+``github_distinct`` property that can be used to filter whether or not
+non-distinct changes should be considered. For example, if a commit is pushed to
+a branch that is not being watched and then later pushed to a watched branch, by
+default, this will be recorded as two separate Changes. In order to record a
+change only the first time the commit appears, you can install a custom
+:class:`ChangeFilter` like this::
+
+    ChangeFilter(filter_fn = lambda c: c.properties.getProperty('github_distinct')
+
 For anything more complicated, define a Python function to recognize the strings you want::
 
     def my_branch_fn(branch):

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -54,7 +54,18 @@ Fixes
 
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* By default, non-distinct commits received via
+  :class:`buildbot.status.web.hooks.github.GitHubEventHandler` now get recorded
+  as a :class:`Change`. In this way, a commit pushed to a branch that is not
+  being watched (e.g. a dev branch) will still get acted on when it is later
+  pushed to a branch that is being watched (e.g. master). In the past, such a
+  commit would get ignored and not built because it was non-distinct. To disable
+  this behavior and revert to the old behavior, install a :class:`ChangeFilter`
+  that checks the ``github_distinct`` property:
 
+.. code-block:: python
+
+  ChangeFilter(filter_fn=lambda c: c.properties.getProperty('github_distinct'))
 
 Buildslave
 ----------


### PR DESCRIPTION
In the github hook, we currently ignore commits that we have seen before. This
causes a bug in the following situation:

- Builds are scheduled for master only
- Commit X is pushed to a dev branch
- Commit X gets recorded as a change, associated with that dev branch. It does
  not trigger a build because the branch is not master.
- Commit X is pushed to master without a merge (it's already cleanly rebased on
  master).
- Commit X is ignored, thus not triggering a build, even though the commit has
  never been built before and it's a new addition to master.

Fix this bug by recording a change every time a commit enters a scheduled
branch, even if we have seen the commit before. Update the tests accordingly.