### PR TITLE
GerritEventLogPoller

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -364,7 +364,7 @@ class GerritEventLogPoller(GerritChangeSourceBase):
     @staticmethod
     def now():
         """patchable now (datetime is not patchable as builtin)"""
-        return datetime.datetime.now()
+        return datetime.datetime.utcnow()
 
     @defer.inlineCallbacks
     def poll(self):
@@ -372,7 +372,7 @@ class GerritEventLogPoller(GerritChangeSourceBase):
         if last_event_ts is None:
             last_event = self.now()
         else:
-            last_event = datetime.datetime.fromtimestamp(last_event_ts)
+            last_event = datetime.datetime.utcfromtimestamp(last_event_ts)
         last_event_formatted = last_event.strftime("%Y-%d-%m %H:%M:%S")
         res = yield self._http.get("/plugins/events-log/events/", params=dict(t1=last_event_formatted))
         lines = yield res.content()

--- a/master/buildbot/newsfragments/gerrit_eventlog_poller.feature
+++ b/master/buildbot/newsfragments/gerrit_eventlog_poller.feature
@@ -1,1 +1,1 @@
-* New :bb:chsrc:`_GerritEventLogPoller` poller to poll gerrit changes via http API.
+New :bb:chsrc:`GerritEventLogPoller` poller to poll Gerrit changes via http API.

--- a/master/buildbot/newsfragments/gerrit_eventlog_poller.feature
+++ b/master/buildbot/newsfragments/gerrit_eventlog_poller.feature
@@ -1,0 +1,1 @@
+* New :bb:chsrc:`_GerritEventLogPoller` poller to poll gerrit changes via http API.

--- a/master/buildbot/test/unit/test_changes_gerritchangesource.py
+++ b/master/buildbot/test/unit/test_changes_gerritchangesource.py
@@ -14,11 +14,15 @@
 # Copyright Buildbot Team Members
 from future.utils import iteritems
 
+import datetime
 import types
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.changes import gerritchangesource
+from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.fake import fakedb
 from buildbot.test.fake.change import Change
 from buildbot.test.util import changesource
 from buildbot.util import json
@@ -210,6 +214,105 @@ class TestGerritChangeSource(changesource.ChangeSourceMixin,
             c = self.master.data.updates.changesAdded[0]
             self.assertEqual(c['project'], "world")
         return d
+
+
+class TestGerritEventLogPoller(changesource.ChangeSourceMixin,
+                               unittest.TestCase):
+    NOW_TIMESTAMP = 1479302598
+    EVENT_TIMESTAMP = 1479302599
+    NOW_FORMATTED = '2016-16-11 14:23:18'
+    EVENT_FORMATTED = '2016-16-11 14:23:19'
+    OBJECTID = 1234
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.setUpChangeSource()
+        yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.master.stopService()
+        yield self.tearDownChangeSource()
+
+    @defer.inlineCallbacks
+    def newChangeSource(self, **kwargs):
+        auth = kwargs.pop('auth', ('log', 'pass'))
+        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+            self.master, self, 'gerrit', auth=auth)
+        self.changesource = gerritchangesource.GerritEventLogPoller(
+            'gerrit', auth=auth, gitBaseURL="ssh://someuser@somehost:29418", pollAtLaunch=False, **kwargs)
+
+    @defer.inlineCallbacks
+    def startChangeSource(self):
+        yield self.changesource.setServiceParent(self.master)
+        yield self.attachChangeSource(self.changesource)
+
+    # tests
+    @defer.inlineCallbacks
+    def test_now(self):
+        yield self.newChangeSource()
+        self.changesource.now()
+
+    @defer.inlineCallbacks
+    def test_describe(self):
+        # describe is not used yet in buildbot nine, but it can still be useful in the future, so lets
+        # implement and test it
+        yield self.newChangeSource()
+        self.assertSubstring('GerritEventLogPoller', self.changesource.describe())
+
+    @defer.inlineCallbacks
+    def test_name(self):
+        yield self.newChangeSource()
+        self.assertEqual('GerritEventLogPoller:gerrit', self.changesource.name)
+
+    @defer.inlineCallbacks
+    def test_lineReceived_patchset_created(self):
+        self.master.db.insertTestData([
+            fakedb.Object(id=self.OBJECTID, name='GerritEventLogPoller:gerrit',
+                          class_name='GerritEventLogPoller')])
+        yield self.newChangeSource()
+        self.changesource.now = lambda: datetime.datetime.fromtimestamp(self.NOW_TIMESTAMP)
+        self._http.expect(method='get', ep='/plugins/events-log/events/',
+                          params={'t1': self.NOW_FORMATTED},
+                          content_json=dict(
+                              type="patchset-created",
+                              change=dict(
+                                  branch="br",
+                                  project="pr",
+                                  number="4321",
+                                  owner=dict(name="Dustin", email="dustin@mozilla.com"),
+                                  url="http://buildbot.net",
+                                  subject="fix 1234"
+                              ),
+                              eventCreatedOn=self.EVENT_TIMESTAMP,
+                              patchSet=dict(revision="abcdef", number="12")))
+
+        yield self.startChangeSource()
+        yield self.changesource.poll()
+        self.assertEqual(len(self.master.data.updates.changesAdded), 1)
+        c = self.master.data.updates.changesAdded[0]
+        for k, v in iteritems(c):
+            self.assertEqual(TestGerritChangeSource.expected_change[k], v)
+        self.master.db.state.assertState(self.OBJECTID, last_event_ts=self.EVENT_TIMESTAMP)
+
+        # do a second poll, it should ask for the next events
+        self._http.expect(method='get', ep='/plugins/events-log/events/',
+                          params={'t1': self.EVENT_FORMATTED},
+                          content_json=dict(
+                              type="patchset-created",
+                              change=dict(
+                                  branch="br",
+                                  project="pr",
+                                  number="4321",
+                                  owner=dict(name="Dustin", email="dustin@mozilla.com"),
+                                  url="http://buildbot.net",
+                                  subject="fix 1234"
+                              ),
+                              eventCreatedOn=self.EVENT_TIMESTAMP + 1,
+                              patchSet=dict(revision="abcdef", number="12")))
+
+        yield self.changesource.poll()
+        self.master.db.state.assertState(self.OBJECTID, last_event_ts=self.EVENT_TIMESTAMP + 1)
 
 
 class TestGerritChangeFilter(unittest.TestCase):

--- a/master/buildbot/test/unit/test_changes_gerritchangesource.py
+++ b/master/buildbot/test/unit/test_changes_gerritchangesource.py
@@ -220,8 +220,8 @@ class TestGerritEventLogPoller(changesource.ChangeSourceMixin,
                                unittest.TestCase):
     NOW_TIMESTAMP = 1479302598
     EVENT_TIMESTAMP = 1479302599
-    NOW_FORMATTED = '2016-16-11 14:23:18'
-    EVENT_FORMATTED = '2016-16-11 14:23:19'
+    NOW_FORMATTED = '2016-16-11 13:23:18'
+    EVENT_FORMATTED = '2016-16-11 13:23:19'
     OBJECTID = 1234
 
     @defer.inlineCallbacks
@@ -271,7 +271,7 @@ class TestGerritEventLogPoller(changesource.ChangeSourceMixin,
             fakedb.Object(id=self.OBJECTID, name='GerritEventLogPoller:gerrit',
                           class_name='GerritEventLogPoller')])
         yield self.newChangeSource()
-        self.changesource.now = lambda: datetime.datetime.fromtimestamp(self.NOW_TIMESTAMP)
+        self.changesource.now = lambda: datetime.datetime.utcfromtimestamp(self.NOW_TIMESTAMP)
         self._http.expect(method='get', ep='/plugins/events-log/events/',
                           params={'t1': self.NOW_FORMATTED},
                           content_json=dict(

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -76,6 +76,7 @@ Git
 Repo/Gerrit
 
 * :bb:chsrc:`GerritChangeSource` connects to Gerrit via SSH to get a live stream of changes
+* :bb:chsrc:`GerritEventLogPoller` connects to Gerrit via HTTP with the help of the plugin events-log_
 
 Monotone
 
@@ -1119,6 +1120,48 @@ A configuration for this source might look like:
         handled_events=["patchset-created", "change-merged"])
 
 See :file:`master/docs/examples/git_gerrit.cfg` or :file:`master/docs/examples/repo_gerrit.cfg` in the Buildbot distribution for a full example setup of Git+Gerrit or Repo+Gerrit of :bb:chsrc:`GerritChangeSource`.
+
+
+.. _GerritEventLogPoller:
+
+GerritEventLogPoller
+~~~~~~~~~~~~~~~~~~~~~
+
+.. py:class:: buildbot.changes.gerritchangesource.GerritEventLogPoller
+
+The :bb:chsrc:`GerritEventLogPoller` class is similar to :bb:chsrc:`GerritChangeSource` but connects to the Gerrit server by its HTTP interface and uses the events-log_ plugin.
+
+The :bb:chsrc:`GerritEventLogPoller` accepts the following arguments:
+
+``baseURL``
+    the HTTP url where to find Gerrit
+
+``auth``
+    a requests authentication configuration.
+   if Gerrit is configured with ``BasicAuth``, then it shall be ``('login', 'password')``
+   if Gerrit is configured with ``DigestAuth``, then it shall be ``requests.auth.HTTPDigestAuth('login', 'password')`` from the requests module.
+
+``handled_events``
+    event to be handled (optional).
+    By default processes `patchset-created` and `ref-updated`
+
+``pollInterval``
+    interval in seconds between polls, default is 30 seconds
+
+``pollAtLaunch``
+    Determines when the first poll occurs.
+    True = immediately on launch (default), False = wait for one pollInterval.
+
+``gitBaseURL``
+    The git URL where Gerrit is accessible via git+ssh protocol
+
+``debug``
+    Print Gerrit event in the log (default `False`).
+    This allows to debug event content, but will eventually fill your logs with useless Gerrit event logs.
+
+The same customization can be done as :bb:chsrc:`_GerritChangeSource` for handling special events.
+
+.. _events-log: https://gerrit.googlesource.com/plugins/events-log/
 
 GerritChangeFilter
 ~~~~~~~~~~~~~~~~~~

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -1121,6 +1121,7 @@ A configuration for this source might look like:
 
 See :file:`master/docs/examples/git_gerrit.cfg` or :file:`master/docs/examples/repo_gerrit.cfg` in the Buildbot distribution for a full example setup of Git+Gerrit or Repo+Gerrit of :bb:chsrc:`GerritChangeSource`.
 
+.. bb:chsrc:: GerritEventLogPoller
 
 .. _GerritEventLogPoller:
 
@@ -1138,8 +1139,8 @@ The :bb:chsrc:`GerritEventLogPoller` accepts the following arguments:
 
 ``auth``
     a requests authentication configuration.
-   if Gerrit is configured with ``BasicAuth``, then it shall be ``('login', 'password')``
-   if Gerrit is configured with ``DigestAuth``, then it shall be ``requests.auth.HTTPDigestAuth('login', 'password')`` from the requests module.
+    if Gerrit is configured with ``BasicAuth``, then it shall be ``('login', 'password')``
+    if Gerrit is configured with ``DigestAuth``, then it shall be ``requests.auth.HTTPDigestAuth('login', 'password')`` from the requests module.
 
 ``handled_events``
     event to be handled (optional).
@@ -1159,7 +1160,7 @@ The :bb:chsrc:`GerritEventLogPoller` accepts the following arguments:
     Print Gerrit event in the log (default `False`).
     This allows to debug event content, but will eventually fill your logs with useless Gerrit event logs.
 
-The same customization can be done as :bb:chsrc:`_GerritChangeSource` for handling special events.
+The same customization can be done as :bb:chsrc:`GerritChangeSource` for handling special events.
 
 .. _events-log: https://gerrit.googlesource.com/plugins/events-log/
 


### PR DESCRIPTION
Support for the events-log gerrit plugin

This is a first PR.

The second PR should be a GerritEventLogChangeSource, which should combine ssh and eventlog REST API to be sure not to miss events in case of ssh disconnection.
Multiple inheritence should make that pretty trivial.

A third PR will be the GerritKafkaChangeSource which will connect to a kafka server