### PR TITLE
use new port specification interface in test

### DIFF
--- a/master/buildbot/test/unit/test_changes_pb.py
+++ b/master/buildbot/test/unit/test_changes_pb.py
@@ -202,7 +202,7 @@ class TestPBChangeSource(
 
         self.assertNotRegistered()
 
-        config.slavePortnum = '1234'
+        config.protocols = {'pb': {'port': '1234'}}
 
         yield self.changesource.reconfigServiceWithBuildbotConfig(config)
 


### PR DESCRIPTION
A problem with this test is that if changed line will be completely
omitted (or will be incorrect), test still will pass.
