### PR TITLE
Fix some StringIO usages for Python 3

### DIFF
--- a/master/buildbot/db/migrate_utils.py
+++ b/master/buildbot/db/migrate_utils.py
@@ -38,7 +38,7 @@ def test_unicode(migrate_engine):
 
     # insert a unicode value in there
     u = u"Frosty the \N{SNOWMAN}"
-    b = '\xff\xff\x00'
+    b = b'\xff\xff\x00'
     ins = test_unicode.insert().values(u=u, b=b)
     migrate_engine.execute(ins)
 
@@ -46,7 +46,7 @@ def test_unicode(migrate_engine):
     row = migrate_engine.execute(sa.select([test_unicode])).fetchall()[0]
     assert isinstance(row['u'], text_type)
     assert row['u'] == u
-    assert isinstance(row['b'], str)
+    assert isinstance(row['b'], bytes)
     assert row['b'] == b
 
     # drop the test table

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -140,7 +140,8 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
         # public attributes
         self.name = ("%s:%s" % (self.hostname,
                                 os.path.abspath(self.basedir or '.')))
-        self.name = self.name.decode('ascii', 'replace')
+        if isinstance(self.name, bytes):
+            self.name = self.name.decode('ascii', 'replace')
         self.masterid = None
 
     def create_child_services(self):

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -193,14 +193,17 @@ class SyncLogFileWrapper(logobserver.LogObserver):
     # write methods
 
     def addStdout(self, data):
+        data = bytes2NativeString(data)
         self.chunks.append((self.STDOUT, data))
         self._delay(lambda: self.asyncLogfile.addStdout(data))
 
     def addStderr(self, data):
+        data = bytes2NativeString(data)
         self.chunks.append((self.STDERR, data))
         self._delay(lambda: self.asyncLogfile.addStderr(data))
 
     def addHeader(self, data):
+        data = bytes2NativeString(data)
         self.chunks.append((self.HEADER, data))
         self._delay(lambda: self.asyncLogfile.addHeader(data))
 

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -22,6 +22,7 @@ from future.utils import string_types
 from future.utils import text_type
 
 import re
+from io import StringIO
 
 from twisted.internet import defer
 from twisted.internet import error
@@ -31,7 +32,6 @@ from twisted.python import deprecate
 from twisted.python import failure
 from twisted.python import log
 from twisted.python import versions
-from twisted.python.compat import NativeStringIO
 from twisted.python.failure import Failure
 from twisted.python.reflect import accumulateClassList
 from twisted.web.util import formatFailure
@@ -224,7 +224,7 @@ class SyncLogFileWrapper(logobserver.LogObserver):
 
     def readlines(self):
         alltext = "".join(self.getChunks([self.STDOUT], onlyText=True))
-        io = NativeStringIO(alltext)
+        io = StringIO(alltext)
         return io.readlines()
 
     def getChunks(self, channels=None, onlyText=False):
@@ -384,9 +384,11 @@ class BuildStep(results.ResultComputingConfigMixin,
                 except AttributeError as e:
                     # if the callable raises an AttributeError
                     # python thinks it is actually workdir that is not existing.
-                    # python will then swallow the attribute error and call __getattr__ from worker_transition
+                    # python will then swallow the attribute error and call
+                    # __getattr__ from worker_transition
                     raise raise_with_traceback(CallableAttributeError(e))
-                    # we re-raise the original exception by changing its type, but keeping its stacktrace
+                    # we re-raise the original exception by changing its type,
+                    # but keeping its stacktrace
             else:
                 return self.build.workdir
 

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -32,6 +32,7 @@ from buildbot.status import builder
 from buildbot.status import buildrequest
 from buildbot.status import buildset
 from buildbot.util import bbcollections
+from buildbot.util import bytes2NativeString
 from buildbot.util import service
 from buildbot.util.eventual import eventually
 
@@ -347,7 +348,8 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         builder_status.setTags(tags)
         builder_status.description = description
         builder_status.master = self.master
-        builder_status.basedir = os.path.join(self.basedir, basedir)
+        builder_status.basedir = os.path.join(bytes2NativeString(self.basedir),
+                                              bytes2NativeString(basedir))
         builder_status.name = name  # it might have been updated
         builder_status.status = self
 

--- a/master/buildbot/steps/subunit.py
+++ b/master/buildbot/steps/subunit.py
@@ -16,8 +16,9 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from StringIO import StringIO
 from unittest import TestResult
+
+from twisted.python.compat import NativeStringIO
 
 from buildbot.process import logobserver
 from buildbot.process.results import FAILURE
@@ -46,7 +47,7 @@ class SubunitLogObserver(logobserver.LogLineObserver, TestResult):
         self.PROGRESS_SET = PROGRESS_SET
         self.PROGRESS_PUSH = PROGRESS_PUSH
         self.PROGRESS_POP = PROGRESS_POP
-        self.warningio = StringIO()
+        self.warningio = NativeStringIO()
         self.protocol = TestProtocolServer(self, self.warningio)
         self.skips = []
         self.seen_tags = set()  # don't yet know what tags does in subunit

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -145,11 +145,10 @@ class OldPerlModuleTest(shell.Test):
 
     def evaluateCommand(self, cmd):
         # Get stdio, stripping pesky newlines etc.
-        lines = map(
-            lambda line: line.replace('\r\n', '').replace(
-                '\r', '').replace('\n', ''),
-            self.getLog('stdio').readlines()
-        )
+        lines = [
+            line.replace('\r\n', '').replace('\r', '').replace('\n', '')
+            for line in self.getLog('stdio').readlines()
+        ]
         # .. the rest of this method isn't htat interesting, as long as the
         # statement above worked
         assert lines == ['a', 'b', 'c']

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from future.utils import iteritems
 
-from StringIO import StringIO
+from io import StringIO
 
 import mock
 

--- a/master/buildbot/test/integration/test_trigger.py
+++ b/master/buildbot/test/integration/test_trigger.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import StringIO
+from io import StringIO
 
 from twisted.internet import defer
 
@@ -62,7 +62,7 @@ class TriggeringMaster(RunMasterBase):
             build['steps'][1]['state_string'], 'triggered trigsched')
         builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), 2)
-        dump = StringIO.StringIO()
+        dump = StringIO()
         for b in builds:
             yield self.printBuild(b, dump)
         # depending on the environment the number of lines is different between

--- a/master/buildbot/test/unit/test_scripts_upgrade_master.py
+++ b/master/buildbot/test/unit/test_scripts_upgrade_master.py
@@ -17,12 +17,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
-import StringIO
 import sys
 
 import mock
 
 from twisted.internet import defer
+from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot import config as config_module
@@ -209,7 +209,7 @@ class TestUpgradeMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
     def test_upgradeDatabaseFail(self):
         setup = mock.Mock(side_effect=lambda **kwargs: defer.succeed(None))
         self.patch(connector.DBConnector, 'setup', setup)
-        self.patch(sys, 'stderr', StringIO.StringIO())
+        self.patch(sys, 'stderr', NativeStringIO())
         upgrade = mock.Mock(
             side_effect=lambda **kwargs: defer.fail(Exception("o noz")))
         self.patch(model.Model, 'upgrade', upgrade)

--- a/master/buildbot/test/unit/test_steps_subunit.py
+++ b/master/buildbot/test/unit/test_steps_subunit.py
@@ -16,10 +16,9 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import StringIO
-
 import mock
 
+from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 from zope.interface import implementer
 
@@ -44,7 +43,7 @@ class TestSetPropertiesFromEnv(steps.BuildStepMixin, unittest.TestCase):
         self.logobserver.errors = []
         self.logobserver.skips = []
         self.logobserver.testsRun = 0
-        self.logobserver.warningio = StringIO.StringIO()
+        self.logobserver.warningio = NativeStringIO()
         self.patch(subunit, 'SubunitLogObserver',
                    lambda: self.logobserver)
         return self.setUpBuildStep()

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -18,13 +18,13 @@ from __future__ import division
 from __future__ import print_function
 from future.utils import itervalues
 
-import StringIO
 import sys
 
 import mock
 
 from twisted.internet import defer
 from twisted.internet import reactor
+from twisted.python.compat import NativeStringIO
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 from zope.interface import implementer
@@ -140,7 +140,7 @@ class RunMasterBase(unittest.TestCase):
         @defer.inlineCallbacks
         def dump():
             if not self._passed:
-                dump = StringIO.StringIO()
+                dump = NativeStringIO()
                 print("FAILED! dumping build db for debug", file=dump)
                 builds = yield self.master.data.get(("builds",))
                 for build in builds:

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -382,7 +382,7 @@ def join_list(maybeList):
 
 def command_to_string(command):
     words = command
-    if isinstance(words, (str, text_type)):
+    if isinstance(words, string_types):
         words = words.split()
 
     try:
@@ -398,7 +398,7 @@ def command_to_string(command):
 
     # strip instances and other detritus (which can happen if a
     # description is requested before rendering)
-    words = [w for w in words if isinstance(w, (str, text_type))]
+    words = [w for w in words if isinstance(w, (string_types))]
 
     if len(words) < 1:
         return None
@@ -409,7 +409,8 @@ def command_to_string(command):
 
     # cmd was a comand and thus probably a bytestring.  Be gentle in
     # trying to covert it.
-    rv = rv.decode('ascii', 'replace')
+    if isinstance(rv, bytes):
+        rv = rv.decode('ascii', 'replace')
 
     return rv
 

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -31,6 +31,7 @@ import buildbot_worker
 from buildbot_worker import monkeypatches
 from buildbot_worker.commands import base
 from buildbot_worker.commands import registry
+from buildbot_worker.compat import bytes2NativeString
 
 
 class UnknownCommand(pb.Error):
@@ -79,7 +80,8 @@ class WorkerForBuilderBase(service.Service):
     def setBuilddir(self, builddir):
         assert self.parent
         self.builddir = builddir
-        self.basedir = os.path.join(self.bot.basedir, self.builddir)
+        self.basedir = os.path.join(bytes2NativeString(self.bot.basedir),
+                                    bytes2NativeString(self.builddir))
         if not os.path.isdir(self.basedir):
             os.makedirs(self.basedir)
 


### PR DESCRIPTION
This fixes the following tests under Python 3:

```
trial buildbot.test.unit.test_steps_subunit
trial buildbot.test.unit.test_scripts_upgrade_master
trial buildbot.test.integration.test_custom_buildstep
```

There are some interdependencies on `buildbot_net_usage_data.py` so when https://github.com/buildbot/buildbot/pull/2631 is merged, that will help.