### PR TITLE
fix e2e tests when the builder id change

### DIFF
--- a/smokes/e2e/builder.coffee
+++ b/smokes/e2e/builder.coffee
@@ -4,30 +4,29 @@
 # http://www.lindstromhenrik.com/using-protractor-with-coffeescript/
 
 class builderPage
-    constructor: (builder, forcename) ->
-        @builderID = {
-            "runtest" : 1
-            "slowruntest": 2
-        }[builder]
+    constructor: (@builder, forcename) ->
         @forceName=forcename
 
     goDefault: ->
         browser.get('#/builders')
 
     go: () ->
-        browser.get('#/builders/#{@builderID}/')
+        browser.get('#/builders')
+        element.all(By.partialLinkText(@builder)).first().click()
 
     goForce: (forcename) ->
-        browser.get("#/builders/#{@builderID}/force/#{@forceName}")
+        browser.get('#/builders')
+        element.all(By.partialLinkText(@builder)).first().click()
+        element.all(By.buttonText(@forceName)).first().click()
 
     getBuildCount: () ->
-        return element.all(By.css('span.badge-status.results_SUCCESS')).count()
+        return element.all(By.css('span.badge-status.results_SUCCESS')).get(0).getText()
 
     waitNextBuildFinished: (reference) ->
         self = this
         buildCountIncrement = () ->
             self.getBuildCount().then (currentBuildCount) ->
                 return +currentBuildCount == +reference + 1
-        browser.wait(buildCountIncrement, 2000)
+        browser.wait(buildCountIncrement, 10000)
 
 module.exports = builderPage

--- a/smokes/e2e/console.coffee
+++ b/smokes/e2e/console.coffee
@@ -3,10 +3,12 @@
 # inspired by this methodology
 # http://www.lindstromhenrik.com/using-protractor-with-coffeescript/
 
-class waterfallPage
+class consolePage
     constructor: ->
 
     go: ->
-        browser.get('#/waterfall')
+        browser.get('#/console')
+    countSuccess: () ->
+        element.all(By.css('.badge-status.results_SUCCESS')).count()
 
-module.exports = waterfallPage
+module.exports = consolePage

--- a/smokes/e2e/force.scenarios.coffee
+++ b/smokes/e2e/force.scenarios.coffee
@@ -25,5 +25,4 @@ describe('', () ->
                 force.getStartButton().click()
                 builder.go()
                 builder.waitNextBuildFinished(lastbuild)
-                expect(element.all(By.css('rect.success')).count()).toBeGreaterThan(0)
 )

--- a/smokes/e2e/hook.scenarios.coffee
+++ b/smokes/e2e/hook.scenarios.coffee
@@ -1,21 +1,24 @@
+consolePage = require('./console.coffee')
+builderPage = require('./builder.coffee')
+
 describe 'change hook', () ->
+    builder = null
+    console = null
+    beforeEach(() ->
+        builder = new builderPage('runtest', 'force')
+        console = new consolePage()
+    )
     it 'should create a build', () ->
-        browser.get('#/builders/1')
-        lastbuild = element.all(By.css('span.badge-status.results_SUCCESS')).count()
-        browser.executeAsyncScript (done)->
-            $.post('change_hook/base', {
-                comments:'sd',
-                project:'pyflakes'
-                repository:'git://github.com/buildbot/pyflakes.git'
-                author:'foo'
-                branch:'master'
-                }, done)
-        browser.get('#/builders/1')
-        successBuildIncrease =  ->
-            lastbuild.then (lastbuild)->
-                element.all(By.css('span.badge-status.results_SUCCESS'))
-                .count().then (nextbuild)->
-                    return +nextbuild == +lastbuild + 1
-        browser.wait(successBuildIncrease, 20000)
-        browser.get('#/console')
-        expect(element.all(By.css('.badge-status.results_SUCCESS')).count()).toBeGreaterThan(0)
+        builder.go()
+        builder.getBuildCount().then (lastbuild) ->
+            browser.executeAsyncScript (done)->
+                $.post('change_hook/base', {
+                    comments:'sd',
+                    project:'pyflakes'
+                    repository:'git://github.com/buildbot/pyflakes.git'
+                    author:'foo'
+                    branch:'master'
+                    }, done)
+            builder.waitNextBuildFinished(lastbuild)
+        console.go()
+        expect(console.countSuccess()).toBeGreaterThan(0)


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests

You cannot hardcode builderid, as this can change according to the color of the moon.
Probably builderids depend on the dictionary order.

So we change the strategy so that we find the ids by clicking on the UI links