### PR TITLE
Remove types.StringTypes which is gone in Python 3

### DIFF
--- a/master/buildbot/plugins/db.py
+++ b/master/buildbot/plugins/db.py
@@ -23,7 +23,6 @@ from future.utils import string_types
 
 import traceback
 from pkg_resources import iter_entry_points
-from types import StringTypes
 
 from zope.interface import Invalid
 from zope.interface.verify import verifyClass

--- a/master/buildbot/plugins/db.py
+++ b/master/buildbot/plugins/db.py
@@ -16,6 +16,7 @@
 # pylint: disable=C0111
 from future.utils import iteritems
 from future.utils import itervalues
+from future.utils import string_types
 
 import traceback
 from pkg_resources import iter_entry_points
@@ -145,7 +146,7 @@ class _NSNode(object):
             child.load()
 
     def add(self, name, entry):
-        assert isinstance(name, StringTypes) and isinstance(entry,
+        assert isinstance(name, string_types) and isinstance(entry,
                                                             _PluginEntry)
         self._add(name, entry)
 
@@ -184,12 +185,12 @@ class _NSNode(object):
             return child
 
     def info(self, name):
-        assert isinstance(name, StringTypes)
+        assert isinstance(name, string_types)
 
         return self._get(name).info
 
     def get(self, name):
-        assert isinstance(name, StringTypes)
+        assert isinstance(name, string_types)
 
         return self._get(name).value
 

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -16,7 +16,6 @@
 from future.utils import string_types
 
 import re
-from types import StringType
 
 from twisted.internet import defer
 from twisted.python import log
@@ -92,7 +91,7 @@ class P4(Source):
             config.error(
                 "Either provide p4viewspec or p4base and p4branch (and optionally p4extra_views")
 
-        if p4viewspec and isinstance(p4viewspec, StringType):
+        if p4viewspec and isinstance(p4viewspec, string_types):
             config.error(
                 "p4viewspec must not be a string, and should be a sequence of 2 element sequences")
 

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -22,6 +22,7 @@ from twisted.python import log
 
 from buildbot import config
 from buildbot import interfaces
+from buildbot import util
 from buildbot.interfaces import WorkerTooOldError
 from buildbot.process import buildstep
 from buildbot.process.properties import Interpolate
@@ -231,12 +232,12 @@ class P4(Source):
         command.extend(doCommand)
 
         def encodeArg(arg):
-            if isinstance(arg, string_types):
-                return arg.encode('utf-8')
-            elif isinstance(arg, tuple):
+            if isinstance(arg, tuple):
                 # If a tuple, then the second element is the argument that will
                 # be used when executing the command.
-                return (arg[0], arg[1].encode('utf-8'), arg[2])
+                return (arg[0], util.encodeString(arg[1]), arg[2])
+            else:
+                return util.encodeString(arg)
 
         command = [encodeArg(c) for c in command]
         return command

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -174,6 +174,13 @@ def safeTranslate(s):
     return s.translate(badchars_map)
 
 
+def encodeString(s, encoding='utf-8'):
+    if isinstance(s, text_type):
+        return s.encode(encoding)
+    else:
+        return s
+
+
 def none_or_str(x):
     if x is not None and not isinstance(x, str):
         return str(x)


### PR DESCRIPTION
Updated diff, originally taken from https://github.com/buildbot/buildbot/pull/2388
