### PR TITLE
improvements for buildbotNetUsageData

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -707,6 +707,7 @@ statm
 statusdict
 stderr
 stdin
+stdlib
 stdout
 stepid
 stickysidebar

--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -23,7 +23,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from future.moves import urllib
 from future.moves.urllib import request as urllib_request
-from future.moves.urllib.request import urlopen as urllib_open
 
 import hashlib
 import inspect
@@ -93,8 +92,7 @@ def basicData(master):
     # to get as much as possible an unique id
     # we hash it to not leak private information about the installation such as hostnames and domain names
     installid = hashlib.sha1(
-        master.name  # master name contains hostname + master basepath
-        +
+        master.name +  # master name contains hostname + master basepath
         socket.getfqdn()  # we add the fqdn to account for people
                           # call their buildbot host 'buildbot' and install it in /var/lib/buildbot
     ).hexdigest()
@@ -184,7 +182,7 @@ def _sendBuildbotNetUsageData(data):
         log.msg("buildbotNetUsageData: Could not send using https, "
                 "please `pip install 'requests[security]'` for proper SSL implementation`")
         data['buggySSL'] = True
-        res = _sendWithUrlib2(PHONE_HOME_URL.replace("https://", "http://"), data)
+        res = _sendWithUrlib(PHONE_HOME_URL.replace("https://", "http://"), data)
 
     log.msg("buildbotNetUsageData: buildbot.net said:", res)
 

--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -21,13 +21,15 @@ urllib2 supports http_proxy already urllib2 is blocking and thus everything is d
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.moves import urllib
+from future.moves.urllib import request as urllib_request
+from future.moves.urllib.request import urlopen as urllib_open
 
 import hashlib
 import inspect
 import json
 import platform
 import socket
-import urllib2
 
 from twisted.internet import threads
 from twisted.python import log
@@ -145,16 +147,16 @@ def computeUsageData(master):
     return data
 
 
-def _sendWithUrlib2(url, data):
+def _sendWithUrlib(url, data):
     data = json.dumps(data)
     clen = len(data)
-    req = urllib2.Request(url, data, {
+    req = urllib_request.Request(url, data, {
         'Content-Type': 'application/json',
         'Content-Length': clen
     })
     try:
-        f = urllib2.urlopen(req)
-    except urllib2.URLError:
+        f = urllib_request.urlopen(req)
+    except urllib.error.URLError:
         return None
     res = f.read()
     f.close()
@@ -176,7 +178,7 @@ def _sendBuildbotNetUsageData(data):
     res = _sendWithRequests(PHONE_HOME_URL, data)
     # then we try with stdlib, which not always work with https
     if res is None:
-        res = _sendWithUrlib2(PHONE_HOME_URL, data)
+        res = _sendWithUrlib(PHONE_HOME_URL, data)
     # at last stage
     if res is None:
         log.msg("buildbotNetUsageData: Could not send using https, "

--- a/master/buildbot/newsfragments/usagedata.bugfix
+++ b/master/buildbot/newsfragments/usagedata.bugfix
@@ -1,0 +1,1 @@
+:bb:cfg:`buildbotNetUsageData` now uses ``requests`` if available and will default to HTTP if a bogus SSL implementation is found. It will also correctly send information about the platform type.

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -99,6 +99,7 @@ class Tests(unittest.TestCase):
 
     def test_urllib2(self):
         self.patch(buildbot.buildbot_net_usage_data, '_sendWithRequests', lambda _, __: None)
+
         class FakeRequest(object):
             def __init__(self, *args, **kwargs):
                 self.args = args
@@ -122,7 +123,7 @@ class Tests(unittest.TestCase):
         _sendBuildbotNetUsageData({'foo': 'bar'})
         self.assertEqual(len(open_url), 1)
         self.assertEqual(open_url[0].request.args,
-                        ('https://events.buildbot.net/events/phone_home',
+                         ('https://events.buildbot.net/events/phone_home',
                          '{"foo": "bar"}', {'Content-Length': 14, 'Content-Type': 'application/json'}))
 
     def test_urllib2_real(self):

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -127,9 +127,9 @@ class Tests(unittest.TestCase):
                          ('https://events.buildbot.net/events/phone_home',
                          '{"foo": "bar"}', {'Content-Length': 14, 'Content-Type': 'application/json'}))
 
-    def test_urllib2_real(self):
+    def test_real(self):
         if "TEST_BUILDBOTNET_USAGEDATA" not in os.environ:
             raise SkipTest(
-                "hyper integration tests only run when environment variable TEST_HYPER is set")
+                "_sendBuildbotNetUsageData real test only run when environment variable TEST_BUILDBOTNET_USAGEDATA is set")
 
         _sendBuildbotNetUsageData({'foo': 'bar'})

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -16,9 +16,10 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from future.builtins import range
+from future.moves.urllib import request as urllib_request
+from future.moves.urllib.request import urlopen as urllib_urlopen
 
 import os
-import urllib2
 from unittest.case import SkipTest
 
 from twisted.internet import reactor
@@ -97,7 +98,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(sorted(data.keys()),
                          sorted(['db']))
 
-    def test_urllib2(self):
+    def test_urllib(self):
         self.patch(buildbot.buildbot_net_usage_data, '_sendWithRequests', lambda _, __: None)
 
         class FakeRequest(object):
@@ -118,8 +119,8 @@ class Tests(unittest.TestCase):
             def close(self):
                 pass
 
-        self.patch(urllib2, "Request", FakeRequest)
-        self.patch(urllib2, "urlopen", urlopen)
+        self.patch(urllib_request, "Request", FakeRequest)
+        self.patch(urllib_request, "urlopen", urlopen)
         _sendBuildbotNetUsageData({'foo': 'bar'})
         self.assertEqual(len(open_url), 1)
         self.assertEqual(open_url[0].request.args,

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from future.builtins import range
 from future.moves.urllib import request as urllib_request
-from future.moves.urllib.request import urlopen as urllib_urlopen
 
 import os
 from unittest.case import SkipTest
@@ -130,6 +129,7 @@ class Tests(unittest.TestCase):
     def test_real(self):
         if "TEST_BUILDBOTNET_USAGEDATA" not in os.environ:
             raise SkipTest(
-                "_sendBuildbotNetUsageData real test only run when environment variable TEST_BUILDBOTNET_USAGEDATA is set")
+                "_sendBuildbotNetUsageData real test only run when environment variable"
+                " TEST_BUILDBOTNET_USAGEDATA is set")
 
         _sendBuildbotNetUsageData({'foo': 'bar'})

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -17,12 +17,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from future.builtins import range
 
+import os
 import urllib2
+from unittest.case import SkipTest
 
 from twisted.internet import reactor
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 
+import buildbot.buildbot_net_usage_data
 from buildbot.buildbot_net_usage_data import _sendBuildbotNetUsageData
 from buildbot.buildbot_net_usage_data import computeUsageData
 from buildbot.config import BuilderConfig
@@ -95,7 +98,7 @@ class Tests(unittest.TestCase):
                          sorted(['db']))
 
     def test_urllib2(self):
-
+        self.patch(buildbot.buildbot_net_usage_data, '_sendWithRequests', lambda _, __: None)
         class FakeRequest(object):
             def __init__(self, *args, **kwargs):
                 self.args = args
@@ -121,3 +124,10 @@ class Tests(unittest.TestCase):
         self.assertEqual(open_url[0].request.args,
                         ('https://events.buildbot.net/events/phone_home',
                          '{"foo": "bar"}', {'Content-Length': 14, 'Content-Type': 'application/json'}))
+
+    def test_urllib2_real(self):
+        if "TEST_BUILDBOTNET_USAGEDATA" not in os.environ:
+            raise SkipTest(
+                "hyper integration tests only run when environment variable TEST_HYPER is set")
+
+        _sendBuildbotNetUsageData({'foo': 'bar'})


### PR DESCRIPTION
:bb:cfg:`buildbotNetUsageData` now uses ``requests`` if available and will default to HTTP if a bogus SSL implementation is found.
It will also correctly send information about the platform type.
