### PR TITLE
0.9.1 release notes

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -78,8 +78,6 @@ matrix:
 # Dependencies installation commands
 install:
   - pip install -U pip
-  # pycparser wheel is broken, and sometime mistakingly re-publish the wheels
-  - pip install --no-binary pycparser
   # codecov is the interface to codecov.io; see after_success
   # Install MySQL-python for tests that uses real MySQL
   # Install psycopg2 and pg8000 for tests that uses real PostgreSQL

--- a/master/docs/manual/installation/nine-upgrade.rst
+++ b/master/docs/manual/installation/nine-upgrade.rst
@@ -7,6 +7,19 @@ Upgrading a Buildbot instance from 0.8.x to 0.9.x may require a number of change
 Those changes are summarized here.
 If you are starting fresh with 0.9.0 or later, you can safely skip this section.
 
+First important note is that Buildbot does not support an upgrade of a 0.8.x instance to 0.9.x.
+Notably the build data and logs will not be accessible anymore if you upgraded, thus the database migration scripts have been dropped.
+
+You should not ``pip upgrade -U buildbot``, but rather start from a clean virtualenv aside from your old master.
+You can keep your old master instance to serve the old build status.
+
+Buildbot is now composed of several Python packages and Javascript UI, and the easiest way to install it is to run the following command within a virtualenv:
+
+.. code-block:: bash
+
+  pip install 'buildbot[bundle]'
+
+
 Config File Syntax
 ------------------
 

--- a/master/docs/relnotes/0.9.0.rst
+++ b/master/docs/relnotes/0.9.0.rst
@@ -1,11 +1,8 @@
 Release Notes for Buildbot ``0.9.0``
 ========================================
 
-.. warning::
-
-    The following are temporary release notes for unreleased version of buildbot.
-
 The following are the release notes for Buildbot ``0.9.0``.
+This version was released on October 6, 2016.
 
 This is a concatenation of important changes done between 0.8.12 and 0.9.0.
 This does not contain details of the bug fixes related to the nine beta and rc period.
@@ -655,6 +652,4 @@ For a more detailed description of the changes made in this version, see the git
 
 .. code-block:: bash
 
-   git log v0.9.0b9..v0.9.0rc1
-
-Note that Buildbot-0.8.11 was never released.
+   git log v0.8.12..v0.9.0

--- a/master/docs/relnotes/0.9.1.rst
+++ b/master/docs/relnotes/0.9.1.rst
@@ -1,0 +1,180 @@
+Release Notes for Buildbot ``0.9.1``
+========================================
+
+The following are the release notes for Buildbot ``0.9.1``.
+This version was released on October 6, 2016.
+
+This is a concatenation of important changes done between 0.8.12 and 0.9.1.
+This does not contain details of the bug fixes related to the nine beta and rc period.
+This document was written during the very long period of nine development.
+It might contain some incoherencies, *please* help us and report them on irc or trac.
+
+See :ref:`Upgrading to Nine` for a guide to upgrading from 0.8.x to 0.9.x
+
+Master
+------
+
+Features
+~~~~~~~~
+
+* Add support for hyper.sh via :class:`HyperLatentWorker`
+  Hyper_ is a CaaS solution for hosting docker container in the cloud, billed to the second.
+  It forms a very cost efficient solution to run your CI in the cloud.
+
+* The :bb:step:`Trigger` step now supports ``unimportantSchedulerNames``
+
+* add a UI button to allow to cancel the whole queue for a builder
+
+* Buildbot log viewer now support 256 colors ANSI codes
+
+* new :bb:step:`GitHub` which correctly checkout the magic branch like ``refs/pull/xx/merge``.
+
+* :class:`MailNotifier` now supports a `schedulers` constructor argument that
+  allows you to send mail only for builds triggered by the specified list of
+  schedulers.
+
+* :class:`MailNotifier` now supports a `branches` constructor argument that
+  allows you to send mail only for builds triggered by the specified list of
+  branches.
+
+* Optimization of the data api filtering, sorting and paging, speeding up a lot the UI when the master has lots of builds.
+
+* :bb:reporter:`GerritStatusPush` now accepts a ``notify`` parameter to control who gets emailed by Gerrit.
+
+* Add a ``format_fn`` parameter to the ``HttpStatusPush`` reporter to customize the information being pushed.
+
+* Latent Workers can now start in parallel.
+
+    * The build started by latent worker will be created while the latent worker is substantiated.
+
+    * Latent Workers will now report startup issues in the UI.
+
+* Workers will be temporarily put in quarantine in case of build preparation issues.
+    This avoids master and database overload in case of bad worker configuration.
+    The quarantine is implemented with an exponential back-off timer.
+
+* Master Stop will now stop all builds, and wait for all workers to properly disconnect.
+  Previously, the worker connections was stopped, which incidentally made all their builds marked retried.
+  Now, builds started with a :class:`Triggereable` scheduler will be cancelled, while other builds will be retried.
+  The master will make sure that all latent workers are stopped.
+
+* The ``MessageFormatter`` class also allows inline-templates with the ``template`` parameter.
+
+* The ``MessageFormatter`` class allows custom mail's subjects with the ``subject`` and ``subject_name`` parameters.
+
+* The ``MessageFormatter`` class allows extending the context given to the Templates via the ``ctx`` parameter.
+
+* The new ``MessageFormatterMissingWorker`` class allows to customize the message sent when a worker is missing.
+
+* The :bb:worker:`OpenStackLatentWorker` worker now supports rendering the block device parameters.
+  The ``volume_size`` parameter will be automatically calculated if it is ``None``.
+
+.. _Hyper: https://hyper.sh
+
+Fixes
+~~~~~
+
+* fix the UI to allow to cancel a buildrequest (:bug:`3582`)
+
+* :bb:chsrc:`GitHub` change hook now correctly use the refs/pull/xx/merge branch for testing PRs.
+
+* Fix the UI to better adapt to different screen width (:bug:`3614`)
+
+* Don't log :class:`AlreadyClaimedError`.
+  They are normal in case of :bb:step:`Trigger` cancelling, and in a multimaster configuration.
+
+* Fix issues with worker disconnection.
+  When a worker disconnects, its current buildstep must be interrupted and the buildrequests should be retried.
+
+* Fix the worker missing email notification.
+
+* Fix issue with worker builder list not being updated in UI when buildmaster is reconfigured (:bug:`3629`)
+
+
+Changes for Developers
+~~~~~~~~~~~~~~~~~~~~~~
+
+Features
+~~~~~~~~
+
+* New :class:`SharedService` can be used by steps, reporters, etc to implement per master resource limit.
+
+* New :class:`HttpClientService` can be used by steps, reporters, etc to implement HTTP client.
+  This class will automatically choose between `treq`_ and `txrequests`_, whichever is installed, in order to access HTTP servers.
+  This class comes with a fake implementation helping to write unit tests.
+
+* All HTTP reporters have been ported to :class:`HttpClientService`
+
+.. _txrequests: https://pypi.python.org/pypi/txrequests
+.. _treq: https://pypi.python.org/pypi/treq
+
+Fixes
+~~~~~
+
+
+Deprecations, Removals, and Non-Compatible Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* By default, non-distinct commits received via
+  :class:`buildbot.status.web.hooks.github.GitHubEventHandler` now get recorded
+  as a :class:`Change`. In this way, a commit pushed to a branch that is not
+  being watched (e.g. a dev branch) will still get acted on when it is later
+  pushed to a branch that is being watched (e.g. master). In the past, such a
+  commit would get ignored and not built because it was non-distinct. To disable
+  this behavior and revert to the old behavior, install a :class:`ChangeFilter`
+  that checks the ``github_distinct`` property:
+
+.. code-block:: python
+
+  ChangeFilter(filter_fn=lambda c: c.properties.getProperty('github_distinct'))
+
+
+* setup.py 'scripts' have been converted to console_scripts entry point.
+  This makes them more portable and compatible with wheel format.
+  Most consequences are for the windows users:
+
+  * ``buildbot.bat`` does not exist anymore, and is replaced by ``buildbot.exe``, which is generated by the console_script entrypoint.
+
+  * ``buildbot_service.py`` is replaced by ``buildbot_windows_service.exe``, which is generated by the console_script entrypoint
+    As this script has been written in 2006, has only inline documentation and no unit tests, it is not guaranteed to be working.
+    Please help improving the windows situation.
+
+* The ``user`` and ``password`` parameters of the ``HttpStatusPush`` reporter have been deprecated in favor of the ``auth`` parameter.
+
+* The ``template_name`` parameter of the ``MessageFormatter`` class has been deprecated in favor of ``template_filename``.
+
+
+Worker
+------
+
+Fixes
+~~~~~
+
+Changes for Developers
+~~~~~~~~~~~~~~~~~~~~~~
+
+Deprecations, Removals, and Non-Compatible Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* The worker now requires at least Twisted 10.2.0.
+
+* setup.py 'scripts' have been converted to console_scripts entry point.
+  This makes them more portable and compatible with wheel format.
+  Most consequences are for the windows users:
+
+  * ``buildbot_worker.bat`` does not exist anymore, and is replaced by ``buildbot_worker.exe``, which is generated by the console_script entrypoint.
+
+  * ``buildbot_service.py`` is replaced by ``buildbot_worker_windows_service.exe``, which is generated by the console_script entrypoint
+    As this script has been written in 2006, has only inline documentation and no unit tests, it is not guaranteed to be working.
+    Please help improving the windows situation.
+
+* :class:`AbstractLatentWorker` is now in :py:mod:`buildbot.worker.latent` instead of :py:mod:`buildbot.worker.base`.
+
+Details
+-------
+
+For a more detailed description of the changes made in this version, see the git log itself:
+
+.. code-block:: bash
+
+   git log v0.9.0..v0.9.1

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -11,9 +11,6 @@ Release Notes for Buildbot ``|version|``
        please point to the bug using syntax: (:bug:`NNN`)
        please point to classes using syntax: :py:class:`~buildbot.reporters.http.HttpStatusBase`
 
-..
-    NOTE: When releasing 0.9.0, combine these notes with those from 0.9.0b*
-    into one single set of notes.  Also, link prominently to the migration guide.
 
 The following are the release notes for Buildbot ``|version|``.
 
@@ -25,78 +22,8 @@ Master
 Features
 ~~~~~~~~
 
-* Add support for hyper.sh via :class:`HyperLatentWorker`
-  Hyper_ is a CaaS solution for hosting docker container in the cloud, billed to the second.
-  It forms a very cost efficient solution to run your CI in the cloud.
-
-* The :bb:step:`Trigger` step now supports ``unimportantSchedulerNames``
-
-* add a UI button to allow to cancel the whole queue for a builder
-
-* Buildbot log viewer now support 256 colors ANSI codes
-
-* new :bb:step:`GitHub` which correctly checkout the magic branch like ``refs/pull/xx/merge``.
-
-* :class:`MailNotifier` now supports a `schedulers` constructor argument that
-  allows you to send mail only for builds triggered by the specified list of
-  schedulers.
-
-* :class:`MailNotifier` now supports a `branches` constructor argument that
-  allows you to send mail only for builds triggered by the specified list of
-  branches.
-
-* Optimization of the data api filtering, sorting and paging, speeding up a lot the UI when the master has lots of builds.
-
-* :bb:reporter:`GerritStatusPush` now accepts a ``notify`` parameter to control who gets emailed by Gerrit.
-
-* Add a ``format_fn`` parameter to the ``HttpStatusPush`` reporter to customize the information being pushed.
-
-* Latent Workers can now start in parallel.
-
-    * The build started by latent worker will be created while the latent worker is substantiated.
-
-    * Latent Workers will now report startup issues in the UI.
-
-* Workers will be temporarily put in quarantine in case of build preparation issues.
-    This avoids master and database overload in case of bad worker configuration.
-    The quarantine is implemented with an exponential back-off timer.
-
-* Master Stop will now stop all builds, and wait for all workers to properly disconnect.
-  Previously, the worker connections was stopped, which incidentally made all their builds marked retried.
-  Now, builds started with a :class:`Triggereable` scheduler will be cancelled, while other builds will be retried.
-  The master will make sure that all latent workers are stopped.
-
-* The ``MessageFormatter`` class also allows inline-templates with the ``template`` parameter.
-
-* The ``MessageFormatter`` class allows custom mail's subjects with the ``subject`` and ``subject_name`` parameters.
-
-* The ``MessageFormatter`` class allows extending the context given to the Templates via the ``ctx`` parameter.
-
-* The new ``MessageFormatterMissingWorker`` class allows to customize the message sent when a worker is missing.
-
-* The :bb:worker:`OpenStackLatentWorker` worker now supports rendering the block device parameters.
-  The ``volume_size`` parameter will be automatically calculated if it is ``None``.
-
-.. _Hyper: https://hyper.sh
-
 Fixes
 ~~~~~
-
-* fix the UI to allow to cancel a buildrequest (:bug:`3582`)
-
-* :bb:chsrc:`GitHub` change hook now correctly use the refs/pull/xx/merge branch for testing PRs.
-
-* Fix the UI to better adapt to different screen width (:bug:`3614`)
-
-* Don't log :class:`AlreadyClaimedError`.
-  They are normal in case of :bb:step:`Trigger` cancelling, and in a multimaster configuration.
-
-* Fix issues with worker disconnection.
-  When a worker disconnects, its current buildstep must be interrupted and the buildrequests should be retried.
-
-* Fix the worker missing email notification.
-
-* Fix issue with worker builder list not being updated in UI when buildmaster is reconfigured (:bug:`3629`)
 
 
 Changes for Developers
@@ -105,52 +32,12 @@ Changes for Developers
 Features
 ~~~~~~~~
 
-* New :class:`SharedService` can be used by steps, reporters, etc to implement per master resource limit.
-
-* New :class:`HttpClientService` can be used by steps, reporters, etc to implement HTTP client.
-  This class will automatically choose between `treq`_ and `txrequests`_, whichever is installed, in order to access HTTP servers.
-  This class comes with a fake implementation helping to write unit tests.
-
-* All HTTP reporters have been ported to :class:`HttpClientService`
-
-.. _txrequests: https://pypi.python.org/pypi/txrequests
-.. _treq: https://pypi.python.org/pypi/treq
-
 Fixes
 ~~~~~
 
 
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-* By default, non-distinct commits received via
-  :class:`buildbot.status.web.hooks.github.GitHubEventHandler` now get recorded
-  as a :class:`Change`. In this way, a commit pushed to a branch that is not
-  being watched (e.g. a dev branch) will still get acted on when it is later
-  pushed to a branch that is being watched (e.g. master). In the past, such a
-  commit would get ignored and not built because it was non-distinct. To disable
-  this behavior and revert to the old behavior, install a :class:`ChangeFilter`
-  that checks the ``github_distinct`` property:
-
-.. code-block:: python
-
-  ChangeFilter(filter_fn=lambda c: c.properties.getProperty('github_distinct'))
-
-
-* setup.py 'scripts' have been converted to console_scripts entry point.
-  This makes them more portable and compatible with wheel format.
-  Most consequences are for the windows users:
-
-  * ``buildbot.bat`` does not exist anymore, and is replaced by ``buildbot.exe``, which is generated by the console_script entrypoint.
-
-  * ``buildbot_service.py`` is replaced by ``buildbot_windows_service.exe``, which is generated by the console_script entrypoint
-    As this script has been written in 2006, has only inline documentation and no unit tests, it is not guaranteed to be working.
-    Please help improving the windows situation.
-
-* The ``user`` and ``password`` parameters of the ``HttpStatusPush`` reporter have been deprecated in favor of the ``auth`` parameter.
-
-* The ``template_name`` parameter of the ``MessageFormatter`` class has been deprecated in favor of ``template_filename``.
-
 
 Worker
 ------
@@ -163,20 +50,6 @@ Changes for Developers
 
 Deprecations, Removals, and Non-Compatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-* The worker now requires at least Twisted 10.2.0.
-
-* setup.py 'scripts' have been converted to console_scripts entry point.
-  This makes them more portable and compatible with wheel format.
-  Most consequences are for the windows users:
-
-  * ``buildbot_worker.bat`` does not exist anymore, and is replaced by ``buildbot_worker.exe``, which is generated by the console_script entrypoint.
-
-  * ``buildbot_service.py`` is replaced by ``buildbot_worker_windows_service.exe``, which is generated by the console_script entrypoint
-    As this script has been written in 2006, has only inline documentation and no unit tests, it is not guaranteed to be working.
-    Please help improving the windows situation.
-
-* :class:`AbstractLatentWorker` is now in :py:mod:`buildbot.worker.latent` instead of :py:mod:`buildbot.worker.base`.
 
 Details
 -------
@@ -196,6 +69,7 @@ Newer versions are also available here:
 .. toctree::
     :maxdepth: 1
 
+    0.9.1
     0.9.0
     0.9.0rc4
     0.9.0rc3


### PR DESCRIPTION
This also contains merge commit of the 0.9.0 tag to master, which I forgot to push as well as cleanup of pycparse no binary which was inefficient anyway

