### PR TITLE
When trying to call decode(), make sure we are doing it on bytes.

### DIFF
--- a/master/buildbot/changes/pb.py
+++ b/master/buildbot/changes/pb.py
@@ -67,11 +67,11 @@ class ChangePerspective(NewCredPerspective):
         # in the first place, but older clients do not, so this fallback is
         # useful.
         for key in changedict:
-            if isinstance(changedict[key], str):
+            if isinstance(changedict[key], bytes):
                 changedict[key] = changedict[key].decode('utf8', 'replace')
         changedict['files'] = list(changedict['files'])
         for i, file in enumerate(changedict.get('files', [])):
-            if isinstance(file, str):
+            if isinstance(file, bytes):
                 changedict['files'][i] = file.decode('utf8', 'replace')
 
         files = []

--- a/master/buildbot/test/unit/test_changes_pb.py
+++ b/master/buildbot/test/unit/test_changes_pb.py
@@ -420,7 +420,7 @@ class TestChangePerspective(unittest.TestCase):
 
     def test_addChange_non_utf8_bytestring(self):
         cp = pb.ChangePerspective(self.master, None)
-        bogus_utf8 = '\xff\xff\xff\xff'
+        bogus_utf8 = b'\xff\xff\xff\xff'
         replacement = bogus_utf8.decode('utf8', 'replace')
         d = cp.perspective_addChange(dict(author=bogus_utf8, files=['a']))
 


### PR DESCRIPTION
This fixes the following test on Python 3:

```
trial buildbot.test.unit.test_changes_pb
```