### PR TITLE
fix tests for innodb engine

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -30,7 +30,7 @@ env:
   - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=sqlite:////tmp/test_db.sqlite
   # Configuration that runs tests with real MySQL database (TODO does not work yet with our docker image)
   - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest
-  #- TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest?storage_engine=InnoDB
+  - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest?storage_engine=InnoDB
   # Configuration that runs tests with real PostgreSQL database with pg8000 and psycopg2 drivers
   # psycopg2 uses Peer Authentication which is configured in the dockerfile, while pg8000 use md5 auth with dummy password
   #- TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=postgresql+psycopg2:///bbtest

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   # Helps to detect issues with incorrect database setup/cleanup in tests.
   # Configuration that runs tests with real MySQL database
   - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest
-  #- TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest?storage_engine=InnoDB
+  - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest?storage_engine=InnoDB
   # Configuration that runs tests with real PostgreSQL database with pg8000 and psycopg2 drivers
   - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=postgresql+psycopg2:///bbtest?user=postgres
   - TWISTED=latest SQLALCHEMY=latest TESTS=trial BUILDBOT_TEST_DB_URL=postgresql+pg8000:///bbtest?user=postgres

--- a/master/buildbot/db/migrate/versions/047_cascading_deletes.py
+++ b/master/buildbot/db/migrate/versions/047_cascading_deletes.py
@@ -42,9 +42,10 @@ def upgrade(migrate_engine):
                     # migrate.xx.ForeignKeyConstraint is changing the model so initializing here
                     # would break the iteration (Set changed size during iteration)
                     fks_to_change.append((
-                        (fk.columns, [c.column]), dict(name=fk.name, ondelete='CASCADE')))
+                        table, (fk.columns, [c.column]), dict(name=fk.name, ondelete='CASCADE')))
 
-    for args, kwargs in fks_to_change:
+    for table, args, kwargs in fks_to_change:
         fk = ForeignKeyConstraint(*args, **kwargs)
+        table.append_constraint(fk)
         fk.drop()
         fk.create()

--- a/master/buildbot/db/migrate/versions/047_cascading_deletes.py
+++ b/master/buildbot/db/migrate/versions/047_cascading_deletes.py
@@ -29,16 +29,23 @@ def upgrade(migrate_engine):
     builder_masters = sautils.Table('builder_masters', metadata, autoload=True)
     configured_workers = sautils.Table('configured_workers', metadata,
                                        autoload=True)
+    fks_to_change = []
+    # we need to parse the reflected model in order to find the automatic fk name that was put
+    # mysql and pgsql have different naming convention so this is not very easy to have generic code working.
+    for table, keys in [(builder_masters, (builders.c.id, masters.c.id)),
+                        (configured_workers, (builder_masters.c.id, workers.c.id))]:
+        for fk in table.constraints:
+            if not isinstance(fk, sa.ForeignKeyConstraint):
+                continue
+            for c in fk.elements:
+                if c.column in keys:
+                    # migrate.xx.ForeignKeyConstraint is changing the model so initializing here
+                    # would break the iteration (Set changed size during iteration)
+                    fks_to_change.append((
+                        (fk.columns, [c.column]), dict(name=fk.name, ondelete='CASCADE')))
 
-    for fk in (ForeignKeyConstraint([builder_masters.c.builderid],
-                                    [builders.c.id], ondelete='CASCADE'),
-               ForeignKeyConstraint([builder_masters.c.masterid],
-                                    [masters.c.id], ondelete='CASCADE'),
-               ForeignKeyConstraint([configured_workers.c.buildermasterid],
-                                    [builder_masters.c.id], ondelete='CASCADE'),
-               ForeignKeyConstraint([configured_workers.c.workerid],
-                                    [workers.c.id], ondelete='CASCADE'),
-               ):
+    for args, kwargs in fks_to_change:
+        fk = ForeignKeyConstraint(*args, **kwargs)
         if migrate_engine.dialect.name != 'sqlite':
             fk.drop()
         fk.create()

--- a/master/buildbot/db/migrate/versions/047_cascading_deletes.py
+++ b/master/buildbot/db/migrate/versions/047_cascading_deletes.py
@@ -46,6 +46,5 @@ def upgrade(migrate_engine):
 
     for args, kwargs in fks_to_change:
         fk = ForeignKeyConstraint(*args, **kwargs)
-        if migrate_engine.dialect.name != 'sqlite':
-            fk.drop()
+        fk.drop()
         fk.create()

--- a/master/buildbot/db/users.py
+++ b/master/buildbot/db/users.py
@@ -196,7 +196,8 @@ class UsersConnectorComponent(base.DBConnectorComponent):
                     & (tbl_info.c.attr_type == attr_type))
                 res = conn.execute(q, attr_data=attr_data)
                 if res.rowcount == 0:
-                    _race_hook and _race_hook(conn)
+                    if _race_hook is not None:
+                        _race_hook(conn)
 
                     # the update hit 0 rows, so try inserting a new one
                     try:

--- a/master/buildbot/test/unit/test_db_users.py
+++ b/master/buildbot/test/unit/test_db_users.py
@@ -208,7 +208,7 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
 
         def check_user(uid):
             # creates a new user
-            self.assertEqual(uid, 2)
+            self.assertNotEqual(uid, 1)
 
             def thd(conn):
                 users_tbl = self.db.model.users

--- a/master/buildbot/test/unit/test_db_users.py
+++ b/master/buildbot/test/unit/test_db_users.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import sqlalchemy
+
 from twisted.trial import unittest
 
 from buildbot.db import users
@@ -431,7 +433,7 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
         # the existing transaction) and executes a conflicting insert in that
         # connection.  This will cause the insert in the db method to fail, and
         # the data in this insert (8.8.8.8) will appear below.
-
+        transaction_wins = []
         if (self.db.pool.engine.dialect.name == 'sqlite' and
                 self.db.pool.engine.url.database not in [None, ':memory:']):
             # It's not easy to work with file-based SQLite via multiple
@@ -443,10 +445,15 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
 
         def race_thd(conn):
             conn = self.db.pool.engine.connect()
-            conn.execute(self.db.model.users_info.insert(),
-                         uid=1, attr_type='IPv4',
-                         attr_data='8.8.8.8')
-
+            try:
+                r = conn.execute(self.db.model.users_info.insert(),
+                                 uid=1, attr_type='IPv4',
+                                 attr_data='8.8.8.8')
+                r.close()
+            except sqlalchemy.exc.OperationalError:
+                # some engine (mysql innodb) will enforce lock until the transaction is over
+                transaction_wins.append(True)
+                # scope variable, we modify a list so that modification is visible in parent scope
         d = self.insertTestData(self.user1_rows)
 
         def update1(_):
@@ -461,7 +468,10 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
 
         def check1(usdict):
             self.assertEqual(usdict['identifier'], 'soap')
-            self.assertEqual(usdict['IPv4'], '8.8.8.8')
+            if transaction_wins:
+                self.assertEqual(usdict['IPv4'], '123.134.156.167')
+            else:
+                self.assertEqual(usdict['IPv4'], '8.8.8.8')
             self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
         d.addCallback(check1)
         return d


### PR DESCRIPTION
There is a slight behaviour difference with innodb engine which locks the table on an update until transaction end even if the update didn't change anything.

