### PR TITLE
BuildbotServiceManager: support reconfiguration for legacy services

### DIFF
--- a/master/buildbot/changes/base.py
+++ b/master/buildbot/changes/base.py
@@ -96,8 +96,8 @@ class ReconfigurablePollingChangeSource(ChangeSource):
 
 
 class PollingChangeSource(ReconfigurablePollingChangeSource):
-    # Legacy code will be very painful to port to BuildbotService lifecyle
-    # because the unit tests keep doing shortcuts for the Service lifecycle (i.e by no calling startService)
+    # Legacy code will be very painful to port to BuildbotService life cycle
+    # because the unit tests keep doing shortcuts for the Service life cycle (i.e by no calling startService)
     # instead of porting everything at once, we make a class to support legacy
 
     def checkConfig(self, name=None, pollInterval=60 * 10, pollAtLaunch=False):

--- a/master/buildbot/changes/base.py
+++ b/master/buildbot/changes/base.py
@@ -20,6 +20,7 @@ from twisted.internet import defer
 from twisted.python import log
 from zope.interface import implementer
 
+from buildbot import config
 from buildbot.interfaces import IChangeSource
 from buildbot.util import service
 from buildbot.util.poll import method as poll_method
@@ -53,12 +54,27 @@ class ChangeSource(service.ClusteredBuildbotService):
                                                                  None)
 
 
-class PollingChangeSource(ChangeSource):
+class ReconfigurablePollingChangeSource(ChangeSource):
+    pollInterval = None
+    pollAtLaunch = None
 
-    def __init__(self, name=None, pollInterval=60 * 10, pollAtLaunch=False):
-        ChangeSource.__init__(self, name=name)
-        self.pollInterval = pollInterval
+    def checkConfig(self, name=None, pollInterval=60 * 10, pollAtLaunch=False):
+        ChangeSource.checkConfig(self, name=name)
+        if pollInterval < 0:
+            config.error("interval must be >= 0: {}".format(pollInterval))
+
+    @defer.inlineCallbacks
+    def reconfigService(self, name=None, pollInterval=60 * 10, pollAtLaunch=False):
+        self.pollInterval, prevPollInterval = pollInterval, self.pollInterval
         self.pollAtLaunch = pollAtLaunch
+        yield ChangeSource.reconfigService(self, name=name)
+
+        # pollInterval change is the only value which makes sense to reconfigure check.
+        if prevPollInterval != pollInterval and self.doPoll.started:
+            yield self.doPoll.stop()
+            # As a implementation detail, poller will 'pollAtReconfigure' if poll interval changes
+            # and pollAtLaunch=True
+            yield self.doPoll.start(interval=self.pollInterval, now=self.pollAtLaunch)
 
     def poll(self):
         pass
@@ -77,3 +93,19 @@ class PollingChangeSource(ChangeSource):
 
     def deactivate(self):
         return self.doPoll.stop()
+
+
+class PollingChangeSource(ReconfigurablePollingChangeSource):
+    # Legacy code will be very painful to port to BuildbotService lifecyle
+    # because the unit tests keep doing shortcuts for the Service lifecycle (i.e by no calling startService)
+    # instead of porting everything at once, we make a class to support legacy
+
+    def checkConfig(self, name=None, pollInterval=60 * 10, pollAtLaunch=False):
+        ReconfigurablePollingChangeSource.checkConfig(self, name=name, pollInterval=60 * 10, pollAtLaunch=False)
+        self.pollInterval = pollInterval
+        self.pollAtLaunch = pollAtLaunch
+
+    def reconfigService(self, *args, **kwargs):
+        # BuildbotServiceManager will detect such exception and swap old service with new service,
+        # instead of just reconfiguring
+        raise NotImplementedError()

--- a/master/buildbot/changes/manager.py
+++ b/master/buildbot/changes/manager.py
@@ -16,58 +16,10 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from twisted.internet import defer
-from twisted.python import log
-from zope.interface import implementer
-
-from buildbot import interfaces
-from buildbot import util
-from buildbot.process import metrics
-from buildbot.util import service
+from buildbot.process.measured_service import MeasuredBuildbotServiceManager
 
 
-@implementer(interfaces.IEventSource)
-class ChangeManager(service.ReconfigurableServiceMixin, service.AsyncMultiService):
-
-    """
-    This is the master-side service which receives file change notifications
-    from version-control systems.
-
-    It is a Twisted service, which has instances of
-    L{buildbot.interfaces.IChangeSource} as child services. These are added by
-    the master with C{addSource}.
-    """
-
-    name = "change_manager"
-
-    @defer.inlineCallbacks
-    def reconfigServiceWithBuildbotConfig(self, new_config):
-        timer = metrics.Timer(
-            "ChangeManager.reconfigServiceWithBuildbotConfig")
-        timer.start()
-
-        removed, added = util.diffSets(
-            set(self),
-            new_config.change_sources)
-
-        if removed or added:
-            log.msg("adding %d new changesources, removing %d" %
-                    (len(added), len(removed)))
-
-            for src in removed:
-                yield src.deactivate()
-                yield defer.maybeDeferred(
-                    src.disownServiceParent)
-
-            for src in added:
-                yield src.setServiceParent(self)
-
-        num_sources = len(list(self))
-        assert num_sources == len(new_config.change_sources)
-        metrics.MetricCountEvent.log("num_sources", num_sources, absolute=True)
-
-        # reconfig any newly-added change sources, as well as existing
-        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                   new_config)
-
-        timer.stop()
+class ChangeManager(MeasuredBuildbotServiceManager):
+    name = "ChangeManager"
+    managed_services_name = "changesources"
+    config_attr = "change_sources"

--- a/master/buildbot/newsfragments/reconfigurableservices.bugfix
+++ b/master/buildbot/newsfragments/reconfigurableservices.bugfix
@@ -1,0 +1,1 @@
+:bb:cfg:`schedulers`. and :bb:cfg:`change_source` are now properly taking configuration change in account with ``buildbot reconfig``.

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -92,7 +92,7 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
         self._change_consumer = None
         self._change_consumption_lock = defer.DeferredLock()
 
-    def reconfigureService(self, *args, **kwargs):
+    def reconfigService(self, *args, **kwargs):
         raise NotImplementedError()
 
     # activity handling

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -92,6 +92,9 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
         self._change_consumer = None
         self._change_consumption_lock = defer.DeferredLock()
 
+    def reconfigureService(self, *args, **kwargs):
+        raise NotImplementedError()
+
     # activity handling
 
     def activate(self):

--- a/master/buildbot/test/integration/test_integration_scheduler_reconfigure.py
+++ b/master/buildbot/test/integration/test_integration_scheduler_reconfigure.py
@@ -1,0 +1,81 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from twisted.internet import defer
+
+from buildbot.plugins import schedulers
+from buildbot.test.util.integration import RunMasterBase
+
+
+# This integration test creates a master and worker environment,
+# with one builders and a shellcommand step
+# meant to be a template for integration steps
+class ShellMaster(RunMasterBase):
+
+    @defer.inlineCallbacks
+    def test_shell(self):
+        cfg = masterConfig()
+        yield self.setupConfig(cfg)
+
+        change = dict(branch="master",
+                      files=["foo.c"],
+                      author="me@foo.com",
+                      comments="good stuff",
+                      revision="HEAD",
+                      project="none"
+                      )
+        # switch the configuration of the scheduler, and make sure the correct builder is run
+        cfg['schedulers'] = [
+            schedulers.AnyBranchScheduler(
+                name="sched1",
+                builderNames=["testy2"]),
+            schedulers.ForceScheduler(
+                name="sched2",
+                builderNames=["testy1"])
+        ]
+        yield self.master.reconfig()
+        build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
+        self.assertEqual(build['buildid'], 1)
+        builder = yield self.master.data.get(('builders', build['builderid']))
+        self.assertEqual(builder['name'], 'testy2')
+
+
+# master configuration
+def masterConfig():
+    c = {}
+    from buildbot.config import BuilderConfig
+    from buildbot.process.factory import BuildFactory
+    from buildbot.plugins import steps, schedulers
+
+    c['schedulers'] = [
+        schedulers.AnyBranchScheduler(
+            name="sched1",
+            builderNames=["testy1"]),
+        schedulers.ForceScheduler(
+            name="sched2",
+            builderNames=["testy2"])
+    ]
+    f = BuildFactory()
+    f.addStep(steps.ShellCommand(command='echo hello'))
+    c['builders'] = [
+        BuilderConfig(name=name,
+                      workernames=["local1"],
+                      factory=f)
+        for name in ['testy1', 'testy2']
+    ]
+    return c

--- a/master/buildbot/test/integration/test_integration_scheduler_reconfigure.py
+++ b/master/buildbot/test/integration/test_integration_scheduler_reconfigure.py
@@ -60,7 +60,7 @@ def masterConfig():
     c = {}
     from buildbot.config import BuilderConfig
     from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers
+    from buildbot.plugins import steps
 
     c['schedulers'] = [
         schedulers.AnyBranchScheduler(

--- a/master/buildbot/test/unit/test_changes_base.py
+++ b/master/buildbot/test/unit/test_changes_base.py
@@ -158,7 +158,7 @@ class TestPollingChangeSource(changesource.ChangeSourceMixin, unittest.TestCase)
 
         @d.addCallback
         def check(_):
-            # it doesnt do anything because it was already claimed
+            # it doesn't do anything because it was already claimed
             self.assertEqual(loops, [])
 
         reactor.callWhenRunning(d.callback, None)
@@ -259,7 +259,7 @@ class TestReconfigurablePollingChangeSource(changesource.ChangeSourceMixin, unit
 
         yield self.runClockFor(12)
 
-        # it doesnt do anything because it was already claimed
+        # it doesn't do anything because it was already claimed
         self.assertEqual(loops, [])
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_changes_base.py
+++ b/master/buildbot/test/unit/test_changes_base.py
@@ -183,3 +183,96 @@ class TestPollingChangeSource(changesource.ChangeSourceMixin, unittest.TestCase)
             self.assertEqual(loops, [0.0, 5.0, 10.0])
         reactor.callWhenRunning(d.callback, None)
         return d
+
+
+class TestReconfigurablePollingChangeSource(changesource.ChangeSourceMixin, unittest.TestCase):
+
+    class Subclass(base.ReconfigurablePollingChangeSource):
+        pass
+
+    def setUp(self):
+        # patch in a Clock so we can manipulate the reactor's time
+        self.clock = task.Clock()
+        self.patch(reactor, 'callLater', self.clock.callLater)
+        self.patch(reactor, 'seconds', self.clock.seconds)
+
+        d = self.setUpChangeSource()
+
+        @d.addCallback
+        def create_changesource(_):
+            self.attachChangeSource(self.Subclass(name="DummyCS"))
+        return d
+
+    def tearDown(self):
+        return self.tearDownChangeSource()
+
+    def runClockFor(self, secs):
+        self.clock.pump([1.0] * secs)
+
+    @defer.inlineCallbacks
+    def test_loop_loops(self):
+        # track when poll() gets called
+        loops = []
+        self.changesource.poll = \
+            lambda: loops.append(self.clock.seconds())
+
+        yield self.startChangeSource()
+        yield self.changesource.reconfigServiceWithSibling(self.Subclass(
+            name="DummyCS", pollInterval=5, pollAtLaunch=False))
+
+        yield self.runClockFor(12)
+        # note that it does *not* poll at time 0
+        self.assertEqual(loops, [5.0, 10.0])
+
+    @defer.inlineCallbacks
+    def test_loop_exception(self):
+        # track when poll() gets called
+        loops = []
+
+        def poll():
+            loops.append(self.clock.seconds())
+            raise RuntimeError("oh noes")
+        self.changesource.poll = poll
+
+        yield self.startChangeSource()
+        yield self.changesource.reconfigServiceWithSibling(self.Subclass(
+            name="DummyCS", pollInterval=5, pollAtLaunch=False))
+
+        yield self.runClockFor(12)
+        # note that it keeps looping after error
+        self.assertEqual(loops, [5.0, 10.0])
+        self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 2)
+
+    @defer.inlineCallbacks
+    def test_poll_only_if_activated(self):
+        """The polling logic only applies if the source actually starts!"""
+
+        self.setChangeSourceToMaster(self.OTHER_MASTER_ID)
+
+        loops = []
+        self.changesource.poll = \
+            lambda: loops.append(self.clock.seconds())
+
+        yield self.startChangeSource()
+        yield self.changesource.reconfigServiceWithSibling(self.Subclass(
+            name="DummyCS", pollInterval=5, pollAtLaunch=False))
+
+        yield self.runClockFor(12)
+
+        # it doesnt do anything because it was already claimed
+        self.assertEqual(loops, [])
+
+    @defer.inlineCallbacks
+    def test_pollAtLaunch(self):
+        # track when poll() gets called
+        loops = []
+        self.changesource.poll = \
+            lambda: loops.append(self.clock.seconds())
+        yield self.startChangeSource()
+        yield self.changesource.reconfigServiceWithSibling(self.Subclass(
+            name="DummyCS", pollInterval=5, pollAtLaunch=True))
+
+        yield self.runClockFor(12)
+
+        # note that it *does* poll at time 0
+        self.assertEqual(loops, [0.0, 5.0, 10.0])

--- a/master/buildbot/test/unit/test_changes_manager.py
+++ b/master/buildbot/test/unit/test_changes_manager.py
@@ -19,52 +19,83 @@ from future.builtins import range
 
 import mock
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
+from buildbot.changes import base
 from buildbot.changes import manager
 from buildbot.test.fake import fakemaster
-from buildbot.util import service
-
-
-class FakeChangeSource(service.ClusteredBuildbotService):
-    pass
 
 
 class TestChangeManager(unittest.TestCase):
 
     def setUp(self):
-        self.master = fakemaster.make_master()
+        self.master = fakemaster.make_master(testcase=self, wantData=True)
         self.cm = manager.ChangeManager()
+        self.master.startService()
         self.cm.setServiceParent(self.master)
         self.new_config = mock.Mock()
 
-    def make_sources(self, n):
+    def tearDown(self):
+        return self.master.stopService()
+
+    def make_sources(self, n, klass=base.ChangeSource, **kwargs):
         for i in range(n):
-            src = FakeChangeSource(name='ChangeSource %d' % i)
+            src = klass(name='ChangeSource %d' % i, **kwargs)
             yield src
 
+    @defer.inlineCallbacks
     def test_reconfigService_add(self):
         src1, src2 = self.make_sources(2)
         src1.setServiceParent(self.cm)
         self.new_config.change_sources = [src1, src2]
 
-        d = self.cm.reconfigServiceWithBuildbotConfig(self.new_config)
+        yield self.cm.reconfigServiceWithBuildbotConfig(self.new_config)
 
-        @d.addCallback
-        def check(_):
-            self.assertIdentical(src2.parent, self.cm)
-            self.assertIdentical(src2.master, self.master)
-        return d
+        self.assertIdentical(src2.parent, self.cm)
+        self.assertIdentical(src2.master, self.master)
 
+    @defer.inlineCallbacks
     def test_reconfigService_remove(self):
         src1, = self.make_sources(1)
         src1.setServiceParent(self.cm)
         self.new_config.change_sources = []
 
-        d = self.cm.reconfigServiceWithBuildbotConfig(self.new_config)
+        self.assertTrue(src1.running)
+        yield self.cm.reconfigServiceWithBuildbotConfig(self.new_config)
 
-        @d.addCallback
-        def check(_):
-            self.assertIdentical(src1.parent, None)
-            self.assertIdentical(src1.master, None)
-        return d
+        self.assertFalse(src1.running)
+
+    @defer.inlineCallbacks
+    def test_reconfigService_change_reconfigurable(self):
+        src1, = self.make_sources(1, base.ReconfigurablePollingChangeSource, pollInterval=1)
+        src1.setServiceParent(self.cm)
+
+        src2, = self.make_sources(1, base.ReconfigurablePollingChangeSource, pollInterval=2)
+
+        self.new_config.change_sources = [src2]
+
+        self.assertTrue(src1.running)
+        self.assertEqual(src1.pollInterval, 1)
+        yield self.cm.reconfigServiceWithBuildbotConfig(self.new_config)
+
+        self.assertTrue(src1.running)
+        self.assertFalse(src2.running)
+        self.assertEqual(src1.pollInterval, 2)
+
+    @defer.inlineCallbacks
+    def test_reconfigService_change_legacy(self):
+        src1, = self.make_sources(1, base.PollingChangeSource, pollInterval=1)
+        src1.setServiceParent(self.cm)
+
+        src2, = self.make_sources(1, base.PollingChangeSource, pollInterval=2)
+
+        self.new_config.change_sources = [src2]
+
+        self.assertTrue(src1.running)
+        self.assertEqual(src1.pollInterval, 1)
+        yield self.cm.reconfigServiceWithBuildbotConfig(self.new_config)
+
+        self.assertFalse(src1.running)
+        self.assertTrue(src2.running)
+        self.assertEqual(src2.pollInterval, 2)

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -76,8 +76,10 @@ class SchedulerManager(unittest.TestCase):
                 assert self.objectid is not None
             d.addCallback(still_set)
             return d
+
         def __repr__(self):
             return "{}(attr={})".format(self.__class__.__name__, self.attr)
+
     class ReconfigSched(Sched):
 
         def reconfigServiceWithSibling(self, new_config):

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -76,7 +76,8 @@ class SchedulerManager(unittest.TestCase):
                 assert self.objectid is not None
             d.addCallback(still_set)
             return d
-
+        def __repr__(self):
+            return "{}(attr={})".format(self.__class__.__name__, self.attr)
     class ReconfigSched(Sched):
 
         def reconfigServiceWithSibling(self, new_config):
@@ -149,3 +150,47 @@ class SchedulerManager(unittest.TestCase):
         # instance
         self.assertIdentical(sch1_new.parent, self.sm)
         self.assertIdentical(sch1_new.master, self.master)
+
+    @defer.inlineCallbacks
+    def test_reconfigService_not_reconfigurable(self):
+        sch1 = self.makeSched(self.Sched, 'sch1', attr='beta')
+        self.new_config.schedulers = dict(sch1=sch1)
+
+        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
+
+        self.assertIdentical(sch1.parent, self.sm)
+        self.assertIdentical(sch1.master, self.master)
+
+        sch1_new = self.makeSched(self.Sched, 'sch1', attr='alpha')
+        self.new_config.schedulers = dict(sch1=sch1_new)
+
+        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
+
+        # sch1 had parameter change but is not reconfigurable, so sch1_new is now the active
+        # instance
+        self.assertEqual(sch1_new.running, True)
+        self.assertEqual(sch1.running, False)
+        self.assertIdentical(sch1_new.parent, self.sm)
+        self.assertIdentical(sch1_new.master, self.master)
+
+    @defer.inlineCallbacks
+    def test_reconfigService_not_reconfigurable_no_change(self):
+        sch1 = self.makeSched(self.Sched, 'sch1', attr='beta')
+        self.new_config.schedulers = dict(sch1=sch1)
+
+        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
+
+        self.assertIdentical(sch1.parent, self.sm)
+        self.assertIdentical(sch1.master, self.master)
+
+        sch1_new = self.makeSched(self.Sched, 'sch1', attr='beta')
+        self.new_config.schedulers = dict(sch1=sch1_new)
+
+        yield self.sm.reconfigServiceWithBuildbotConfig(self.new_config)
+
+        # sch1 had its class name change, so sch1_new is now the active
+        # instance
+        self.assertIdentical(sch1_new.parent, None)
+        self.assertEqual(sch1_new.running, False)
+        self.assertIdentical(sch1_new.master, None)
+        self.assertEqual(sch1.running, True)

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -165,6 +165,7 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
     compare_attrs = ('name', '_config_args', '_config_kwargs')
     name = None
     configured = False
+    objectid = None
 
     def __init__(self, *args, **kwargs):
         name = kwargs.pop("name", None)
@@ -493,8 +494,8 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
             except NotImplementedError:
                 # legacy support. Its too painful to transition old code to new Service lifecycle
                 # so we implement switch of child when the service raises NotImplementedError
-                parent = self.parent
                 # Note this means that self will stop, and sibling will take ownership
                 # means that we have a small time where the service is unavailable.
-                yield self.disownServiceParent()
-                yield config_sibling.setServiceParent(parent)
+                yield svc.disownServiceParent()
+                config_sibling.objectid = svc.objectid
+                yield config_sibling.setServiceParent(self)

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -492,7 +492,7 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
             try:
                 yield svc.reconfigServiceWithSibling(config_sibling)
             except NotImplementedError:
-                # legacy support. Its too painful to transition old code to new Service lifecycle
+                # legacy support. Its too painful to transition old code to new Service life cycle
                 # so we implement switch of child when the service raises NotImplementedError
                 # Note this means that self will stop, and sibling will take ownership
                 # means that we have a small time where the service is unavailable.

--- a/master/docs/developer/cls-changesources.rst
+++ b/master/docs/developer/cls-changesources.rst
@@ -14,10 +14,10 @@ ChangeSource
 
     Change sources which are active on every master should, instead, override ``startService`` and ``stopService``.
 
-PollingChangeSource
--------------------
+ReconfigurablePollingChangeSource
+---------------------------------
 
-.. py:class:: PollingChangeSource
+.. py:class:: ReconfigurablePollingChangeSource
 
     This is a subclass of :py:class:`ChangeSource` which adds polling behavior.
     Its constructor accepts the ``pollInterval`` and ``pollAtLaunch`` arguments as documented for most built-in change sources.
@@ -25,3 +25,11 @@ PollingChangeSource
     Subclasses should override the ``poll`` method.
     This method may return a Deferred.
     Calls to ``poll`` will not overlap.
+
+PollingChangeSource
+-------------------
+
+.. py:class:: PollingChangeSource
+
+    This is a legacy class for polling change sources not yet ported to the :py:class::`BuildbotService` component lifecycle.
+    Do not use for new code.

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -998,6 +998,10 @@ For example, a particular daily scheduler could be configured on multiple master
         BuildbotServices must be aware that during reconfiguration, their methods can still be called by running builds.
         So they should atomically switch old configuration and new configuration, so that the service is always available.
 
+        If this method raises :py:class:`NotImplementedError`, it means the service is legacy, and do not support reconfiguration.
+        The :py:class:`BuildbotServiceManager` parent, will detect this, and swap old service with new service.
+        This behaviour allow smooth transition of old code to new reconfigurable service lifecycle but shall not be used for new code.
+
     .. py:method:: reconfigServiceWithSibling(self, sibling)
 
         Internal method that finds the configuration bits in a sibling, an object with same class that is supposed to replace it from a new configuration.


### PR DESCRIPTION
We have a lot of legacy services (Schedulers and ChangeSources)
which do not support reconfigService, and are not reconfigurable.

Porting everything to reconfigurable is a lot of work, mainly in the unit tests
as they must properly construct a service hierarchy.

Rewritting everything makes few sense, so we add a method so that the
BuildbotServiceManager detects when the service do not support reconfiguration
and then just swap the old service with the new service, instead of reconfigure.
This is racy and not optimal, but much better than not reconfiguring (without warning).

## Contributor Checklist:

* [x] I have updated the unit tests
* [ x I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

