### PR TITLE
Remove `buildbot.util.json`.

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
 import time
 from datetime import datetime
 
@@ -25,7 +27,6 @@ from buildbot.util import ascii2unicode
 from buildbot.util import datetime2epoch
 from buildbot.util import deferredLocked
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class BitbucketPullrequestPoller(base.PollingChangeSource):

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -15,6 +15,7 @@
 from future.utils import iteritems
 
 import datetime
+import json
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -26,7 +27,6 @@ from buildbot import util
 from buildbot.changes import base
 from buildbot.changes.filter import ChangeFilter
 from buildbot.util import httpclientservice
-from buildbot.util import json
 
 
 class GerritChangeFilter(ChangeFilter):

--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
 import os
 import random
 import re
@@ -32,7 +34,6 @@ from twisted.python.procutils import which
 from twisted.spread import pb
 
 from buildbot.status import builder
-from buildbot.util import json
 from buildbot.util import now
 from buildbot.util.eventual import fireEventually
 

--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -19,10 +19,10 @@ from future.utils import iteritems
 from future.utils import text_type
 
 import datetime
+import json
 import re
 
 from buildbot import util
-from buildbot.util import json
 
 
 class Type(object):

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
+
 import sqlalchemy as sa
 
 from twisted.internet import defer
@@ -20,7 +23,6 @@ from twisted.internet import reactor
 from buildbot.db import NULL
 from buildbot.db import base
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class BuildsConnectorComponent(base.DBConnectorComponent):

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -18,6 +18,8 @@ Support for buildsets in the database
 from future.utils import integer_types
 from future.utils import iteritems
 
+import json
+
 import sqlalchemy as sa
 
 from twisted.internet import defer
@@ -27,7 +29,6 @@ from buildbot.db import NULL
 from buildbot.db import base
 from buildbot.util import datetime2epoch
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class BsDict(dict):

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -19,6 +19,8 @@ Support for changes in the database
 from future.utils import iteritems
 from future.utils import itervalues
 
+import json
+
 import sqlalchemy as sa
 
 from twisted.internet import defer
@@ -28,7 +30,6 @@ from twisted.python import log
 from buildbot.db import base
 from buildbot.util import datetime2epoch
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class ChDict(dict):

--- a/master/buildbot/db/state.py
+++ b/master/buildbot/db/state.py
@@ -12,11 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
+
 import sqlalchemy as sa
 import sqlalchemy.exc
 
 from buildbot.db import base
-from buildbot.util import json
 
 
 class _IdNotFoundError(Exception):

--- a/master/buildbot/db/steps.py
+++ b/master/buildbot/db/steps.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
+
 import sqlalchemy as sa
 
 from twisted.internet import defer
@@ -19,7 +22,6 @@ from twisted.internet import reactor
 
 from buildbot.db import base
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class StepsConnectorComponent(base.DBConnectorComponent):

--- a/master/buildbot/db/types/json.py
+++ b/master/buildbot/db/types/json.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+
 import json
 
 from sqlalchemy.types import Text

--- a/master/buildbot/db/types/json.py
+++ b/master/buildbot/db/types/json.py
@@ -12,10 +12,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
+
 from sqlalchemy.types import Text
 from sqlalchemy.types import TypeDecorator
-
-from buildbot.util import json
 
 
 class JsonObject(TypeDecorator):

--- a/master/buildbot/newsfragments/json.removal
+++ b/master/buildbot/newsfragments/json.removal
@@ -1,0 +1,1 @@
+:py:data:`buildbot.util.json` has been deprecated in favor of the standard library :py:mod:`json`.

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -16,6 +16,7 @@ from future.builtins import range
 from future.utils import iteritems
 
 import collections
+import json
 import re
 import weakref
 
@@ -28,7 +29,6 @@ from buildbot import util
 from buildbot.interfaces import IProperties
 from buildbot.interfaces import IRenderable
 from buildbot.util import flatten
-from buildbot.util import json
 from buildbot.worker_transition import reportDeprecatedWorkerNameUsage
 
 

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -12,8 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 from future.utils import iteritems
 
+import json
 import os
 
 from twisted.internet import defer
@@ -25,7 +27,6 @@ from buildbot import pbutil
 from buildbot.process.properties import Properties
 from buildbot.schedulers import base
 from buildbot.util import ascii2unicode
-from buildbot.util import json
 from buildbot.util import netstrings
 from buildbot.util.maildir import MaildirService
 

--- a/master/buildbot/scripts/dataspec.py
+++ b/master/buildbot/scripts/dataspec.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
 import os
 import sys
 
@@ -20,7 +22,6 @@ from twisted.internet import defer
 from buildbot.data import connector
 from buildbot.test.fake import fakemaster
 from buildbot.util import in_reactor
-from buildbot.util import json
 
 
 @in_reactor

--- a/master/buildbot/scripts/processwwwindex.py
+++ b/master/buildbot/scripts/processwwwindex.py
@@ -15,6 +15,7 @@
 from __future__ import division
 from __future__ import print_function
 
+import json
 import os
 
 import jinja2
@@ -23,7 +24,6 @@ from twisted.internet import defer
 
 from buildbot.test.fake import fakemaster
 from buildbot.util import in_reactor
-from buildbot.util import json
 from buildbot.www import auth
 from buildbot.www.config import IndexResource
 from buildbot.www.service import WWWService

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
 import os
 import stat
 
@@ -26,7 +28,6 @@ from buildbot.process.buildstep import FAILURE
 from buildbot.process.buildstep import SKIPPED
 from buildbot.process.buildstep import SUCCESS
 from buildbot.process.buildstep import BuildStep
-from buildbot.util import json
 from buildbot.util.eventual import eventually
 from buildbot.worker_transition import WorkerAPICompatMixin
 from buildbot.worker_transition import reportDeprecatedWorkerNameUsage

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -16,6 +16,8 @@ from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import text_type
 
+import json
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import failure
@@ -23,7 +25,6 @@ from twisted.python import failure
 from buildbot.data import connector
 from buildbot.db.buildrequests import AlreadyClaimedError
 from buildbot.test.util import validation
-from buildbot.util import json
 from buildbot.util import service
 
 

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -25,6 +25,7 @@ from future.utils import text_type
 import base64
 import copy
 import hashlib
+import json
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -35,7 +36,6 @@ from buildbot.db import changesources
 from buildbot.db import schedulers
 from buildbot.test.util import validation
 from buildbot.util import datetime2epoch
-from buildbot.util import json
 from buildbot.util import service
 
 

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
+
 import mock
 
 from twisted.internet import defer
@@ -27,7 +30,6 @@ from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import db
 from buildbot.test.util import www
-from buildbot.util import json
 from buildbot.www import service as wwwservice
 from buildbot.www import auth
 from buildbot.www import authz

--- a/master/buildbot/test/unit/test_changes_gerritchangesource.py
+++ b/master/buildbot/test/unit/test_changes_gerritchangesource.py
@@ -15,6 +15,7 @@
 from future.utils import iteritems
 
 import datetime
+import json
 import types
 
 from twisted.internet import defer
@@ -25,7 +26,6 @@ from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake import fakedb
 from buildbot.test.fake.change import Change
 from buildbot.test.util import changesource
-from buildbot.util import json
 
 
 class TestGerritHelpers(unittest.TestCase):

--- a/master/buildbot/test/unit/test_clients_tryclient.py
+++ b/master/buildbot/test/unit/test_clients_tryclient.py
@@ -12,10 +12,12 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
+
 from twisted.trial import unittest
 
 from buildbot.clients import tryclient
-from buildbot.util import json
 
 
 class createJobfile(unittest.TestCase):

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -12,7 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 import datetime
+import json
 
 import mock
 
@@ -30,7 +32,6 @@ from buildbot.test.util import validation
 from buildbot.util import UTC
 from buildbot.util import datetime2epoch
 from buildbot.util import epoch2datetime
-from buildbot.util import json
 
 
 class Tests(interfaces.InterfaceTests):

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -12,8 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 from future.builtins import range
 
+import json
 import os
 import textwrap
 
@@ -26,7 +28,6 @@ from twisted.trial import unittest
 
 from buildbot.mq import wamp
 from buildbot.test.fake import fakemaster
-from buildbot.util import json
 from buildbot.wamp import connector
 
 

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -16,6 +16,8 @@ from __future__ import division
 from __future__ import print_function
 from future.utils import iteritems
 
+import json
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -36,7 +38,6 @@ from buildbot.schedulers.forcesched import oneCodebase
 from buildbot.test.util import scheduler
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.warnings import assertProducesWarning
-from buildbot.util import json
 from buildbot.worker_transition import DeprecatedWorkerNameWarning
 
 

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -12,7 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 import cStringIO as StringIO
+import json
 import os
 import shutil
 import sys
@@ -27,7 +29,6 @@ from twisted.trial import unittest
 from buildbot.schedulers import trysched
 from buildbot.test.util import dirs
 from buildbot.test.util import scheduler
-from buildbot.util import json
 
 
 class TryBase(unittest.TestCase):

--- a/master/buildbot/test/unit/test_scripts_processwwwindex.py
+++ b/master/buildbot/test/unit/test_scripts_processwwwindex.py
@@ -12,12 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
 import tempfile
 
 from twisted.trial import unittest
 
 from buildbot.scripts import processwwwindex
-from buildbot.util import json
 
 
 class TestUsersClient(unittest.TestCase):

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -12,8 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 from future.utils import iteritems
 
+import json
 import os
 import shutil
 import stat
@@ -38,7 +40,6 @@ from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.util import steps
 from buildbot.test.util.warnings import assertNotProducesWarnings
 from buildbot.test.util.warnings import assertProducesWarning
-from buildbot.util import json
 from buildbot.worker_transition import DeprecatedWorkerAPIWarning
 from buildbot.worker_transition import DeprecatedWorkerNameWarning
 

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
 import os
 import webbrowser
 
@@ -26,7 +28,6 @@ from twisted.web.resource import Resource
 from twisted.web.server import Site
 
 from buildbot.test.util import www
-from buildbot.util import json
 
 try:
     import requests

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -278,7 +278,6 @@ class OAuth2AuthGitHubE2E(www.WwwTestMixin, unittest.TestCase):
             raise unittest.SkipTest(
                 "Need to pass OAUTHCONF path to json file via environ to run this e2e test")
 
-        import json
         config = json.load(open(os.environ['OAUTHCONF']))[self.authClass]
         from buildbot.www import oauth2
         self.auth = self._instantiateAuth(

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -18,6 +18,7 @@ from future.utils import itervalues
 from future.utils import string_types
 from future.utils import text_type
 
+import json
 import re
 
 import mock
@@ -27,7 +28,6 @@ from twisted.trial import unittest
 
 from buildbot.test.fake import endpoint
 from buildbot.test.util import www
-from buildbot.util import json
 from buildbot.www import authz
 from buildbot.www import rest
 from buildbot.www.rest import JSONRPC_CODES

--- a/master/buildbot/test/unit/test_www_sse.py
+++ b/master/buildbot/test/unit/test_www_sse.py
@@ -13,13 +13,13 @@
 #
 # Copyright Buildbot Team Members
 import datetime
+import json
 
 from twisted.trial import unittest
 
 from buildbot.test.unit import test_data_changes
 from buildbot.test.util import www
 from buildbot.util import datetime2epoch
-from buildbot.util import json
 from buildbot.www import sse
 
 

--- a/master/buildbot/test/unit/test_www_ws.py
+++ b/master/buildbot/test/unit/test_www_ws.py
@@ -12,12 +12,14 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
+
 from mock import Mock
 
 from twisted.trial import unittest
 
 from buildbot.test.util import www
-from buildbot.util import json
 from buildbot.www import ws
 
 

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -19,10 +19,10 @@ from future.utils import iteritems
 from future.utils import text_type
 
 import datetime
+import json
 import re
 
 from buildbot.util import UTC
-from buildbot.util import json
 
 # Base class
 

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -17,6 +17,7 @@ from future.utils import integer_types
 from future.utils import iteritems
 
 import cgi
+import json
 import os
 import pkg_resources
 from cStringIO import StringIO
@@ -28,7 +29,6 @@ from twisted.internet import defer
 from twisted.web import server
 
 from buildbot.test.fake import fakemaster
-from buildbot.util import json
 from buildbot.www import auth
 from buildbot.www import authz
 

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 from __future__ import division
 from __future__ import print_function
 
@@ -28,9 +29,12 @@ import locale
 import re
 import textwrap
 import time
+import json
 
 from future.utils import text_type
 from twisted.python import reflect
+from twisted.python.versions import Version
+from twisted.python.deprecate import deprecatedModuleAttribute
 
 from zope.interface import implementer
 
@@ -181,26 +185,14 @@ def ascii2unicode(x):
         return x
     return text_type(x, 'ascii')
 
+_hush_pyflakes = [json]
 
-# place a working json module at 'buildbot.util.json'.  Code is adapted from
-# Paul Wise <pabs@debian.org>:
-#   http://lists.debian.org/debian-python/2010/02/msg00016.html
-# json doesn't exist as a standard module until python2.6
-# However python2.6's json module is much slower than simplejson, so we prefer
-# to use simplejson if available.
-try:
-    import simplejson as json
-    assert json
-except ImportError:
-    import json  # python 2.6 or 2.7
-try:
-    _tmp = json.loads
-except AttributeError:
-    import warnings
-    import sys
-    warnings.warn("Use simplejson, not the old json module.")
-    sys.modules.pop('json')  # get rid of the bad json module
-    import simplejson as json
+deprecatedModuleAttribute(
+    Version("buildbot", 0, 9, 4),
+    message="Use json from the standard library instead.",
+    moduleName="buildbot.util",
+    name="json",
+)
 
 
 def toJson(obj):
@@ -432,7 +424,7 @@ def dictionary_merge(a, b):
 
 
 __all__ = [
-    'naturalSort', 'now', 'formatInterval', 'ComparableMixin', 'json',
+    'naturalSort', 'now', 'formatInterval', 'ComparableMixin',
     'safeTranslate', 'none_or_str',
     'NotABranch', 'deferredLocked', 'UTC',
     'diffSets', 'makeList', 'in_reactor', 'string2boolean',

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import hashlib
+import json
 import socket
 from io import BytesIO
 
@@ -28,7 +29,6 @@ from twisted.python import log
 
 from buildbot import config
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate
-from buildbot.util import json
 from buildbot.worker import AbstractLatentWorker
 
 try:

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
 import os
 import posixpath
 
@@ -22,7 +24,6 @@ from twisted.python import log
 from twisted.web.error import Error
 
 from buildbot.interfaces import IConfigured
-from buildbot.util import json
 from buildbot.www import resource
 
 

--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -17,7 +17,8 @@
 #  and inspired from code from the Chromium project
 # otherwise, Andrew Melo <andrew.melo@gmail.com> wrote the rest
 # but "the rest" is pretty minimal
-from buildbot.util import json
+
+import json
 
 
 def getChanges(request, options=None):

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -12,13 +12,13 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+import json
 import re
 
 from dateutil.parser import parse as dateparse
 
 from twisted.python import log
-
-from buildbot.util import json
 
 
 def _process_change(payload, user, repo, repo_url, project, codebase=None):

--- a/master/buildbot/www/hooks/googlecode.py
+++ b/master/buildbot/www/hooks/googlecode.py
@@ -14,11 +14,11 @@
 # Copyright 2011, Louis Opter <kalessin@kalessin.fr>
 #
 # Quite inspired from the github hook.
+
 import hmac
+import json
 
 from twisted.python import log
-
-from buildbot.util import json
 
 
 class GoogleCodeAuthFailed(Exception):

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -17,6 +17,7 @@ from future.moves.urllib.parse import urlencode
 from future.utils import iteritems
 from future.utils import string_types
 
+import json
 from posixpath import join
 
 import requests
@@ -24,7 +25,6 @@ import requests
 from twisted.internet import defer
 from twisted.internet import threads
 
-from buildbot.util import json
 from buildbot.www import auth
 from buildbot.www import resource
 

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -19,6 +19,7 @@ from future.utils import text_type
 import cgi
 import datetime
 import fnmatch
+import json
 import re
 from contextlib import contextmanager
 
@@ -28,7 +29,6 @@ from twisted.web.error import Error
 
 from buildbot.data import exceptions
 from buildbot.data import resultspec
-from buildbot.util import json
 from buildbot.util import toJson
 from buildbot.www import resource
 from buildbot.www.authz import Forbidden

--- a/master/buildbot/www/sse.py
+++ b/master/buildbot/www/sse.py
@@ -12,8 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 from future.utils import itervalues
 
+import json
 import uuid
 
 from twisted.python import log
@@ -21,7 +23,6 @@ from twisted.web import resource
 from twisted.web import server
 
 from buildbot.data.exceptions import InvalidPathError
-from buildbot.util import json
 from buildbot.util import toJson
 
 

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -15,13 +15,14 @@
 from future.utils import itervalues
 from future.utils import string_types
 
+import json
+
 from autobahn.twisted.resource import WebSocketResource
 from autobahn.twisted.websocket import WebSocketServerFactory
 from autobahn.twisted.websocket import WebSocketServerProtocol
 from twisted.internet import defer
 from twisted.python import log
 
-from buildbot.util import json
 from buildbot.util import toJson
 
 

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -506,18 +506,6 @@ The ``@poll.method`` decorator makes this behavior easy and reliable.
         Force a call to the decorated method now.
         If the decorated method is currently running, another call will begin as soon as it completes.
 
-:py:mod:`buildbot.util.json`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. py:module:: buildbot.util.json
-
-This package is just an import of the best available JSON module.
-Use it instead of a more complex conditional import of :mod:`simplejson` or :mod:`json`:
-
-.. code-block:: python
-
-    from buildbot.util import json
-
 :py:mod:`buildbot.util.maildir`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I didn't bother to add a test of the deprecation, but just manually tested it.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [X] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [X] I have updated the appropriate documentation

