### PR TITLE
Replace itertools.izip with zip to fix errors on Python 3

### DIFF
--- a/master/buildbot/util/tuplematch.py
+++ b/master/buildbot/util/tuplematch.py
@@ -16,13 +16,11 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import itertools
-
 
 def matchTuple(routingKey, filter):
     if len(filter) != len(routingKey):
         return False
-    for k, f in itertools.izip(routingKey, filter):
+    for k, f in zip(routingKey, filter):
         if f is not None and f != k:
             return False
     return True


### PR DESCRIPTION
This way to fix code using itertools.izip is recommended here:

http://www.diveintopython3.net/porting-code-to-python-3-with-2to3.html#itertools

This fixes on Python 3:

```
trial buildbot.test.unit.test_util_tuplematch
```