### PR TITLE
GitHubAuth: Grab the user's primary email address

### DIFF
--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -84,11 +84,12 @@ class OAuth2Auth(www.WwwTestMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_getGithubLoginURL(self):
         res = yield self.githubAuth.getLoginURL('http://redir')
-        exp = ("https://github.com/login/oauth/authorize?state=redirect%3Dhttp%253A%252F%252Fredir&redirect_uri="
-               "h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&client_id=ghclientID")
+        exp = ("https://github.com/login/oauth/authorize?scope=user%3Aemail&state="
+               "redirect%3Dhttp%253A%252F%252Fredir&redirect_uri=h%3A%2Fa%2Fb%2F"
+               "auth%2Flogin&response_type=code&client_id=ghclientID")
         self.assertEqual(res, exp)
         res = yield self.githubAuth.getLoginURL(None)
-        exp = ("https://github.com/login/oauth/authorize?redirect_uri="
+        exp = ("https://github.com/login/oauth/authorize?scope=user%3Aemail&redirect_uri="
                "h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&client_id=ghclientID")
         self.assertEqual(res, exp)
 
@@ -129,7 +130,10 @@ class OAuth2Auth(www.WwwTestMixin, unittest.TestCase):
             dict(  # /user
                 login="bar",
                 name="foo bar",
-                email="bar@foo"),
+                email="buzz@bar"),
+            [  # /user/emails
+                {'email': 'buzz@bar', 'verified': True, 'primary': False},
+                {'email': 'bar@foo', 'verified': True, 'primary': True}],
             [dict(  # /users/bar/orgs
                 login="group",)
              ]])

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -172,11 +172,17 @@ class GitHubAuth(OAuth2Auth):
     name = "GitHub"
     faIcon = "fa-github"
     authUri = 'https://github.com/login/oauth/authorize'
+    authUriAdditionalParams = {'scope': 'user:email'}
     tokenUri = 'https://github.com/login/oauth/access_token'
     resourceEndpoint = 'https://api.github.com'
 
     def getUserInfoFromOAuthClient(self, c):
         user = self.get(c, '/user')
+        emails = self.get(c, '/user/emails')
+        for email in emails:
+            if email.get('primary', False):
+                user['email'] = email['email']
+                break
         orgs = self.get(c, join('/users', user['login'], "orgs"))
         return dict(full_name=user['name'],
                     email=user['email'],

--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -202,6 +202,10 @@ The available classes are described here:
 
     Register your Buildbot instance with the ``BUILDBOT_URL/auth/login`` url as the allowed redirect URI.
 
+    The user's email-address (for e.g. authorization) is set to the "primary" address set by the user in GitHub.
+    When using group-based authorization, the user's groups are equal to the names of the GitHub organizations the user
+    is a member of.
+
     Example::
 
         from buildbot.plugins import util
@@ -609,4 +613,21 @@ More complex config with separation per branch:
             RolesFromOwner(role="owner")
         ]
     )
+    c['www']['authz'] = authz
+
+Using GitHub authentication and allowing access to all endpoints for users in the "BuildBot" organization:
+
+.. code-block:: python
+
+    from buildbot.plugins import *
+    authz = util.Authz(
+      allowRules=[
+        util.AnyEndpointMatcher(role="BuildBot", defaultDeny=True)
+      ],
+      roleMatchers=[
+        util.RolesFromGroups()
+      ]
+    )
+    auth=util.GitHubAuth('CLIENT_ID', 'CLIENT_SECRET')
+    c['www']['auth'] = auth
     c['www']['authz'] = authz


### PR DESCRIPTION
I realized I never properly PR'd this. This PR ensures the user's email is always set to the 'primary' address when authenticating with github. This keeps the address consistent between log-ins so e.g. RolesFromEmails will match.