### PR TITLE
IRC: append build url to failed/successful build

### DIFF
--- a/master/buildbot/newsfragments/ircreporter_url.feature
+++ b/master/buildbot/newsfragments/ircreporter_url.feature
@@ -1,0 +1,2 @@
+:bb:reporter:`IRC` appends the builderURL to a successful/failed build if available
+

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -38,6 +38,7 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import RETRY
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
+from buildbot.reporters import utils
 from buildbot.util import service
 
 # Used in command_HELLO and it's test. 'Hi' in 100 languages.
@@ -550,25 +551,21 @@ class Contact(service.AsyncService):
 
         if self.useRevisions:
             revisions = yield self.getRevisionsForBuild(build)
-            r = "Hey! build %s containing revision(s) [%s] is complete: %s" % \
+            r = "Build %s containing revision(s) [%s] is complete: %s" % \
                 (builderName, ','.join(revisions), results[0])
         else:
-            r = "Hey! build %s #%d is complete: %s" % \
+            r = "Build %s #%d is complete: %s" % \
                 (builderName, buildNumber, results[0])
 
         r += ' [%s]' % maybeColorize(build['state_string'],
                                      results[1], self.useColors)
-        self.send(r)
 
         # FIXME: where do we get the list of changes for a build ?
         # if self.bot.showBlameList and buildResult != SUCCESS and len(build.changes) != 0:
         #    r += '  blamelist: ' + ', '.join(list(set([c.who for c in build.changes])))
-
-        # FIXME: where do we get the base_url? Then do we use the build Link to
-        # make the URL?
-        buildurl = None  # self.bot.status.getBuildbotURL() + build
-        if buildurl:
-            self.send("Build details are at %s" % buildurl)
+        r += " - %s" % utils.getURLForBuild(
+                        self.master, builder['builderid'], buildNumber)
+        self.send(r)
 
     results_descriptions = {
         SUCCESS: ("Success", 'GREEN'),
@@ -622,21 +619,19 @@ class Contact(service.AsyncService):
         results = self.getResultsDescriptionAndColor(build['results'])
         if self.useRevisions:
             revisions = yield self.getRevisionsForBuild(build)
-            r = "Hey! build %s containing revision(s) [%s] is complete: %s" % \
+            r = "Build %s containing revision(s) [%s] is complete: %s" % \
                 (builder_name, ','.join(revisions), results[0])
         else:
-            r = "Hey! build %s #%d is complete: %s" % \
+            r = "Build %s #%d is complete: %s" % \
                 (builder_name, buildnum, results[0])
 
         r += ' [%s]' % maybeColorize(build['state_string'],
                                      results[1], self.useColors)
-        self.send(r)
 
-        # FIXME: where do we get the base_url? Then do we use the build Link to
-        # make the URL?
-        buildurl = None  # self.bot.status.getBuildbotURL() + build
-        if buildurl:
-            self.send("Build details are at %s" % buildurl)
+        r += " - %s" % utils.getURLForBuild(
+                self.master, builder['builderid'], buildnum)
+
+        self.send(r)
 
     @defer.inlineCallbacks
     def command_FORCE(self, args):

--- a/master/buildbot/test/unit/test_reporters_words.py
+++ b/master/buildbot/test/unit/test_reporters_words.py
@@ -518,7 +518,8 @@ class TestContactChannel(unittest.TestCase):
         yield self.sendBuildFinishedMessage(16)
         self.assertEqual(len(self.sent), 1)
         self.assertIn(
-            'Hey! build builder1 #6 is complete: Success []', self.sent)
+                "Build builder1 #6 is complete: Success [] - "
+                "http://localhost:8080/#builders/23/builds/6", self.sent)
 
     @defer.inlineCallbacks
     def test_command_watch_builder1(self):


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [NA] I have updated the appropriate documentation


the retiolum workflow requires buildbot to yield the URL of the last build to track build failures