### PR TITLE
Replace im_func with __func__ on Python 3

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import PY3
 from future.utils import iteritems
 from future.utils import itervalues
 from future.utils import raise_with_traceback
@@ -705,7 +706,10 @@ class BuildStep(results.ResultComputingConfigMixin,
 
     def isNewStyle(self):
         # **temporary** method until new-style steps are the only supported style
-        return self.run.im_func is not BuildStep.run.im_func
+        if PY3:
+            return self.run.__func__ is not BuildStep.run
+        else:
+            return self.run.im_func is not BuildStep.run.im_func
 
     def start(self):
         # New-style classes implement 'run'.

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -377,7 +377,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
 
     def test_updateSummary_running_not_unicode(self):
         step = self.setup_summary_test()
-        step.getCurrentSummary = lambda: {'step': 'bytestring'}
+        step.getCurrentSummary = lambda: {'step': b'bytestring'}
         step._running = True
         step.updateSummary()
         self.clock.advance(1)


### PR DESCRIPTION
im_func is gone on Python 3.
Also, unbound methods are gone on Python 3,
so we must use BuildStep.run instead of BuildStep.run.__func__