### PR TITLE
fix for recent version of sphinx

### DIFF
--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -257,8 +257,9 @@ htmlhelp_basename = 'Buildbotdoc'
 
 # -- Options for LaTeX output --------------------------------------------
 
+latex_elements = {}
 # The paper size ('letter' or 'a4').
-latex_paper_size = 'a4'
+latex_elements['papersize'] = 'a4'
 
 # The font size ('10pt', '11pt' or '12pt').
 # latex_font_size = '11pt'


### PR DESCRIPTION
fix for CI issue:

39
40Warning, treated as error:
41WARNING: latex_paper_size is deprecated. Use latex_elements['papersize'] instead.
42
