### PR TITLE
DockerLatentWorker: fix threading issues

### DIFF
--- a/master/buildbot/newsfragments/thread_safety_of_dockerlatentworker.bugfix
+++ b/master/buildbot/newsfragments/thread_safety_of_dockerlatentworker.bugfix
@@ -1,0 +1,1 @@
+fix threading issue in :py:class:`~buildbot.plugins.worker.DockerLatentWorker`

--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -15,7 +15,12 @@
 
 
 class Client(object):
+    latest = None
+
     def __init__(self, base_url):
+        Client.latest = self
+        self.call_args_create_container = []
+        self.call_args_create_host_config = []
         self._images = [{'RepoTags': ['busybox:latest', 'worker:latest']}]
         self._containers = {}
 
@@ -49,15 +54,16 @@ class Client(object):
         return self._containers.values()
 
     def create_host_config(self, *args, **kwargs):
-        pass
+        self.call_args_create_host_config.append(kwargs)
 
     def create_container(self, image, *args, **kwargs):
+        self.call_args_create_container.append(kwargs)
         name = kwargs.get('name', None)
         if 'buggy' in image:
-            raise Exception("we could not create this container")
+            raise Exception('we could not create this container')
         for c in self._containers.values():
             if c['name'] == name:
-                raise Exception("cannot create with same name")
+                raise Exception('cannot create with same name')
         ret = {
             'Id':
             '8a61192da2b3bb2d922875585e29b74ec0dc4e0117fcbf84c962204e97564cd7',
@@ -67,7 +73,7 @@ class Client(object):
             'started': False,
             'image': image,
             'Id': ret['Id'],
-            "name": name
+            'name': name
         }
         return ret
 

--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -98,7 +98,6 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase):
         self.assertEqual(bs.command, ['/bin/sh'])
         self.assertEqual(bs.dockerfile, "FROM ubuntu")
         self.assertEqual(bs.volumes, [])
-        self.assertEqual(bs.binds, {})
         self.assertEqual(bs.client_args, {
                          'base_url': 'unix:///var/run/docker.sock', 'version': '1.9', 'tls': True})
         self.assertEqual(
@@ -109,25 +108,36 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase):
                               volumes=[Interpolate('/data:/buildslave/%(kw:builder)s/build',
                                        builder=Property('builder'))])
         id, name = self.successResultOf(bs.start_instance(self.build))
-        self.assertEqual(bs.volumes, ['/buildslave/docker_worker/build'])
+        client = docker.Client.latest
+        self.assertEqual(len(client.call_args_create_container), 1)
+        self.assertEqual(client.call_args_create_container[0]['volumes'],
+                         ['/buildslave/docker_worker/build'])
 
     def test_volume_no_suffix(self):
         bs = self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'worker', ['bin/bash'], volumes=['/src/webapp:/opt/webapp'])
         self.successResultOf(bs.start_instance(self.build))
-        self.assertEqual(bs.volumes, ['/opt/webapp'])
-        self.assertEqual(
-            bs.binds, {'/src/webapp': {'bind': '/opt/webapp', 'ro': False}})
+        client = docker.Client.latest
+        self.assertEqual(len(client.call_args_create_container), 1)
+        self.assertEqual(len(client.call_args_create_host_config), 1)
+        self.assertEqual(client.call_args_create_container[0]['volumes'],
+                         ['/opt/webapp'])
+        self.assertEqual(client.call_args_create_host_config[0]['binds'],
+                         {'/src/webapp': {'bind': '/opt/webapp', 'ro': False}})
 
     def test_volume_ro_rw(self):
         bs = self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker', ['bin/bash'],
                               volumes=['/src/webapp:/opt/webapp:ro',
                                        '~:/backup:rw'])
         self.successResultOf(bs.start_instance(self.build))
-        self.assertEqual(
-            bs.volumes, ['/opt/webapp', '/backup'])
-        self.assertEqual(bs.binds, {'/src/webapp': {'bind': '/opt/webapp', 'ro': True},
-                                    '~': {'bind': '/backup', 'ro': False}})
+        client = docker.Client.latest
+        self.assertEqual(len(client.call_args_create_container), 1)
+        self.assertEqual(len(client.call_args_create_host_config), 1)
+        self.assertEqual(client.call_args_create_container[0]['volumes'],
+                         ['/opt/webapp', '/backup'])
+        self.assertEqual(client.call_args_create_host_config[0]['binds'],
+                         {'/src/webapp': {'bind': '/opt/webapp', 'ro': True},
+                          '~': {'bind': '/backup', 'ro': False}})
 
     def test_volume_bad_format(self):
         self.assertRaises(config.ConfigErrors, self.setupWorker, 'bot', 'pass', 'http://localhost:2375',


### PR DESCRIPTION
Previously, the function `_thd_start_instance` was modifying the member variables `binds` and `volumes`. Because the function is running in a separate thread it is possible that multiple threads are trying to modify the variables at the same time. Switching to thread-local variables fixes this issue.