### PR TITLE
fix sendchange --help's description for --encoding

### DIFF
--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -244,8 +244,7 @@ class SendChangeOptions(base.SubcommandOptions):
          "Read the log messages from this file (- for stdin)"),
         ("when", "w", None, "timestamp to use as the change time"),
         ("revlink", "l", '', "Revision link (revlink)"),
-        ("encoding", "e", 'utf8',
-            "Encoding of other parameters (default utf8)"),
+        ("encoding", "e", 'utf8', "Encoding of other parameters"),
     ]
 
     buildbotOptions = [


### PR DESCRIPTION
remove extra one 'default', since it is added automatically

```
...
-e, --encoding=       Encoding of other parameters (default utf8) [default:
		              utf8]
```