### PR TITLE
Properly override stdout on Python 2 and Python 3 in test_scripts_base

### DIFF
--- a/worker/buildbot_worker/test/unit/test_scripts_base.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_base.py
@@ -16,12 +16,12 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import io
 import os
 import sys
 
 from twisted.trial import unittest
 
+from buildbot_worker.compat import NativeStringIO
 from buildbot_worker.scripts import base
 from buildbot_worker.test.util import misc
 
@@ -33,7 +33,7 @@ class TestIsWorkerDir(misc.FileIOMixin, misc.StdoutAssertionsMixin,
 
     def setUp(self):
         # capture output to stdout
-        self.mocked_stdout = io.BytesIO()
+        self.mocked_stdout = NativeStringIO()
         self.patch(sys, "stdout", self.mocked_stdout)
 
         # generate OS specific relative path to buildbot.tac inside basedir


### PR DESCRIPTION
This fixes test_scripts_base on Python 3.