### PR TITLE
Case change on Twisted package name

### DIFF
--- a/worker/buildbot_worker/monkeypatches/__init__.py
+++ b/worker/buildbot_worker/monkeypatches/__init__.py
@@ -26,14 +26,14 @@ def patch_bug4881():
         return
 
     # this bug was only present in Twisted-10.2.0
-    if twisted.version == versions.Version('twisted', 10, 2, 0):
+    if twisted.version == versions.Version(twisted.version.package, 10, 2, 0):
         from buildbot_worker.monkeypatches import bug4881
         bug4881.patch()
 
 
 def patch_bug5079():
     # this bug will hopefully be patched in Twisted-12.0.0
-    if twisted.version < versions.Version('twisted', 12, 0, 0):
+    if twisted.version < versions.Version(twisted.version.package, 12, 0, 0):
         from buildbot_worker.monkeypatches import bug5079
         bug5079.patch()
 


### PR DESCRIPTION
After [this commit](https://github.com/twisted/twisted/commit/4bb0e5a93b57db06202e03388695ee6995bb4459) ``twisted.version.package`` return "Twisted" instead "twisted" which make comparison failing

```
>>> import twisted
>>> from twisted.python import versions
>>> twisted.version
Version('Twisted', 16, 5, 0, release_candidate=1)
>>> twisted.version.package
'Twisted'

>>> twisted.version == versions.Version('twisted', 10, 2, 0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/srv/buildbot-worker/local/lib/python2.7/site-packages/incremental/__init__.py", line 341, in __cmp__
    % (self.package, other.package))
incremental.IncomparableVersions: 'Twisted' != 'twisted'
>>> twisted.version == versions.Version('Twisted', 10, 2, 0)
False

```

full trace-back from twisted.log:
```
2016-10-12 14:23:04+0200 [-] Loading buildbot.tac...
2016-10-12 14:23:04+0200 [-] Loaded.
2016-10-12 14:23:04+0200 [-] twistd 16.5.0rc1 (/srv/buildbot-worker/bin/python 2.7.3) starting up.
2016-10-12 14:23:04+0200 [-] reactor class: twisted.internet.epollreactor.EPollReactor.
2016-10-12 14:23:04+0200 [-] Traceback (most recent call last):
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/bin/buildbot-worker", line 4, in <module>
2016-10-12 14:23:04+0200 [-] runner.run()
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/buildbot_worker/scripts/runner.py", line 254, in run
2016-10-12 14:23:04+0200 [-] sys.exit(subcommandFunction(subconfig))
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/buildbot_worker/scripts/restart.py", line 38, in restart
2016-10-12 14:23:04+0200 [-] return start.startWorker(basedir, quiet, config['nodaemon'])
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/buildbot_worker/scripts/start.py", line 101, in startWorker
2016-10-12 14:23:04+0200 [-] return launch(nodaemon)
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/buildbot_worker/scripts/start.py", line 148, in launch
2016-10-12 14:23:04+0200 [-] run()
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/twisted/scripts/twistd.py", line 29, in run
2016-10-12 14:23:04+0200 [-] app.run(runApp, ServerOptions)
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/twisted/application/app.py", line 648, in run
2016-10-12 14:23:04+0200 [-] runApp(config)
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/twisted/scripts/twistd.py", line 25, in runApp
2016-10-12 14:23:04+0200 [-] _SomeApplicationRunner(config).run()
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/twisted/application/app.py", line 383, in run
2016-10-12 14:23:04+0200 [-] self.postApplication()
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/twisted/scripts/_twistd_unix.py", line 248, in postApplication
2016-10-12 14:23:04+0200 [-] self.startApplication(self.application)
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/twisted/scripts/_twistd_unix.py", line 444, in startApplication
2016-10-12 14:23:04+0200 [-] app.startApplication(application, not self.config['no_save'])
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/twisted/application/app.py", line 664, in startApplication
2016-10-12 14:23:04+0200 [-] service.IService(application).startService()
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/twisted/application/service.py", line 283, in startService
2016-10-12 14:23:04+0200 [-] service.startService()
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/buildbot_worker/pb.py", line 185, in startService
2016-10-12 14:23:04+0200 [-] WorkerBase.startService(self)
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/buildbot_worker/base.py", line 355, in startService
2016-10-12 14:23:04+0200 [-] monkeypatches.patch_all()
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/buildbot_worker/monkeypatches/__init__.py", line 54, in patch_all
2016-10-12 14:23:04+0200 [-] patch_bug4881()
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/buildbot_worker/monkeypatches/__init__.py", line 29, in patch_bug4881
2016-10-12 14:23:04+0200 [-] if twisted.version == versions.Version('twisted', 10, 2, 0):
2016-10-12 14:23:04+0200 [-] File "/srv/buildbot-worker/local/lib/python2.7/site-packages/incremental/__init__.py", line 341, in __cmp__
2016-10-12 14:23:04+0200 [-] % (self.package, other.package))
2016-10-12 14:23:04+0200 [-] incremental.IncomparableVersions: 'Twisted' != 'twisted'
```