### PR TITLE
Install windows service scripts only on windows.

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -376,11 +376,14 @@ setup_args = {
     ]), {
         'console_scripts': [
             'buildbot=buildbot.scripts.runner:run',
-            # this will also be shipped on non windows :-(
-            'buildbot_windows_service=buildbot.scripts.windows_service:HandleCommandLine',
         ]}
     )
 }
+
+if sys.platform == "win32":
+    setup_args['entry_points']['console_scripts'] += [
+            'buildbot_windows_service=buildbot.scripts.windows_service:HandleCommandLine',
+        ]
 
 # set zip_safe to false to force Windows installs to always unpack eggs
 # into directories, which seems to work better --

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -98,10 +98,13 @@ setup_args = {
     'entry_points': {
         'console_scripts': [
             'buildbot-worker=buildbot_worker.scripts.runner:run',
-            # this will also be shipped on non windows :-(
-            'buildbot_worker_windows_service=buildbot_worker.scripts.windows_service:HandleCommandLine',
         ]}
 }
+
+if sys.platform == "win32":
+    setup_args['entry_points']['console_scripts'] += [
+            'buildbot_worker_windows_service=buildbot_worker.scripts.windows_service:HandleCommandLine',
+        ]
 
 # set zip_safe to false to force Windows installs to always unpack eggs
 # into directories, which seems to work better --


### PR DESCRIPTION
Windows service scripts are not needed on non Windows platforms.