### PR TITLE
Add support for Openstack region

### DIFF
--- a/master/buildbot/test/fake/openstack.py
+++ b/master/buildbot/test/fake/openstack.py
@@ -26,7 +26,8 @@ UNKNOWN = 'UNKNOWN'
 # Parts used from novaclient
 class Client():
 
-    def __init__(self, version, username, password, tenant_name, auth_url):
+    def __init__(self, version, username, password, tenant_name, auth_url,
+                 region_name):
         self.images = Images()
         self.servers = Servers()
 

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -56,6 +56,7 @@ class OpenStackLatentWorker(AbstractLatentWorker):
                  # to novaclient.
                  nova_args=None,
                  client_version='2',
+                 region=None,
                  **kwargs):
 
         if not client or not nce:
@@ -72,7 +73,7 @@ class OpenStackLatentWorker(AbstractLatentWorker):
         self.client_version = client_version
         self.novaclient = client.Client(client_version, os_username,
                                         os_password, os_tenant_name,
-                                        os_auth_url)
+                                        os_auth_url, region_name=region)
 
         if block_devices is not None:
             self.block_devices = [

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -55,7 +55,7 @@ class OpenStackLatentWorker(AbstractLatentWorker):
                  # Have a nova_args parameter to allow passing things directly
                  # to novaclient.
                  nova_args=None,
-                 client_version='1.1',
+                 client_version='2',
                  **kwargs):
 
         if not client or not nce:


### PR DESCRIPTION
Hello,

I've added an extra `region` argument to the `__init__()` of `OpenStackLatentWorker`.
We are using this to spawn Worker on different regions.