### PR TITLE
Handle any exception in checkconfig

### DIFF
--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -113,20 +113,25 @@ def isBuildmasterDir(dir):
     return True
 
 
-def getConfigFromTac(basedir):
+def getConfigFromTac(basedir, quiet=False):
     tacFile = os.path.join(basedir, 'buildbot.tac')
     if os.path.exists(tacFile):
         # don't mess with the global namespace, but set __file__ for
         # relocatable buildmasters
         tacGlobals = {'__file__': tacFile}
-        exec(open(tacFile).read(), tacGlobals)
+        try:
+            exec(open(tacFile).read(), tacGlobals)
+        except Exception as e:
+            if not quiet:
+                print(e)
+            raise
         return tacGlobals
     return None
 
 
-def getConfigFileFromTac(basedir):
+def getConfigFileFromTac(basedir, quiet=False):
     # execute the .tac file to see if its configfile location exists
-    config = getConfigFromTac(basedir)
+    config = getConfigFromTac(basedir, quiet=quiet)
     if config:
         return config.get("configfile", "master.cfg")
     else:

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -121,9 +121,9 @@ def getConfigFromTac(basedir, quiet=False):
         tacGlobals = {'__file__': tacFile}
         try:
             exec(open(tacFile).read(), tacGlobals)
-        except Exception as e:
+        except Exception:
             if not quiet:
-                print(e)
+                traceback.print_exc()
             raise
         return tacGlobals
     return None

--- a/master/buildbot/scripts/checkconfig.py
+++ b/master/buildbot/scripts/checkconfig.py
@@ -46,8 +46,8 @@ def checkconfig(config):
     if os.path.isdir(configFile):
         basedir = configFile
         try:
-            configFile = getConfigFileFromTac(basedir)
-        except (SyntaxError, ImportError) as e:
+            configFile = getConfigFileFromTac(basedir, quiet=quiet)
+        except (Exception) as e:
             if not quiet:
                 print("Unable to load 'buildbot.tac' from '%s':" % basedir)
                 print(e)

--- a/master/buildbot/scripts/checkconfig.py
+++ b/master/buildbot/scripts/checkconfig.py
@@ -47,10 +47,10 @@ def checkconfig(config):
         basedir = configFile
         try:
             configFile = getConfigFileFromTac(basedir, quiet=quiet)
-        except (Exception) as e:
+        except Exception:
             if not quiet:
+                # the exception is already printed in base.py
                 print("Unable to load 'buildbot.tac' from '%s':" % basedir)
-                print(e)
             return 1
     else:
         basedir = os.getcwd()


### PR DESCRIPTION

It can be very frustrating to not being able to start buildbot,
because there is a random error in the buildbot tac,
and if no message is displayed

- change in base to display error for buildbot start/upgrade, etc
- also change in checkconfig
- keep the quiet behaviour