### PR TITLE
Compare a string with a string, not an integer.

### DIFF
--- a/master/buildbot/test/unit/test_worker_ec2.py
+++ b/master/buildbot/test/unit/test_worker_ec2.py
@@ -206,7 +206,7 @@ class TestEC2LatentWorker(unittest.TestCase):
         instance_id, image_id, start_time = bs._start_instance()
         self.assertTrue(instance_id.startswith('i-'))
         self.assertTrue(image_id.startswith('ami-'))
-        self.assertTrue(start_time > 0)
+        self.assertTrue(start_time > "00:00:00")
         instances = r.instances.filter(
             Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
         instances = list(instances)


### PR DESCRIPTION
In Python 2, this works:
```
   "00:00:05" > 0
```

but in Python 3, this fails with:

```
TypeError: '>' not supported between instances of 'str' and 'int'
```