### PR TITLE
builderspage: do not load the list of masters for each builder

### DIFF
--- a/master/buildbot/newsfragments/builderspage.feature
+++ b/master/buildbot/newsfragments/builderspage.feature
@@ -1,0 +1,1 @@
+Builders page has been optimized and can now be displayed with 4 http requests whatever is the builder count.

--- a/www/base/src/app/builders/builders.controller.coffee
+++ b/www/base/src/app/builders/builders.controller.coffee
@@ -10,10 +10,11 @@ class Builders extends Controller
                 return "worker_DISCONNECTED"
         $scope.hasActiveMaster = (builder) ->
             active = false
-            if not builder.masters?
+            if not builder.masterids?
                 return false
-            for m in builder.masters
-                if m.active
+            for mid in builder.masterids
+                m = $scope.masters.get(mid)
+                if m? and m.active
                     active = true
             return active
         $scope.settings = bbSettingsService.getSettingsGroup("Builders")
@@ -97,12 +98,10 @@ class Builders extends Controller
         data = dataService.open().closeOnDestroy($scope)
 
         $scope.builders = data.getBuilders()
-        $scope.builders.onNew = (builder) ->
-            builder.loadMasters()
+        $scope.masters = data.getMasters()
 
         # as there is usually lots of builders, its better to get the overall
-        # list of workers, and builds and then associate by builder
-        # @todo, we cannot do same optims for masters due to lack of data api
+        # list of workers, masters, and builds and then associate by builder
         workers = data.getWorkers()
         builds = data.getBuilds(limit: 200, order: '-started_at')
         dataGrouperService.groupBy($scope.builders, workers, 'builderid', 'workers', 'configured_on')

--- a/www/base/src/app/builders/log/logviewer/scrollviewport.spec.coffee
+++ b/www/base/src/app/builders/log/logviewer/scrollviewport.spec.coffee
@@ -1,12 +1,13 @@
 describe 'page with sidebar', ->
     beforeEach (module("app"))
     elmBody = scope = rootScope = queries = timeout = null
+    elmContent = null
     padding = (pix) -> type: "padding", height: pix
     elements = (start, end) -> type: "elements", start: start, end: end
 
     assertDOM = (l) ->
         childs = []
-        $("div", elmBody).each (i, c) -> childs.push(c)
+        $("div", elmContent).each (i, c) -> childs.push(c)
         for item in l
             if item.type == "padding"
                 c = childs.shift()
@@ -18,7 +19,7 @@ describe 'page with sidebar', ->
                     expect($(c).hasClass("padding")).toBe(false, c.outerHTML)
                     expect(c.innerText).toEqual(i.toString() + "a" + i.toString(), c.outerHTML)
     printDOM = ->
-        $("div", elmBody).each ->
+        $("div", elmContent).each ->
             if $(this).hasClass("padding")
                 console.log "padding", $(this).height()
             else
@@ -63,6 +64,7 @@ describe 'page with sidebar', ->
 
         # we need to append to body, so that the element is styled properly, and gets a height
         elmBody.appendTo("body")
+        elmContent = $("div", elmBody)[0]
 
     # ViewPort height is 50, and item height is 10, so a screen should contain 5 item
     it 'should initially load 2 screens', inject ($timeout) ->

--- a/www/base/src/app/common/services/datagrouper/datagrouper.service.coffee
+++ b/www/base/src/app/common/services/datagrouper/datagrouper.service.coffee
@@ -17,8 +17,6 @@ class dataGrouperService extends Factory('common')
                     if temp_dict.hasOwnProperty(item[joinid])
                         item[attribute] = temp_dict[item[joinid]]
                     onNew(item)
-                doGroup = (item) ->
-                    console.log item
                 if joinlist?
                     collection2.onNew  = (item) ->
                         item[joinlist]?.forEach (item2) ->


### PR DESCRIPTION
The data api actually has the list of masterids where the builder is configured
So we can just load the list of all masters aside, and then find out if its active or not

This will optimize a lot performance for masters with lots of builders

- for 60 builders, previously we required 63 requests
- now we require 4 requests

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)

