### PR TITLE
force latent worker to restart if build_wait_timeout is 0

### DIFF
--- a/common/maketarballs.sh
+++ b/common/maketarballs.sh
@@ -2,6 +2,8 @@
 find . -name VERSION -exec rm {} \;
 rm -rf dist
 mkdir dist
+pip install mock wheel
+set -e
 for pkg in pkg master worker www/base www/console_view www/waterfall_view
 do
   pip install -e ${pkg}

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -56,6 +56,10 @@ deprecatedWorkerModuleAttribute(
     compat_name="LatentBuildSlaveFailedToSubstantiate")
 
 
+class LatentWorkerSubstantiatiationCancelled(Exception):
+    pass
+
+
 class IPlugin(Interface):
 
     """

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -352,7 +352,7 @@ class BuildRequestDistributor(service.AsyncMultiService):
         def remove(x):
             self._pendingMSBOCalls.remove(d)
             return x
-        d.addErrback(log.err, "while strting builds on %s" % (new_builders,))
+        d.addErrback(log.err, "while starting builds on %s" % (new_builders,))
 
     def _maybeStartBuildsOn(self, new_builders):
         new_builders = set(new_builders)

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -67,6 +67,8 @@ class LatentController(object):
         self.remote_worker.setServiceParent(self.worker)
 
     def disconnect_worker(self, workdir):
+        # LocalWorker does actually disconnect, so we must fo
+        self.worker.conn = None
         return self.remote_worker.disownServiceParent()
 
     def patchBot(self, case, remoteMethod, patch):

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -56,3 +56,9 @@ class FakeWorker(object):
 
     def canStartBuild(self):
         pass
+
+    def putInQuarantine(self):
+        pass
+
+    def resetQuarantine(self):
+        pass

--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -16,17 +16,23 @@
 import os
 
 from future.builtins import range
+from twisted.internet import defer
+from twisted.python import log
 from twisted.python import threadpool
 from twisted.python.failure import Failure
 from twisted.trial.unittest import SynchronousTestCase
 
 from buildbot.config import BuilderConfig
+from buildbot.interfaces import LatentWorkerFailedToSubstantiate
+from buildbot.interfaces import LatentWorkerSubstantiatiationCancelled
+from buildbot.process.buildstep import BuildStep
 from buildbot.process.factory import BuildFactory
 from buildbot.process.results import SUCCESS
 from buildbot.test.fake.latent import LatentController
 from buildbot.test.fake.reactor import NonThreadPool
 from buildbot.test.fake.reactor import TestReactor
 from buildbot.test.util.integration import getMaster
+from buildbot.test.util.misc import enable_trace
 
 
 class TestException(Exception):
@@ -42,7 +48,22 @@ class Tests(SynchronousTestCase):
         self.patch(threadpool, 'ThreadPool', NonThreadPool)
         self.reactor = TestReactor()
 
+        # to ease debugging we display the error logs in the test log
+        origAddCompleteLog = BuildStep.addCompleteLog
+
+        def addCompleteLog(self, name, _log):
+            if name.endswith("err.text"):
+                log.msg("got error log!", name, _log)
+            return origAddCompleteLog(self, name, _log)
+        self.patch(BuildStep, "addCompleteLog", addCompleteLog)
+
+        if 'BBTRACE' in os.environ:
+            enable_trace(self, ["twisted", "worker_transition.py", "util/tu", "util/path",
+                                "log.py", "/mq/", "/db/", "buildbot/data/", "fake/reactor.py"])
+
     def tearDown(self):
+        # Flush the errors logged by the master stop cancelling the builds.
+        self.flushLoggedErrors(LatentWorkerSubstantiatiationCancelled)
         self.assertFalse(self.master.running, "master is still running!")
 
     def getMaster(self, config_dict):
@@ -92,8 +113,8 @@ class Tests(SynchronousTestCase):
             self.createBuildrequest(master, [builder_id])
 
         # Check that both workers were requested to start.
-        self.assertEqual(controllers[0].started, True)
-        self.assertEqual(controllers[1].started, True)
+        self.assertEqual(controllers[0].starting, True)
+        self.assertEqual(controllers[1].starting, True)
         for controller in controllers:
             controller.start_instance(True)
             controller.auto_stop(True)
@@ -136,6 +157,7 @@ class Tests(SynchronousTestCase):
             set([req['buildrequestid'] for req in unclaimed_build_requests]),
         )
         controller.auto_stop(True)
+        self.flushLoggedErrors(LatentWorkerFailedToSubstantiate)
 
     def test_failed_substantiations_get_requeued(self):
         """
@@ -200,6 +222,7 @@ class Tests(SynchronousTestCase):
         builder_id = self.successResultOf(
             master.data.updates.findBuilderId('testy'))
 
+        controller.auto_stop(True)
         # Trigger a buildrequest
         bsid, brids = self.createBuildrequest(master, [builder_id])
 
@@ -207,19 +230,36 @@ class Tests(SynchronousTestCase):
         self.successResultOf(master.mq.startConsuming(
             lambda key, request: unclaimed_build_requests.append(request),
             ('buildrequests', None, 'unclaimed')))
-
         # The worker fails to substantiate.
         controller.start_instance(
             Failure(TestException("substantiation failed")))
         # Flush the errors logged by the failure.
         self.flushLoggedErrors(TestException)
 
+        # The retry logic should only trigger after a exponential backoff
+        self.assertEqual(controller.starting, False)
+
+        # advance the time to the point where we should retry
+        master.reactor.advance(controller.worker.quarantine_initial_timeout)
+
         # If the worker started again after the failure, then the retry logic will have
         # already kicked in to start a new build on this (the only) worker. We check that
         # a new instance was requested, which indicates that the worker
         # accepted the build.
-        self.assertEqual(controller.started, True)
-        controller.auto_stop(True)
+        self.assertEqual(controller.starting, True)
+
+        # The worker fails to substantiate(again).
+        controller.start_instance(
+            Failure(TestException("substantiation failed")))
+        # Flush the errors logged by the failure.
+        self.flushLoggedErrors(TestException)
+
+        # advance the time to the point where we should not retry
+        master.reactor.advance(controller.worker.quarantine_initial_timeout)
+        self.assertEqual(controller.starting, False)
+        # advance the time to the point where we should retry
+        master.reactor.advance(controller.worker.quarantine_initial_timeout)
+        self.assertEqual(controller.starting, True)
 
     def test_worker_multiple_substantiations_succeed(self):
         """
@@ -300,6 +340,8 @@ class Tests(SynchronousTestCase):
 
         # We never start the worker, rather timeout it.
         master.reactor.advance(controller.worker.missing_timeout)
+        # Flush the errors logged by the failure.
+        self.flushLoggedErrors(defer.TimeoutError)
 
         # When the substantiation fails, the buildrequest becomes unclaimed.
         self.assertEqual(
@@ -360,12 +402,75 @@ class Tests(SynchronousTestCase):
         # should get 2 logs (html and txt) with proper information in there
         self.assertEqual(len(logs), 2)
         logs_by_name = {}
-        for log in logs:
-            fulllog = self.successResultOf(master.data.get(("logs", str(log['logid']), "raw")))
+        for _log in logs:
+            fulllog = self.successResultOf(master.data.get(("logs", str(_log['logid']), "raw")))
             logs_by_name[fulllog['filename']] = fulllog['raw']
 
         for i in ["err_text", "err_html"]:
             self.assertIn("can't create dir", logs_by_name[i])
+            # make sure stacktrace is present in html
+            self.assertIn(os.path.join("integration", "test_latent.py"), logs_by_name[i])
+        controller.auto_stop(True)
+
+    def test_failed_ping_get_requeued(self):
+        """
+        sendBuilderList can fail due to missing permissions on the workdir,
+        the build request becomes unclaimed
+        """
+        controller = LatentController('local')
+        config_dict = {
+            'builders': [
+                BuilderConfig(name="testy",
+                              workernames=["local"],
+                              factory=BuildFactory(),
+                              ),
+            ],
+            'workers': [controller.worker],
+            'protocols': {'null': {}},
+            # Disable checks about missing scheduler.
+            'multiMaster': True,
+        }
+        master = self.getMaster(config_dict)
+        builder_id = self.successResultOf(
+            master.data.updates.findBuilderId('testy'))
+
+        # Trigger a buildrequest
+        bsid, brids = self.createBuildrequest(master, [builder_id])
+
+        unclaimed_build_requests = []
+        self.successResultOf(master.mq.startConsuming(
+            lambda key, request: unclaimed_build_requests.append(request),
+            ('buildrequests', None, 'unclaimed')))
+        logs = []
+        self.successResultOf(master.mq.startConsuming(
+            lambda key, log: logs.append(log),
+            ('logs', None, 'new')))
+
+        # The worker succeed to substantiate
+        def remote_print(self, msg):
+            if msg == "ping":
+                raise TestException("can't ping")
+        controller.patchBot(self, 'remote_print', remote_print)
+        controller.start_instance(True)
+        controller.connect_worker(self)
+
+        # Flush the errors logged by the failure.
+        self.flushLoggedErrors(TestException)
+
+        # When the substantiation fails, the buildrequest becomes unclaimed.
+        self.assertEqual(
+            set(brids),
+            set([req['buildrequestid'] for req in unclaimed_build_requests]),
+        )
+        # should get 2 logs (html and txt) with proper information in there
+        self.assertEqual(len(logs), 2)
+        logs_by_name = {}
+        for _log in logs:
+            fulllog = self.successResultOf(master.data.get(("logs", str(_log['logid']), "raw")))
+            logs_by_name[fulllog['filename']] = fulllog['raw']
+
+        for i in ["err_text", "err_html"]:
+            self.assertIn("can't ping", logs_by_name[i])
             # make sure stacktrace is present in html
             self.assertIn(os.path.join("integration", "test_latent.py"), logs_by_name[i])
         controller.auto_stop(True)

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -12,10 +12,15 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from __future__ import print_function
+
 import cStringIO
 import os
 import sys
+
 from future.utils import text_type
+
+import buildbot
 
 
 class PatcherMixin(object):
@@ -71,3 +76,28 @@ def encodeExecutableAndArgs(executable, args, encoding="utf-8"):
         argsBytes.append(arg)
 
     return (executable, argsBytes)
+
+
+def enable_trace(case, trace_exclusions=None, f=sys.stdout):
+    """This function can be called to enable tracing of the execution
+    """
+    if trace_exclusions is None:
+        trace_exclusions = ["twisted", "worker_transition.py", "util/tu",
+                            "log.py", "/mq/", "/db/", "buildbot/data/", "fake/reactor.py"]
+
+    bbbase = os.path.dirname(buildbot.__file__)
+    state = {'indent': 0}
+
+    def tracefunc(frame, event, arg):
+        if frame.f_code.co_filename.startswith(bbbase):
+            if not any(te in frame.f_code.co_filename for te in trace_exclusions):
+                if event == "call":
+                    state['indent'] += 2
+                    print("-" * state['indent'], frame.f_code.co_filename.replace(bbbase, ""),
+                          frame.f_code.co_name, frame.f_code.co_varnames, file=f)
+                if event == "return":
+                    state['indent'] -= 2
+        return tracefunc
+
+    sys.settrace(tracefunc)
+    case.addCleanup(sys.settrace, lambda _a, _b, _c: None)

--- a/master/buildbot/worker/protocols/null.py
+++ b/master/buildbot/worker/protocols/null.py
@@ -66,6 +66,9 @@ class Connection(base.Connection):
     proxies = {base.FileWriterImpl: FileWriterProxy,
                base.FileReaderImpl: FileReaderProxy}
 
+    def loseConnection(self):
+        pass
+
     def remotePrint(self, message):
         return defer.maybeDeferred(self.worker.bot.remote_print, message)
 

--- a/worker/buildbot_worker/null.py
+++ b/worker/buildbot_worker/null.py
@@ -34,3 +34,8 @@ class LocalWorker(WorkerBase):
         res = yield master.workers.newConnection(conn, self.name)
         if res:
             yield self.parent.attached(conn)
+
+    @defer.inlineCallbacks
+    def stopService(self):
+        yield self.parent.detached()
+        yield WorkerBase.stopService(self)


### PR DESCRIPTION
one commit based on #2414

build_wait_timeout = 0 kind of worked in real reactor, but sometimes some build start, and then are stopped right after

This is because of a deferred race condition which is not happening on the fake reactor

baseWorker.buildFinished will start the process of searching new build
but latentWorker.buildFinished will insubstantiate in parrallel
depending on how fast the db will return the unclaimed buildrequest, a new build can start before the insubstantiation.

by calling baseWorker.buildFinished after doing the insubstantiate, we make sure that this worker will not be selected

This commit also contains test for this case, and fix for LocalSlave to correctly handle its lifecycle.
