### PR TITLE
Replace new.module with types.ModuleType

### DIFF
--- a/master/buildbot/test/unit/test_worker_transition.py
+++ b/master/buildbot/test/unit/test_worker_transition.py
@@ -16,9 +16,9 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import new
 import re
 import sys
+import types
 
 import mock
 
@@ -64,7 +64,7 @@ class Test_deprecatedWorkerModuleAttribute(unittest.TestCase):
 
     def test_produces_warning(self):
         Worker = type("Worker", (object,), {})
-        buildbot_module = new.module('buildbot_module')
+        buildbot_module = types.ModuleType('buildbot_module')
         buildbot_module.Worker = Worker
         with mock.patch.dict(sys.modules,
                              {'buildbot_module': buildbot_module}):
@@ -86,7 +86,7 @@ class Test_deprecatedWorkerModuleAttribute(unittest.TestCase):
         self.assertIdentical(S, Worker)
 
     def test_not_catched_warning(self):
-        buildbot_module = new.module('buildbot_module')
+        buildbot_module = types.ModuleType('buildbot_module')
         buildbot_module.deprecated_attr = 1
         with mock.patch.dict(sys.modules,
                              {'buildbot_module': buildbot_module}):
@@ -111,7 +111,7 @@ class Test_deprecatedWorkerModuleAttribute(unittest.TestCase):
 
     def test_explicit_compat_name(self):
         Worker = type("Worker", (object,), {})
-        buildbot_module = new.module('buildbot_module')
+        buildbot_module = types.ModuleType('buildbot_module')
         buildbot_module.Worker = Worker
         with mock.patch.dict(sys.modules,
                              {'buildbot_module': buildbot_module}):
@@ -135,7 +135,7 @@ class Test_deprecatedWorkerModuleAttribute(unittest.TestCase):
 
     def test_explicit_new_name(self):
         BuildSlave = type("BuildSlave", (object,), {})
-        buildbot_module = new.module('buildbot_module')
+        buildbot_module = types.ModuleType('buildbot_module')
         buildbot_module.BuildSlave = BuildSlave
         with mock.patch.dict(sys.modules,
                              {'buildbot_module': buildbot_module}):
@@ -157,7 +157,7 @@ class Test_deprecatedWorkerModuleAttribute(unittest.TestCase):
 
     def test_explicit_new_name_empty(self):
         BuildSlave = type("BuildSlave", (object,), {})
-        buildbot_module = new.module('buildbot_module')
+        buildbot_module = types.ModuleType('buildbot_module')
         buildbot_module.BuildSlave = BuildSlave
         with mock.patch.dict(sys.modules,
                              {'buildbot_module': buildbot_module}):
@@ -180,7 +180,7 @@ class Test_deprecatedWorkerModuleAttribute(unittest.TestCase):
 
     def test_module_reload(self):
         Worker = type("Worker", (object,), {})
-        buildbot_module = new.module('buildbot_module')
+        buildbot_module = types.ModuleType('buildbot_module')
         buildbot_module.Worker = Worker
         with mock.patch.dict(sys.modules,
                              {'buildbot_module': buildbot_module}):

--- a/master/buildbot/test/unit/test_www_ldapuserinfo.py
+++ b/master/buildbot/test/unit/test_www_ldapuserinfo.py
@@ -18,15 +18,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from future.builtins import range
 
-import new
 import sys
+import types
 
 import mock
 
 from twisted.internet import defer
 from twisted.trial import unittest
 
-fake_ldap = new.module('ldap3')
+fake_ldap = types.ModuleType('ldap3')
 fake_ldap.SEARCH_SCOPE_WHOLE_SUBTREE = 2
 with mock.patch.dict(sys.modules, {'ldap3': fake_ldap}):
     from buildbot.www import ldapuserinfo


### PR DESCRIPTION
"import new" was deprecated in Python 2.6: https://docs.python.org/2/library/new.html
and is gone in Python 3.  "types" should be used instead.
