### PR TITLE
UI Improvements to allow easier visibility for big scale setups

### DIFF
--- a/master/buildbot/newsfragments/masterspage.feature
+++ b/master/buildbot/newsfragments/masterspage.feature
@@ -1,0 +1,1 @@
+Masters page now shows more information about a master (workers, builds, activity timer)

--- a/master/buildbot/newsfragments/paging.feature
+++ b/master/buildbot/newsfragments/paging.feature
@@ -1,0 +1,1 @@
+Builder and Worker page build list now have the ``numbuilds=`` option which allows to show more builds.

--- a/master/buildbot/newsfragments/workerspage.feature
+++ b/master/buildbot/newsfragments/workerspage.feature
@@ -1,0 +1,5 @@
+Workers page improvement:
+Shows which master the worker is connected to.
+Shows correctly the list of builders that this master is configured on (not the list of ``buildermaster`` which nobody cares about).
+Shows list of builds per worker similar to the builders page.
+New worker details page displays the list of builds built by this worker using database optimized query.

--- a/www/base/src/app/builders/builder/builder.controller.coffee
+++ b/www/base/src/app/builders/builder/builder.controller.coffee
@@ -95,7 +95,10 @@ class Builder extends Controller
                 # reinstall contextual actions when coming back from forcesched
                 $scope.$on '$stateChangeSuccess', ->
                     refreshContextMenu()
-            $scope.builds = builder.getBuilds(limit:20, order:'-number')
+            $scope.numbuilds = 200
+            if $stateParams.numbuilds?
+                $scope.numbuilds = +$stateParams.numbuilds
+            $scope.builds = builder.getBuilds(limit:$scope.numbuilds, order:'-number')
             $scope.buildrequests = builder.getBuildrequests(claimed:false)
             $scope.builds.onChange=refreshContextMenu
             $scope.buildrequests.onChange=refreshContextMenu

--- a/www/base/src/app/builders/builder/builder.route.coffee
+++ b/www/base/src/app/builders/builder/builder.route.coffee
@@ -14,7 +14,7 @@ class State extends Config
             controller: "#{name}Controller"
             templateUrl: "views/#{name}.html"
             name: name
-            url: '/builders/:builder'
+            url: '/builders/:builder?numbuilds'
             data: cfg
 
         $stateProvider.state(state)

--- a/www/base/src/app/builders/builder/builder.tpl.jade
+++ b/www/base/src/app/builders/builder/builder.tpl.jade
@@ -23,31 +23,6 @@
               | {{br.submitted_at | timeago }}
           td
           td
-  .row
-    h4 Builds:
-    span(ng-hide='builds.length>0')
-      | None
-    table.table.table-hover.table-striped.table-condensed(ng-show='builds.length>0')
-      tr
-        td(width='100px') #
-        td(width='150px') Started At
-        td(width='150px') Duration
-        td(width='200px') Owner
-        td Status
-      tr(ng-repeat='build in builds | orderBy:"-started_at"')
-          td
-            a(ui-sref="build({builder:builder.builderid, build:build.number})")
-              span.badge-status(ng-class="results2class(build, 'pulse')")
-                  .badge-inactive {{build.number}}
-                  .badge-active {{results2text(build)}}
-          td
-            span(title="{{build.started_at | dateformat:'LLL'}}")
-              | {{build.started_at | timeago }}
-          td
-            span(ng-show="build.complete", title="{{(build.complete_at - build.started_at)| durationformat:'LLL' }}")
-              | {{(build.complete_at - build.started_at)| duration }}
-          td
-          td
-            ul.list-inline
-              li
-                | {{build.state_string}}
+  builds-table(builder="builder", builds="builds")
+  a.btn.btn-default(ui-sref='builder({builder: builder.builderid, numbuilds: numbuilds + 100})', ng-if="builds.length>=numbuilds")
+      | more

--- a/www/base/src/app/builders/builders.controller.coffee
+++ b/www/base/src/app/builders/builders.controller.coffee
@@ -1,5 +1,6 @@
 class Builders extends Controller
-    constructor: ($scope, $log, dataService, resultsService, bbSettingsService, $stateParams, $location) ->
+    constructor: ($scope, $log, dataService, resultsService, bbSettingsService, $stateParams,
+        $location, dataGrouperService) ->
         # make resultsService utilities available in the template
         _.mixin($scope, resultsService)
         $scope.connected2class = (worker) ->
@@ -94,38 +95,15 @@ class Builders extends Controller
                 $scope.tags_filter.splice(i, 1)
 
         data = dataService.open().closeOnDestroy($scope)
-        byNumber = (a, b) -> return a.number - b.number
-        workersByBuilderId = {}
-        buildsByBuilderId = {}
 
         $scope.builders = data.getBuilders()
         $scope.builders.onNew = (builder) ->
-            builder.workers ?= workersByBuilderId[builder.builderid] || []
-            builder.builds ?= buildsByBuilderId[builder.builderid] || []
             builder.loadMasters()
 
         # as there is usually lots of builders, its better to get the overall
         # list of workers, and builds and then associate by builder
         # @todo, we cannot do same optims for masters due to lack of data api
-
         workers = data.getWorkers()
-        workers.onNew = workers.onUpdate =  (worker) ->
-            worker.configured_on?.forEach (conf) ->
-                # the builder might not be yet loaded, so we need to store the worker list
-                if $scope.builders.hasOwnProperty(conf.builderid)
-                    builder = []
-                    workerslist = $scope.builders.get(conf.builderid).workers ?= []
-                else
-                    workerslist = workersByBuilderId[conf.builderid] ?= []
-                workerslist.push(worker)
-
         builds = data.getBuilds(limit: 200, order: '-started_at')
-        builds.onNew = builds.onUpdate = (build) ->
-            # the builder might not be yet loaded, so we need to store the worker list
-            if $scope.builders.hasOwnProperty(build.builderid)
-                builder = []
-                buildslist = $scope.builders.get(build.builderid).builds ?= []
-            else
-                buildslist = buildsByBuilderId[build.builderid] ?= []
-            buildslist.push(build)
-            buildslist.sort(byNumber)
+        dataGrouperService.groupBy($scope.builders, workers, 'builderid', 'workers', 'configured_on')
+        dataGrouperService.groupBy($scope.builders, builds, 'builderid', 'builds')

--- a/www/base/src/app/common/directives/builds/buildstable.directive.coffee
+++ b/www/base/src/app/common/directives/builds/buildstable.directive.coffee
@@ -1,0 +1,14 @@
+class BuildsTable extends Directive('common')
+    constructor: (RecursionHelper) ->
+        return {
+            replace: true
+            restrict: 'E'
+            scope: {builds: '=?', builder: '=?', builders: '=?'}
+            templateUrl: 'views/buildstable.html'
+            controller: '_buildstableController'
+        }
+class _buildstable extends Controller('common')
+    constructor: ($scope, resultsService) ->
+        # make resultsService utilities available in the template
+        _.mixin($scope, resultsService)
+        return

--- a/www/base/src/app/common/directives/builds/buildstable.tpl.jade
+++ b/www/base/src/app/common/directives/builds/buildstable.tpl.jade
@@ -1,0 +1,31 @@
+.row
+    h4 Builds:
+    span(ng-hide='builds.length>0')
+      | None
+    table.table.table-hover.table-striped.table-condensed(ng-show='builds.length>0')
+      tr
+        td(width='200px', ng-show="builders") Builder
+        td(width='100px') #
+        td(width='150px') Started At
+        td(width='150px') Duration
+        td(width='200px') Owner
+        td Status
+      tr(ng-repeat='build in builds | orderBy:"-started_at"')
+          td(ng-show="builders") {{ builders.get(build.builderid).name }}
+          td
+            a(ui-sref="build({builder:build.builderid, build:build.number})")
+              span.badge-status(ng-class="results2class(build, 'pulse')")
+                  span.badge-inactive 
+                    | {{build.number}}
+                  span.badge-active {{results2text(build)}}
+          td
+            span(title="{{build.started_at | dateformat:'LLL'}}")
+              | {{build.started_at | timeago }}
+          td
+            span(ng-show="build.complete", title="{{(build.complete_at - build.started_at)| durationformat:'LLL' }}")
+              | {{(build.complete_at - build.started_at)| duration }}
+          td
+          td
+            ul.list-inline
+              li
+                | {{build.state_string}}

--- a/www/base/src/app/common/services/datagrouper/datagrouper.service.coffee
+++ b/www/base/src/app/common/services/datagrouper/datagrouper.service.coffee
@@ -1,0 +1,39 @@
+# this function is meant to group builds into builders, but is written generically
+# so that it can group any collection into another collection like a database join
+class dataGrouperService extends Factory('common')
+    constructor: ->
+        return {
+            groupBy: (collection1, collection2, joinid, attribute, joinlist) ->
+                # @param collection1: collection holding the groups
+                # @param collection2: collection that will be split into the collection1
+                # @param joinid: the id that should be present in both collection items,
+                #                and meant to match them
+                # @param attribute: the collection1 item's attribute where to store collection2 groups
+                # @param joinlist: optionnal attribute of collection2 items if the collection2
+                #                  is pointing to several item of collection1
+                temp_dict = {}
+                onNew = collection1.onNew
+                collection1.onNew = (item) ->
+                    if temp_dict.hasOwnProperty(item[joinid])
+                        item[attribute] = temp_dict[item[joinid]]
+                    onNew(item)
+                doGroup = (item) ->
+                    console.log item
+                if joinlist?
+                    collection2.onNew  = (item) ->
+                        item[joinlist]?.forEach (item2) ->
+                            # the collection1 might not be yet loaded, so we need to store the worker list
+                            if collection1.hasOwnProperty(item2[joinid])
+                                group = collection1.get(item2[joinid])[attribute] ?= []
+                            else
+                                group = temp_dict[item2[joinid]] ?= []
+                            group.push(item)
+                else
+                    collection2.onNew = (item) ->
+                        # the collection1 might not be yet loaded, so we need to store the worker list
+                        if collection1.hasOwnProperty(item[joinid])
+                            group = collection1.get(item[joinid])[attribute] ?= []
+                        else
+                            group = temp_dict[item[joinid]] ?= []
+                        group.push(item)
+        }

--- a/www/base/src/app/masters/masters.controller.coffee
+++ b/www/base/src/app/masters/masters.controller.coffee
@@ -1,4 +1,15 @@
 class Masters extends Controller
-    constructor: ($scope, dataService, publicFieldsFilter) ->
-        dataService.open().closeOnDestroy($scope).getMasters().onChange = (masters) ->
-            $scope.masters = masters.map (master) -> publicFieldsFilter(master)
+    constructor: ($scope, dataService, dataGrouperService, resultsService, $stateParams) ->
+        _.mixin($scope, resultsService)
+        $scope.maybeHideMaster = (master) ->
+            if $stateParams.master?
+                return master.masterid != +$stateParams.master
+            return 0
+        data = dataService.open().closeOnDestroy($scope)
+        $scope.masters = data.getMasters()
+        $scope.builders = data.getBuilders()
+        workers = data.getWorkers()
+
+        builds = data.getBuilds(limit: 100, order: '-started_at')
+        dataGrouperService.groupBy($scope.masters, builds, 'masterid', 'builds')
+        dataGrouperService.groupBy($scope.masters, workers, 'masterid', 'workers', 'connected_to')

--- a/www/base/src/app/masters/masters.route.coffee
+++ b/www/base/src/app/masters/masters.route.coffee
@@ -10,11 +10,17 @@ class State extends Config
             caption: 'Build Masters'
 
         # Register new state
-        state =
+        $stateProvider.state
             controller: "#{name}Controller"
             templateUrl: "views/#{name}.html"
             name: name
             url: '/masters'
             data: cfg
 
-        $stateProvider.state(state)
+        # master page is actually same as masters, just filtered
+        $stateProvider.state
+            controller: "#{name}Controller"
+            templateUrl: "views/#{name}.html"
+            name: 'master'
+            url: '/masters/:master'
+            data: {}

--- a/www/base/src/app/masters/masters.tpl.jade
+++ b/www/base/src/app/masters/masters.tpl.jade
@@ -1,5 +1,25 @@
 .container
-  .row
-    ul
-      lu(ng-repeat='master in masters')
-        rawdata(data='master')
+    .row
+        table.table.table-hover.table-striped.table-condensed
+            tr
+                th Active
+                th Name
+                th Recent Builds
+                th Workers
+                th Last Active
+            tr(ng-repeat='master in masters | orderBy: ["-active", "name"]', ng-hide="maybeHideMaster(master)")
+                td 
+                    i.fa.fa-check.text-success(ng-show="master.active")
+                    i.fa.fa-times.text-danger(ng-hide="master.active")
+                td {{ master.name}}
+                td
+                    span(ng-repeat="build in master.builds | orderBy : '-number' |limitTo: '20' ")
+                        a(ui-sref='build({builder: build.builderid, build: build.number})')
+                            span.badge-status(ng-class="results2class(build, 'pulse')")
+                              | {{ builders.get(build.builderid).name }}/{{ build.number }}
+                td
+                    span(ng-repeat="worker in master.workers | orderBy : 'name'")
+                        a(ui-sref='workers({worker: workerid})')
+                            span.badge-status.results_SUCCESS
+                              | {{ worker.name }}
+                td {{master.last_active | timeago}}

--- a/www/base/src/app/workers/workers.route.coffee
+++ b/www/base/src/app/workers/workers.route.coffee
@@ -14,8 +14,16 @@ class State extends Config
             controller: "#{name}Controller"
             templateUrl: "views/#{name}.html"
             name: name
-            url: '/workers'
+            url: '/workers?numbuilds'
             data: cfg
+
+        # worker page is actually same as worker, just filtered
+        $stateProvider.state
+            controller: "#{name}Controller"
+            templateUrl: "views/#{name}.html"
+            name: 'worker'
+            url: '/workers/:worker?numbuilds'
+            data: {}
 
         bbSettingsServiceProvider.addSettingsGroup
             name:'Workers'

--- a/www/base/src/app/workers/workers.tpl.jade
+++ b/www/base/src/app/workers/workers.tpl.jade
@@ -2,24 +2,42 @@
     .row
         table.table.table-hover.table-striped.table-condensed
             tr
+                th Masters
                 th WorkerName
-                th Status
+                th Recent Builds
                 th Builders
-                th Infos
-            tr(ng-repeat='worker in workers | orderBy: ["name"]',
-               ng-show="settings.show_old_workers.value || worker.configured_on.length > 0")
-                td {{worker.name}}
-                td {{worker.connected_to.length}} connection
+                th(ng-repeat="info in worker_infos") {{ capitalize(info) }}
+                    
+            tr(ng-repeat='worker in workers | orderBy: ["-num_connections", "name"]',
+               ng-hide="maybeHideWorker(worker)")
+                td 
+                    div(ng-hide="worker.num_connections")
+                        i.fa.fa-times.text-danger(title="disconnected")
+                    div(ng-repeat="masterid in worker.connected_to")
+                        a(ui-sref="master({master:masterid.masterid})")
+                            span.badge-status.results_SUCCESS(title="{{ masters.get(masterid.masterid).name }}")
+                                | {{ masterid.masterid }}
+                td 
+                    a(ui-sref='worker({worker: worker.workerid})')
+                        | {{worker.name}}
                 td
-                    span(ng-repeat="buildermaster in worker.configured_on")
-                        a(ui-sref="builder({builder: buildermaster.builderid})")
-                            | {{ builders.get(buildermaster.builderid).name +
-                            |    maybeGetMasterNameFromBuilderMaster(buildermaster)}}
-                        | &nbsp;
+                    span(ng-repeat="build in worker.builds | orderBy : '-number' |limitTo: '7' ")
+                        a(ui-sref='build({builder: build.builderid, build: build.number})')
+                            span.badge-status(ng-class="results2class(build, 'pulse')")
+                              | {{ builders.get(build.builderid).name }}/{{ build.number }}
                 td
-                    rawdata(data='worker.workerinfo')
-    .row
+                    ul.list-inline
+                        li(ng-repeat='builder in getUniqueBuilders(worker) | orderBy: ["name"]')
+                            a(ui-sref="builder({builder: builder.builderid})")
+                                | {{ builder.name }}
+                td(ng-repeat="info in worker_infos")
+                    | {{ worker.workerinfo[info] }}
+    .row(ng-hide="builds")
         .form-group
             label.checkbox-inline
                 input(type="checkbox" name="{{settings.show_old_workers.name}}" ng-model="settings.show_old_workers.value")
                 | {{settings.show_old_workers.caption}}
+    div(ng-if="builds")
+        builds-table(builds="builds", builders="builders", ng-if="builds")
+        a.btn.btn-default(ui-sref='worker({worker: worker.workerid, numbuilds: numbuilds + 100})', ng-if="builds.length==numbuilds")
+            | more

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -129,6 +129,8 @@ li.unstyled{
 .no-margin{
   margin: 0px !important;
 }
+.mouse-over-only  {display: none;}
+span:hover>.mouse-over-only  {display: inline;}
 
 /* flex row will make the row grow automatically given the size of the content
    This will make sure all the inside div will fill all content.


### PR DESCRIPTION
- Workers page now shows which master the worker is connected to
- Workers page now shows correctly the list of builders that this master is configured on (not anymore the list of buildermaster which nobody cares about)
- Workers page shows list of builds per worker similar to the builders page
- New worker page displays the list of builds built by this worker

- Masters page now shows more information about a master (workers, builds, activity timer)

- Builder and Worker page build list now have the numbuilds= option which allows to show more builds
  I had delayed this feature a lot because it is hard to do it nicely (i.e without page reload)
  This implementation is the naive version with a page reload

## Contributor Checklist:

* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)

![image](https://cloud.githubusercontent.com/assets/109859/21857741/d11357c8-d826-11e6-816e-3c5c558efe4d.png)

![image](https://cloud.githubusercontent.com/assets/109859/21857758/e23c34a2-d826-11e6-9829-cefbe3bb5071.png)

![image](https://cloud.githubusercontent.com/assets/109859/21857785/fb5c8b76-d826-11e6-86bb-af5df4bf3d5e.png)

![image](https://cloud.githubusercontent.com/assets/109859/21857820/175b157c-d827-11e6-9ee9-f48419b725ac.png)


