### PR TITLE
change isort configuration

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,9 @@
 [settings]
 line_length=110
-known_third_party=twisted,migrate,sqlalchemy,ldap3,klein,future,requests,MySQLdb,zope,coverage,autobahn,pkg_resources,jinja2,mock,dateutil,sphinx,setuptools
+known_future_library=future
+known_twisted=twisted,zope,autobahn,klein
+known_mock=mock
+known_third_party=migrate,sqlalchemy,ldap3,txrequests,requests,MySQLdb,coverage,jinja2,dateutil,sphinx,setuptools
 known_first_party=buildbot,buildbot_worker
 force_single_line=1
-
+sections=FUTURE,FUTURE_LIBRARY,STDLIB,THIRDPARTY,MOCK,TWISTED,FIRSTPARTY,LOCALFOLDER

--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import time
-
 from future.utils import iteritems
 from future.utils import text_type
+
+import time
+
 from twisted.internet import defer
 from twisted.python import log
 from twisted.web import html

--- a/master/buildbot/changes/filter.py
+++ b/master/buildbot/changes/filter.py
@@ -12,9 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import re
-
 from future.utils import iteritems
+
+import re
 
 from buildbot.util import ComparableMixin
 from buildbot.util import NotABranch

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import iteritems
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet.protocol import ProcessProtocol

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -13,14 +13,15 @@
 #
 # Copyright Buildbot Team Members
 
-import itertools
-import os
-import re
-
 from future.moves.urllib.parse import quote as urlquote
 from future.utils import iterkeys
 from future.utils import itervalues
 from future.utils import text_type
+
+import itertools
+import os
+import re
+
 from twisted.internet import defer
 from twisted.internet import utils
 from twisted.python import log
@@ -314,7 +315,8 @@ class GitPoller(base.PollingChangeSource, StateMixin):
             failures = [r[1] for r in results if not r[0]]
             if failures:
                 for failure in failures:
-                    log.error(failure, "while processing changes for {} {}".format(newRev, branch))
+                    log.error(
+                        failure, "while processing changes for {} {}".format(newRev, branch))
                 # just fail on the first error; they're probably all related!
                 failures[0].raiseException()
 

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -13,10 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from future.utils import text_type
+
 import os
 import time
 
-from future.utils import text_type
 from twisted.internet import defer
 from twisted.internet import utils
 from twisted.python import log

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -16,6 +16,8 @@
 """
 Parse various kinds of 'CVS notify' email.
 """
+from future.utils import text_type
+
 import calendar
 import datetime
 import re
@@ -26,7 +28,6 @@ from email.utils import mktime_tz
 from email.utils import parseaddr
 from email.utils import parsedate_tz
 
-from future.utils import text_type
 from twisted.internet import defer
 from twisted.python import log
 from zope.interface import implementer

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -17,12 +17,14 @@
 
 # Many thanks to Dave Peticolas for contributing this module
 
+from future.utils import text_type
+
 import datetime
 import os
 import re
 
 import dateutil.tz
-from future.utils import text_type
+
 from twisted.internet import defer
 from twisted.internet import protocol
 from twisted.internet import reactor

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -15,11 +15,12 @@
 # Based on the work of Dave Peticolas for the P4poll
 # Changed to svn (using xml.dom.minidom) by Niklaus Giger
 # Hacked beyond recognition by Brian Warner
+from future.moves.urllib.parse import quote_plus as urlquote_plus
+from future.utils import text_type
+
 import os
 import xml.dom.minidom
 
-from future.moves.urllib.parse import quote_plus as urlquote_plus
-from future.utils import text_type
 from twisted.internet import defer
 from twisted.internet import utils
 from twisted.python import log

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -12,6 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import itervalues
+from future.utils import string_types
+from future.utils import text_type
+
 import os
 import re
 import sys
@@ -19,10 +24,6 @@ import traceback
 import warnings
 from types import MethodType
 
-from future.utils import iteritems
-from future.utils import itervalues
-from future.utils import string_types
-from future.utils import text_type
 from twisted.python import failure
 from twisted.python import log
 from zope.interface import implementer

--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -13,11 +13,12 @@
 #
 # Copyright Buildbot Team Members
 
+from future.builtins import range
+from future.moves.collections import UserList
+
 import copy
 import re
 
-from future.builtins import range
-from future.moves.collections import UserList
 from twisted.internet import defer
 
 from buildbot.data import exceptions

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 from future.utils import iteritems
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -12,9 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
+
 import copy
 
-from future.utils import itervalues
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -12,9 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import text_type
+
 import copy
 
-from future.utils import text_type
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -13,9 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from future.utils import text_type
+
 import inspect
 
-from future.utils import text_type
 from twisted.internet import defer
 from twisted.python import reflect
 

--- a/master/buildbot/data/forceschedulers.py
+++ b/master/buildbot/data/forceschedulers.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 from future.utils import text_type
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/data/properties.py
+++ b/master/buildbot/data/properties.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 from future.utils import iteritems
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import iteritems
+
 from twisted.python import log
 
 from buildbot.data import base
@@ -94,7 +95,8 @@ class Filter(FieldBase):
 
 def nonecmp(a, b):
     # Some fields are nullable, and could raise TypeException, when REST is requesting sorting
-    # I order to fix that, we create a custom cmp function which treats None as smaller than anything
+    # I order to fix that, we create a custom cmp function which treats None
+    # as smaller than anything
     if a is None and b is None:
         return 0
     if a is None:
@@ -106,7 +108,8 @@ def nonecmp(a, b):
 
 class ResultSpec(object):
 
-    __slots__ = ['filters', 'fields', 'properties', 'order', 'limit', 'offset', 'fieldMapping']
+    __slots__ = ['filters', 'fields', 'properties',
+                 'order', 'limit', 'offset', 'fieldMapping']
 
     def __init__(self, filters=None, fields=None, properties=None, order=None,
                  limit=None, offset=None):
@@ -217,12 +220,14 @@ class ResultSpec(object):
         order = self.order
         unmatched_filters = []
         unmatched_order = []
-        # apply the filters if the name of field is found in the model, and db2data
+        # apply the filters if the name of field is found in the model, and
+        # db2data
         for f in filters:
             try:
                 query = self.applyFilterToSQLQuery(query, f)
             except KeyError:
-                # if filter is unmatched, we will do the filtering manually in self.apply
+                # if filter is unmatched, we will do the filtering manually in
+                # self.apply
                 unmatched_filters.append(f)
 
         # apply order if necessary
@@ -231,7 +236,8 @@ class ResultSpec(object):
                 try:
                     query = self.applyOrderToSQLQuery(query, o)
                 except KeyError:
-                    # if order is unmatched, we will do the ordering manually in self.apply
+                    # if order is unmatched, we will do the ordering manually
+                    # in self.apply
                     unmatched_order.append(o)
 
         # we cannot limit in sql if there is missing filtering or ordering

--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -13,13 +13,13 @@
 #
 # Copyright Buildbot Team Members
 
-import datetime
-import re
-
 # See "Type Validation" in master/docs/developer/tests.rst
 from future.utils import integer_types
 from future.utils import iteritems
 from future.utils import text_type
+
+import datetime
+import re
 
 from buildbot import util
 from buildbot.util import json

--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import sqlalchemy as sa
+
 from twisted.internet import defer
 
 from buildbot.db import base

--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -16,6 +16,7 @@
 import itertools
 
 import sqlalchemy as sa
+
 from twisted.internet import reactor
 from twisted.python import log
 

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
+
 from twisted.internet import defer
 from twisted.internet import reactor
 
@@ -140,7 +141,8 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
                                           started_at=started_at, complete_at=None,
                                           state_string=state_string))
                 except (sa.exc.IntegrityError, sa.exc.ProgrammingError) as e:
-                    # pg 9.5 gives this error which makes it pass some build numbers
+                    # pg 9.5 gives this error which makes it pass some build
+                    # numbers
                     if 'duplicate key value violates unique constraint "builds_pkey"' not in str(e):
                         new_number += 1
                     continue

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -15,9 +15,11 @@
 """
 Support for buildsets in the database
 """
-import sqlalchemy as sa
 from future.utils import integer_types
 from future.utils import iteritems
+
+import sqlalchemy as sa
+
 from twisted.internet import defer
 from twisted.internet import reactor
 

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -16,9 +16,11 @@
 """
 Support for changes in the database
 """
-import sqlalchemy as sa
 from future.utils import iteritems
 from future.utils import itervalues
+
+import sqlalchemy as sa
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/db/changesources.py
+++ b/master/buildbot/db/changesources.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import sqlalchemy as sa
+
 from twisted.internet import defer
 
 from buildbot.db import NULL

--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -31,6 +31,7 @@ import sqlalchemy as sa
 from sqlalchemy.engine import strategies
 from sqlalchemy.engine import url
 from sqlalchemy.pool import NullPool
+
 from twisted.python import log
 
 from buildbot.util import sautils

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -12,9 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import sqlalchemy as sa
 from future.builtins import range
 from future.utils import itervalues
+
+import sqlalchemy as sa
+
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/db/masters.py
+++ b/master/buildbot/db/masters.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import sqlalchemy as sa
+
 from twisted.internet import reactor
 
 from buildbot.db import base

--- a/master/buildbot/db/migrate/versions/045_worker_transition.py
+++ b/master/buildbot/db/migrate/versions/045_worker_transition.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import sqlalchemy as sa
+
 from twisted.python import log
 
 from buildbot.db.types.json import JsonObject

--- a/master/buildbot/db/migrate_utils.py
+++ b/master/buildbot/db/migrate_utils.py
@@ -14,9 +14,10 @@
 # Copyright Buildbot Team Members
 
 
+from future.utils import text_type
+
 import sqlalchemy as sa
 
-from future.utils import text_type
 from buildbot.util import sautils
 
 

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -17,6 +17,7 @@ import migrate
 import migrate.versioning.repository
 import sqlalchemy as sa
 from migrate import exceptions
+
 from twisted.python import log
 from twisted.python import util
 
@@ -33,6 +34,7 @@ except ImportError:
 
 
 class EightUpgradeError(Exception):
+
     def __init__(self):
         message = """You are trying to upgrade a buildbot 0.8.x master to buildbot 0.9.x
         This is not supported. Please start from a clean database
@@ -837,7 +839,8 @@ class Model(base.DBConnectorComponent):
             # if the migrate_version table exists, we can just let migrate
             # take care of this process.
             if table_exists(engine, 'migrate_version'):
-                r = engine.execute("select version from migrate_version limit 1")
+                r = engine.execute(
+                    "select version from migrate_version limit 1")
                 old_version = r.scalar()
                 if old_version < 40:
                     raise EightUpgradeError()

--- a/master/buildbot/db/pool.py
+++ b/master/buildbot/db/pool.py
@@ -20,6 +20,7 @@ import time
 import traceback
 
 import sqlalchemy as sa
+
 from twisted.internet import threads
 from twisted.python import log
 from twisted.python import threadpool

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -12,9 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import sqlalchemy as sa
 import sqlalchemy.exc
-from future.utils import iteritems
+
 from twisted.internet import defer
 
 from buildbot.db import NULL
@@ -143,7 +145,8 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                 # ok, that was us, so we just do nothing
                 if row['masterid'] == masterid:
                     return
-                raise SchedulerAlreadyClaimedError("already claimed by {}".format(row['name']))
+                raise SchedulerAlreadyClaimedError(
+                    "already claimed by {}".format(row['name']))
 
         return self.db.pool.do(thd)
 

--- a/master/buildbot/db/sourcestamps.py
+++ b/master/buildbot/db/sourcestamps.py
@@ -16,6 +16,7 @@
 import base64
 
 import sqlalchemy as sa
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/db/steps.py
+++ b/master/buildbot/db/steps.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
+
 from twisted.internet import defer
 from twisted.internet import reactor
 

--- a/master/buildbot/db/workers.py
+++ b/master/buildbot/db/workers.py
@@ -12,8 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import sqlalchemy as sa
 from future.utils import itervalues
+
+import sqlalchemy as sa
+
 from twisted.internet import defer
 
 from buildbot.db import base

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -12,12 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import datetime
 import os
 import signal
 import socket
 
-from future.utils import iteritems
 from twisted.application import internet
 from twisted.internet import defer
 from twisted.internet import task
@@ -290,7 +291,8 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
             yield service.AsyncMultiService.startService(self)
 
             # We make sure the housekeeping is done before configuring in order to cleanup
-            # any remaining claimed schedulers or change sources from zombie masters
+            # any remaining claimed schedulers or change sources from zombie
+            # masters
             yield self.data.updates.expireMasters(forceHouseKeeping=True)
 
             # give all services a chance to load the new configuration, rather
@@ -322,7 +324,8 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
 
     def sendBuildbotNetUsageData(self):
         if "TRIAL_PYTHONPATH" in os.environ and self.config.buildbotNetUsageData is not None:
-            raise RuntimeError("Shoud not enable buildbotNetUsageData in trial tests!")
+            raise RuntimeError(
+                "Shoud not enable buildbotNetUsageData in trial tests!")
         sendBuildbotNetUsageData(self)
 
     @defer.inlineCallbacks

--- a/master/buildbot/monkeypatches/testcase_assert.py
+++ b/master/buildbot/monkeypatches/testcase_assert.py
@@ -14,9 +14,10 @@
 # Copyright Buildbot Team Members
 
 
+from future.utils import string_types
+
 import re
 import unittest
-from future.utils import string_types
 
 
 def _assertRaisesRegexp(self, expected_exception, expected_regexp,

--- a/master/buildbot/mq/wamp.py
+++ b/master/buildbot/mq/wamp.py
@@ -60,7 +60,8 @@ class WampMQ(service.ReconfigurableServiceMixin, base.MQBase):
 
     def startConsuming(self, callback, _filter, persistent_name=None):
         if persistent_name is not None:
-            log.err('wampmq: persistant queues are not persisted: %s %s' % (persistent_name, _filter))
+            log.err('wampmq: persistant queues are not persisted: %s %s' %
+                    (persistent_name, _filter))
 
         qr = QueueRef(callback)
 

--- a/master/buildbot/plugins/db.py
+++ b/master/buildbot/plugins/db.py
@@ -14,11 +14,13 @@
 # Copyright Buildbot Team Members
 #
 # pylint: disable=C0111
-from types import StringTypes
-
 from future.utils import iteritems
 from future.utils import itervalues
+
+from types import StringTypes
+
 from pkg_resources import iter_entry_points
+
 from zope.interface import Invalid
 from zope.interface.verify import verifyClass
 

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 from future.utils import itervalues
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log
@@ -82,7 +83,8 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
                     # As we stop the builds, builder.building might change during loop
                     # so we need to copy the list
                     for build in list(builder.building):
-                        # if build is waited for then this is a sub-build, so no need to retry it
+                        # if build is waited for then this is a sub-build, so
+                        # no need to retry it
                         if sum(br.waitedFor for br in build.requests):
                             results = CANCELLED
                         else:
@@ -109,7 +111,8 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             for builder in self.builders.values():
                 if builder.building:
                     num_builds = len(builder.building)
-                    log.msg("Builder %s has %i builds running" % (builder, num_builds))
+                    log.msg("Builder %s has %i builds running" %
+                            (builder, num_builds))
                     n += num_builds
             if n > 0:
                 log.msg(

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -12,10 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import string_types
+
 import warnings
 import weakref
-
-from future.utils import string_types
 
 from twisted.application import internet
 from twisted.application import service

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -12,11 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import calendar
-
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import text_type
+
+import calendar
+
 from twisted.internet import defer
 
 from buildbot.data import resultspec

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 import random
 from datetime import datetime
+
 from dateutil.tz import tzutc
 
 from twisted.internet import defer

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -12,12 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import re
-
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import string_types
 from future.utils import text_type
+
+import re
 
 from twisted.internet import defer
 from twisted.internet import error

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -12,11 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import re
-
 from future.utils import itervalues
 from future.utils import string_types
 from future.utils import text_type
+
+import re
+
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/process/metrics.py
+++ b/master/buildbot/process/metrics.py
@@ -33,6 +33,8 @@ Basic architecture:
 """
 from __future__ import division
 from __future__ import print_function
+from future.utils import iteritems
+from future.utils import lrange
 
 import gc
 import os
@@ -40,8 +42,6 @@ import sys
 from collections import defaultdict
 from collections import deque
 
-from future.utils import iteritems
-from future.utils import lrange
 from twisted.application import service
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -12,12 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+from future.utils import iteritems
+
 import collections
 import re
 import weakref
 
-from future.builtins import range
-from future.utils import iteritems
 from twisted.internet import defer
 from twisted.python.components import registerAdapter
 from zope.interface import implementer

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 from future.utils import string_types
+
 from twisted.internet import defer
 from twisted.internet import error
 from twisted.python import log

--- a/master/buildbot/process/users/manual.py
+++ b/master/buildbot/process/users/manual.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import string_types
+
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -15,12 +15,13 @@
 """
 Push events to Gerrit
 """
+from future.builtins import range
+from future.utils import iteritems
+
 import time
 import warnings
 from distutils.version import LooseVersion
 
-from future.builtins import range
-from future.utils import iteritems
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet.protocol import ProcessProtocol

--- a/master/buildbot/reporters/hipchat.py
+++ b/master/buildbot/reporters/hipchat.py
@@ -1,4 +1,5 @@
 from future.utils import string_types
+
 from twisted.internet import defer
 from twisted.python import log
 
@@ -69,7 +70,8 @@ class HipChatStatusPush(HttpStatusPushBase):
         }
         return event_messages.get(event_name, '')
 
-    # use this as an extension point to inject extra parameters into your postData
+    # use this as an extension point to inject extra parameters into your
+    # postData
     def getExtraParams(self, build, event_name):
         return {}
 
@@ -84,9 +86,11 @@ class HipChatStatusPush(HttpStatusPushBase):
 
         urls = []
         if 'id_or_email' in postData:
-            urls.append(self.user_notify % (self.endpoint, postData.pop('id_or_email'), self.auth_token))
+            urls.append(self.user_notify % (self.endpoint,
+                                            postData.pop('id_or_email'), self.auth_token))
         if 'room_id_or_name' in postData:
-            urls.append(self.room_notify % (self.endpoint, postData.pop('room_id_or_name'), self.auth_token))
+            urls.append(self.room_notify % (self.endpoint,
+                                            postData.pop('room_id_or_name'), self.auth_token))
 
         if urls:
             for url in urls:

--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -13,9 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from future.utils import iteritems
+
 import abc
 
-from future.utils import iteritems
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import string_types
+
 import re
 # this incantation teaches email to output utf-8 using 7- or 8-bit encoding,
 # although it has no effect before python-2.7.
@@ -22,8 +25,6 @@ from email.mime.text import MIMEText
 from email.utils import formatdate
 from StringIO import StringIO
 
-from future.utils import iteritems
-from future.utils import string_types
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log as twlog

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -15,6 +15,7 @@
 from future.moves.collections import UserList
 from future.utils import lrange
 from future.utils import string_types
+
 from twisted.internet import defer
 from twisted.python import log
 
@@ -170,8 +171,10 @@ def getResponsibleUsersForBuild(master, buildid):
             blamelist.add(owner)
         else:
             blamelist.update(owner)
-            log.msg("Warning: owner property is a list for buildid {}. ".format(buildid))
-            log.msg("Please report a bug: changes: {}. properties: {}".format(changes, properties))
+            log.msg(
+                "Warning: owner property is a list for buildid {}. ".format(buildid))
+            log.msg("Please report a bug: changes: {}. properties: {}".format(
+                changes, properties))
 
     # add owner from properties
     if 'owners' in properties:

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -15,13 +15,13 @@
 # Copyright Buildbot Team Members
 from __future__ import division
 from __future__ import print_function
+from future.builtins import range
+from future.utils import text_type
 
 import random
 import re
 import shlex
 
-from future.builtins import range
-from future.utils import text_type
 from twisted.internet import defer
 from twisted.internet import protocol
 from twisted.internet import reactor
@@ -595,8 +595,8 @@ class Contact(service.AsyncService):
             prevResult = prevBuild['results']
 
             required_notification_control_string = ''.join((self.results_descriptions.get(prevResult)[0].lower(),
-                                                         'To',
-                                                         self.results_descriptions.get(build['results'])[0].capitalize()))
+                                                            'To',
+                                                            self.results_descriptions.get(build['results'])[0].capitalize()))
 
             if (self.notify_for(required_notification_control_string)):
                 defer.returnValue(True)

--- a/master/buildbot/revlinks.py
+++ b/master/buildbot/revlinks.py
@@ -13,8 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
-import re
 from future.utils import text_type
+
+import re
 
 
 class RevlinkMatch(object):
@@ -43,7 +44,8 @@ GithubRevlink = RevlinkMatch(
 class GitwebMatch(RevlinkMatch):
 
     def __init__(self, repo_urls, revlink):
-        RevlinkMatch.__init__(self, repo_urls=repo_urls, revlink=revlink + r'?p=\g<repo>;a=commit;h=%s')
+        RevlinkMatch.__init__(self, repo_urls=repo_urls,
+                              revlink=revlink + r'?p=\g<repo>;a=commit;h=%s')
 
 SourceforgeGitRevlink = GitwebMatch(
     repo_urls=[r'^git://([^.]*).git.sourceforge.net/gitroot/(?P<repo>.*)$',
@@ -54,7 +56,8 @@ SourceforgeGitRevlink = GitwebMatch(
 
 # SourceForge recently upgraded to another platform called Allura
 # See introduction: https://sourceforge.net/p/forge/documentation/Classic%20vs%20New%20SourceForge%20projects/
-# And as reference: https://sourceforge.net/p/forge/community-docs/SVN%20and%20project%20upgrades/
+# And as reference:
+# https://sourceforge.net/p/forge/community-docs/SVN%20and%20project%20upgrades/
 SourceforgeGitRevlink_AlluraPlatform = RevlinkMatch(
     repo_urls=[r'git://git.code.sf.net/p/(?P<repo>.*)$',
                r'http://git.code.sf.net/p/(?P<repo>.*)$',

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 from future.utils import string_types
+
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-from collections import defaultdict
-
 from future.utils import iteritems
 from future.utils import itervalues
+
+from collections import defaultdict
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -12,12 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import re
-import traceback
-
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import string_types
+
+import re
+import traceback
+
 from twisted.internet import defer
 from twisted.python.reflect import accumulateClassList
 

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.utils import itervalues
 from future.utils import string_types
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/schedulers/triggerable.py
+++ b/master/buildbot/schedulers/triggerable.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import itervalues
+
 from twisted.internet import defer
 from twisted.python import failure
 from zope.interface import implementer

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -12,9 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import os
 
-from future.utils import iteritems
 from twisted.internet import defer
 from twisted.protocols import basic
 from twisted.python import log

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from __future__ import division
 from __future__ import print_function
+from future.builtins import range
 
 import copy
 import os
@@ -22,7 +23,6 @@ import sys
 import traceback
 from contextlib import contextmanager
 
-from future.builtins import range
 from twisted.internet import defer
 from twisted.python import runtime
 from twisted.python import usage

--- a/master/buildbot/scripts/create_master.py
+++ b/master/buildbot/scripts/create_master.py
@@ -14,11 +14,12 @@
 # Copyright Buildbot Team Members
 from __future__ import division
 from __future__ import print_function
+from future.utils import iteritems
 
 import os
 
 import jinja2
-from future.utils import iteritems
+
 from twisted.internet import defer
 from twisted.python import util
 

--- a/master/buildbot/scripts/processwwwindex.py
+++ b/master/buildbot/scripts/processwwwindex.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import os
 
 import jinja2
+
 from twisted.internet import defer
 
 from buildbot.test.fake import fakemaster

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -20,12 +20,13 @@
 # pages and texinfo documentation.
 from __future__ import division
 from __future__ import print_function
+from future.builtins import range
 
 import sys
 import textwrap
 
 import sqlalchemy as sa
-from future.builtins import range
+
 from twisted.python import reflect
 from twisted.python import usage
 

--- a/master/buildbot/scripts/windows_service.py
+++ b/master/buildbot/scripts/windows_service.py
@@ -65,12 +65,11 @@
 
 from __future__ import division
 from __future__ import print_function
+from future.builtins import range
 
 import os
 import sys
 import threading
-
-from future.builtins import range
 
 import pywintypes
 import servicemanager
@@ -234,7 +233,8 @@ class BBService(win32serviceutil.ServiceFramework):
             self.info("Starting BuildBot in directory '%s'" % (bbdir, ))
             hstop = self.hWaitStop
 
-            cmd = '%s --spawn %d start --nodaemon %s' % (self.runner_prefix, hstop, bbdir)
+            cmd = '%s --spawn %d start --nodaemon %s' % (
+                self.runner_prefix, hstop, bbdir)
             # print "cmd is", cmd
             h, t, output = self.createProcess(cmd)
             child_infos.append((bbdir, h, t, output))

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -12,11 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import os
-
 from future.moves.urllib.parse import quote as urlquote
 from future.utils import iteritems
 from future.utils import itervalues
+
+import os
+
 from twisted.internet import defer
 from twisted.python import log
 from zope.interface import implementer

--- a/master/buildbot/steps/cmake.py
+++ b/master/buildbot/steps/cmake.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import iteritems
+
 from twisted.internet import defer
 
 from buildbot import config

--- a/master/buildbot/steps/http.py
+++ b/master/buildbot/steps/http.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import iteritems
+
 from twisted.internet import defer
 from twisted.internet import reactor
 

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -12,14 +12,15 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import string_types
+
 import os
 import pprint
 import re
 from builtins import bytes
 from builtins import str
 
-from future.utils import iteritems
-from future.utils import string_types
 from twisted.internet import defer
 from twisted.internet import error
 from twisted.internet import reactor

--- a/master/buildbot/steps/mtrlogobserver.py
+++ b/master/buildbot/steps/mtrlogobserver.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+
 import re
 import sys
 
-from future.builtins import range
 from twisted.enterprise import adbapi
 from twisted.internet import defer
 from twisted.python import log

--- a/master/buildbot/steps/package/rpm/rpmbuild.py
+++ b/master/buildbot/steps/package/rpm/rpmbuild.py
@@ -14,9 +14,9 @@
 # Portions Copyright Buildbot Team Members
 # Portions Copyright Dan Radez <dradez+buildbot@redhat.com>
 # Portions Copyright Steve 'Ashcrow' Milner <smilner+buildbot@redhat.com>
-import os
-
 from future.utils import iteritems
+
+import os
 
 from buildbot import config
 from buildbot.process import buildstep
@@ -122,7 +122,8 @@ class RpmBuild(ShellCommand):
         # The unit tests expect a certain order, so we sort the dict to keep
         # format the same every time
         for k, v in sorted(iteritems(rpm_extras_dict)):
-            self.rpmbuild = '{0} --define "{1} {2}"'.format(self.rpmbuild, k, v)
+            self.rpmbuild = '{0} --define "{1} {2}"'.format(
+                self.rpmbuild, k, v)
 
         self.rpmbuild = '{0} -ba {1}'.format(self.rpmbuild, self.specfile)
 

--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -12,9 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import re
-
 from future.utils import iteritems
+
+import re
 
 from buildbot import config
 from buildbot.process import logobserver

--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -15,9 +15,10 @@
 """
 BuildSteps that are specific to the Twisted source tree
 """
+from future.builtins import range
+
 import re
 
-from future.builtins import range
 from twisted.python import log
 
 from buildbot.process import logobserver

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -12,12 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import inspect
-import re
-
 from future.utils import PY3
 from future.utils import iteritems
 from future.utils import string_types
+
+import inspect
+import re
+
 from twisted.python import failure
 from twisted.python import log
 from twisted.python.deprecate import deprecatedModuleAttribute

--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import iteritems
+
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-from distutils.version import LooseVersion
-
 from future.utils import iteritems
 from future.utils import string_types
+
+from distutils.version import LooseVersion
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -13,10 +13,11 @@
 #
 # Copyright Buildbot Team Members
 # Portions Copyright 2013 Bad Dog Consulting
+from future.utils import string_types
+
 import re
 from types import StringType
 
-from future.utils import string_types
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -12,14 +12,15 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import re
-import xml.dom.minidom
-import xml.parsers.expat
-
 from future.moves.urllib.parse import quote as urlquote
 from future.moves.urllib.parse import unquote as urlunquote
 from future.moves.urllib.parse import urlparse
 from future.moves.urllib.parse import urlunparse
+
+import re
+import xml.dom.minidom
+import xml.parsers.expat
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 from future.utils import itervalues
+
 from twisted.internet import defer
 from twisted.python import log
 
@@ -221,13 +222,15 @@ class Trigger(BuildStep):
         schedulers_and_props_list = []
 
         # To be back compatible we need to differ between old and new style
-        # schedulers_and_props can either consist of 2 elements tuple or dictionary
+        # schedulers_and_props can either consist of 2 elements tuple or
+        # dictionary
         for element in schedulers_and_props:
             if isinstance(element, dict):
                 schedulers_and_props_list = schedulers_and_props
                 break
             else:
-                # Old-style back compatibility: Convert tuple to dict and make it important
+                # Old-style back compatibility: Convert tuple to dict and make
+                # it important
                 d = {
                     'sched_name': element[0],
                     'props_to_set': element[1],

--- a/master/buildbot/test/fake/endpoint.py
+++ b/master/buildbot/test/fake/endpoint.py
@@ -16,6 +16,7 @@
 # This is a static resource type and set of endpoints uesd as common data by
 # tests.
 from future.utils import itervalues
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -16,6 +16,7 @@
 import posixpath
 
 import mock
+
 from twisted.python import components
 
 from buildbot import config

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -15,6 +15,7 @@
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import text_type
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import failure

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -18,13 +18,14 @@ A complete re-implementation of the database connector components, but without
 using a database.  These classes should pass the same tests as are applied to
 the real connector components.
 """
+from future.utils import iteritems
+from future.utils import itervalues
+from future.utils import text_type
+
 import base64
 import copy
 import hashlib
 
-from future.utils import iteritems
-from future.utils import itervalues
-from future.utils import text_type
 from twisted.internet import defer
 from twisted.internet import reactor
 
@@ -668,14 +669,17 @@ class FakeDBComponent(object):
             if field.startswith('-'):
                 field = field[1:]
             return field in rs.fieldMapping
-        filters = [self.mapFilter(f, rs.fieldMapping) for f in rs.filters if applicable(f.field)]
+        filters = [self.mapFilter(f, rs.fieldMapping)
+                   for f in rs.filters if applicable(f.field)]
         order = []
         offset = limit = None
         if rs.order:
-            order = [self.mapOrder(o, rs.fieldMapping) for o in rs.order if applicable(o)]
+            order = [self.mapOrder(o, rs.fieldMapping)
+                     for o in rs.order if applicable(o)]
         if len(filters) == len(rs.filters) and rs.order is not None and len(order) == len(rs.order):
             offset, limit = rs.offset, rs.limit
-        rs = resultspec.ResultSpec(filters=filters, order=order, limit=limit, offset=offset)
+        rs = resultspec.ResultSpec(
+            filters=filters, order=order, limit=limit, offset=offset)
         return rs.apply(data)
 
 

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -16,6 +16,7 @@ import os
 import weakref
 
 import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from zope.interface import implementer

--- a/master/buildbot/test/fake/logfile.py
+++ b/master/buildbot/test/fake/logfile.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from future.utils import itervalues
 from future.utils import text_type
+
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import itervalues
+
 from twisted.internet import defer
 from twisted.python import failure
 

--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -15,6 +15,7 @@
 from StringIO import StringIO
 
 from mock import Mock
+
 from twisted.internet import defer
 from twisted.web import server
 

--- a/master/buildbot/test/fuzz/test_lru.py
+++ b/master/buildbot/test/fuzz/test_lru.py
@@ -12,9 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import lrange
+
 import random
 
-from future.utils import lrange
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -12,10 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 from StringIO import StringIO
 
 import mock
-from future.utils import iteritems
+
 from twisted.internet import defer
 from twisted.internet import error
 from twisted.internet import reactor

--- a/master/buildbot/test/integration/test_hyper.py
+++ b/master/buildbot/test/integration/test_hyper.py
@@ -12,11 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import string_types
+
 import json
 import os
 from unittest.case import SkipTest
 
-from future.utils import string_types
 from twisted.internet import defer
 
 from buildbot.process.results import SUCCESS
@@ -40,7 +41,8 @@ class HyperMaster(RunMasterBase):
 
     def setUp(self):
         if "TEST_HYPER" not in os.environ:
-            raise SkipTest("hyper integration tests only run when environment variable TEST_HYPER is set")
+            raise SkipTest(
+                "hyper integration tests only run when environment variable TEST_HYPER is set")
         if workerhyper.Hyper is None:
             raise SkipTest("hyper is not installed")
         try:
@@ -99,7 +101,8 @@ def masterConfig():
                       workernames=["hyper0"],
                       factory=f),
         BuilderConfig(name="build",
-                      workernames=["hyper" + str(i) for i in range(NUM_CONCURRENT)],
+                      workernames=["hyper" + str(i)
+                                   for i in range(NUM_CONCURRENT)],
                       factory=f2)]
     hyperconfig = workerhyper.Hyper.guess_config()
     if isinstance(hyperconfig, string_types):
@@ -108,7 +111,8 @@ def masterConfig():
     masterFQDN = os.environ.get('masterFQDN')
     c['workers'] = [
         HyperLatentWorker('hyper' + str(i), 'passwd', hyperhost, hyperconfig['accesskey'],
-                          hyperconfig['secretkey'], 'buildbot/buildbot-worker:master',
+                          hyperconfig[
+                              'secretkey'], 'buildbot/buildbot-worker:master',
                           masterFQDN=masterFQDN)
         for i in range(NUM_CONCURRENT)
     ]

--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -13,9 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from future.builtins import range
+
 import os
 
-from future.builtins import range
 from twisted.internet import defer
 from twisted.python import log
 from twisted.python import threadpool
@@ -69,7 +70,8 @@ class Tests(SynchronousTestCase):
         self.assertFalse(self.master.running, "master is still running!")
 
     def getMaster(self, config_dict):
-        self.master = master = self.successResultOf(getMaster(self, self.reactor, config_dict))
+        self.master = master = self.successResultOf(
+            getMaster(self, self.reactor, config_dict))
         return master
 
     def createBuildrequest(self, master, builder_ids):
@@ -108,7 +110,8 @@ class Tests(SynchronousTestCase):
             'multiMaster': True,
         }
         master = self.getMaster(config_dict)
-        builder_id = self.successResultOf(master.data.updates.findBuilderId('testy'))
+        builder_id = self.successResultOf(
+            master.data.updates.findBuilderId('testy'))
 
         # Request two builds.
         for i in range(2):
@@ -389,7 +392,8 @@ class Tests(SynchronousTestCase):
         # The worker succeed to substantiate
         def remote_setBuilderList(self, dirs):
             raise TestException("can't create dir")
-        controller.patchBot(self, 'remote_setBuilderList', remote_setBuilderList)
+        controller.patchBot(self, 'remote_setBuilderList',
+                            remote_setBuilderList)
         controller.start_instance(True)
         controller.connect_worker(self)
 
@@ -405,13 +409,15 @@ class Tests(SynchronousTestCase):
         self.assertEqual(len(logs), 2)
         logs_by_name = {}
         for _log in logs:
-            fulllog = self.successResultOf(master.data.get(("logs", str(_log['logid']), "raw")))
+            fulllog = self.successResultOf(
+                master.data.get(("logs", str(_log['logid']), "raw")))
             logs_by_name[fulllog['filename']] = fulllog['raw']
 
         for i in ["err_text", "err_html"]:
             self.assertIn("can't create dir", logs_by_name[i])
             # make sure stacktrace is present in html
-            self.assertIn(os.path.join("integration", "test_latent.py"), logs_by_name[i])
+            self.assertIn(os.path.join(
+                "integration", "test_latent.py"), logs_by_name[i])
         controller.auto_stop(True)
 
     def test_failed_ping_get_requeued(self):
@@ -468,13 +474,15 @@ class Tests(SynchronousTestCase):
         self.assertEqual(len(logs), 2)
         logs_by_name = {}
         for _log in logs:
-            fulllog = self.successResultOf(master.data.get(("logs", str(_log['logid']), "raw")))
+            fulllog = self.successResultOf(
+                master.data.get(("logs", str(_log['logid']), "raw")))
             logs_by_name[fulllog['filename']] = fulllog['raw']
 
         for i in ["err_text", "err_html"]:
             self.assertIn("can't ping", logs_by_name[i])
             # make sure stacktrace is present in html
-            self.assertIn(os.path.join("integration", "test_latent.py"), logs_by_name[i])
+            self.assertIn(os.path.join(
+                "integration", "test_latent.py"), logs_by_name[i])
         controller.auto_stop(True)
 
     def test_worker_close_connection_while_building(self):

--- a/master/buildbot/test/integration/test_try_client.py
+++ b/master/buildbot/test/integration/test_try_client.py
@@ -15,6 +15,7 @@
 import os
 
 import mock
+
 from twisted.cred import credentials
 from twisted.internet import defer
 from twisted.internet import reactor

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -21,6 +21,7 @@ import migrate
 import migrate.versioning.api
 from sqlalchemy.engine import reflection
 from sqlalchemy.exc import DatabaseError
+
 from twisted.internet import defer
 from twisted.python import util
 from twisted.trial import unittest

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -37,6 +37,7 @@ except ImportError:
 
 @implementer(IBuildStepFactory)
 class StepController(object):
+
     def __init__(self, **kwargs):
         self.kwargs = kwargs
         self.steps = []
@@ -95,7 +96,8 @@ class Tests(SynchronousTestCase):
             'protocols': {'null': {}},
             'multiMaster': True,
         }
-        self.master = master = self.successResultOf(getMaster(self, self.reactor, config_dict))
+        self.master = master = self.successResultOf(
+            getMaster(self, self.reactor, config_dict))
         builder_ids = [
             self.successResultOf(master.data.updates.findBuilderId('testy-1')),
             self.successResultOf(master.data.updates.findBuilderId('testy-2')),
@@ -150,7 +152,8 @@ class Tests(SynchronousTestCase):
             'protocols': {'null': {}},
             'multiMaster': True,
         }
-        self.master = master = self.successResultOf(getMaster(self, self.reactor, config_dict))
+        self.master = master = self.successResultOf(
+            getMaster(self, self.reactor, config_dict))
         builder_ids = [
             self.successResultOf(master.data.updates.findBuilderId('testy-1')),
             self.successResultOf(master.data.updates.findBuilderId('testy-2')),

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.cred import credentials
 from twisted.internet import defer
 from twisted.internet import reactor

--- a/master/buildbot/test/unit/test_changes_base.py
+++ b/master/buildbot/test/unit/test_changes_base.py
@@ -16,6 +16,7 @@ from __future__ import division
 from __future__ import print_function
 
 import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import task

--- a/master/buildbot/test/unit/test_changes_gerritchangesource.py
+++ b/master/buildbot/test/unit/test_changes_gerritchangesource.py
@@ -12,9 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import types
 
-from future.utils import iteritems
 from twisted.trial import unittest
 
 from buildbot.changes import gerritchangesource

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -12,12 +12,14 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import string_types
+from future.utils import text_type
+
 import os
 import re
 
 import mock
-from future.utils import string_types
-from future.utils import text_type
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_changes_manager.py
+++ b/master/buildbot/test/unit/test_changes_manager.py
@@ -12,9 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+
 import mock
 
-from future.builtins import range
 from twisted.trial import unittest
 
 from buildbot.changes import manager

--- a/master/buildbot/test/unit/test_changes_p4poller.py
+++ b/master/buildbot/test/unit/test_changes_p4poller.py
@@ -15,6 +15,7 @@
 import datetime
 
 import dateutil.tz
+
 from twisted.internet import error
 from twisted.internet import reactor
 from twisted.python import failure

--- a/master/buildbot/test/unit/test_changes_pb.py
+++ b/master/buildbot/test/unit/test_changes_pb.py
@@ -16,6 +16,7 @@ from __future__ import division
 from __future__ import print_function
 
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_clients_sendchange.py
+++ b/master/buildbot/test/unit/test_clients_sendchange.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.spread import pb

--- a/master/buildbot/test/unit/test_clients_usersclient.py
+++ b/master/buildbot/test/unit/test_clients_usersclient.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.spread import pb

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -23,13 +23,15 @@ try:
 except ImportError:
     # Python 3
     import builtins
+from future.builtins import range
+from future.utils import iteritems
+
 import os
 import re
 import textwrap
 
 import mock
-from future.builtins import range
-from future.utils import iteritems
+
 from twisted.internet import defer
 from twisted.trial import unittest
 from zope.interface import implementer
@@ -474,7 +476,8 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         with assertProducesWarning(
                 config.ConfigWarning,
                 message_pattern=r"`eventHorizon` is deprecated and will be removed in a future version."):
-            self.do_test_load_global(dict(eventHorizon=10, buildbotNetUsageData=None))
+            self.do_test_load_global(
+                dict(eventHorizon=10, buildbotNetUsageData=None))
 
     def test_load_global_logHorizon(self):
         self.do_test_load_global(dict(logHorizon=10), logHorizon=10)

--- a/master/buildbot/test/unit/test_contrib_buildbot_cvs_mail.py
+++ b/master/buildbot/test/unit/test_contrib_buildbot_cvs_mail.py
@@ -15,12 +15,12 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+from future.utils import text_type
 
 import os
 import re
 import sys
 
-from future.utils import text_type
 from twisted.internet import defer
 from twisted.internet import protocol
 from twisted.internet import reactor

--- a/master/buildbot/test/unit/test_data_base.py
+++ b/master/buildbot/test/unit/test_data_base.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.trial import unittest
 
 from buildbot.data import base

--- a/master/buildbot/test/unit/test_data_builders.py
+++ b/master/buildbot/test/unit/test_data_builders.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_data_buildrequests.py
+++ b/master/buildbot/test/unit/test_data_buildrequests.py
@@ -15,6 +15,7 @@
 import datetime
 
 import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_changes.py
+++ b/master/buildbot/test/unit/test_data_changes.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_changesources.py
+++ b/master/buildbot/test/unit/test_data_changesources.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_connector.py
+++ b/master/buildbot/test/unit/test_data_connector.py
@@ -12,8 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import mock
 from future.builtins import range
+
+import mock
+
 from twisted.internet import defer
 from twisted.python import reflect
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_logchunks.py
+++ b/master/buildbot/test/unit/test_data_logchunks.py
@@ -14,11 +14,11 @@
 # Copyright Buildbot Team Members
 from __future__ import division
 from __future__ import print_function
+from future.builtins import range
+from future.utils import text_type
 
 import textwrap
 
-from future.builtins import range
-from future.utils import text_type
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_data_logs.py
+++ b/master/buildbot/test/unit/test_data_logs.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_data_masters.py
+++ b/master/buildbot/test/unit/test_data_masters.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_properties.py
+++ b/master/buildbot/test/unit/test_data_properties.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_data_resultspec.py
+++ b/master/buildbot/test/unit/test_data_resultspec.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import lrange
+
 import datetime
 import random
 
-from future.utils import lrange
 from twisted.trial import unittest
 
 from buildbot.data import base

--- a/master/buildbot/test/unit/test_data_schedulers.py
+++ b/master/buildbot/test/unit/test_data_schedulers.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_workers.py
+++ b/master/buildbot/test/unit/test_data_workers.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_base.py
+++ b/master/buildbot/test/unit/test_db_base.py
@@ -14,8 +14,10 @@
 # Copyright Buildbot Team Members
 import hashlib
 
-import mock
 import sqlalchemy as sa
+
+import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_buildrequests.py
+++ b/master/buildbot/test/unit/test_db_buildrequests.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import datetime
-
 from future.builtins import range
 from future.utils import lrange
+
+import datetime
+
 from twisted.internet import task
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_builds.py
+++ b/master/buildbot/test/unit/test_db_builds.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import lrange
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest
@@ -327,7 +328,8 @@ class RealTests(Tests):
 
     @defer.inlineCallbacks
     def test_getBuilds_resultSpecFilter(self):
-        rs = resultspec.ResultSpec(filters=[resultspec.Filter('complete_at', 'ne', [None])])
+        rs = resultspec.ResultSpec(
+            filters=[resultspec.Filter('complete_at', 'ne', [None])])
         rs.fieldMapping = {'complete_at': 'builds.complete_at'}
         yield self.insertTestData(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(resultSpec=rs)
@@ -343,14 +345,17 @@ class RealTests(Tests):
         yield self.insertTestData(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(resultSpec=rs)
 
-        # applying the spec in the db layer should have emptied the order in resultSpec
+        # applying the spec in the db layer should have emptied the order in
+        # resultSpec
         self.assertEqual(rs.order, None)
-        # assert applying the same order at the data layer will give the same results
+        # assert applying the same order at the data layer will give the same
+        # results
         rs = resultspec.ResultSpec(order=['-started_at'])
         ordered_bdicts = rs.apply(bdicts)
         self.assertEqual(ordered_bdicts, bdicts)
 
-        # assert applying a oposite order at the data layer will give different results
+        # assert applying a oposite order at the data layer will give different
+        # results
         rs = resultspec.ResultSpec(order=['started_at'])
         ordered_bdicts = rs.apply(bdicts)
         self.assertNotEqual(ordered_bdicts, bdicts)
@@ -361,11 +366,13 @@ class RealTests(Tests):
         rs.fieldMapping = {'started_at': 'builds.started_at'}
         yield self.insertTestData(self.backgroundData + self.threeBuilds)
         bdicts = yield self.db.builds.getBuilds(resultSpec=rs)
-        # applying the spec in the db layer should have emptied the limit and offset in resultSpec
+        # applying the spec in the db layer should have emptied the limit and
+        # offset in resultSpec
         self.assertEqual(rs.limit, None)
         self.assertEqual(rs.offset, None)
 
-        # assert applying the same filter at the data layer will give the same results
+        # assert applying the same filter at the data layer will give the same
+        # results
         rs = resultspec.ResultSpec(order=['-started_at'], limit=1, offset=2)
         bdicts2 = yield self.db.builds.getBuilds()
         ordered_bdicts = rs.apply(bdicts2)

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -15,6 +15,7 @@
 import datetime
 
 import mock
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_changes.py
+++ b/master/buildbot/test/unit/test_db_changes.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import sqlalchemy as sa
-
 from future.builtins import range
 from future.utils import iteritems
+
+import sqlalchemy as sa
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_connector.py
+++ b/master/buildbot/test/unit/test_db_connector.py
@@ -15,6 +15,7 @@
 import os
 
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_enginestrategy.py
+++ b/master/buildbot/test/unit/test_db_enginestrategy.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from sqlalchemy.engine import url
 from sqlalchemy.pool import NullPool
+
 from twisted.python import runtime
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+
 import base64
 import textwrap
 
-from future.builtins import range
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_migrate_versions_040_add_builder_tags.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_040_add_builder_tags.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
+
 from twisted.trial import unittest
 
 from buildbot.test.util import migration

--- a/master/buildbot/test/unit/test_db_migrate_versions_041_add_N_N_tagsbuilders.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_041_add_N_N_tagsbuilders.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
+
 from twisted.trial import unittest
 
 from buildbot.test.util import migration

--- a/master/buildbot/test/unit/test_db_migrate_versions_042_add_build_properties_table.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_042_add_build_properties_table.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
+
 from twisted.trial import unittest
 
 from buildbot.test.util import migration

--- a/master/buildbot/test/unit/test_db_migrate_versions_043_add_changes_parent.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_043_add_changes_parent.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
+
 from twisted.trial import unittest
 
 from buildbot.test.util import migration

--- a/master/buildbot/test/unit/test_db_migrate_versions_044_add_step_hidden.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_044_add_step_hidden.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
+
 from twisted.trial import unittest
 
 from buildbot.test.util import migration

--- a/master/buildbot/test/unit/test_db_migrate_versions_045_worker_transition.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_045_worker_transition.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
 from sqlalchemy.engine.reflection import Inspector
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_migrate_versions_046_mysql_innodb_compatibility.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_046_mysql_innodb_compatibility.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import sqlalchemy as sa
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_migrate_versions_047_cascading_deleletes.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_047_cascading_deleletes.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import sqlalchemy as sa
+
 from twisted.trial import unittest
 
 from buildbot.test.util import migration

--- a/master/buildbot/test/unit/test_db_model.py
+++ b/master/buildbot/test/unit/test_db_model.py
@@ -15,6 +15,7 @@
 import os
 
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_pool.py
+++ b/master/buildbot/test/unit/test_db_pool.py
@@ -16,6 +16,7 @@ import os
 import time
 
 import sqlalchemy as sa
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_sourcestamps.py
+++ b/master/buildbot/test/unit/test_db_sourcestamps.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import iteritems
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_steps.py
+++ b/master/buildbot/test/unit/test_db_steps.py
@@ -12,9 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+
 import time
 
-from future.builtins import range
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_workers.py
+++ b/master/buildbot/test/unit/test_db_workers.py
@@ -14,10 +14,10 @@
 # Copyright Buildbot Team Members
 from __future__ import division
 from __future__ import print_function
+from future.builtins import range
 
 import mock
 
-from future.builtins import range
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -16,6 +16,7 @@ import os
 import signal
 
 import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/test/unit/test_mq.py
+++ b/master/buildbot/test/unit/test_mq.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_mq_base.py
+++ b/master/buildbot/test/unit/test_mq_base.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_mq_simple.py
+++ b/master/buildbot/test/unit/test_mq_simple.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.trial import unittest
 
 from buildbot.mq import simple

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -12,13 +12,15 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+
 import os
 import textwrap
 
 import mock
+
 from autobahn.wamp.types import EventDetails
 from autobahn.wamp.types import SubscribeOptions
-from future.builtins import range
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_pbmanager.py
+++ b/master/buildbot/test/unit/test_pbmanager.py
@@ -16,6 +16,7 @@
 Test clean shutdown functionality of the master
 """
 import mock
+
 from twisted.cred import credentials
 from twisted.internet import defer
 from twisted.spread import pb

--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -18,6 +18,7 @@ Unit tests for the plugin framework
 import re
 
 import mock
+
 from twisted.trial import unittest
 from zope.interface import implementer
 

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -27,7 +28,8 @@ from buildbot.test.fake import fakemaster
 class TestCleanShutdown(unittest.TestCase):
 
     def setUp(self):
-        self.master = master = fakemaster.make_master(testcase=self, wantData=True)
+        self.master = master = fakemaster.make_master(
+            testcase=self, wantData=True)
         self.botmaster = BotMaster()
         self.botmaster.setServiceParent(master)
         self.reactor = mock.Mock()

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -16,6 +16,7 @@ import operator
 
 from mock import Mock
 from mock import call
+
 from twisted.internet import defer
 from twisted.trial import unittest
 from zope.interface import implementer

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -12,11 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+from future.utils import text_type
+
 import random
 
 import mock
-from future.utils import iteritems
-from future.utils import text_type
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_process_buildrequest.py
+++ b/master/buildbot/test/unit/test_process_buildrequest.py
@@ -12,8 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import mock
 from future.utils import itervalues
+
+import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -12,9 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import mock
 from future.builtins import range
 from future.utils import iteritems
+
+import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import failure

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -14,10 +14,11 @@
 # Copyright Buildbot Team Members
 from __future__ import division
 from __future__ import print_function
-
-import mock
 from future.utils import itervalues
 from future.utils import text_type
+
+import mock
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.python import log
@@ -543,7 +544,8 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
         step.locks = []
         step.renderables = []
         step.build.render = lambda x: defer.succeed(x)
-        step.master.data.updates.addStep = lambda **kwargs: defer.succeed((0, 0, 0))
+        step.master.data.updates.addStep = lambda **kwargs: defer.succeed(
+            (0, 0, 0))
         step.addLogWithFailure = lambda x: defer.succeed(None)
         step.run = lambda: defer.fail(RuntimeError('got exception'))
         res = yield step.startStep(mock.Mock())

--- a/master/buildbot/test/unit/test_process_cache.py
+++ b/master/buildbot/test/unit/test_process_cache.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.trial import unittest
 
 from buildbot.process import cache

--- a/master/buildbot/test/unit/test_process_debug.py
+++ b/master/buildbot/test/unit/test_process_debug.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_process_factory.py
+++ b/master/buildbot/test/unit/test_process_factory.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+
 from random import choice
 from string import ascii_uppercase
 
-from future.builtins import range
 from twisted.trial import unittest
 
 from buildbot.process.buildstep import BuildStep

--- a/master/buildbot/test/unit/test_process_log.py
+++ b/master/buildbot/test/unit/test_process_log.py
@@ -12,8 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import mock
 from future.utils import text_type
+
+import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_process_logobserver.py
+++ b/master/buildbot/test/unit/test_process_logobserver.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_process_metrics.py
+++ b/master/buildbot/test/unit/test_process_metrics.py
@@ -12,11 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+from future.utils import lrange
+
 import gc
 import sys
 
-from future.builtins import range
-from future.utils import lrange
 from twisted.internet import task
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -15,6 +15,7 @@
 from copy import deepcopy
 
 import mock
+
 from twisted.internet import defer
 from twisted.python import components
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_process_remotecommand.py
+++ b/master/buildbot/test/unit/test_process_remotecommand.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import mock
+
 from twisted.trial import unittest
 
 from buildbot.process import remotecommand

--- a/master/buildbot/test/unit/test_process_remotetransfer.py
+++ b/master/buildbot/test/unit/test_process_remotetransfer.py
@@ -17,6 +17,7 @@ import stat
 import tempfile
 
 from mock import Mock
+
 from twisted.trial import unittest
 
 from buildbot.process import remotetransfer

--- a/master/buildbot/test/unit/test_process_results.py
+++ b/master/buildbot/test/unit/test_process_results.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import lrange
+
 from twisted.python import log
 from twisted.trial import unittest
 
@@ -28,9 +29,9 @@ class TestResults(unittest.TestCase):
 
     def test_worst_status(self):
         self.assertEqual(results.WARNINGS,
-            results.worst_status(results.SUCCESS, results.WARNINGS))
+                         results.worst_status(results.SUCCESS, results.WARNINGS))
         self.assertEqual(results.CANCELLED,
-            results.worst_status(results.SKIPPED, results.CANCELLED))
+                         results.worst_status(results.SKIPPED, results.CANCELLED))
 
     def test_sort_worst_status(self):
         res = lrange(len(results.Results))

--- a/master/buildbot/test/unit/test_process_users_manager.py
+++ b/master/buildbot/test/unit/test_process_users_manager.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_process_users_manual.py
+++ b/master/buildbot/test/unit/test_process_users_manual.py
@@ -17,6 +17,7 @@
 # no current implementation utilizes it aside from scripts.runner.
 
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_reporter_bitbucket.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucket.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from mock import Mock
 from mock import call
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -13,11 +13,13 @@
 #
 # Copyright Buildbot Team Members
 
+from future.builtins import range
+
 import warnings
 
-from future.builtins import range
 from mock import Mock
 from mock import call
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_reporter_github.py
+++ b/master/buildbot/test/unit/test_reporter_github.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from mock import Mock
 from mock import call
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_reporter_http.py
+++ b/master/buildbot/test/unit/test_reporter_http.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from mock import Mock
 from mock import call
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_reporter_stash.py
+++ b/master/buildbot/test/unit/test_reporter_stash.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from mock import Mock
 from mock import call
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_reporters_hipchat.py
+++ b/master/buildbot/test/unit/test_reporters_hipchat.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 from mock import Mock
 from mock import call
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_reporters_irc.py
+++ b/master/buildbot/test/unit/test_reporters_irc.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.application import internet
 from twisted.internet import defer
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -17,6 +17,7 @@ import copy
 import sys
 
 from mock import Mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_reporters_words.py
+++ b/master/buildbot/test/unit/test_reporters_words.py
@@ -12,10 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import re
 
 import mock
-from future.utils import iteritems
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import task
@@ -147,18 +149,23 @@ class TestContactChannel(unittest.TestCase):
         yield self.do_test_command('notify', exp_UsageError=True)
         yield self.do_test_command('notify', args="invalid arg", exp_UsageError=True)
         yield self.do_test_command('notify', args="on")
-        self.assertEqual(self.sent, ["The following events are being notified: ['started', 'finished']"])
+        self.assertEqual(
+            self.sent, ["The following events are being notified: ['started', 'finished']"])
         yield self.do_test_command('notify', args="off")
-        self.assertEqual(self.sent, ['The following events are being notified: []'])
+        self.assertEqual(
+            self.sent, ['The following events are being notified: []'])
         yield self.do_test_command('notify', args="on started")
-        self.assertEqual(self.sent, ["The following events are being notified: ['started']"])
+        self.assertEqual(
+            self.sent, ["The following events are being notified: ['started']"])
         yield self.do_test_command('notify', args="off started")
-        self.assertEqual(self.sent, ['The following events are being notified: []'])
+        self.assertEqual(
+            self.sent, ['The following events are being notified: []'])
         yield self.assertFailure(
             self.do_test_command('notify', args="off finished"),
             KeyError)
         yield self.do_test_command('notify', args="list")
-        self.assertEqual(self.sent, ['The following events are being notified: []'])
+        self.assertEqual(
+            self.sent, ['The following events are being notified: []'])
 
     @defer.inlineCallbacks
     def notify_build_test(self, notify_args):

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -16,6 +16,7 @@ from __future__ import division
 from __future__ import print_function
 
 import mock
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_schedulers_basic.py
+++ b/master/buildbot/test/unit/test_schedulers_basic.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -14,8 +14,8 @@
 # Copyright Buildbot Team Members
 from __future__ import division
 from __future__ import print_function
-
 from future.utils import iteritems
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
@@ -15,6 +15,7 @@
 import time
 
 import mock
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.python import log

--- a/master/buildbot/test/unit/test_schedulers_triggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_triggerable.py
@@ -12,8 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import mock
 from future.utils import itervalues
+
+import mock
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.python import log

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -18,6 +18,7 @@ import shutil
 import sys
 
 import mock
+
 import twisted
 from twisted.internet import defer
 from twisted.protocols import basic

--- a/master/buildbot/test/unit/test_scripts_checkconfig.py
+++ b/master/buildbot/test/unit/test_scripts_checkconfig.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import cStringIO
 import os
 import re
@@ -19,7 +21,7 @@ import sys
 import textwrap
 
 import mock
-from future.utils import iteritems
+
 from twisted.trial import unittest
 
 from buildbot.scripts import base

--- a/master/buildbot/test/unit/test_scripts_cleanupdb.py
+++ b/master/buildbot/test/unit/test_scripts_cleanupdb.py
@@ -16,6 +16,7 @@ import os
 import textwrap
 
 import sqlalchemy as sa
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_scripts_create_master.py
+++ b/master/buildbot/test/unit/test_scripts_create_master.py
@@ -12,10 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
+
 import os
 
 import mock
-from future.utils import itervalues
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_scripts_runner.py
+++ b/master/buildbot/test/unit/test_scripts_runner.py
@@ -18,6 +18,7 @@ import os
 import sys
 
 import mock
+
 from twisted.python import log
 from twisted.python import runtime
 from twisted.python import usage

--- a/master/buildbot/test/unit/test_scripts_trycmd.py
+++ b/master/buildbot/test/unit/test_scripts_trycmd.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.trial import unittest
 
 from buildbot.clients import tryclient

--- a/master/buildbot/test/unit/test_scripts_upgrade_master.py
+++ b/master/buildbot/test/unit/test_scripts_upgrade_master.py
@@ -17,6 +17,7 @@ import StringIO
 import sys
 
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.internet import threads
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_steps_mswin.py
+++ b/master/buildbot/test/unit/test_steps_mswin.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.builtins import range
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_steps_mtrlogobserver.py
+++ b/master/buildbot/test/unit/test_steps_mtrlogobserver.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.enterprise import adbapi
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_steps_source_base_Source.py
+++ b/master/buildbot/test/unit/test_steps_source_base_Source.py
@@ -15,6 +15,7 @@
 from exceptions import AttributeError
 
 import mock
+
 from twisted.trial import unittest
 
 from buildbot.steps.source import Source

--- a/master/buildbot/test/unit/test_steps_subunit.py
+++ b/master/buildbot/test/unit/test_steps_subunit.py
@@ -15,6 +15,7 @@
 import StringIO
 
 import mock
+
 from twisted.trial import unittest
 from zope.interface import implementer
 

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import os
 import shutil
 import stat
@@ -19,8 +21,8 @@ import tarfile
 import tempfile
 from cStringIO import StringIO
 
-from future.utils import iteritems
 from mock import Mock
+
 from twisted.trial import unittest
 
 from buildbot import config
@@ -316,7 +318,8 @@ class TestDirectoryUpload(steps.BuildStepMixin, unittest.TestCase):
 
     def testWorker2_16(self):
         self.setupStep(
-            transfer.DirectoryUpload(workersrc="srcdir", masterdest=self.destdir),
+            transfer.DirectoryUpload(
+                workersrc="srcdir", masterdest=self.destdir),
             worker_version={'*': '2.16'})
 
         self.expectCommands(

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from mock import Mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import failure
@@ -567,6 +568,7 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
 
     def test_getSchedulersAndProperties_back_comp(self):
         class DynamicTrigger(trigger.Trigger):
+
             def getSchedulersAndProperties(self):
                 return [("a", {}, False), ("b", {}, True)]
 
@@ -578,7 +580,8 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
     def test_unimportantsShedulerNames(self):
-        self.setupStep(trigger.Trigger(schedulerNames=['a', 'b'], unimportantSchedulerNames=['b']))
+        self.setupStep(trigger.Trigger(schedulerNames=[
+                       'a', 'b'], unimportantSchedulerNames=['b']))
         self.scheduler_a.result = SUCCESS
         self.scheduler_b.result = FAILURE
         self.expectOutcome(result=SUCCESS, state_string='triggered a, b')
@@ -586,7 +589,8 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
     def test_unimportantsShedulerNames_with_more_brids_for_bsid(self):
-        self.setupStep(trigger.Trigger(schedulerNames=['a', 'c'], unimportantSchedulerNames=['c']))
+        self.setupStep(trigger.Trigger(schedulerNames=[
+                       'a', 'c'], unimportantSchedulerNames=['c']))
         self.scheduler_a.result = SUCCESS
         self.scheduler_c.result = FAILURE
         self.expectOutcome(result=SUCCESS, state_string='triggered a, c')

--- a/master/buildbot/test/unit/test_steps_vstudio.py
+++ b/master/buildbot/test/unit/test_steps_vstudio.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from mock import Mock
+
 from twisted.trial import unittest
 
 from buildbot.process.properties import Property

--- a/master/buildbot/test/unit/test_steps_worker.py
+++ b/master/buildbot/test/unit/test_steps_worker.py
@@ -15,6 +15,7 @@
 import stat
 
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_util.py
+++ b/master/buildbot/test/unit/test_util.py
@@ -12,12 +12,14 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import text_type
+
 import datetime
 import locale
 import os
 
 import mock
-from future.utils import text_type
+
 from twisted.internet import reactor
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_util_debounce.py
+++ b/master/buildbot/test/unit/test_util_debounce.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import itervalues
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.python import failure

--- a/master/buildbot/test/unit/test_util_identifiers.py
+++ b/master/buildbot/test/unit/test_util_identifiers.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import text_type
+
 from twisted.python import log
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_util_lru.py
+++ b/master/buildbot/test/unit/test_util_lru.py
@@ -12,11 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+
 import gc
 import random
 import string
 
-from future.builtins import range
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import failure

--- a/master/buildbot/test/unit/test_util_service.py
+++ b/master/buildbot/test/unit/test_util_service.py
@@ -12,9 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import mock
 from future.builtins import range
 from future.utils import text_type
+
+import mock
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_wamp_connector.py
+++ b/master/buildbot/test/unit/test_wamp_connector.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_worker_base.py
+++ b/master/buildbot/test/unit/test_worker_base.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import task

--- a/master/buildbot/test/unit/test_worker_libvirt.py
+++ b/master/buildbot/test/unit/test_worker_libvirt.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import utils

--- a/master/buildbot/test/unit/test_worker_local.py
+++ b/master/buildbot/test/unit/test_worker_local.py
@@ -15,6 +15,7 @@
 import os
 
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_worker_manager.py
+++ b/master/buildbot/test/unit/test_worker_manager.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 from zope.interface import implementer

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -14,6 +14,7 @@
 # Portions Copyright Buildbot Team Members
 # Portions Copyright 2013 Cray Inc.
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_worker_protocols_base.py
+++ b/master/buildbot/test/unit/test_worker_protocols_base.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.trial import unittest
 
 from buildbot.test.fake import fakemaster

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 from twisted.spread import pb as twisted_pb
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_worker_transition.py
+++ b/master/buildbot/test/unit/test_worker_transition.py
@@ -17,6 +17,7 @@ import re
 import sys
 
 import mock
+
 from twisted.python.deprecate import deprecatedModuleAttribute
 from twisted.python.versions import Version
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_www_auth.py
+++ b/master/buildbot/test/unit/test_www_auth.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.cred.checkers import InMemoryUsernamePasswordDatabaseDontUse
 from twisted.internet import defer
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_www_config.py
+++ b/master/buildbot/test/unit/test_www_config.py
@@ -15,6 +15,7 @@
 import json
 
 import mock
+
 from twisted.internet import defer
 from twisted.python import log
 from twisted.python import util

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -15,6 +15,7 @@
 import calendar
 
 import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -88,7 +89,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
             change["comments"], "Update Catalan translation to e38cb41.")
         self.assertEqual(change["branch"], "master")
         self.assertEqual(change[
-                          "revlink"], "http://localhost/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327")
+            "revlink"], "http://localhost/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327")
 
         change = self.changeHook.master.addedChanges[1]
         self.assertEqual(change["repository"], "git@localhost:diaspora.git")
@@ -104,7 +105,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(change["comments"], "fixed readme")
         self.assertEqual(change["branch"], "master")
         self.assertEqual(change[
-                          "revlink"], "http://localhost/diaspora/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7")
+            "revlink"], "http://localhost/diaspora/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7")
 
         self.assertEqual(change.get("project"), project)
         self.assertEqual(change.get("codebase"), codebase)

--- a/master/buildbot/test/unit/test_www_ldapuserinfo.py
+++ b/master/buildbot/test/unit/test_www_ldapuserinfo.py
@@ -13,11 +13,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+
 import new
 import sys
 
 import mock
-from future.builtins import range
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -16,6 +16,7 @@ import os
 import webbrowser
 
 import mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import threads

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -12,14 +12,16 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import re
-
-import mock
 from future.builtins import range
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import string_types
 from future.utils import text_type
+
+import re
+
+import mock
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_www_service.py
+++ b/master/buildbot/test/unit/test_www_service.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import mock
+
 from twisted.cred.checkers import InMemoryUsernamePasswordDatabaseDontUse
 from twisted.internet import defer
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_www_ws.py
+++ b/master/buildbot/test/unit/test_www_ws.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from mock import Mock
+
 from twisted.trial import unittest
 
 from buildbot.test.util import www

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -15,6 +15,7 @@
 import os
 
 from sqlalchemy.schema import MetaData
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/test/util/gpo.py
+++ b/master/buildbot/test/util/gpo.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import iteritems
+
 from twisted.internet import defer
 from twisted.internet import utils
 

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -14,12 +14,13 @@
 # Copyright Buildbot Team Members
 from __future__ import division
 from __future__ import print_function
+from future.utils import itervalues
 
 import StringIO
 import sys
 
 import mock
-from future.utils import itervalues
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python.filepath import FilePath
@@ -110,7 +111,7 @@ class RunMasterBase(unittest.TestCase):
         m = yield getMaster(self, reactor, config_dict)
         self.master = m
         self.assertFalse(stop.called,
-                    "startService tried to stop the reactor; check logs")
+                         "startService tried to stop the reactor; check logs")
 
         if not startWorker:
             return

--- a/master/buildbot/test/util/interfaces.py
+++ b/master/buildbot/test/util/interfaces.py
@@ -12,11 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.builtins import range
+from future.utils import PY3
+
 import inspect
 
 import pkg_resources
-from future.builtins import range
-from future.utils import PY3
+
 from twisted.trial import unittest
 
 

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -17,6 +17,7 @@ import os
 import migrate
 import migrate.versioning.api
 import sqlalchemy as sa
+
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -13,12 +13,11 @@
 #
 # Copyright Buildbot Team Members
 from __future__ import print_function
+from future.utils import text_type
 
 import cStringIO
 import os
 import sys
-
-from future.utils import text_type
 
 import buildbot
 

--- a/master/buildbot/test/util/pbmanager.py
+++ b/master/buildbot/test/util/pbmanager.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import mock
+
 from twisted.internet import defer
 
 

--- a/master/buildbot/test/util/querylog.py
+++ b/master/buildbot/test/util/querylog.py
@@ -54,7 +54,8 @@ class _QueryToTwistedHandler(logging.Handler):
 
 
 def start_log_queries(log_query_result=False, record_mode=False):
-    handler = _QueryToTwistedHandler(log_query_result=log_query_result, record_mode=record_mode)
+    handler = _QueryToTwistedHandler(
+        log_query_result=log_query_result, record_mode=record_mode)
 
     # In 'sqlalchemy.engine' logging namespace SQLAlchemy outputs SQL queries
     # on INFO level, and SQL queries results on DEBUG level.
@@ -105,4 +106,5 @@ class SqliteMaxVariableMixin(object):
         finally:
             stop_log_queries(handler)
             for line in handler.records:
-                self.assertFalse(line.count("?") > 999, "too much variables in " + line)
+                self.assertFalse(line.count("?") > 999,
+                                 "too much variables in " + line)

--- a/master/buildbot/test/util/reporter.py
+++ b/master/buildbot/test/util/reporter.py
@@ -16,7 +16,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
 from future.utils import iteritems
 
 from buildbot.test.fake import fakedb
@@ -58,7 +57,8 @@ class ReporterTestMixin(object):
         ])
         for i, results in enumerate(buildResults):
             self.db.insertTestData([
-                fakedb.BuildRequest(id=11 + i, buildsetid=98, builderid=79 + i),
+                fakedb.BuildRequest(
+                    id=11 + i, buildsetid=98, builderid=79 + i),
                 fakedb.Build(id=20 + i, number=i, builderid=79 + i, buildrequestid=11 + i, workerid=13,
                              masterid=92, results=results, state_string=u"buildText"),
                 fakedb.Step(id=50 + i, buildid=20 + i, number=5, name='make'),
@@ -66,8 +66,10 @@ class ReporterTestMixin(object):
                            num_lines=7),
                 fakedb.LogChunk(logid=60 + i, first_line=0, last_line=1, compressed=0,
                                 content=u'Unicode log with non-ascii (\u00E5\u00E4\u00F6).'),
-                fakedb.BuildProperty(buildid=20 + i, name="workername", value="sl"),
-                fakedb.BuildProperty(buildid=20 + i, name="reason", value="because"),
+                fakedb.BuildProperty(
+                    buildid=20 + i, name="workername", value="sl"),
+                fakedb.BuildProperty(
+                    buildid=20 + i, name="reason", value="because"),
             ])
             for k, v in iteritems(self.TEST_PROPS):
                 self.db.insertTestData([

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -14,10 +14,11 @@
 # Copyright Buildbot Team Members
 from __future__ import division
 from __future__ import print_function
-
-import mock
 from future.utils import iteritems
 from future.utils import itervalues
+
+import mock
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.python import log

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -13,13 +13,13 @@
 #
 # Copyright Buildbot Team Members
 
-import datetime
-import re
-
 # See "Type Validation" in master/docs/developer/tests.rst
 from future.utils import integer_types
 from future.utils import iteritems
 from future.utils import text_type
+
+import datetime
+import re
 
 from buildbot.util import UTC
 from buildbot.util import json

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -12,16 +12,19 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.moves.urllib.parse import unquote as urlunquote
+from future.utils import integer_types
+from future.utils import iteritems
+
 import cgi
 import os
 from cStringIO import StringIO
 from uuid import uuid1
 
-import mock
 import pkg_resources
-from future.moves.urllib.parse import unquote as urlunquote
-from future.utils import integer_types
-from future.utils import iteritems
+
+import mock
+
 from twisted.internet import defer
 from twisted.web import server
 

--- a/master/buildbot/util/config.py
+++ b/master/buildbot/util/config.py
@@ -12,9 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import re
 
-from future.utils import iteritems
 from twisted.python.components import registerAdapter
 from zope.interface import implementer
 

--- a/master/buildbot/util/croniter.py
+++ b/master/buildbot/util/croniter.py
@@ -7,6 +7,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 from __future__ import print_function
+from future.builtins import range
 
 import re
 from datetime import datetime
@@ -14,7 +15,6 @@ from time import mktime
 from time import time
 
 from dateutil.relativedelta import relativedelta
-from future.builtins import range
 
 search_re = re.compile(r'^([^-]+)-([^-/]+)(/(.*))?$')
 only_int_re = re.compile(r'^\d+$')

--- a/master/buildbot/util/identifiers.py
+++ b/master/buildbot/util/identifiers.py
@@ -13,10 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
-import re
-
 from future.utils import string_types
 from future.utils import text_type
+
+import re
+
 from buildbot import util
 
 ident_re = re.compile('^[a-zA-Z_-][a-zA-Z0-9_-]*$')

--- a/master/buildbot/util/lru.py
+++ b/master/buildbot/util/lru.py
@@ -12,11 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.moves.itertools import filterfalse
+
 from collections import defaultdict
 from collections import deque
 from weakref import WeakValueDictionary
 
-from future.moves.itertools import filterfalse
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/util/misc.py
+++ b/master/buildbot/util/misc.py
@@ -17,6 +17,7 @@ Miscellaneous utilities; these should be imported from C{buildbot.util}, not
 directly from this module.
 """
 from future.utils import string_types
+
 from twisted.internet import reactor
 
 

--- a/master/buildbot/util/pathmatch.py
+++ b/master/buildbot/util/pathmatch.py
@@ -12,9 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import re
-
 from future.utils import iteritems
+
+import re
 
 _ident_re = re.compile('^[a-zA-Z_-][.a-zA-Z0-9_-]*$')
 

--- a/master/buildbot/util/raml.py
+++ b/master/buildbot/util/raml.py
@@ -12,12 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import copy
 import json
 import os
 
 import ramlfications
-from future.utils import iteritems
 
 try:
     from collections import OrderedDict
@@ -39,7 +40,8 @@ class RamlSpec(object):
         # waiting for raml1.0 support in ramlfications
         # we cannot use its raml parser
         # so we just use its loader
-        fn = os.path.join(os.path.dirname(__file__), os.pardir, 'spec', 'api.raml')
+        fn = os.path.join(os.path.dirname(__file__),
+                          os.pardir, 'spec', 'api.raml')
         self.api = ramlfications.load(fn)
         with open(fn) as f:
             self.rawraml = f.read()

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 from future.utils import itervalues
+
 from twisted.application import service
 from twisted.internet import defer
 from twisted.internet import task

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -13,11 +13,12 @@
 #
 # Portions Copyright Buildbot Team Members
 # Portions Copyright Canonical Ltd. 2009
+from future.utils import itervalues
+
 import time
 from email.message import Message
 from email.utils import formatdate
 
-from future.utils import itervalues
 from twisted.internet import defer
 from twisted.python import log
 from twisted.python.reflect import namedModule
@@ -597,8 +598,10 @@ class AbstractWorker(service.BuildbotService, object):
     def putInQuarantine(self):
         if self.quarantine_timer:  # already in quarantine
             return
-        self.quarantine_timer = self.master.reactor.callLater(self.quarantine_timeout, self.exitQuarantine)
-        log.msg("{} has been put in quarantine for {}s".format(self.name, self.quarantine_timeout))
+        self.quarantine_timer = self.master.reactor.callLater(
+            self.quarantine_timeout, self.exitQuarantine)
+        log.msg("{} has been put in quarantine for {}s".format(
+            self.name, self.quarantine_timeout))
         # next we will wait twice as long
         self.quarantine_timeout *= 2
         if self.quarantine_timeout > self.quarantine_max_timeout:

--- a/master/buildbot/worker/hyper.py
+++ b/master/buildbot/worker/hyper.py
@@ -44,7 +44,8 @@ log = Logger()
 class HyperLatentWorker(AbstractLatentWorker):
     """hyper.sh is a docker CaaS company"""
     instance = None
-    ALLOWED_SIZES = ['s1', 's2', 's3', 's4', 'm1', 'm2', 'm3', 'l1', 'l2', 'l3']
+    ALLOWED_SIZES = ['s1', 's2', 's3', 's4',
+                     'm1', 'm2', 'm3', 'l1', 'l2', 'l3']
     threadPool = None
     client = None
     image = None
@@ -68,12 +69,14 @@ class HyperLatentWorker(AbstractLatentWorker):
                          " HyperLatentWorker")
 
         if hyper_size not in self.ALLOWED_SIZES:
-            config.error("Size is not valid %s vs %r".format(hyper_size, self.ALLOWED_SIZES))
+            config.error("Size is not valid %s vs %r".format(
+                hyper_size, self.ALLOWED_SIZES))
 
     def reconfigService(self, name, password, hyper_host,
                         hyper_accesskey, hyper_secretkey, image, hyper_size="s3", masterFQDN=None, **kwargs):
         AbstractLatentWorker.reconfigService(self, name, password, **kwargs)
-        self.confighash = hashlib.sha1(hyper_host + hyper_accesskey + hyper_secretkey).hexdigest()[:6]
+        self.confighash = hashlib.sha1(
+            hyper_host + hyper_accesskey + hyper_secretkey).hexdigest()[:6]
         self.masterhash = hashlib.sha1(self.master.name).hexdigest()[:6]
         self.size = hyper_size
 
@@ -104,7 +107,8 @@ class HyperLatentWorker(AbstractLatentWorker):
         if self.registration is not None:
             result["BUILDMASTER_PORT"] = str(self.registration.getPBPort())
         if ":" in self.masterFQDN:
-            result["BUILDMASTER"], result["BUILDMASTER_PORT"] = self.masterFQDN.split(":")
+            result["BUILDMASTER"], result[
+                "BUILDMASTER_PORT"] = self.masterFQDN.split(":")
         return result
 
     def runInThread(self, meth, *args, **kwargs):
@@ -115,9 +119,11 @@ class HyperLatentWorker(AbstractLatentWorker):
         if self.threadPool is None:
             key = self.confighash
             if key not in HyperLatentWorker.class_singletons:
-                threadPool = threadpool.ThreadPool(minthreads=10, maxthreads=10, name='hyper')
+                threadPool = threadpool.ThreadPool(
+                    minthreads=10, maxthreads=10, name='hyper')
                 threadPool.start()
-                # simple reference counter to stop the pool when the last latent worker is stopped
+                # simple reference counter to stop the pool when the last
+                # latent worker is stopped
                 threadPool.refs = 0
                 client = Hyper(self.client_args)
                 HyperLatentWorker.class_singletons[key] = (threadPool, client)
@@ -135,7 +141,8 @@ class HyperLatentWorker(AbstractLatentWorker):
                 self.client.close()
                 yield self.threadPool.stop()
                 key = self.confighash
-                # if key in not in the singleton, there is a bug somewhere so this will raise
+                # if key in not in the singleton, there is a bug somewhere so
+                # this will raise
                 del HyperLatentWorker.class_singletons[key]
 
             self.threadPool = self.client = None
@@ -153,7 +160,8 @@ class HyperLatentWorker(AbstractLatentWorker):
         return ('%s-%s' % ('buildbot' + self.masterhash, self.workername)).replace("_", "-")
 
     def _thd_cleanup_instance(self):
-        instances = self.client.containers(filters=dict(name=self.getContainerName()))
+        instances = self.client.containers(
+            filters=dict(name=self.getContainerName()))
         for instance in instances:
             self.client.remove_container(instance['Id'], v=True, force=True)
 

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -13,9 +13,10 @@
 #
 # Portions Copyright Buildbot Team Members
 # Portions Copyright Canonical Ltd. 2009
+from future.utils import itervalues
+
 import time
 
-from future.utils import itervalues
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log
@@ -94,7 +95,8 @@ class AbstractLatentWorker(AbstractWorker):
                     self.missing_timeout,
                     self._substantiation_failed, defer.TimeoutError())
             self.substantiation_build = build
-            # if substantiate fails synchronously we need to have the deferred ready to be notified
+            # if substantiate fails synchronously we need to have the deferred
+            # ready to be notified
             d = self._substantiation_notifier.wait()
             if self.conn is None:
                 self._substantiate(build)
@@ -108,7 +110,8 @@ class AbstractLatentWorker(AbstractWorker):
         try:
             d = self.start_instance(build)
         except Exception:
-            # if start_instance crashes without defer, we still handle the cleanup
+            # if start_instance crashes without defer, we still handle the
+            # cleanup
             d = defer.fail(failure.Failure())
 
         def start_instance_result(result):
@@ -205,13 +208,16 @@ class AbstractLatentWorker(AbstractWorker):
         assert not sb.isBusy()
         if not self.building:
             if self.build_wait_timeout == 0:
-                # we insubstantiate asynchronously to trigger more bugs with the fake reactor
+                # we insubstantiate asynchronously to trigger more bugs with
+                # the fake reactor
                 self.master.reactor.callLater(0, self.insubstantiate)
-                # insubstantiate will automatically retry to create build for this worker
+                # insubstantiate will automatically retry to create build for
+                # this worker
             else:
                 self._setBuildWaitTimer()
 
-        # AbstractWorker.buildFinished() will try to start the next build for that worker
+        # AbstractWorker.buildFinished() will try to start the next build for
+        # that worker
         AbstractWorker.buildFinished(self, sb)
 
     def _clearBuildWaitTimer(self):
@@ -242,7 +248,8 @@ class AbstractLatentWorker(AbstractWorker):
 
         self.insubstantiating = False
         if self._substantiation_notifier:
-            self._substantiation_notifier.notify(failure.Failure(LatentWorkerSubstantiatiationCancelled()))
+            self._substantiation_notifier.notify(
+                failure.Failure(LatentWorkerSubstantiatiationCancelled()))
         self.botmaster.maybeStartBuildsForWorker(self.name)
 
     @defer.inlineCallbacks

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -15,10 +15,10 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from future.utils import itervalues
 
 import contextlib
 
-from future.utils import itervalues
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/worker_transition.py
+++ b/master/buildbot/worker_transition.py
@@ -20,11 +20,12 @@ Use of old API generates Python warning which may be logged, ignored or treated
 as an error using Python builtin warnings API.
 """
 
+from future.utils import iteritems
+
 import functools
 import sys
 import warnings
 
-from future.utils import iteritems
 from twisted.python.deprecate import deprecatedModuleAttribute as _deprecatedModuleAttribute
 from twisted.python.deprecate import getWarningMethod
 from twisted.python.deprecate import setWarningMethod

--- a/master/buildbot/www/authz/endpointmatchers.py
+++ b/master/buildbot/www/authz/endpointmatchers.py
@@ -12,9 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import string_types
+
 import inspect
 
-from future.utils import string_types
 from twisted.internet import defer
 
 from buildbot.data.exceptions import InvalidPathError

--- a/master/buildbot/www/avatar.py
+++ b/master/buildbot/www/avatar.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import hashlib
-
 from future.moves.urllib.parse import urlencode
 from future.moves.urllib.parse import urljoin
+
+import hashlib
+
 from twisted.internet import defer
 
 from buildbot.util import config

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -16,6 +16,7 @@ import os
 import posixpath
 
 import jinja2
+
 from twisted.internet import defer
 from twisted.python import log
 from twisted.web.error import Error

--- a/master/buildbot/www/hooks/bitbucket.py
+++ b/master/buildbot/www/hooks/bitbucket.py
@@ -16,6 +16,7 @@
 import json
 
 from dateutil.parser import parse as dateparse
+
 from twisted.python import log
 
 

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -18,6 +18,7 @@ import re
 from hashlib import sha1
 
 from dateutil.parser import parse as dateparse
+
 from twisted.python import log
 
 try:

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -15,6 +15,7 @@
 import re
 
 from dateutil.parser import parse as dateparse
+
 from twisted.python import log
 
 from buildbot.util import json

--- a/master/buildbot/www/hooks/gitorious.py
+++ b/master/buildbot/www/hooks/gitorious.py
@@ -17,6 +17,7 @@
 import re
 
 from dateutil.parser import parse as dateparse
+
 from twisted.python import log
 
 try:

--- a/master/buildbot/www/ldapuserinfo.py
+++ b/master/buildbot/www/ldapuserinfo.py
@@ -12,8 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-import ldap3
 from future.moves.urllib.parse import urlparse
+
+import ldap3
+
 from twisted.internet import threads
 
 from buildbot.util import flatten

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -12,13 +12,15 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-from posixpath import join
-
-import requests
 from future.moves.urllib.parse import parse_qs
 from future.moves.urllib.parse import urlencode
 from future.utils import iteritems
 from future.utils import string_types
+
+from posixpath import join
+
+import requests
+
 from twisted.internet import defer
 from twisted.internet import threads
 

--- a/master/buildbot/www/plugin.py
+++ b/master/buildbot/www/plugin.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 import pkg_resources
+
 from twisted.web import static
 
 

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -12,15 +12,16 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.moves.urllib.parse import urlparse
+from future.utils import iteritems
+from future.utils import text_type
+
 import cgi
 import datetime
 import fnmatch
 import re
 from contextlib import contextmanager
 
-from future.moves.urllib.parse import urlparse
-from future.utils import iteritems
-from future.utils import text_type
 from twisted.internet import defer
 from twisted.python import log
 from twisted.web.error import Error

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -12,9 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import iteritems
+
 import os
 
-from future.utils import iteritems
 from twisted.application import strports
 from twisted.cred.portal import IRealm
 from twisted.cred.portal import Portal

--- a/master/buildbot/www/sse.py
+++ b/master/buildbot/www/sse.py
@@ -12,9 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+from future.utils import itervalues
+
 import uuid
 
-from future.utils import itervalues
 from twisted.python import log
 from twisted.web import resource
 from twisted.web import server

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -12,11 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright  Team Members
+from future.utils import itervalues
+from future.utils import string_types
+
 from autobahn.twisted.resource import WebSocketResource
 from autobahn.twisted.websocket import WebSocketServerFactory
 from autobahn.twisted.websocket import WebSocketServerProtocol
-from future.utils import itervalues
-from future.utils import string_types
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/contrib/bitbucket_buildbot.py
+++ b/master/contrib/bitbucket_buildbot.py
@@ -11,13 +11,14 @@ bitbucket repository for the user who initiated bitbucket_buildbot.py
 bitbucket_buildbot.py is based on github_buildbot.py
 """
 
+from future.utils import iteritems
+
 import logging
 import sys
 import tempfile
 import traceback
 from optparse import OptionParser
 
-from future.utils import iteritems
 from twisted.cred import credentials
 from twisted.internet import reactor
 from twisted.spread import pb

--- a/master/contrib/bk_buildbot.py
+++ b/master/contrib/bk_buildbot.py
@@ -24,7 +24,6 @@ from twisted.spread import pb
 '''
 
 
-
 # We have hackish "-d" handling here rather than in the Options
 # subclass below because a common error will be to not have twisted in
 # PYTHONPATH; we want to be able to print that error to the log if

--- a/master/contrib/buildbot_json.py
+++ b/master/contrib/buildbot_json.py
@@ -31,6 +31,10 @@
 
 from __future__ import division
 from __future__ import print_function
+from future.builtins import range
+from future.utils import lrange
+from future.utils import string_types
+from future.utils import text_type
 
 import code
 import datetime
@@ -42,11 +46,6 @@ import sys
 import time
 import urllib
 import urllib2
-
-from future.builtins import range
-from future.utils import lrange
-from future.utils import string_types
-from future.utils import text_type
 
 """Queries buildbot through the json interface.
 """
@@ -188,7 +187,8 @@ class AddressableDataNode(AddressableBaseDataNode):  # pylint: disable=W0223
     """Automatically encodes the url."""
 
     def __init__(self, parent, url, data):
-        super(AddressableDataNode, self).__init__(parent, urllib.quote(url), data)
+        super(AddressableDataNode, self).__init__(
+            parent, urllib.quote(url), data)
 
 
 class NonAddressableDataNode(Node):  # pylint: disable=W0223
@@ -434,7 +434,8 @@ class AddressableNodeList(NodeList):
                 if not (child in self._cache and self._cache[child].cached_data)
             ]
             if to_fetch:
-                # Similar to cache(). The only reason to sort is to simplify testing.
+                # Similar to cache(). The only reason to sort is to simplify
+                # testing.
                 params = '&'.join(
                     'select=%s' % urllib.quote(str(v)) for v in sorted(to_fetch))
                 data = self.read('?' + params)
@@ -1038,7 +1039,8 @@ def CMDpending(parser, args):
                     print('  revision: %s' % pending['source']['revision'])
                 for change in pending['source']['changes']:
                     print('  change:')
-                    print('    comment: %r' % text_type(change['comments'][:50]))
+                    print('    comment: %r' %
+                          text_type(change['comments'][:50]))
                     print('    who:     %s' % change['who'])
     return 0
 
@@ -1127,7 +1129,8 @@ def find_idle_busy_slaves(parser, args, show_idle):
         builder = buildbot.builders[builder]
         if options.slaves:
             # Only the subset of slaves connected to the builder.
-            slaves = list(set(options.slaves).intersection(set(builder.slaves.names)))
+            slaves = list(set(options.slaves).intersection(
+                set(builder.slaves.names)))
             if not slaves:
                 continue
         else:
@@ -1156,7 +1159,8 @@ def last_failure(
         builder = buildbot.builders[builder]
         if slaves:
             # Only the subset of slaves connected to the builder.
-            builder_slaves = list(set(slaves).intersection(set(builder.slaves.names)))
+            builder_slaves = list(
+                set(slaves).intersection(set(builder.slaves.names)))
             if not builder_slaves:
                 continue
         else:
@@ -1372,7 +1376,8 @@ def CMDcount(parser, args):
     align_name = max(len(b) for b in counts)
     align_number = max(len(str(c)) for c in counts.itervalues())
     for builder in sorted(counts):
-        print('%*s: %*d' % (align_name, builder, align_number, counts[builder]))
+        print('%*s: %*d' %
+              (align_name, builder, align_number, counts[builder]))
     print('Total: %d' % sum(counts.itervalues()))
     return 0
 

--- a/master/contrib/check_buildbot.py
+++ b/master/contrib/check_buildbot.py
@@ -2,12 +2,10 @@
 
 from __future__ import division
 from __future__ import print_function
+from future.utils import lrange
 
 import sys
 import urllib
-
-from future.utils import lrange
-
 
 """check_buildbot.py -H hostname -p httpport [options]
 
@@ -53,7 +51,8 @@ def main():
     options, args = parser.parse_args()
 
     if options.hostname and options.httpport:
-        url = "http://%s:%s/json/metrics" % (options.hostname, options.httpport)
+        url = "http://%s:%s/json/metrics" % (options.hostname,
+                                             options.httpport)
     elif options.url:
         url = options.url
     else:
@@ -83,7 +82,8 @@ def main():
             alarm_code = STATUS_CODES[alarm_state[0]]
         except (KeyError, IndexError):
             status = UNKNOWN
-            messages.append("%s has unknown alarm state %s" % (alarm_name, alarm_state))
+            messages.append("%s has unknown alarm state %s" %
+                            (alarm_name, alarm_state))
             continue
 
         status = max(status, alarm_code)

--- a/master/contrib/coverage2text.py
+++ b/master/contrib/coverage2text.py
@@ -5,6 +5,7 @@ import sys
 from coverage import coverage
 from coverage.results import Numbers
 from coverage.summary import SummaryReporter
+
 from twisted.python import usage
 
 

--- a/master/contrib/fakechange.py
+++ b/master/contrib/fakechange.py
@@ -45,8 +45,6 @@ buildbot.master.makeApp (this service is turned ON by default).
 """
 
 
-
-
 def done(*args):
     reactor.stop()
 

--- a/master/contrib/generate_changelog.py
+++ b/master/contrib/generate_changelog.py
@@ -23,8 +23,6 @@ Generates changelog information using git.
 __docformat__ = 'restructuredtext'
 
 
-
-
 def print_err(msg):
     """
     Wrapper to make printing to stderr nicer.

--- a/master/contrib/git_buildbot.py
+++ b/master/contrib/git_buildbot.py
@@ -23,6 +23,9 @@
 #
 # Largely based on contrib/hooks/post-receive-email from git.
 
+from future.utils import iteritems
+from future.utils import text_type
+
 import commands
 import logging
 import os
@@ -31,8 +34,6 @@ import subprocess
 import sys
 from optparse import OptionParser
 
-from future.utils import iteritems
-from future.utils import text_type
 from twisted.cred import credentials
 from twisted.internet import defer
 from twisted.internet import reactor

--- a/master/contrib/github_buildbot.py
+++ b/master/contrib/github_buildbot.py
@@ -13,6 +13,8 @@ This version of github_buildbot.py parses v3 of the github webhook api, with the
 
 """
 
+from future.utils import iteritems
+
 import hmac
 import logging
 import os
@@ -25,7 +27,6 @@ from httplib import INTERNAL_SERVER_ERROR
 from httplib import OK
 from optparse import OptionParser
 
-from future.utils import iteritems
 from twisted.cred import credentials
 from twisted.internet import reactor
 from twisted.spread import pb

--- a/master/contrib/hgbuildbot.py
+++ b/master/contrib/hgbuildbot.py
@@ -140,13 +140,14 @@
 # This would strip everything until (and including) the 4th "/" in the repo's
 # path leaving only "myrepo" left.  This would then be append to the base URL.
 
+from future.builtins import range
+
 import json
 import os
 import os.path
 
 import requests
 
-from future.builtins import range
 from mercurial.encoding import fromlocal
 from mercurial.node import hex
 from mercurial.node import nullid

--- a/master/contrib/post_build_request.py
+++ b/master/contrib/post_build_request.py
@@ -126,83 +126,83 @@ parser = optparse.OptionParser(description=description,
                                version=__version__)
 
 parser.add_option("-w", "--who", dest='author', metavar="AUTHOR",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             Who is submitting this request.
             This becomes the Change.author attribute.
             This defaults to the name of the user running this script
             """))
 parser.add_option("-f", "--file", dest='files', action="append", metavar="FILE",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             Add a file to the change request.
             This is added to the Change.files attribute.
             NOTE: Setting the file URL is not supported
             """))
 parser.add_option("-c", "--comments", dest='comments', metavar="COMMENTS",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             Comments for the change. This becomes the Change.comments attribute
             """))
 parser.add_option("-R", "--revision", dest='revision', metavar="REVISION",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             This is the revision of the change.
             This becomes the Change.revision attribute.
             """))
 parser.add_option("-W", "--when", dest='when', metavar="WHEN",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             This this the date of the change.
             This becomes the Change.when attribute.
             """))
 parser.add_option("-b", "--branch", dest='branch', metavar="BRANCH",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             This this the branch of the change.
             This becomes the Change.branch attribute.
             """))
 parser.add_option("-C", "--category", dest='category', metavar="CAT",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             Category for change. This becomes the Change.category attribute, which
             can be used within the buildmaster to filter changes.
             """))
 parser.add_option("--revlink", dest='revlink', metavar="REVLINK",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             This this the revlink of the change.
             This becomes the Change.revlink.
             """))
 parser.add_option("-p", "--property", dest='properties', action="callback", callback=propertyCB,
                   type="string", metavar="PROP",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             This adds a single property. This can be specified multiple times.
             The argument is a string representing python dictionary. For example,
             {'foo' : [ 'bar', 'baz' ]}
             This becomes the Change.properties attribute.
             """))
 parser.add_option("-r", "--repository", dest='repository', metavar="PATH",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             Repository for use by buildbot slaves to checkout code.
             This becomes the Change.repository attribute.
             Exmaple: :ext:myhost:/cvsroot
             """))
 parser.add_option("-P", "--project", dest='project', metavar="PROJ",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             The project for the source. Often set to the CVS module being modified. This becomes
             the Change.project attribute.
             """))
 parser.add_option("-v", "--verbose", dest='verbosity', action="count",
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             Print more detail. Shows the response status and reason received from the master. If
             specified twice, it also shows the raw response.
             """))
 parser.add_option("-H", "--host", dest='host', metavar="HOST",
                   default='localhost:8010',
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             Host and optional port of buildbot. For example, bbhost:8010
             Defaults to %default
             """))
 parser.add_option("-u", "--urlpath", dest='urlpath', metavar="URLPATH",
                   default='/change_hook/base',
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             Path portion of URL. Defaults to %default
             """))
 parser.add_option("-t", "--testing", action="store_true", dest="amTesting", default=False,
-            help=textwrap.dedent("""\
+                  help=textwrap.dedent("""\
             Just print values and exit.
             """))
 parser.set_defaults(properties={})

--- a/master/contrib/svn_buildbot.py
+++ b/master/contrib/svn_buildbot.py
@@ -18,6 +18,7 @@
 
 from __future__ import division
 from __future__ import print_function
+from future.utils import text_type
 
 import commands
 import os
@@ -25,7 +26,6 @@ import re
 import sets
 import sys
 
-from future.utils import text_type
 from twisted.cred import credentials
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -40,7 +40,6 @@ from twisted.spread import pb
 /path/to/svn_buildbot.py --repository "$REPOS" --revision "$REV" \
 --bbserver localhost --bbport 9989 --username myuser --auth passwd
 '''
-
 
 
 # We have hackish "-d" handling here rather than in the Options

--- a/master/contrib/svn_watcher.py
+++ b/master/contrib/svn_watcher.py
@@ -212,7 +212,8 @@ if __name__ == '__main__':
     # if watch is specified, run until stopped
     if opts.watch or opts.interval:
         oldRevision = -1
-        print("Watching for changes in repo %s for master %s." % (repo_url, bbmaster))
+        print("Watching for changes in repo %s for master %s." %
+              (repo_url, bbmaster))
         while True:
             try:
                 oldRevision = checkChanges(repo_url, bbmaster, oldRevision)

--- a/master/contrib/trac/bbwatcher/api.py
+++ b/master/contrib/trac/bbwatcher/api.py
@@ -1,7 +1,8 @@
+from future.builtins import range
+
 import urlparse
 import xmlrpclib
 
-from future.builtins import range
 from model import Build
 from model import Builder
 
@@ -14,7 +15,8 @@ class BuildBotSystem(object):
             url = '%s://%s/xmlrpc' % (scheme, loc)
             self.server = xmlrpclib.ServerProxy(url)
         except Exception as e:
-            raise ValueError('Invalid BuildBot XML-RPC server %s: %s' % (url, e))
+            raise ValueError(
+                'Invalid BuildBot XML-RPC server %s: %s' % (url, e))
 
     def getAllBuildsInInterval(self, start, stop):
         return self.server.getAllBuildsInInterval(start, stop)

--- a/master/contrib/viewcvspoll.py
+++ b/master/contrib/viewcvspoll.py
@@ -7,14 +7,13 @@ import os.path
 import time
 
 import MySQLdb  # @UnresolvedImport
+
 from twisted.cred import credentials
 from twisted.internet import reactor
 from twisted.python import log
 from twisted.spread import pb
 
 """Based on the fakechanges.py contrib script"""
-
-
 
 
 class ViewCvsPoller:

--- a/master/contrib/webhook_status.py
+++ b/master/contrib/webhook_status.py
@@ -1,6 +1,7 @@
+from future.utils import string_types
+
 import urllib
 
-from future.utils import string_types
 from twisted.internet import reactor
 from twisted.python import log
 from twisted.web import client

--- a/master/docs/bbdocs/ext.py
+++ b/master/docs/bbdocs/ext.py
@@ -13,8 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
-from docutils import nodes
 from future.utils import iteritems
+
+from docutils import nodes
 from sphinx import addnodes
 from sphinx.domains import Domain
 from sphinx.domains import Index
@@ -72,7 +73,8 @@ class BBRefTargetDirective(Directive):
             else:
                 indextype = 'single'
                 indexentry = tpl % (fullname,)
-            entries.append((indextype, indexentry, targetname, targetname, None))
+            entries.append(
+                (indextype, indexentry, targetname, targetname, None))
 
         if entries:
             inode = addnodes.index(entries=entries)
@@ -216,10 +218,10 @@ class BBDomain(Domain):
                                               'single: %s Build Step',
                                           ]),
         'reporter': make_ref_target_directive('reporter',
-                                            indextemplates=[
-                                                'single: Reporter Targets; %s',
-                                                'single: %s Reporter Target',
-                                            ]),
+                                              indextemplates=[
+                                                  'single: Reporter Targets; %s',
+                                                  'single: %s Reporter Target',
+                                              ]),
         'worker': make_ref_target_directive('worker',
                                             indextemplates=[
                                                 'single: Build Workers; %s',
@@ -239,7 +241,8 @@ class BBDomain(Domain):
                                          doc_field_types=[
                                              TypedField('key', label='Keys', names=('key',),
                                                         typenames=('type',), can_collapse=True),
-                                             Field('var', label='Variable', names=('var',)),
+                                             Field('var', label='Variable',
+                                                   names=('var',)),
                                          ]),
         'event': make_ref_target_directive('event',
                                            indextemplates=[
@@ -271,16 +274,16 @@ class BBDomain(Domain):
                                                           can_collapse=True),
                                            ]),
         'raction': make_ref_target_directive('raction',
-                                           indextemplates=[
-                                               'single: Resource Action; %s',
-                                           ],
-                                           name_annotation='POST with method:',
-                                           has_content=True,
-                                           doc_field_types=[
-                                               TypedField('body', label='Body keys',
-                                                          names=('body',), typenames=('type',),
-                                                          can_collapse=True),
-                                           ]),
+                                             indextemplates=[
+                                                 'single: Resource Action; %s',
+                                             ],
+                                             name_annotation='POST with method:',
+                                             has_content=True,
+                                             doc_field_types=[
+                                                 TypedField('body', label='Body keys',
+                                                            names=('body',), typenames=('type',),
+                                                            can_collapse=True),
+                                             ]),
     }
 
     roles = {

--- a/worker/buildbot_worker/commands/utils.py
+++ b/worker/buildbot_worker/commands/utils.py
@@ -13,9 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from future.utils import text_type
+
 import os
 
-from future.utils import text_type
 from twisted.python import log
 from twisted.python import runtime
 from twisted.python.procutils import which

--- a/worker/buildbot_worker/monkeypatches/bug4881.py
+++ b/worker/buildbot_worker/monkeypatches/bug4881.py
@@ -14,8 +14,9 @@
 #
 # Copyright Buildbot Team Members
 
-import os
 from future.utils import lrange
+
+import os
 
 from twisted.internet import process
 from twisted.python import log

--- a/worker/buildbot_worker/monkeypatches/testcase_assert.py
+++ b/worker/buildbot_worker/monkeypatches/testcase_assert.py
@@ -14,9 +14,10 @@
 # Copyright Buildbot Team Members
 
 
+from future.utils import string_types
+
 import re
 import unittest
-from future.utils import string_types
 
 
 def _assertRaisesRegexp(self, expected_exception, expected_regexp,

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -17,6 +17,11 @@
 Support for running 'shell commands'
 """
 
+from future.builtins import range
+from future.utils import iteritems
+from future.utils import string_types
+from future.utils import text_type
+
 import os
 import pprint
 import re
@@ -28,10 +33,6 @@ import traceback
 from collections import deque
 from tempfile import NamedTemporaryFile
 
-from future.builtins import range
-from future.utils import iteritems
-from future.utils import string_types
-from future.utils import text_type
 from twisted.internet import defer
 from twisted.internet import error
 from twisted.internet import protocol

--- a/worker/buildbot_worker/scripts/windows_service.py
+++ b/worker/buildbot_worker/scripts/windows_service.py
@@ -65,12 +65,11 @@
 
 from __future__ import division
 from __future__ import print_function
+from future.builtins import range
 
 import os
 import sys
 import threading
-
-from future.builtins import range
 
 import pywintypes
 import servicemanager
@@ -234,7 +233,8 @@ class BBService(win32serviceutil.ServiceFramework):
             self.info("Starting BuildBot in directory '%s'" % (bbdir, ))
             hstop = self.hWaitStop
 
-            cmd = '%s --spawn %d start --nodaemon %s' % (self.runner_prefix, hstop, bbdir)
+            cmd = '%s --spawn %d start --nodaemon %s' % (
+                self.runner_prefix, hstop, bbdir)
             # print "cmd is", cmd
             h, t, output = self.createProcess(cmd)
             child_infos.append((bbdir, h, t, output))

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -13,12 +13,14 @@
 #
 # Copyright Buildbot Team Members
 
+from future.builtins import range
+
 import multiprocessing
 import os
 import shutil
 
 import mock
-from future.builtins import range
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import task

--- a/worker/buildbot_worker/test/unit/test_bot_Worker.py
+++ b/worker/buildbot_worker/test/unit/test_bot_Worker.py
@@ -18,6 +18,7 @@ import shutil
 import socket
 
 from mock import Mock
+
 from twisted.cred import checkers
 from twisted.cred import portal
 from twisted.internet import defer

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -22,6 +22,7 @@ import sys
 import time
 
 from mock import Mock
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import task

--- a/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
@@ -16,6 +16,7 @@
 import os
 
 import mock
+
 from twisted.trial import unittest
 
 from buildbot_worker.scripts import create_worker
@@ -645,7 +646,8 @@ class TestCreateWorker(misc.StdoutAssertionsMixin, unittest.TestCase):
         won't break generated TAC file.
         """
 
-        p = mock.patch.dict(self.options, {"basedir": r"C:\buildbot-worker dir\\"})
+        p = mock.patch.dict(
+            self.options, {"basedir": r"C:\buildbot-worker dir\\"})
         p.start()
         try:
             self.assertTACFileContents(self.options)

--- a/worker/buildbot_worker/test/unit/test_scripts_restart.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_restart.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import mock
+
 from twisted.trial import unittest
 
 from buildbot_worker.scripts import restart

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -17,6 +17,7 @@ import os
 import sys
 
 import mock
+
 from twisted.python import log
 from twisted.python import usage
 from twisted.trial import unittest

--- a/worker/buildbot_worker/test/unit/test_scripts_start.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_start.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import mock
+
 from twisted.trial import unittest
 
 from buildbot_worker.scripts import start

--- a/worker/buildbot_worker/test/unit/test_scripts_stop.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_stop.py
@@ -19,6 +19,7 @@ import signal
 import time
 
 import mock
+
 from twisted.trial import unittest
 
 from buildbot_worker.scripts import stop

--- a/worker/buildbot_worker/test/util/misc.py
+++ b/worker/buildbot_worker/test/util/misc.py
@@ -23,6 +23,9 @@ try:
 except ImportError:
     # Python 3
     import builtins
+from future.utils import PY3
+from future.utils import string_types
+
 import errno
 import os
 import re
@@ -32,8 +35,7 @@ from io import BytesIO
 from io import StringIO
 
 import mock
-from future.utils import PY3
-from future.utils import string_types
+
 from twisted.python import log
 
 from buildbot_worker.scripts import base

--- a/worker/buildbot_worker/util.py
+++ b/worker/buildbot_worker/util.py
@@ -13,10 +13,11 @@
 #
 # Copyright Buildbot Team Members
 
+from future.utils import string_types
+
 import itertools
 import textwrap
 import time
-from future.utils import string_types
 
 
 def remove_userpassword(url):


### PR DESCRIPTION
move future library on top of the imports
put twisted+zope+autobahn appart from the other 3rd party

We discussed on the stringio PR that we would put the future at the same place as the stdlib.
I wasn't able to do that, isort will always put the __future__ import at the same place as the future imports.
I think actually it is better to put future at the same place as __future__ (__future__ is required to be always first by python anyway)