### PR TITLE
Fix buildbot.test.unit.test_util_raml on Python 3

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -31,6 +31,7 @@ from twisted.python import deprecate
 from twisted.python import failure
 from twisted.python import log
 from twisted.python import versions
+from twisted.python.compat import NativeStringIO
 from twisted.python.failure import Failure
 from twisted.python.reflect import accumulateClassList
 from twisted.web.util import formatFailure
@@ -60,12 +61,6 @@ from buildbot.util import debounce
 from buildbot.util import flatten
 from buildbot.worker_transition import WorkerAPICompatMixin
 from buildbot.worker_transition import deprecatedWorkerClassMethod
-
-try:
-    import cStringIO as StringIO
-    assert StringIO
-except ImportError:
-    import StringIO
 
 
 class BuildStepFailed(Exception):
@@ -228,7 +223,7 @@ class SyncLogFileWrapper(logobserver.LogObserver):
 
     def readlines(self):
         alltext = "".join(self.getChunks([self.STDOUT], onlyText=True))
-        io = StringIO.StringIO(alltext)
+        io = NativeStringIO(alltext)
         return io.readlines()
 
     def getChunks(self, channels=None, onlyText=False):

--- a/master/buildbot/process/remotetransfer.py
+++ b/master/buildbot/process/remotetransfer.py
@@ -21,6 +21,7 @@ import tarfile
 import tempfile
 from io import BytesIO
 
+from buildbot.util import unicode2bytes
 from buildbot.worker.protocols import base
 
 
@@ -56,6 +57,7 @@ class FileWriter(base.FileWriterImpl):
         @type  data: C{string}
         @param data: String of data to write
         """
+        data = unicode2bytes(data)
         if self.remaining is not None:
             if len(data) > self.remaining:
                 data = data[:self.remaining]
@@ -195,4 +197,5 @@ class StringFileReader(FileReader):
     """
 
     def __init__(self, s):
+        s = unicode2bytes(s)
         FileReader.__init__(self, BytesIO(s))

--- a/master/buildbot/process/remotetransfer.py
+++ b/master/buildbot/process/remotetransfer.py
@@ -19,14 +19,9 @@ from __future__ import print_function
 import os
 import tarfile
 import tempfile
+from io import BytesIO
 
 from buildbot.worker.protocols import base
-
-try:
-    from cStringIO import StringIO
-    assert StringIO
-except ImportError:
-    from StringIO import StringIO
 
 
 """
@@ -200,4 +195,4 @@ class StringFileReader(FileReader):
     """
 
     def __init__(self, s):
-        FileReader.__init__(self, StringIO(s))
+        FileReader.__init__(self, BytesIO(s))

--- a/master/buildbot/test/unit/test_util_netstrings.py
+++ b/master/buildbot/test/unit/test_util_netstrings.py
@@ -27,13 +27,13 @@ class NetstringParser(unittest.TestCase):
     def test_valid_netstrings(self):
         p = netstrings.NetstringParser()
         p.feed("5:hello,5:world,")
-        self.assertEqual(p.strings, ['hello', 'world'])
+        self.assertEqual(p.strings, [b'hello', b'world'])
 
     def test_valid_netstrings_byte_by_byte(self):
         # (this is really testing twisted's support, but oh well)
         p = netstrings.NetstringParser()
         [p.feed(c) for c in "5:hello,5:world,"]
-        self.assertEqual(p.strings, ['hello', 'world'])
+        self.assertEqual(p.strings, [b'hello', b'world'])
 
     def test_invalid_netstring(self):
         p = netstrings.NetstringParser()
@@ -44,4 +44,4 @@ class NetstringParser(unittest.TestCase):
         p = netstrings.NetstringParser()
         p.feed("11:hello world,6:foob")
         # note that the incomplete 'foobar' does not appear here
-        self.assertEqual(p.strings, ['hello world'])
+        self.assertEqual(p.strings, [b'hello world'])

--- a/master/buildbot/util/netstrings.py
+++ b/master/buildbot/util/netstrings.py
@@ -21,6 +21,8 @@ from twisted.internet.interfaces import ITransport
 from twisted.protocols import basic
 from zope.interface import implementer
 
+from buildbot.util import unicode2bytes
+
 
 @implementer(IAddress)
 class NullAddress(object):
@@ -66,6 +68,7 @@ class NetstringParser(basic.NetstringReceiver):
         self.strings = []
 
     def feed(self, data):
+        data = unicode2bytes(data)
         self.dataReceived(data)
         # dataReceived handles errors unusually quietly!
         if self.brokenPeer:

--- a/master/buildbot/util/raml.py
+++ b/master/buildbot/util/raml.py
@@ -93,7 +93,7 @@ class RamlSpec(object):
 
     def iter_actions(self, endpoint):
         ACTIONS_MAGIC = '/actions/'
-        for k, v in endpoint.iteritems():
+        for k, v in iteritems(endpoint):
             if k.startswith(ACTIONS_MAGIC):
                 k = k[len(ACTIONS_MAGIC):]
                 v = v['post']


### PR DESCRIPTION
This fixes on Python 3:

```
trial buildbot.test.unit.test_util_raml
```

Due to interdependencies, removal of cStringIO in a few other places was required to allow the module to import
and the test to run on Python 3.