### PR TITLE
httpclientservice: do not use urljoin

### DIFF
--- a/master/buildbot/test/fake/httpclientservice.py
+++ b/master/buildbot/test/fake/httpclientservice.py
@@ -60,8 +60,8 @@ class HTTPClientService(service.SharedService):
     quiet = False
 
     def __init__(self, base_url, auth=None, headers=None):
-        service.SharedService.__init__(self)
         assert not base_url.endswith("/"), "baseurl should not end with /"
+        service.SharedService.__init__(self)
         self._base_url = base_url
         self._auth = auth
 

--- a/master/buildbot/test/fake/httpclientservice.py
+++ b/master/buildbot/test/fake/httpclientservice.py
@@ -61,6 +61,7 @@ class HTTPClientService(service.SharedService):
 
     def __init__(self, base_url, auth=None, headers=None):
         service.SharedService.__init__(self)
+        assert not base_url.endswith("/"), "baseurl should not end with /"
         self._base_url = base_url
         self._auth = auth
 

--- a/master/buildbot/test/unit/test_reporters_hipchat.py
+++ b/master/buildbot/test/unit/test_reporters_hipchat.py
@@ -36,7 +36,8 @@ class TestHipchatStatusPush(unittest.TestCase, ReporterTestMixin):
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield self.master.stopService()
+        if self.master.running:
+            yield self.master.stopService()
 
     @defer.inlineCallbacks
     def createReporter(self, **kwargs):
@@ -59,9 +60,8 @@ class TestHipchatStatusPush(unittest.TestCase, ReporterTestMixin):
         yield self.createReporter(auth_token=2)
         config._errors.addError.assert_any_call('auth_token must be a string')
 
-    @defer.inlineCallbacks
     def test_endpointTypeCheck(self):
-        yield self.createReporter(endpoint=2)
+        HipChatStatusPush(auth_token="2", endpoint=2)
         config._errors.addError.assert_any_call('endpoint must be a string')
 
     @defer.inlineCallbacks

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -88,8 +88,8 @@ class HTTPClientService(service.SharedService):
     MAX_THREADS = 5
 
     def __init__(self, base_url, auth=None, headers=None):
-        service.SharedService.__init__(self)
         assert not base_url.endswith("/"), "baseurl should not end with /: " + base_url
+        service.SharedService.__init__(self)
         self._base_url = base_url
         self._auth = auth
         self._headers = headers

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 
 import json as jsonmodule
 import textwrap
-import urlparse
 
 from twisted.internet import defer
 from twisted.web.client import Agent
@@ -90,6 +89,7 @@ class HTTPClientService(service.SharedService):
 
     def __init__(self, base_url, auth=None, headers=None):
         service.SharedService.__init__(self)
+        assert not base_url.endswith("/"), "baseurl should not end with /: " + base_url
         self._base_url = base_url
         self._auth = auth
         self._headers = headers
@@ -133,7 +133,8 @@ class HTTPClientService(service.SharedService):
             return self._pool.closeCachedConnections()
 
     def _prepareRequest(self, ep, kwargs):
-        url = urlparse.urljoin(self._base_url, ep)
+        assert ep.startswith("/"), "ep should start with /: " + ep
+        url = self._base_url + ep
         if self._auth is not None and 'auth' not in kwargs:
             kwargs['auth'] = self._auth
         headers = kwargs.get('headers', {})


### PR DESCRIPTION
urljoin is stripping the last path if it does not with /
we rather join manually, and enforce baseurl does not end with / and ep start with /