### PR TITLE
Don't recommend using addCallback as a function decorator

### DIFF
--- a/master/docs/developer/style.rst
+++ b/master/docs/developer/style.rst
@@ -82,7 +82,10 @@ In all cases, please prefer maintainability and readability over performance.
 Nested Callbacks
 ................
 
-First, an admonition: do not create extra class methods that represent the continuations of the first::
+First, an admonition: do not create extra class methods that represent the continuations of the first:
+
+
+.. code-block:: python
 
     def myMethod(self):
         d = ...
@@ -93,7 +96,9 @@ First, an admonition: do not create extra class methods that represent the conti
 Invariably, this extra method gets separated from its parent as the code
 evolves, and the result is completely unreadable. Instead, include all of the
 code for a particular function or method within the same indented block, using
-nested functions::
+nested functions:
+
+.. code-block:: python
 
     def getRevInfo(revname):
         # for example only! See above a better implementation with inlineCallbacks
@@ -116,7 +121,9 @@ nested functions::
 
 it is usually best to make the first operation occur within a callback, as the
 deferred machinery will then handle any exceptions as a failure in the outer
-Deferred.  As a shortcut, ``d.addCallback`` works as a decorator::
+Deferred.  As a shortcut, ``d.addCallback`` works as a decorator:
+
+.. code-block:: python
 
     d = defer.succeed(None)
     @d.addCallback
@@ -128,9 +135,9 @@ Deferred.  As a shortcut, ``d.addCallback`` works as a decorator::
     ``d.addCallback`` is not really a decorator as it does not return a modified function.
     As a result in previous code, ``rev_parse`` value is actually the Deferred.
     In general the :class:`inlineCallbacks` method is preferred inside new code as it keeps the code easier to read.
-    As a general rule of thumb, when you need more than 2 callbacks in the same method, its time to switch it to  :class:`inlineCallbacks`.
+    As a general rule of thumb, when you need more than 2 callbacks in the same method, it's time to switch it to  :class:`inlineCallbacks`.
     This would be for example the case for previous :py:func:`getRevInfo`.
-    See this `discussion <https://github.com/buildbot/buildbot/pull/2523>`_ with twisted experts for more information.
+    See this `discussion <https://github.com/buildbot/buildbot/pull/2523>`_ with Twisted experts for more information.
 
 Be careful with local variables. For example, if ``parse_rev_parse``, above,
 merely assigned ``rev = res.strip()``, then that variable would be local to
@@ -149,7 +156,9 @@ inlineCallbacks
 :class:`twisted.internet.defer.inlineCallbacks` is a great help to writing code
 that makes a lot of asynchronous calls, particularly if those calls are made in
 loop or conditionals.  Refer to the Twisted documentation for the details, but
-the style within Buildbot is as follows::
+the style within Buildbot is as follows:
+
+.. code-block:: python
 
     from twisted.internet import defer
 
@@ -188,7 +197,7 @@ Note that code using ``deferredGenerator`` is no longer acceptable in Buildbot.
 
 The previous :py:func:`getRevInfo` example implementation should rather be written as:
 
-.. code-block::
+.. code-block:: python
 
     @defer.inlineCallbacks
     def getRevInfo(revname):
@@ -219,7 +228,9 @@ Joining Sequences
 It's often the case that you'll want to perform multiple operations in
 parallel, and re-join the results at the end. For this purpose, you'll want to
 use a `DeferredList <http://twistedmatrix.com/documents/current/api/twisted.internet.defer.DeferredList.html>`_
-::
+:
+
+.. code-block:: python
 
     def getRevInfo(revname):
         results = {}


### PR DESCRIPTION
``addCallback`` returns a ``Deferred``.

A decorator should return a callable.

```
In [10]: d = succeed(object())

In [11]: @d.addCallback
def foo(result):
    pass
   ....: 

In [12]: foo
Out[12]: <Deferred at 0x7f6d5ca75170 current result: None>
```