### PR TITLE
Fix openstack test on Python 3

### DIFF
--- a/master/buildbot/test/fake/openstack.py
+++ b/master/buildbot/test/fake/openstack.py
@@ -140,5 +140,5 @@ class Instance():
 # Parts used from novaclient.exceptions.
 
 
-class NotFound():
+class NotFound(Exception):
     pass

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -152,7 +152,7 @@ class TestOpenStackWorker(unittest.TestCase):
     @defer.inlineCallbacks
     def test_getImage_callable(self):
         def image_callable(images):
-            filtered = filter(lambda i: i.id == 'uuid1', images)
+            filtered = list(filter(lambda i: i.id == 'uuid1', images))
             return filtered[0].id
 
         bs = openstack.OpenStackLatentWorker('bot', 'pass', flavor=1,

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -32,8 +32,10 @@ from buildbot.worker import AbstractLatentWorker
 try:
     import novaclient.exceptions as nce
     from novaclient import client
+    from novaclient.exceptions import NotFound
     _hush_pyflakes = [nce, client]
 except ImportError:
+    NotFound = Exception
     nce = None
     client = None
 
@@ -205,7 +207,7 @@ class OpenStackLatentWorker(AbstractLatentWorker):
                          instance.id))
             try:
                 inst = self.novaclient.servers.get(instance.id)
-            except nce.NotFound:
+            except NotFound:
                 log.msg('%s %s instance %s (%s) went missing' %
                         (self.__class__.__name__, self.workername,
                          instance.id, instance.name))
@@ -238,7 +240,7 @@ class OpenStackLatentWorker(AbstractLatentWorker):
         # instance.update().
         try:
             inst = self.novaclient.servers.get(instance.id)
-        except nce.NotFound:
+        except NotFound:
             # If can't find the instance, then it's already gone.
             log.msg('%s %s instance %s (%s) already terminated' %
                     (self.__class__.__name__, self.workername, instance.id,


### PR DESCRIPTION
This fixes the following on Python 3:

trial buildbot.test.unit.test_worker_openstack