### PR TITLE
port to stable : buildbotNetUsageData implementation

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
 line_length=110
-known_third_party=twisted,migrate,sqlalchemy,ldap3,klein
+known_third_party=twisted,migrate,sqlalchemy,ldap3,klein,future
 force_single_line=1
 

--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -1,0 +1,159 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+"""
+This files implement buildbotNetUsageData options
+It uses urllib2 instead of requests in order to avoid requiring another dependency for statistics feature.
+urllib2 supports http_proxy already urllib2 is blocking and thus everything is done from a thread.
+"""
+import hashlib
+import inspect
+import json
+import platform
+import socket
+import urllib2
+
+from twisted.internet import threads
+from twisted.python import log
+
+from buildbot.process.buildstep import _BuildStepFactory
+from buildbot.www.config import IndexResource
+
+# This can't change! or we will need to make sure we are compatible with all
+# released version of buildbot >=0.9.0
+PHONE_HOME_URL = "https://events.buildbot.net/events/phone_home"
+
+
+def get_distro():
+    for distro in ('linux_distribution', 'mac_ver', 'win32_ver', 'java_ver'):
+        if hasattr(platform, distro):
+            return getattr(platform, distro)()
+
+
+def getName(obj):
+    """This method finds the first parent class which is within the buildbot namespace
+    it prepends the name with as many ">" as the class is subclassed
+    """
+    # elastic search does not like '.' in dict keys, so we replace by /
+    def sanitize(name):
+        return name.replace(".", "/")
+    if isinstance(obj, _BuildStepFactory):
+        klass = obj.factory
+    else:
+        klass = type(obj)
+    name = ""
+    klasses = (klass, ) + inspect.getmro(klass)
+    for klass in klasses:
+        if hasattr(klass, "__module__") and klass.__module__.startswith("buildbot."):
+            return sanitize(name + klass.__module__ + "." + klass.__name__)
+        else:
+            name += ">"
+    return sanitize(type(obj).__name__)
+
+
+def countPlugins(plugins_uses, l):
+    if isinstance(l, dict):
+        l = l.values()
+    for i in l:
+        name = getName(i)
+        plugins_uses.setdefault(name, 0)
+        plugins_uses[name] += 1
+
+
+def basicData(master):
+
+    plugins_uses = {}
+    countPlugins(plugins_uses, master.config.workers)
+    countPlugins(plugins_uses, master.config.builders)
+    countPlugins(plugins_uses, master.config.schedulers)
+    countPlugins(plugins_uses, master.config.services)
+    countPlugins(plugins_uses, master.config.change_sources)
+    for b in master.config.builders:
+        countPlugins(plugins_uses, b.factory.steps)
+
+    # we hash the master's name + various other master dependent variables
+    # to get as much as possible an unique id
+    # we hash it to not leak private information about the installation such as hostnames and domain names
+    installid = hashlib.sha1(
+        master.name  # master name contains hostname + master basepath
+        +
+        socket.getfqdn()  # we add the fqdn to account for people
+                          # call their buildbot host 'buildbot' and install it in /var/lib/buildbot
+    ).hexdigest()
+    return {
+        'installid': installid,
+        'versions': dict(IndexResource.getEnvironmentVersions()),
+        'platform': {
+            'machine': platform.machine(),
+            'processor': platform.processor(),
+            'python_implementation': platform.python_implementation(),
+            # xBSD including osx will disclose too much information after [4] like where it was built
+            'version': " ".join(platform.version().split(' ')[:4]),
+            'distro': get_distro()
+        },
+        'plugins': plugins_uses,
+        'db': master.config.db['db_url'].split("://")[0],
+        'mq': master.config.mq['type'],
+        'www_plugins': master.config.www['plugins'].keys()
+    }
+
+
+def fullData(master):
+    """
+        Send the actual configuration of the builders, how the steps are agenced.
+        Note that full data will never send actual detail of what command is run, name of servers, etc.
+    """
+
+    builders = []
+    for b in master.config.builders:
+        steps = []
+        for step in b.factory.steps:
+            steps.append(getName(step))
+        builders.append(steps)
+    return {'builders': builders}
+
+
+def computeUsageData(master):
+    if master.config.buildbotNetUsageData is None:
+        return
+    data = basicData(master)
+
+    if master.config.buildbotNetUsageData != "basic":
+        data.update(fullData(master))
+
+    if callable(master.config.buildbotNetUsageData):
+        data = master.config.buildbotNetUsageData(data)
+
+    return data
+
+
+def _sendBuildbotNetUsageData(data):
+    log.msg("buildbotNetUsageData: sending {}".format(data))
+    data = json.dumps(data)
+    clen = len(data)
+    req = urllib2.Request(PHONE_HOME_URL, data, {'Content-Type': 'application/json', 'Content-Length': clen})
+    f = urllib2.urlopen(req)
+    res = f.read()
+    f.close()
+    log.msg("buildbotNetUsageData: buildbot.net said:", res)
+
+
+def sendBuildbotNetUsageData(master):
+    if master.config.buildbotNetUsageData is None:
+        return
+    data = computeUsageData(master)
+    if data is None:
+        return
+    threads.deferToThread(_sendBuildbotNetUsageData, data)

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -1,0 +1,119 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import urllib2
+
+from twisted.internet import reactor
+from twisted.python.filepath import FilePath
+from twisted.trial import unittest
+
+from buildbot.buildbot_net_usage_data import _sendBuildbotNetUsageData
+from buildbot.buildbot_net_usage_data import computeUsageData
+from buildbot.config import BuilderConfig
+from buildbot.master import BuildMaster
+from buildbot.plugins import steps
+from buildbot.process.factory import BuildFactory
+from buildbot.schedulers.forcesched import ForceScheduler
+from buildbot.test.util.integration import DictLoader
+from buildbot.worker.base import Worker
+
+
+class Tests(unittest.TestCase):
+
+    def getMaster(self, config_dict):
+        """
+        Create a started ``BuildMaster`` with the given configuration.
+        """
+        basedir = FilePath(self.mktemp())
+        basedir.createDirectory()
+        master = BuildMaster(
+            basedir.path, reactor=reactor, config_loader=DictLoader(config_dict))
+        master.config = master.config_loader.loadConfig()
+        return master
+
+    def getBaseConfig(self):
+        return {
+            'builders': [
+                BuilderConfig(name="testy",
+                              workernames=["local1", "local2"],
+                              factory=BuildFactory([steps.ShellCommand(command='echo hello')])),
+            ],
+            'workers': [Worker('local' + str(i), 'pass') for i in xrange(3)],
+            'schedulers': [
+                ForceScheduler(
+                    name="force",
+                    builderNames=["testy"])
+            ],
+            'protocols': {'null': {}},
+            'multiMaster': True,
+        }
+
+    def test_basic(self):
+        master = self.getMaster(self.getBaseConfig())
+        data = computeUsageData(master)
+        self.assertEquals(sorted(data.keys()),
+                          sorted(['versions', 'db', 'platform', 'installid', 'mq', 'plugins', 'www_plugins']))
+        self.assertEquals(data['plugins']['buildbot/worker/base/Worker'], 3)
+        self.assertEquals(sorted(data['plugins'].keys()), sorted(
+            ['buildbot/schedulers/forcesched/ForceScheduler', 'buildbot/worker/base/Worker',
+             'buildbot/steps/shell/ShellCommand', 'buildbot/config/BuilderConfig']))
+
+    def test_full(self):
+        c = self.getBaseConfig()
+        c['buildbotNetUsageData'] = 'full'
+        master = self.getMaster(c)
+        data = computeUsageData(master)
+        self.assertEquals(sorted(data.keys()),
+                          sorted(['versions', 'db', 'installid', 'platform', 'mq', 'plugins',
+                                  'builders', 'www_plugins']))
+
+    def test_custom(self):
+        c = self.getBaseConfig()
+
+        def myCompute(data):
+            return dict(db=data['db'])
+        c['buildbotNetUsageData'] = myCompute
+        master = self.getMaster(c)
+        data = computeUsageData(master)
+        self.assertEquals(sorted(data.keys()),
+                          sorted(['db']))
+
+    def test_urllib2(self):
+
+        class FakeRequest(object):
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+        open_url = []
+
+        class urlopen(object):
+            def __init__(self, r):
+                self.request = r
+                open_url.append(self)
+
+            def read(self):
+                return "ok"
+
+            def close(self):
+                pass
+
+        self.patch(urllib2, "Request", FakeRequest)
+        self.patch(urllib2, "urlopen", urlopen)
+        _sendBuildbotNetUsageData({'foo': 'bar'})
+        self.assertEqual(len(open_url), 1)
+        self.assertEqual(open_url[0].request.args,
+                        ('https://events.buildbot.net/events/phone_home',
+                         '{"foo": "bar"}', {'Content-Length': 14, 'Content-Type': 'application/json'}))

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -60,6 +60,7 @@ global_defaults = dict(
     protocols={},
     multiMaster=False,
     manhole=None,
+    buildbotNetUsageData='basic',
     www=dict(port=None, plugins={},
              auth={'name': 'NoAuth'}, authz={},
              avatar_methods={'name': 'gravatar'},
@@ -460,7 +461,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.do_test_load_global(dict(changeHorizon=None), changeHorizon=None)
 
     def test_load_global_eventHorizon(self):
-        self.do_test_load_global(dict(eventHorizon=10), eventHorizon=10)
+        self.do_test_load_global(dict(eventHorizon=None), eventHorizon=None)
 
     def test_load_global_logHorizon(self):
         self.do_test_load_global(dict(logHorizon=10), logHorizon=10)

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -31,6 +31,7 @@ from buildbot.interfaces import IConfigLoader
 from buildbot.test.fake import fakedata
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemq
+from buildbot.test.fake.botmaster import FakeBotMaster
 from buildbot.test.util import dirs
 from buildbot.test.util import logging
 
@@ -176,6 +177,8 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
             self.reactor = self.make_reactor()
             self.master = master.BuildMaster(
                 self.basedir, reactor=self.reactor, config_loader=DefaultLoader())
+            self.master.sendBuildbotNetUsageData = mock.Mock()
+            self.master.botmaster = FakeBotMaster()
             self.db = self.master.db = fakedb.FakeDBConnector(self)
             self.db.setServiceParent(self.master)
             self.mq = self.master.mq = fakemq.FakeMQConnector(self)

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -55,6 +55,7 @@ def getMaster(case, reactor, config_dict):
     """
     basedir = FilePath(case.mktemp())
     basedir.createDirectory()
+    config_dict['buildbotNetUsageData'] = None
     master = BuildMaster(
         basedir.path, reactor=reactor, config_loader=DictLoader(config_dict))
 

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -823,6 +823,100 @@ Currently, only `InfluxDB`_ is supported as a storage backend.
    ``name=None``
      (Optional) The name of this storage backend.
 
+.. bb:cfg:: buildbotNetUsageData
+
+BuildbotNetUsageData
+~~~~~~~~~~~~~~~~~~~~~
+
+Since buildbot 0.9.0, buildbot has a simple feature which sends usage analysis info to buildbot.net.
+This is very important for buildbot developers to understand how the community is using the tools.
+This allows to better prioritize issues, and understand what plugins are actually being used.
+This will also be a tool to decide whether to keep support for very old tools.
+For example buildbot contains support for the venerable CVS, but we have no information whether it actually works beyond the unit tests.
+We rely on the community to test and report issues with the old features.
+
+With BuildbotNetUsageData, we can know exactly what combination of plugins are working together, how much people are customizing plugins, what versions of the main dependencies people run.
+
+We take your privacy very seriously.
+
+BuildbotNetUsageData will never send information specific to your Code or Intellectual Property.
+No repository url, shell command values, host names, ip address or custom class names.
+If it does, then this is a bug, please report.
+
+We still need to track unique number for installation.
+This is done via doing a sha1 hash of master's hostname, installation path and fqdn.
+Using a secure hash means there is no way of knowing hostname, path and fqdn given the hash, but still there is a different hash for each master.
+
+You can see exactly what is sent in the master's twisted.log.
+Usage data is sent every time the master is started.
+
+BuildbotNetUsageData can be configured with 4 values:
+
+* ``c['buildbotNetUsageData'] = None`` disables the feature
+
+* ``c['buildbotNetUsageData'] = 'basic'`` sends the basic information to buildbot including:
+
+    * versions of buildbot, python and twisted
+    * platform information (CPU, OS, distribution, python flavor (i.e CPython vs PyPy))
+    * mq and database type (mysql or sqlite?)
+    * www plugins usage
+    * Plugins usages:
+      This counts the number of time each class of buildbot is used in your configuration.
+      This counts workers, builders, steps, schedulers, change sources.
+      If the plugin is subclassed, then it will be prefixed with a `>`
+
+    example of basic report (for the metabuildbot):
+
+    .. code-block:: javascript
+
+        {
+        'versions': {
+            'Python': '2.7.6',
+            'Twisted': '15.5.0',
+            'Buildbot': '0.9.0rc2-176-g5fa9dbf'
+        },
+        'platform': {
+            'machine': 'x86_64',
+            'python_implementation': 'CPython',
+            'version': '#140-Ubuntu SMP Mon Jul',
+            'processor':
+            'x86_64',
+            'distro:': ('Ubuntu', '14.04', 'trusty')
+            },
+        'db': 'sqlite',
+        'mq': 'simple',
+        'plugins': {
+            'buildbot.schedulers.forcesched.ForceScheduler': 2,
+            'buildbot.schedulers.triggerable.Triggerable': 1,
+            'buildbot.config.BuilderConfig': 4,
+            'buildbot.schedulers.basic.AnyBranchScheduler': 2,
+            'buildbot.steps.source.git.Git': 4,
+            '>>buildbot.steps.trigger.Trigger': 2,
+            '>>>buildbot.worker.base.Worker': 4,
+            'buildbot.reporters.irc.IRC': 1,
+            '>>>buildbot.process.buildstep.LoggingBuildStep': 2},
+        'www_plugins': ['buildbot_travis', 'waterfall_view']
+        }
+
+* ``c['buildbotNetUsageData'] = 'full'`` sends the basic information plus additional information:
+
+    * configuration of each builders: how the steps are arranged together. for ex:
+
+    .. code-block:: javascript
+
+        {
+            'builders': [
+                ['buildbot.steps.source.git.Git', '>>>buildbot.process.buildstep.LoggingBuildStep'],
+                ['buildbot.steps.source.git.Git', '>>buildbot.steps.trigger.Trigger'],
+                ['buildbot.steps.source.git.Git', '>>>buildbot.process.buildstep.LoggingBuildStep'],
+                ['buildbot.steps.source.git.Git', '>>buildbot.steps.trigger.Trigger']]
+        }
+
+* ``c['buildbotNetUsageData'] = myCustomFunction``. You can also specify exactly what to send using a callback.
+
+    The custom function will take the generated data from full report in the form of a dictionary, and return a customized report as a jsonable dictionary. You can use this to filter any information you dont want to disclose. You can use a custom http_proxy environment variable in order to not send any data while developing your callback.
+
+
 .. bb:cfg:: user_managers
 
 .. _Users-Options:

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -22,6 +22,8 @@ See :ref:`Upgrading to Nine` for a guide to upgrading from 0.8.x to 0.9.x
 Master
 ------
 
+* add tool to send usage data to buildbot.net :bb:cfg:`buildbotNetUsageData`
+
 Features
 ~~~~~~~~
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -199,6 +199,7 @@ cp
 cpdir
 cppcheck
 Cppcheck
+CPython
 Cred
 credentails
 creds
@@ -625,6 +626,7 @@ pyflakes
 Pyflakes
 pyjade
 pypi
+PyPy
 pysqlite
 pythonic
 Pythonic


### PR DESCRIPTION
This feature sends data to the buildbot.net statistics server
This will allow the buildbot developers to better understand the buildbot
installation base and thus to better prioritize new developements

This is an opt-out design.

By default it sends basic information, with a warning in the log.

User can the opt-out for no information sent or opt-in for more information.