### PR TITLE
Name and password must be bytes before calling credentials.UsernamePassword

### DIFF
--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -31,6 +31,7 @@ from twisted.spread import pb
 from buildbot_worker.base import BotBase
 from buildbot_worker.base import WorkerBase
 from buildbot_worker.base import WorkerForBuilderBase
+from buildbot_worker.compat import unicode2bytes
 from buildbot_worker.pbutil import ReconnectingPBClientFactory
 from buildbot_worker.util import HangCheckFactory
 
@@ -167,6 +168,9 @@ class Worker(WorkerBase, service.MultiService):
             self, name, basedir, umask=umask, unicode_encoding=unicode_encoding)
         if keepalive == 0:
             keepalive = None
+
+        name = unicode2bytes(name, self.bot.unicode_encoding)
+        passwd = unicode2bytes(passwd, self.bot.unicode_encoding)
 
         self.numcpus = numcpus
         self.shutdown_loop = None

--- a/worker/buildbot_worker/test/unit/test_bot_Worker.py
+++ b/worker/buildbot_worker/test/unit/test_bot_Worker.py
@@ -103,7 +103,7 @@ class TestWorker(misc.PatcherMixin, unittest.TestCase):
         self.realm = MasterRealm(perspective, on_attachment)
         p = portal.Portal(self.realm)
         p.registerChecker(
-            checkers.InMemoryUsernamePasswordDatabaseDontUse(testy="westy"))
+            checkers.InMemoryUsernamePasswordDatabaseDontUse(testy=b"westy"))
         self.listeningport = reactor.listenTCP(
             0, pb.PBServerFactory(p), interface='127.0.0.1')
         # return the dynamically allocated port number


### PR DESCRIPTION
This fixes tests on Python 3