### PR TITLE
Fix buildbot.test.unit.test_www_hooks_github on Python 3

### DIFF
--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -16,11 +16,10 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from StringIO import StringIO
-
 from mock import Mock
 
 from twisted.internet import defer
+from twisted.python.compat import NativeStringIO
 from twisted.web import server
 
 
@@ -57,7 +56,7 @@ class FakeRequest(Mock):
             args = {}
 
         self.args = args
-        self.content = StringIO(content)
+        self.content = NativeStringIO(content)
         self.site = Mock()
         self.site.buildbot_service = Mock()
         self.uri = '/'

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -19,9 +19,9 @@ from __future__ import print_function
 import hmac
 from calendar import timegm
 from hashlib import sha1
-from StringIO import StringIO
 
 from twisted.internet import defer
+from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
@@ -289,7 +289,7 @@ def _prepare_request(event, payload, _secret=None, headers=None):
     }
 
     if isinstance(payload, str):
-        request.content = StringIO(payload)
+        request.content = NativeStringIO(payload)
         request.received_headers[_HEADER_CT] = _CT_JSON
 
         if _secret is not None:

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -26,6 +26,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+from buildbot.util import unicode2bytes
 from buildbot.www.change_hook import ChangeHookResource
 from buildbot.www.hooks.github import _HEADER_CT
 from buildbot.www.hooks.github import _HEADER_EVENT
@@ -293,7 +294,9 @@ def _prepare_request(event, payload, _secret=None, headers=None):
         request.received_headers[_HEADER_CT] = _CT_JSON
 
         if _secret is not None:
-            signature = hmac.new(_secret, msg=payload, digestmod=sha1)
+            signature = hmac.new(unicode2bytes(_secret),
+                                 msg=unicode2bytes(payload),
+                                 digestmod=sha1)
             request.received_headers[_HEADER_SIGNATURE] = \
                 'sha1=%s' % (signature.hexdigest(),)
     else:

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import PY3
 
 import hmac
 from calendar import timegm
@@ -454,7 +455,10 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = _prepare_request('push', '')
 
         yield self.request.test_render(self.changeHook)
-        expected = "No JSON object could be decoded"
+        if PY3:
+            expected = "Expecting value: line 1 column 1 (char 0)"
+        else:
+            expected = "No JSON object could be decoded"
         self.assertEqual(len(self.changeHook.master.addedChanges), 0)
         self.assertEqual(self.request.written, expected)
         self.request.setResponseCode.assert_called_with(400, expected)

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -25,6 +25,8 @@ from dateutil.parser import parse as dateparse
 
 from twisted.python import log
 
+from buildbot.util import unicode2bytes
+
 try:
     import json
     assert json
@@ -78,7 +80,9 @@ class GitHubEventHandler(object):
             if hash_type != 'sha1':
                 raise ValueError('Unknown hash type: %s' % (hash_type,))
 
-            mac = hmac.new(self._secret, msg=content, digestmod=sha1)
+            mac = hmac.new(unicode2bytes(self._secret),
+                           msg=unicode2bytes(content),
+                           digestmod=sha1)
             # NOTE: hmac.compare_digest should be used, but it's only available
             # starting Python 2.7.7
             if mac.hexdigest() != hexdigest:


### PR DESCRIPTION
This fixes on Python 3:

```
trial buildbot.test.unit.test_www_hooks_github
```