### PR TITLE
Fix the tag handling for the "builders" page

### DIFF
--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -241,7 +241,7 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
         # respect addition order
         for name in self.botmaster.builderNames:
             bldr = self.getBuilder(name)
-            if bldr.matchesAnyTag(tags):
+            if bldr.builder_status.matchesAnyTag(tags):
                 l.append(name)
         return util.naturalSort(l)
 


### PR DESCRIPTION
This patch fixes an issue where navigating to /builders?tag=something gives "exceptions.AttributeError: 'Builder' object
has no attribute 'matchesAnyTag'". This was because the self.botmaster.builders is a list of Builder objects that don't
have that particular method. The Builder object has a member that is a BuilderStatus object that does have that method
though, and it looks like that is intended to hold information like tags, so calling matchesAnyTag on
bldr.builder_status instead of directly on bldr solves the problem.