### PR TITLE
Gitlab reporter was missing in the setup.

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -305,6 +305,7 @@ setup_args = {
             ('buildbot.reporters.gerrit_verify_status', ['GerritVerifyStatusPush']),
             ('buildbot.reporters.http', ['HttpStatusPush']),
             ('buildbot.reporters.github', ['GitHubStatusPush']),
+            ('buildbot.reporters.gitlab.py', ['GitLabStatusPush']),
             ('buildbot.reporters.stash', ['StashStatusPush']),
             ('buildbot.reporters.bitbucket', ['BitbucketStatusPush']),
             ('buildbot.reporters.irc', ['IRC']),


### PR DESCRIPTION
The gitlabstatuspush reporter (mentioned in the doc http://docs.buildbot.net/latest/full.html#gitlabstatuspush) was not in the package. I assume that is the way to add it correctly.
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

No more errors were reported by trial buildbot.tests although I'm not sure this is the right way to fix the bug. 
