### PR TITLE
secrets

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -47,6 +47,7 @@ from buildbot.process.botmaster import BotMaster
 from buildbot.process.builder import BuilderControl
 from buildbot.process.users.manager import UserManagerManager
 from buildbot.schedulers.manager import SchedulerManager
+from buildbot.secrets.manager import SecretManager
 from buildbot.status.master import Status
 from buildbot.util import ascii2unicode
 from buildbot.util import check_functional_environment
@@ -143,6 +144,8 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
     def create_child_services(self):
         # note that these are order-dependent.  If you get the order wrong,
         # you'll know it, as the master will fail to start.
+        self.secret_manager = SecretManager()
+        self.secret_manager.setServiceParent(self)
 
         self.metrics = metrics.MetricLogObserver()
         self.metrics.setServiceParent(self)

--- a/master/buildbot/secrets/__init__.py
+++ b/master/buildbot/secrets/__init__.py
@@ -1,0 +1,14 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members

--- a/master/buildbot/secrets/manager.py
+++ b/master/buildbot/secrets/manager.py
@@ -1,0 +1,70 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+"""
+manage providers and handle secrets
+"""
+from future.utils import itervalues
+from future.utils import text_type
+
+from buildbot.secrets.secret import ActualSecret
+from buildbot.secrets.secret import Secret
+from buildbot.util.service import BuildbotService
+
+
+class SecretManager(BuildbotService):
+    """
+    Secret manager
+    """
+    name = 'secrets'
+
+    config_attr = 'providers'
+
+    def getConfigDict(self):
+        return {
+            'name': self.name,
+            'providers': [
+                p.getConfigDict() for p in itervalues(self.namedServices)
+            ]
+        }
+
+    def get_provider(self, provider_name):
+        """
+        get provider by its name
+        """
+        provider = self.namedServices.get(provider_name, None)
+
+        assert provider, 'unknown secret provider: {}'.format(provider_name)
+
+    def get(self, secret, *args, **kwargs):
+        """
+        get a secret from the provider defined in the secret using args and
+        kwargs
+        """
+        allowed_types = (text_type, Secret)
+        assert isinstance(secret, allowed_types), \
+            'secret must be an instance of {!r}'.format(allowed_types)
+
+        if isinstance(secret, text_type):
+            # backward compatibility, produce a warning?
+            value, props = secret, None
+            source_name = 'Plain text secret'
+        else:
+            provider = self.get_provider(secret.provider_name)
+            value, props = provider.get(*args, **kwargs)
+            source_name = repr(provider)
+
+        return ActualSecret(
+            '{}: args={!r}, kwargs={!r}'.format(source_name, args, kwargs),
+            value, props=props)

--- a/master/buildbot/secrets/provider/__init__.py
+++ b/master/buildbot/secrets/provider/__init__.py
@@ -1,0 +1,14 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members

--- a/master/buildbot/secrets/provider/base.py
+++ b/master/buildbot/secrets/provider/base.py
@@ -1,0 +1,28 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+"""
+secret provider interface
+"""
+from buildbot.util.service import BuildbotService
+
+
+class SecretProviderBase(BuildbotService):
+    """
+    ...
+    """
+    def get(self, *args, **kwargs):
+        """
+        this should be an abstract method
+        """

--- a/master/buildbot/secrets/provider/file.py
+++ b/master/buildbot/secrets/provider/file.py
@@ -1,0 +1,48 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+"""
+file based providers
+"""
+import os
+
+from buildbot.secrets.provider.base import SecretProviderBase
+
+
+class SecretInAFile(SecretProviderBase):
+    """
+    basic provider where each secret is stored in a separate file under the
+    given directory
+    """
+    def __init__(self, name, dirname, ext=None):
+        super(SecretInAFile, self).__init__(name=name)
+
+        self._dirname = dirname
+        self._ext = ext
+
+    def get(self, entry):
+        """
+        get the value from the file identified by 'entry'
+        """
+        filename = os.path.join(self._dirname, entry)
+        if self._ext:
+            filename += self._ext
+
+        assert os.path.isfile(filename), \
+            'File {} does not exist'.format(filename)
+
+        with open(filename) as source:
+            secret = source.read().strip()
+
+        return secret, None

--- a/master/buildbot/secrets/secret.py
+++ b/master/buildbot/secrets/secret.py
@@ -1,0 +1,71 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+"""
+secrets as to be used during configuration and run-time
+"""
+
+
+class Secret(object):
+    """
+    ...
+    """
+    def __init__(self, provider_name):
+        self._provider_name = provider_name
+
+    @property
+    def provider_name(self):
+        """
+        where the secret is stored
+        """
+        return self._provider_name
+
+
+class ActualSecret(object):
+    """
+    ...
+    """
+    def __init__(self, source, value, props=None):
+        if props is None:
+            props = dict()
+
+        self._source = source
+        self._value = value
+        self._props = props
+
+    @property
+    def source(self):
+        """
+        source of the secret
+        """
+        return self._source
+
+    @property
+    def value(self):
+        """
+        secret value
+        """
+        return self._value
+
+    @property
+    def props(self):
+        """
+        possible extra properties
+        """
+        return self._props
+
+    def __str__(self):
+        return '{}: {!r}'.format(self._source, self._props)
+
+    display = __str__


### PR DESCRIPTION
A return to the topic raised in #2314.  Please note that this is in no way complete: it's only a skeleton to show the basic idea.

Design goals:
- **not** to implement any kind of sophisticated secret storage
- make it possible to implement interfaces to secret storages out there
- provide incremental path to convert to the new API

---

Let me try to write down first what I have in mind...

The `master.cfg` will have something like this

``` python
c['secrets'] = [
    ...,
    secrets.SecretInAFile('basic'),
    ...
]
```

In the places where we want to use one of the secrets provided by it, we'd refer to that particular provider as

``` python
c['workers'] = [
    ...,
    worker.Worker('user', secrets.Secret('basic'), ...),
    ...
]
```

and in the place where we actually need that secret, we'd use

``` python
    def something(user, secret, ...):
        actual_secret = self.master.secrets.get(secret, user)
        ...
        actual_secret.value
```

whatever passed to `.get` after `secret` is provider specific as well as the actual value of the secret.
