### PR TITLE
Added a try/except around a call to multiprocessing.cpu_count()

### DIFF
--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -318,6 +318,8 @@ class BotBase(service.MultiService):
             try:
                 self.numcpus = multiprocessing.cpu_count()
             except NotImplementedError:
+                log.msg("warning: could not detect the number of CPUs for "
+                        "this worker. Assuming 1 CPU.")
                 self.numcpus = 1
         files['environ'] = os.environ.copy()
         files['system'] = os.name

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -315,7 +315,10 @@ class BotBase(service.MultiService):
                 if os.path.isfile(filename):
                     files[f] = open(filename, "r").read()
         if not self.numcpus:
-            self.numcpus = multiprocessing.cpu_count()
+            try:
+                self.numcpus = multiprocessing.cpu_count()
+            except NotImplementedError:
+                self.numcpus = 1
         files['environ'] = os.environ.copy()
         files['system'] = os.name
         files['basedir'] = self.basedir


### PR DESCRIPTION
In some situations, the multiprocessing.cpu_count() function can raise NotImplementedError. I.e. this can happen on Windows if the environment will lack the 'NUMBER_OF_PROCESSORS' variable, or this variable will contain a non-numeric character.

If this exception will occur, the worker will use a substitution value of 1 CPU.

I'm not entirely sure if changing the documentation nor test suite is necessary. 