### PR TITLE
Force GitPoller revisions to be ascii

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -251,7 +251,8 @@ class GitPoller(base.PollingChangeSource, StateMixin):
 
         # get the change list
         revListArgs = ([r'--format=%H', r'%s' % newRev] +
-                       [r'^%s' % rev for rev in self.lastRev.values()] +
+                       [r'^%s' % rev.encode('ascii', 'ignore')
+                        for rev in self.lastRev.values()] +
                        [r'--'])
         self.changeCount = 0
         results = yield self._dovccmd('log', revListArgs, path=self.workdir)


### PR DESCRIPTION
This is a shot in the dark. Twisted keeps complaining about
wanting strings instead of unicode when the gitpoller is running. It
looks like the unicode strings are coming from that self.lastRev variable.

(cherry picked from commit a6b9bd640277f30dc9774f2c4040ca904e67f35c)