### PR TITLE
Render OpenStackLatentWorker block devices

### DIFF
--- a/master/buildbot/test/fake/openstack.py
+++ b/master/buildbot/test/fake/openstack.py
@@ -22,20 +22,69 @@ DELETED = 'DELETED'
 ERROR = 'ERROR'
 UNKNOWN = 'UNKNOWN'
 
+TEST_UUIDS = {
+    'image': '28a65eb4-f354-4420-97dc-253b826547f7',
+    'volume': '65fbb9f1-c4d5-40a8-a233-ad47c52bb837',
+    'snapshot': 'ab89152d-3c26-4d30-9ae5-65b705f874b7',
+}
+
 
 # Parts used from novaclient
 class Client():
 
     def __init__(self, version, username, password, tenant_name, auth_url):
-        self.images = Images()
+        self.images = ItemManager()
+        self.images._add_items([Image(TEST_UUIDS['image'], 'CirrOS 0.3.4', 13287936)])
+        self.volumes = ItemManager()
+        self.volumes._add_items([Volume(TEST_UUIDS['volume'], 'CirrOS 0.3.4', 4)])
+        self.volume_snapshots = ItemManager()
+        self.volume_snapshots._add_items([Snapshot(TEST_UUIDS['snapshot'], 'CirrOS 0.3.4', 2)])
         self.servers = Servers()
 
 
-class Images():
-    images = []
+class ItemManager():
+
+    def __init__(self):
+        self._items = {}
+
+    def _add_items(self, new_items):
+        for item in new_items:
+            self._items[item.id] = item
 
     def list(self):
-        return self.images
+        return self._items.values()
+
+    def get(self, uuid):
+        if uuid in self._items:
+            return self._items[uuid]
+        else:
+            raise NotFound
+
+
+# This exists because Image needs an attribute that isn't supported by
+# namedtuple. And once the base code is there might as well have Volume and
+# Snapshot use it too.
+class Item():
+
+    def __init__(self, id, name, size):
+        self.id = id
+        self.name = name
+        self.size = size
+
+
+class Image(Item):
+
+    def __init__(self, *args, **kwargs):
+        Item.__init__(self, *args, **kwargs)
+        setattr(self, 'OS-EXT-IMG-SIZE:size', self.size)
+
+
+class Volume(Item):
+    pass
+
+
+class Snapshot(Item):
+    pass
 
 
 class Servers():

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -99,37 +99,41 @@ class TestOpenStackWorker(unittest.TestCase):
         bs.instance = mock.Mock()
         self.assertFailure(bs.start_instance(None), ValueError)
 
+    @defer.inlineCallbacks
     def test_start_instance_fail_to_find(self):
         bs = openstack.OpenStackLatentWorker(
             'bot', 'pass', **self.bs_image_args)
         bs._poll_resolution = 0
         self.patch(novaclient.Servers, 'fail_to_get', True)
-        self.assertRaises(interfaces.LatentWorkerFailedToSubstantiate,
-                          bs._start_instance)
+        yield self.assertFailure(bs.start_instance(None),
+                                 interfaces.LatentWorkerFailedToSubstantiate)
 
+    @defer.inlineCallbacks
     def test_start_instance_fail_to_start(self):
         bs = openstack.OpenStackLatentWorker(
             'bot', 'pass', **self.bs_image_args)
         bs._poll_resolution = 0
         self.patch(novaclient.Servers, 'fail_to_start', True)
-        self.assertRaises(interfaces.LatentWorkerFailedToSubstantiate,
-                          bs._start_instance)
+        yield self.assertFailure(bs.start_instance(None),
+                                 interfaces.LatentWorkerFailedToSubstantiate)
 
+    @defer.inlineCallbacks
     def test_start_instance_success(self):
         bs = openstack.OpenStackLatentWorker(
             'bot', 'pass', **self.bs_image_args)
         bs._poll_resolution = 0
-        uuid, image_uuid, time_waiting = bs._start_instance()
+        uuid, image_uuid, time_waiting = yield bs.start_instance(None)
         self.assertTrue(uuid)
         self.assertEqual(image_uuid, 'image-uuid')
         self.assertTrue(time_waiting)
 
+    @defer.inlineCallbacks
     def test_start_instance_check_meta(self):
         meta_arg = {'some_key': 'some-value'}
         bs = openstack.OpenStackLatentWorker('bot', 'pass', meta=meta_arg,
                                              **self.bs_image_args)
         bs._poll_resolution = 0
-        uuid, image_uuid, time_waiting = bs._start_instance()
+        uuid, image_uuid, time_waiting = yield bs.start_instance(None)
         self.assertIn('meta', bs.instance.boot_kwargs)
         self.assertIdentical(bs.instance.boot_kwargs['meta'], meta_arg)
 

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -91,12 +91,17 @@ class TestOpenStackWorker(unittest.TestCase):
     @defer.inlineCallbacks
     def test_getImage_callable(self):
         def image_callable(images):
-            return images[0]
+            filtered = filter(lambda i: i.id == 'uuid1', images)
+            return filtered[0].id
 
         bs = openstack.OpenStackLatentWorker('bot', 'pass', flavor=1,
                                              image=image_callable, **self.os_auth)
         os_client = bs.novaclient
-        os_client.images.images = ['uuid1', 'uuid2', 'uuid2']
+        os_client.images._add_items([
+            novaclient.Image('uuid1', 'name1', 1),
+            novaclient.Image('uuid2', 'name2', 1),
+            novaclient.Image('uuid3', 'name3', 1),
+            ])
         image_uuid = yield bs._getImage(self.build)
         self.assertEqual('uuid1', image_uuid)
 

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -97,7 +97,7 @@ class TestOpenStackWorker(unittest.TestCase):
         bs = openstack.OpenStackLatentWorker(
             'bot', 'pass', **self.bs_image_args)
         bs.instance = mock.Mock()
-        self.assertRaises(ValueError, bs.start_instance, None)
+        self.assertFailure(bs.start_instance(None), ValueError)
 
     def test_start_instance_fail_to_find(self):
         bs = openstack.OpenStackLatentWorker(

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -119,6 +119,18 @@ class TestOpenStackWorker(unittest.TestCase):
         self.patch(lw, "_start_instance", check_volume_sizes)
         yield lw.start_instance(self.build)
 
+    @defer.inlineCallbacks
+    def test_constructor_block_devices_missing(self):
+        block_devices = [
+            {'source_type': 'image', 'uuid': '9fb2e6e8-110d-4388-8c23-0fcbd1e2fcc1'},
+        ]
+
+        lw = openstack.OpenStackLatentWorker('bot', 'pass', flavor=1,
+                                             block_devices=block_devices,
+                                             **self.os_auth)
+        yield self.assertFailure(lw.start_instance(self.build),
+                                 novaclient.NotFound)
+
     def test_constructor_no_image(self):
         """
         Must have one of image or block_devices specified.

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -124,10 +124,12 @@ class OpenStackLatentWorker(AbstractLatentWorker):
             image_uuid = image
         return image_uuid
 
+    @defer.inlineCallbacks
     def start_instance(self, build):
         if self.instance is not None:
             raise ValueError('instance active')
-        return threads.deferToThread(self._start_instance)
+        res = yield threads.deferToThread(self._start_instance)
+        defer.returnValue(res)
 
     def _start_instance(self):
         image_uuid = self._getImage(self.novaclient, self.image)

--- a/master/docs/manual/cfg-workers-openstack.rst
+++ b/master/docs/manual/cfg-workers-openstack.rst
@@ -71,6 +71,7 @@ These are the same details set in either environment variables or passed as opti
 ``block_devices``
     A list of dictionaries.
     Each dictionary specifies a block device to set up during instance creation.
+    The values support using properties from the build and will be rendered when the instance is started.
 
     Supported keys
 
@@ -78,8 +79,9 @@ These are the same details set in either environment variables or passed as opti
         (required):
         The image, snapshot, or volume UUID.
     ``volume_size``
-        (required):
+        (optional):
         Size of the block device in GiB.
+        If not specified, the minimum size in GiB to contain the source will be calculated and used.
     ``device_name``
         (optional): defaults to ``vda``.
         The name of the device in the instance; e.g. vda or xda.

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -74,6 +74,9 @@ Features
 
 * The new ``MessageFormatterMissingWorker`` class allows to customize the message sent when a worker is missing.
 
+* The :bb:worker:`OpenStackLatentWorker` worker now supports rendering the block device parameters.
+  The ``volume_size`` parameter will be automatically calculated if it is ``None``.
+
 .. _Hyper: https://hyper.sh
 
 Fixes


### PR DESCRIPTION
Render the values in the `block_devices` parameter. Also support automatically calculating the `volume_size`.