### PR TITLE
Do not allow failures when running "trial buildbot_worker.test" under Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,6 @@ matrix:
     # python 3 tests
     - python: "3.5"
       env: TWISTED=latest TESTS=trial_worker SQLALCHEMY=latest
-  allow_failures:
-    - python: "3.5"
 
 # Dependencies installation commands
 install:


### PR DESCRIPTION
The following seems to work for me under Python 3.5:

```
#!/bin/sh
# Create the virtual env
python3 -m venv myenv-py3
# Source the virtual env
. myenv-py3/bin/activate
# print python version
which python
python --version
#
#
git clone https://github.com/buildbot/buildbot buildbot3_test
cd buildbot3_test
pip install -e pkg
pip install -e 'master[tls,test]'
pip install -e worker
trial buildbot_worker.test
```

The Travis Python 3.5 builder seems to be passing now, so we can
remove it from allow_errors.

This will be one way to prevent people from adding Python 3 unfriendly code to buildbot_worker.

*trial buildbot.test* still doesn't fully work under Python 3, but the Travis Python 3.5 builder is not running that.