### PR TITLE
Add absolute_import and print_function future imports.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -8,3 +8,4 @@ known_third_party=migrate,sqlalchemy,ldap3,txrequests,requests,MySQLdb,coverage,
 known_first_party=buildbot,buildbot_worker
 force_single_line=1
 sections=FUTURE,FUTURE_LIBRARY,STDLIB,THIRDPARTY,MOCK,TWISTED,FIRSTPARTY,LOCALFOLDER
+add_imports=from __future__ import absolute_import,from __future__ import print_function

--- a/common/porttostable.py
+++ b/common/porttostable.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -16,7 +16,7 @@
 # Keep in sync with slave/buildslave/__init__.py
 #
 # We can't put this method in utility modules, because they import dependancy packages
-#
+
 from __future__ import division
 from __future__ import print_function
 from __future__ import with_statement

--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -18,6 +18,10 @@ This files implement buildbotNetUsageData options
 It uses urllib2 instead of requests in order to avoid requiring another dependency for statistics feature.
 urllib2 supports http_proxy already urllib2 is blocking and thus everything is done from a thread.
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import hashlib
 import inspect
 import json

--- a/master/buildbot/buildrequest.py
+++ b/master/buildbot/buildrequest.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.process.buildrequest import BuildRequest
 
 _hush_pyflakes = [BuildRequest]

--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -16,6 +16,9 @@
 # This module is left for backward compatibility of old-named worker API.
 # It should never be imported by Buildbot.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.worker.ec2 import EC2LatentWorker as _EC2LatentWorker
 from buildbot.worker_transition import deprecatedWorkerModuleAttribute
 from buildbot.worker_transition import reportDeprecatedWorkerModuleUsage

--- a/master/buildbot/buildslave/libvirt.py
+++ b/master/buildbot/buildslave/libvirt.py
@@ -16,6 +16,9 @@
 # This module is left for backward compatibility of old-named worker API.
 # It should never be imported by Buildbot.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.worker.libvirt import LibVirtWorker as _LibVirtWorker
 from buildbot.worker_transition import deprecatedWorkerModuleAttribute
 from buildbot.worker_transition import reportDeprecatedWorkerModuleUsage

--- a/master/buildbot/buildslave/openstack.py
+++ b/master/buildbot/buildslave/openstack.py
@@ -16,6 +16,9 @@
 # This module is left for backward compatibility of old-named worker API.
 # It should never be imported by Buildbot.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.worker.openstack import OpenStackLatentWorker as _OpenStackLatentWorker
 from buildbot.worker_transition import deprecatedWorkerModuleAttribute
 from buildbot.worker_transition import reportDeprecatedWorkerModuleUsage

--- a/master/buildbot/changes/base.py
+++ b/master/buildbot/changes/base.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import log
 from zope.interface import implementer

--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 import time
 from datetime import datetime

--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import text_type
 

--- a/master/buildbot/changes/filter.py
+++ b/master/buildbot/changes/filter.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import re

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import datetime

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.moves.urllib.parse import quote as urlquote
 from future.utils import itervalues
 from future.utils import text_type

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 import os

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -16,6 +16,9 @@
 """
 Parse various kinds of 'CVS notify' email.
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 import calendar

--- a/master/buildbot/changes/manager.py
+++ b/master/buildbot/changes/manager.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import log
 from zope.interface import implementer

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -17,6 +17,8 @@
 
 # Many thanks to Dave Peticolas for contributing this module
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 import datetime

--- a/master/buildbot/changes/pb.py
+++ b/master/buildbot/changes/pb.py
@@ -14,6 +14,9 @@
 # Copyright Buildbot Team Members
 
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -15,6 +15,9 @@
 # Based on the work of Dave Peticolas for the P4poll
 # Changed to svn (using xml.dom.minidom) by Niklaus Giger
 # Hacked beyond recognition by Brian Warner
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.moves.urllib.parse import quote_plus as urlquote_plus
 from future.utils import text_type
 

--- a/master/buildbot/clients/base.py
+++ b/master/buildbot/clients/base.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.python import log
 from twisted.spread import pb
 

--- a/master/buildbot/clients/sendchange.py
+++ b/master/buildbot/clients/sendchange.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.cred import credentials
 from twisted.internet import reactor
 from twisted.spread import pb

--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 import os
 import random

--- a/master/buildbot/clients/usersclient.py
+++ b/master/buildbot/clients/usersclient.py
@@ -16,6 +16,9 @@
 # this class is known to contain cruft and will be looked at later, so
 # no current implementation utilizes it aside from scripts.runner.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.cred import credentials
 from twisted.internet import reactor
 from twisted.spread import pb

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import string_types

--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.moves.collections import UserList
 

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from twisted.internet import defer

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 import copy

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 import copy

--- a/master/buildbot/data/changesources.py
+++ b/master/buildbot/data/changesources.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 import inspect

--- a/master/buildbot/data/exceptions.py
+++ b/master/buildbot/data/exceptions.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 # copy some exceptions from the DB layer
 from buildbot.db.schedulers import SchedulerAlreadyClaimedError
 

--- a/master/buildbot/data/forceschedulers.py
+++ b/master/buildbot/data/forceschedulers.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 from twisted.internet import defer

--- a/master/buildbot/data/logchunks.py
+++ b/master/buildbot/data/logchunks.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/data/masters.py
+++ b/master/buildbot/data/masters.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/data/patches.py
+++ b/master/buildbot/data/patches.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.data import base
 from buildbot.data import types
 

--- a/master/buildbot/data/properties.py
+++ b/master/buildbot/data/properties.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from twisted.internet import defer

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from twisted.python import log

--- a/master/buildbot/data/root.py
+++ b/master/buildbot/data/root.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/data/schedulers.py
+++ b/master/buildbot/data/schedulers.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/data/sourcestamps.py
+++ b/master/buildbot/data/sourcestamps.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 # See "Type Validation" in master/docs/developer/tests.rst
 from future.utils import integer_types
 from future.utils import iteritems

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/db/base.py
+++ b/master/buildbot/db/base.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import hashlib
 import itertools
 

--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from twisted.internet import defer

--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import itertools
 
 import sqlalchemy as sa

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 
 import sqlalchemy as sa

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -15,6 +15,9 @@
 """
 Support for buildsets in the database
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import integer_types
 from future.utils import iteritems
 

--- a/master/buildbot/db/buildslaves.py
+++ b/master/buildbot/db/buildslaves.py
@@ -16,6 +16,9 @@
 # This module is left for backward compatibility of old-named worker API.
 # It should never be imported by Buildbot.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.db.workers import WorkersConnectorComponent as _WorkersConnectorComponent
 from buildbot.worker_transition import deprecatedWorkerModuleAttribute
 from buildbot.worker_transition import reportDeprecatedWorkerModuleUsage

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -16,6 +16,9 @@
 """
 Support for changes in the database
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 

--- a/master/buildbot/db/changesources.py
+++ b/master/buildbot/db/changesources.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from twisted.internet import defer

--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import textwrap
 
 from twisted.application import internet

--- a/master/buildbot/db/dbconfig.py
+++ b/master/buildbot/db/dbconfig.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import ProgrammingError
 

--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -23,6 +23,9 @@ special cases that Buildbot needs.  Those include:
 
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import re
 

--- a/master/buildbot/db/exceptions.py
+++ b/master/buildbot/db/exceptions.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 
 class DatabaseNotReadyError(Exception):
     pass

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import itervalues
 

--- a/master/buildbot/db/masters.py
+++ b/master/buildbot/db/masters.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from twisted.internet import reactor

--- a/master/buildbot/db/migrate/versions/040_add_builder_tags.py
+++ b/master/buildbot/db/migrate/versions/040_add_builder_tags.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from buildbot.util import sautils

--- a/master/buildbot/db/migrate/versions/041_add_N_N_tagsbuilders.py
+++ b/master/buildbot/db/migrate/versions/041_add_N_N_tagsbuilders.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from buildbot.util import sautils

--- a/master/buildbot/db/migrate/versions/042_add_build_properties_table.py
+++ b/master/buildbot/db/migrate/versions/042_add_build_properties_table.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from buildbot.util import sautils

--- a/master/buildbot/db/migrate/versions/043_changes_parent.py
+++ b/master/buildbot/db/migrate/versions/043_changes_parent.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from buildbot.util import sautils

--- a/master/buildbot/db/migrate/versions/044_add_step_hidden.py
+++ b/master/buildbot/db/migrate/versions/044_add_step_hidden.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from buildbot.util import sautils

--- a/master/buildbot/db/migrate/versions/045_worker_transition.py
+++ b/master/buildbot/db/migrate/versions/045_worker_transition.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from twisted.python import log

--- a/master/buildbot/db/migrate/versions/046_mysql_innodb_compatibility.py
+++ b/master/buildbot/db/migrate/versions/046_mysql_innodb_compatibility.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 from migrate import changeset
 from sqlalchemy.sql import func

--- a/master/buildbot/db/migrate/versions/047_cascading_deletes.py
+++ b/master/buildbot/db/migrate/versions/047_cascading_deletes.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 from migrate.changeset.constraint import ForeignKeyConstraint
 from migrate.exceptions import NotSupportedError

--- a/master/buildbot/db/migrate_utils.py
+++ b/master/buildbot/db/migrate_utils.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 import sqlalchemy as sa

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import migrate
 import migrate.versioning.repository
 import sqlalchemy as sa

--- a/master/buildbot/db/pool.py
+++ b/master/buildbot/db/pool.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import sqlalchemy as sa

--- a/master/buildbot/db/sourcestamps.py
+++ b/master/buildbot/db/sourcestamps.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import base64
 
 import sqlalchemy as sa

--- a/master/buildbot/db/state.py
+++ b/master/buildbot/db/state.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 
 import sqlalchemy as sa

--- a/master/buildbot/db/steps.py
+++ b/master/buildbot/db/steps.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 
 import sqlalchemy as sa

--- a/master/buildbot/db/tags.py
+++ b/master/buildbot/db/tags.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.db import base
 
 

--- a/master/buildbot/db/types/json.py
+++ b/master/buildbot/db/types/json.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 from __future__ import absolute_import
+from __future__ import print_function
 
 import json
 

--- a/master/buildbot/db/users.py
+++ b/master/buildbot/db/users.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import and_
 

--- a/master/buildbot/db/workers.py
+++ b/master/buildbot/db/workers.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 import sqlalchemy as sa

--- a/master/buildbot/errors.py
+++ b/master/buildbot/errors.py
@@ -13,6 +13,10 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
+
 # Having them here prevents all kind of circular dependencies
 
 

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -22,6 +22,9 @@ Define the interfaces that are implemented by various buildbot classes.
 # pylint: disable=no-self-argument
 # pylint: disable=no-method-argument
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from zope.interface import Attribute
 from zope.interface import Interface
 

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/manhole.py
+++ b/master/buildbot/manhole.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import datetime

--- a/master/buildbot/monkeypatches/decorators.py
+++ b/master/buildbot/monkeypatches/decorators.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import util
 

--- a/master/buildbot/monkeypatches/python14653.py
+++ b/master/buildbot/monkeypatches/python14653.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import calendar
 import time
 

--- a/master/buildbot/monkeypatches/servicechecks.py
+++ b/master/buildbot/monkeypatches/servicechecks.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 
 def patch():
     """

--- a/master/buildbot/monkeypatches/testcase_assert.py
+++ b/master/buildbot/monkeypatches/testcase_assert.py
@@ -13,7 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
-
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 
 import re

--- a/master/buildbot/mq/base.py
+++ b/master/buildbot/mq/base.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log

--- a/master/buildbot/mq/connector.py
+++ b/master/buildbot/mq/connector.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.python.reflect import namedObject
 
 from buildbot.util import service

--- a/master/buildbot/mq/simple.py
+++ b/master/buildbot/mq/simple.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import pprint
 
 from twisted.internet import defer

--- a/master/buildbot/mq/wamp.py
+++ b/master/buildbot/mq/wamp.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals

--- a/master/buildbot/pbmanager.py
+++ b/master/buildbot/pbmanager.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.application import strports
 from twisted.cred import checkers
 from twisted.cred import credentials

--- a/master/buildbot/pbutil.py
+++ b/master/buildbot/pbutil.py
@@ -17,6 +17,9 @@
 """Base classes handy for use with PB clients.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import protocol
 from twisted.python import log
 from twisted.spread import pb

--- a/master/buildbot/plugins/db.py
+++ b/master/buildbot/plugins/db.py
@@ -14,6 +14,9 @@
 # Copyright Buildbot Team Members
 #
 # pylint: disable=C0111
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 

--- a/master/buildbot/process/base.py
+++ b/master/buildbot/process/base.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.process.build import Build
 
 _hush_pyflakes = [Build]

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 
 import warnings

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import text_type

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import random
 from datetime import datetime
 

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import raise_with_traceback

--- a/master/buildbot/process/cache.py
+++ b/master/buildbot/process/cache.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from buildbot.util import lru

--- a/master/buildbot/process/debug.py
+++ b/master/buildbot/process/debug.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.util import service

--- a/master/buildbot/process/factory.py
+++ b/master/buildbot/process/factory.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import warnings
 
 from twisted.python import deprecate

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 from future.utils import string_types
 from future.utils import text_type

--- a/master/buildbot/process/logobserver.py
+++ b/master/buildbot/process/logobserver.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from zope.interface import implementer
 
 from buildbot import interfaces

--- a/master/buildbot/process/measured_service.py
+++ b/master/buildbot/process/measured_service.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.process import metrics

--- a/master/buildbot/process/metrics.py
+++ b/master/buildbot/process/metrics.py
@@ -31,6 +31,8 @@ Basic architecture:
           \/
     MetricWatcher
 """
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.utils import iteritems

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import iteritems
 

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import string_types
 

--- a/master/buildbot/process/remotetransfer.py
+++ b/master/buildbot/process/remotetransfer.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import tarfile
 import tempfile

--- a/master/buildbot/process/results.py
+++ b/master/buildbot/process/results.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import lrange
 
 SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY, CANCELLED = lrange(7)

--- a/master/buildbot/process/slavebuilder.py
+++ b/master/buildbot/process/slavebuilder.py
@@ -16,6 +16,9 @@
 # This module is left for backward compatibility of old-named worker API.
 # It should never be imported by Buildbot.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.process.workerforbuilder import AbstractWorkerForBuilder as _AbstractWorkerForBuilder
 from buildbot.process.workerforbuilder import LatentWorkerForBuilder as _LatentWorkerForBuilder
 from buildbot.process.workerforbuilder import WorkerForBuilder as _WorkerForBuilder

--- a/master/buildbot/process/subunitlogobserver.py
+++ b/master/buildbot/process/subunitlogobserver.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 # this used to be referenced here, so we keep a link for old time's sake
 import buildbot.steps.subunit
 

--- a/master/buildbot/process/users/manager.py
+++ b/master/buildbot/process/users/manager.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.application import service
 from twisted.internet import defer
 

--- a/master/buildbot/process/users/manual.py
+++ b/master/buildbot/process/users/manual.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 
 from twisted.internet import defer

--- a/master/buildbot/process/users/users.py
+++ b/master/buildbot/process/users/users.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 from hashlib import sha1
 

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import log
 from twisted.python.constants import NamedConstant

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from urlparse import urlparse
 
 from twisted.internet import defer

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -15,6 +15,9 @@
 """
 Push events to Gerrit
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import iteritems
 

--- a/master/buildbot/reporters/gerrit_verify_status.py
+++ b/master/buildbot/reporters/gerrit_verify_status.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import failure
 

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from twisted.internet import defer

--- a/master/buildbot/reporters/hipchat.py
+++ b/master/buildbot/reporters/hipchat.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 
 from twisted.internet import defer

--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import abc

--- a/master/buildbot/reporters/irc.py
+++ b/master/buildbot/reporters/irc.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.application import internet
 from twisted.internet import task
 from twisted.python import log

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import string_types
 

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 import jinja2

--- a/master/buildbot/reporters/stash.py
+++ b/master/buildbot/reporters/stash.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.process.properties import Interpolate

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.moves.collections import UserList
 from future.utils import lrange
 from future.utils import string_types

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -13,6 +13,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.builtins import range

--- a/master/buildbot/revlinks.py
+++ b/master/buildbot/revlinks.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 import re

--- a/master/buildbot/scheduler.py
+++ b/master/buildbot/scheduler.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.schedulers.basic import AnyBranchScheduler
 from buildbot.schedulers.basic import Scheduler
 from buildbot.schedulers.dependent import Dependent

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import string_types
 

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 

--- a/master/buildbot/schedulers/dependent.py
+++ b/master/buildbot/schedulers/dependent.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot import config

--- a/master/buildbot/schedulers/filter.py
+++ b/master/buildbot/schedulers/filter.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 # old (pre-0.8.4) location for ChangeFilter
 from buildbot.changes.filter import ChangeFilter
 

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import string_types

--- a/master/buildbot/schedulers/manager.py
+++ b/master/buildbot/schedulers/manager.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.process.measured_service import MeasuredBuildbotServiceManager
 
 

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 from future.utils import string_types
 

--- a/master/buildbot/schedulers/triggerable.py
+++ b/master/buildbot/schedulers/triggerable.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 from twisted.internet import defer

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import json

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.builtins import range

--- a/master/buildbot/scripts/checkconfig.py
+++ b/master/buildbot/scripts/checkconfig.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/scripts/cleanupdb.py
+++ b/master/buildbot/scripts/cleanupdb.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import with_statement

--- a/master/buildbot/scripts/create_master.py
+++ b/master/buildbot/scripts/create_master.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.utils import iteritems

--- a/master/buildbot/scripts/dataspec.py
+++ b/master/buildbot/scripts/dataspec.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 import os
 import sys

--- a/master/buildbot/scripts/logwatcher.py
+++ b/master/buildbot/scripts/logwatcher.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/scripts/processwwwindex.py
+++ b/master/buildbot/scripts/processwwwindex.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/scripts/reconfig.py
+++ b/master/buildbot/scripts/reconfig.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/scripts/restart.py
+++ b/master/buildbot/scripts/restart.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -18,6 +18,8 @@
 #
 # Also don't forget to mirror your changes on command-line options in manual
 # pages and texinfo documentation.
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.builtins import range

--- a/master/buildbot/scripts/sendchange.py
+++ b/master/buildbot/scripts/sendchange.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/scripts/stop.py
+++ b/master/buildbot/scripts/stop.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/scripts/trycmd.py
+++ b/master/buildbot/scripts/trycmd.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 
 def trycmd(config):
     from buildbot.clients import tryclient

--- a/master/buildbot/scripts/tryserver.py
+++ b/master/buildbot/scripts/tryserver.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import sys
 import time

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/scripts/user.py
+++ b/master/buildbot/scripts/user.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/scripts/windows_service.py
+++ b/master/buildbot/scripts/windows_service.py
@@ -63,6 +63,7 @@
 
 # Written by Mark Hammond, 2006.
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.builtins import range

--- a/master/buildbot/spec/indent.py
+++ b/master/buildbot/spec/indent.py
@@ -1,4 +1,8 @@
 #!/usr/bin/python
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 import sys
 

--- a/master/buildbot/statistics/capture.py
+++ b/master/buildbot/statistics/capture.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/statistics/stats_service.py
+++ b/master/buildbot/statistics/stats_service.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/statistics/storage_backends/base.py
+++ b/master/buildbot/statistics/storage_backends/base.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import abc
 
 

--- a/master/buildbot/statistics/storage_backends/influxdb_client.py
+++ b/master/buildbot/statistics/storage_backends/influxdb_client.py
@@ -12,15 +12,19 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-try:
-    from influxdb import InfluxDBClient
-except ImportError:
-    InfluxDBClient = None
+
+from __future__ import absolute_import
+from __future__ import print_function
 
 from twisted.python import log
 
 from buildbot import config
 from buildbot.statistics.storage_backends.base import StatsStorageBase
+
+try:
+    from influxdb import InfluxDBClient
+except ImportError:
+    InfluxDBClient = None
 
 
 class InfluxStorageService(StatsStorageBase):

--- a/master/buildbot/status/base.py
+++ b/master/buildbot/status/base.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 
 from zope.interface import implementer
 

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from zope.interface import implementer

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import itertools
 import os
 

--- a/master/buildbot/status/buildrequest.py
+++ b/master/buildbot/status/buildrequest.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import log
 from zope.interface import implementer

--- a/master/buildbot/status/buildset.py
+++ b/master/buildbot/status/buildset.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from zope.interface import implementer
 

--- a/master/buildbot/status/client.py
+++ b/master/buildbot/status/client.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.python import log
 
 from buildbot.status import base

--- a/master/buildbot/status/event.py
+++ b/master/buildbot/status/event.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from zope.interface import implementer
 
 from buildbot import interfaces

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.moves.urllib.parse import quote as urlquote
 from future.utils import iteritems
 from future.utils import itervalues

--- a/master/buildbot/status/worker.py
+++ b/master/buildbot/status/worker.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import time
 
 from zope.interface import implementer

--- a/master/buildbot/steps/cmake.py
+++ b/master/buildbot/steps/cmake.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from twisted.internet import defer

--- a/master/buildbot/steps/cppcheck.py
+++ b/master/buildbot/steps/cppcheck.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from buildbot.process import logobserver

--- a/master/buildbot/steps/http.py
+++ b/master/buildbot/steps/http.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from twisted.internet import defer

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import string_types
 

--- a/master/buildbot/steps/maxq.py
+++ b/master/buildbot/steps/maxq.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot import config
 from buildbot.process import buildstep
 from buildbot.process.results import FAILURE

--- a/master/buildbot/steps/mswin.py
+++ b/master/buildbot/steps/mswin.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.python import log
 
 from buildbot.process.results import EXCEPTION

--- a/master/buildbot/steps/mtrlogobserver.py
+++ b/master/buildbot/steps/mtrlogobserver.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import re

--- a/master/buildbot/steps/package/deb/lintian.py
+++ b/master/buildbot/steps/package/deb/lintian.py
@@ -17,6 +17,9 @@
 Steps and objects related to lintian
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot import config
 from buildbot.process import buildstep
 from buildbot.process.results import FAILURE

--- a/master/buildbot/steps/package/deb/pbuilder.py
+++ b/master/buildbot/steps/package/deb/pbuilder.py
@@ -16,6 +16,10 @@
 """
 Steps and objects related to pbuilder
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 import stat
 import time

--- a/master/buildbot/steps/package/rpm/mock.py
+++ b/master/buildbot/steps/package/rpm/mock.py
@@ -17,6 +17,9 @@
 Steps and objects related to mock building.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from buildbot import config

--- a/master/buildbot/steps/package/rpm/rpmbuild.py
+++ b/master/buildbot/steps/package/rpm/rpmbuild.py
@@ -14,6 +14,9 @@
 # Portions Copyright Buildbot Team Members
 # Portions Copyright Dan Radez <dradez+buildbot@redhat.com>
 # Portions Copyright Steve 'Ashcrow' Milner <smilner+buildbot@redhat.com>
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import os

--- a/master/buildbot/steps/package/rpm/rpmlint.py
+++ b/master/buildbot/steps/package/rpm/rpmlint.py
@@ -17,6 +17,9 @@
 Steps and objects related to rpmlint.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.steps.package import util as pkgutil
 from buildbot.steps.shell import Test
 

--- a/master/buildbot/steps/package/rpm/rpmspec.py
+++ b/master/buildbot/steps/package/rpm/rpmspec.py
@@ -18,6 +18,9 @@
 library to populate parameters from and rpmspec file into a memory structure
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from buildbot.steps.shell import ShellCommand

--- a/master/buildbot/steps/package/util.py
+++ b/master/buildbot/steps/package/util.py
@@ -14,6 +14,9 @@
 # Portions Copyright Buildbot Team Members
 # Portions Copyright Marius Rieder <marius.rieder@durchmesser.ch>
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.process import logobserver
 
 

--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import re

--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -15,6 +15,9 @@
 """
 BuildSteps that are specific to the Twisted source tree
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import re

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import PY3
 from future.utils import iteritems
 from future.utils import string_types

--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from twisted.internet import defer

--- a/master/buildbot/steps/slave.py
+++ b/master/buildbot/steps/slave.py
@@ -16,6 +16,8 @@
 # This module is left for backward compatibility of old-named worker API.
 # It should never be imported by Buildbot.
 
+from __future__ import absolute_import
+from __future__ import print_function
 
 from buildbot.steps.worker import CompositeStepMixin
 from buildbot.steps.worker import CopyDirectory

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.python import log
 
 from buildbot.process import buildstep

--- a/master/buildbot/steps/source/bzr.py
+++ b/master/buildbot/steps/source/bzr.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.internet import defer

--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/steps/source/darcs.py
+++ b/master/buildbot/steps/source/darcs.py
@@ -15,6 +15,10 @@
 """
 Source step code for darcs
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/steps/source/gerrit.py
+++ b/master/buildbot/steps/source/gerrit.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.steps.source.git import Git
 
 

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import string_types
 

--- a/master/buildbot/steps/source/github.py
+++ b/master/buildbot/steps/source/github.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.steps.source.git import Git
 
 

--- a/master/buildbot/steps/source/mercurial.py
+++ b/master/buildbot/steps/source/mercurial.py
@@ -15,6 +15,10 @@
 """
 Source step code for mercurial
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/steps/source/mtn.py
+++ b/master/buildbot/steps/source/mtn.py
@@ -15,6 +15,10 @@
 """
 Source step code for Monotone
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 # Portions Copyright 2013 Bad Dog Consulting
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 
 import re

--- a/master/buildbot/steps/source/repo.py
+++ b/master/buildbot/steps/source/repo.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 import textwrap
 

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.moves.urllib.parse import quote as urlquote
 from future.moves.urllib.parse import unquote as urlunquote
 from future.moves.urllib.parse import urlparse

--- a/master/buildbot/steps/subunit.py
+++ b/master/buildbot/steps/subunit.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from StringIO import StringIO
 from unittest import TestResult
 

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 import os
 import stat

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -15,6 +15,9 @@
 
 # Visual studio steps
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from buildbot import config

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import stat
 
 from buildbot.process import buildstep

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.util import service

--- a/master/buildbot/test/fake/bworkermanager.py
+++ b/master/buildbot/test/fake/bworkermanager.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.util import service

--- a/master/buildbot/test/fake/change.py
+++ b/master/buildbot/test/fake/change.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.process.properties import Properties
 from buildbot.test.fake.state import State
 

--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 
 class Client(object):
     latest = None

--- a/master/buildbot/test/fake/endpoint.py
+++ b/master/buildbot/test/fake/endpoint.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 # This is a static resource type and set of endpoints uesd as common data by
 # tests.
 from future.utils import itervalues

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import posixpath
 
 import mock

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import text_type

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -18,6 +18,9 @@ A complete re-implementation of the database connector components, but without
 using a database.  These classes should pass the same tests as are applied to
 the real connector components.
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import text_type

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import weakref
 

--- a/master/buildbot/test/fake/fakemq.py
+++ b/master/buildbot/test/fake/fakemq.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.mq import base

--- a/master/buildbot/test/fake/fakeprotocol.py
+++ b/master/buildbot/test/fake/fakeprotocol.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.worker.protocols import base

--- a/master/buildbot/test/fake/fakestats.py
+++ b/master/buildbot/test/fake/fakestats.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.process import buildstep

--- a/master/buildbot/test/fake/hyper.py
+++ b/master/buildbot/test/fake/hyper.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 
 class Client(object):
     instance = None

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet.defer import Deferred
 from twisted.internet.defer import succeed
 from twisted.python.filepath import FilePath

--- a/master/buildbot/test/fake/libvirt.py
+++ b/master/buildbot/test/fake/libvirt.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 
 class Domain(object):
 

--- a/master/buildbot/test/fake/logfile.py
+++ b/master/buildbot/test/fake/logfile.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 from future.utils import text_type
 

--- a/master/buildbot/test/fake/openstack.py
+++ b/master/buildbot/test/fake/openstack.py
@@ -14,6 +14,9 @@
 # Portions Copyright Buildbot Team Members
 # Portions Copyright 2013 Cray Inc.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import uuid
 
 ACTIVE = 'ACTIVE'

--- a/master/buildbot/test/fake/pbmanager.py
+++ b/master/buildbot/test/fake/pbmanager.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.util import service

--- a/master/buildbot/test/fake/reactor.py
+++ b/master/buildbot/test/fake/reactor.py
@@ -20,6 +20,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet.base import _ThreePhaseEvent
 from twisted.internet.interfaces import IReactorCore
 from twisted.internet.interfaces import IReactorThreads

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 from twisted.internet import defer

--- a/master/buildbot/test/fake/state.py
+++ b/master/buildbot/test/fake/state.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 
 class State(object):
 

--- a/master/buildbot/test/fake/step.py
+++ b/master/buildbot/test/fake/step.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.process.buildstep import BuildStep

--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from StringIO import StringIO
 
 from mock import Mock

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.internet import defer

--- a/master/buildbot/test/fuzz/test_lru.py
+++ b/master/buildbot/test/fuzz/test_lru.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import lrange
 
 import random

--- a/master/buildbot/test/integration/test_URLs.py
+++ b/master/buildbot/test/integration/test_URLs.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.process.results import SUCCESS

--- a/master/buildbot/test/integration/test_commandmixin.py
+++ b/master/buildbot/test/integration/test_commandmixin.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.process import results

--- a/master/buildbot/test/integration/test_compositestepmixin.py
+++ b/master/buildbot/test/integration/test_compositestepmixin.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.process import results

--- a/master/buildbot/test/integration/test_configs.py
+++ b/master/buildbot/test/integration/test_configs.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.python import util

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from StringIO import StringIO

--- a/master/buildbot/test/integration/test_customservices.py
+++ b/master/buildbot/test/integration/test_customservices.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.test.util.decorators import flaky

--- a/master/buildbot/test/integration/test_hyper.py
+++ b/master/buildbot/test/integration/test_hyper.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 
 import json

--- a/master/buildbot/test/integration/test_integration_mastershell.py
+++ b/master/buildbot/test/integration/test_integration_mastershell.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.test.util.integration import RunMasterBase

--- a/master/buildbot/test/integration/test_integration_template.py
+++ b/master/buildbot/test/integration/test_integration_template.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.test.util.integration import RunMasterBase

--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import os

--- a/master/buildbot/test/integration/test_log_finish.py
+++ b/master/buildbot/test/integration/test_log_finish.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.plugins import steps

--- a/master/buildbot/test/integration/test_mailnotifier.py
+++ b/master/buildbot/test/integration/test_mailnotifier.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import base64
 
 from twisted.internet import defer

--- a/master/buildbot/test/integration/test_marathon.py
+++ b/master/buildbot/test/integration/test_marathon.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 from unittest.case import SkipTest
 

--- a/master/buildbot/test/integration/test_master.py
+++ b/master/buildbot/test/integration/test_master.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet.task import deferLater

--- a/master/buildbot/test/integration/test_setpropertyfromcommand.py
+++ b/master/buildbot/test/integration/test_setpropertyfromcommand.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import task

--- a/master/buildbot/test/integration/test_stop_trigger.py
+++ b/master/buildbot/test/integration/test_stop_trigger.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sys
 import textwrap
 

--- a/master/buildbot/test/integration/test_transfer.py
+++ b/master/buildbot/test/integration/test_transfer.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import shutil
 

--- a/master/buildbot/test/integration/test_trigger.py
+++ b/master/buildbot/test/integration/test_trigger.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import StringIO
 
 from twisted.internet import defer

--- a/master/buildbot/test/integration/test_try_client.py
+++ b/master/buildbot/test/integration/test_try_client.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 import mock

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import shutil
 import sqlite3

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet.defer import Deferred
 from twisted.python import threadpool
 from twisted.trial.unittest import SynchronousTestCase

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.cred import credentials

--- a/master/buildbot/test/integration/test_worker_transition.py
+++ b/master/buildbot/test/integration/test_worker_transition.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from twisted.internet import defer

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 
 import mock

--- a/master/buildbot/test/regressions/test_bad_change_properties_rows.py
+++ b/master/buildbot/test/regressions/test_bad_change_properties_rows.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.db import changes

--- a/master/buildbot/test/regressions/test_oldpaths.py
+++ b/master/buildbot/test/regressions/test_oldpaths.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 

--- a/master/buildbot/test/regressions/test_steps_shell_WarningCountingShellCommand.py
+++ b/master/buildbot/test/regressions/test_steps_shell_WarningCountingShellCommand.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from twisted.trial import unittest

--- a/master/buildbot/test/test_extra_coverage.py
+++ b/master/buildbot/test/test_extra_coverage.py
@@ -17,6 +17,9 @@
 # included in the coverage because none of the tests import
 # them; this results in a more accurate total coverage percent.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot import worker
 from buildbot.changes import p4poller
 from buildbot.changes import svnpoller

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import urllib2
 
 from twisted.internet import reactor

--- a/master/buildbot/test/unit/test_changes_base.py
+++ b/master/buildbot/test/unit/test_changes_base.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/test/unit/test_changes_bitbucket.py
+++ b/master/buildbot/test/unit/test_changes_bitbucket.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 from datetime import datetime
 

--- a/master/buildbot/test/unit/test_changes_changes.py
+++ b/master/buildbot/test/unit/test_changes_changes.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import pprint
 import re
 import textwrap

--- a/master/buildbot/test/unit/test_changes_filter.py
+++ b/master/buildbot/test/unit/test_changes_filter.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_changes_gerritchangesource.py
+++ b/master/buildbot/test/unit/test_changes_gerritchangesource.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import datetime

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 from future.utils import text_type
 

--- a/master/buildbot/test/unit/test_changes_hgpoller.py
+++ b/master/buildbot/test/unit/test_changes_hgpoller.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_changes_mail.py
+++ b/master/buildbot/test/unit/test_changes_mail.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_changes_mail_CVSMaildirSource.py
+++ b/master/buildbot/test/unit/test_changes_mail_CVSMaildirSource.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from email import message_from_string
 from email.utils import mktime_tz
 from email.utils import parsedate_tz

--- a/master/buildbot/test/unit/test_changes_manager.py
+++ b/master/buildbot/test/unit/test_changes_manager.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import mock

--- a/master/buildbot/test/unit/test_changes_p4poller.py
+++ b/master/buildbot/test/unit/test_changes_p4poller.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import datetime
 
 import dateutil.tz

--- a/master/buildbot/test/unit/test_changes_pb.py
+++ b/master/buildbot/test/unit/test_changes_pb.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/test/unit/test_changes_svnpoller.py
+++ b/master/buildbot/test/unit/test_changes_svnpoller.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import xml.dom.minidom
 

--- a/master/buildbot/test/unit/test_clients_sendchange.py
+++ b/master/buildbot/test/unit/test_clients_sendchange.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_clients_tryclient.py
+++ b/master/buildbot/test/unit/test_clients_tryclient.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_clients_usersclient.py
+++ b/master/buildbot/test/unit/test_clients_usersclient.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -17,12 +17,9 @@
 # We need to use the native __builtin__ module on Python 2,
 # and builtins module on Python 3, because we need to override
 # the actual native open method.
-try:
-    # Python 2
-    import __builtin__ as builtins
-except ImportError:
-    # Python 3
-    import builtins
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import iteritems
 
@@ -53,6 +50,13 @@ from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.util import service
 from buildbot.worker_transition import DeprecatedWorkerAPIWarning
 from buildbot.worker_transition import DeprecatedWorkerNameWarning
+
+try:
+    # Python 2
+    import __builtin__ as builtins
+except ImportError:
+    # Python 3
+    import builtins
 
 global_defaults = dict(
     title='Buildbot',

--- a/master/buildbot/test/unit/test_contrib_buildbot_cvs_mail.py
+++ b/master/buildbot/test/unit/test_contrib_buildbot_cvs_mail.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals

--- a/master/buildbot/test/unit/test_data_base.py
+++ b/master/buildbot/test/unit/test_data_base.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_builders.py
+++ b/master/buildbot/test/unit/test_data_builders.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_data_buildrequests.py
+++ b/master/buildbot/test/unit/test_data_buildrequests.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import datetime
 
 import mock

--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_data_buildsets.py
+++ b/master/buildbot/test/unit/test_data_buildsets.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_changes.py
+++ b/master/buildbot/test/unit/test_data_changes.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_data_changesources.py
+++ b/master/buildbot/test/unit/test_data_changesources.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_data_connector.py
+++ b/master/buildbot/test/unit/test_data_connector.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import mock

--- a/master/buildbot/test/unit/test_data_forceschedulers.py
+++ b/master/buildbot/test/unit/test_data_forceschedulers.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_data_logchunks.py
+++ b/master/buildbot/test/unit/test_data_logchunks.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.builtins import range

--- a/master/buildbot/test/unit/test_data_logs.py
+++ b/master/buildbot/test/unit/test_data_logs.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_data_masters.py
+++ b/master/buildbot/test/unit/test_data_masters.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_data_patches.py
+++ b/master/buildbot/test/unit/test_data_patches.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.data import patches

--- a/master/buildbot/test/unit/test_data_properties.py
+++ b/master/buildbot/test/unit/test_data_properties.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_data_resultspec.py
+++ b/master/buildbot/test/unit/test_data_resultspec.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import lrange
 
 import datetime

--- a/master/buildbot/test/unit/test_data_root.py
+++ b/master/buildbot/test/unit/test_data_root.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_data_schedulers.py
+++ b/master/buildbot/test/unit/test_data_schedulers.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_data_sourcestamps.py
+++ b/master/buildbot/test/unit/test_data_sourcestamps.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.data import sourcestamps

--- a/master/buildbot/test/unit/test_data_steps.py
+++ b/master/buildbot/test/unit/test_data_steps.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_data_types.py
+++ b/master/buildbot/test/unit/test_data_types.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.data import types

--- a/master/buildbot/test/unit/test_data_workers.py
+++ b/master/buildbot/test/unit/test_data_workers.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_db_base.py
+++ b/master/buildbot/test/unit/test_db_base.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import hashlib
 
 import sqlalchemy as sa

--- a/master/buildbot/test/unit/test_db_builders.py
+++ b/master/buildbot/test/unit/test_db_builders.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_buildrequests.py
+++ b/master/buildbot/test/unit/test_db_buildrequests.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import lrange
 

--- a/master/buildbot/test/unit/test_db_builds.py
+++ b/master/buildbot/test/unit/test_db_builds.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import lrange
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import datetime
 import json
 

--- a/master/buildbot/test/unit/test_db_changes.py
+++ b/master/buildbot/test/unit/test_db_changes.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import iteritems
 

--- a/master/buildbot/test/unit/test_db_changesources.py
+++ b/master/buildbot/test/unit/test_db_changesources.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_connector.py
+++ b/master/buildbot/test/unit/test_db_connector.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 import mock

--- a/master/buildbot/test/unit/test_db_dbconfig.py
+++ b/master/buildbot/test/unit/test_db_dbconfig.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import threads
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_enginestrategy.py
+++ b/master/buildbot/test/unit/test_db_enginestrategy.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from sqlalchemy.engine import url
 from sqlalchemy.pool import NullPool
 

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import base64

--- a/master/buildbot/test/unit/test_db_masters.py
+++ b/master/buildbot/test/unit/test_db_masters.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_migrate_versions_040_add_builder_tags.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_040_add_builder_tags.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_migrate_versions_041_add_N_N_tagsbuilders.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_041_add_N_N_tagsbuilders.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_migrate_versions_042_add_build_properties_table.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_042_add_build_properties_table.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_migrate_versions_043_add_changes_parent.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_043_add_changes_parent.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_migrate_versions_044_add_step_hidden.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_044_add_step_hidden.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_migrate_versions_045_worker_transition.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_045_worker_transition.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 from sqlalchemy.engine.reflection import Inspector
 

--- a/master/buildbot/test/unit/test_db_migrate_versions_046_mysql_innodb_compatibility.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_046_mysql_innodb_compatibility.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_db_migrate_versions_047_cascading_deleletes.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_047_cascading_deleletes.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy as sa
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_model.py
+++ b/master/buildbot/test/unit/test_db_model.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 import mock

--- a/master/buildbot/test/unit/test_db_pool.py
+++ b/master/buildbot/test/unit/test_db_pool.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import time
 

--- a/master/buildbot/test/unit/test_db_schedulers.py
+++ b/master/buildbot/test/unit/test_db_schedulers.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_db_sourcestamps.py
+++ b/master/buildbot/test/unit/test_db_sourcestamps.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_db_state.py
+++ b/master/buildbot/test/unit/test_db_state.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.db import state
 from buildbot.test.fake import fakedb
 from buildbot.test.util import connector_component

--- a/master/buildbot/test/unit/test_db_steps.py
+++ b/master/buildbot/test/unit/test_db_steps.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import time

--- a/master/buildbot/test/unit/test_db_users.py
+++ b/master/buildbot/test/unit/test_db_users.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sqlalchemy
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_db_workers.py
+++ b/master/buildbot/test/unit/test_db_workers.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.builtins import range

--- a/master/buildbot/test/unit/test_fake_httpclientservice.py
+++ b/master/buildbot/test/unit/test_fake_httpclientservice.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_interfaces.py
+++ b/master/buildbot/test/unit/test_interfaces.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot import interfaces

--- a/master/buildbot/test/unit/test_locks.py
+++ b/master/buildbot/test/unit/test_locks.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.locks import WorkerLock

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import signal
 

--- a/master/buildbot/test/unit/test_mq.py
+++ b/master/buildbot/test/unit/test_mq.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_mq_base.py
+++ b/master/buildbot/test/unit/test_mq_base.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_mq_simple.py
+++ b/master/buildbot/test/unit/test_mq_simple.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import json

--- a/master/buildbot/test/unit/test_pbmanager.py
+++ b/master/buildbot/test/unit/test_pbmanager.py
@@ -15,6 +15,10 @@
 """
 Test clean shutdown functionality of the master
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.cred import credentials

--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -15,6 +15,10 @@
 """
 Unit tests for the plugin framework
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 import mock

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import operator
 
 from mock import Mock

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import text_type
 

--- a/master/buildbot/test/unit/test_process_buildrequest.py
+++ b/master/buildbot/test/unit/test_process_buildrequest.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 import mock

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import iteritems
 

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.utils import itervalues

--- a/master/buildbot/test/unit/test_process_cache.py
+++ b/master/buildbot/test/unit/test_process_cache.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_process_debug.py
+++ b/master/buildbot/test/unit/test_process_debug.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_process_factory.py
+++ b/master/buildbot/test/unit/test_process_factory.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 from random import choice

--- a/master/buildbot/test/unit/test_process_log.py
+++ b/master/buildbot/test/unit/test_process_log.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 import mock

--- a/master/buildbot/test/unit/test_process_logobserver.py
+++ b/master/buildbot/test/unit/test_process_logobserver.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_process_metrics.py
+++ b/master/buildbot/test/unit/test_process_metrics.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import lrange
 

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from copy import deepcopy
 
 import mock

--- a/master/buildbot/test/unit/test_process_remotecommand.py
+++ b/master/buildbot/test/unit/test_process_remotecommand.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_process_remotetransfer.py
+++ b/master/buildbot/test/unit/test_process_remotetransfer.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import stat
 import tempfile

--- a/master/buildbot/test/unit/test_process_results.py
+++ b/master/buildbot/test/unit/test_process_results.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import lrange
 
 from twisted.python import log

--- a/master/buildbot/test/unit/test_process_users_manager.py
+++ b/master/buildbot/test/unit/test_process_users_manager.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_process_users_manual.py
+++ b/master/buildbot/test/unit/test_process_users_manual.py
@@ -16,6 +16,9 @@
 # this class is known to contain cruft and will be looked at later, so
 # no current implementation utilizes it aside from scripts.runner.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_process_users_users.py
+++ b/master/buildbot/test/unit/test_process_users_users.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.process.users import users

--- a/master/buildbot/test/unit/test_process_workerforbuilder.py
+++ b/master/buildbot/test/unit/test_process_workerforbuilder.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial.unittest import TestCase
 
 from buildbot.process.workerforbuilder import AbstractWorkerForBuilder

--- a/master/buildbot/test/unit/test_reporter_bitbucket.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucket.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from mock import Mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import warnings

--- a/master/buildbot/test/unit/test_reporter_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit_verify_status.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import datetime
 
 from mock import Mock

--- a/master/buildbot/test/unit/test_reporter_github.py
+++ b/master/buildbot/test/unit/test_reporter_github.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from mock import Mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_reporter_gitlab.py
+++ b/master/buildbot/test/unit/test_reporter_gitlab.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from mock import Mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_reporter_http.py
+++ b/master/buildbot/test/unit/test_reporter_http.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from mock import Mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_reporter_stash.py
+++ b/master/buildbot/test/unit/test_reporter_stash.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from mock import Mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_reporters_hipchat.py
+++ b/master/buildbot/test/unit/test_reporters_hipchat.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from mock import Mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_reporters_irc.py
+++ b/master/buildbot/test/unit/test_reporters_irc.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.application import internet

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import base64
 import copy
 import sys

--- a/master/buildbot/test/unit/test_reporters_message.py
+++ b/master/buildbot/test/unit/test_reporters_message.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import textwrap
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_reporters_utils.py
+++ b/master/buildbot/test/unit/test_reporters_utils.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import textwrap
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_reporters_words.py
+++ b/master/buildbot/test/unit/test_reporters_words.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import re

--- a/master/buildbot/test/unit/test_revlinks.py
+++ b/master/buildbot/test/unit/test_revlinks.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.revlinks import GithubRevlink

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/test/unit/test_schedulers_basic.py
+++ b/master/buildbot/test/unit/test_schedulers_basic.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_schedulers_dependent.py
+++ b/master/buildbot/test/unit/test_schedulers_dependent.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.utils import iteritems

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import time
 
 import mock

--- a/master/buildbot/test/unit/test_schedulers_timed_NightlyBase.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_NightlyBase.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import time
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_schedulers_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_NightlyTriggerable.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import task
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_schedulers_timed_Timed.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Timed.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_schedulers_triggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_triggerable.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 import mock

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import cStringIO as StringIO
 import json
 import os

--- a/master/buildbot/test/unit/test_scripts_base.py
+++ b/master/buildbot/test/unit/test_scripts_base.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import cStringIO
 import os
 import string

--- a/master/buildbot/test/unit/test_scripts_checkconfig.py
+++ b/master/buildbot/test/unit/test_scripts_checkconfig.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import cStringIO

--- a/master/buildbot/test/unit/test_scripts_cleanupdb.py
+++ b/master/buildbot/test/unit/test_scripts_cleanupdb.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import textwrap
 
@@ -20,13 +24,14 @@ import sqlalchemy as sa
 from twisted.internet import defer
 from twisted.trial import unittest
 
-import test_db_logs
 from buildbot.db.connector import DBConnector
 from buildbot.scripts import cleanupdb
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import db
 from buildbot.test.util import dirs
 from buildbot.test.util import misc
+
+from . import test_db_logs
 
 try:
     import lz4

--- a/master/buildbot/test/unit/test_scripts_create_master.py
+++ b/master/buildbot/test/unit/test_scripts_create_master.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 import os

--- a/master/buildbot/test/unit/test_scripts_processwwwindex.py
+++ b/master/buildbot/test/unit/test_scripts_processwwwindex.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 import tempfile
 

--- a/master/buildbot/test/unit/test_scripts_restart.py
+++ b/master/buildbot/test/unit/test_scripts_restart.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_scripts_runner.py
+++ b/master/buildbot/test/unit/test_scripts_runner.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import cStringIO
 import getpass
 import os

--- a/master/buildbot/test/unit/test_scripts_sendchange.py
+++ b/master/buildbot/test/unit/test_scripts_sendchange.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_scripts_start.py
+++ b/master/buildbot/test/unit/test_scripts_start.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/test/unit/test_scripts_stop.py
+++ b/master/buildbot/test/unit/test_scripts_stop.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import signal
 import time

--- a/master/buildbot/test/unit/test_scripts_trycmd.py
+++ b/master/buildbot/test/unit/test_scripts_trycmd.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_scripts_tryserver.py
+++ b/master/buildbot/test/unit/test_scripts_tryserver.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import sys
 from cStringIO import StringIO

--- a/master/buildbot/test/unit/test_scripts_upgrade_master.py
+++ b/master/buildbot/test/unit/test_scripts_upgrade_master.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import StringIO
 import sys

--- a/master/buildbot/test/unit/test_scripts_user.py
+++ b/master/buildbot/test/unit/test_scripts_user.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_steps_cmake.py
+++ b/master/buildbot/test/unit/test_steps_cmake.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial.unittest import TestCase
 
 from buildbot.config import ConfigErrors

--- a/master/buildbot/test/unit/test_steps_cppcheck.py
+++ b/master/buildbot/test/unit/test_steps_cppcheck.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.process.properties import WithProperties

--- a/master/buildbot/test/unit/test_steps_http.py
+++ b/master/buildbot/test/unit/test_steps_http.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import reactor
 from twisted.trial import unittest
 from twisted.web.resource import Resource

--- a/master/buildbot/test/unit/test_steps_master.py
+++ b/master/buildbot/test/unit/test_steps_master.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import pprint
 import sys

--- a/master/buildbot/test/unit/test_steps_maxq.py
+++ b/master/buildbot/test/unit/test_steps_maxq.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot import config

--- a/master/buildbot/test/unit/test_steps_mswin.py
+++ b/master/buildbot/test/unit/test_steps_mswin.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_steps_mtrlogobserver.py
+++ b/master/buildbot/test/unit/test_steps_mtrlogobserver.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.enterprise import adbapi

--- a/master/buildbot/test/unit/test_steps_package_deb_lintian.py
+++ b/master/buildbot/test/unit/test_steps_package_deb_lintian.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot import config

--- a/master/buildbot/test/unit/test_steps_package_deb_pbuilder.py
+++ b/master/buildbot/test/unit/test_steps_package_deb_pbuilder.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import stat
 import time
 

--- a/master/buildbot/test/unit/test_steps_package_rpm_mock.py
+++ b/master/buildbot/test/unit/test_steps_package_rpm_mock.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot import config

--- a/master/buildbot/test/unit/test_steps_package_rpm_rpmbuild.py
+++ b/master/buildbot/test/unit/test_steps_package_rpm_rpmbuild.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_steps_package_rpm_rpmlint.py
+++ b/master/buildbot/test/unit/test_steps_package_rpm_rpmlint.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.process.results import SUCCESS

--- a/master/buildbot/test/unit/test_steps_python.py
+++ b/master/buildbot/test/unit/test_steps_python.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot import config

--- a/master/buildbot/test/unit/test_steps_python_twisted.py
+++ b/master/buildbot/test/unit/test_steps_python_twisted.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import textwrap
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 import textwrap
 

--- a/master/buildbot/test/unit/test_steps_shellsequence.py
+++ b/master/buildbot/test/unit/test_steps_shellsequence.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.process.properties import WithProperties

--- a/master/buildbot/test/unit/test_steps_source_base_Source.py
+++ b/master/buildbot/test/unit/test_steps_source_base_Source.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from exceptions import AttributeError
 
 import mock

--- a/master/buildbot/test/unit/test_steps_source_bzr.py
+++ b/master/buildbot/test/unit/test_steps_source_bzr.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.internet import error

--- a/master/buildbot/test/unit/test_steps_source_cvs.py
+++ b/master/buildbot/test/unit/test_steps_source_cvs.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import time
 
 from twisted.internet import error

--- a/master/buildbot/test/unit/test_steps_source_darcs.py
+++ b/master/buildbot/test/unit/test_steps_source_darcs.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import error
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_steps_source_gerrit.py
+++ b/master/buildbot/test/unit/test_steps_source_gerrit.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.process.results import SUCCESS

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import error
 from twisted.python.reflect import namedModule
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_steps_source_github.py
+++ b/master/buildbot/test/unit/test_steps_source_github.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.process.results import SUCCESS
 from buildbot.steps.source import github
 from buildbot.test.fake.remotecommand import Expect

--- a/master/buildbot/test/unit/test_steps_source_mercurial.py
+++ b/master/buildbot/test/unit/test_steps_source_mercurial.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import error
 from twisted.python.reflect import namedModule
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_steps_source_mtn.py
+++ b/master/buildbot/test/unit/test_steps_source_mtn.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import error
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_steps_source_p4.py
+++ b/master/buildbot/test/unit/test_steps_source_p4.py
@@ -13,6 +13,10 @@
 #
 # Copyright Buildbot Team Members
 # Portions Copyright 2013 Bad Dog Consulting
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import platform
 import textwrap
 

--- a/master/buildbot/test/unit/test_steps_source_repo.py
+++ b/master/buildbot/test/unit/test_steps_source_repo.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import error
 from twisted.python.reflect import namedModule
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_steps_subunit.py
+++ b/master/buildbot/test/unit/test_steps_subunit.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import StringIO
 
 import mock

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import json

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from mock import Mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_steps_vstudio.py
+++ b/master/buildbot/test/unit/test_steps_vstudio.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from mock import Mock
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_steps_worker.py
+++ b/master/buildbot/test/unit/test_steps_worker.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import stat
 
 import mock

--- a/master/buildbot/test/unit/test_test_util_gpo.py
+++ b/master/buildbot/test/unit/test_test_util_gpo.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sys
 
 import twisted

--- a/master/buildbot/test/unit/test_test_util_validation.py
+++ b/master/buildbot/test/unit/test_test_util_validation.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import datetime
 
 from twisted.python import log

--- a/master/buildbot/test/unit/test_test_util_warnings.py
+++ b/master/buildbot/test/unit/test_test_util_warnings.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import warnings
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_util.py
+++ b/master/buildbot/test/unit/test_util.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 import datetime

--- a/master/buildbot/test/unit/test_util_ComparableMixin.py
+++ b/master/buildbot/test/unit/test_util_ComparableMixin.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot import util

--- a/master/buildbot/test/unit/test_util_bbcollections.py
+++ b/master/buildbot/test/unit/test_util_bbcollections.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.util import bbcollections

--- a/master/buildbot/test/unit/test_util_codebase.py
+++ b/master/buildbot/test/unit/test_util_codebase.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_util_debounce.py
+++ b/master/buildbot/test/unit/test_util_debounce.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_util_eventual.py
+++ b/master/buildbot/test/unit/test_util_eventual.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import log
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_util_httpclientservice.py
+++ b/master/buildbot/test/unit/test_util_httpclientservice.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 import os
 

--- a/master/buildbot/test/unit/test_util_identifiers.py
+++ b/master/buildbot/test/unit/test_util_identifiers.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 from twisted.python import log

--- a/master/buildbot/test/unit/test_util_interfaces.py
+++ b/master/buildbot/test/unit/test_util_interfaces.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.test.util import interfaces

--- a/master/buildbot/test/unit/test_util_lineboundaries.py
+++ b/master/buildbot/test/unit/test_util_lineboundaries.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_util_lru.py
+++ b/master/buildbot/test/unit/test_util_lru.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import gc

--- a/master/buildbot/test/unit/test_util_maildir.py
+++ b/master/buildbot/test/unit/test_util_maildir.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_util_misc.py
+++ b/master/buildbot/test/unit/test_util_misc.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_util_netstrings.py
+++ b/master/buildbot/test/unit/test_util_netstrings.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.protocols import basic
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_util_notifier.py
+++ b/master/buildbot/test/unit/test_util_notifier.py
@@ -19,6 +19,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.python.failure import Failure
 from twisted.trial.unittest import SynchronousTestCase
 

--- a/master/buildbot/test/unit/test_util_pathmatch.py
+++ b/master/buildbot/test/unit/test_util_pathmatch.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.util import pathmatch

--- a/master/buildbot/test/unit/test_util_poll.py
+++ b/master/buildbot/test/unit/test_util_poll.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/test/unit/test_util_raml.py
+++ b/master/buildbot/test/unit/test_util_raml.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import textwrap
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_util_sautils.py
+++ b/master/buildbot/test/unit/test_util_sautils.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.util import sautils

--- a/master/buildbot/test/unit/test_util_service.py
+++ b/master/buildbot/test/unit/test_util_service.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import text_type
 

--- a/master/buildbot/test/unit/test_util_ssl.py
+++ b/master/buildbot/test/unit/test_util_ssl.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_util_state.py
+++ b/master/buildbot/test/unit/test_util_state.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.test.fake.fakemaster import make_master

--- a/master/buildbot/test/unit/test_util_subscriptions.py
+++ b/master/buildbot/test/unit/test_util_subscriptions.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.util import subscription

--- a/master/buildbot/test/unit/test_util_tuplematch.py
+++ b/master/buildbot/test/unit/test_util_tuplematch.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.test.util import tuplematching

--- a/master/buildbot/test/unit/test_wamp_connector.py
+++ b/master/buildbot/test/unit/test_wamp_connector.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_worker_base.py
+++ b/master/buildbot/test/unit/test_worker_base.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import threads
 from twisted.python import threadpool
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_worker_ec2.py
+++ b/master/buildbot/test/unit/test_worker_ec2.py
@@ -13,6 +13,10 @@
 #
 # Portions Copyright Buildbot Team Members
 # Portions Copyright 2014 Longaccess private company
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_worker_hyper.py
+++ b/master/buildbot/test/unit/test_worker_hyper.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import threadpool
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_worker_libvirt.py
+++ b/master/buildbot/test/unit/test_worker_libvirt.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_worker_local.py
+++ b/master/buildbot/test/unit/test_worker_local.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 import mock

--- a/master/buildbot/test/unit/test_worker_manager.py
+++ b/master/buildbot/test/unit/test_worker_manager.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_worker_marathon.py
+++ b/master/buildbot/test/unit/test_worker_marathon.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -13,6 +13,10 @@
 #
 # Portions Copyright Buildbot Team Members
 # Portions Copyright 2013 Cray Inc.
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_worker_protocols_base.py
+++ b/master/buildbot/test/unit/test_worker_protocols_base.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/unit/test_worker_transition.py
+++ b/master/buildbot/test/unit/test_worker_transition.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import new
 import re
 import sys

--- a/master/buildbot/test/unit/test_www_auth.py
+++ b/master/buildbot/test/unit/test_www_auth.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.cred.checkers import InMemoryUsernamePasswordDatabaseDontUse

--- a/master/buildbot/test/unit/test_www_authz.py
+++ b/master/buildbot/test/unit/test_www_authz.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_www_avatar.py
+++ b/master/buildbot/test/unit/test_www_avatar.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_www_config.py
+++ b/master/buildbot/test/unit/test_www_config.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 
 import mock

--- a/master/buildbot/test/unit/test_www_endpointmatchers.py
+++ b/master/buildbot/test/unit/test_www_endpointmatchers.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_www_hooks_base.py
+++ b/master/buildbot/test/unit/test_www_hooks_base.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_www_hooks_bitbucket.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucket.py
@@ -13,6 +13,10 @@
 #
 # Copyright Buildbot Team Members
 # Copyright Manba Team
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import calendar
 
 from twisted.internet.defer import inlineCallbacks

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import hmac
 from calendar import timegm
 from hashlib import sha1

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import calendar
 
 import mock

--- a/master/buildbot/test/unit/test_www_hooks_gitorious.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitorious.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import calendar
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_www_hooks_googlecode.py
+++ b/master/buildbot/test/unit/test_www_hooks_googlecode.py
@@ -14,6 +14,10 @@
 # Copyright 2011 Louis Opter <kalessin@kalessin.fr>
 #
 # Written from the github change hook unit test
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import StringIO
 
 from twisted.trial import unittest

--- a/master/buildbot/test/unit/test_www_hooks_poller.py
+++ b/master/buildbot/test/unit/test_www_hooks_poller.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_www_ldapuserinfo.py
+++ b/master/buildbot/test/unit/test_www_ldapuserinfo.py
@@ -13,6 +13,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import new

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 import os
 import webbrowser

--- a/master/buildbot/test/unit/test_www_resource.py
+++ b/master/buildbot/test/unit/test_www_resource.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.test.util import www

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import iteritems
 from future.utils import itervalues

--- a/master/buildbot/test/unit/test_www_roles.py
+++ b/master/buildbot/test/unit/test_www_roles.py
@@ -11,6 +11,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot.test.util.config import ConfigErrorsMixin

--- a/master/buildbot/test/unit/test_www_service.py
+++ b/master/buildbot/test/unit/test_www_service.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.cred import strcred

--- a/master/buildbot/test/unit/test_www_sse.py
+++ b/master/buildbot/test/unit/test_www_sse.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import datetime
 import json
 

--- a/master/buildbot/test/unit/test_www_ws.py
+++ b/master/buildbot/test/unit/test_www_ws.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 
 from mock import Mock

--- a/master/buildbot/test/util/changesource.py
+++ b/master/buildbot/test/util/changesource.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import task
 

--- a/master/buildbot/test/util/config.py
+++ b/master/buildbot/test/util/config.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot import config
 
 

--- a/master/buildbot/test/util/connector_component.py
+++ b/master/buildbot/test/util/connector_component.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.db import model
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import db

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from sqlalchemy.schema import MetaData

--- a/master/buildbot/test/util/decorators.py
+++ b/master/buildbot/test/util/decorators.py
@@ -15,6 +15,10 @@
 """
 Various decorators for test cases
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import sys
 

--- a/master/buildbot/test/util/dirs.py
+++ b/master/buildbot/test/util/dirs.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import shutil
 

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.data import base

--- a/master/buildbot/test/util/fuzz.py
+++ b/master/buildbot/test/util/fuzz.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.internet import defer

--- a/master/buildbot/test/util/gpo.py
+++ b/master/buildbot/test/util/gpo.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from twisted.internet import defer

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.utils import itervalues

--- a/master/buildbot/test/util/interfaces.py
+++ b/master/buildbot/test/util/interfaces.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import PY3
 

--- a/master/buildbot/test/util/logging.py
+++ b/master/buildbot/test/util/logging.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from twisted.python import log

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 import migrate

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import print_function
 from future.utils import text_type
 

--- a/master/buildbot/test/util/pbmanager.py
+++ b/master/buildbot/test/util/pbmanager.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.internet import defer

--- a/master/buildbot/test/util/properties.py
+++ b/master/buildbot/test/util/properties.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from zope.interface import implementer
 
 from buildbot.interfaces import IRenderable

--- a/master/buildbot/test/util/protocols.py
+++ b/master/buildbot/test/util/protocols.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.test.util import interfaces
 
 

--- a/master/buildbot/test/util/querylog.py
+++ b/master/buildbot/test/util/querylog.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot.schedulers import base

--- a/master/buildbot/test/util/sourcesteps.py
+++ b/master/buildbot/test/util/sourcesteps.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from buildbot.test.util import steps

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.utils import iteritems

--- a/master/buildbot/test/util/tuplematching.py
+++ b/master/buildbot/test/util/tuplematching.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 
 class TupleMatchingMixin(object):
 

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 # See "Type Validation" in master/docs/developer/tests.rst
 from future.utils import integer_types
 from future.utils import iteritems

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.moves.urllib.parse import unquote as urlunquote
 from future.utils import integer_types
 from future.utils import iteritems

--- a/master/buildbot/util/_notifier.py
+++ b/master/buildbot/util/_notifier.py
@@ -19,6 +19,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet.defer import Deferred
 
 

--- a/master/buildbot/util/bbcollections.py
+++ b/master/buildbot/util/bbcollections.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 # this is here for compatibility
 from collections import defaultdict
 

--- a/master/buildbot/util/codebase.py
+++ b/master/buildbot/util/codebase.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 

--- a/master/buildbot/util/config.py
+++ b/master/buildbot/util/config.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import re

--- a/master/buildbot/util/croniter.py
+++ b/master/buildbot/util/croniter.py
@@ -5,6 +5,7 @@
 # Pyflakes warnings corrected
 
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.builtins import range

--- a/master/buildbot/util/debounce.py
+++ b/master/buildbot/util/debounce.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import functools
 
 from twisted.internet import defer

--- a/master/buildbot/util/eventual.py
+++ b/master/buildbot/util/eventual.py
@@ -14,6 +14,10 @@
 # Copyright Buildbot Team Members
 #
 # copied from foolscap
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log

--- a/master/buildbot/util/identifiers.py
+++ b/master/buildbot/util/identifiers.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 from future.utils import text_type
 

--- a/master/buildbot/util/lineboundaries.py
+++ b/master/buildbot/util/lineboundaries.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from twisted.internet import defer

--- a/master/buildbot/util/logger.py
+++ b/master/buildbot/util/logger.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 try:
     from twisted.logger import Logger
 except ImportError:

--- a/master/buildbot/util/lru.py
+++ b/master/buildbot/util/lru.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.moves.itertools import filterfalse
 
 from collections import defaultdict

--- a/master/buildbot/util/maildir.py
+++ b/master/buildbot/util/maildir.py
@@ -18,6 +18,10 @@ linux dirwatcher API (if available) to look for new files. The
 .messageReceived method is invoked with the filename of the new message,
 relative to the top of the maildir (so it will look like "new/blahblah").
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.application import internet

--- a/master/buildbot/util/misc.py
+++ b/master/buildbot/util/misc.py
@@ -16,6 +16,9 @@
 Miscellaneous utilities; these should be imported from C{buildbot.util}, not
 directly from this module.
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 
 from twisted.internet import reactor

--- a/master/buildbot/util/netstrings.py
+++ b/master/buildbot/util/netstrings.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet.interfaces import IAddress
 from twisted.internet.interfaces import ITransport
 from twisted.protocols import basic

--- a/master/buildbot/util/pathmatch.py
+++ b/master/buildbot/util/pathmatch.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import re

--- a/master/buildbot/util/poll.py
+++ b/master/buildbot/util/poll.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import task

--- a/master/buildbot/util/raml.py
+++ b/master/buildbot/util/raml.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import copy

--- a/master/buildbot/util/sautils.py
+++ b/master/buildbot/util/sautils.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from contextlib import contextmanager
 
 import sqlalchemy as sa

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 import hashlib

--- a/master/buildbot/util/ssl.py
+++ b/master/buildbot/util/ssl.py
@@ -12,10 +12,15 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
-"""This modules acts the same as twisted.internet.ssl except it does not raise ImportError
 
-    Modules using this should call ensureHasSSL in order to make sure that the user installed buildbot[tls]
 """
+This modules acts the same as twisted.internet.ssl except it does not raise ImportError
+
+Modules using this should call ensureHasSSL in order to make sure that the user installed buildbot[tls]
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
 
 try:
     from twisted.internet.ssl import *  # noqa pylint: disable=unused-wildcard-import, wildcard-import

--- a/master/buildbot/util/state.py
+++ b/master/buildbot/util/state.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 

--- a/master/buildbot/util/subscription.py
+++ b/master/buildbot/util/subscription.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.python import failure
 from twisted.python import log
 

--- a/master/buildbot/util/tuplematch.py
+++ b/master/buildbot/util/tuplematch.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import itertools
 
 

--- a/master/buildbot/wamp/connector.py
+++ b/master/buildbot/wamp/connector.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright  Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import txaio
 from autobahn.twisted.wamp import ApplicationSession
 from autobahn.twisted.wamp import Service

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -13,6 +13,9 @@
 #
 # Portions Copyright Buildbot Team Members
 # Portions Copyright Canonical Ltd. 2009
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 import time

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-# Needed so that this module name don't clash with docker-py on older python.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -18,6 +18,8 @@ A latent worker that uses EC2 to instantiate the workers on demand.
 
 Tested with Python boto 1.5c
 """
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.utils import integer_types

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -13,6 +13,9 @@
 #
 # Portions Copyright Buildbot Team Members
 # Portions Copyright Canonical Ltd. 2009
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 import random

--- a/master/buildbot/worker/libvirt.py
+++ b/master/buildbot/worker/libvirt.py
@@ -13,6 +13,7 @@
 #
 # Portions Copyright Buildbot Team Members
 # Portions Copyright 2010 Isotoma Limited
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/master/buildbot/worker/local.py
+++ b/master/buildbot/worker/local.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Portions Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from twisted.internet import defer

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import log
 

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -13,6 +13,8 @@
 #
 # Portions Copyright Buildbot Team Members
 # Portions Copyright 2013 Cray Inc.
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from buildbot.util import service

--- a/master/buildbot/worker/protocols/null.py
+++ b/master/buildbot/worker/protocols/null.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -12,6 +12,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/master/buildbot/worker_transition.py
+++ b/master/buildbot/worker_transition.py
@@ -20,6 +20,8 @@ Use of old API generates Python warning which may be logged, ignored or treated
 as an error using Python builtin warnings API.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import functools

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from twisted.cred.checkers import FilePasswordDB

--- a/master/buildbot/www/authz/authz.py
+++ b/master/buildbot/www/authz/authz.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import fnmatch
 import re
 

--- a/master/buildbot/www/authz/endpointmatchers.py
+++ b/master/buildbot/www/authz/endpointmatchers.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 
 import inspect

--- a/master/buildbot/www/authz/roles.py
+++ b/master/buildbot/www/authz/roles.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 

--- a/master/buildbot/www/avatar.py
+++ b/master/buildbot/www/avatar.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.moves.urllib.parse import urlencode
 from future.moves.urllib.parse import urljoin
 

--- a/master/buildbot/www/change_hook.py
+++ b/master/buildbot/www/change_hook.py
@@ -17,6 +17,10 @@
 #  and inspired from code from the Chromium project
 # otherwise, Andrew Melo <andrew.melo@gmail.com> wrote the rest
 # but "the rest" is pretty minimal
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from twisted.internet import defer

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 import os
 import posixpath

--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -18,6 +18,9 @@
 # otherwise, Andrew Melo <andrew.melo@gmail.com> wrote the rest
 # but "the rest" is pretty minimal
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 
 

--- a/master/buildbot/www/hooks/bitbucket.py
+++ b/master/buildbot/www/hooks/bitbucket.py
@@ -13,6 +13,10 @@
 #
 # Copyright Buildbot Team Members
 # Copyright 2013 (c) Mamba Team
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 
 from dateutil.parser import parse as dateparse

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import hmac
 import logging
 import re

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 import re
 

--- a/master/buildbot/www/hooks/gitorious.py
+++ b/master/buildbot/www/hooks/gitorious.py
@@ -14,6 +14,10 @@
 # Copyright Buildbot Team Members
 #
 # note: this file is based on github.py
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import re
 
 from dateutil.parser import parse as dateparse

--- a/master/buildbot/www/hooks/googlecode.py
+++ b/master/buildbot/www/hooks/googlecode.py
@@ -15,6 +15,9 @@
 #
 # Quite inspired from the github hook.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import hmac
 import json
 

--- a/master/buildbot/www/hooks/poller.py
+++ b/master/buildbot/www/hooks/poller.py
@@ -16,6 +16,9 @@
 # This change hook allows GitHub or a hand crafted curl inovcation to "knock on
 # the door" and trigger a change source to poll.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot.changes.base import PollingChangeSource
 
 

--- a/master/buildbot/www/ldapuserinfo.py
+++ b/master/buildbot/www/ldapuserinfo.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.moves.urllib.parse import urlparse
 
 import ldap3

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.moves.urllib.parse import parse_qs
 from future.moves.urllib.parse import urlencode
 from future.utils import iteritems

--- a/master/buildbot/www/plugin.py
+++ b/master/buildbot/www/plugin.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import pkg_resources
 
 from twisted.web import static

--- a/master/buildbot/www/resource.py
+++ b/master/buildbot/www/resource.py
@@ -12,6 +12,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import log
 from twisted.web import resource

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.moves.urllib.parse import urlparse
 from future.utils import iteritems
 from future.utils import text_type

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import os

--- a/master/buildbot/www/sse.py
+++ b/master/buildbot/www/sse.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 
 import json

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -12,6 +12,9 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright  Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import itervalues
 from future.utils import string_types
 

--- a/master/contrib/SimpleConfig.py
+++ b/master/contrib/SimpleConfig.py
@@ -84,6 +84,9 @@
 # A variant of this script has been deployed in our shop for
 # about six months, and has proven quite useful.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 import os
 import random

--- a/master/contrib/bitbucket_buildbot.py
+++ b/master/contrib/bitbucket_buildbot.py
@@ -11,6 +11,8 @@ bitbucket repository for the user who initiated bitbucket_buildbot.py
 bitbucket_buildbot.py is based on github_buildbot.py
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import logging

--- a/master/contrib/bk_buildbot.py
+++ b/master/contrib/bk_buildbot.py
@@ -7,6 +7,7 @@
 #
 # Amar Takhar <amar@ntp.org>
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/buildbot_cvs_mail.py
+++ b/master/contrib/buildbot_cvs_mail.py
@@ -12,6 +12,7 @@
 #
 # Options handling done right by djmitche
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals

--- a/master/contrib/buildbot_json.py
+++ b/master/contrib/buildbot_json.py
@@ -29,6 +29,7 @@
 
 # NOTE: This file is NOT under GPL.  See above.
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.builtins import range

--- a/master/contrib/bzr_buildbot.py
+++ b/master/contrib/bzr_buildbot.py
@@ -95,15 +95,8 @@ Contact Information
 Maintainer/author: gary.poster@canonical.com
 """
 
-try:
-    import buildbot.util
-    import buildbot.changes.base
-    import buildbot.changes.changes
-except ImportError:
-    DEFINE_POLLER = False
-else:
-    DEFINE_POLLER = True
-
+from __future__ import absolute_import
+from __future__ import print_function
 
 # Work around Twisted bug.
 # See http://twistedmatrix.com/trac/ticket/3591
@@ -125,6 +118,15 @@ from twisted.python import failure
 import bzrlib.branch
 import bzrlib.errors
 import bzrlib.trace
+
+try:
+    import buildbot.util
+    import buildbot.changes.base
+    import buildbot.changes.changes
+except ImportError:
+    DEFINE_POLLER = False
+else:
+    DEFINE_POLLER = True
 
 
 #

--- a/master/contrib/check_buildbot.py
+++ b/master/contrib/check_buildbot.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.utils import lrange

--- a/master/contrib/check_smtp.py
+++ b/master/contrib/check_smtp.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python -tt
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/coverage2text.py
+++ b/master/contrib/coverage2text.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sys
 
 from coverage import coverage

--- a/master/contrib/darcs_buildbot.py
+++ b/master/contrib/darcs_buildbot.py
@@ -17,6 +17,7 @@
 # machine. You will also need the Python/XML distribution installed (the
 # "python2.3-xml" package under debian).
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/fakechange.py
+++ b/master/contrib/fakechange.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/fakemaster.py
+++ b/master/contrib/fakemaster.py
@@ -11,6 +11,7 @@
 # Original Author: Chris AtLee <catlee@mozilla.com>
 # Licensed under the MPL version 2.0
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/generate_changelog.py
+++ b/master/contrib/generate_changelog.py
@@ -10,6 +10,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/git_buildbot.py
+++ b/master/contrib/git_buildbot.py
@@ -23,6 +23,8 @@
 #
 # Largely based on contrib/hooks/post-receive-email from git.
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 from future.utils import text_type
 

--- a/master/contrib/github_buildbot.py
+++ b/master/contrib/github_buildbot.py
@@ -13,6 +13,8 @@ This version of github_buildbot.py parses v3 of the github webhook api, with the
 
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 import hmac

--- a/master/contrib/googlecode_atom.py
+++ b/master/contrib/googlecode_atom.py
@@ -23,6 +23,9 @@
 #   c['change_source'] = [ poller ]
 #
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import datetime
 from xml.dom import minidom
 

--- a/master/contrib/hgbuildbot.py
+++ b/master/contrib/hgbuildbot.py
@@ -140,6 +140,8 @@
 # This would strip everything until (and including) the 4th "/" in the repo's
 # path leaving only "myrepo" left.  This would then be append to the base URL.
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import json

--- a/master/contrib/post_build_request.py
+++ b/master/contrib/post_build_request.py
@@ -16,6 +16,7 @@
 # Portions Copyright Buildbot Team Members
 # Portions Copyright 2013 OpenGamma Inc. and the OpenGamma group of companies
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/run_maxq.py
+++ b/master/contrib/run_maxq.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env jython
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/svn_buildbot.py
+++ b/master/contrib/svn_buildbot.py
@@ -16,6 +16,7 @@
 # edit your svn-repository/hooks/post-commit file, and add lines that look
 # like this:
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.utils import text_type

--- a/master/contrib/svn_watcher.py
+++ b/master/contrib/svn_watcher.py
@@ -20,6 +20,7 @@
 # 22.03.10 by Johnnie Pittman, added support for category and interval
 # options.
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/svnpoller.py
+++ b/master/contrib/svnpoller.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
 # USA
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/trac/bbwatcher/api.py
+++ b/master/contrib/trac/bbwatcher/api.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import urlparse

--- a/master/contrib/trac/bbwatcher/model.py
+++ b/master/contrib/trac/bbwatcher/model.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
 from datetime import datetime
 
 from trac.util.datefmt import utc

--- a/master/contrib/trac/bbwatcher/web_ui.py
+++ b/master/contrib/trac/bbwatcher/web_ui.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/trac/setup.py
+++ b/master/contrib/trac/setup.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
 from setuptools import setup
 
 from bbwatcher import __version__

--- a/master/contrib/viewcvspoll.py
+++ b/master/contrib/viewcvspoll.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/contrib/webhook_status.py
+++ b/master/contrib/webhook_status.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 
 import urllib

--- a/master/docs/bbdocs/ext.py
+++ b/master/docs/bbdocs/ext.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import iteritems
 
 from docutils import nodes

--- a/master/docs/bbdocs/highlighterrors.py
+++ b/master/docs/bbdocs/highlighterrors.py
@@ -1,4 +1,6 @@
 
+from __future__ import absolute_import
+from __future__ import print_function
 
 import sys
 import textwrap

--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -11,6 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -19,6 +19,9 @@
 Standard setup script.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import glob
 import os
 import pkg_resources

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 # Method to add build step taken from here
 # https://seasonofcode.com/posts/how-to-add-custom-build-steps-and-commands-to-setuppy.html
 import distutils.cmd

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -126,7 +126,7 @@ class BuildJsCommand(distutils.cmd.Command):
         if os.path.exists("gulpfile.js"):
             yarn_version = check_output("yarn --version")
             npm_version = check_output("npm -v")
-            print "yarn:", yarn_version, "npm: ", npm_version
+            print("yarn:", yarn_version, "npm: ", npm_version)
             npm_bin = check_output("npm bin").strip()
             assert npm_version != "", "need nodejs and npm installed in current PATH"
             assert LooseVersion(npm_version) >= LooseVersion(

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -15,6 +15,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from setuptools import setup
 
 import buildbot_pkg

--- a/pkg/test_buildbot_pkg.py
+++ b/pkg/test_buildbot_pkg.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import shutil
 from subprocess import call

--- a/worker/buildbot_worker/__init__.py
+++ b/worker/buildbot_worker/__init__.py
@@ -17,6 +17,7 @@
 #
 # We can't put this method in utility modules, because they import dependancy packages
 #
+
 from __future__ import division
 from __future__ import print_function
 from __future__ import with_statement

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import multiprocessing
 import os.path
 import socket

--- a/worker/buildbot_worker/bot.py
+++ b/worker/buildbot_worker/bot.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot_worker.null import LocalWorker
 from buildbot_worker.pb import Worker
 

--- a/worker/buildbot_worker/commands/base.py
+++ b/worker/buildbot_worker/commands/base.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 
 import os
 import shutil

--- a/worker/buildbot_worker/commands/fs.py
+++ b/worker/buildbot_worker/commands/fs.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import glob
 import os
 import shutil

--- a/worker/buildbot_worker/commands/registry.py
+++ b/worker/buildbot_worker/commands/registry.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.python import reflect
 
 commandRegistry = {

--- a/worker/buildbot_worker/commands/shell.py
+++ b/worker/buildbot_worker/commands/shell.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 from buildbot_worker import runprocess

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import tarfile
 import tempfile

--- a/worker/buildbot_worker/commands/utils.py
+++ b/worker/buildbot_worker/commands/utils.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import text_type
 
 import os

--- a/worker/buildbot_worker/exceptions.py
+++ b/worker/buildbot_worker/exceptions.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 
 class AbandonChain(Exception):
 

--- a/worker/buildbot_worker/interfaces.py
+++ b/worker/buildbot_worker/interfaces.py
@@ -17,6 +17,9 @@
 # pylint: disable=no-self-argument
 # pylint: disable=no-method-argument
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from zope.interface import Interface
 
 

--- a/worker/buildbot_worker/monkeypatches/bug4881.py
+++ b/worker/buildbot_worker/monkeypatches/bug4881.py
@@ -14,6 +14,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import lrange
 
 import os

--- a/worker/buildbot_worker/monkeypatches/bug5079.py
+++ b/worker/buildbot_worker/monkeypatches/bug5079.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted import version
 from twisted.python import log
 from twisted.python import versions

--- a/worker/buildbot_worker/monkeypatches/testcase_assert.py
+++ b/worker/buildbot_worker/monkeypatches/testcase_assert.py
@@ -13,7 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
-
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import string_types
 
 import re

--- a/worker/buildbot_worker/null.py
+++ b/worker/buildbot_worker/null.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 from buildbot_worker.base import WorkerBase

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os.path
 import signal
 

--- a/worker/buildbot_worker/pbutil.py
+++ b/worker/buildbot_worker/pbutil.py
@@ -17,6 +17,9 @@
 """Base classes handy for use with PB clients.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.cred import error
 from twisted.internet import protocol
 from twisted.internet import reactor

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -17,6 +17,8 @@
 Support for running 'shell commands'
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 from future.utils import iteritems
 from future.utils import string_types

--- a/worker/buildbot_worker/scripts/base.py
+++ b/worker/buildbot_worker/scripts/base.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/worker/buildbot_worker/scripts/create_worker.py
+++ b/worker/buildbot_worker/scripts/create_worker.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/worker/buildbot_worker/scripts/logwatcher.py
+++ b/worker/buildbot_worker/scripts/logwatcher.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/worker/buildbot_worker/scripts/restart.py
+++ b/worker/buildbot_worker/scripts/restart.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -16,6 +16,7 @@
 # N.B.: don't import anything that might pull in a reactor yet. Some of our
 # subcommands want to load modules that need the gtk reactor.
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/worker/buildbot_worker/scripts/start.py
+++ b/worker/buildbot_worker/scripts/start.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/worker/buildbot_worker/scripts/stop.py
+++ b/worker/buildbot_worker/scripts/stop.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/worker/buildbot_worker/scripts/windows_service.py
+++ b/worker/buildbot_worker/scripts/windows_service.py
@@ -63,6 +63,7 @@
 
 # Written by Mark Hammond, 2006.
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.builtins import range

--- a/worker/buildbot_worker/test/fake/remote.py
+++ b/worker/buildbot_worker/test/fake/remote.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 
 

--- a/worker/buildbot_worker/test/fake/runprocess.py
+++ b/worker/buildbot_worker/test/fake/runprocess.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.python import failure
 

--- a/worker/buildbot_worker/test/fake/workerforbuilder.py
+++ b/worker/buildbot_worker/test/fake/workerforbuilder.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/worker/buildbot_worker/test/test_extra_coverage.py
+++ b/worker/buildbot_worker/test/test_extra_coverage.py
@@ -17,6 +17,9 @@
 # included in the coverage because none of the tests import
 # them; this results in a more accurate total coverage percent.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot_worker.scripts import logwatcher
 
 modules = []  # for the benefit of pyflakes

--- a/worker/buildbot_worker/test/test_util_hangcheck.py
+++ b/worker/buildbot_worker/test/test_util_hangcheck.py
@@ -2,6 +2,9 @@
 Tests for `buildbot_worker.util._hangcheck`.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import reactor
 from twisted.internet.defer import CancelledError
 from twisted.internet.defer import Deferred

--- a/worker/buildbot_worker/test/unit/runprocess-scripts.py
+++ b/worker/buildbot_worker/test/unit/runprocess-scripts.py
@@ -18,6 +18,9 @@
 # have access to any of the Buildbot source.  Functions here should be kept
 # very simple!
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import select
 import signal

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
 from future.builtins import range
 
 import multiprocessing

--- a/worker/buildbot_worker/test/unit/test_bot_Worker.py
+++ b/worker/buildbot_worker/test/unit/test_bot_Worker.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import shutil
 import socket

--- a/worker/buildbot_worker/test/unit/test_commands_base.py
+++ b/worker/buildbot_worker/test/unit/test_commands_base.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/worker/buildbot_worker/test/unit/test_commands_fs.py
+++ b/worker/buildbot_worker/test/unit/test_commands_fs.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import shutil
 

--- a/worker/buildbot_worker/test/unit/test_commands_registry.py
+++ b/worker/buildbot_worker/test/unit/test_commands_registry.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot_worker.commands import registry

--- a/worker/buildbot_worker/test/unit/test_commands_shell.py
+++ b/worker/buildbot_worker/test/unit/test_commands_shell.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot_worker.commands import shell

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import io
 import os
 import shutil

--- a/worker/buildbot_worker/test/unit/test_commands_utils.py
+++ b/worker/buildbot_worker/test/unit/test_commands_utils.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -12,6 +12,8 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright Buildbot Team Members
+
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/worker/buildbot_worker/test/unit/test_scripts_base.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_base.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import io
 import os
 import sys

--- a/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 
 import mock

--- a/worker/buildbot_worker/test/unit/test_scripts_restart.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_restart.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.trial import unittest

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import sys
 

--- a/worker/buildbot_worker/test/unit/test_scripts_start.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_start.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import mock
 
 from twisted.trial import unittest

--- a/worker/buildbot_worker/test/unit/test_scripts_stop.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_stop.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import errno
 import os
 import signal

--- a/worker/buildbot_worker/test/unit/test_util.py
+++ b/worker/buildbot_worker/test/unit/test_util.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.trial import unittest
 
 from buildbot_worker import util

--- a/worker/buildbot_worker/test/util/command.py
+++ b/worker/buildbot_worker/test/util/command.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import shutil
 

--- a/worker/buildbot_worker/test/util/compat.py
+++ b/worker/buildbot_worker/test/util/compat.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import sys
 
 import twisted

--- a/worker/buildbot_worker/test/util/misc.py
+++ b/worker/buildbot_worker/test/util/misc.py
@@ -17,12 +17,9 @@
 # We need to use the native __builtin__ module on Python 2,
 # and builtins module on Python 3, because we need to override
 # the actual native open method.
-try:
-    # Python 2
-    import __builtin__ as builtins
-except ImportError:
-    # Python 3
-    import builtins
+
+from __future__ import absolute_import
+from __future__ import print_function
 from future.utils import PY3
 from future.utils import string_types
 
@@ -39,6 +36,13 @@ import mock
 from twisted.python import log
 
 from buildbot_worker.scripts import base
+
+try:
+    # Python 2
+    import __builtin__ as builtins
+except ImportError:
+    # Python 3
+    import builtins
 
 
 def nl(s):

--- a/worker/buildbot_worker/test/util/sourcecommand.py
+++ b/worker/buildbot_worker/test/util/sourcecommand.py
@@ -13,6 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 from buildbot_worker import runprocess
 from buildbot_worker.test.util import command
 

--- a/worker/buildbot_worker/util/_hangcheck.py
+++ b/worker/buildbot_worker/util/_hangcheck.py
@@ -6,6 +6,10 @@ expects the client to talk first, when a PB client talks to an HTTP
 server, neither side will talk, leading to a hung connection. This
 wrapper will disconnect in that case, and inform the caller.
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 from twisted.internet.interfaces import IProtocol
 from twisted.internet.interfaces import IProtocolFactory
 from twisted.python.components import proxyForInterface

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -19,6 +19,9 @@
 Standard setup script.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 import sys
 from distutils.command.install_data import install_data

--- a/www/base/setup.py
+++ b/www/base/setup.py
@@ -15,6 +15,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/www/codeparameter/setup.py
+++ b/www/codeparameter/setup.py
@@ -15,6 +15,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/www/console_view/setup.py
+++ b/www/console_view/setup.py
@@ -15,6 +15,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/www/md_base/setup.py
+++ b/www/md_base/setup.py
@@ -15,6 +15,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/www/nestedexample/buildbot_nestedexample/api.py
+++ b/www/nestedexample/buildbot_nestedexample/api.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
 import json
 
 from klein import Klein

--- a/www/nestedexample/setup.py
+++ b/www/nestedexample/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 

--- a/www/waterfall_view/setup.py
+++ b/www/waterfall_view/setup.py
@@ -15,6 +15,7 @@
 #
 # Copyright Buildbot Team Members
 
+from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 


### PR DESCRIPTION
I tripped over not having `absolute_import` in #2582, so add them everywhere (and insure they stay added).

Builds on #2582 since they touch the same imports.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [X] I have updated the appropriate documentation

