### PR TITLE
Update cfg-reporters.rst

### DIFF
--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -178,6 +178,9 @@ MailNotifier arguments
     (list of strings).
     A combination of:
 
+    ``cancelled``
+        Send mail about builds which were cancelled.
+
     ``change``
         Send mail about builds which change status.
 


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

## Description:

The mode 'cancelled' is not documented. Below is the discussion (on IRC) with @seankelly regarding this:

(04:08:30 PM) slondono: skelly, is my assumption that a cancelled build is a FAILURE, correct?
(04:11:16 PM) skelly: there is a CANCELLED result, so I'm guessing it does not count
(04:11:28 PM) skelly: and cancelled is a possible mode
(04:13:02 PM) slondono: it is? it is not in the docs, from what I could see http://docs.buildbot.net/current/manual/cfg-reporters.html?highlight=mailnotifier#mailnotifier-arguments
...
(04:13:41 PM) skelly: it is in the code
(04:13:57 PM) skelly: I don't see it in the docs either

The mode is in the code as aforementioned, and can be viewed at: https://github.com/buildbot/buildbot/blob/master/master/buildbot/reporters/mail.py#L319