### PR TITLE
Use twisted.python.compat.NativeStringIO when overriding stdout or stderr

### DIFF
--- a/master/buildbot/test/unit/test_scripts_base.py
+++ b/master/buildbot/test/unit/test_scripts_base.py
@@ -16,13 +16,13 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import cStringIO
 import os
 import string
 import textwrap
 
 from twisted.python import runtime
 from twisted.python import usage
+from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot import config as config_module
@@ -36,7 +36,7 @@ class TestIBD(dirs.DirsMixin, misc.StdoutAssertionsMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpDirs('test')
-        self.stdout = cStringIO.StringIO()
+        self.stdout = NativeStringIO()
         self.setUpStdoutAssertions()
 
     def test_isBuildmasterDir_no_dir(self):

--- a/master/buildbot/test/unit/test_scripts_checkconfig.py
+++ b/master/buildbot/test/unit/test_scripts_checkconfig.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from future.utils import iteritems
 
-import cStringIO
 import os
 import re
 import sys
@@ -25,6 +24,7 @@ import textwrap
 
 import mock
 
+from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot.scripts import base
@@ -59,8 +59,8 @@ class TestConfigLoader(dirs.DirsMixin, unittest.TestCase):
                 f.write(contents)
 
         old_stdout, old_stderr = sys.stdout, sys.stderr
-        stdout = sys.stdout = cStringIO.StringIO()
-        stderr = sys.stderr = cStringIO.StringIO()
+        stdout = sys.stdout = NativeStringIO()
+        stderr = sys.stderr = NativeStringIO()
         try:
             checkconfig._loadConfig(
                 basedir='configdir', configFile="master.cfg", quiet=False)

--- a/master/buildbot/test/unit/test_scripts_runner.py
+++ b/master/buildbot/test/unit/test_scripts_runner.py
@@ -16,7 +16,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import cStringIO
 import getpass
 import os
 import sys
@@ -26,6 +25,7 @@ import mock
 from twisted.python import log
 from twisted.python import runtime
 from twisted.python import usage
+from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot.scripts import base
@@ -841,7 +841,7 @@ class TestRun(unittest.TestCase):
 
     def test_run_bad(self):
         self.patch(sys, 'argv', ['buildbot', 'my', '-l'])
-        stdout = cStringIO.StringIO()
+        stdout = NativeStringIO()
         self.patch(sys, 'stdout', stdout)
         try:
             runner.run()

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -17,9 +17,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 from future.utils import text_type
 
-import cStringIO
 import os
 import sys
+
+from twisted.python.compat import NativeStringIO
 
 import buildbot
 
@@ -49,7 +50,7 @@ class StdoutAssertionsMixin(object):
     """
 
     def setUpStdoutAssertions(self):
-        self.stdout = cStringIO.StringIO()
+        self.stdout = NativeStringIO()
         self.patch(sys, 'stdout', self.stdout)
 
     def assertWasQuiet(self):


### PR DESCRIPTION
sys.stdout is bytes on Py2, and unicode on Py3,
so we need to be careful when overriding it.