### PR TITLE
Return source branch for Bitbucket PR

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -146,7 +146,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
                         comments=u'pull-request #%d: %s\n%s' % (
                             nr, title, prlink),
                         when_timestamp=datetime2epoch(updated),
-                        branch=self.branch,
+                        branch=branch,
                         category=self.category,
                         project=self.project,
                         repository=ascii2unicode(repo),


### PR DESCRIPTION
Instead of returning the source branch for a pull-request, the previous
code was returning the destination branch. This would mean the change
that was emitted would have the wrong branch details and the git
checkout would fail.
