### PR TITLE
RFC: Authentication for read only access to Web UI

### DIFF
--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -175,7 +175,7 @@ class GitHubAuth(OAuth2Auth):
     name = "GitHub"
     faIcon = "fa-github"
     authUri = 'https://github.com/login/oauth/authorize'
-    authUriAdditionalParams = {'scope': 'user:email'}
+    authUriAdditionalParams = {'scope': 'user'}
     tokenUri = 'https://github.com/login/oauth/access_token'
     resourceEndpoint = 'https://api.github.com'
 
@@ -186,7 +186,8 @@ class GitHubAuth(OAuth2Auth):
             if email.get('primary', False):
                 user['email'] = email['email']
                 break
-        orgs = self.get(c, join('/users', user['login'], "orgs"))
+        orgs = self.get(c, '/user/orgs')
+
         return dict(full_name=user['name'],
                     email=user['email'],
                     username=user['login'],
@@ -212,3 +213,25 @@ class GitLabAuth(OAuth2Auth):
                     email=user["email"],
                     avatar_url=user["avatar_url"],
                     groups=[g["path"] for g in groups])
+
+
+class BitbucketAuth(OAuth2Auth):
+    name = "Bitbucket"
+    faIcon = "fa-bitbucket"
+    authUri = 'https://bitbucket.org/site/oauth2/authorize'
+    tokenUri = 'https://bitbucket.org/site/oauth2/access_token'
+    resourceEndpoint = 'https://api.bitbucket.org/2.0'
+
+    def getUserInfoFromOAuthClient(self, c):
+        user = self.get(c, '/user')
+        emails = self.get(c, '/user/emails')
+        for email in emails["values"]:
+            if email.get('is_primary', False):
+                user['email'] = email['email']
+                break
+        orgs = self.get(c, '/teams?role=member')
+        return dict(full_name=user['display_name'],
+                    email=user['email'],
+                    username=user['username'],
+                    groups=[org['username'] for org in orgs["values"]]
+        )


### PR DESCRIPTION
This is most definitely not mergeable as is, and is mainly a request for comments.

## Authentication for read only access to Web UI
I have tried to figure out how to enforce authentication for accessing the Web UI. The last trace I found of a discussion on this is in [these emails](http://comments.gmane.org/gmane.comp.python.buildbot.devel/11478) which indicate this is not supported yet.

This PR adds a call to _assertUserAllowed()_ in `www/config.IndexResource.renderIndex()`
which enforces authentication based on the allowRules. However, this changes the behavior of the current code such that AnyEndpointMatcher now matches any access to the Web UI.

According to the docs, the endpoint matchers are only responsible for the REST endpoints, so
I presume a proper solution would add a separate set of allowRules for viewing the different parts of the Web UI?

## oauth2.GitHubAuth
`https://api.github.com/users/{username}/orgs` only returns the organizations for the user that are publicly visible. Is that intended?
This has been changed to `https://api.github.com/user/orgs' which returns all organziations for the user (requires scope=user)

## oauth2.BitbucketAuth
Implemented

## Contributor Checklist:
* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

## Feedback

Please give feedback on how I can improve this, or even better, make the required changes yourself if you desire.