### PR TITLE
fix issue with workdir callback example raising AttributeException.

### DIFF
--- a/master/buildbot/newsfragments/workdir.bugfix
+++ b/master/buildbot/newsfragments/workdir.bugfix
@@ -1,0 +1,1 @@
+fix issue with factory.workdir AttributeError are not properly reported.

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -984,6 +984,36 @@ class TestShellMixin(steps.BuildStepMixin,
         yield self.runStep()
 
     @defer.inlineCallbacks
+    def test_example_build_workdir_callable(self):
+        self.setupStep(ShellMixinExample(), wantDefaultWorkdir=False)
+        self.build.workdir = lambda x: '/alternate'
+        self.expectCommands(
+            ExpectShell(workdir='/alternate', command=['./cleanup.sh'])
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        yield self.runStep()
+
+    @defer.inlineCallbacks
+    def test_example_build_workdir_rendereable(self):
+        self.setupStep(ShellMixinExample(), wantDefaultWorkdir=False)
+        self.build.workdir = properties.Property("myproperty")
+        self.properties.setProperty("myproperty", "/myproperty", "test")
+        self.expectCommands(
+            ExpectShell(workdir='/myproperty', command=['./cleanup.sh'])
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        yield self.runStep()
+
+    @defer.inlineCallbacks
+    def test_example_build_workdir_callable_attribute_error(self):
+        self.setupStep(ShellMixinExample(), wantDefaultWorkdir=False)
+        self.build.workdir = lambda x: x.p  # will raise AttributeError
+        self.expectException(buildstep.CallableAttributeError)
+        yield self.runStep()
+
+    @defer.inlineCallbacks
     def test_example_step_workdir(self):
         self.setupStep(ShellMixinExample(workdir='/alternate'))
         self.build.workdir = '/overridden'

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -466,17 +466,23 @@ The skeleton of such a project would look like::
 Factory Workdir Functions
 -------------------------
 
+.. note::
+
+    While factory workdir function is still supported, it is better to just use the fact that workdir is a :index:`renderables <renderable>` attribute of every steps.
+    A Renderable has access to much more contextual information, and also can return a deferred.
+    So you could say ``build_factory.workdir = util.Interpolate("%(src:repository)s`` to achieve similar goal.
+
 It is sometimes helpful to have a build's workdir determined at runtime based on the parameters of the build.
 To accomplish this, set the ``workdir`` attribute of the build factory to a callable.
-That callable will be invoked with the :class:`SourceStamp` for the build, and should return the appropriate workdir.
+That callable will be invoked with the list of :class:`SourceStamp` for the build, and should return the appropriate workdir.
 Note that the value must be returned immediately - Deferreds are not supported.
 
 This can be useful, for example, in scenarios with multiple repositories submitting changes to Buildbot.
 In this case you likely will want to have a dedicated workdir per repository, since otherwise a sourcing step with mode = "update" will fail as a workdir with a working copy of repository A can't be "updated" for changes from a repository B.
 Here is an example how you can achieve workdir-per-repo::
 
-        def workdir(source_stamp):
-            return hashlib.md5(source_stamp.repository).hexdigest()[:8]
+        def workdir(source_stamps):
+            return hashlib.md5(source_stamps[0].repository).hexdigest()[:8]
 
         build_factory = factory.BuildFactory()
         build_factory.workdir = workdir


### PR DESCRIPTION
if the callable raises an AttributeError
python thinks it is actually workdir that is not existing.
python will then swallow the attribute error and call __getattr__ from worker_transition

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

