### PR TITLE
master/setup.py: Add missed testing templates

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -206,6 +206,8 @@ setup_args = {
         ]),
         include("buildbot/spec", "*.raml"),
         include("buildbot/spec/types", "*.raml"),
+        include("buildbot/test/unit/test_templates_dir", "*.html"),
+        include("buildbot/test/unit/test_templates_dir/plugin", "*.*"),
     ] + include_statics("buildbot/www/static"),
     'cmdclass': {'install_data': install_data_twisted,
                  'sdist': our_sdist},

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -87,6 +87,10 @@ setup_args = {
         "buildbot_worker.commands",
         "buildbot_worker.scripts",
         "buildbot_worker.monkeypatches",
+        "buildbot_worker.test",
+        "buildbot_worker.test.fake",
+        "buildbot_worker.test.unit",
+        "buildbot_worker.test.util",
     ],
     # mention data_files, even if empty, so install_data is called and
     # VERSION gets copied


### PR DESCRIPTION

This patch applied to buildbot-0.9.2 along with unpacking the missed files/dirs corrects the test failure I experienced.  This patch adds the installation of those missed files.  With this I can now run "trial buildbot" on the installed code which now completes successfully.  The tests run via the ebuild during the install process using "setup.py test" also pass.

The missing templates tarball I created for patching the source tarball can be found here:
http://dev.gentoo.org/~dolsen/distfiles/buildbot-test_templates.tar.xz