### PR TITLE
Fix exception in the trigger

### DIFF
--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -189,12 +189,14 @@ class Trigger(BuildStep):
         for was_cb, results in rclist:
             if isinstance(results, tuple):
                 results, brids_dict = results
+            else:
+                brids_dict = {}
 
             if not was_cb:
                 yield self.addLogWithFailure(results)
                 results = EXCEPTION
 
-            # brids_dict.values() rapresents the list of brids kicked by a certain scheduler.
+            # brids_dict.values() represents the list of brids kicked by a certain scheduler.
             # We want to ignore the result of ANY brid that was kicked off
             # by an UNimportant scheduler.
             if set(unimportant_brids).issuperset(set(brids_dict.values())):


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation


Fix exception like:
```
Traceback (most recent call last):
1  File ".../lib/python2.7/site-packages/twisted/internet/defer.py", line 1184, in gotResult
2    _inlineCallbacks(r, g, deferred)
3  File ".../lib/python2.7/site-packages/twisted/internet/defer.py", line 1128, in _inlineCallbacks
4    result = g.send(result)
5  File ".../lib/python2.7/site-packages/buildbot-0.9.1-py2.7.egg/buildbot/steps/trigger.py", line 301, in run
6    results = yield self.worstStatus(results, rclist, unimportant_brids)
7  File ".../lib/python2.7/site-packages/twisted/internet/defer.py", line 1274, in unwindGenerator
8    return _inlineCallbacks(None, gen, Deferred())
9---  ---
10  File ".../lib/python2.7/site-packages/twisted/internet/defer.py", line 1128, in _inlineCallbacks
11    result = g.send(result)
12  File ".../lib/python2.7/site-packages/buildbot-0.9.1-py2.7.egg/buildbot/steps/trigger.py", line 200, in worstStatus
13    if set(unimportant_brids).issuperset(set(brids_dict.values())):
14exceptions.UnboundLocalError: local variable 'brids_dict' referenced before assignment
```