### PR TITLE
Add __le__() and __eq__() methods in classes with __cmp__().

### DIFF
--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -143,7 +143,15 @@ class Change:
             self.codebase)
 
     def __cmp__(self, other):
+        # NOTE: __cmp__() and cmp() are gone on Python 3,
+        #       in favor of __le__ and __eq__().
         return self.number - other.number
+
+    def __eq__(self, other):
+        return self.number == other.number
+
+    def __lt__(self, other):
+        return self.number < other.number
 
     def asText(self):
         data = ""

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -117,8 +117,20 @@ class Row(object):
         self.__dict__.update(self.values)
 
     def __cmp__(self, other):
+        # NOTE: __cmp__() and cmp() are gone on Python 3,
+        #       in favor of __le__ and __eq__().
         return cmp(self.__class__, other.__class__) \
             or cmp(self.values, other.values)
+
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__ and
+                self.values == other.values)
+
+    def __lt__(self, other):
+        if self.__class__ != other.__class__:
+            raise TypeError("Cannot compare {} and {}".format(
+                              self.__class__, other.__class__))
+        return self.values < other.values
 
     def __repr__(self):
         return '%s(**%r)' % (self.__class__.__name__, self.values)


### PR DESCRIPTION
In Python 3, __cmp__() and cmp() are gone, in favor of __le__()
and __eq__().

See:
http://python3porting.com/problems.html#unorderable-types-cmp-and-cmp