### PR TITLE
Fix revlink generation when a change is added

### DIFF
--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -140,6 +140,10 @@ class Change(base.ResourceType):
         else:
             uid = None
 
+        if not revlink and revision and repository and callable(self.master.config.revlink):
+            # generate revlink from revision and repository using the configured callable
+            revlink = self.master.config.revlink(revision, repository) or u''
+
         if callable(category):
             pre_change = self.master.config.preChangeGenerator(author=author,
                                                                files=files,

--- a/master/buildbot/newsfragments/revlink_generation.bugfix
+++ b/master/buildbot/newsfragments/revlink_generation.bugfix
@@ -1,0 +1,1 @@
+Fixed `addChange` in `:py:class:`~buildbot.data.changes.Change` to use the `revlink` configuration option to generate the revlink.

--- a/master/buildbot/test/unit/test_data_changes.py
+++ b/master/buildbot/test/unit/test_data_changes.py
@@ -332,3 +332,61 @@ class Change(interfaces.InterfaceTests, unittest.TestCase):
         )
         return self.do_test_addChange(kwargs,
                                       expectedRoutingKey, expectedMessage, expectedRow)
+
+    def test_addChange_repository_revision(self):
+        self.master.config = mock.Mock(name='master.config')
+        self.master.config.revlink = lambda rev, repo: 'foo%sbar%sbaz' % (repo, rev)
+        # revlink is default here
+        kwargs = dict(author=u'warner', branch=u'warnerdb',
+                      category=u'devel', comments=u'fix whitespace',
+                      files=[u'master/buildbot/__init__.py'],
+                      project=u'Buildbot', repository=u'git://warner',
+                      codebase=u'', revision=u'0e92a098b', when_timestamp=256738404,
+                      properties={u'foo': 20})
+        expectedRoutingKey = ('changes', '500', 'new')
+        # When no revlink is passed to addChange, but a repository and revision is
+        # passed, the revlink should be constructed by calling the revlink callable
+        # in the config. We thus expect a revlink of 'foogit://warnerbar0e92a098bbaz'
+        expectedMessage = {
+            'author': u'warner',
+            'branch': u'warnerdb',
+            'category': u'devel',
+            'codebase': u'',
+            'comments': u'fix whitespace',
+            'changeid': 500,
+            'files': [u'master/buildbot/__init__.py'],
+            'parent_changeids': [],
+            'project': u'Buildbot',
+            'properties': {u'foo': (20, u'Change')},
+            'repository': u'git://warner',
+            'revision': u'0e92a098b',
+            'revlink': u'foogit://warnerbar0e92a098bbaz',
+            'when_timestamp': 256738404,
+            'sourcestamp': {
+                'branch': u'warnerdb',
+                'codebase': u'',
+                'patch': None,
+                'project': u'Buildbot',
+                'repository': u'git://warner',
+                'revision': u'0e92a098b',
+                'created_at': epoch2datetime(10000000),
+                'ssid': 100,
+            },
+            # uid
+        }
+        expectedRow = fakedb.Change(
+            changeid=500,
+            author='warner',
+            comments='fix whitespace',
+            branch='warnerdb',
+            revision='0e92a098b',
+            revlink='foogit://warnerbar0e92a098bbaz',
+            when_timestamp=256738404,
+            category='devel',
+            repository='git://warner',
+            codebase='',
+            project='Buildbot',
+            sourcestampid=100,
+        )
+        return self.do_test_addChange(kwargs,
+                                      expectedRoutingKey, expectedMessage, expectedRow)


### PR DESCRIPTION
If no revlink is specified in the call to `Changes.addChange`, but a repository and revision is available, and the config has a revlink callable set, then `addChange` now calls that callable to generate a revlink.

The `revlink` configuration now works as documented.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [X] I have updated the appropriate documentation