### PR TITLE
Use api.bitbucket.org for endpoint

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -83,7 +83,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
         self.lastPoll = time.time()
         log.msg("BitbucketPullrequestPoller: polling "
                 "Bitbucket repository %s/%s, branch: %s" % (self.owner, self.slug, self.branch))
-        url = "https://bitbucket.org/api/2.0/repositories/%s/%s/pullrequests" % (
+        url = "https://api.bitbucket.org/2.0/repositories/%s/%s/pullrequests" % (
             self.owner, self.slug)
         return client.getPage(url, timeout=self.pollInterval)
 


### PR DESCRIPTION
Using bitbucket.org/api/ endpoint has consequences that subsequent url in the results will use bitbucket.org/!api/ which intended for bitbucket own use. If someone try to add authentication support, bitbucket.org/!api/ will return 401 status code even the credentials is valid.

Reference - https://bitbucket.org/atlassian/atlassian-connect-express/pull-requests/109/use-apibitbucketorg-instead-of-api/diff