### PR TITLE
Replace first argument to exec() with a string.

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -29,6 +29,7 @@ from types import MethodType
 
 from twisted.python import failure
 from twisted.python import log
+from twisted.python.compat import execfile
 from zope.interface import implementer
 
 from buildbot import interfaces
@@ -103,7 +104,8 @@ def loadConfigDict(basedir, configFileName):
         ])
 
     try:
-        f = open(filename, "r")
+        with open(filename, "r"):
+            pass
     except IOError as e:
         raise ConfigErrors([
             "unable to open configuration file %r: %s" % (filename, e),
@@ -121,7 +123,7 @@ def loadConfigDict(basedir, configFileName):
     sys.path.append(basedir)
     try:
         try:
-            exec(f, localDict)
+            execfile(filename, localDict)
         except ConfigErrors:
             raise
         except SyntaxError:
@@ -136,7 +138,6 @@ def loadConfigDict(basedir, configFileName):
                   always_raise=True,
                   )
     finally:
-        f.close()
         sys.path[:] = old_sys_path
 
     if 'BuildmasterConfig' not in localDict:


### PR DESCRIPTION
exec() in Python 3 no longer accepts an open file descriptor.

Python 2 exec statement accepts an open file descriptor:
https://docs.python.org/2/reference/simple_stmts.html#exec

but Python 3 exec does not:
https://docs.python.org/3/library/functions.html#exec

