### PR TITLE
Rename __nonzero__ to __bool__ to fix tests on Python 3.

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import PY3
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import string_types
@@ -61,8 +62,10 @@ class ConfigErrors(Exception):
     def merge(self, errors):
         self.errors.extend(errors.errors)
 
-    def __nonzero__(self):
-        return len(self.errors)
+    def __bool__(self):
+        return bool(len(self.errors))
+    if not PY3:
+        __nonzero__ = __bool__
 
 
 _errors = None

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from future.builtins import range
+from future.utils import PY3
 from future.utils import iteritems
 
 import collections
@@ -92,8 +93,10 @@ class Properties(util.ComparableMixin):
         rv = self.properties[name][0]
         return rv
 
-    def __nonzero__(self):
+    def __bool__(self):
         return bool(self.properties)
+    if not PY3:
+        __nonzero__ = __bool__
 
     def getPropertySource(self, name):
         return self.properties[name][1]

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 from builtins import bytes
 from future.moves.urllib.parse import urlsplit
 from future.moves.urllib.parse import urlunsplit
+from future.utils import PY3
 from future.utils import string_types
 from future.utils import text_type
 
@@ -222,8 +223,10 @@ def toJson(obj):
 
 class NotABranch:
 
-    def __nonzero__(self):
+    def __bool__(self):
         return False
+    if not PY3:
+        __nonzero__ = __bool__
 
 
 NotABranch = NotABranch()

--- a/master/buildbot/util/_notifier.py
+++ b/master/buildbot/util/_notifier.py
@@ -21,6 +21,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import PY3
 
 from twisted.internet.defer import Deferred
 
@@ -39,5 +40,7 @@ class Notifier(object):
         for waiter in waiters:
             waiter.callback(result)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return bool(self._waiters)
+    if not PY3:
+        __nonzero__ = __bool__


### PR DESCRIPTION
__nonzero__ has been replaced by __bool__ in Python 3.

See:
https://docs.python.org/2/reference/datamodel.html#basic-customization
https://docs.python.org/3/reference/datamodel.html#basic-customization