### PR TITLE
bugfix: cmake step now inherits from new style BuildStep

### DIFF
--- a/master/buildbot/steps/cmake.py
+++ b/master/buildbot/steps/cmake.py
@@ -17,11 +17,11 @@ from future.utils import iteritems
 from twisted.internet import defer
 
 from buildbot import config
-from buildbot.process.buildstep import LoggingBuildStep
+from buildbot.process.buildstep import BuildStep
 from buildbot.process.buildstep import ShellMixin
 
 
-class CMake(ShellMixin, LoggingBuildStep):
+class CMake(ShellMixin, BuildStep):
     DEFAULT_CMAKE = 'cmake'
 
     name = 'cmake'
@@ -53,7 +53,7 @@ class CMake(ShellMixin, LoggingBuildStep):
         self.options = options
 
         self.cmake = cmake
-
+        kwargs = self.setupShellMixin(kwargs, prohibitArgs=['command'])
         super(CMake, self).__init__(**kwargs)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_steps_cmake.py
+++ b/master/buildbot/test/unit/test_steps_cmake.py
@@ -79,6 +79,16 @@ class TestCMake(BuildStepMixin, TestCase):
         self.setupStep(CMake(definitions=definition))
         self.expect_and_run_command('-D%s=%s' % definition.items()[0])
 
+    def test_environment(self):
+        command = [CMake.DEFAULT_CMAKE]
+        environment = {'a': 'b'}
+        self.setupStep(CMake(env=environment))
+        self.expectCommands(
+            ExpectShell(
+                command=command, workdir='wkdir', env={'a': 'b'}) + 0)
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
     def test_definitions_interpolation(self):
         b_value = 'real_b'
 


### PR DESCRIPTION
Otherwise using env in cmake leads to `unkown keyword` error.
Inherting from BuildStep instead from LoggingBuildStep and modifying __init__ process according to ShellSequence seems to solve the issue for me.