### PR TITLE
Stop using loop variable outside the loop

### DIFF
--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -110,7 +110,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
                 n += len(builder.building)
             if n > 0:
                 log.msg(
-                    "Not shutting down, builder %s has %i builds running" % (builder, n))
+                    "Not shutting down, there are %i builds running" % n)
                 log.msg("Trying shutdown sequence again")
                 yield util.asyncSleep(1)
             else:

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -107,7 +107,10 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             # Check that there really aren't any running builds
             n = 0
             for builder in self.builders.values():
-                n += len(builder.building)
+                if builder.building:
+                    num_builds = len(builder.building)
+                    log.msg("Builder %s has %i builds running" % (builder, num_builds))
+                    n += num_builds
             if n > 0:
                 log.msg(
                     "Not shutting down, there are %i builds running" % n)


### PR DESCRIPTION
The builder variable is from the now-exited loop over self.builders.