### PR TITLE
add notice about `/json` web status removal to nine release notes

### DIFF
--- a/master/docs/relnotes/0.9.0.rst
+++ b/master/docs/relnotes/0.9.0.rst
@@ -53,7 +53,7 @@ But the devil is in the details:
  * For a single master, nothing else is required.
 
 Note for distro package maintainers: The npm dependency hell
-.............................................................
+............................................................
 
 In order to *build* the ``buildbot-www`` package, you'll need Node.
 

--- a/master/docs/relnotes/0.9.0.rst
+++ b/master/docs/relnotes/0.9.0.rst
@@ -380,6 +380,8 @@ Deprecations, Removals, and Non-Compatible Changes
 
 * ``usePTY`` default value has been changed from ``slave-config`` to ``None`` (use of ``slave-config`` will still work).
 
+* ``/json`` web status was removed. :ref:`Data_API` should be used instead.
+
 WebStatus
 .........
 


### PR DESCRIPTION
`/json` wasn't documented in Eight branch, but at least `/json/metrics` was mentioned in Eight docs, so IMO it worth to mention this change.
