### PR TITLE
Add a few more filters to MailNotifier

### DIFF
--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -111,8 +111,7 @@ class MailNotifier(service.BuildbotService):
                     messageFormatter=None, extraHeaders=None,
                     addPatch=True, useTls=False,
                     smtpUser=None, smtpPassword=None, smtpPort=25,
-                    name=None
-                    ):
+                    name=None):
         if ESMTPSenderFactory is None:
             config.error("twisted-mail is not installed - cannot "
                          "send mail")
@@ -171,8 +170,7 @@ class MailNotifier(service.BuildbotService):
                         messageFormatter=None, extraHeaders=None,
                         addPatch=True, useTls=False,
                         smtpUser=None, smtpPassword=None, smtpPort=25,
-                        name=None
-                        ):
+                        name=None):
 
         if extraRecipients is None:
             extraRecipients = []
@@ -315,8 +313,7 @@ class MailNotifier(service.BuildbotService):
             subject = self.subject % {'result': Results[results],
                                       'projectName': title,
                                       'title': title,
-                                      'builder': builderName,
-                                      }
+                                      'builder': builderName}
 
         assert '\n' not in subject, \
             "Subject cannot contain newlines"

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -111,7 +111,7 @@ class MailNotifier(service.BuildbotService):
                     messageFormatter=None, extraHeaders=None,
                     addPatch=True, useTls=False,
                     smtpUser=None, smtpPassword=None, smtpPort=25,
-                    name=None, schedulers=None):
+                    name=None, schedulers=None, branches=None):
         if ESMTPSenderFactory is None:
             config.error("twisted-mail is not installed - cannot "
                          "send mail")
@@ -144,6 +144,8 @@ class MailNotifier(service.BuildbotService):
                 self.name += "_builders_" + "+".join(builders)
             if schedulers is not None:
                 self.name += "_schedulers_" + "+".join(schedulers)
+            if branches is not None:
+                self.name += "_branches_" + "+".join(branches)
 
         if '\n' in subject:
             config.error(
@@ -172,7 +174,7 @@ class MailNotifier(service.BuildbotService):
                         messageFormatter=None, extraHeaders=None,
                         addPatch=True, useTls=False,
                         smtpUser=None, smtpPassword=None, smtpPort=25,
-                        name=None, schedulers=None):
+                        name=None, schedulers=None, branches=None):
 
         if extraRecipients is None:
             extraRecipients = []
@@ -184,6 +186,7 @@ class MailNotifier(service.BuildbotService):
         self.tags = tags
         self.builders = builders
         self.schedulers = schedulers
+        self.branches = branches
         self.addLogs = addLogs
         self.relayhost = relayhost
         self.subject = subject
@@ -271,10 +274,13 @@ class MailNotifier(service.BuildbotService):
         # here is where we actually do something.
         builder = build['builder']
         scheduler = build['properties'].get('scheduler', [None])[0]
+        branch = build['properties'].get('branch', [None])[0]
         results = build['results']
         if self.builders is not None and builder['name'] not in self.builders:
             return False  # ignore this build
         if self.schedulers is not None and scheduler not in self.schedulers:
+            return False  # ignore this build
+        if self.branches is not None and branch not in self.branches:
             return False  # ignore this build
         if self.tags is not None and \
                 not self.matchesAnyTag(builder['tags']):

--- a/master/buildbot/test/integration/test_setpropertyfromcommand.py
+++ b/master/buildbot/test/integration/test_setpropertyfromcommand.py
@@ -23,7 +23,7 @@ from buildbot.test.util.integration import RunMasterBase
 # we make sure that we can reconfigure the master while build is running
 
 
-class SetProperyFromCommand(RunMasterBase):
+class SetPropertyFromCommand(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_setProp(self):

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -81,6 +81,8 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
                     buildid=_id, name="reason", value="because"),
                 fakedb.BuildProperty(
                     buildid=_id, name="scheduler", value="checkin"),
+                fakedb.BuildProperty(
+                    buildid=_id, name="branch", value="master"),
             ])
         res = yield utils.getDetailsForBuildset(self.master, 98, wantProperties=True,
                                                 wantPreviousBuild=wantPreviousBuild)
@@ -260,7 +262,7 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         self.assertTrue(mn.isMailNeeded(build))
 
     @defer.inlineCallbacks
-    def test_isMailNeeded_schedulers_positive(self):
+    def test_isMailNeeded_schedulers_sends_mail(self):
         _, builds = yield self.setupBuildResults(SUCCESS)
 
         build = builds[0]
@@ -270,13 +272,33 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         self.assertTrue(mn.isMailNeeded(build))
 
     @defer.inlineCallbacks
-    def test_isMailNeeded_schedulers_negative(self):
+    def test_isMailNeeded_schedulers_doesnt_send_mail(self):
         _, builds = yield self.setupBuildResults(SUCCESS)
 
         build = builds[0]
         # force tags
         mn = yield self.setupMailNotifier('from@example.org',
                                           schedulers=['some-random-scheduler'])
+        self.assertFalse(mn.isMailNeeded(build))
+
+    @defer.inlineCallbacks
+    def test_isMailNeeded_branches_sends_mail(self):
+        _, builds = yield self.setupBuildResults(SUCCESS)
+
+        build = builds[0]
+        # force tags
+        mn = yield self.setupMailNotifier('from@example.org',
+                                          branches=['master'])
+        self.assertTrue(mn.isMailNeeded(build))
+
+    @defer.inlineCallbacks
+    def test_isMailNeeded_branches_doesnt_send_mail(self):
+        _, builds = yield self.setupBuildResults(SUCCESS)
+
+        build = builds[0]
+        # force tags
+        mn = yield self.setupMailNotifier('from@example.org',
+                                          branches=['some-random-branch'])
         self.assertFalse(mn.isMailNeeded(build))
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -79,6 +79,8 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
                     buildid=_id, name="workername", value="sl"),
                 fakedb.BuildProperty(
                     buildid=_id, name="reason", value="because"),
+                fakedb.BuildProperty(
+                    buildid=_id, name="scheduler", value="checkin"),
             ])
         res = yield utils.getDetailsForBuildset(self.master, 98, wantProperties=True,
                                                 wantPreviousBuild=wantPreviousBuild)
@@ -256,6 +258,26 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         mn = yield self.setupMailNotifier('from@example.org',
                                           tags=["fast"])
         self.assertTrue(mn.isMailNeeded(build))
+
+    @defer.inlineCallbacks
+    def test_isMailNeeded_schedulers_positive(self):
+        _, builds = yield self.setupBuildResults(SUCCESS)
+
+        build = builds[0]
+        # force tags
+        mn = yield self.setupMailNotifier('from@example.org',
+                                          schedulers=['checkin'])
+        self.assertTrue(mn.isMailNeeded(build))
+
+    @defer.inlineCallbacks
+    def test_isMailNeeded_schedulers_negative(self):
+        _, builds = yield self.setupBuildResults(SUCCESS)
+
+        build = builds[0]
+        # force tags
+        mn = yield self.setupMailNotifier('from@example.org',
+                                          schedulers=['some-random-scheduler'])
+        self.assertFalse(mn.isMailNeeded(build))
 
     @defer.inlineCallbacks
     def run_simple_test_sends_email_for_mode(self, mode, result, shouldSend=True):

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -310,6 +310,11 @@ MailNotifier arguments
     Defaults to ``None`` (all tags).
     Use either builders or tags, but not both.
 
+``schedulers``
+    (list of strings).
+    A list of scheduler names to serve status information for.
+    Defaults to ``None`` (all schedulers).
+
 ``addLogs``
     (boolean).
     If ``True``, include all build logs as attachments to the messages.

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -315,6 +315,11 @@ MailNotifier arguments
     A list of scheduler names to serve status information for.
     Defaults to ``None`` (all schedulers).
 
+``branches``
+    (list of strings).
+    A list of branch names to serve status information for.
+    Defaults to ``None`` (all branches).
+
 ``addLogs``
     (boolean).
     If ``True``, include all build logs as attachments to the messages.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -41,6 +41,10 @@ Features
 
 * new :bb:step:`GitHub` which correctly checkout the magic branch like ``refs/pull/xx/merge``.
 
+* :class:`MailNotifier` now supports a `schedulers` constructor argument that
+  allows you to send mail only for builds triggered by the specified list of
+  schedulers.
+
 Fixes
 ~~~~~
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -44,6 +44,9 @@ Features
 * :class:`MailNotifier` now supports a `schedulers` constructor argument that
   allows you to send mail only for builds triggered by the specified list of
   schedulers.
+* :class:`MailNotifier` now supports a `branches` constructor argument that
+  allows you to send mail only for builds triggered by the specified list of
+  branches.
 
 Fixes
 ~~~~~


### PR DESCRIPTION
This patchset contains a combination of minor changes (typo fixes, PEP8 cleanup) and the addition of two new filters for MailNotifier: schedulers and branches. These new filters let you send mail only if a given build was generated by a given set of schedulers, or a given set of branches. An example of when this is useful is when you want to send mail for builds triggered by the "checkin" scheduler, or the official nightly, but not for unofficial builds triggered by developers.