### PR TITLE
Use timeout from configuration file when deleting directory.

### DIFF
--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -146,7 +146,7 @@ class SVN(Source):
             yield self._dovccmd(command)
 
     def clobber(self):
-        d = self.runRmdir(self.workdir)
+        d = self.runRmdir(self.workdir, timeout=self.timeout)
         d.addCallback(lambda _: self._checkout())
         return d
 
@@ -168,7 +168,7 @@ class SVN(Source):
 
     @defer.inlineCallbacks
     def copy(self):
-        yield self.runRmdir(self.workdir)
+        yield self.runRmdir(self.workdir, timeout=self.timeout)
 
         checkout_dir = 'source'
         if self.codebase:
@@ -361,7 +361,7 @@ class SVN(Source):
                 if self.workerVersionIsOlderThan('rmdir', '2.14'):
                     d = self.removeFiles(files)
                 else:
-                    d = self.runRmdir(files, abandonOnFailure=False)
+                    d = self.runRmdir(files, abandonOnFailure=False, timeout=self.timeout)
             return d
 
         @d.addCallback
@@ -394,7 +394,7 @@ class SVN(Source):
     @defer.inlineCallbacks
     def removeFiles(self, files):
         for filename in files:
-            res = yield self.runRmdir(filename, abandonOnFailure=False)
+            res = yield self.runRmdir(filename, abandonOnFailure=False, timeout=self.timeout)
             if res:
                 defer.returnValue(res)
                 return
@@ -485,7 +485,7 @@ class SVN(Source):
                         % (repeats, delay))
                 self.retry = (delay, repeats - 1)
                 df = defer.Deferred()
-                df.addCallback(lambda _: self.runRmdir(self.workdir))
+                df.addCallback(lambda _: self.runRmdir(self.workdir, timeout=self.timeout))
                 df.addCallback(lambda _: self._checkout())
                 reactor.callLater(delay, df.callback, None)
                 return df

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -423,7 +423,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             Expect('stat', dict(file='wkdir/.svn',
                                 logEnviron=True))
             + 1,
-            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True})
+            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True, 'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/trunk/app',
@@ -453,13 +453,13 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             Expect('stat', dict(file='wkdir/.svn',
                                 logEnviron=True))
             + 1,
-            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True})
+            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True, 'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/trunk/app',
                                  '.', '--non-interactive', '--no-auth-cache'])
             + 1,
-            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True})
+            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True, 'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/trunk/app',
@@ -496,7 +496,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             + ExpectShell.log('stdio',  # expecting ../trunk/app
                               stdout="""<?xml version="1.0"?><url>http://svn.local/branch/foo/app</url>""")
             + 0,
-            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True})
+            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True, 'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/trunk/app',
@@ -682,7 +682,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('rmdir', {'dir': 'wkdir',
-                             'logEnviron': True})
+                             'logEnviron': True,
+                             'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout',
@@ -713,7 +714,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('rmdir', {'dir': 'wkdir',
-                             'logEnviron': True})
+                             'logEnviron': True,
+                             'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout',
@@ -788,19 +790,19 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             Expect('stat', {'file': 'wkdir/.svn',
                             'logEnviron': True})
             + 1,
-            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True})
+            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True, 'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/app/trunk',
                                  '.', '--non-interactive', '--no-auth-cache'])
             + 1,
-            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True})
+            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True, 'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/app/trunk',
                                  '.', '--non-interactive', '--no-auth-cache'])
             + 1,
-            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True})
+            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True, 'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/app/trunk',
@@ -893,7 +895,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,
             Expect('rmdir', {'dir':
                              ['wkdir/svn_external_path/unversioned_file2'],
-                             'logEnviron': True})
+                             'logEnviron': True,
+                             'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'update',
@@ -1006,7 +1009,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             Expect('stat', {'file': 'wkdir/.svn',
                             'logEnviron': True})
             + 1,
-            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True})
+            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True, 'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/app/trunk',
@@ -1037,7 +1040,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             Expect('stat', {'file': 'wkdir/.svn',
                             'logEnviron': True})
             + 1,
-            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True})
+            Expect('rmdir', {'dir': 'wkdir', 'logEnviron': True, 'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'checkout', 'http://svn.local/app/trunk',
@@ -1084,11 +1087,13 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,
             Expect('rmdir', {'dir':
                              'wkdir/svn_external_path/unversioned_file1',
-                             'logEnviron': True})
+                             'logEnviron': True,
+                             'timeout': 1200})
             + 0,
             Expect('rmdir', {'dir':
                              'wkdir/svn_external_path/unversioned_file2',
-                             'logEnviron': True})
+                             'logEnviron': True,
+                             'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'update',
@@ -1136,7 +1141,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             Expect('rmdir', {'dir':
                              ['wkdir/svn_external_path/unversioned_file1',
                               'wkdir/svn_external_path/unversioned_file2'],
-                             'logEnviron': True})
+                             'logEnviron': True,
+                             'timeout': 1200})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['svn', 'update',
@@ -1164,7 +1170,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1200))
             + 0,
             Expect('stat', dict(file='source/app/.svn',
                                 logEnviron=True))
@@ -1208,7 +1215,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1200))
             + 0,
             Expect('stat', dict(file='source/.svn',
                                 logEnviron=True))
@@ -1250,7 +1258,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1200))
             + 0,
             Expect('stat', dict(file='source/.svn',
                                 logEnviron=True))
@@ -1300,10 +1309,12 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,
             Expect('rmdir', dict(dir=['wkdir/svn_external_path/unversioned_file1',
                                       'wkdir/svn_external_path/unversioned_file2'],
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1200))
             + 0,
             Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1200))
             + 0,
             Expect('stat', dict(file='source/.svn',
                                 logEnviron=True))
@@ -1373,10 +1384,12 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,
             Expect('rmdir', dict(dir=['wkdir/svn_external_path/unversioned_file1',
                                       'wkdir/svn_external_path/unversioned_file2'],
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1200))
             + 0,
             Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1200))
             + 0,
             Expect('stat', dict(file='source/.svn',
                                 logEnviron=True))
@@ -1438,7 +1451,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1))
             + 0,
             Expect('stat', dict(file='source/.svn',
                                 logEnviron=True))
@@ -1485,7 +1499,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1200))
             + 0,
             Expect('stat', dict(file='source/.svn',
                                 logEnviron=True))
@@ -1528,7 +1543,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1200))
             + 0,
             Expect('stat', dict(file='source/.svn',
                                 logEnviron=True))
@@ -1731,7 +1747,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('rmdir', {'dir': 'wkdir',
-                             'logEnviron': True})
+                             'logEnviron': True,
+                             'timeout': 1200})
             + 1,
         )
         self.expectOutcome(result=FAILURE)
@@ -1749,7 +1766,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1200))
             + 1,
         )
         self.expectOutcome(result=FAILURE)
@@ -1767,7 +1785,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                                 logEnviron=True))
             + 1,
             Expect('rmdir', dict(dir='wkdir',
-                                 logEnviron=True))
+                                 logEnviron=True,
+                                 timeout=1200))
             + 0,
             Expect('stat', dict(file='source/.svn',
                                 logEnviron=True))
@@ -1823,7 +1842,8 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,
             Expect('rmdir', {'dir':
                              ['wkdir/svn_external_path/unversioned_file2'],
-                             'logEnviron': True})
+                             'logEnviron': True,
+                             'timeout': 1200})
             + 1,
         )
         self.expectOutcome(result=FAILURE)


### PR DESCRIPTION
The svn step does not take the timeout value from the configuration file into account when deleting directories. This causes timeouts on our setup when deleting big directories over network shares.

This patch makess the svn step behave like e.g. the git step.