### PR TITLE
switch releasenote generation to towncrier

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Remove this paragraph
+Please have a look at our developer documentation before submitting your Pull Request.
+
+http://trac.buildbot.net/wiki/Development
+And especially:
+http://trac.buildbot.net/wiki/SubmittingPatches
+
+## Contributor Checklist:
+
+* [ ] I have updated the unit tests
+* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
+* [ ] I have updated the appropriate documentation
+

--- a/master/buildbot/newsfragments/README.txt
+++ b/master/buildbot/newsfragments/README.txt
@@ -1,0 +1,15 @@
+This is the directory for news fragments used by towncrier: https://github.com/hawkowl/towncrier
+
+towncrier has a few standard types of news fragments, signified by the file extension. These are:
+
+.feature: Signifying a new feature.
+.bugfix: Signifying a bug fix.
+.doc: Signifying a documentation improvement.
+.removal: Signifying a deprecation or removal of public API.
+
+The core of the filename can be the fixed issue number of any uniq text relative to your work.
+Buildbot project does not require a tracking ticket to be made for each contribution even if this is appreciated.
+
+Please point to the bug using syntax: (:bug:`NNN`)
+please point to classes using syntax: :py:class:`~buildbot.reporters.http.HttpStatusBase`
+

--- a/master/buildbot/newsfragments/gerritverifystatuspush.feature
+++ b/master/buildbot/newsfragments/gerritverifystatuspush.feature
@@ -1,0 +1,1 @@
+New :bb:reporter:`GerritVerifyStatusPush` can send multiple review status for the same Gerrit change.

--- a/master/buildbot/newsfragments/no_pass_for_dockerworker.feature
+++ b/master/buildbot/newsfragments/no_pass_for_dockerworker.feature
@@ -1,0 +1,2 @@
+``password`` in :py:class:`~buildbot.plugins.worker.DockerLatentWorker` and :py:class:`~buildbot.plugins.worker.HyperLatentWorker`, can be None.
+  In that case, they will be auto-generated from random number.

--- a/master/buildbot/newsfragments/stashreporter_parameters.feature
+++ b/master/buildbot/newsfragments/stashreporter_parameters.feature
@@ -1,0 +1,2 @@
+:bb:reporter:`StashStatusPush` now accepts ``key``, ``buildName``, ``endDescription``, ``startDescription``, and ``verbose``  parameters to control the JSON sent to Stash.
+

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -1,74 +1,11 @@
-Release Notes for Buildbot ``|version|``
-========================================
-
 ..
-    Any change that adds a feature or fixes a bug should have an entry here.
-    Most simply need an additional bulleted list item, but more significant
-    changes can be given a subsection of their own.
+    Don't write to this file anymore!!
 
-    If you can:
+    Buildbot now uses towncrier to manage its release notes.
+    towncrier helps to avoid the need for rebase when several people work at the same time on the releasenote files.
 
-       please point to the bug using syntax: (:bug:`NNN`)
-       please point to classes using syntax: :py:class:`~buildbot.reporters.http.HttpStatusBase`
+    Each PR should come with a file in the master/buildbot/newsfragment directory
 
-
-The following are the release notes for Buildbot ``|version|``.
-
-See :ref:`Upgrading to Nine` for a guide to upgrading from 0.8.x to 0.9.x
-
-Master
-------
-
-Features
-~~~~~~~~
-
-* ``password`` in :py:class:`~buildbot.plugins.worker.DockerLatentWorker` and :py:class:`~buildbot.plugins.worker.HyperLatentWorker`, can be None.
-  In that case, they will be auto-generated from random number.
-
-* :bb:reporter:`StashStatusPush` now accepts ``key``, ``buildName``, ``endDescription``, ``startDescription``, and ``verbose``  parameters to control the JSON sent to Stash.
-
-* New :bb:reporter:`GerritVerifyStatusPush` can send multiple review status for the same Gerrit change.
-
-Fixes
-~~~~~
-
-
-Changes for Developers
-~~~~~~~~~~~~~~~~~~~~~~
-
-Features
-~~~~~~~~
-
-Fixes
-~~~~~
-
-
-Deprecations, Removals, and Non-Compatible Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Worker
-------
-
-Fixes
-~~~~~
-
-Changes for Developers
-~~~~~~~~~~~~~~~~~~~~~~
-
-Deprecations, Removals, and Non-Compatible Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Details
--------
-
-For a more detailed description of the changes made in this version, see the git log itself:
-
-.. code-block:: bash
-
-   git log v0.9.0rc1..master
-
-Older Versions
---------------
 
 Release notes for older versions of Buildbot are available in the :src:`master/docs/relnotes/` directory of the source tree.
 Newer versions are also available here:

--- a/towncrier.ini
+++ b/towncrier.ini
@@ -1,0 +1,5 @@
+[towncrier]
+package_dir = master
+package = buildbot
+; The filename that it will write to, relative to the current dir
+filename = master/docs/relnotes/index.rst


### PR DESCRIPTION
I got tired of rebasing the PR because the releasenote conflicts.

As per @tomprince suggestion, I propose we move to towncrier to manage release notes.
