### PR TITLE
GitlabStatusPush: Use branch name as ref

### DIFF
--- a/master/buildbot/newsfragments/gitlab_ref.bugfix
+++ b/master/buildbot/newsfragments/gitlab_ref.bugfix
@@ -1,0 +1,1 @@
+Fixed `ref` to point to `branch` instead of commit `sha` in :py:class:`~buildbot.reporters.GitlabStatusPush`

--- a/master/buildbot/test/unit/test_reporter_gitlab.py
+++ b/master/buildbot/test/unit/test_reporter_gitlab.py
@@ -69,21 +69,21 @@ class TestGitLabStatusPush(unittest.TestCase, ReporterTestMixin):
             '/api/v3/projects/1/statuses/d34db33fd43db33f',
             json={'state': 'pending',
                   'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                  'ref': 'd34db33fd43db33f',
+                  'ref': 'master',
                   'description': 'Build started.', 'name': 'buildbot/Builder0'})
         self._http.expect(
             'post',
             '/api/v3/projects/1/statuses/d34db33fd43db33f',
             json={'state': 'success',
                   'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                  'ref': 'd34db33fd43db33f',
+                  'ref': 'master',
                   'description': 'Build done.', 'name': 'buildbot/Builder0'})
         self._http.expect(
             'post',
             '/api/v3/projects/1/statuses/d34db33fd43db33f',
             json={'state': 'failed',
                   'target_url': 'http://localhost:8080/#builders/79/builds/0',
-                  'ref': 'd34db33fd43db33f',
+                  'ref': 'master',
                   'description': 'Build done.', 'name': 'buildbot/Builder0'})
 
         build['complete'] = False


### PR DESCRIPTION
* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation


Gitlab expects branch name as ref, not commit hash.