### PR TITLE
[RFC] Auth check on REST API

### DIFF
--- a/master/buildbot/newsfragments/www_rest_auth.feature
+++ b/master/buildbot/newsfragments/www_rest_auth.feature
@@ -1,1 +1,1 @@
-Implement support for authentication in REST API in :py:class:`~buildbot.www.rest.V2RootResource`.
+Buildbot can know be configured to deny read access to REST api resources based on authorization rules.

--- a/master/buildbot/newsfragments/www_rest_auth.feature
+++ b/master/buildbot/newsfragments/www_rest_auth.feature
@@ -1,1 +1,1 @@
-Buildbot can know be configured to deny read access to REST api resources based on authorization rules.
+Buildbot can now be configured to deny read access to REST api resources based on authorization rules.

--- a/master/buildbot/newsfragments/www_rest_auth.feature
+++ b/master/buildbot/newsfragments/www_rest_auth.feature
@@ -1,0 +1,1 @@
+Implement support for authentication in REST API in :py:class:`~buildbot.www.rest.V2RootResource`.

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+import mock
+
 from twisted.internet import defer
 from twisted.internet import protocol
 from twisted.internet import reactor
@@ -28,6 +30,7 @@ from buildbot.test.util import www
 from buildbot.util import json
 from buildbot.www import service as wwwservice
 from buildbot.www import auth
+from buildbot.www import authz
 
 SOMETIME = 1348971992
 OTHERTIME = 1008971992
@@ -80,12 +83,14 @@ class Www(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase):
             port='tcp:0:interface=127.0.0.1',
             debug=True,
             auth=auth.NoAuth(),
+            authz=authz.Authz(),
             avatar_methods=[],
             logfileName='http.log')
         master.www = wwwservice.WWWService()
         master.www.setServiceParent(master)
         yield master.www.startService()
         yield master.www.reconfigServiceWithBuildbotConfig(master.config)
+        master.www.site.sessionFactory = mock.Mock(return_value=mock.Mock())
 
         # now that we have a port, construct the real URL and insert it into
         # the config.  The second reconfig isn't really required, but doesn't

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -337,6 +337,8 @@ class V2RootResource(resource.Resource):
             request.write(json.dumps(dict(error=msg)))
 
         with self.handleErrors(writeError):
+            yield self.master.www.assertUserAllowed(request, tuple(request.postpath), request.method, {})
+
             ep, kwargs = self.getEndpoint(request)
 
             rspec = self.decodeResultSpec(request, ep)


### PR DESCRIPTION
As per [this comment](https://github.com/buildbot/buildbot/pull/2524#pullrequestreview-11279351) adding authentication check on the REST API is the most important step to improve security.

Would this be close to a solution? This does change the behavior of the current `AnyEndpointMatcher`, making it even more strict that before.

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation