### PR TITLE
replace ":file:" with ":src:" in docs where applicable

### DIFF
--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -147,7 +147,16 @@ intersphinx_mapping = {
 extlinks = {
     'bug': ('http://trac.buildbot.net/ticket/%s', 'bug #'),
     'pull': ('https://github.com/buildbot/buildbot/pull/%s', 'pull request '),
-    'src': ('https://github.com/buildbot/buildbot/blob/master/%s', None),
+    # Renders as link with whole url, e.g.
+    #   :src-link:`master`
+    # renders as
+    #   "https://github.com/buildbot/buildbot/blob/master/master".
+    # Explicit title can be used for customizing how link looks like:
+    #   :src-link:`master's directory <master>`
+    'src-link': ('https://github.com/buildbot/buildbot/blob/master/%s', None),
+    # "pretty" reference that looks like relative path in Buildbot source tree
+    # by default.
+    'src': ('https://github.com/buildbot/buildbot/blob/master/%s', ''),
 }
 
 # Sphinx' link checker.

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -1791,7 +1791,7 @@ Also, adjust the fake database table definitions in :src:`master/buildbot/test/f
 Your upgrade script should have unit tests.  The classes in :src:`master/buildbot/test/util/migration.py` make this straightforward.
 Unit test scripts should be named e.g., :file:`test_db_migrate_versions_015_remove_bad_master_objectid.py`.
 
-The :file:`master/buildbot/test/integration/test_upgrade.py` also tests
+The :src:`master/buildbot/test/integration/test_upgrade.py <master/buildbot/test/integration/test_upgrade.py>` also tests
 upgrades, and will confirm that the resulting database matches the model.  If
 you encounter implicit indexes on MySQL, that do not appear on SQLite or
 Postgres, add them to ``implied_indexes`` in

--- a/master/docs/developer/plugins-publish.rst
+++ b/master/docs/developer/plugins-publish.rst
@@ -59,7 +59,7 @@ Once you have your component packaged, it's quite straightforward: you just need
 (You might have seen different ways to specify the value for ``entry_points``, however they all do the same thing.
 Full description of possible ways is available in `setuptools documentation <https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins>`_.)
 
-After the :file:`setup.py` file is updated, you can build and install it:
+After the :src:`setup.py <master/setup.py>` file is updated, you can build and install it:
 
 .. code-block:: none
 

--- a/master/docs/developer/tests.rst
+++ b/master/docs/developer/tests.rst
@@ -70,8 +70,9 @@ project.  All new code must meet this requirement.
 
 Unit test modules are be named after the package or class they test, replacing
 ``.`` with ``_`` and omitting the ``buildbot_``. For example,
-:file:`test_status_web_authz_Authz.py` tests the :class:`Authz` class in
-:file:`buildbot/status/web/authz.py`. Modules with only one class, or a few
+:src:`test_schedulers_timed_Periodic.py <buildbot/test/unit/test_schedulers_timed_Periodic.py>`
+tests the :class:`Periodic` class in
+:src:`buildbot/schedulers/timed.py`. Modules with only one class, or a few
 trivial classes, can be tested in a single test module. For more complex
 situations, prefer to use multiple test modules.
 
@@ -107,7 +108,7 @@ context, an interface is any boundary between testable units.
 Ideally, all interfaces, both public and private, should be tested.  Certainly,
 any *public* interfaces need interface tests.
 
-Interface tests are most often found in files named for the "real" implementation, e.g., :file:`test_db_changes.py`.
+Interface tests are most often found in files named for the "real" implementation, e.g., :src:`test_db_changes.py <master/buildbot/test/unit/test_db_changes.py>`.
 When there is ambiguity, test modules should be named after the interface they are testing.
 Interface tests have the following form::
 

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -1706,7 +1706,7 @@ Server error logs are added as additional log files, useful to debug test failur
 
 Optionally, data about the test run and any test failures can be inserted into a database for further analysis and report generation.
 To use this facility, create an instance of :class:`twisted.enterprise.adbapi.ConnectionPool` with connections to the database.
-The necessary tables can be created automatically by setting ``autoCreateTables`` to ``True``, or manually using the SQL found in the :file:`mtrlogobserver.py` source file.
+The necessary tables can be created automatically by setting ``autoCreateTables`` to ``True``, or manually using the SQL found in the :src:`mtrlogobserver.py <master/buildbot/steps/mtrlogobserver.py>` source file.
 
 One problem with specifying a database is that each reload of the configuration will get a new instance of ``ConnectionPool`` (even if the connection parameters are the same).
 To avoid that Buildbot thinks the builder configuration has changed because of this, use the :class:`steps.mtrlogobserver.EqConnectionPool` subclass of :class:`ConnectionPool`, which implements an equality operation that avoids this problem.
@@ -1743,7 +1743,7 @@ The :bb:step:`MTR` step's arguments are:
 ``autoCreateTables``
     Boolean, defaults to ``False``.
     If ``True`` (and ``dbpool`` is specified), the necessary database tables will be created automatically if they do not exist already.
-    Alternatively, the tables can be created manually from the SQL statements found in the :file:`mtrlogobserver.py` source file.
+    Alternatively, the tables can be created manually from the SQL statements found in the :src:`mtrlogobserver.py <master/buildbot/steps/mtrlogobserver.py>` source file.
 
 ``test_type``
     Short string that will be inserted into the database in the row for the test run.

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -24,19 +24,19 @@ Choosing a Change Source
 There are a variety of :class:`ChangeSource` classes available, some of which are meant to be used in conjunction with other tools to deliver :class:`Change` events from the VC repository to the buildmaster.
 
 As a quick guide, here is a list of VC systems and the :class:`ChangeSource`\s that might be useful with them.
-Note that some of these modules are in Buildbot's :file:`contrib` directory, meaning that they have been offered by other users in hopes they may be useful, and might require some additional work to make them functional.
+Note that some of these modules are in Buildbot's :src:`master/contrib` directory, meaning that they have been offered by other users in hopes they may be useful, and might require some additional work to make them functional.
 
 CVS
 
-* :bb:chsrc:`CVSMaildirSource` (watching mail sent by :file:`contrib/buildbot_cvs_mail.py` script)
+* :bb:chsrc:`CVSMaildirSource` (watching mail sent by :src:`master/contrib/buildbot_cvs_mail.py` script)
 * :bb:chsrc:`PBChangeSource` (listening for connections from ``buildbot sendchange`` run in a loginfo script)
-* :bb:chsrc:`PBChangeSource` (listening for connections from a long-running :file:`contrib/viewcvspoll.py` polling process which examines the ViewCVS database directly)
+* :bb:chsrc:`PBChangeSource` (listening for connections from a long-running :src:`master/contrib/viewcvspoll.py` polling process which examines the ViewCVS database directly)
 * :bb:chsrc:`Change Hooks` in WebStatus
 
 SVN
 
-* :bb:chsrc:`PBChangeSource` (listening for connections from :file:`contrib/svn_buildbot.py` run in a postcommit script)
-* :bb:chsrc:`PBChangeSource` (listening for connections from a long-running :file:`contrib/svn_watcher.py` or :file:`contrib/svnpoller.py` polling process
+* :bb:chsrc:`PBChangeSource` (listening for connections from :src:`master/contrib/svn_buildbot.py` run in a postcommit script)
+* :bb:chsrc:`PBChangeSource` (listening for connections from a long-running :src:`master/contrib/svn_watcher.py` or :src:`master/contrib/svnpoller.py` polling process
 * :bb:chsrc:`SVNCommitEmailMaildirSource` (watching for email sent by :file:`commit-email.pl`)
 * :bb:chsrc:`SVNPoller` (polling the SVN repository)
 * :bb:chsrc:`Change Hooks` in WebStatus
@@ -44,12 +44,12 @@ SVN
 
 Darcs
 
-* :bb:chsrc:`PBChangeSource` (listening for connections from :file:`contrib/darcs_buildbot.py` in a commit script)
+* :bb:chsrc:`PBChangeSource` (listening for connections from :src:`src/contrib/darcs_buildbot.py` in a commit script)
 * :bb:chsrc:`Change Hooks` in WebStatus
 
 Mercurial
 
-* :bb:chsrc:`Change Hooks` in WebStatus (including :file:`contrib/hgbuildbot.py`, configurable in a ``changegroup`` hook)
+* :bb:chsrc:`Change Hooks` in WebStatus (including :src:`master/contrib/hgbuildbot.py`, configurable in a ``changegroup`` hook)
 * `BitBucket change hook <BitBucket hook>`_ (specifically designed for BitBucket notifications, but requiring a publicly-accessible WebStatus)
 * :bb:chsrc:`HgPoller` (polling a remote Mercurial repository)
 * :bb:chsrc:`GoogleCodeAtomPoller` (polling the commit feed for a GoogleCode Git repository)
@@ -58,14 +58,14 @@ Mercurial
 
 Bzr (the newer Bazaar)
 
-* :bb:chsrc:`PBChangeSource` (listening for connections from :file:`contrib/bzr_buildbot.py` run in a post-change-branch-tip or commit hook)
+* :bb:chsrc:`PBChangeSource` (listening for connections from :src:`master/contrib/bzr_buildbot.py` run in a post-change-branch-tip or commit hook)
 * :bb:chsrc:`BzrPoller` (polling the Bzr repository)
 * :bb:chsrc:`Change Hooks` in WebStatus
 
 Git
 
-* :bb:chsrc:`PBChangeSource` (listening for connections from :file:`contrib/git_buildbot.py` run in the post-receive hook)
-* :bb:chsrc:`PBChangeSource` (listening for connections from :file:`contrib/github_buildbot.py`, which listens for notifications from GitHub)
+* :bb:chsrc:`PBChangeSource` (listening for connections from :src:`master/contrib/git_buildbot.py` run in the post-receive hook)
+* :bb:chsrc:`PBChangeSource` (listening for connections from :src:`master/contrib/github_buildbot.py`, which listens for notifications from GitHub)
 * :bb:chsrc:`Change Hooks` in WebStatus
 * :bb:chsrc:`GitHub` change hook (specifically designed for GitHub notifications, but requiring a publicly-accessible WebStatus)
 * :bb:chsrc:`BitBucket` change hook (specifically designed for BitBucket notifications, but requiring a publicly-accessible WebStatus)
@@ -263,7 +263,7 @@ CVSMaildirSource
 
 .. py:class:: buildbot.changes.mail.CVSMaildirSource
 
-This parser works with the :file:`buildbot_cvs_maildir.py` script in the :file:`contrib` directory.
+This parser works with the :src:`master/contrib/buildbot_cvs_mail.py` script.
 
 The script sends an email containing all the files submitted in one directory.
 It is invoked by using the :file:`CVSROOT/loginfo` facility.
@@ -278,10 +278,10 @@ For example:
 
     c['change_source'] = changes.CVSMaildirSource("/home/buildbot/Mail")
 
-Configuration of CVS and :file:`buildbot_cvs_mail.py`
-#####################################################
+Configuration of CVS and :src:`buildbot_cvs_mail.py <master/contrib/buildbot_cvs_mail.py>`
+##########################################################################################
 
-CVS must be configured to invoke the :file:`buildbot_cvs_mail.py` script when files are checked in.
+CVS must be configured to invoke the :src:`buildbot_cvs_mail.py <master/contrib/buildbot_cvs_mail.py>` script when files are checked in.
 This is done via the CVS loginfo configuration file.
 
 To update this, first do:
@@ -301,7 +301,7 @@ cd to the CVSROOT directory and edit the file loginfo, adding a line like:
    For cvs version 1.12.x, the ``--path %p`` option is required.
    Version 1.11.x and 1.12.x report the directory path differently.
 
-The above example you put the :file:`buildbot_cvs_mail.py` script under /cvsroot/CVSROOT.
+The above example you put the :src:`buildbot_cvs_mail.py <master/contrib/buildbot_cvs_mail.py>` script under /cvsroot/CVSROOT.
 It can be anywhere.
 Run the script with --help to see all the options.
 At the very least, the options ``-e`` (email) and ``-P`` (project) should be specified.
@@ -428,7 +428,7 @@ Bzr Hook
 
 Bzr is also written in Python, and the Bzr hook depends on Twisted to send the changes.
 
-To install, put :file:`contrib/bzr_buildbot.py` in one of your plugins locations a bzr plugins directory (e.g., :file:`~/.bazaar/plugins`).
+To install, put :src:`master/contrib/bzr_buildbot.py` in one of your plugins locations a bzr plugins directory (e.g., :file:`~/.bazaar/plugins`).
 Then, in one of your bazaar conf files (e.g., :file:`~/.bazaar/locations.conf`), set the location you want to connect with Buildbot with these keys:
 
   * ``buildbot_on``
@@ -673,7 +673,7 @@ Bzr Poller
 ~~~~~~~~~~
 
 If you cannot insert a Bzr hook in the server, you can use the :bb:chsrc:`BzrPoller`.
-To use it, put :file:`contrib/bzr_buildbot.py` somewhere that your Buildbot configuration can import it.
+To use it, put :src:`master/contrib/bzr_buildbot.py` somewhere that your Buildbot configuration can import it.
 Even putting it in the same directory as the :file:`master.cfg` should work.
 Install the poller in the Buildbot configuration as with any other change source.
 Minimally, provide a URL that you want to poll (``bzr://``, ``bzr+ssh://``, or ``lp:``), making sure the Buildbot user has necessary privileges.
@@ -698,7 +698,7 @@ The ``BzrPoller`` parameters are:
 
 ``branch_name``
     Any value to be used as the branch name.
-    Defaults to None, or specify a string, or specify the constants from :file:`bzr_buildbot.py` ``SHORT`` or ``FULL`` to get the short branch name or full branch address.
+    Defaults to None, or specify a string, or specify the constants from :src:`bzr_buildbot.py <master/contrib/bzr_buildbot.py>` ``SHORT`` or ``FULL`` to get the short branch name or full branch address.
 
 ``blame_merge_author``
     normally, the user that commits the revision is the user that is responsible for the change.
@@ -712,7 +712,7 @@ The ``BzrPoller`` parameters are:
 GitPoller
 ~~~~~~~~~
 
-If you cannot take advantage of post-receive hooks as provided by :file:`contrib/git_buildbot.py` for example, then you can use the :bb:chsrc:`GitPoller`.
+If you cannot take advantage of post-receive hooks as provided by :src:`master/contrib/git_buildbot.py` for example, then you can use the :bb:chsrc:`GitPoller`.
 
 The :bb:chsrc:`GitPoller` periodically fetches from a remote Git repository and processes any changes.
 It requires its own working directory for operation.
@@ -1238,4 +1238,4 @@ As an example, to poll the Ostinato project's commit feed every 3 hours, the con
 
 .. note::
 
-   You will need to download :file:`googlecode_atom.py` from the Buildbot source and install it somewhere on your :envvar:`PYTHONPATH` first.
+   You will need to download :src:`master/contrib/googlecode_atom.py` from the Buildbot source and install it somewhere on your :envvar:`PYTHONPATH` first.

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -93,7 +93,7 @@ If your SMTP host requires authentication before it allows you to send emails, t
 
 .. note::
 
-   If for some reasons you are not able to send a notification with TLS enabled and specified user name and password, you might want to use :file:`contrib/check-smtp.py` to see if it works at all.
+   If for some reasons you are not able to send a notification with TLS enabled and specified user name and password, you might want to use :src:`master/contrib/check-smtp.py` to see if it works at all.
 
 If you want to require Transport Layer Security (TLS), then you can also set ``useTls``::
 
@@ -281,7 +281,7 @@ MailNotifier arguments
     Most of the time you can use a simple Domain instance.
     As a shortcut, you can pass as string: this will be treated as if you had provided ``Domain(str)``.
     For example, ``lookup='example.com'`` will allow mail to be sent to all developers whose SVN usernames match their ``example.com`` account names.
-    See :file:`buildbot/reporters/mail.py` for more details.
+    See :src:`master/buildbot/reporters/mail.py` for more details.
 
     Regardless of the setting of ``lookup``, ``MailNotifier`` will also send mail to addresses in the ``extraRecipients`` list.
 
@@ -737,7 +737,7 @@ GerritStatusPush can send a separate review for each build that completes, or a 
 
 .. seealso::
 
-   :file:`master/docs/examples/git_gerrit.cfg` and :file:`master/docs/examples/repo_gerrit.cfg` in the Buildbot distribution provide a full example setup of Git+Gerrit or Repo+Gerrit of :bb:reporter:`GerritStatusPush`.
+   :src:`master/docs/examples/git_gerrit.cfg` and :src:`master/docs/examples/repo_gerrit.cfg` in the Buildbot distribution provide a full example setup of Git+Gerrit or Repo+Gerrit of :bb:reporter:`GerritStatusPush`.
 
 
 .. bb:reporter:: HttpStatusPush

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -120,9 +120,9 @@ Reuse same image for different workers
 
 Previous simple example hardcodes the worker name into the dockerfile, which will not work if you want to share your docker image between workers.
 
-You can find in buildbot source code in ``master/contrib/docker`` one example configurations:
+You can find in buildbot source code in :src:`master/contrib/docker` one example configurations:
 
-``pythonnode_worker``
+:src:`pythonnode_worker <master/contrib/docker/pythonnode_worker/>`
     a worker with Python and node installed, which demonstrate how to reuse the base worker to create variations of build environments.
     It is based on the official ``buildbot/buildbot-worker`` image.
 

--- a/master/docs/manual/cfg-workers-libvirt.rst
+++ b/master/docs/manual/cfg-workers-libvirt.rst
@@ -51,7 +51,7 @@ Because this image may need updating a lot, we strongly suggest scripting its cr
 If you want to have multiple workers using the same base image it can be annoying to duplicate the image just to change the buildbot credentials.
 One option is to use libvirt's DHCP server to allocate an identity to the worker: DHCP sets a hostname, and the worker takes its identity from that.
 
-Doing all this is really beyond the scope of the manual, but there is a :file:`vmbuilder` script and a :file:`network.xml` file to create such a DHCP server in :file:`contrib/` (:ref:`Contrib-Scripts`) that should get you started:
+Doing all this is really beyond the scope of the manual, but there is a :src:`vmbuilder <master/contrib/libvirt/vmbuilder>` script and a :src:`network.xml <master/contrib/libvirt/network.xml>` file to create such a DHCP server in :src:`master/contrib/` (:ref:`Contrib-Scripts`) that should get you started:
 
 .. code-block:: bash
 

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -21,7 +21,7 @@ An example www configuration line which enables change_hook and two DIALECTS:
 
 Within the www config dictionary arguments, the ``change_hook`` key enables/disables the module and ``change_hook_dialects`` whitelists DIALECTs where the keys are the module names and the values are optional arguments which will be passed to the hooks.
 
-The :file:`post_build_request.py` script in :file:`master/contrib` allows for the submission of an arbitrary change request.
+The :src:`master/contrib/post_build_request.py` script allows for the submission of an arbitrary change request.
 Run :command:`post_build_request.py --help` for more information.
 The ``base`` dialect must be enabled for this to work.
 
@@ -86,7 +86,7 @@ GitHub hook
 
 .. note::
 
-   There is a standalone HTTP server available for receiving GitHub notifications as well: :file:`contrib/github_buildbot.py`.
+   There is a standalone HTTP server available for receiving GitHub notifications as well: :src:`master/contrib/github_buildbot.py`.
    This script may be useful in cases where you cannot expose the WebStatus for public consumption.
 
 The GitHub hook has the following parameters:
@@ -184,7 +184,7 @@ When this is setup you should add a `POST` service pointing to ``/change_hook/bi
 For example, it the grid URL is ``http://builds.example.com/bbot/grid``, then point BitBucket to ``http://builds.example.com/change_hook/bitbucket``.
 To specify a project associated to the repository, append ``?project=name`` to the URL.
 
-Note that there is a standalone HTTP server available for receiving BitBucket notifications, as well: :file:`contrib/bitbucket_buildbot.py`.
+Note that there is a standalone HTTP server available for receiving BitBucket notifications, as well: :src:`master/contrib/bitbucket_buildbot.py`.
 This script may be useful in cases where you cannot expose the WebStatus for public consumption.
 
 .. warning::

--- a/master/docs/manual/deploy.rst
+++ b/master/docs/manual/deploy.rst
@@ -107,5 +107,5 @@ Again, :samp:`buildbot-worker restart {BASEDIR}` will speed up the process.
 Contrib Scripts
 ~~~~~~~~~~~~~~~
 
-While some features of Buildbot are included in the distribution, others are only available in :file:`contrib/` in the source directory.
+While some features of Buildbot are included in the distribution, others are only available in :src:`master/contrib/` in the source directory.
 The latest versions of such scripts are available at :src:`master/contrib`.

--- a/master/docs/relnotes/0.9.0.rst
+++ b/master/docs/relnotes/0.9.0.rst
@@ -278,7 +278,7 @@ Fixes
 * :bb:chsrc:`P4Source`'s ``server_tz`` parameter now works correctly.
 
 * The ``revlink`` in changes produced by the Bitbucket hook now correctly includes the ``changes/`` portion of the URL.
-* :bb:chsrc:`PBChangeSource`'s git hook :file:`contrib/git_buildbot.py` now supports git tags
+* :bb:chsrc:`PBChangeSource`'s git hook :src:`master/contrib/git_buildbot.py` now supports git tags
 
   A pushed git tag generates a change event with the ``branch`` property equal to the tag name.
   To schedule builds based on buildbot tags, one could use something like this:

--- a/master/docs/relnotes/0.9.0.rst
+++ b/master/docs/relnotes/0.9.0.rst
@@ -592,7 +592,7 @@ Features
 * The :class:`DockerLatentWorker` image attribute is now renderable (can take properties in account).
 
 * The :class:`DockerLatentWorker` sets environment variables describing how to connect to the master.
-  Example dockerfiles can be found in ``master/contrib/docker``.
+  Example dockerfiles can be found in :src:`master/contrib/docker`.
 
 * :class:`DockerLatentWorker` now has a ``hostconfig`` parameter that can be used to setup host configuration when creating a new container.
 

--- a/master/docs/relnotes/0.9.0b1.rst
+++ b/master/docs/relnotes/0.9.0b1.rst
@@ -199,7 +199,7 @@ Fixes
 * :bb:chsrc:`P4Source`'s ``server_tz`` parameter now works correctly.
 
 * The ``revlink`` in changes produced by the Bitbucket hook now correctly includes the ``changes/`` portion of the URL.
-* :bb:chsrc:`PBChangeSource`'s git hook :file:`contrib/git_buildbot.py` now supports git tags
+* :bb:chsrc:`PBChangeSource`'s git hook :src:`master/contrib/git_buildbot.py` now supports git tags
 
   A pushed git tag generates a change event with the ``branch`` property equal to the tag name.
   To schedule builds based on buildbot tags, one could use something like this:

--- a/master/docs/relnotes/0.9.0b6.rst
+++ b/master/docs/relnotes/0.9.0b6.rst
@@ -42,7 +42,7 @@ Features
 * The :class:`DockerLatentBuildSlave` image attribute is now renderable (can take properties in account).
 
 * The :class:`DockerLatentBuildSlave` sets environment variables describing how to connect to the master.
-  Example dockerfiles can be found in ``master/contrib/docker``.
+  Example dockerfiles can be found in :src:`master/contrib/docker`.
 
 
 Details


### PR DESCRIPTION
Makes references to source code clickable and checkable
(via `linkcheck`).

Also replaces default :src:`something` rendering style from
`https://github.com/buildbot/buildbot/blob/master/something` to
`something`.

`src-link` should be used for old functionality (which almost useless IMO).
