### PR TITLE
remove reflection from worker commands registry

### DIFF
--- a/worker/buildbot_worker/commands/registry.py
+++ b/worker/buildbot_worker/commands/registry.py
@@ -16,26 +16,27 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from twisted.python import reflect
+import buildbot_worker.commands.fs
+import buildbot_worker.commands.shell
+import buildbot_worker.commands.transfer
 
 commandRegistry = {
-    # command name : fully qualified factory name (callable)
-    "shell": "buildbot_worker.commands.shell.WorkerShellCommand",
-    "uploadFile": "buildbot_worker.commands.transfer.WorkerFileUploadCommand",
-    "uploadDirectory": "buildbot_worker.commands.transfer.WorkerDirectoryUploadCommand",
-    "downloadFile": "buildbot_worker.commands.transfer.WorkerFileDownloadCommand",
-    "mkdir": "buildbot_worker.commands.fs.MakeDirectory",
-    "rmdir": "buildbot_worker.commands.fs.RemoveDirectory",
-    "cpdir": "buildbot_worker.commands.fs.CopyDirectory",
-    "stat": "buildbot_worker.commands.fs.StatFile",
-    "glob": "buildbot_worker.commands.fs.GlobPath",
-    "listdir": "buildbot_worker.commands.fs.ListDir",
+    # command name : fully qualified factory (callable)
+    "shell": buildbot_worker.commands.shell.WorkerShellCommand,
+    "uploadFile": buildbot_worker.commands.transfer.WorkerFileUploadCommand,
+    "uploadDirectory": buildbot_worker.commands.transfer.WorkerDirectoryUploadCommand,
+    "downloadFile": buildbot_worker.commands.transfer.WorkerFileDownloadCommand,
+    "mkdir": buildbot_worker.commands.fs.MakeDirectory,
+    "rmdir": buildbot_worker.commands.fs.RemoveDirectory,
+    "cpdir": buildbot_worker.commands.fs.CopyDirectory,
+    "stat": buildbot_worker.commands.fs.StatFile,
+    "glob": buildbot_worker.commands.fs.GlobPath,
+    "listdir": buildbot_worker.commands.fs.ListDir,
 }
 
 
 def getFactory(command):
-    factory_name = commandRegistry[command]
-    factory = reflect.namedObject(factory_name)
+    factory = commandRegistry[command]
     return factory
 
 


### PR DESCRIPTION
Worker is tending to be more "dumb" with more logic moved to master.
This way it's easier to maintain hordes of workers --- no need to
upgrade each one for every minor fix or feature (since all features are in
master).

Previously having lazily-loaded commands was useful --- not all workers
had Python modules to work with different flavours of VCS and tricky
commands.

Currently worker have only minimal basic commands which are available
on all worker installation (they mostly use standard Python modules),
so there is no point in lazy-loading.

Also removal of lazy loading makes modules dependencies explicit which
should help IDE and tools such as pyinstaller.

