### PR TITLE
exceptions module is gone in Python 3

### DIFF
--- a/master/buildbot/test/unit/test_steps_source_base_Source.py
+++ b/master/buildbot/test/unit/test_steps_source_base_Source.py
@@ -16,8 +16,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from exceptions import AttributeError
-
 import mock
 
 from twisted.trial import unittest


### PR DESCRIPTION
AttributeError is in builtins in Python 3,
and in Python 2 there is no need to import it, because exceptions.AttributeError is available
by default.