### PR TITLE
fix issue with OpenSSL not installed giving errors

### DIFF
--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -27,7 +27,6 @@ from StringIO import StringIO
 
 from twisted.internet import defer
 from twisted.internet import reactor
-from twisted.internet import ssl
 from twisted.python import log as twlog
 from zope.interface import implementer
 
@@ -45,6 +44,7 @@ from buildbot.reporters import utils
 from buildbot.reporters.message import MessageFormatter as DefaultMessageFormatter
 from buildbot.reporters.message import MessageFormatterMissingWorker
 from buildbot.util import service
+from buildbot.util import ssl
 
 charset.add_charset('utf-8', charset.SHORTEST, None, 'utf-8')
 
@@ -53,7 +53,6 @@ try:
     ESMTPSenderFactory = ESMTPSenderFactory  # for pyflakes
 except ImportError:
     ESMTPSenderFactory = None
-
 
 # Email parsing can be complex. We try to take a very liberal
 # approach. The local part of an email address matches ANY non
@@ -161,6 +160,9 @@ class MailNotifier(service.BuildbotService):
         if extraHeaders:
             if not isinstance(extraHeaders, dict):
                 config.error("extraHeaders must be a dictionary")
+
+        if useSmtps:
+            ssl.ensureHasSSL(self.__class__.__name__)
 
         # you should either limit on builders or tags, not both
         if builders is not None and tags is not None:

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -35,6 +35,7 @@ from buildbot.reporters.mail import MailNotifier
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.util.config import ConfigErrorsMixin
+from buildbot.util import ssl
 
 py_27 = sys.version_info[0] > 2 or (sys.version_info[0] == 2
                                     and sys.version_info[1] >= 7)
@@ -615,6 +616,7 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase):
         self.assertEqual(1, len(fakereactor.method_calls))
         self.assertIn(('connectTCP', ('localhost', 25, None), {}), fakereactor.method_calls)
 
+    @ssl.skipUnless
     @defer.inlineCallbacks
     def test_sendMessageOverSsl(self):
         fakereactor = Mock()

--- a/master/buildbot/test/unit/test_util_ssl.py
+++ b/master/buildbot/test/unit/test_util_ssl.py
@@ -1,0 +1,39 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import mock
+
+from twisted.trial import unittest
+
+from buildbot import config
+from buildbot.util import ssl
+
+
+class Tests(unittest.TestCase):
+
+    @ssl.skipUnless
+    def test_ClientContextFactory(self):
+        from twisted.internet.ssl import ClientContextFactory
+        self.assertEqual(ssl.ClientContextFactory, ClientContextFactory)
+
+    @ssl.skipUnless
+    def test_ConfigError(self):
+        ssl.ssl_import_error = "lib xxx do not exist"
+        ssl.has_ssl = False
+        self.patch(config, "_errors", mock.Mock())
+        ssl.ensureHasSSL("myplugin")
+        config._errors.addError.assert_called_with(
+            "TLS dependencies required for myplugin are not installed : "
+            "lib xxx do not exist\n pip install 'buildbot[tls]'")

--- a/master/buildbot/util/ssl.py
+++ b/master/buildbot/util/ssl.py
@@ -18,7 +18,7 @@
 """
 
 try:
-    from twisted.internet.ssl import *  # noqa
+    from twisted.internet.ssl import *  # noqa pylint: disable=unused-wildcard-import, wildcard-import
     ssl_import_error = None
     has_ssl = True
 except ImportError as e:

--- a/master/buildbot/util/ssl.py
+++ b/master/buildbot/util/ssl.py
@@ -1,0 +1,38 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+"""This modules acts the same as twisted.internet.ssl except it does not raise ImportError
+
+    Modules using this should call ensureHasSSL in order to make sure that the user installed buildbot[tls]
+"""
+
+try:
+    from twisted.internet.ssl import *  # noqa
+    ssl_import_error = None
+    has_ssl = True
+except ImportError as e:
+    ssl_import_error = str(e)
+    has_ssl = False
+
+
+def ensureHasSSL(module):
+    from buildbot.config import error
+    if not has_ssl:
+        error("TLS dependencies required for {} are not installed : {}\n pip install 'buildbot[tls]'".format(
+            module, ssl_import_error))
+
+
+def skipUnless(f):
+    import unittest
+    return unittest.skipUnless(has_ssl, "TLS dependencies required")(f)

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -1267,3 +1267,22 @@ For example, a particular daily scheduler could be configured on multiple master
                     self.assertEqual(response.getErrorMessage(), '404: server did not succeed')
 
 .. _AngularJS ngMock: https://docs.angularjs.org/api/ngMock/service/$httpBackend
+
+:py:mod:`buildbot.util.ssl`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module is a copy of :py:mod:`twisted.internet.ssl` except it won't crash with :py:class:`ImportError` if :py:mod:`pyopenssl` is not installed.
+If you need to use :py:mod:`twisted.internet.ssl`, please instead use :py:mod:`buildbot.util.ssl`, and call :py:func:`ssl.ensureHasSSL` in :py:meth:`checkConfig` to provide helpful message to the user, only if he enabled SSL for your plugin.
+
+.. py:function:: ensureHasSSL(plugin_name)
+
+    :param plugin_name: name of the plugin. Usually ``self.__class__.__name__``
+
+    Call this function to provide helpful config error to the user in case of ``OpenSSL`` not installed.
+
+
+.. py:function:: skipUnless(f)
+
+    :param f: decorated test
+
+    Test decorator which will skip the test if ``OpenSSL`` is not installed.

--- a/master/setup.py
+++ b/master/setup.py
@@ -492,7 +492,7 @@ else:
             # There are bugs with extras inside extras:
             # <https://github.com/pypa/pip/issues/3516>
             # so we explicitly include Twisted[tls] dependencies.
-            'pyopenssl >= 0.13',
+            'pyopenssl >= 16.0.0',
             'service_identity',
             'idna >= 0.6',
         ],


### PR DESCRIPTION
factorize the ssl import tweaks into its own module

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation


