### PR TITLE
Add logEnviron flag to MasterShellCommand

### DIFF
--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -50,6 +50,7 @@ class MasterShellCommand(BuildStep):
         self.env = kwargs.pop('env', None)
         self.usePTY = kwargs.pop('usePTY', 0)
         self.interruptSignal = kwargs.pop('interruptSignal', 'KILL')
+        self.logEnviron = kwargs.pop('logEnviron', True)
 
         BuildStep.__init__(self, **kwargs)
 
@@ -139,7 +140,9 @@ class MasterShellCommand(BuildStep):
                                            "lists; key '%s' is incorrect" % (key,))
                     newenv[key] = p.sub(subst, env[key])
             env = newenv
-        stdio_log.addHeader(" env: %r\n" % (env,))
+
+        if self.logEnviron:
+            stdio_log.addHeader(" env: %r\n" % (env,))
 
         # TODO add a timeout?
         self.process = reactor.spawnProcess(self.LocalPP(self), argv[0], argv,


### PR DESCRIPTION
Added the logEnviron flag to the MasterShellCommand
step. The master may have variables in it's environment
(such as AWS credentials) which we do not want to leak
into a log.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>