### PR TITLE
trigger: naming of triggered build result depending on triggered build not on overall status

### DIFF
--- a/master/buildbot/newsfragments/triggerstep_buildURL_generation.bugfix
+++ b/master/buildbot/newsfragments/triggerstep_buildURL_generation.bugfix
@@ -1,0 +1,1 @@
+Fixed `addBuildURLs` in `:py:class: `~buildbot.steps.trigger.Trigger` to use results from triggered builds to include in the URL name exposed by API.

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -216,7 +216,7 @@ class Trigger(BuildStep):
                     for build in builds:
                         num = build['number']
                         url = self.master.status.getURLForBuild(builderid, num)
-                        yield self.addURL("%s: %s #%d" % (statusToString(results),
+                        yield self.addURL("%s: %s #%d" % (statusToString(build["results"]),
                                                           builderDict["name"], num), url)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -512,6 +512,18 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
         self.expectTriggeredLinks('afailed')
         return self.runStep()
 
+    def test_waitForFinish_split_failure(self):
+        self.setupStep(trigger.Trigger(schedulerNames=['a', 'b'],
+                                       waitForFinish=True))
+        self.scheduler_a.result = FAILURE
+        self.scheduler_b.result = SUCCESS
+        self.expectOutcome(result=FAILURE, state_string='triggered a, b')
+        self.expectTriggeredWith(
+            a=(True, [], {}),
+            b=(True, [], {}))
+        self.expectTriggeredLinks('afailed', 'b')
+        return self.runStep()
+
     @defer.inlineCallbacks
     def test_waitForFinish_exception(self):
         self.setupStep(trigger.Trigger(schedulerNames=['a', 'b'],

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -81,10 +81,18 @@ class FakeSourceStamp(object):
 class FakeSchedulerManager(object):
     pass
 
+
 # Magic numbers that relate brid to other build settings
-BRID_TO_BSID = lambda brid: brid + 2000
-BRID_TO_BID = lambda brid: brid + 3000
-BRID_TO_BUILD_NUMBER = lambda brid: brid + 4000
+def BRID_TO_BSID(brid):
+    return brid + 2000
+
+
+def BRID_TO_BID(brid):
+    return brid + 3000
+
+
+def BRID_TO_BUILD_NUMBER(brid):
+    return brid + 4000
 
 
 class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
@@ -123,12 +131,15 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
         b.brids = {78: 22}
         c.brids = {79: 33, 80: 44}
 
-        make_fake_br = lambda brid, builderid: fakedb.BuildRequest(
-            id=brid, buildsetid=BRID_TO_BSID(brid), builderid=builderid)
-        make_fake_build = lambda brid: fakedb.Build(
-            buildrequestid=brid, id=BRID_TO_BID(brid),
-            number=BRID_TO_BUILD_NUMBER(brid), masterid=9,
-            workerid=13)
+        def make_fake_br(brid, builderid):
+            return fakedb.BuildRequest(
+                id=brid, buildsetid=BRID_TO_BSID(brid), builderid=builderid)
+
+        def make_fake_build(brid):
+            return fakedb.Build(
+                buildrequestid=brid, id=BRID_TO_BID(brid),
+                number=BRID_TO_BUILD_NUMBER(brid), masterid=9,
+                workerid=13)
 
         m.db.insertTestData([
             fakedb.Builder(id=77, name='A'),


### PR DESCRIPTION
Currently the exposed URLs in `step['urls']` have a `name` key which has a prepended result string which is derived from the current status of the triggerbuild I think.  This makes trigger step results i.e. in reporters useless because if one build inside the trigger fails all builds are prepended with `failure: `. To make life easier for mail report generation I changed the corresponding code to use the results of the triggered builds to generatio the results string.

I am aware that tests with `waitForFinish` in TriggerSteps are failing now and that's the reason why  I submit this PR now. I'm not sure how to `fix` the tests to resemble the same result. To pass checks for generated URLs the corresponding builds for each trigger would have to be marked with `SUCCESS/FAILURE` in the db to receive URLs with `success/failure` in them instead of `not finished`.

For me this PR is now working and user are happy to receive meaningful emails telling them which of the triggered builds failed.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation


