### PR TITLE
Call existing disconnect method if there should be no wait

### DIFF
--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -195,12 +195,7 @@ class AbstractLatentWorker(AbstractWorker):
 
         if not self.building:
             if self.build_wait_timeout == 0:
-                d = self.insubstantiate()
-                # try starting builds for this worker after insubstantiating;
-                # this will cause the worker to re-substantiate immediately if
-                # there are pending build requests.
-                d.addCallback(lambda _:
-                              self.botmaster.maybeStartBuildsForWorker(self.workername))
+                self._soft_disconnect()
             else:
                 self._setBuildWaitTimer()
 


### PR DESCRIPTION
When build_wait_timeout is greater than 0, a timer is set to call _soft_disconnect. That method has some checking and then does a proper disconnect and insubstantiate. Furthermore, within the insubstantiate
method, it already checks if there are builds pending to cause the worker to substantiate again immediately. When build_wait_timeout is 0, the timer doesn't need to be set so call what it would otherwise call. This will ensure the two cases stay in sync.

Fixes trac #3610.