### PR TITLE
Singleton service

### DIFF
--- a/master/buildbot/test/unit/test_util_service.py
+++ b/master/buildbot/test/unit/test_util_service.py
@@ -715,31 +715,31 @@ class BuildbotServiceManager(unittest.TestCase):
             'name': 'services'})
 
 
-class UnderTestSingletonService(service.SingletonService):
+class UnderTestSharedService(service.SharedService):
     def __init__(self, arg1=None):
-        service.SingletonService.__init__(self)
+        service.SharedService.__init__(self)
 
 
 class UnderTestDependentService(service.AsyncService):
     @defer.inlineCallbacks
     def startService(self):
-        self.dependent = yield UnderTestSingletonService.getService(self.parent)
+        self.dependent = yield UnderTestSharedService.getService(self.parent)
 
     def stopService(self):
         assert self.dependent.running
 
 
-class SingletonService(unittest.SynchronousTestCase):
+class SharedService(unittest.SynchronousTestCase):
     def test_bad_constructor(self):
         parent = service.AsyncMultiService()
-        self.failureResultOf(UnderTestSingletonService.getService(parent, arg2="foo"))
+        self.failureResultOf(UnderTestSharedService.getService(parent, arg2="foo"))
 
     def test_creation(self):
         parent = service.AsyncMultiService()
-        r = self.successResultOf(UnderTestSingletonService.getService(parent))
-        r2 = self.successResultOf(UnderTestSingletonService.getService(parent))
-        r3 = self.successResultOf(UnderTestSingletonService.getService(parent, "arg1"))
-        r4 = self.successResultOf(UnderTestSingletonService.getService(parent, "arg1"))
+        r = self.successResultOf(UnderTestSharedService.getService(parent))
+        r2 = self.successResultOf(UnderTestSharedService.getService(parent))
+        r3 = self.successResultOf(UnderTestSharedService.getService(parent, "arg1"))
+        r4 = self.successResultOf(UnderTestSharedService.getService(parent, "arg1"))
         self.assertIdentical(r, r2)
         self.assertNotIdentical(r, r3)
         self.assertIdentical(r3, r4)
@@ -748,7 +748,7 @@ class SingletonService(unittest.SynchronousTestCase):
     def test_startup(self):
         """the service starts when parent starts and stop"""
         parent = service.AsyncMultiService()
-        r = self.successResultOf(UnderTestSingletonService.getService(parent))
+        r = self.successResultOf(UnderTestSharedService.getService(parent))
         self.assertEqual(r.running, 0)
         self.successResultOf(parent.startService())
         self.assertEqual(r.running, 1)
@@ -759,9 +759,9 @@ class SingletonService(unittest.SynchronousTestCase):
         """the service starts during the getService if parent already started"""
         parent = service.AsyncMultiService()
         self.successResultOf(parent.startService())
-        r = self.successResultOf(UnderTestSingletonService.getService(parent))
+        r = self.successResultOf(UnderTestSharedService.getService(parent))
         self.assertEqual(r.running, 1)
-        # then we stop the parent, and the singleton stops
+        # then we stop the parent, and the shared service stops
         self.successResultOf(parent.stopService())
         self.assertEqual(r.running, 0)
 

--- a/master/buildbot/test/unit/test_util_service.py
+++ b/master/buildbot/test/unit/test_util_service.py
@@ -713,3 +713,61 @@ class BuildbotServiceManager(unittest.TestCase):
                 'kwargs': {'a': 2},
                 'name': 'basic'}],
             'name': 'services'})
+
+
+class UnderTestSingletonService(service.SingletonService):
+    def __init__(self, arg1=None):
+        service.SingletonService.__init__(self)
+
+
+class UnderTestDependentService(service.AsyncService):
+    @defer.inlineCallbacks
+    def startService(self):
+        self.dependent = yield UnderTestSingletonService.getService(self.parent)
+
+    def stopService(self):
+        assert self.dependent.running
+
+
+class SingletonService(unittest.SynchronousTestCase):
+    def test_bad_constructor(self):
+        parent = service.AsyncMultiService()
+        self.failureResultOf(UnderTestSingletonService.getService(parent, arg2="foo"))
+
+    def test_creation(self):
+        parent = service.AsyncMultiService()
+        r = self.successResultOf(UnderTestSingletonService.getService(parent))
+        r2 = self.successResultOf(UnderTestSingletonService.getService(parent))
+        r3 = self.successResultOf(UnderTestSingletonService.getService(parent, "arg1"))
+        r4 = self.successResultOf(UnderTestSingletonService.getService(parent, "arg1"))
+        self.assertIdentical(r, r2)
+        self.assertNotIdentical(r, r3)
+        self.assertIdentical(r3, r4)
+        self.assertEqual(len(list(iter(parent))), 2)
+
+    def test_startup(self):
+        """the service starts when parent starts and stop"""
+        parent = service.AsyncMultiService()
+        r = self.successResultOf(UnderTestSingletonService.getService(parent))
+        self.assertEqual(r.running, 0)
+        self.successResultOf(parent.startService())
+        self.assertEqual(r.running, 1)
+        self.successResultOf(parent.stopService())
+        self.assertEqual(r.running, 0)
+
+    def test_already_started(self):
+        """the service starts during the getService if parent already started"""
+        parent = service.AsyncMultiService()
+        self.successResultOf(parent.startService())
+        r = self.successResultOf(UnderTestSingletonService.getService(parent))
+        self.assertEqual(r.running, 1)
+        # then we stop the parent, and the singleton stops
+        self.successResultOf(parent.stopService())
+        self.assertEqual(r.running, 0)
+
+    def test_already_stopped_last(self):
+        parent = service.AsyncMultiService()
+        o = UnderTestDependentService()
+        o.setServiceParent(parent)
+        self.successResultOf(parent.startService())
+        self.successResultOf(parent.stopService())

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -127,6 +127,7 @@ class SharedService(AsyncMultiService):
         try:
             instance = cls(*args, **kwargs)
         except Exception:
+            # we transform all exceptions into failure
             return defer.fail(failure.Failure())
         # The class is not required to initialized its name
         # but we use the name to identify the instance in the parent service

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -116,7 +116,7 @@ class MasterService(AsyncMultiService):
         return self
 
 
-class SingletonService(AsyncMultiService):
+class SharedService(AsyncMultiService):
     """a service that is created only once per parameter set in a parent service"""
 
     @classmethod
@@ -137,7 +137,7 @@ class SingletonService(AsyncMultiService):
         @d.addCallback
         def returnInstance(res):
             # we put the service on top of the list, so that it is stopped the last
-            # This make sense as the singleton service is used as a dependency
+            # This make sense as the shared service is used as a dependency
             # for other service
             parent.services.remove(instance)
             parent.services.insert(0, instance)

--- a/master/buildbot/worker/hyper.py
+++ b/master/buildbot/worker/hyper.py
@@ -46,9 +46,14 @@ class HyperLatentManager(service.SharedService):
     """A shared service class that manages all the connections to the hyper cloud
 
     There is one instance of this manager per host, accesskey, secretkey tuple.
-    This manager manages its own thread pull, as Hyper_sh is blocking
+    This manager manages its own thread pull, as Hyper_sh is blocking.
+
+    You can change the maximum number of concurent access to hyper using
+
+    import buildbot.worker.hyper
+    buildbot.worker.hyper.HyperLatentManager.MAX_THREADS = 1
+    This feature is undocumented for now, as we are not sure if this is ideal API.
     """
-    name = "HyperLatentManager"
     MAX_THREADS = 5
 
     def __init__(self, hyper_host, hyper_accesskey, hyper_secretkey):

--- a/master/buildbot/worker/hyper.py
+++ b/master/buildbot/worker/hyper.py
@@ -42,8 +42,8 @@ except ImportError:
 log = Logger()
 
 
-class HyperLatentManager(service.SingletonService):
-    """A singleton class that manages all the connections to the hyper cloud
+class HyperLatentManager(service.SharedService):
+    """A shared service class that manages all the connections to the hyper cloud
 
     There is one instance of this manager per host, accesskey, secretkey tuple.
     This manager manages its own thread pull, as Hyper_sh is blocking
@@ -52,7 +52,7 @@ class HyperLatentManager(service.SingletonService):
     MAX_THREADS = 5
 
     def __init__(self, hyper_host, hyper_accesskey, hyper_secretkey):
-        service.SingletonService.__init__(self)
+        service.SharedService.__init__(self)
         # Prepare the parameters for the Docker Client object.
         self._client_args = {'clouds': {
             hyper_host: {

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -891,7 +891,7 @@ For example, a particular daily scheduler could be configured on multiple master
     This class implements a generic Service that needs to be instantiated as a singleton according to its parameters.
     It is a common use case to need this for accessing remote services.
     Having a singleton to access a remote allows to limit the number of simultaneous access to the same services.
-    Thus, several completely independent buildbot services can use that singleton to access the service, and automatically synchronize themselves to not overwhelm it.
+    Thus, several completely independent Buildbot services can use that singleton to access the service, and automatically synchronize themselves to not overwhelm it.
 
     .. py:method:: __init__(self, *args, **kwargs)
 
@@ -909,8 +909,8 @@ For example, a particular daily scheduler could be configured on multiple master
         Class method.
         Takes same arguments as the constructor of the service.
         Get a unique name for that instance of a service.
-        Used to decide if we need to create a new object.
-        Default implementation will hash args and kwargs and use ``<classname>_<hash>`` as the name
+        This returned name is the key inside the parent's service dictionary that is used to decide if the instance has already been created before or if there is a need to create a new object.
+        Default implementation will hash args and kwargs and use ``<classname>_<hash>`` as the name.
 
     .. py:method:: getService(cls, parentService, *args, **kwargs)
 
@@ -921,8 +921,6 @@ For example, a particular daily scheduler could be configured on multiple master
         Takes same arguments as the constructor of the service (plus the `parentService` at the beginning of the list).
         Construct an instance of the service if needed, and place it at the beginning of the `parentService` service list.
         Placing it at the beginning will guarantee that the singleton will be stopped after the other services.
-
-
 
 .. py:class:: BuildbotService
 

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -262,7 +262,7 @@ Several small utilities are available at the top-level :mod:`buildbot.util` pack
 
         maximum allowed size of the cache
 
-    .. py:method:: get(key, \*\*miss_fn_kwargs)
+    .. py:method:: get(key, **miss_fn_kwargs)
 
         :param key: cache key
         :param miss_fn_kwargs: keyword arguments to the ``miss_fn``
@@ -359,7 +359,7 @@ For example::
 
 The package defines "later" as "next time the reactor has control", so this is a good way to avoid long loops that block other activity in the reactor.
 
-.. py:function:: eventually(cb, *args, \*\*kwargs)
+.. py:function:: eventually(cb, *args, **kwargs)
 
     :param cb: callable to invoke later
     :param args: args to pass to ``cb``
@@ -808,7 +808,7 @@ The first two classes are more robust implementations of two Twisted classes, an
 
 .. class:: AsyncMultiService
 
-    This class is similar to :py:class:`twisted.application.service.MultiService`, except that it handles Deferreds returned from child services` ``startService`` and ``stopService`` methods.
+    This class is similar to :py:class:`twisted.application.service.MultiService`, except that it handles Deferreds returned from child services ``startService`` and ``stopService`` methods.
 
     Twisted's service implementation does not support asynchronous ``startService`` methods.
     The reasoning is that all services should start at process startup, with no need to coordinate between them.
@@ -886,23 +886,25 @@ For example, a particular daily scheduler could be configured on multiple master
         Therefore, in this method it is safe to reassign the "active" status to another instance.
         This method may return a Deferred.
 
-.. py:class:: SingletonService
+.. py:class:: SharedService
 
-    This class implements a generic Service that needs to be instantiated as a singleton according to its parameters.
+    This class implements a generic Service that needs to be instantiated only once according to its parameters.
     It is a common use case to need this for accessing remote services.
-    Having a singleton to access a remote allows to limit the number of simultaneous access to the same services.
-    Thus, several completely independent Buildbot services can use that singleton to access the service, and automatically synchronize themselves to not overwhelm it.
+    Having a shared service allows to limit the number of simultaneous access to the same remote service.
+    Thus, several completely independent Buildbot services can use that :py:class:`SharedService` to access the remote service, and automatically synchronize themselves to not overwhelm it.
 
     .. py:method:: __init__(self, *args, **kwargs)
 
         Constructor of the service.
 
-        Note that unlike :py:class:`BuildbotService` SingletonService is not reconfigurable, and uses the classical constructor method
+        Note that unlike :py:class:`BuildbotService`, :py:class:`SharedService` is not reconfigurable and uses the classical constructor method.
 
         Reconfigurability would mean to add some kind of reference counting of the users, which will make the design much more complicated to use.
-        This means that the SingletonService will not be destroyed when there is no more users, it will be destroyed at the master's stopService
+        This means that the SharedService will not be destroyed when there is no more users, it will be destroyed at the master's stopService
+        It is important that those :py:class:`SharedService` life cycles are properly handled.
+        Twisted will indeed wait for any thread pool to finish at master stop, which will not happen if the thread pools are not properly closed.
 
-        The lifecycle of the SingletonService is the same as a service, it must implement startService and stopService in order to allocate and free its resources.
+        The lifecycle of the SharedService is the same as a service, it must implement startService and stopService in order to allocate and free its resources.
 
     .. py:method:: getName(cls, *args, **kwargs)
 
@@ -914,13 +916,13 @@ For example, a particular daily scheduler could be configured on multiple master
 
     .. py:method:: getService(cls, parentService, *args, **kwargs)
 
-        :param parentService: an AsyncMultiService class where to lookup and register the singleton (usually the root service, the master)
+        :param parentService: an :py:class:`AsyncMultiService` where to lookup and register the :py:class:`SharedService` (usually the root service, the master)
         :returns: instance of the service via Deferred
 
         Class method.
         Takes same arguments as the constructor of the service (plus the `parentService` at the beginning of the list).
         Construct an instance of the service if needed, and place it at the beginning of the `parentService` service list.
-        Placing it at the beginning will guarantee that the singleton will be stopped after the other services.
+        Placing it at the beginning will guarantee that the :py:class:`SharedService` will be stopped after the other services.
 
 .. py:class:: BuildbotService
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -66,6 +66,9 @@ Changes for Developers
 Features
 ~~~~~~~~
 
+* New :class:`SharedService` can be used by steps, reporters, etc to implement per master resource limit.
+
+
 Fixes
 ~~~~~
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -648,6 +648,7 @@ recomended
 reconf
 reconfig
 reconfigService
+Reconfigurability
 refactored
 refactoring
 Refactoring


### PR DESCRIPTION

This class implements a generic Service that needs to be instantiated as a singleton according to its parameters.
It is a common use case to need this for accessing remote services.
Having a singleton to access a remote allows to limit the number of simultaneous access to the same services.
Thus, several completely independent buildbot services can use that singleton to access the service, and automatically synchronize themselves to not overwhelm it.