### PR TITLE
fix bitbucketstatuspush

### DIFF
--- a/master/buildbot/newsfragments/bitbucketreporter.bugfix
+++ b/master/buildbot/newsfragments/bitbucketreporter.bugfix
@@ -1,1 +1,1 @@
-Fix :bb:reporters`BitbucketStatusPush` ``ep should start with /`` assertion error.
+Fix :bb:reporter:`BitbucketStatusPush` ``ep should start with /`` assertion error.

--- a/master/buildbot/newsfragments/bitbucketreporter.bugfix
+++ b/master/buildbot/newsfragments/bitbucketreporter.bugfix
@@ -1,0 +1,1 @@
+Fix :bb:reporters`BitbucketStatusPush` ``ep should start with /`` assertion error.

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -59,15 +59,14 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
     def send(self, build):
         results = build['results']
         oauth_request = yield self.oauthhttp.post("",
-                                                  json=_GET_TOKEN_DATA)
+                                                  data=_GET_TOKEN_DATA)
         if oauth_request.code == 200:
             content_json = yield oauth_request.json()
             token = content_json['access_token']
         else:
             content = yield oauth_request.content()
-            log.error("{}: unable to authenticate to Bitbucket {}".format(
-                oauth_request.code, content
-            ))
+            log.error("{code}: unable to authenticate to Bitbucket {content}",
+                      code=oauth_request.code, content=content)
             return
 
         if build['complete']:
@@ -93,8 +92,8 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
             response = yield self._http.post(bitbucket_uri, json=body)
             if response.code != 201:
                 content = yield response.content()
-                log.error("%s: unable to upload Bitbucket status: %s" %
-                        (response.code, content))
+                log.error("{code}: unable to upload Bitbucket status {content}",
+                          code=response.code, content=content)
 
     @staticmethod
     def get_owner_and_repo(repourl):

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -115,6 +115,8 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
 
         if path.endswith('.git'):
             path = path[:-4]
+        while path.endswith('/'):
+            path = path[:-1]
 
         parts = path.split('/')
 

--- a/master/buildbot/reporters/hipchat.py
+++ b/master/buildbot/reporters/hipchat.py
@@ -96,5 +96,5 @@ class HipChatStatusPush(HttpStatusPushBase):
             response = yield self._http.post(url, params=dict(auth_token=self.auth_token), json=postData)
             if response.code != 200:
                 content = yield response.content()
-                log.error("%s: unable to upload status: %s" %
-                          (response.code, content))
+                log.error("{code}: unable to upload status: {content}",
+                          code=response.code, content=content)

--- a/master/buildbot/reporters/stash.py
+++ b/master/buildbot/reporters/stash.py
@@ -77,5 +77,5 @@ class StashStatusPush(http.HttpStatusPushBase):
                              status=status, sha=sha)
             else:
                 content = yield response.content()
-                log.error("Unable to send Stash status ({code}): {content}",
+                log.error("{code}: Unable to send Stash status: {content}",
                           code=response.code, content=content)

--- a/master/buildbot/test/fake/httpclientservice.py
+++ b/master/buildbot/test/fake/httpclientservice.py
@@ -110,6 +110,7 @@ class HTTPClientService(service.SharedService):
                               "expected more http requests:\n {!r}".format(self._expected))
 
     def _doRequest(self, method, ep, params=None, data=None, json=None):
+        assert ep == "" or ep.startswith("/"), "ep should start with /: " + ep
         if not self.quiet:
             log.debug("{method} {ep} {params!r} <- {data!r}",
                       method=method, ep=ep, params=params, data=data or json)

--- a/master/buildbot/test/unit/test_reporter_bitbucket.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucket.py
@@ -62,7 +62,7 @@ class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin):
     def test_basic(self):
         build = yield self.setupBuildResults(SUCCESS)
 
-        self.oauthhttp.expect('post', '', json={'grant_type': 'client_credentials'},
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
                               content_json={'access_token': 'foo'})
         # we make sure proper calls to txrequests have been made
         self._http.expect(
@@ -74,7 +74,7 @@ class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin):
                 'key': u'Builder0',
                 'name': u'Builder0'},
             code=201),
-        self.oauthhttp.expect('post', '', json={'grant_type': 'client_credentials'},
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
                               content_json={'access_token': 'foo'})
         self._http.expect(
             'post',
@@ -85,7 +85,7 @@ class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin):
                 'key': u'Builder0',
                 'name': u'Builder0'},
             code=201),
-        self.oauthhttp.expect('post', '', json={'grant_type': 'client_credentials'},
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
                               content_json={'access_token': 'foo'})
         self._http.expect(
             'post',
@@ -105,6 +105,16 @@ class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin):
 
         build['results'] = FAILURE
         self.bsp.buildFinished(('build', 20, 'finished'), build)
+
+    @defer.inlineCallbacks
+    def test_unable_to_authenticate(self):
+        build = yield self.setupBuildResults(SUCCESS)
+
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'}, code=400,
+                              content_json={
+                                  "error_description": "Unsupported grant type: None",
+                                  "error": "invalid_grant"})
+        self.bsp.buildStarted(('build', 20, 'started'), build)
 
 
 class TestBitbucketStatusPushRepoParsing(unittest.TestCase):

--- a/master/buildbot/test/unit/test_reporter_bitbucket.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucket.py
@@ -144,6 +144,7 @@ class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin
         self.assertLogged('This commit is unknown to us')
         self.assertLogged('invalid_commit')
 
+
 class TestBitbucketStatusPushRepoParsing(unittest.TestCase):
 
     def parse(self, repourl):

--- a/master/buildbot/test/unit/test_reporter_bitbucket.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucket.py
@@ -25,10 +25,11 @@ from buildbot.reporters.bitbucket import _OAUTH_URL
 from buildbot.reporters.bitbucket import BitbucketStatusPush
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake import fakemaster
+from buildbot.test.util.logging import LoggingMixin
 from buildbot.test.util.reporter import ReporterTestMixin
 
 
-class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin):
+class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin):
     TEST_REPO = u'https://example.org/user/repo'
 
     @defer.inlineCallbacks
@@ -114,8 +115,34 @@ class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin):
                               content_json={
                                   "error_description": "Unsupported grant type: None",
                                   "error": "invalid_grant"})
+        self.setUpLogging()
         self.bsp.buildStarted(('build', 20, 'started'), build)
+        self.assertLogged('400: unable to authenticate to Bitbucket')
 
+    @defer.inlineCallbacks
+    def test_unable_to_send_status(self):
+        build = yield self.setupBuildResults(SUCCESS)
+
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
+                              content_json={'access_token': 'foo'})
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            'post',
+            u'/user/repo/commit/d34db33fd43db33f/statuses/build',
+            json={
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'state': 'INPROGRESS',
+                'key': u'Builder0',
+                'name': u'Builder0'},
+            code=404,
+            content_json={
+                "error_description": "This commit is unknown to us",
+                "error": "invalid_commit"}),
+        self.setUpLogging()
+        self.bsp.buildStarted(('build', 20, 'started'), build)
+        self.assertLogged('404: unable to upload Bitbucket status')
+        self.assertLogged('This commit is unknown to us')
+        self.assertLogged('invalid_commit')
 
 class TestBitbucketStatusPushRepoParsing(unittest.TestCase):
 

--- a/master/buildbot/test/util/logging.py
+++ b/master/buildbot/test/util/logging.py
@@ -28,10 +28,13 @@ class LoggingMixin(object):
         r = re.compile(regexp)
         for event in self._logEvents:
             msg = log.textFromEventDict(event)
+            if msg is not None:
+                assert not msg.startswith("Unable to format event"), msg
             if msg is not None and r.search(msg):
                 return
         self.fail(
-            "%r not matched in log output.\n%s " % (regexp, self._logEvents))
+            "%r not matched in log output.\n%s " % (
+                regexp, [log.textFromEventDict(e) for e in self._logEvents]))
 
     def assertWasQuiet(self):
         self.assertEqual([

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -133,7 +133,7 @@ class HTTPClientService(service.SharedService):
             return self._pool.closeCachedConnections()
 
     def _prepareRequest(self, ep, kwargs):
-        assert ep.startswith("/"), "ep should start with /: " + ep
+        assert ep == "" or ep.startswith("/"), "ep should start with /: " + ep
         url = self._base_url + ep
         if self._auth is not None and 'auth' not in kwargs:
             kwargs['auth'] = self._auth


### PR DESCRIPTION
for bitbucket the oauth ep is "" so it cannot start with / (the baseurl shall already point to the correct ep)

## Contributor Checklist:

* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)

