### PR TITLE
Control who gets notified by GerritStatusPush

### DIFF
--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -145,11 +145,12 @@ class GerritStatusPush(service.BuildbotService):
     startArg = None
     summaryCB = None
     summaryArg = None
+    _gerrit_notify = None
 
     def reconfigService(self, server, username, reviewCB=DEFAULT_REVIEW,
                         startCB=None, port=29418, reviewArg=None,
                         startArg=None, summaryCB=DEFAULT_SUMMARY, summaryArg=None,
-                        identity_file=None, builders=None):
+                        identity_file=None, builders=None, notify=None):
 
         # If neither reviewCB nor summaryCB were specified, default to sending
         # out "summary" reviews. But if we were given a reviewCB and only a
@@ -176,6 +177,7 @@ class GerritStatusPush(service.BuildbotService):
         self.summaryCB = summaryCB
         self.summaryArg = summaryArg
         self.builders = builders
+        self._gerrit_notify = notify
 
     def _gerritCmd(self, *args):
         '''Construct a command as a list of strings suitable for
@@ -398,6 +400,10 @@ class GerritStatusPush(service.BuildbotService):
             return
 
         command = self._gerritCmd("review", "--project %s" % (project,))
+
+        if self._gerrit_notify is not None:
+            command.append('--notify %s' % str(self._gerrit_notify))
+
         message = result.get('message', None)
         if message:
             command.append("--message '%s'" % message.replace("'", "\""))

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -465,3 +465,23 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
             'ssh',
             ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'review', '--project project',
              "--message 'bla'", '--verified 1', 'revision'])
+
+        # now test the notify argument, even though _gerrit_notify
+        # is private, work around that
+        gsp._gerrit_notify = 'OWNER'
+        gsp.processVersion('2.6', lambda: None)
+        spawnSkipFirstArg = Mock()
+        yield gsp.sendCodeReview('project', 'revision', {'message': 'bla', 'labels': {'Verified': 1}})
+        spawnSkipFirstArg.assert_called_once_with(
+            'ssh',
+            ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'review',
+             '--project project', '--notify OWNER', "--message 'bla'", '--label Verified=1', 'revision'])
+
+        # gerrit versions <= 2.5 uses other syntax
+        gsp.processVersion('2.4', lambda: None)
+        spawnSkipFirstArg = Mock()
+        yield gsp.sendCodeReview('project', 'revision', {'message': 'bla', 'labels': {'Verified': 1}})
+        spawnSkipFirstArg.assert_called_once_with(
+            'ssh',
+            ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'review', '--project project', '--notify OWNER',
+             "--message 'bla'", '--verified 1', 'revision'])

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -665,7 +665,7 @@ GerritStatusPush
 :class:`GerritStatusPush` sends review of the :class:`Change` back to the Gerrit server, optionally also sending a message when a build is started.
 GerritStatusPush can send a separate review for each build that completes, or a single review summarizing the results for all of the builds.
 
-.. py:class:: GerritStatusPush(server, username, reviewCB, startCB, port, reviewArg, startArg, summaryCB, summaryArg, identity_file, ...)
+.. py:class:: GerritStatusPush(server, username, reviewCB, startCB, port, reviewArg, startArg, summaryCB, summaryArg, identity_file, builders, notify...)
 
    :param string server: Gerrit SSH server's address to use for push event notifications.
    :param string username: Gerrit SSH server's username.
@@ -738,6 +738,9 @@ GerritStatusPush can send a separate review for each build that completes, or a 
    :param builders: (optional) list of builders to send results for.
                     This method allows to filter results for a specific set of builder.
                     By default, or if builders is None, then no filtering is performed.
+   :param notify: (optional) control who gets notified by Gerrit once the status is posted.
+                  The possible values for `notify` can be found in your version of the
+                  Gerrit documentation for the `gerrit review` command.
 
 .. note::
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -51,6 +51,8 @@ Features
 
 * Optimization of the data api filtering, sorting and paging, speeding up a lot the UI when the master has lots of builds.
 
+* :bb:reporter:`GerritStatusPush` now accepts a ``notify`` parameter to control who gets emailed by Gerrit.
+
 Fixes
 ~~~~~
 


### PR DESCRIPTION
Allow the GerritStatusPush object to accept who to notify as an argument. The notify argument is a string
which accepts values found in the gerrit documentation for the `--notify` flag. The argument is set to None by
default to maintain current functionality.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>