### PR TITLE
Fix hashColumns.encode() on Python 3

### DIFF
--- a/master/buildbot/db/base.py
+++ b/master/buildbot/db/base.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import text_type
 
 import hashlib
 import itertools
@@ -92,14 +93,14 @@ class DBConnectorComponent(object):
 
     def hashColumns(self, *args):
         def encode(x):
-            try:
-                return x.encode('utf8')
-            except AttributeError:
-                if x is None:
-                    return '\xf5'
-                return str(x)
+            if x is None:
+                return b'\xf5'
+            elif isinstance(x, text_type):
+                return x.encode('utf-8')
+            else:
+                return str(x).encode('utf-8')
 
-        return hashlib.sha1('\0'.join(map(encode, args))).hexdigest()
+        return hashlib.sha1(b'\0'.join(map(encode, args))).hexdigest()
 
     def doBatch(self, batch, batch_n=500):
         iterator = iter(batch)

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -131,13 +131,14 @@ class Row(object):
     def hashColumns(self, *args):
         # copied from master/buildbot/db/base.py
         def encode(x):
-            try:
-                return x.encode('utf8')
-            except AttributeError:
-                if x is None:
-                    return '\xf5'
-                return str(x)
-        return hashlib.sha1('\0'.join(map(encode, args))).hexdigest()
+            if x is None:
+                return b'\xf5'
+            elif isinstance(x, text_type):
+                return x.encode('utf-8')
+            else:
+                return str(x).encode('utf-8')
+
+        return hashlib.sha1(b'\0'.join(map(encode, args))).hexdigest()
 
     @defer.inlineCallbacks
     def checkForeignKeys(self, db, t):

--- a/master/buildbot/test/unit/test_db_base.py
+++ b/master/buildbot/test/unit/test_db_base.py
@@ -64,19 +64,19 @@ class TestBase(unittest.TestCase):
 
     def test_hashColumns_single(self):
         self.assertEqual(self.comp.hashColumns('master'),
-                         self._sha1('master'))
+                         self._sha1(b'master'))
 
     def test_hashColumns_multiple(self):
         self.assertEqual(self.comp.hashColumns('a', None, 'b', 1),
-                         self._sha1('a\0\xf5\x00b\x001'))
+                         self._sha1(b'a\0\xf5\x00b\x001'))
 
     def test_hashColumns_None(self):
         self.assertEqual(self.comp.hashColumns(None),
-                         self._sha1('\xf5'))
+                         self._sha1(b'\xf5'))
 
     def test_hashColumns_integer(self):
         self.assertEqual(self.comp.hashColumns(11),
-                         self._sha1('11'))
+                         self._sha1(b'11'))
 
     def test_hashColumns_unicode_ascii_match(self):
         self.assertEqual(self.comp.hashColumns('master'),
@@ -99,7 +99,7 @@ class TestBaseAsConnectorComponent(unittest.TestCase,
     @defer.inlineCallbacks
     def test_findSomethingId_race(self):
         tbl = self.db.model.masters
-        hash = hashlib.sha1('somemaster').hexdigest()
+        hash = hashlib.sha1(b'somemaster').hexdigest()
 
         def race_thd(conn):
             conn.execute(tbl.insert(),
@@ -116,7 +116,7 @@ class TestBaseAsConnectorComponent(unittest.TestCase,
     @defer.inlineCallbacks
     def test_findSomethingId_new(self):
         tbl = self.db.model.masters
-        hash = hashlib.sha1('somemaster').hexdigest()
+        hash = hashlib.sha1(b'somemaster').hexdigest()
         id = yield self.db.base.findSomethingId(
             tbl=self.db.model.masters,
             whereclause=(tbl.c.name_hash == hash),
@@ -127,7 +127,7 @@ class TestBaseAsConnectorComponent(unittest.TestCase,
     @defer.inlineCallbacks
     def test_findSomethingId_existing(self):
         tbl = self.db.model.masters
-        hash = hashlib.sha1('somemaster').hexdigest()
+        hash = hashlib.sha1(b'somemaster').hexdigest()
 
         yield self.insertTestData([
             fakedb.Master(id=7, name='somemaster', name_hash=hash),


### PR DESCRIPTION
This fixes on Python 3:

```
trial buildbot.test.unit.test_db_base
```
