### PR TITLE
fix buildbot multimaster with latest autobahn

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,7 @@
 [settings]
 line_length=110
 known_future_library=future
-known_twisted=twisted,zope,autobahn,klein
+known_twisted=twisted,zope,autobahn,klein,txaio
 known_mock=mock
 known_third_party=migrate,sqlalchemy,ldap3,txrequests,requests,MySQLdb,coverage,jinja2,dateutil,sphinx,setuptools
 known_first_party=buildbot,buildbot_worker

--- a/master/buildbot/mq/wamp.py
+++ b/master/buildbot/mq/wamp.py
@@ -42,7 +42,8 @@ class WampMQ(service.ReconfigurableServiceMixin, base.MQBase):
 
     @classmethod
     def messageTopic(cls, routingKey):
-        ifNone = lambda v, default: default if v is None else v
+        def ifNone(v, default):
+            return default if v is None else v
         # replace None values by "" in routing key
         routingKey = [ifNone(key, "") for key in routingKey]
         # then join them with "dot", and add the prefix

--- a/master/buildbot/newsfragments/wamp.bugfix
+++ b/master/buildbot/newsfragments/wamp.bugfix
@@ -1,0 +1,2 @@
+Fix :ref:`mq-Wamp` :bb:cfg:`mq` support by removing ``debug``, ``debug_amp`` and ``debug_app`` from the :bb:cfg:`mq` config, which is not available in latest version of `Python Autobahn <http://autobahn.ws>`_.
+You can now use ``wamp_debug_level`` option instead.

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -148,10 +148,7 @@ class WampMQ(unittest.TestCase):
 
 
 class FakeConfig(object):
-    mq = dict(type='wamp', router_url="wss://foo", realm="buildbot",
-              debug_websockets=False,  # set if connection looks bad
-              debug_lowlevel=False,  # set if protocol looks bad
-              )
+    mq = dict(type='wamp', router_url="wss://foo", realm="realm1")
 
 
 class WampMQReal(unittest.TestCase):
@@ -162,7 +159,10 @@ class WampMQReal(unittest.TestCase):
     """
     HOW_TO_RUN = textwrap.dedent("""\
         define WAMP_ROUTER_URL to a wamp router to run this test
-        e.g: WAMP_ROUTER_URL=ws://localhost:8000/ws""")
+        > crossbar init
+        > crossbar start &
+        > export WAMP_ROUTER_URL=ws://localhost:8080/ws
+        > trial buildbot.unit.test_mq_wamp""")
     # if connection is bad, this test can timeout easily
     # we reduce the timeout to help maintain the sanity of the developer
     timeout = 2

--- a/master/buildbot/wamp/connector.py
+++ b/master/buildbot/wamp/connector.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright  Team Members
+import txaio
 from autobahn.twisted.wamp import ApplicationSession
 from autobahn.twisted.wamp import Service
 from autobahn.wamp.exception import TransportLost
@@ -19,6 +20,7 @@ from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log
 
+from buildbot.util import ascii2unicode
 from buildbot.util import service
 
 
@@ -138,13 +140,11 @@ class WampConnector(service.ReconfigurableServiceMixin, service.AsyncMultiServic
         self.app = self.serviceClass(
             url=self.router_url,
             extra=dict(master=self.master, parent=self),
-            realm=wamp.get('realm', 'buildbot'),
-            make=make,
-            debug=wamp.get('debug_websockets', False),
-            debug_wamp=wamp.get('debug_lowlevel', False),
-            debug_app=wamp.get('debug', False)
+            realm=ascii2unicode(wamp.get('realm', 'buildbot')),
+            make=make
         )
-
+        wamp_debug_level = wamp.get('wamp_debug_level', 'error')
+        txaio.set_global_log_level(wamp_debug_level)
         yield self.app.setServiceParent(self)
         yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
                                                                                    new_config)

--- a/master/docs/manual/concepts.rst
+++ b/master/docs/manual/concepts.rst
@@ -611,6 +611,12 @@ multiple *source steps* - one for each codebase
 Multimaster
 -----------
 
+.. Warning::
+
+    Buildbot Multimaster is considered experimental.
+    There are still some companies using it in production.
+    Don't hesitate to use the mailing lists to share your experience.
+
 .. blockdiag::
 
     blockdiag multimaster {


### PR DESCRIPTION
Autobahn lost its debug options in favor of txaio optimized logging system.

improve the multimaster documentation


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

