### PR TITLE
add qtile theme files to sdist

### DIFF
--- a/master/MANIFEST.in
+++ b/master/MANIFEST.in
@@ -8,6 +8,8 @@ include docs/*.rst
 include docs/_images/*
 include docs/_static/*
 include docs/_templates/*
+include docs/_themes/qtile/*
+include docs/_themes/qtile/static/*
 include docs/tutorial/*.rst
 include docs/tutorial/_images/*.png
 include docs/manual/*.rst


### PR DESCRIPTION
Building documentation from sdist fails as qtile theme is missing in the tarball