### PR TITLE
Fix buildbot.test.unit.test_steps_shell on Python 3

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -134,8 +134,9 @@ class ShellCommand(buildstep.LoggingBuildStep):
         # check validity of arguments being passed to RemoteShellCommand
         invalid_args = []
         if PY3:
-            valid_rsc_args = inspect.signature(
+            signature = inspect.signature(
                 remotecommand.RemoteShellCommand.__init__)
+            valid_rsc_args = signature.parameters.keys()
         else:
             valid_rsc_args = inspect.getargspec(
                 remotecommand.RemoteShellCommand.__init__)[0]


### PR DESCRIPTION
This fixes on Python 3:

```
trial buildbot.test.unit.test_steps_shell
```
