### PR TITLE
Implement missing worker email in the email reporter

### DIFF
--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -137,6 +137,14 @@ class Worker(base.ResourceType):
         self.produceEvent(bs, 'disconnected')
 
     @base.updateMethod
+    @defer.inlineCallbacks
+    def workerMissing(self, workerid, masterid, last_connection, notify):
+        bs = yield self.master.data.get(('workers', workerid))
+        bs['last_connection'] = last_connection
+        bs['notify'] = notify
+        self.produceEvent(bs, 'missing')
+
+    @base.updateMethod
     def deconfigureAllWorkersForMaster(self, masterid):
         # unconfigure all workers for this master
         return self.master.db.workers.deconfigureAllWorkersForMaster(

--- a/master/buildbot/reporters/templates/missing_mail.txt
+++ b/master/buildbot/reporters/templates/missing_mail.txt
@@ -1,0 +1,10 @@
+The Buildbot working for '{{buildbot_title}}' has noticed that the worker named {{worker.name}} went away.
+
+It last disconnected at {{worker.last_connection}}.
+
+{% if 'admin' in worker['workerinfo'] %}
+The admin on record (as reported by WORKER:info/admin) was {{worker.workerinfo.admin}}.
+{% endif %}
+
+Sincerely,
+ -The Buildbot

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -510,7 +510,6 @@ class AbstractWorker(service.BuildbotService, object):
 
         return True
 
-
     def _gracefulChanged(self, graceful):
         """This is called when our graceful shutdown setting changes"""
         self.maybeShutdown()

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -16,8 +16,6 @@
 from future.utils import itervalues
 
 import time
-from email.message import Message
-from email.utils import formatdate
 
 from twisted.internet import defer
 from twisted.python import log
@@ -28,7 +26,6 @@ from buildbot import config
 from buildbot.interfaces import IWorker
 from buildbot.process import metrics
 from buildbot.process.properties import Properties
-from buildbot.reporters.mail import MailNotifier
 from buildbot.status.worker import WorkerStatus
 from buildbot.util import ascii2unicode
 from buildbot.util import service
@@ -304,26 +301,13 @@ class AbstractWorker(service.BuildbotService, object):
         # notify people, but only if we're still in the config
         if not self.parent:
             return
-
-        buildmaster = self.botmaster.master
-        status = buildmaster.getStatus()
-        text = "The Buildbot working for '%s'\n" % status.getTitle()
-        text += ("has noticed that the worker named %s went away\n" %
-                 self.name)
-        text += "\n"
-        text += ("It last disconnected at %s (buildmaster-local time)\n" %
-                 time.ctime(time.time() - self.missing_timeout))  # approx
-        text += "\n"
-        text += "The admin on record (as reported by WORKER:info/admin)\n"
-        text += "was '%s'.\n" % self.worker_status.getAdmin()
-        text += "\n"
-        text += "Sincerely,\n"
-        text += " The Buildbot\n"
-        text += " %s\n" % status.getTitleURL()
-        text += "\n"
-        text += "%s\n" % status.getURLForThing(self.worker_status)
-        subject = "Buildbot: worker %s was lost" % (self.name,)
-        return self._mail_missing_message(subject, text)
+        last_connection = time.ctime(time.time() - self.missing_timeout)
+        yield self.master.data.updates.workerMissing(
+            workerid=self.workerid,
+            masterid=self.master.masterid,
+            last_connection=last_connection,
+            notify=self.notify_on_missing
+        )
 
     def updateWorker(self):
         """Called to add or remove builders after the worker has connected.
@@ -526,34 +510,6 @@ class AbstractWorker(service.BuildbotService, object):
 
         return True
 
-    def _mail_missing_message(self, subject, text):
-        # FIXME: This should be handled properly via the event api
-        # we should send a missing message on the mq, and let any reporter
-        # handle that
-
-        # first, see if we have a MailNotifier we can use. This gives us a
-        # fromaddr and a relayhost.
-        buildmaster = self.botmaster.master
-        for st in buildmaster.services:
-            if isinstance(st, MailNotifier):
-                break
-        else:
-            # if not, they get a default MailNotifier, which always uses SMTP
-            # to localhost and uses a dummy fromaddr of "buildbot".
-            log.msg("worker-missing msg using default MailNotifier")
-            st = MailNotifier("buildbot")
-        # now construct the mail
-
-        m = Message()
-        m.set_payload(text)
-        m['Date'] = formatdate(localtime=True)
-        m['Subject'] = subject
-        m['From'] = st.fromaddr
-        recipients = self.notify_on_missing
-        m['To'] = ", ".join(recipients)
-        d = st.sendMessage(m, recipients)
-        # return the Deferred for testing purposes
-        return d
 
     def _gracefulChanged(self, graceful):
         """This is called when our graceful shutdown setting changes"""

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -15,8 +15,6 @@
 # Portions Copyright Canonical Ltd. 2009
 from future.utils import itervalues
 
-import time
-
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -178,21 +178,12 @@ class AbstractLatentWorker(AbstractWorker):
         if not self.parent or not self.notify_on_missing:
             return
 
-        buildmaster = self.botmaster.master
-        status = buildmaster.getStatus()
-        text = "The Buildbot working for '%s'\n" % status.getTitle()
-        text += ("has noticed that the latent worker named %s \n" %
-                 self.name)
-        text += "never substantiated after a request\n"
-        text += "\n"
-        text += ("The request was made at %s (buildmaster-local time)\n" %
-                 time.ctime(time.time() - self.missing_timeout))  # approx
-        text += "\n"
-        text += "Sincerely,\n"
-        text += " The Buildbot\n"
-        text += " %s\n" % status.getTitleURL()
-        subject = "Buildbot: worker %s never substantiated" % (self.name,)
-        return self._mail_missing_message(subject, text)
+        return self.master.data.updates.workerMissing(
+            workerid=self.workerid,
+            masterid=self.master.masterid,
+            last_connection="Latent worker never connected",
+            notify=self.notify_on_missing
+        )
 
     def canStartBuild(self):
         # we were disconnected, but all the builds are not yet cleaned up.

--- a/master/contrib/docker/master/buildbot.tac
+++ b/master/contrib/docker/master/buildbot.tac
@@ -1,7 +1,9 @@
 import sys
 
 from twisted.application import service
-from twisted.python.log import ILogObserver, FileLogObserver
+from twisted.python.log import FileLogObserver
+from twisted.python.log import ILogObserver
+
 from buildbot.master import BuildMaster
 
 basedir = '/var/lib/buildbot'

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -319,12 +319,20 @@ The constructor to that class takes the following arguments:
 ``subject``
     Alternatively, this is the content of the subject of the mail as string.
 
+
 ``ctx``
     This is an extension of the standard context that will be given to the templates.
     Use this to add content to the templates that is otherwise not available.
 
-    Alternatively, you can subclass MessageFormatter and override the :py:method`buildAdditionalContext` in order to grab more context from the data API.
-    :py:method`buildAdditionalContext` is given a master instance, and the ctx object, can modify the ctx object, and return a deferred.
+    Alternatively, you can subclass MessageFormatter and override the :py:meth:`buildAdditionalContext` in order to grab more context from the data API.
+
+    .. py:method:: buildAdditionalContext(master, ctx)
+
+        :param master: the master object
+        :param ctx: the context dictionary to enhance
+        :returns: optionally deferred
+
+        default implementation will add ``self.ctx`` into the current template context
 
 ``wantProperties``
     This parameter (defaults to True) will extend the content of the given ``build`` object with the Properties from the build.
@@ -373,39 +381,12 @@ List of responsible users
 
 
 MessageFormatterMissingWorkers arguments
-+++++++++++++++++++++++++++++++++++++++++
+++++++++++++++++++++++++++++++++++++++++
 The easiest way to use the ``messageFormatterMissingWorkers`` parameter is to create a new instance of the ``reporters.MessageFormatterMissingWorkers`` class.
 
-The constructor to that class takes the following arguments:
+The constructor to that class takes the same arguments as MessageFormatter, minus ``wantLogs``, ``wantProperties``, ``wantSteps``.
 
-``template_dir``
-    This is the directory that is used to look for the various templates.
-
-``template_filename``
-    This is the name of the file in the ``template_dir`` directory that will be used to generate the body of the mail.
-    It defaults to ``default_mail.txt``.
-
-``template``
-    If this parameter is set, this parameter indicates the content of the template used to generate the body of the mail as string.
-
-``template_type``
-    This indicates the type of the generated template.
-    Use either 'plain' (the default) or 'html'.
-
-``subject_filename``
-    This is the name of the file in the ``template_dir`` directory that contains the content of the subject of the mail.
-
-``subject``
-    Alternatively, this is the content of the subject of the mail as string.
-
-``ctx``
-    This is an extension of the standard context that will be given to the templates.
-    Use this to add content to the templates that is otherwise not available.
-
-    Alternatively, you can subclass MessageFormatter and override the :py:method`buildAdditionalContext` in order to grab more context from the data API.
-    :py:method`buildAdditionalContext` is given a master instance, and the ctx object, can modify the ctx object, and return a deferred.
-
-The default ctx for the missing worker email is made of:
+The default ``ctx`` for the missing worker email is made of:
 
 ``buildbot_title``
     The buildbot title as per ``c['title']`` from the ``master.cfg``

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -287,6 +287,11 @@ MailNotifier arguments
     A dictionary containing key/value pairs of extra headers to add to sent e-mails.
     Both the keys and the values may be a `Interpolate` instance.
 
+``messageFormatterMissingWorker``
+    This is an optional instance of the ``reporters.messageFormatterMissingWorker`` class that can be used to generate a custom mail message for missing workers.
+    This class uses the Jinja2_ templating language to generate the body and optionally the subject of the mails.
+    Templates can either be given inline (as string), or read from the filesystem.
+
 
 MessageFormatter arguments
 ++++++++++++++++++++++++++
@@ -317,6 +322,9 @@ The constructor to that class takes the following arguments:
 ``ctx``
     This is an extension of the standard context that will be given to the templates.
     Use this to add content to the templates that is otherwise not available.
+
+    Alternatively, you can subclass MessageFormatter and override the :py:method`buildAdditionalContext` in order to grab more context from the data API.
+    :py:method`buildAdditionalContext` is given a master instance, and the ctx object, can modify the ctx object, and return a deferred.
 
 ``wantProperties``
     This parameter (defaults to True) will extend the content of the given ``build`` object with the Properties from the build.
@@ -362,6 +370,57 @@ Worker name
 
 List of responsible users
     ``{{ blamelist | join(', ') }}``
+
+
+MessageFormatterMissingWorkers arguments
++++++++++++++++++++++++++++++++++++++++++
+The easiest way to use the ``messageFormatterMissingWorkers`` parameter is to create a new instance of the ``reporters.MessageFormatterMissingWorkers`` class.
+
+The constructor to that class takes the following arguments:
+
+``template_dir``
+    This is the directory that is used to look for the various templates.
+
+``template_filename``
+    This is the name of the file in the ``template_dir`` directory that will be used to generate the body of the mail.
+    It defaults to ``default_mail.txt``.
+
+``template``
+    If this parameter is set, this parameter indicates the content of the template used to generate the body of the mail as string.
+
+``template_type``
+    This indicates the type of the generated template.
+    Use either 'plain' (the default) or 'html'.
+
+``subject_filename``
+    This is the name of the file in the ``template_dir`` directory that contains the content of the subject of the mail.
+
+``subject``
+    Alternatively, this is the content of the subject of the mail as string.
+
+``ctx``
+    This is an extension of the standard context that will be given to the templates.
+    Use this to add content to the templates that is otherwise not available.
+
+    Alternatively, you can subclass MessageFormatter and override the :py:method`buildAdditionalContext` in order to grab more context from the data API.
+    :py:method`buildAdditionalContext` is given a master instance, and the ctx object, can modify the ctx object, and return a deferred.
+
+The default ctx for the missing worker email is made of:
+
+``buildbot_title``
+    The buildbot title as per ``c['title']`` from the ``master.cfg``
+
+``buildbot_url``
+    The buildbot title as per ``c['title']`` from the ``master.cfg``
+
+``worker``
+    The worker object as defined in the REST api plus two attributes:
+
+    ``notify``
+        List of emails to be notified for this worker.
+
+    ``last_connection``
+        String describing the approximate the time of last connection for this worker.
 
 .. _Jinja2: http://jinja.pocoo.org/docs/dev/templates/
 
@@ -888,10 +947,10 @@ It uses private token auth, and the token owner is required to have at least dev
 
 .. py:class:: GitLabStatusPush(token, startDescription=None, endDescription=None, context=None, baseURL=None, verbose=False)
 
-    :param string token: Private token of user permitted to update status for commits 
-    :param string startDescription: Description used when build starts 
-    :param string endDescription: Description used when build ends 
-    :param string context: Name of your build system, eg. continuous-integration/buildbot 
+    :param string token: Private token of user permitted to update status for commits
+    :param string startDescription: Description used when build starts
+    :param string endDescription: Description used when build ends
+    :param string context: Name of your build system, eg. continuous-integration/buildbot
     :param string baseURL: the base url of the GitLab host, up to and optionally including the first `/` of the path. Do not include /api/
     :param string verbose: Be more verbose
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -72,6 +72,8 @@ Features
 
 * The ``MessageFormatter`` class allows extending the context given to the Templates via the ``ctx`` parameter.
 
+* The new ``MessageFormatterMissingWorker`` class allows to customize the message sent when a worker is missing.
+
 .. _Hyper: https://hyper.sh
 
 Fixes
@@ -89,6 +91,7 @@ Fixes
 * Fix issues with worker disconnection.
   When a worker disconnects, its current buildstep must be interrupted and the buildrequests should be retried.
 
+* Fix the worker missing email notification.
 
 Changes for Developers
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is done via creating a custom event message
which the mail reporter can listen to
note that an irc reporter could also listen to the message and alert accordingly