### PR TITLE
tutorial/tour: minor text and formatting changes

### DIFF
--- a/master/docs/tutorial/tour.rst
+++ b/master/docs/tutorial/tour.rst
@@ -149,7 +149,7 @@ Once you've logged in, you will see some new options that allow you to force a b
 .. image:: _images/force-build.png
    :alt: force a build.
 
-Click *Force Build* - there's no need to fill in any of the fields in this case.
+Click *Start Build* - there's no need to fill in any of the fields in this case.
 Next, click on `view in waterfall <http://localhost:8010/waterfall?show=runtests>`_.
 
 You will now see:
@@ -166,7 +166,7 @@ First, start an IRC client of your choice, connect to irc.freenode.org and join 
 In this example we will use ``#buildbot-test``, so go join that channel.
 (*Note: please do not join the main buildbot channel!*)
 
-Edit :file:'master.cfg' and look for the *STATUS TARGETS* section.
+Edit :file:`master.cfg` and look for the *STATUS TARGETS* section.
 At the end of that section add the lines::
 
   from buildbot.status import irc


### PR DESCRIPTION
The picture says "Start Build", not "Force Build" (that is the old UI).
___
Other issues in the tutorial that are not addressed here:

 - Had to use `virtualenv --python=python2` since Python 3 apparently does not work yet, but `pip install buildbot[bundle]` fails with a strange error (`Please install buildbot, buildbot_pkg, and mock modules in order to install that package, or use the pre-build .whl modules available on pypi`). Reported before in https://github.com/buildbot/buildbot-website/issues/10.
 - FirstRun refers to virtualenv "bb-master", but the follow-up uses "sandbox"
 - outdated pictures (using old web UI)
 - IRCBot example does not work, apparently it got moved from .status to .reporters and needs to be added to `c['reporters']` instead of `c['status']`.
 - Text mentions a login, but the Force Build option can be used without. The example configuration does not contain the authorization configuration mentioned in the tutorial.