### PR TITLE
Replace filter() with list comprehensions in a few places for Python 3

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -19,7 +19,6 @@ from future.moves.urllib.parse import quote as urlquote
 from future.utils import itervalues
 from future.utils import text_type
 
-import itertools
 import os
 import re
 
@@ -241,8 +240,9 @@ class GitPoller(base.PollingChangeSource, StateMixin):
 
         @d.addCallback
         def process(git_output):
-            fileList = [decode_file(file) for file in itertools.ifilter(
-                lambda s: len(s), git_output.splitlines())]
+            fileList = [decode_file(file)
+                        for file in
+                        [s for s in git_output.splitlines() if len(s)]]
             return fileList
         return d
 

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -168,9 +168,9 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         if branches is True or callable(branches):
             branches = yield self._getBranches()
             if callable(self.branches):
-                branches = filter(self.branches, branches)
+                branches = [b for b in branches if self.branches(b)]
             else:
-                branches = filter(self._headsFilter, branches)
+                branches = [b for b in branches if self._headsFilter(b)]
 
         refspecs = [
             '+%s:%s' % (self._removeHeads(branch), self._trackerBranch(branch))

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -152,7 +152,7 @@ class GitOutputParsing(gpo.GetProcessOutputMixin, unittest.TestCase):
             ['log', '--name-only', '--no-walk',
                 '--format=%n', self.dummyRevStr, '--'],
             filesStr,
-            filter(lambda x: x.strip(), filesStr.splitlines(), ),
+            [l for l in filesStr.splitlines() if l.strip()],
             emptyRaisesException=False,
         )
 

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -152,7 +152,7 @@ class TestOpenStackWorker(unittest.TestCase):
     @defer.inlineCallbacks
     def test_getImage_callable(self):
         def image_callable(images):
-            filtered = list(filter(lambda i: i.id == 'uuid1', images))
+            filtered = [i for i in images if i.id == 'uuid1']
             return filtered[0].id
 
         bs = openstack.OpenStackLatentWorker('bot', 'pass', flavor=1,

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -2212,7 +2212,7 @@ The `uploadDone` method is called once for each uploaded file and can be used to
 
         def allUploadsDone(self, result, sources, masterdest):
             if self.url:
-                notLinked = filter(lambda src: not self.linkFile(src), sources)
+                notLinked = [src for src in sources if not self.linkFile(src)]
                 numFiles = len(notLinked)
                 if numFiles:
                     self.addURL(self.url, '... %d more' % numFiles)


### PR DESCRIPTION
Replace filter() with list comprehensions in a few places,
do deal with different filter implementation in Python 3.
Code is slightly more readable as well.