### PR TITLE
Add a backport of `SynchronousTestCasa`

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -42,6 +42,12 @@ env:
   # Configuration to run `python setup.py test` to check this test runner.
   # - TWISTED=latest SQLALCHEMY=latest TESTS=setuppy_test
 
+  # Tests for the worker on old versions of twisted.
+  - TWISTED=10.2.0 SQLALCHEMY=latest TESTS=trial_worker
+  - TWISTED=11.1.0 SQLALCHEMY=latest TESTS=trial_worker
+  - TWISTED=12.2.0 SQLALCHEMY=latest TESTS=trial_worker
+  - TWISTED=13.2.0 SQLALCHEMY=latest TESTS=trial_worker
+
 cache:
   directories:
     - $HOME/.cache/pip

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -91,13 +91,13 @@ install:
       [ $TESTS != trial -a $TESTS != coverage -a $TESTS != lint -a $TESTS != js ] || \
       pip install -e pkg \
                   -e 'master[tls,test]' \
-                  -e worker \
+                  -e 'worker[test]' \
                   MySQL-python \
                   psycopg2 \
                   pg8000 \
                   codecov
 
-      [ $TESTS != trial_worker ] || pip install -e worker
+      [ $TESTS != trial_worker ] || pip install -e 'worker[test]'
 
       [ $TESTS != trial -a $TESTS != coverage ] || pip install --pre buildbot_www
       [ $TESTS != py3 ] || pip install -e worker future

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,15 +83,15 @@ install:
   - |
       [ $TESTS != trial -a $TESTS != coverage -a $TESTS != lint -a $TESTS != js ] || \
       pip install -e pkg \
-                  -e master[tls,test] \
-                  -e worker \
+                  -e 'master[tls,test]' \
+                  -e 'worker[test]' \
                   MySQL-python \
                   psycopg2 \
                   pg8000 \
 
   - |
       [ $TESTS != trial_worker ] || \
-      pip install -e worker
+      pip install -e 'worker[test]'
 
   # install buildbot_www from pip in order to run the www tests
   - "[ $TESTS != trial -a $TESTS != coverage ] || pip install --pre buildbot_www"

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -149,13 +149,6 @@ Deprecations, Removals, and Non-Compatible Changes
 * The ``template_name`` parameter of the ``MessageFormatter`` class has been deprecated in favor of ``template_filename``.
 
 
-Buildslave
-----------
-
-Deprecations, Removals, and Non-Compatible Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
 Worker
 ------
 
@@ -167,6 +160,8 @@ Changes for Developers
 
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* The worker now requires at least Twisted 10.2.0.
 
 * setup.py 'scripts' have been converted to console_scripts entry point.
   This makes them more portable and compatible with wheel format.

--- a/worker/buildbot_worker/backports/__init__.py
+++ b/worker/buildbot_worker/backports/__init__.py
@@ -1,0 +1,22 @@
+# coding=utf-8
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+try:
+    from twisted.trial.unittest import SynchronousTestCase
+except ImportError:
+    from twisted.trial.unittest import TestCase as SynchronousTestCase
+
+__all__ = ['SynchronousTestCase']

--- a/worker/buildbot_worker/test/test_util_hangcheck.py
+++ b/worker/buildbot_worker/test/test_util_hangcheck.py
@@ -14,11 +14,11 @@ from twisted.python.failure import Failure
 from twisted.spread.pb import PBClientFactory
 from twisted.test.proto_helpers import AccumulatingProtocol
 from twisted.test.proto_helpers import StringTransport
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.trial.unittest import TestCase
 from twisted.web.server import Site
 from twisted.web.static import Data
 
+from ..backports import SynchronousTestCase
 from ..util import HangCheckFactory
 from ..util._hangcheck import HangCheckProtocol
 

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -119,7 +119,7 @@ except ImportError:
     pass
 else:
     setup_args['install_requires'] = [
-        'twisted >= 8.0.0',
+        'twisted >= 10.2.0',
         'future',
     ]
 


### PR DESCRIPTION
This actually just makes `TestCase` pretend to be `SynchronousTestCase` currently, since the difference is mostly just that `SynchronousTestCase` does less. (There is also some stuff that was add to `SynchronousTestCase` that makes synchronous testing easier, but on versions with that code `TestCase` inherits from it).

This incidentally bumps the minimum version of twisted required for the worker to 10.2.0, which is 5y 12mo old, and is the old version that we tested against that supports deferred cancellation, which was used in #2464. (It was introduced in 10.1.0, bu that that wasn't in our test matrix, and 10.2.0 is plenty old enough).