### PR TITLE
Replace MySQL-python with mysqlclient.

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -80,7 +80,7 @@ matrix:
 install:
   - pip install -U pip
   # codecov is the interface to codecov.io; see after_success
-  # Install MySQL-python for tests that uses real MySQL
+  # Install mysqlclient for tests that uses real MySQL
   # Install psycopg2 and pg8000 for tests that uses real PostgreSQL
   - |
       # pip installs
@@ -91,7 +91,7 @@ install:
       pip install -e pkg \
                   -e 'master[tls,test]' \
                   -e 'worker[test]' \
-                  MySQL-python \
+                  mysqlclient \
                   psycopg2 \
                   pg8000 \
                   codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,14 +76,14 @@ install:
   - "[ $TWISTED = latest ] || pip install Twisted==$TWISTED"
   - "[ $SQLALCHEMY = latest ] || pip install sqlalchemy==$SQLALCHEMY"
 
-  # Install MySQL-python for tests that uses real MySQL
+  # Install mysqlclient for tests that uses real MySQL
   # Install psycopg2 and pg8000 for tests that uses real PostgreSQL
   - |
       [ $TESTS != trial -a $TESTS != coverage -a $TESTS != lint -a $TESTS != js ] || \
       pip install -e pkg \
                   -e 'master[tls,test]' \
                   -e 'worker[test]' \
-                  MySQL-python \
+                  mysqlclient \
                   psycopg2 \
                   pg8000 \
 

--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -164,6 +164,7 @@ commitish
 committer
 committers
 compability
+compat
 comparaison
 completers
 comspec
@@ -465,6 +466,7 @@ multithreading
 mumbo
 munge
 mysql
+mysqlclient
 mysqld
 mysql's
 namedtuple

--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -63,10 +63,10 @@ def patch_mysqlclient_warnings():
         from _mysql_exceptions import Warning
         # MySQLdb.compat is only present in mysqlclient
         import MySQLdb.compat  # noqa pylint: disable=unused-import
-    except ImportError as e:
+    except ImportError:
         return
     # workaround for https://twistedmatrix.com/trac/ticket/9005
-    # libmysqlclient is easier to patch than twisted
+    # mysqlclient is easier to patch than twisted
     # we swap _mysql_exceptions.Warning arguments so that the code is in second place
 
     def patched_init(self, *args):

--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -58,6 +58,26 @@ def patch_testcase_assert_raises_regexp():
 
 
 @onlyOnce
+def patch_mysqlclient_warnings():
+    try:
+        from _mysql_exceptions import Warning
+        # MySQLdb.compat is only present in mysqlclient
+        import MySQLdb.compat  # noqa pylint: disable=unused-import
+    except ImportError as e:
+        return
+    # workaround for https://twistedmatrix.com/trac/ticket/9005
+    # libmysqlclient is easier to patch than twisted
+    # we swap _mysql_exceptions.Warning arguments so that the code is in second place
+
+    def patched_init(self, *args):
+        if isinstance(args[0], long):
+            super(Warning, self).__init__(args[1], args[0], *args[2:])
+        else:
+            super(Warning, self).__init__(*args)
+    Warning.__init__ = patched_init
+
+
+@onlyOnce
 def patch_decorators():
     from buildbot.monkeypatches import decorators
     decorators.patch()
@@ -68,5 +88,6 @@ def patch_all(for_tests=False):
         patch_servicechecks()
         patch_testcase_assert_raises_regexp()
         patch_decorators()
+        patch_mysqlclient_warnings()
 
     patch_python14653()

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -1943,8 +1943,8 @@ To run tests with MySQL:
 
 .. code-block:: bash
 
-   # Install MySQL-python.
-   pip install MySQL-python
+   # Install mysqlclient
+   pip install mysqlclient
    # Start container with MySQL 5.5.
    # It will listen on port 13306 on localhost.
    sudo docker run --name bb-test-mysql -e MYSQL_ROOT_PASSWORD=password \

--- a/master/docs/manual/deploy.rst
+++ b/master/docs/manual/deploy.rst
@@ -21,20 +21,17 @@ Additional Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Depending on the selected database, further Python packages will be required.
-Consult the SQLAlchemy dialect list for a full description.
-The most common choice for MySQL is
+Consult the `SQLAlchemy`_ dialect list for a full description.
+The most common choice for MySQL is `mysqlclient`_.
+Any reasonably recent version should suffice.
 
-mysqlclient: https://github.com/PyMySQL/mysqlclient-python
+The most common choice for Postgres is `Psycopg`_
+Any reasonably recent version should suffice.
 
-  To communicate with MySQL, SQLAlchemy requires mysqlclient.
-  Any reasonably recent version of mysqlclient should suffice.
+.. _SQLAlchemy: http://www.sqlalchemy.org/
+.. _Psycopg: http://initd.org/psycopg/
+.. _mysqlclient: https://github.com/PyMySQL/mysqlclient-python
 
-The most common choice for Postgres is
-
-Psycopg: http://initd.org/psycopg/
-
-    SQLAlchemy uses Psycopg to communicate with Postgres.
-    Any reasonably recent version should suffice.
 
 .. _Maintenance:
 

--- a/master/docs/manual/deploy.rst
+++ b/master/docs/manual/deploy.rst
@@ -24,10 +24,10 @@ Depending on the selected database, further Python packages will be required.
 Consult the SQLAlchemy dialect list for a full description.
 The most common choice for MySQL is
 
-MySQL-Python: http://mysql-python.sourceforge.net/
+mysqlclient: https://github.com/PyMySQL/mysqlclient-python
 
-  To communicate with MySQL, SQLAlchemy requires MySQL-Python.
-  Any reasonably recent version of MySQL-Python should suffice.
+  To communicate with MySQL, SQLAlchemy requires mysqlclient.
+  Any reasonably recent version of mysqlclient should suffice.
 
 The most common choice for Postgres is
 


### PR DESCRIPTION
MySQL-python does not work on Python 3.
On the Python Wall of Superpowers ( https://python3wos.appspot.com/ ),
mysqlclient is listed as the Python 3 alternative to MySQL-python.
