### PR TITLE
Set the default SSL verification for session objects in OAuth2Auth.

### DIFF
--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -108,6 +108,7 @@ class OAuth2Auth(auth.AuthBase):
     def createSessionFromToken(self, token):
         s = requests.Session()
         s.params = {'access_token': token['access_token']}
+        s.verify = self.sslVerify
         return s
 
     def get(self, session, path):


### PR DESCRIPTION
The `verifyCode` method considers the `sslVerify` attribute, but the session object currently not.

Would it be a problem to expose the `sslVerify` attribute to the `__init__` method?