### PR TITLE
WIP: use buildbotURLAliases to cover different hostnames.

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -184,7 +184,7 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
         # global
         self.title = 'Buildbot'
         self.titleURL = 'http://buildbot.net'
-        self.buildbotURL = 'http://localhost:8080/'
+        self.buildbotURL = 'http://localhost:8010/'
         self.buildbotURLAliases = []
         self.changeHorizon = None
         self.logHorizon = None

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -185,6 +185,7 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
         self.title = 'Buildbot'
         self.titleURL = 'http://buildbot.net'
         self.buildbotURL = 'http://localhost:8080/'
+        self.buildbotURLAliases = []
         self.changeHorizon = None
         self.logHorizon = None
         self.buildHorizon = None
@@ -240,6 +241,7 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
     _known_config_keys = set([
         "buildbotNetUsageData",
         "buildbotURL",
+        "buildbotURLAliases",
         "buildCacheSize",
         "builders",
         "buildHorizon",

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -184,7 +184,7 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
         # global
         self.title = 'Buildbot'
         self.titleURL = 'http://buildbot.net'
-        self.buildbotURL = 'http://localhost:8010/'
+        self.buildbotURL = 'http://localhost:8080/'
         self.buildbotURLAliases = []
         self.changeHorizon = None
         self.logHorizon = None

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -131,7 +131,8 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
     def getBuildbotURLAliases(self):
         if self.master.config.buildbotURLAliases:
-            return self.master.config.buildbotURLAliases
+            return self.master.config.buildbotURLAliases.append(
+              self.master.config.buildbotURL)
         return [self.master.config.buildbotURL]
 
     def getStatus(self):

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -130,10 +130,10 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         return self.master.config.buildbotURL
 
     def getBuildbotURLAliases(self):
-        if self.master.config.buildbotURLAliases:
-            return self.master.config.buildbotURLAliases.append(
+        if not self.master.config.buildbotURLAliases:
+            self.master.config.buildbotURLAliases.append(
                 self.master.config.buildbotURL)
-        return [self.master.config.buildbotURL]
+        return self.master.config.buildbotURLAliases
 
     def getStatus(self):
         # some listeners expect their .parent to be a BuildMaster object, and

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -129,6 +129,11 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
     def getBuildbotURL(self):
         return self.master.config.buildbotURL
 
+    def getBuildbotURLAliases(self):
+        if self.master.config.buildbotURLAliases:
+            return self.master.config.buildbotURLAliases
+        return [self.master.config.buildbotURL]
+
     def getStatus(self):
         # some listeners expect their .parent to be a BuildMaster object, and
         # use this method to get the Status object.  This is documented, so for
@@ -418,6 +423,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             'title': self.getTitle(),
             'titleURL': self.getTitleURL(),
             'buildbotURL': self.getBuildbotURL(),
+            'buildbotURLAliases': self.getBuildbotURLAliases(),
             # TODO: self.getSchedulers()
             # self.getChangeSources()
         }

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -132,7 +132,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
     def getBuildbotURLAliases(self):
         if self.master.config.buildbotURLAliases:
             return self.master.config.buildbotURLAliases.append(
-              self.master.config.buildbotURL)
+                self.master.config.buildbotURL)
         return [self.master.config.buildbotURL]
 
     def getStatus(self):

--- a/master/buildbot/test/fake/fakestats.py
+++ b/master/buildbot/test/fake/fakestats.py
@@ -21,6 +21,7 @@ from buildbot.statistics import stats_service
 from buildbot.statistics.storage_backends.base import StatsStorageBase
 from buildbot.status.master import Status as status_service
 
+
 class FakeStatsStorageService(StatsStorageBase):
 
     """

--- a/master/buildbot/test/fake/fakestats.py
+++ b/master/buildbot/test/fake/fakestats.py
@@ -93,7 +93,6 @@ class FakeInfluxDBClient(object):
 
 class FakeStatusService(status_service):
 
-
     """
     Fake StatusService for use in fakemaster
     """
@@ -108,5 +107,3 @@ class FakeStatusService(status_service):
     @master.setter
     def master(self, value):
         self._master = value
-
-

--- a/master/buildbot/test/fake/fakestats.py
+++ b/master/buildbot/test/fake/fakestats.py
@@ -19,7 +19,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.statistics import capture
 from buildbot.statistics import stats_service
 from buildbot.statistics.storage_backends.base import StatsStorageBase
-
+from buildbot.status.master import Status as status_service
 
 class FakeStatsStorageService(StatsStorageBase):
 
@@ -89,3 +89,24 @@ class FakeInfluxDBClient(object):
 
     def write_points(self, points):
         self.points.extend(points)
+
+
+class FakeStatusService(status_service):
+
+
+    """
+    Fake StatusService for use in fakemaster
+    """
+    def __init__(self, master=None, *args, **kwargs):
+        status_service.__init__(self, *args, **kwargs)
+        self.master = master
+
+    @property
+    def master(self):
+        return self._master
+
+    @master.setter
+    def master(self, value):
+        self._master = value
+
+

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -58,6 +58,7 @@ global_defaults = dict(
     title='Buildbot',
     titleURL='http://buildbot.net',
     buildbotURL='http://localhost:8080/',
+    buildbotURLAliases=[],
     changeHorizon=None,
     logHorizon=None,
     buildHorizon=None,

--- a/master/buildbot/test/unit/test_status_master.py
+++ b/master/buildbot/test/unit/test_status_master.py
@@ -38,4 +38,4 @@ class TestStatusMaster(unittest.TestCase):
 
     def test_getBuildURLAliases_usefn(self):
         b = self.status_service.getBuildbotURLAliases()
-        self.assertEqual(b, ['http://localhost:8010/'])
+        self.assertEqual(b, ['http://localhost:8080/'])

--- a/master/buildbot/test/unit/test_status_master.py
+++ b/master/buildbot/test/unit/test_status_master.py
@@ -1,0 +1,41 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+from twisted.trial import unittest
+
+from buildbot import config
+from buildbot.test.fake import fakemaster
+from buildbot.test.fake import fakestats
+
+
+class TestStatusMaster(unittest.TestCase):
+
+    def setUp(self):
+        self.master = fakemaster.make_master(testcase=self, wantMq=True,
+                                             wantData=True, wantDb=True)
+        self.master.config = config.MasterConfig()
+        self.master.config.www['port'] = 8010
+        self.status_service = fakestats.FakeStatusService(master=self.master)
+
+    def test_getBuildURLAliases_empty(self):
+        self.assertEqual(self.master.config.buildbotURLAliases, [])
+
+    def test_getBuildURLAliases_set(self):
+        self.master.config.buildbotURLAliases.append('http://localhost2:8010')
+        self.assertEqual(self.master.config.buildbotURLAliases,
+                         ['http://localhost2:8010'])
+
+    def test_getBuildURLAliases_usefn(self):
+        b = self.status_service.getBuildbotURLAliases()
+        self.assertEqual(b, ['http://localhost:8010/'])

--- a/www/base/src/app/home/home.tpl.jade
+++ b/www/base/src/app/home/home.tpl.jade
@@ -1,5 +1,5 @@
 .container
-  .row(ng-if="config.buildbotURL != baseurl and config.buildbotURLAliases.indexof(baseurl) === -1")
+  .row(ng-if="config.buildbotURLAliases.indexof(baseurl) === -1")
       .alert.alert-danger Warning: 
           | c['BuildbotURL'] is misconfigured to
           pre {{config.buildbotURL}}

--- a/www/base/src/app/home/home.tpl.jade
+++ b/www/base/src/app/home/home.tpl.jade
@@ -1,5 +1,5 @@
 .container
-  .row(ng-if="config.buildbotURL != baseurl")
+  .row(ng-if="config.buildbotURL != baseurl and config.buildbotURLAliases.indexof(baseurl) === -1")
       .alert.alert-danger Warning: 
           | c['BuildbotURL'] is misconfigured to
           pre {{config.buildbotURL}}


### PR DESCRIPTION
a possible wip to allow different aliases for the host.
