### PR TITLE
optimize the logCompression memory fooprint

### DIFF
--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -57,7 +57,8 @@ class LogsConnectorComponent(base.DBConnectorComponent):
 
     # Postgres and MySQL will both allow bigger sizes than this.  The limit
     # for MySQL appears to be max_packet_size (default 1M).
-    MAX_CHUNK_SIZE = 65536
+    MAX_CHUNK_SIZE = 65536  # a chunk may not be bigger than this
+    MAX_CHUNK_LINES = 1000  # a chunk may not have more lines than this
     COMPRESSION_MODE = {"raw": {"id": 0, "dumps": lambda x: x, "read": lambda x: x},
                         "gz": {"id": 1, "dumps": dumps_gzip, "read": read_gzip},
                         "bz2": {"id": 2, "dumps": dumps_bz2, "read": read_bz2},
@@ -67,7 +68,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
     total_compressed_bytes = 0
 
     def _getLog(self, whereclause):
-        def thd(conn):
+        def thd_getLog(conn):
             q = self.db.model.logs.select(whereclause=whereclause)
             res = conn.execute(q)
             row = res.fetchone()
@@ -77,7 +78,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                 rv = self._logdictFromRow(row)
             res.close()
             return rv
-        return self.db.pool.do(thd)
+        return self.db.pool.do(thd_getLog)
 
     def getLog(self, logid):
         return self._getLog(self.db.model.logs.c.id == logid)
@@ -87,7 +88,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
         return self._getLog((tbl.c.slug == slug) & (tbl.c.stepid == stepid))
 
     def getLogs(self, stepid=None):
-        def thd(conn):
+        def thdGetLogs(conn):
             tbl = self.db.model.logs
             q = tbl.select()
             if stepid is not None:
@@ -95,10 +96,10 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             q = q.order_by(tbl.c.id)
             res = conn.execute(q)
             return [self._logdictFromRow(row) for row in res.fetchall()]
-        return self.db.pool.do(thd)
+        return self.db.pool.do(thdGetLogs)
 
     def getLogLines(self, logid, first_line, last_line):
-        def thd(conn):
+        def thdGetLogLines(conn):
             # get a set of chunks that completely cover the requested range
             tbl = self.db.model.logchunks
             q = sa.select([tbl.c.first_line, tbl.c.last_line,
@@ -110,6 +111,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             rv = []
             for row in conn.execute(q):
                 # Retrieve associated "reader" and extract the data
+                # Note that row.content is stored as bytes, and our caller expects unicode
                 data = self.COMPRESSION_BYID[
                     row.compressed]["read"](row.content)
                 content = data.decode('utf-8')
@@ -128,12 +130,12 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                     content = content[:idx]
                 rv.append(content)
             return u'\n'.join(rv) + u'\n' if rv else u''
-        return self.db.pool.do(thd)
+        return self.db.pool.do(thdGetLogLines)
 
     def addLog(self, stepid, name, slug, type):
         assert type in 'tsh', "Log type must be one of t, s, or h"
 
-        def thd(conn):
+        def thdAddLog(conn):
             try:
                 r = conn.execute(self.db.model.logs.insert(),
                                  dict(name=name, slug=slug, stepid=stepid,
@@ -142,7 +144,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                 raise KeyError(
                     "log with slug '%r' already exists in this step" % (slug,))
-        return self.db.pool.do(thd)
+        return self.db.pool.do(thdAddLog)
 
     def thdCompressChunk(self, chunk):
         # Set the default compressed mode to "raw" id
@@ -175,7 +177,6 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                               last_line=last_line, content=chunk,
                               compressed=compressed_id)).close()
             chunk_first_line = last_line + 1
-
         conn.execute(self.db.model.logs.update(whereclause=(self.db.model.logs.c.id == logid)),
                      num_lines=last_line + 1).close()
         return first_line, last_line
@@ -184,19 +185,20 @@ class LogsConnectorComponent(base.DBConnectorComponent):
         # check for trailing newline and strip it for storage -- chunks omit
         # the trailing newline
         assert content[-1] == u'\n'
-        content = content[:-1]
+        # Note that row.content is stored as bytes, and our caller is sending unicode
+        content = content[:-1].encode('utf-8')
         q = sa.select([self.db.model.logs.c.num_lines])
         q = q.where(self.db.model.logs.c.id == logid)
         res = conn.execute(q)
-        row = res.fetchone()
+        num_lines = res.fetchone()
         res.close()
-        if not row:
+        if not num_lines:
             return  # ignore a missing log
 
         return self.thdSplitAndAppendChunk(conn=conn,
                                            logid=logid,
-                                           content=content.encode('utf-8'),
-                                           first_line=row[0])
+                                           content=content,
+                                           first_line=num_lines[0])
 
     def appendLog(self, logid, content):
         def thdappendLog(conn):
@@ -237,60 +239,95 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             return truncline, content[i + 1:]
 
     def finishLog(self, logid):
-        def thd(conn):
+        def thdfinishLog(conn):
             tbl = self.db.model.logs
             q = tbl.update(whereclause=(tbl.c.id == logid))
             conn.execute(q, complete=1)
-        return self.db.pool.do(thd)
+        return self.db.pool.do(thdfinishLog)
 
     @defer.inlineCallbacks
     def compressLog(self, logid):
         def thdcompressLog(conn):
-            # get the set of chunks
             tbl = self.db.model.logchunks
             q = sa.select([tbl.c.first_line, tbl.c.last_line, sa.func.length(tbl.c.content),
                            tbl.c.compressed])
             q = q.where(tbl.c.logid == logid)
             q = q.order_by(tbl.c.first_line)
+
             rows = conn.execute(q)
-            uncompressed_length = 0
+            todo_gather_list = []
             numchunks = 0
             totlength = 0
+            todo_numchunks = 0
+            todo_first_line = 0
+            todo_last_line = 0
+            todo_length = 0
+            # first pass, we fetch the full list of chunks (without content) and find out
+            # the chunk groups which could use some gathering.
             for row in rows:
-                if row.compressed == 0:
-                    uncompressed_length += row.length_1
+                if (todo_length + row.length_1 > self.MAX_CHUNK_SIZE or
+                        (row.last_line - todo_first_line) > self.MAX_CHUNK_LINES):
+                    if todo_numchunks > 1:
+                        # this group is worth re-compressing
+                        todo_gather_list.append((todo_first_line, todo_last_line))
+                    todo_first_line = row.first_line
+                    todo_length = 0
+                    todo_numchunks = 0
+
+                todo_last_line = row.last_line
+                # note that we count the compressed size for efficiency reason
+                # unlike to the on-the-flow chunk splitter
+                todo_length += row.length_1
                 totlength += row.length_1
+                todo_numchunks += 1
                 numchunks += 1
             rows.close()
-            # do nothing if its not worth.
-            # if uncompressed_length < 200 and numchunks < 4:
-            #    return
-            q = sa.select(
-                [tbl.c.first_line, tbl.c.last_line, tbl.c.content, tbl.c.compressed])
-            q = q.where(tbl.c.logid == logid)
-            q = q.order_by(tbl.c.first_line)
-            rows = conn.execute(q)
-            wholelog = ""
-            for row in rows:
-                wholelog += self.COMPRESSION_BYID[row.compressed][
-                    "read"](row.content).decode('utf-8') + "\n"
-            rows.close()
 
-            if len(wholelog) == 0:
-                return 0
+            if numchunks > 1:
+                # last chunk group
+                todo_gather_list.append((todo_first_line, todo_last_line))
 
-            transaction = conn.begin()
-            d = tbl.delete()
-            d = d.where(tbl.c.logid == logid)
-            conn.execute(d).close()
-            conn.execute(self.db.model.logs.update(whereclause=(self.db.model.logs.c.id == logid)),
-                         num_lines=0).close()
-            self.thdAppendLog(conn, logid, wholelog)
-            transaction.commit()
+            for todo_first_line, todo_last_line in todo_gather_list:
+                # decompress this group of chunks. Note that the content is binary bytes.
+                # no need to decode anything as we are going to put in back stored as bytes anyway
+                q = sa.select(
+                    [tbl.c.first_line, tbl.c.last_line, tbl.c.content, tbl.c.compressed])
+                q = q.where(tbl.c.logid == logid)
+                q = q.where(tbl.c.first_line >= todo_first_line)
+                q = q.where(tbl.c.last_line <= todo_last_line)
+                q = q.order_by(tbl.c.first_line)
+                rows = conn.execute(q)
+                chunk = b""
+                for row in rows:
+                    if chunk:
+                        chunk += b"\n"
+                    chunk += self.COMPRESSION_BYID[row.compressed][
+                        "read"](row.content)
+                rows.close()
+
+                # Transaction is necessary so that readers dont see disappeared chunks
+                transaction = conn.begin()
+
+                # we remove the chunks that we are compressing
+                d = tbl.delete()
+                d = d.where(tbl.c.logid == logid)
+                d = d.where(tbl.c.first_line >= todo_first_line)
+                d = d.where(tbl.c.last_line <= todo_last_line)
+                conn.execute(d).close()
+
+                # and we recompress them in one big chunk
+                chunk, compressed_id = self.thdCompressChunk(chunk)
+                conn.execute(tbl.insert(),
+                             dict(logid=logid, first_line=todo_first_line,
+                                  last_line=todo_last_line, content=chunk,
+                                  compressed=compressed_id)).close()
+                transaction.commit()
+
+            # calculate how many bytes we saved
             q = sa.select([sa.func.sum(sa.func.length(tbl.c.content))])
             q = q.where(tbl.c.logid == logid)
             newsize = conn.execute(q).fetchone()[0]
-            return len(wholelog) - newsize
+            return totlength - newsize
 
         saved = yield self.db.pool.do(thdcompressLog)
         defer.returnValue(saved)

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -189,7 +189,7 @@ class Model(base.DBConnectorComponent):
         sa.Column('first_line', sa.Integer, nullable=False),
         sa.Column('last_line', sa.Integer, nullable=False),
         # log contents, including a terminating newline, encoded in utf-8 or,
-        # if 'compressed' is true, compressed with gzip
+        # if 'compressed' is not 0, compressed with gzip, bzip2 or lz4
         sa.Column('content', sa.LargeBinary(65536)),
         sa.Column('compressed', sa.SmallInteger, nullable=False),
     )

--- a/master/buildbot/newsfragments/logoptimization.feature
+++ b/master/buildbot/newsfragments/logoptimization.feature
@@ -1,0 +1,1 @@
+Optimize the memory consumption of the log compression process. Buildbot do not load the whole log into memory anymore. This should improve a lot buildbot memory footprint.

--- a/master/buildbot/scripts/cleanupdb.py
+++ b/master/buildbot/scripts/cleanupdb.py
@@ -35,7 +35,6 @@ def doCleanupDatabase(config, master_cfg):
 
     master = BuildMaster(config['basedir'])
     master.config = master_cfg
-    print(master.config.logCompressionMethod)
     db = master.db
     yield db.setup(check_version=False, verbose=not config['quiet'])
     res = yield db.logs.getLogs()
@@ -43,7 +42,7 @@ def doCleanupDatabase(config, master_cfg):
     percent = 0
     saved = 0
     for log in res:
-        saved += yield db.logs.compressLog(log['id'])
+        saved += yield db.logs.compressLog(log['id'], force=config['force'])
         i += 1
         if not config['quiet'] and percent != i * 100 / len(res):
             percent = i * 100 / len(res)

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -662,6 +662,7 @@ class CleanupDBOptions(base.BasedirMixin, base.SubcommandOptions):
     subcommandFunction = "buildbot.scripts.cleanupdb.cleanupDatabase"
     optFlags = [
         ["quiet", "q", "Do not emit the commands being run"],
+        ["force", "f", "Force log recompression (useful when changing compression algorithm)"],
         # when this command has several maintainance jobs, we should make
         # them optional here. For now there is only one.
     ]

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -2142,7 +2142,7 @@ class FakeLogsComponent(FakeDBComponent):
             self.logs['id'].complete = 1
         return defer.succeed(None)
 
-    def compressLog(self, logid):
+    def compressLog(self, logid, force=False):
         return defer.succeed(None)
 
 

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -468,7 +468,7 @@ class RealTests(Tests):
             'compressed': 3})
 
     @defer.inlineCallbacks
-    def do_addLogLines_huge_log(self, NUM_CHUNKS=3000, chunk=u'xy' * 70 + '\n' * 3):
+    def do_addLogLines_huge_log(self, NUM_CHUNKS=3000, chunk=(u'xy' * 70 + u'\n') * 3):
         if chunk.endswith("\n"):
             chunk = chunk[:-1]
         linesperchunk = chunk.count("\n") + 1

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -132,7 +132,7 @@ class Tests(interfaces.InterfaceTests):
 
     def test_signature_compressLog(self):
         @self.assertArgSpecMatches(self.db.logs.compressLog)
-        def compressLog(self, logid):
+        def compressLog(self, logid, force=False):
             pass
 
     # method tests


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)


Previous implementation will load the whole log into memory in order to reinject it into
the log splitter.

This version will rather group the chunk in order to gather them in one efficiently compressed chunk