### PR TITLE
Fix duplicate worker usecase

### DIFF
--- a/master/buildbot/newsfragments/duplicate_worker.bugfix
+++ b/master/buildbot/newsfragments/duplicate_worker.bugfix
@@ -1,0 +1,1 @@
+Fix duplicate worker usecase, where a worker with the same name would make the other worker also disconnect (:bug:`3656`)

--- a/master/buildbot/newsfragments/duplicate_worker.bugfix
+++ b/master/buildbot/newsfragments/duplicate_worker.bugfix
@@ -1,1 +1,1 @@
-Fix duplicate worker usecase, where a worker with the same name would make the other worker also disconnect (:bug:`3656`)
+Fix duplicate worker use case, where a worker with the same name would make the other worker also disconnect (:bug:`3656`)

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -181,15 +181,15 @@ class TestWorkerComm(unittest.TestCase):
         self.buildworker = None
         self.port = None
         self.workerworker = None
-        self.connector = None
+        self.connectors = []
         self._detach_deferreds = []
 
         # patch in our FakeBuilder for the regular Builder class
         self.patch(botmaster, 'Builder', FakeBuilder)
 
     def tearDown(self):
-        if self.connector:
-            self.connector.disconnect()
+        for connector in self.connectors:
+            connector.disconnect()
         deferreds = self._detach_deferreds + [
             self.pbmanager.stopService(),
             self.botmaster.stopService(),
@@ -254,7 +254,8 @@ class TestWorkerComm(unittest.TestCase):
 
             return workerworker
 
-        self.connector = reactor.connectTCP("127.0.0.1", self.port, factory)
+        self.connectors.append(
+            reactor.connectTCP("127.0.0.1", self.port, factory))
 
         if not waitForBuilderList:
             return login_d
@@ -282,7 +283,6 @@ class TestWorkerComm(unittest.TestCase):
         # wait for the resulting detach
         yield worker.waitForDetach()
 
-    @flaky(bugNumber=2761)
     @defer.inlineCallbacks
     def test_duplicate_worker(self):
         yield self.addWorker()

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -30,7 +30,6 @@ from buildbot.process import builder
 from buildbot.process import factory
 from buildbot.status import master
 from buildbot.test.fake import fakemaster
-from buildbot.test.util.decorators import flaky
 from buildbot.util.eventual import eventually
 from buildbot.worker import manager as workermanager
 

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -114,6 +114,8 @@ class WorkerManager(MeasuredBuildbotServiceManager):
                 old_conn.loseConnection()
                 log.msg("Connected worker '%s' ping timed out after %d seconds"
                         % (workerName, self.PING_TIMEOUT))
+            except RuntimeError:
+                raise
             except Exception as e:
                 old_conn.loseConnection()
                 log.msg("Got error while trying to ping connected worker %s:"


### PR DESCRIPTION

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)

A worker with the same name would make the other worker also disconnect.

Fix the flakyness of the test case that tested this case.
(needed to force disconnection of the pb for both workers)