### PR TITLE
Logviewer fixes

### DIFF
--- a/master/buildbot/newsfragments/logviewer.bugfix
+++ b/master/buildbot/newsfragments/logviewer.bugfix
@@ -1,1 +1,1 @@
-Fix issue with logviewer not staying at bottom of the log when loading log lines.
+Fix issue with log viewer not staying at bottom of the log when loading log lines.

--- a/master/buildbot/newsfragments/logviewer.bugfix
+++ b/master/buildbot/newsfragments/logviewer.bugfix
@@ -1,0 +1,1 @@
+Fix issue with logviewer not staying at bottom of the log when loading log lines.

--- a/master/buildbot/newsfragments/logviewer_line.feature
+++ b/master/buildbot/newsfragments/logviewer_line.feature
@@ -1,1 +1,1 @@
-Logviewer line numbers are no longer selectable, so that it is easier to copy paste.
+Log viewer line numbers are no longer selectable, so that it is easier to copy paste.

--- a/master/buildbot/newsfragments/logviewer_line.feature
+++ b/master/buildbot/newsfragments/logviewer_line.feature
@@ -1,0 +1,1 @@
+Logviewer line numbers are no longer selectable, so that it is easier to copy paste.

--- a/www/base/src/app/builders/log/logviewer/logviewer.tpl.jade
+++ b/www/base/src/app/builders/log/logviewer/logviewer.tpl.jade
@@ -8,7 +8,7 @@
   pre.row.log(ng-show="log.type!='h'", scroll-viewport)
     span(ng-if="log.type=='s' || log.type=='t'")
         div(scroll="line in lines", scroll-position="log.num_lines", load-all="loadAll", is-loading="isLoading", total-size="log.num_lines", style="height:18px")
-            span.linenumber {{::$index}}
+            span.linenumber.no-select {{::$index}}
             span.no-wrap(class="{{::line.class}}") {{::line.content}}
   div.panel(ng-if="log.type=='h'", ng-class="log.name=='err.html' && 'panel-danger' || 'panel-default'")
     div.panel-heading

--- a/www/base/src/app/builders/log/logviewer/scrollviewport.directive.coffee
+++ b/www/base/src/app/builders/log/logviewer/scrollviewport.directive.coffee
@@ -114,8 +114,10 @@ class Scroll extends Directive
                         tempScope.$destroy()
 
                     # init with 1 row 0 size padding
-                    buffer[0] = padding(0)
-                    element.after(buffer[0])
+                    buffer[0] = padding(0,0)
+                    parent = angular.element("<div>")
+                    element.after(parent)
+                    parent.append(buffer[0])
 
                     viewportScope = viewport.scope() || $rootScope
 
@@ -221,9 +223,10 @@ class Scroll extends Directive
                         if newSize > buffer.length
                             lastElementIndex = findElement(buffer.length - 1)
                             lastElement = buffer[lastElementIndex]
+                            parent.height(newSize*rowHeight)
+                            buffer[newSize - 1] = undefined
                             if lastElement._height?
                                 lastElement.set_height(newSize - lastElementIndex)
-                            buffer[newSize - 1] = undefined
 
                             $timeout -> maybeUpdateView()
 


### PR DESCRIPTION
Some fixes and improvements for the logviewer

* make line number unselectable
 
    So that it is easier to copy paste


* fix logviewer bad scrolling

    While the scrollviewport is updating, there is a chance
    that the overall size of elements decrease.

    If we are scrolled to the bottom, then the scroll viewport will automatically
    go up to fit new smaller size, and not go back down when the new elements are inserted.

    Thus we will not see the end of the log anymore.
    We add a parent div, which is always of the maximum log size