### PR TITLE
gerritVerifyStatusPush: gerrit reporter using gerrit verify-status plugin

### DIFF
--- a/master/buildbot/reporters/gerrit_verify_status.py
+++ b/master/buildbot/reporters/gerrit_verify_status.py
@@ -1,0 +1,198 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.python import failure
+
+from buildbot.process.properties import Interpolate
+from buildbot.process.properties import Properties
+from buildbot.process.results import CANCELLED
+from buildbot.process.results import EXCEPTION
+from buildbot.process.results import FAILURE
+from buildbot.process.results import RETRY
+from buildbot.process.results import SKIPPED
+from buildbot.process.results import SUCCESS
+from buildbot.process.results import WARNINGS
+from buildbot.reporters import http
+from buildbot.util import httpclientservice
+from buildbot.util.logger import Logger
+
+log = Logger()
+
+
+class GerritVerifyStatusPush(http.HttpStatusPushBase):
+    name = "GerritVerifyStatusPush"
+    neededDetails = dict(wantProperties=True)
+    # overridable constants
+    RESULTS_TABLE = {
+        SUCCESS: 1,
+        WARNINGS: 1,
+        FAILURE: -1,
+        SKIPPED: 0,
+        EXCEPTION: 0,
+        RETRY: 0,
+        CANCELLED: 0
+    }
+    DEFAULT_RESULT = -1
+
+    @defer.inlineCallbacks
+    def reconfigService(self, baseURL, auth,
+                        startDescription=None, endDescription=None,
+                        verification_name=None, abstain=False, category=None, reporter=None,
+                        verbose=False, **kwargs):
+        yield http.HttpStatusPushBase.reconfigService(self, **kwargs)
+
+        if baseURL.endswith('/'):
+            baseURL = baseURL[:-1]
+
+        self._http = yield httpclientservice.HTTPClientService.getService(
+            self.master, baseURL, auth=auth)
+
+        self.verification_name = verification_name or Interpolate('%(prop:buildername)s')
+        self.reporter = reporter or "buildbot"
+        self.abstain = abstain
+        self.category = category
+        self.startDescription = startDescription or 'Build started.'
+        self.endDescription = endDescription or 'Build done.'
+        self.verbose = verbose
+
+    def createStatus(self,
+                     change_id, revision_id, name, value, abstain=None,
+                     rerun=None, comment=None, url=None, reporter=None,
+                     category=None, duration=None):
+        """
+        Abstract the POST REST api documented here:
+        https://gerrit.googlesource.com/plugins/verify-status/+/master/src/main/resources/Documentation/rest-api-changes.md
+
+        :param change_id: The change_id for the change tested (can be in the long form e.g:
+            myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940 or in the short integer form).
+        :param revision_id: the revision_id tested can be the patchset number or
+            the commit id (short or long).
+        :param name: The name of the job.
+        :param value: The pass/fail result for this job: -1: fail 0: unstable, 1: succeed
+        :param abstain: Whether the value counts as a vote (defaults to false)
+        :param rerun: Whether this result is from a re-test on the same patchset
+        :param comment: A short comment about this job
+        :param url: The url link to more info about this job
+        :reporter: The user that verified this job
+        :category: A category for this job
+        "duration": The time it took to run this job
+
+        :return: A deferred with the result from Gerrit.
+        """
+        payload = {
+            'name': name,
+            'value': value}
+
+        if abstain is not None:
+            payload['abstain'] = abstain
+
+        if rerun is not None:
+            payload['rerun'] = rerun
+
+        if comment is not None:
+            payload['comment'] = comment
+
+        if url is not None:
+            payload['url'] = url
+
+        if reporter is not None:
+            payload['reporter'] = reporter
+
+        if category is not None:
+            payload['category'] = category
+
+        if duration is not None:
+            payload['duration'] = duration
+
+        if self.verbose:
+            log.info(
+                'Sending Gerrit status for {change_id}/{revision_id}: data={data}',
+                change_id=change_id, revision_id=revision_id, data=payload)
+
+        return self._http.post('/'.join([
+            '/a/changes', str(change_id), 'revisions', str(revision_id), 'verify-status~verifications']),
+            json=payload)
+
+    def formatDuration(self, duration):
+        """Format the duration.
+
+        This method could be overriden if really needed, as the duration format in gerrit
+        is an arbitrary string.
+        :param duration: duration in timedelta
+        """
+        days = duration.days
+        hours, remainder = divmod(duration.seconds, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        if days:
+            return '{} day{} {}h {}m {}s'.format(
+                days, "s" if days > 1 else "",
+                hours, minutes, seconds)
+        elif hours:
+            return '{}h {}m {}s'.format(hours, minutes, seconds)
+        else:
+            return '{}m {}s'.format(minutes, seconds)
+
+    def getGerritChanges(self, props):
+        """ Get the gerrit changes
+
+            Must return a list of dictionary with at list change_id, and revision_id,
+            which format is the one accepted by the gerrit REST API as of
+            /changes/:change_id/revision/:revision_id paths (see gerrit doc)
+            :param props: an IProperty
+        """
+        if 'gerrit_changes' in props:
+            return props.getProperty('gerrit_changes')
+
+        if 'event.change.number' in props:
+            return [{
+                'change_id': props.getProperty('event.change.number'),
+                'revision_id': props.getProperty('event.patchSet.number')}
+            ]
+        return []
+
+    @defer.inlineCallbacks
+    def send(self, build):
+        props = Properties.fromDict(build['properties'])
+        if build['complete']:
+            value = self.RESULTS_TABLE.get(build['results'], self.DEFAULT_RESULT)
+            comment = yield props.render(self.endDescription)
+            duration = self.formatDuration(build['complete_at'] - build['started_at'])
+
+        else:
+            value = 0
+            comment = yield props.render(self.startDescription)
+            duration = 'pending'
+
+        print build['results'], value
+        name = yield props.render(self.verification_name)
+        reporter = yield props.render(self.reporter)
+        category = yield props.render(self.category)
+        abstain = yield props.render(self.abstain)
+        # TODO: find reliable way to find out whether its a rebuild
+        rerun = None
+
+        changes = yield self.getGerritChanges(props)
+        for change in changes:
+            try:
+                yield self.createStatus(
+                    change['change_id'], change['revision_id'],
+                    name, value, abstain=abstain,
+                    rerun=rerun, comment=comment, url=build['url'], reporter=reporter,
+                    category=category, duration=duration)
+            except Exception:
+                log.failure(
+                    'Failed to send status!',
+                    failure=failure.Failure())

--- a/master/buildbot/test/fake/httpclientservice.py
+++ b/master/buildbot/test/fake/httpclientservice.py
@@ -57,6 +57,7 @@ class HTTPClientService(service.SharedService):
 
     getName from the fake and getName from the real must return the same values.
     """
+    quiet = False
 
     def __init__(self, base_url, auth=None, headers=None):
         service.SharedService.__init__(self)
@@ -108,8 +109,9 @@ class HTTPClientService(service.SharedService):
                               "expected more http requests:\n {!r}".format(self._expected))
 
     def _doRequest(self, method, ep, params=None, data=None, json=None):
-        log.debug("{method} {ep} {params!r} <- {data!r}",
-                  method=method, ep=ep, params=params, data=data or json)
+        if not self.quiet:
+            log.debug("{method} {ep} {params!r} <- {data!r}",
+                      method=method, ep=ep, params=params, data=data or json)
         if not self._expected:
             raise AssertionError(
                 "Not expecting a request, while we got: "
@@ -126,8 +128,9 @@ class HTTPClientService(service.SharedService):
                     expect['method'], expect['ep'], expect['params'], expect['data'], expect['json'],
                     method, ep, params, data, json,
                 ))
-        log.debug("{method} {ep} -> {code} {content!r}",
-                  method=method, ep=ep, code=expect['code'], content=expect['content'])
+        if not self.quiet:
+            log.debug("{method} {ep} -> {code} {content!r}",
+                      method=method, ep=ep, code=expect['code'], content=expect['content'])
         return defer.succeed(ResponseWrapper(expect['code'], expect['content']))
 
     # lets be nice to the auto completers, and don't generate that code

--- a/master/buildbot/test/unit/test_reporter_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit_verify_status.py
@@ -1,0 +1,373 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+import datetime
+
+from mock import Mock
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot import config
+from buildbot.process.properties import Interpolate
+from buildbot.process.properties import Properties
+from buildbot.process.properties import renderer
+from buildbot.process.results import FAILURE
+from buildbot.process.results import SUCCESS
+from buildbot.reporters.gerrit_verify_status import GerritVerifyStatusPush
+from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.fake import fakemaster
+from buildbot.test.util import logging
+from buildbot.test.util.reporter import ReporterTestMixin
+
+from .test_changes_gerritchangesource import TestGerritChangeSource
+
+
+class TestGerritVerifyStatusPush(unittest.TestCase, ReporterTestMixin, logging.LoggingMixin):
+    TEST_PROPS = {'gerrit_changes': [{'change_id': 12, 'revision_id': 2}]}
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        # ignore config error if txrequests is not installed
+        self.patch(config, '_errors', Mock())
+        self.master = fakemaster.make_master(
+            testcase=self, wantData=True, wantDb=True, wantMq=True)
+
+        yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def createGerritStatus(self, **kwargs):
+        auth = kwargs.pop('auth', ('log', 'pass'))
+        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+            self.master, self, "gerrit", auth=auth)
+        self.sp = sp = GerritVerifyStatusPush("gerrit", auth=auth, **kwargs)
+        sp.sessionFactory = Mock(return_value=Mock())
+        yield sp.setServiceParent(self.master)
+
+    def tearDown(self):
+        return self.master.stopService()
+
+    @defer.inlineCallbacks
+    def setupBuildResults(self, buildResults):
+        self.insertTestData([buildResults], buildResults)
+        build = yield self.master.data.get(("builds", 20))
+        defer.returnValue(build)
+
+    @defer.inlineCallbacks
+    def test_basic(self):
+        yield self.createGerritStatus()
+        build = yield self.setupBuildResults(SUCCESS)
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build started.',
+                'abstain': False,
+                'name': u'Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 0,
+                'duration': 'pending'
+            })
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build done.',
+                'abstain': False,
+                'name': u'Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 1,
+                'duration': '2h 1m 4s'
+            })
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build done.',
+                'abstain': False,
+                'name': u'Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': -1,
+                'duration': '2h 1m 4s'
+            })
+        build['complete'] = False
+        build['complete_at'] = None
+        self.sp.buildStarted(("build", 20, "started"), build)
+        build['complete'] = True
+        build['complete_at'] = build['started_at'] + datetime.timedelta(hours=2, minutes=1, seconds=4)
+        self.sp.buildFinished(("build", 20, "finished"), build)
+        build['results'] = FAILURE
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
+    def test_custom_description(self):
+        yield self.createGerritStatus(
+            startDescription=Interpolate("started %(prop:buildername)s"),
+            endDescription=Interpolate("finished %(prop:buildername)s"))
+        build = yield self.setupBuildResults(SUCCESS)
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'started Builder0',
+                'abstain': False,
+                'name': u'Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 0,
+                'duration': 'pending'
+            })
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'finished Builder0',
+                'abstain': False,
+                'name': u'Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 1,
+                'duration': '2h 1m 4s'
+            })
+        build['complete'] = False
+        build['complete_at'] = None
+        self.sp.buildStarted(("build", 20, "started"), build)
+        build['complete'] = True
+        build['complete_at'] = build['started_at'] + datetime.timedelta(hours=2, minutes=1, seconds=4)
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
+    def test_custom_name(self):
+        yield self.createGerritStatus(
+            verification_name=Interpolate("builder %(prop:buildername)s"))
+        build = yield self.setupBuildResults(SUCCESS)
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build started.',
+                'abstain': False,
+                'name': u'builder Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 0,
+                'duration': 'pending'
+            })
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build done.',
+                'abstain': False,
+                'name': u'builder Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 1,
+                'duration': '2h 1m 4s'
+            })
+        build['complete'] = False
+        build['complete_at'] = None
+        self.sp.buildStarted(("build", 20, "started"), build)
+        build['complete'] = True
+        build['complete_at'] = build['started_at'] + datetime.timedelta(hours=2, minutes=1, seconds=4)
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
+    def test_custom_abstain(self):
+        yield self.createGerritStatus(
+            abstain=renderer(lambda p: p.getProperty("buildername") == 'Builder0'))
+        build = yield self.setupBuildResults(SUCCESS)
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build started.',
+                'abstain': True,
+                'name': u'Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 0,
+                'duration': 'pending'
+            })
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build done.',
+                'abstain': True,
+                'name': u'Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 1,
+                'duration': '2h 1m 4s'
+            })
+        build['complete'] = False
+        build['complete_at'] = None
+        self.sp.buildStarted(("build", 20, "started"), build)
+        build['complete'] = True
+        build['complete_at'] = build['started_at'] + datetime.timedelta(hours=2, minutes=1, seconds=4)
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
+    def test_custom_category(self):
+        yield self.createGerritStatus(
+            category=renderer(lambda p: p.getProperty("buildername")))
+        build = yield self.setupBuildResults(SUCCESS)
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build started.',
+                'abstain': False,
+                'category': 'Builder0',
+                'name': u'Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 0,
+                'duration': 'pending'
+            })
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build done.',
+                'abstain': False,
+                'category': 'Builder0',
+                'name': u'Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 1,
+                'duration': '2h 1m 4s'
+            })
+        build['complete'] = False
+        build['complete_at'] = None
+        self.sp.buildStarted(("build", 20, "started"), build)
+        build['complete'] = True
+        build['complete_at'] = build['started_at'] + datetime.timedelta(hours=2, minutes=1, seconds=4)
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
+    def test_custom_reporter(self):
+        yield self.createGerritStatus(
+            reporter=renderer(lambda p: p.getProperty("buildername")))
+        build = yield self.setupBuildResults(SUCCESS)
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build started.',
+                'abstain': False,
+                'name': u'Builder0',
+                'reporter': 'Builder0',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 0,
+                'duration': 'pending'
+            })
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build done.',
+                'abstain': False,
+                'name': u'Builder0',
+                'reporter': 'Builder0',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 1,
+                'duration': '2h 1m 4s'
+            })
+        build['complete'] = False
+        build['complete_at'] = None
+        self.sp.buildStarted(("build", 20, "started"), build)
+        build['complete'] = True
+        build['complete_at'] = build['started_at'] + datetime.timedelta(hours=2, minutes=1, seconds=4)
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
+    def test_verbose(self):
+        yield self.createGerritStatus(verbose=True)
+        build = yield self.setupBuildResults(SUCCESS)
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build started.',
+                'abstain': False,
+                'name': u'Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 0,
+                'duration': 'pending'
+            })
+        self.setUpLogging()
+        self.sp.buildStarted(("build", 20, "started"), build)
+        self.assertLogged("Sending Gerrit status for")
+
+    @defer.inlineCallbacks
+    def test_not_verbose(self):
+        yield self.createGerritStatus(verbose=False)
+        build = yield self.setupBuildResults(SUCCESS)
+        self._http.expect(
+            method='post',
+            ep='/a/changes/12/revisions/2/verify-status~verifications',
+            json={
+                'comment': 'Build started.',
+                'abstain': False,
+                'name': u'Builder0',
+                'reporter': 'buildbot',
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'value': 0,
+                'duration': 'pending'
+            })
+        self.setUpLogging()
+        self._http.quiet = True
+        self.sp.buildStarted(("build", 20, "started"), build)
+        self.assertWasQuiet()
+
+    @defer.inlineCallbacks
+    def test_format_duration(self):
+        yield self.createGerritStatus(verbose=False)
+        self.assertEqual(
+            self.sp.formatDuration(datetime.timedelta(seconds=1)),
+            "0m 1s")
+        self.assertEqual(
+            self.sp.formatDuration(datetime.timedelta(hours=1, seconds=1)),
+            "1h 0m 1s")
+        self.assertEqual(
+            self.sp.formatDuration(datetime.timedelta(days=1, seconds=1)),
+            "1 day 0h 0m 1s")
+        self.assertEqual(
+            self.sp.formatDuration(datetime.timedelta(days=2, seconds=1)),
+            "2 days 0h 0m 1s")
+
+    @defer.inlineCallbacks
+    def test_gerrit_changes(self):
+        yield self.createGerritStatus()
+
+        # from chdict:
+        chdict = TestGerritChangeSource.expected_change
+        props = Properties.fromDict(dict([
+            (k, (v, 'change')) for k, v in chdict['properties'].items()]))
+        changes = self.sp.getGerritChanges(props)
+        self.assertEqual(changes, [
+            {'change_id': '4321', 'revision_id': '12'}
+        ])

--- a/master/buildbot/test/util/logging.py
+++ b/master/buildbot/test/util/logging.py
@@ -32,3 +32,7 @@ class LoggingMixin(object):
                 return
         self.fail(
             "%r not matched in log output.\n%s " % (regexp, self._logEvents))
+
+    def assertWasQuiet(self):
+        self.assertEqual([
+            log.textFromEventDict(event) for event in self._logEvents], [])

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -363,10 +363,10 @@ URL to build page
 
 URL to buildbot main page
     ``{{ buildbot_url }}``
-    
+
 Status of the build as string.
     This require extending the context of the Formatter via the ``ctx`` parameter with: ``ctx=dict(statuses=util.Results)``.
-    
+
     ``{{ statuses[results] }}``
 
 Build text
@@ -1070,3 +1070,47 @@ Here's a complete example:
                 result['color'] = 'green' if build['results'] == 0 else 'red'
                 result['notify'] = (build['results'] != 0)
             return result
+
+.. bb:reporter:: GerritVerifyStatusPush
+
+GerritVerifyStatusPush
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. py:class:: buildbot.status.status_gerrit_verify_status.GerritVerifyStatusPush
+
+:class:`GerritVerifyStatusPush` sends a verify status to gerrit using the verify-status_ Gerrit plugin.
+
+It is an alternate method to :bb:reporter:`GerritStatusPush`, which uses the SSH API to send reviews.
+
+The verify-status_ plugin allows several CI statuses to be sent for the same change, and display them separately in the Gerrit UI.
+
+Most parameters are :index:`renderables <renderable>`
+
+.. py:class:: GerritVerifyStatusPush(
+    baseURL, auth,
+    startDescription="Build started.", endDescription="Build done.",
+    verification_name=Interpolate("%(prop:buildername)s"), abstain=False, category=None, reporter=None,
+    verbose=False, **kwargs)
+
+   :param string baseURL: Gerrit HTTP base URL
+   :param string auth: a requests authentication configuration.
+       if Gerrit is configured with ``BasicAuth``, then it shall be ``('login', 'password')``
+       if Gerrit is configured with ``DigestAuth``, then it shall be ``requests.auth.HTTPDigestAuth('login', 'password')`` from the requests module.
+    :param renderable string startDescription: the comment sent when the build is starting.
+    :param renderable string endDescription: the comment sent when the build is finishing.
+    :param renderable string verification_name: the name of the job displayed in the gerrit UI.
+    :param renderable boolean abstain: whether this results should be counted as voting.
+    :param renderable boolean category: Category of the build.
+    :param renderable boolean reporter: The user that verified this build
+    :param boolean verbose: Whether to log every requests.
+    :param list builders: only send update for specified builders
+
+This reporter is integrated with :class:`GerritChangeSource`, and will update changes detected by this change source.
+
+This reporter can also send reports for changes triggered manually provided that there is a property in the build named ``gerrit_changes``, containing the list of changes that were tested.
+This property must be a list of dictionaries, containing ``change_id`` and ``revision_id`` keys, as defined in the revision endpoints of the `gerrit documentation`_
+
+.. _txrequests: https://pypi.python.org/pypi/txrequests
+.. _verify-status_: https://gerrit.googlesource.com/plugins/verify-status
+verify-status_
+.. _gerrit documentation: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#revision-endpoints

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -1078,7 +1078,7 @@ GerritVerifyStatusPush
 
 .. py:class:: buildbot.status.status_gerrit_verify_status.GerritVerifyStatusPush
 
-:class:`GerritVerifyStatusPush` sends a verify status to gerrit using the verify-status_ Gerrit plugin.
+:class:`GerritVerifyStatusPush` sends a verify status to Gerrit using the verify-status_ Gerrit plugin.
 
 It is an alternate method to :bb:reporter:`GerritStatusPush`, which uses the SSH API to send reviews.
 
@@ -1092,13 +1092,13 @@ Most parameters are :index:`renderables <renderable>`
     verification_name=Interpolate("%(prop:buildername)s"), abstain=False, category=None, reporter=None,
     verbose=False, **kwargs)
 
-   :param string baseURL: Gerrit HTTP base URL
-   :param string auth: a requests authentication configuration.
+    :param string baseURL: Gerrit HTTP base URL
+    :param string auth: a requests authentication configuration.
        if Gerrit is configured with ``BasicAuth``, then it shall be ``('login', 'password')``
        if Gerrit is configured with ``DigestAuth``, then it shall be ``requests.auth.HTTPDigestAuth('login', 'password')`` from the requests module.
     :param renderable string startDescription: the comment sent when the build is starting.
     :param renderable string endDescription: the comment sent when the build is finishing.
-    :param renderable string verification_name: the name of the job displayed in the gerrit UI.
+    :param renderable string verification_name: the name of the job displayed in the Gerrit UI.
     :param renderable boolean abstain: whether this results should be counted as voting.
     :param renderable boolean category: Category of the build.
     :param renderable boolean reporter: The user that verified this build
@@ -1108,9 +1108,8 @@ Most parameters are :index:`renderables <renderable>`
 This reporter is integrated with :class:`GerritChangeSource`, and will update changes detected by this change source.
 
 This reporter can also send reports for changes triggered manually provided that there is a property in the build named ``gerrit_changes``, containing the list of changes that were tested.
-This property must be a list of dictionaries, containing ``change_id`` and ``revision_id`` keys, as defined in the revision endpoints of the `gerrit documentation`_
+This property must be a list of dictionaries, containing ``change_id`` and ``revision_id`` keys, as defined in the revision endpoints of the `Gerrit documentation`_
 
 .. _txrequests: https://pypi.python.org/pypi/txrequests
-.. _verify-status_: https://gerrit.googlesource.com/plugins/verify-status
-verify-status_
-.. _gerrit documentation: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#revision-endpoints
+.. _verify-status: https://gerrit.googlesource.com/plugins/verify-status
+.. _Gerrit documentation: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#revision-endpoints

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -27,6 +27,8 @@ Features
 
 * :bb:reporter:`StashStatusPush` now accepts ``key``, ``buildName``, ``endDescription``, ``startDescription``, and ``verbose``  parameters to control the JSON sent to Stash.
 
+* New :bb:reporter:`GerritVerifyStatusPush` can send multiple review status for the same gerrit change.
+
 Fixes
 ~~~~~
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -27,7 +27,7 @@ Features
 
 * :bb:reporter:`StashStatusPush` now accepts ``key``, ``buildName``, ``endDescription``, ``startDescription``, and ``verbose``  parameters to control the JSON sent to Stash.
 
-* New :bb:reporter:`GerritVerifyStatusPush` can send multiple review status for the same gerrit change.
+* New :bb:reporter:`GerritVerifyStatusPush` can send multiple review status for the same Gerrit change.
 
 Fixes
 ~~~~~

--- a/master/setup.py
+++ b/master/setup.py
@@ -28,7 +28,6 @@ from distutils.core import setup
 from distutils.version import LooseVersion
 
 import pkg_resources
-
 from buildbot import version
 
 if "bdist_wheel" in sys.argv:
@@ -302,6 +301,7 @@ setup_args = {
             ('buildbot.reporters.mail', ['MailNotifier']),
             ('buildbot.reporters.message', ['MessageFormatter']),
             ('buildbot.reporters.gerrit', ['GerritStatusPush']),
+            ('buildbot.reporters.gerrit_verify_status', ['GerritVerifyStatusPush']),
             ('buildbot.reporters.http', ['HttpStatusPush']),
             ('buildbot.reporters.github', ['GitHubStatusPush']),
             ('buildbot.reporters.stash', ['StashStatusPush']),


### PR DESCRIPTION
Gerrit 2.13 has a new verify-status plugin which allows several CI status to be pushed for the same commit (like for github)

https://gerrit.googlesource.com/plugins/verify-status/