### PR TITLE
transfer: add glob parameter to MultipleFileUpload

### DIFF
--- a/master/buildbot/newsfragments/multifileupload_glob.feature
+++ b/master/buildbot/newsfragments/multifileupload_glob.feature
@@ -1,0 +1,1 @@
+:py:class: `~buildbot.steps.transfer.MultipleFilUpload` now supports the `glob` parameter. If `glob` is set to `True` all `workersrcs` parameters will be run through `glob` and the result will be uploaded to `masterdest`

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -277,7 +277,7 @@ class MultipleFileUpload(_TransferBuildStep, WorkerAPICompatMixin,
 
         _TransferBuildStep.__init__(self, workdir=workdir, **buildstep_kwargs)
 
-        self.workersrcs = workersrcs
+        self.workersrcs = workersrcs if isinstance(workersrcs, list) else [workersrcs]
         self._registerOldWorkerAttr("workersrcs")
         self.masterdest = masterdest
         self.maxsize = maxsize

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -279,14 +279,14 @@ class CompositeStepMixin():
                                                'logEnviron': self.logEnviron, },
                                      **kwargs)
 
-    def runGlob(self, path):
+    def runGlob(self, path, **kwargs):
         """ find files matching a shell-style pattern"""
         def commandComplete(cmd):
             return cmd.updates['files'][-1]
 
         return self.runRemoteCommand('glob', {'path': path,
                                               'logEnviron': self.logEnviron, },
-                                     evaluateCommand=commandComplete)
+                                     evaluateCommand=commandComplete, **kwargs)
 
     def getFileContentFromWorker(self, filename, abandonOnFailure=False):
         self.checkWorkerHasCommand("uploadFile")

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -520,6 +520,25 @@ class TestMultipleFileUpload(steps.BuildStepMixin, unittest.TestCase):
         d = self.runStep()
         return d
 
+    def testMultipleString(self):
+        self.setupStep(
+            transfer.MultipleFileUpload(workersrcs="srcfile", masterdest=self.destdir))
+        self.expectCommands(
+            Expect('stat', dict(file="srcfile",
+                                workdir='wkdir'))
+            + Expect.update('stat', [stat.S_IFREG, 99, 99])
+            + 0,
+            Expect('uploadFile', dict(
+                workersrc="srcfile", workdir='wkdir',
+                blocksize=16384, maxsize=None, keepstamp=False,
+                writer=ExpectRemoteRef(remotetransfer.FileWriter)))
+            + Expect.behavior(uploadString("Hello world!"))
+            + 0)
+        self.expectOutcome(
+            result=SUCCESS, state_string="uploading 1 file")
+        d = self.runStep()
+        return d
+
     def testGlob(self):
         self.setupStep(
             transfer.MultipleFileUpload(

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -2175,7 +2175,8 @@ Transferring Multiple Files At Once
 
 In addition to the :bb:step:`FileUpload` and :bb:step:`DirectoryUpload` steps there is the :bb:step:`MultipleFileUpload` step for uploading a bunch of files (and directories) in a single :class:`BuildStep`.
 The step supports all arguments that are supported by :bb:step:`FileUpload` and :bb:step:`DirectoryUpload`, but instead of a the single ``workersrc`` parameter it takes a (plural) ``workersrcs`` parameter.
-This parameter should either be a list, or something that can be rendered as a list.::
+This parameter should either be a list, or something that can be rendered as a list.
+Additionally it supports the ``glob`` parameter if this parameter is set to ``True`` all arguments in ``workersrcs`` will be parsed through ``glob`` and the results will be uploaded to ``masterdest``.::
 
     from buildbot.plugins import steps
 


### PR DESCRIPTION
I was able to add `glob` functionality to the MultipleFilesUpload step. But I'm not quite satisfied because I had to inherit from `CompositeStepMixin` and add `**kwargs` to the `runGlob` function there. Is there a better way? Just implement the `runGlob` in `transfer.py` ? 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

