### PR TITLE
fix getURLForThing for worker

### DIFF
--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -190,7 +190,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         # IWorkerStatus
         if interfaces.IWorkerStatus.providedBy(thing):
             worker = thing
-            return prefix + "#buildslaves/%s" % (
+            return prefix + "#workers/%s" % (
                 urlquote(worker.getName(), safe=''),
             )
 


### PR DESCRIPTION
Not used in Buildbot codebase and AFAIK deprecated, but until we completely remove IStatus let it at least look correct.
