### PR TITLE
Fix some buildbot tests under Python 3

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -41,6 +41,7 @@ from buildbot.process.results import computeResultAndTermination
 from buildbot.process.results import statusToString
 from buildbot.process.results import worst_status
 from buildbot.reporters.utils import getURLForBuild
+from buildbot.util import bytes2NativeString
 from buildbot.util.eventual import eventually
 from buildbot.worker_transition import WorkerAPICompatMixin
 from buildbot.worker_transition import deprecatedWorkerClassMethod
@@ -228,8 +229,8 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         self.getProperties().updateFromProperties(worker_properties)
         if workerforbuilder.worker.worker_basedir:
             builddir = self.path_module.join(
-                workerforbuilder.worker.worker_basedir,
-                self.builder.config.workerbuilddir)
+                bytes2NativeString(workerforbuilder.worker.worker_basedir),
+                bytes2NativeString(self.builder.config.workerbuilddir))
             self.setProperty("builddir", builddir, "worker")
 
         self.workername = workerforbuilder.worker.workername

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -57,6 +57,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.process.results import Results
 from buildbot.process.results import worst_status
+from buildbot.util import bytes2NativeString
 from buildbot.util import debounce
 from buildbot.util import flatten
 from buildbot.worker_transition import WorkerAPICompatMixin
@@ -804,6 +805,7 @@ class BuildStep(results.ResultComputingConfigMixin,
         logid = yield self.master.data.updates.addLog(self.stepid,
                                                       util.ascii2unicode(name), u'h')
         l = self._newLog(name, u'h', logid)
+        html = bytes2NativeString(html)
         yield l.addContent(html)
         yield l.finish()
 

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -29,6 +29,7 @@ from buildbot import pbutil
 from buildbot.process.properties import Properties
 from buildbot.schedulers import base
 from buildbot.util import ascii2unicode
+from buildbot.util import bytes2NativeString
 from buildbot.util import netstrings
 from buildbot.util.maildir import MaildirService
 
@@ -154,7 +155,7 @@ class Try_Jobdir(TryBase):
             raise BadJobfile("unable to parse netstrings")
         if not p.strings:
             raise BadJobfile("could not find any complete netstrings")
-        ver = p.strings.pop(0)
+        ver = bytes2NativeString(p.strings.pop(0))
 
         v1_keys = ['jobid', 'branch', 'baserev', 'patch_level', 'patch_body']
         v2_keys = v1_keys + ['repository', 'project']
@@ -167,7 +168,7 @@ class Try_Jobdir(TryBase):
 
         def extract_netstrings(p, keys):
             for i, key in enumerate(keys):
-                parsed_job[key] = p.strings[i]
+                parsed_job[key] = bytes2NativeString(p.strings[i])
 
         def postprocess_parsed_job():
             # apply defaults and handle type casting
@@ -181,7 +182,8 @@ class Try_Jobdir(TryBase):
         if ver <= "4":
             i = int(ver) - 1
             extract_netstrings(p, keys[i])
-            parsed_job['builderNames'] = p.strings[len(keys[i]):]
+            parsed_job['builderNames'] = [bytes2NativeString(s)
+                                          for s in p.strings[len(keys[i]):]]
             postprocess_parsed_job()
         elif ver == "5":
             try:

--- a/master/buildbot/scripts/tryserver.py
+++ b/master/buildbot/scripts/tryserver.py
@@ -21,6 +21,8 @@ import sys
 import time
 from hashlib import md5
 
+from buildbot.util import unicode2bytes
+
 
 def tryserver(config):
     jobdir = os.path.expanduser(config["jobdir"])
@@ -30,12 +32,13 @@ def tryserver(config):
     # going to MD5 the contents and prepend a timestamp.
     timestring = "%d" % time.time()
     m = md5()
+    job = unicode2bytes(job)
     m.update(job)
     jobhash = m.hexdigest()
     fn = "%s-%s" % (timestring, jobhash)
     tmpfile = os.path.join(jobdir, "tmp", fn)
     newfile = os.path.join(jobdir, "new", fn)
-    with open(tmpfile, "w") as f:
+    with open(tmpfile, "wb") as f:
         f.write(job)
     os.rename(tmpfile, newfile)
 

--- a/master/buildbot/test/unit/test_scripts_tryserver.py
+++ b/master/buildbot/test/unit/test_scripts_tryserver.py
@@ -18,8 +18,8 @@ from __future__ import print_function
 
 import os
 import sys
-from cStringIO import StringIO
 
+from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot.scripts import tryserver
@@ -35,7 +35,7 @@ class TestStatusLog(dirs.DirsMixin, unittest.TestCase):
 
     def test_trycmd(self):
         config = dict(jobdir='jobdir')
-        inputfile = StringIO('this is my try job')
+        inputfile = NativeStringIO('this is my try job')
         self.patch(sys, 'stdin', inputfile)
 
         rc = tryserver.tryserver(config)

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -174,8 +174,8 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
             desttimestamp = (os.path.getatime(self.destfile),
                              os.path.getmtime(self.destfile))
 
-            srctimestamp = map(int, timestamp)
-            desttimestamp = map(int, desttimestamp)
+            srctimestamp = [int(t) for t in timestamp]
+            desttimestamp = [int(d) for d in desttimestamp]
 
             self.assertEqual(srctimestamp[0], desttimestamp[0])
             self.assertEqual(srctimestamp[1], desttimestamp[1])

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -1098,8 +1098,9 @@ class TestJSONPropertiesDownload(unittest.TestCase):
                 self.assertEqual(kwargs['workerdest'], 'props.json')
                 reader = kwargs['reader']
                 data = reader.remote_read(100)
-                self.assertEqual(
-                    data, json.dumps(dict(sourcestamps=[ss.asDict()], properties={'key1': 'value1'})))
+                actualJson = json.loads(data)
+                expectedJson = dict(sourcestamps=[ss.asDict()], properties={'key1': 'value1'})
+                self.assertEqual(actualJson, expectedJson)
                 break
         else:
             raise ValueError("No downloadFile command found")
@@ -1128,8 +1129,9 @@ class TestJSONPropertiesDownload(unittest.TestCase):
                 self.assertEqual(kwargs['slavedest'], 'props.json')
                 reader = kwargs['reader']
                 data = reader.remote_read(100)
-                self.assertEqual(
-                    data, json.dumps(dict(sourcestamps=[ss.asDict()], properties={'key1': 'value1'})))
+                actualJson = json.loads(data)
+                expectedJson = dict(sourcestamps=[ss.asDict()], properties={'key1': 'value1'})
+                self.assertEqual(actualJson, expectedJson)
                 break
         else:
             raise ValueError("No downloadFile command found")

--- a/master/buildbot/test/util/interfaces.py
+++ b/master/buildbot/test/util/interfaces.py
@@ -64,6 +64,14 @@ class InterfaceTests(object):
             except AttributeError:
                 return func
 
+        def filter_argspec(func):
+            if PY3:
+                return filter(
+                    inspect.getfullargspec(remove_decorators(func)))
+            else:
+                return filter(
+                    inspect.getargspec(remove_decorators(func)))
+
         def assert_same_argspec(expected, actual):
             if expected != actual:
                 msg = "Expected: %s; got: %s" % (
@@ -71,29 +79,14 @@ class InterfaceTests(object):
                     inspect.formatargspec(*actual))
                 self.fail(msg)
 
-        if PY3:
-            actual_argspec = filter(
-                inspect.signature(remove_decorators(actualMethod)))
-        else:
-            actual_argspec = filter(
-                inspect.getargspec(remove_decorators(actualMethod)))
+        actual_argspec = filter_argspec(actualMethod)
 
         for fakeMethod in fakeMethods:
-            if PY3:
-                fake_argspec = filter(
-                    inspect.signature(remove_decorators(fakeMethod)))
-            else:
-                fake_argspec = filter(
-                    inspect.getargspec(remove_decorators(fakeMethod)))
+            fake_argspec = filter_argspec(fakeMethod)
             assert_same_argspec(actual_argspec, fake_argspec)
 
         def assert_same_argspec_decorator(decorated):
-            if PY3:
-                expected_argspec = filter(
-                    inspect.signature(remove_decorators(decorated)))
-            else:
-                expected_argspec = filter(
-                    inspect.getargspec(remove_decorators(decorated)))
+            expected_argspec = filter_argspec(decorated)
             assert_same_argspec(expected_argspec, actual_argspec)
             # The decorated function works as usual.
             return decorated

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -34,6 +34,7 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake import logfile
 from buildbot.test.fake import remotecommand
 from buildbot.test.fake import worker
+from buildbot.util import bytes2NativeString
 
 
 def _dict_diff(d1, d2):
@@ -221,6 +222,7 @@ class BuildStepMixin(object):
 
         def addHTMLLog(name, html):
             l = logfile.FakeLogFile(name, step)
+            html = bytes2NativeString(html)
             l.addStdout(html)
             return defer.succeed(None)
         step.addHTMLLog = addHTMLLog

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -23,12 +23,12 @@ from future.utils import iteritems
 import json
 import os
 import pkg_resources
-from cStringIO import StringIO
 from uuid import uuid1
 
 import mock
 
 from twisted.internet import defer
+from twisted.python.compat import NativeStringIO
 from twisted.web import server
 
 from buildbot.test.fake import fakemaster
@@ -177,7 +177,7 @@ class WwwTestMixin(RequiresWwwMixin):
         id = id or self.UUID
         request = self.make_request(path)
         request.method = "POST"
-        request.content = StringIO(requestJson or json.dumps(
+        request.content = NativeStringIO(requestJson or json.dumps(
             {"jsonrpc": "2.0", "method": action, "params": params, "id": id}))
         request.input_headers = {'content-type': content_type}
         rv = rsrc.render(request)

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -200,6 +200,27 @@ def unicode2bytes(x, encoding='utf8'):
     return x
 
 
+def bytes2NativeString(x, encoding='utf-8'):
+    """
+    Convert C{bytes} to a native C{str}.
+
+    On Python 3 and higher, str and bytes
+    are not equivalent.  In this case, decode
+    the bytes, and return a native string.
+
+    On Python 2 and lower, str and bytes
+    are equivalent.  In this case, just
+    just return the native string.
+
+    @param x: a string of type C{bytes}
+    @param encoding: an optional codec, default: 'utf-8'
+    @return: a string of type C{str}
+    """
+    if isinstance(x, bytes) and str != bytes:
+        return x.decode(encoding)
+    return x
+
+
 _hush_pyflakes = [json]
 
 deprecatedModuleAttribute(


### PR DESCRIPTION
These tests now work under Python 3:

```
trial buildbot.test.unit.test_steps_transfer
trial buildbot.test.unit.test_scripts_tryserver
trial buildbot.test.unit.test_schedulers_trysched
```