### PR TITLE
latent: remove the substantiated variable

### DIFF
--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -67,8 +67,9 @@ class LatentController(object):
         self.remote_worker.setServiceParent(self.worker)
 
     def disconnect_worker(self, workdir):
-        # LocalWorker does actually disconnect, so we must fo
-        self.worker.conn = None
+        self.worker.conn, conn = None, self.worker.conn
+        # LocalWorker does actually disconnect, so we must force diconnection via detached
+        conn.notifyDisconnected()
         return self.remote_worker.disownServiceParent()
 
     def patchBot(self, case, remoteMethod, patch):

--- a/master/buildbot/test/fake/step.py
+++ b/master/buildbot/test/fake/step.py
@@ -1,0 +1,60 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet.defer import Deferred
+
+from buildbot.process.buildstep import BuildStep
+from buildbot.process.results import CANCELLED
+
+
+class BuildStepController(object):
+
+    """
+    A controller for ``ControllableBuildStep``.
+
+    https://glyph.twistedmatrix.com/2015/05/separate-your-fakes-and-your-inspectors.html
+    """
+
+    def __init__(self, **kwargs):
+        self.step = ControllableBuildStep(self, **kwargs)
+        self.running = False
+
+    def finish_step(self, result):
+        assert self.running
+        self.running = False
+        d, self._run_deferred = self._run_deferred, None
+        d.callback(result)
+
+
+class ControllableBuildStep(BuildStep):
+
+    """
+    A latent worker that can be contolled by tests.
+    """
+    name = "controllableStep"
+
+    def __init__(self, controller):
+        BuildStep.__init__(self)
+        self._controller = controller
+
+    def run(self):
+        assert not self._controller.running
+
+        self._controller.running = True
+        self._controller._run_deferred = Deferred()
+        return self._controller._run_deferred
+
+    def interrupt(self, reason):
+        self._controller.finish_step(CANCELLED)

--- a/master/buildbot/test/unit/test_worker_libvirt.py
+++ b/master/buildbot/test/unit/test_worker_libvirt.py
@@ -59,7 +59,6 @@ class TestLibVirtWorker(unittest.TestCase):
         yield bs._find_existing_deferred
 
         self.assertEqual(bs.domain.domain, d)
-        self.assertEqual(bs.substantiated, True)
 
     @defer.inlineCallbacks
     def test_prepare_base_image_none(self):

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -205,7 +205,8 @@ class AbstractLatentWorker(AbstractWorker):
         assert not sb.isBusy()
         if not self.building:
             if self.build_wait_timeout == 0:
-                self.insubstantiate()
+                # we insubstantiate asynchronously to trigger more bugs with the fake reactor
+                self.master.reactor.callLater(0, self.insubstantiate)
                 # insubstantiate will automatically retry to create build for this worker
             else:
                 self._setBuildWaitTimer()

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -38,7 +38,6 @@ class AbstractLatentWorker(AbstractWorker):
     See ec2.py for a concrete example.
     """
 
-    substantiated = False
     substantiation_build = None
     insubstantiating = False
     build_wait_timer = None
@@ -79,8 +78,12 @@ class AbstractLatentWorker(AbstractWorker):
         # responsible for shutting down instance.
         raise NotImplementedError
 
+    @property
+    def substantiated(self):
+        return self.conn is not None
+
     def substantiate(self, sb, build):
-        if self.substantiated:
+        if self.conn is not None:
             self._clearBuildWaitTimer()
             self._setBuildWaitTimer()
             return defer.succeed(True)
@@ -144,7 +147,6 @@ class AbstractLatentWorker(AbstractWorker):
             return
         log.msg(r"Worker %s substantiated \o/" % (self.name,))
 
-        self.substantiated = True
         if not self._substantiation_notifier:
             log.msg("No substantiation deferred for %s" % (self.name,))
         else:
@@ -229,7 +231,6 @@ class AbstractLatentWorker(AbstractWorker):
         self.insubstantiating = True
         self._clearBuildWaitTimer()
         d = self.stop_instance(fast)
-        self.substantiated = False
         try:
             yield d
         except Exception as e:

--- a/master/buildbot/worker/libvirt.py
+++ b/master/buildbot/worker/libvirt.py
@@ -192,7 +192,6 @@ class LibVirtWorker(AbstractLatentWorker):
             name = yield d.name()
             if name.startswith(self.workername):
                 self.domain = d
-                self.substantiated = True
                 break
 
         self.ready = True

--- a/master/buildbot/worker/protocols/null.py
+++ b/master/buildbot/worker/protocols/null.py
@@ -31,6 +31,7 @@ class ProxyMixin():
     def __init__(self, impl):
         assert isinstance(impl, self.ImplClass)
         self.impl = impl
+        self._disconnect_listeners = []
 
     def callRemote(self, message, *args, **kw):
         method = getattr(self.impl, "remote_%s" % message, None)


### PR DESCRIPTION
self.conn is not None is equivalent, and works even when the worker is detached from the other end

we keep it as an calculated property as this is in the Interface API :-/

This prevent some worker_ping errors in production after some container have been force closed