### PR TITLE
Fix the documentation about the HttpStatusPush

### DIFF
--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -766,7 +766,7 @@ HttpStatusPush
 ::
 
     from buildbot.plugins import reporters
-    sp = reporters.HttpStatusPush(serverUrl="http://example.com/submit")
+    sp = reporters.HttpStatusPush(serverUrl="http://example.com/submit", user="jdoe", password="S3cre1")
     c['services'].append(sp)
 
 :class:`HttpStatusPush` builds on :class:`StatusPush` and sends HTTP requests to ``serverUrl``, with all the items json-encoded.


### PR DESCRIPTION
user and password are actually mandatory parameters.

As shortly said in IRC, I think it would make more sense to have an 'auth' parameter there, that would allow us to offer other types of authentication tham simply BasicAuth, and that would allow us to set the default to None.