### PR TITLE
Support SSL connections in mail notifier

### DIFF
--- a/master/buildbot/newsfragments/mail_over_ssl.feature
+++ b/master/buildbot/newsfragments/mail_over_ssl.feature
@@ -1,0 +1,1 @@
+:bb:reporter:`MailNotifier` now accepts ``useSmtps`` parameter for initiating connection over an SSL/TLS encrypted connection (SMTPS)

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -112,7 +112,7 @@ class MailNotifier(service.BuildbotService):
                     lookup=None, extraRecipients=None,
                     sendToInterestedUsers=True,
                     messageFormatter=None, extraHeaders=None,
-                    addPatch=True, useTls=False, useSsl=False,
+                    addPatch=True, useTls=False, useSmtps=False,
                     smtpUser=None, smtpPassword=None, smtpPort=25,
                     name=None, schedulers=None, branches=None):
         if ESMTPSenderFactory is None:
@@ -175,7 +175,7 @@ class MailNotifier(service.BuildbotService):
                         lookup=None, extraRecipients=None,
                         sendToInterestedUsers=True,
                         messageFormatter=None, extraHeaders=None,
-                        addPatch=True, useTls=False, useSsl=False,
+                        addPatch=True, useTls=False, useSmtps=False,
                         smtpUser=None, smtpPassword=None, smtpPort=25,
                         name=None, schedulers=None, branches=None,
                         messageFormatterMissingWorker=None):
@@ -208,7 +208,7 @@ class MailNotifier(service.BuildbotService):
         self.extraHeaders = extraHeaders
         self.addPatch = addPatch
         self.useTls = useTls
-        self.useSsl = useSsl
+        self.useSmtps = useSmtps
         self.smtpUser = smtpUser
         self.smtpPassword = smtpPassword
         self.smtpPort = smtpPort
@@ -522,7 +522,7 @@ class MailNotifier(service.BuildbotService):
             result, requireTransportSecurity=self.useTls,
             requireAuthentication=useAuth)
 
-        if self.useSsl:
+        if self.useSmtps:
             reactor.connectSSL(self.relayhost, self.smtpPort, sender_factory, ssl.ClientContextFactory())
         else:
             reactor.connectTCP(self.relayhost, self.smtpPort, sender_factory)

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -19,7 +19,6 @@ import sys
 from mock import Mock
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.trial import unittest
 
 from buildbot import config
@@ -30,8 +29,8 @@ from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
-from buildbot.reporters import utils
 from buildbot.reporters import mail
+from buildbot.reporters import utils
 from buildbot.reporters.mail import MailNotifier
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
@@ -581,7 +580,6 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         text = mail.get_payload()
         self.assertIn("has noticed that the worker named myworker went away", text)
 
-
     @defer.inlineCallbacks
     def do_test_sendMessage(self, **mnKwargs):
         fakeSenderFactory = Mock()
@@ -593,7 +591,7 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
 
         mn.messageFormatter = Mock(spec=mn.messageFormatter)
         mn.messageFormatter.formatMessageForBuildResults.return_value = {"body": "body", "type": "text",
-                                            "subject": "subject"}
+                                                                         "subject": "subject"}
 
         mn.findInterrestedUsersEmails = Mock(spec=mn.findInterrestedUsersEmails)
         mn.findInterrestedUsersEmails.return_value = "<recipients>"
@@ -602,7 +600,7 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         mn.processRecipients.return_value = "<processedrecipients>"
 
         mn.createEmail = Mock(spec=mn.createEmail)
-        mn.createEmail.return_value.as_string = Mock(return_value = "<email>")
+        mn.createEmail.return_value.as_string = Mock(return_value="<email>")
 
         yield mn.buildMessage("mybldr", builds, SUCCESS)
         defer.returnValue((mn, builds))
@@ -626,6 +624,7 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
 
         self.assertEqual(1, len(fakereactor.method_calls))
         self.assertIn(('connectSSL', ('localhost', 25, None, fakereactor.connectSSL.call_args[0][3]), {}), fakereactor.method_calls)
+
 
 def create_msgdict(funny_chars=u'\u00E5\u00E4\u00F6'):
     unibody = u'Unicode body with non-ascii (%s).' % funny_chars

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -256,6 +256,10 @@ MailNotifier arguments
     When this argument is ``True`` (default is ``False``) ``MailNotifier`` sends emails using TLS and authenticates with the ``relayhost``.
     When using TLS the arguments ``smtpUser`` and ``smtpPassword`` must also be specified.
 
+``useSsl``
+    (boolean).
+    When this argument is ``True`` (default is ``False``) ``MailNotifier`` sends emails using SSL and authenticates with the ``relayhost``.
+
 ``smtpUser``
     (string).
     The user name to use when authenticating with the ``relayhost``.

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -256,9 +256,10 @@ MailNotifier arguments
     When this argument is ``True`` (default is ``False``) ``MailNotifier`` sends emails using TLS and authenticates with the ``relayhost``.
     When using TLS the arguments ``smtpUser`` and ``smtpPassword`` must also be specified.
 
-``useSsl``
+``useSmtps``
     (boolean).
-    When this argument is ``True`` (default is ``False``) ``MailNotifier`` sends emails using SSL and authenticates with the ``relayhost``.
+    When this argument is ``True`` (default is ``False``) ``MailNotifier`` connects to ``relayhost`` over an encrypted SSL/TLS connection.
+    This configuration is typically used over port 465.
 
 ``smtpUser``
     (string).

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -253,8 +253,8 @@ MailNotifier arguments
 
 ``useTls``
     (boolean).
-    When this argument is ``True`` (default is ``False``) ``MailNotifier`` sends emails using TLS and authenticates with the ``relayhost``.
-    When using TLS the arguments ``smtpUser`` and ``smtpPassword`` must also be specified.
+    When this argument is ``True`` (default is ``False``) ``MailNotifier`` requires that STARTTLS encryption is used for the connection with the ``relayhost``.
+    Authentication is required for STARTTLS so the arguments ``smtpUser`` and ``smtpPassword`` must also be specified.
 
 ``useSmtps``
     (boolean).


### PR DESCRIPTION
Currently the mail notifier report plugin only supports encryption using STARTTLS. Since my provider doesn't have any support for this I never managed to get the plugin working.
With this patch I got it working by adding optional support for connecting over SSL.