### PR TITLE
reliability improvments for hyper

### DIFF
--- a/master/buildbot/test/unit/test_worker_hyper.py
+++ b/master/buildbot/test/unit/test_worker_hyper.py
@@ -128,3 +128,13 @@ class TestHyperLatentWorker(unittest.SynchronousTestCase):
         self.assertIsNotNone(worker.client)
         self.assertEqual(worker.instance, None)
         # teardown makes sure all containers are cleaned up
+
+    def test_start_worker_but_already_created_with_same_name(self):
+        worker = self.makeWorker(image="cool")
+        worker.maybeCreateSingletons()
+        worker.client.create_container(image="foo", name=worker.getContainerName())
+        d = worker.substantiate(None, FakeBuild())
+        self.reactor.advance(.1)
+        worker.attached(FakeBot())
+        self.successResultOf(d)
+        self.assertIsNotNone(worker.client)

--- a/master/buildbot/util/logger.py
+++ b/master/buildbot/util/logger.py
@@ -1,0 +1,35 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+try:
+    from twisted.logger import Logger
+except ImportError:
+    from twisted.python import log
+
+    class Logger(object):
+        """A simplistic backporting of the new logger system for old versions of twisted"""
+        def _log(self, format, *args, **kwargs):
+            log.msg(format.format(args, **kwargs))
+
+        # legacy logging system do not support log level.
+        # We dont bother inventing something. If needed, user can upgrade
+        debug = _log
+        info = _log
+        warn = _log
+        error = _log
+        critical = _log
+
+        def failure(self, format, failure, *args, **kwargs):
+            log.error(failure, format.format(args, **kwargs))

--- a/master/buildbot/util/logger.py
+++ b/master/buildbot/util/logger.py
@@ -33,3 +33,4 @@ except ImportError:
 
         def failure(self, format, failure, *args, **kwargs):
             log.error(failure, format.format(args, **kwargs))
+__all__ = ["Logger"]

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -139,7 +139,6 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
         # sibling == self is using ComparableMixin's implementation
         # only compare compare_attrs
         if self.configured and sibling == self:
-
             return defer.succeed(None)
         self.configured = True
         return self.reconfigService(*sibling._config_args,

--- a/master/buildbot/worker/hyper.py
+++ b/master/buildbot/worker/hyper.py
@@ -17,12 +17,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import hashlib
 import socket
+import time
 
 from twisted.internet import reactor as global_reactor
 from twisted.internet import defer
 from twisted.internet import threads
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.python import threadpool
 
 from buildbot import config
@@ -31,10 +33,12 @@ from buildbot.worker import AbstractLatentWorker
 
 try:
     import docker
-    from hypercompose.api import Hyper
-    _hush_pyflakes = [docker, Hyper]
+    from hyper_sh import Client as Hyper
+    [docker, Hyper]
 except ImportError:
     Hyper = None
+
+log = Logger()
 
 
 class HyperLatentWorker(AbstractLatentWorker):
@@ -43,8 +47,10 @@ class HyperLatentWorker(AbstractLatentWorker):
     ALLOWED_SIZES = ['s1', 's2', 's3', 's4', 'm1', 'm2', 'm3', 'l1', 'l2', 'l3']
     threadPool = None
     client = None
+    image = None
     reactor = global_reactor
     client_args = None
+    class_singletons = {}
 
     def checkConfig(self, name, password, hyper_host,
                     hyper_accesskey, hyper_secretkey, image, hyper_size="s3", masterFQDN=None, **kwargs):
@@ -58,7 +64,7 @@ class HyperLatentWorker(AbstractLatentWorker):
         AbstractLatentWorker.checkConfig(self, name, password, **kwargs)
 
         if not Hyper:
-            config.error("The python modules 'docker-py>=1.4' and 'hypercompose' are needed to use a"
+            config.error("The python modules 'docker-py>=1.4' and 'hyper_sh' are needed to use a"
                          " HyperLatentWorker")
 
         if hyper_size not in self.ALLOWED_SIZES:
@@ -66,10 +72,10 @@ class HyperLatentWorker(AbstractLatentWorker):
 
     def reconfigService(self, name, password, hyper_host,
                         hyper_accesskey, hyper_secretkey, image, hyper_size="s3", masterFQDN=None, **kwargs):
-
         AbstractLatentWorker.reconfigService(self, name, password, **kwargs)
+        self.confighash = hashlib.sha1(hyper_host + hyper_accesskey + hyper_secretkey).hexdigest()[:6]
+        self.masterhash = hashlib.sha1(self.master.name).hexdigest()[:6]
         self.size = hyper_size
-        self.image = image
 
         # Prepare the parameters for the Docker Client object.
         self.client_args = {'clouds': {
@@ -78,6 +84,7 @@ class HyperLatentWorker(AbstractLatentWorker):
                 "secretkey": hyper_secretkey
             }
         }}
+        self.image = image
         if not masterFQDN:  # also match empty string (for UI)
             masterFQDN = socket.getfqdn()
         self.masterFQDN = masterFQDN
@@ -86,13 +93,7 @@ class HyperLatentWorker(AbstractLatentWorker):
     def stopService(self):
         # stopService will call stop_instance if the worker was up.
         yield AbstractLatentWorker.stopService(self)
-        # we cleanup our thread and session (or reactor.stop will hang)
-        if self.client is not None:
-            self.client.close()
-            self.client = None
-        if self.threadPool is not None:
-            yield self.threadPool.stop()
-            self.threadPool = None
+        yield self.maybeDeleteSingletons()
 
     def createEnvironment(self):
         result = {
@@ -106,42 +107,81 @@ class HyperLatentWorker(AbstractLatentWorker):
             result["BUILDMASTER"], result["BUILDMASTER_PORT"] = self.masterFQDN.split(":")
         return result
 
+    def runInThread(self, meth, *args, **kwargs):
+        self.maybeCreateSingletons()
+        return threads.deferToThreadPool(self.reactor, self.threadPool, meth, *args, **kwargs)
+
+    def maybeCreateSingletons(self):
+        if self.threadPool is None:
+            key = self.confighash
+            if key not in HyperLatentWorker.class_singletons:
+                threadPool = threadpool.ThreadPool(minthreads=10, maxthreads=10, name='hyper')
+                threadPool.start()
+                # simple reference counter to stop the pool when the last latent worker is stopped
+                threadPool.refs = 0
+                client = Hyper(self.client_args)
+                HyperLatentWorker.class_singletons[key] = (threadPool, client)
+            else:
+                threadPool, client = HyperLatentWorker.class_singletons[key]
+            threadPool.refs += 1
+            self.threadPool = threadPool
+            self.client = client
+
+    @defer.inlineCallbacks
+    def maybeDeleteSingletons(self):
+        if self.threadPool is not None:
+            self.threadPool.refs -= 1
+            if self.threadPool.refs == 0:
+                self.client.close()
+                yield self.threadPool.stop()
+                key = self.confighash
+                # if key in not in the singleton, there is a bug somewhere so this will raise
+                del HyperLatentWorker.class_singletons[key]
+
+            self.threadPool = self.client = None
+
     @defer.inlineCallbacks
     def start_instance(self, build):
         if self.instance is not None:
             raise ValueError('instance active')
 
-        if self.threadPool is None:
-            # requests_aws4 is documented to not be thread safe, so we must serialize access
-            self.threadPool = threadpool.ThreadPool(minthreads=1, maxthreads=1, name='hyper')
-            self.threadPool.start()
-
-        if self.client is None:
-            self.client = Hyper(self.client_args)
-
         image = yield build.render(self.image)
-        res = yield threads.deferToThreadPool(self.reactor, self.threadPool, self._thd_start_instance, image)
-        defer.returnValue(res)
+        yield self.runInThread(self._thd_start_instance, image)
+        defer.returnValue(True)
+
+    def getContainerName(self):
+        return ('%s-%s' % ('buildbot' + self.masterhash, self.workername)).replace("_", "-")
+
+    def _thd_cleanup_instance(self):
+        instances = self.client.containers(filters=dict(name=self.getContainerName()))
+        for instance in instances:
+            self.client.remove_container(instance['Id'], v=True, force=True)
 
     def _thd_start_instance(self, image):
+        t1 = time.time()
+        self._thd_cleanup_instance()
+        t2 = time.time()
         instance = self.client.create_container(
             image,
             environment=self.createEnvironment(),
             labels={
                 'sh_hyper_instancetype': self.size
             },
-            name=('%s%s' % (self.workername, id(self))).replace("_", "-")
+            name=self.getContainerName()
         )
+        t3 = time.time()
 
         if instance.get('Id') is None:
             raise LatentWorkerFailedToSubstantiate(
                 'Failed to start container'
             )
-        shortid = instance['Id'][:6]
-        log.msg('Container created, Id: %s...' % (shortid,))
         instance['image'] = image
         self.instance = instance
         self.client.start(instance)
+        t4 = time.time()
+        log.debug('{name}:{containerid}: Container started in {total_time:.2f}', name=self.name,
+                  containerid=self.shortid,
+                  clean_time=t2 - t1, create_time=t3 - t2, start_time=t4 - t3, total_time=t4 - t1)
         return [instance['Id'], image]
 
     def stop_instance(self, fast=False):
@@ -150,14 +190,28 @@ class HyperLatentWorker(AbstractLatentWorker):
             # instance never attached, and it's because, somehow, we never
             # started.
             return defer.succeed(None)
-        instance = self.instance
-        self.instance = None
-        return threads.deferToThreadPool(self.reactor, self.threadPool,
-                                         self._thd_stop_instance, instance, fast)
+        return self.runInThread(self._thd_stop_instance, fast)
 
-    def _thd_stop_instance(self, instance, fast):
-        log.msg('Stopping container %s...' % instance['Id'][:6])
-        self.client.stop(instance['Id'])
+    @property
+    def shortid(self):
+        if self.instance is None:
+            return None
+        return self.instance['Id'][:6]
+
+    def _thd_stop_instance(self, fast):
+        if self.instance is None:
+            return
+        log.debug('{name}:{containerid}: Stopping container', name=self.name,
+                  containerid=self.shortid)
+        t1 = time.time()
+        self.client.stop(self.instance['Id'])
+        t2 = time.time()
         if not fast:
-            self.client.wait(instance['Id'])
-        self.client.remove_container(instance['Id'], v=True, force=True)
+            self.client.wait(self.instance['Id'])
+        t3 = time.time()
+        self.client.remove_container(self.instance['Id'], v=True, force=True)
+        t4 = time.time()
+        log.debug('{name}:{containerid}: Stopped container in {total_time:.2f}', name=self.name,
+                  containerid=self.shortid,
+                  stop_time=t2 - t1, wait_time=t3 - t2, remove_time=t4 - t3, total_time=t4 - t1)
+        self.instance = None

--- a/master/buildbot/worker/hyper.py
+++ b/master/buildbot/worker/hyper.py
@@ -24,11 +24,11 @@ import time
 from twisted.internet import reactor as global_reactor
 from twisted.internet import defer
 from twisted.internet import threads
-from twisted.logger import Logger
 from twisted.python import threadpool
 
 from buildbot import config
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate
+from buildbot.util.logger import Logger
 from buildbot.worker import AbstractLatentWorker
 
 try:


### PR DESCRIPTION
- create a singleton instance for the threadpool and client.
  before the threadpool was created for each latent worker, so they were independent.

- remove any previous container with the same name

- some improvements to the integration tests so that we can stress the code using real infra

- log of the creation and destruction time for elk monitoring