### PR TITLE
UI for optimization the trigger step use cases

### DIFF
--- a/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.coffee
@@ -9,9 +9,8 @@ class Buildrequestsummary extends Directive('common')
             controller: '_buildrequestsummaryController'
         }
 
-
 class _buildrequestsummary extends Controller('common')
-    constructor: ($scope, dataService, findBuilds, resultsService) ->
+    constructor: ($scope, dataService, buildersService, findBuilds, resultsService) ->
         _.mixin($scope, resultsService)
         $scope.$watch "buildrequest.claimed", (n, o) ->
             if n  # if it is unclaimed, then claimed, we need to try again
@@ -23,5 +22,5 @@ class _buildrequestsummary extends Controller('common')
             $scope.buildrequest = buildrequest
             data.getBuildsets(buildrequest.buildsetid).onNew = (buildset) ->
                 $scope.buildset = buildset
-            data.getBuilders(buildrequest.builderid).onNew = (builder) ->
-                $scope.builder = builder
+
+            $scope.builder = buildersService.getBuilder(buildrequest.builderid)

--- a/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.tpl.jade
@@ -6,7 +6,7 @@ div
       .panel-heading.no-select
           .flex-row
               .flex-grow-1
-                a(ui-sref="builder({builder:builder.builderid})")
+                a(ui-sref="builder({builder:buildrequest.builderid})")
                     | {{builder.name}}
                 | #{' '}/ buildrequests /#{' '}
                 a(ui-sref="buildrequest({buildrequest:buildrequest.buildrequestid})")

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.coffee
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.coffee
@@ -8,7 +8,7 @@ class Buildsticker extends Directive('common')
             controller: '_buildstickerController'
         }
 class _buildsticker extends Controller('common')
-    constructor: ($scope, dataService, resultsService, $urlMatcherFactory, $location) ->
+    constructor: ($scope, dataService, buildersService, resultsService, $urlMatcherFactory, $location) ->
         $scope.$watch (-> moment().unix()), ->
             $scope.now = moment().unix()
 
@@ -18,5 +18,4 @@ class _buildsticker extends Controller('common')
         data = dataService.open().closeOnDestroy($scope)
         $scope.$watch 'build', (build) ->
             if not $scope.builder
-                data.getBuilders(build.builderid).onNew = (builder) ->
-                    $scope.builder = builder
+                $scope.builder = buildersService.getBuilder(build.builderid)

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
@@ -10,8 +10,9 @@ class Buildsummary extends Directive('common')
             controller: '_buildsummaryController'
             controllerAs: 'buildsummary'
         }
+
 class _buildsummary extends Controller('common')
-    constructor: ($scope, dataService, resultsService, $urlMatcherFactory, $location, $interval, RESULTS) ->
+    constructor: ($scope, dataService, resultsService, buildersService, $urlMatcherFactory, $location, $interval, RESULTS) ->
         self = this
         # make resultsService utilities available in the template
         _.mixin($scope, resultsService)
@@ -84,26 +85,26 @@ class _buildsummary extends Controller('common')
         $scope.$watch (=> @build), (build) ->
             if not build? then return
             if @builder then return
-
-            data.getBuilders(build.builderid).onNew = (builder) ->
-                self.builder = builder
+            self.builder = buildersService.getBuilder(build.builderid)
 
             build.getProperties().onNew = (properties) ->
                 self.properties = properties
                 self.reason = self.getBuildProperty('reason')
 
-            self.steps = build.getSteps()
+            $scope.$watch (-> details), (details) ->
+                if details != NONE and not self.steps?
+                    self.steps = build.getSteps()
 
-            self.steps.onNew = (step) ->
-                step.loadLogs()
-                # onUpdate is only called onUpdate, not onNew, but we need to update our additional needed attributes
-                self.steps.onUpdate(step)
+                    self.steps.onNew = (step) ->
+                        step.loadLogs()
+                        # onUpdate is only called onUpdate, not onNew
+                        # but we need to update our additional needed attributes
+                        self.steps.onUpdate(step)
 
-            self.steps.onUpdate = (step) ->
-                step.fulldisplay = step.complete == 0 || step.results > 0
-                if step.complete
-                    step.duration = step.complete_at - step.started_at
+                    self.steps.onUpdate = (step) ->
+                        step.fulldisplay = step.complete == 0 || step.results > 0
+                        if step.complete
+                            step.duration = step.complete_at - step.started_at
         $scope.$watch (=> @parentbuild), (build,o) ->
             if not build? then return
-            data.getBuilders(build.builderid).onNew = (builder) ->
-                self.parentbuilder = builder
+            self.parentbuilder = buildersService.getBuilder(build.builderid)

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -9,7 +9,7 @@
                     | {{buildsummary.levelOfDetails()}}
                 | #{' '}
                 span(ng-if="buildsummary.prefix") {{buildsummary.prefix}}#{' '}
-                a(ui-sref="build({builder:buildsummary.builder.builderid, build:buildsummary.build.number})")
+                a(ui-sref="build({builder:buildsummary.build.builderid, build:buildsummary.build.number})")
                   | {{buildsummary.builder.name}}/{{buildsummary.build.number}}#{' '}
                 span(ng-if="buildsummary.reason") | {{buildsummary.reason}}
             .flex-grow-1.text-right
@@ -48,7 +48,7 @@
               a(ng-href="api/v2/logs/{{log.logid}}/raw")
                   i.fa.fa-download
               | #{' '}
-              a(ui-sref="log({builder:buildsummary.builder.builderid, build:buildsummary.build.number, step: step.number, log:log.slug})")
+              a(ui-sref="log({builder:buildsummary.build.builderid, build:buildsummary.build.number, step: step.number, log:log.slug})")
                   | {{log.name}}
               | #{' '}({{log.num_lines}} line{{log.num_lines > 1?'s':''}})
         ul

--- a/www/base/src/app/common/services/buildercache/buildercache.service.coffee
+++ b/www/base/src/app/common/services/buildercache/buildercache.service.coffee
@@ -1,0 +1,23 @@
+# builder data used everywhere in the UI, so we implement a simple cache
+
+# TODO this caching mechanism needs to be implemented eventually in data module
+# Its much more complicated to do this generically, and keep the event mecanism,
+# this is why we do this temporary workaround
+
+# Objects returned by this service cannot use onNew/onUpdate mechanism of data module (as they are shared)
+
+class buildersService extends Factory('common')
+    constructor: ($log, dataService) ->
+        # we use an always on dataService instance
+        data = dataService.open()
+        cache = {}
+        return {
+            getBuilder: (id) ->
+                if cache.hasOwnProperty(id)
+                    return cache[id]
+                else
+                    cache[id] = {}
+                    data.getBuilders(id).onNew = (builder) ->
+                        _.assign(cache[id], builder)
+                    return cache[id]
+        }


### PR DESCRIPTION
When there is a trigger step with lots of triggered build, the UI starts to be very slow
especially with high latency

This is because lots of information if gathered. This patch change this to:

- do not fetch steps and logs of sub builds until user ask for it (via details != NONE)
- cache builder information and share it between buildsummary and buildrequestsummary directives