### PR TITLE
logpreview: new directive to show the preview of the logs within the buildsummary

### DIFF
--- a/master/buildbot/newsfragments/logpreview.feature
+++ b/master/buildbot/newsfragments/logpreview.feature
@@ -1,0 +1,3 @@
+Changed the build page so that the preview of the logs are shown in live.
+It is a preview means the last lines of log.
+How many lines is configurable per user in the user settings page.

--- a/www/base/src/app/builders/builds/build.route.coffee
+++ b/www/base/src/app/builders/builds/build.route.coffee
@@ -1,5 +1,5 @@
 class State extends Config
-    constructor: ($stateProvider) ->
+    constructor: ($stateProvider, bbSettingsServiceProvider) ->
 
         # Name of the state
         name = 'build'
@@ -14,3 +14,17 @@ class State extends Config
                 pageTitle: _.template("Buildbot: builder <%= builder %> build <%= build %>")
 
         $stateProvider.state(state)
+        bbSettingsServiceProvider.addSettingsGroup
+            name:'LogPreview'
+            caption: 'LogPreview related settings'
+            items:[
+                type:'integer'
+                name:'loadlines'
+                caption:'Initial number of lines to load'
+                default_value: 40
+            ,
+                type:'integer'
+                name:'maxlines'
+                caption:'Maximum number of lines to show'
+                default_value: 40
+            ]

--- a/www/base/src/app/builders/log/logviewer/logpreview.directive.coffee
+++ b/www/base/src/app/builders/log/logviewer/logpreview.directive.coffee
@@ -1,0 +1,80 @@
+class Logpreview extends Directive
+    constructor: ($sce, restService, ansicodesService, bbSettingsService) ->
+        return {
+            replace: true
+            transclude: true
+            restrict: 'E'
+            scope: {log:"<", buildnumber:"<", builderid:"<", step:"<"},
+            templateUrl: "views/logpreview.html"
+            controllerAs: "logpreview"
+            bindToController: true
+            controller: ["$scope", ($scope) ->
+
+                @settings = bbSettingsService.getSettingsGroup("LogPreview")
+                loading = $sce.trustAs($sce.HTML, "...")
+                unwatch = $scope.$watch "logpreview.log", (n, o) =>
+                    @log.lines = []
+                    if not n?
+                        return
+                    unwatch()
+                    if @log.type == 'h'
+                        restService.get("logs/#{@log.logid}/contents").then (content) =>
+                            @log.content = $sce.trustAs($sce.HTML, content.logchunks[0].content)
+                    else
+                        $scope.$watch "logpreview.log.num_lines", loadLines
+                loadLines = (num_lines) =>
+                    if @log.lines.length == 0
+                        # initial load. only load the last few lines
+                        offset = @log.num_lines - @settings.loadlines.value
+                        limit = @settings.loadlines.value
+                        if offset < 0
+                            offset = 0
+                            limit = @log.num_lines
+                    else
+                        # The last element of the line is the last line loaded
+                        # This might be actually a loading marker
+                        offset = @log.lines[@log.lines.length - 1].number + 1
+                        limit = @log.num_lines - offset
+                        # if log is advancing very fast no need to load too much lines
+                        if limit > @settings.maxlines.value
+                            offset = @log.num_lines - @settings.maxlines.value
+                            limit = @settings.maxlines.value
+
+
+                    # this acts as a marker of the last loaded element
+                    # note that several elements can be loading at the same time
+                    # as we follow the log updates
+
+                    loading_element =
+                        content: loading
+                        number: offset + limit - 1
+                    @log.lines.push(loading_element)
+
+                    restService.get("logs/#{@log.logid}/contents",
+                                    offset: offset,
+                                    limit: limit).then (content) =>
+                        content = content.logchunks[0].content
+                        lines = content.split("\n")
+                        # there is a trailing '\n' generates an empty line in the end
+                        if lines.length > 1
+                            lines.pop()
+                        number = offset
+                        # remove the loading element
+                        @log.lines.splice(@log.lines.indexOf(loading_element), 1)
+                        for line in lines
+                            logclass = "o"
+                            if line.length > 0 and (@log.type == 's')
+                                logclass = line[0]
+                                line = line[1..]
+                            # we just push the lines in the end, and will apply sort eventually
+                            @log.lines.push
+                                content:  $sce.trustAs($sce.HTML, ansicodesService.ansi2html(line))
+                                class: "log_" + logclass
+                                number: number
+                            number += 1
+                        @log.lines.sort (a,b) -> a.number - b.number
+                        @log.lines.splice(0, @log.lines.length - @settings.maxlines.value)
+            ]
+            link: (scope, elm, attr) ->
+                ansicodesService.injectStyle()
+        }

--- a/www/base/src/app/builders/log/logviewer/logpreview.less
+++ b/www/base/src/app/builders/log/logviewer/logpreview.less
@@ -1,0 +1,3 @@
+.logpreview {
+    margin-top:20px;
+}

--- a/www/base/src/app/builders/log/logviewer/logpreview.tpl.jade
+++ b/www/base/src/app/builders/log/logviewer/logpreview.tpl.jade
@@ -1,0 +1,18 @@
+div.logpreview.panel(ng-class="logpreview.log.name=='err.html' && 'panel-danger' || 'panel-default'")
+  div.panel-heading
+    .panel-title
+      .flex-row
+        div.flex-grow-3 {{logpreview.log.name}}
+        div.flex-grow-1
+            div.pull-right
+                a(ui-sref="log({builder:logpreview.builderid, build:logpreview.buildnumber, step: logpreview.step.number, log:logpreview.log.slug})")
+                  | #{' '}view all {{logpreview.log.num_lines}} line{{logpreview.log.num_lines > 1?'s':''}}
+                | #{' '}
+                a.btn.btn-default.btn-xs(ng-href="api/v2/logs/{{logpreview.log.logid}}/raw", description="download log")
+                  i.fa.fa-download
+                  | #{' '} download
+  pre.log(ng-show="logpreview.log.type!='h'")
+    div(ng-repeat="line in logpreview.log.lines", style="height:18px")
+        span.linenumber.no-select {{line.number}}
+        span.select.no-wrap(class="{{line.class}}", ng-bind-html="line.content")
+  div.panel-body(ng-if="logpreview.log.type=='h'", ng-bind-html="logpreview.log.content")

--- a/www/base/src/app/builders/log/logviewer/logviewer.less
+++ b/www/base/src/app/builders/log/logviewer/logviewer.less
@@ -17,6 +17,8 @@ pre.log {
         white-space: pre;
         word-wrap: normal;
     }
+  margin-top: 0px;
+  margin-bottom: 0px;
   overflow: auto;
 }
 

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
@@ -22,7 +22,6 @@ class _buildsummary extends Controller('common')
             "#{baseurl}#buildrequests/{buildrequestid:[0-9]+}")
         buildURLMatcher = $urlMatcherFactory.compile(
             "#{baseurl}#builders/{builderid:[0-9]+}/builds/{buildid:[0-9]+}")
-
         # to get an update of the current builds every seconds, we need to update self.now
         # but we want to stop counting when the scope destroys!
         stop = $interval =>
@@ -96,13 +95,13 @@ class _buildsummary extends Controller('common')
                     self.steps = build.getSteps()
 
                     self.steps.onNew = (step) ->
-                        step.loadLogs()
+                        step.logs = step.getLogs()
                         # onUpdate is only called onUpdate, not onNew
                         # but we need to update our additional needed attributes
                         self.steps.onUpdate(step)
 
                     self.steps.onUpdate = (step) ->
-                        step.fulldisplay = step.complete == 0 || step.results > 0
+                        step.fulldisplay = step.complete == false || step.results > 0
                         if step.complete
                             step.duration = step.complete_at - step.started_at
         $scope.$watch (=> @parentbuild), (build,o) ->

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -42,18 +42,13 @@
             | #{' '}
             i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':step.fulldisplay}", ng-if="step.logs.length")
             | #{' '} {{step.name}}
-        div.anim-stepdetails(ng-show="step.fulldisplay")
-          ul
-            li(ng-repeat="log in step.logs")
-              a(ng-href="api/v2/logs/{{log.logid}}/raw")
-                  i.fa.fa-download
-              | #{' '}
-              a(ui-sref="log({builder:buildsummary.build.builderid, build:buildsummary.build.number, step: step.number, log:log.slug})")
-                  | {{log.name}}
-              | #{' '}({{log.num_lines}} line{{log.num_lines > 1?'s':''}})
         ul
           li(ng-if='!(buildsummary.isBuildRequestURL(url.url) || buildsummary.isBuildURL(url.url))', ng-repeat="url in step.urls")
             a(target="_blank", ng-href="{{url.url}}") {{url.name}}
         ul.list-unstyled
           li(ng-if='buildsummary.isBuildRequestURL(url.url)', ng-repeat="url in step.urls")
             buildrequestsummary(style="margin-left:30px;margin-top:8px",buildrequestid='buildsummary.getBuildRequestIDFromURL(url.url)')
+        div.anim-stepdetails(ng-if="step.fulldisplay")
+          logpreview(ng-repeat="log in step.logs", log="log",
+                     builderid="buildsummary.build.builderid", buildnumber="buildsummary.build.number",
+                     step="step")

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -83,6 +83,14 @@
   -ms-user-select: none;
   user-select: none;
 }
+.select {
+  -webkit-touch-callout: initial;
+  -webkit-user-select: initial;
+  -khtml-user-select: initial;
+  -moz-user-select: initial;
+  -ms-user-select: initial;
+  user-select: initial;
+}
 
 .avatar {
   background-size: 32px 32px;

--- a/www/data_module/src/services/data/data.service.coffee
+++ b/www/data_module/src/services/data/data.service.coffee
@@ -22,7 +22,7 @@ class Data extends Provider
                 [args, query] = dataUtilsService.splitOptions(args)
                 subscribe = accessor = undefined
 
-                # subscribe for changes if 'subscribe' is true or undefined
+                # subscribe for changes if 'subscribe' is true
                 subscribe = query.subscribe == true
                 accessor = query.accessor
                 if subscribe and not accessor


### PR DESCRIPTION
Only a preview of the log is shown i.e the last bits of the logs.
How many lines is configurable in the user ui settings page
Log is automatically followed when the step is on going

![image](https://cloud.githubusercontent.com/assets/109859/21723564/37f648e6-d431-11e6-8690-7375b80ea9ef.png)
