### PR TITLE
GIT: Syncronize sub-submodules

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -542,7 +542,7 @@ class Git(Source):
     def _syncSubmodule(self, _=None):
         rc = RC_SUCCESS
         if self.submodules:
-            rc = yield self._dovccmd(['submodule', 'sync'])
+            rc = yield self._dovccmd(['submodule', 'sync', '--recursive'])
         defer.returnValue(rc)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Should syncronize sub-submodules as well. Therefore add '--recursive'.
Recursive option doesn't do anything at all, if there are no sub-submodules.