### PR TITLE
Fix broken docs links

### DIFF
--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -175,6 +175,7 @@ linkcheck_ignore = [
     # Anchor check fails on rendered user files on GitHub, since GitHub uses
     # custom prefix for anchors in user generated content.
     r'https://github\.com/buildbot/guanlecoja-ui/tree/master#changelog',
+    r'http://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-apps',
 ]
 linkcheck_timeout = 10
 linkcheck_retries = 3

--- a/master/docs/developer/tests.rst
+++ b/master/docs/developer/tests.rst
@@ -70,9 +70,9 @@ project.  All new code must meet this requirement.
 
 Unit test modules are be named after the package or class they test, replacing
 ``.`` with ``_`` and omitting the ``buildbot_``. For example,
-:src:`test_schedulers_timed_Periodic.py <buildbot/test/unit/test_schedulers_timed_Periodic.py>`
+:src:`test_schedulers_timed_Periodic.py <master/buildbot/test/unit/test_schedulers_timed_Periodic.py>`
 tests the :class:`Periodic` class in
-:src:`buildbot/schedulers/timed.py`. Modules with only one class, or a few
+:src:`master/buildbot/schedulers/timed.py`. Modules with only one class, or a few
 trivial classes, can be tested in a single test module. For more complex
 situations, prefer to use multiple test modules.
 

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -43,7 +43,7 @@ SVN
 
 Darcs
 
-* :bb:chsrc:`PBChangeSource` (listening for connections from :src:`src/contrib/darcs_buildbot.py` in a commit script)
+* :bb:chsrc:`PBChangeSource` (listening for connections from :src:`master/contrib/darcs_buildbot.py` in a commit script)
 * :bb:chsrc:`Change Hooks` in WebStatus
 
 Mercurial

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -93,7 +93,7 @@ If your SMTP host requires authentication before it allows you to send emails, t
 
 .. note::
 
-   If for some reasons you are not able to send a notification with TLS enabled and specified user name and password, you might want to use :src:`master/contrib/check-smtp.py` to see if it works at all.
+   If for some reasons you are not able to send a notification with TLS enabled and specified user name and password, you might want to use :src:`master/contrib/check_smtp.py` to see if it works at all.
 
 If you want to require Transport Layer Security (TLS), then you can also set ``useTls``::
 

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -913,7 +913,7 @@ It requires `txrequests`_ package to allow interaction with the Bitbucket REST a
 It uses OAuth 2.x to authenticate with Bitbucket.
 To enable this, you need to go to your Bitbucket Settings -> OAuth page.
 Click "Add consumer".
-Give the new consumer a name, eg 'buildbot', and put in any URL as the callback (this is needed for Oauth 2.x but is not used by this reporter, eg 'https://localhost:8010/callback').
+Give the new consumer a name, eg 'buildbot', and put in any URL as the callback (this is needed for Oauth 2.x but is not used by this reporter, eg 'http://localhost:8010/callback').
 Give the consumer Repositories:Write access.
 After creating the consumer, you will then be able to see the OAuth key and secret.
 

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -210,7 +210,7 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     (optional)
     This allow to use TLS when connecting with the Docker socket.
     This should be a ``docker.tls.TLSConfig`` object.
-    See `docker-py's own documentation <https://docker-py.readthedocs.io/en/latest/tls/>`_ for more details on how to initialise this object.
+    See `docker-py's own documentation <https://docker-py.readthedocs.io/en/1.10.4/tls/>`_ for more details on how to initialise this object.
 
 ``followStartupLogs``
     (optional, defaults to false)
@@ -223,7 +223,7 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
 
 ``hostconfig``
     (optional)
-    Extra host configuration parameters passed as a dictionary used to create HostConfig object. See `docker-py's HostConfig documentation <https://docker-py.readthedocs.io/en/latest/hostconfig/>`_ for all the supported options.
+    Extra host configuration parameters passed as a dictionary used to create HostConfig object. See `docker-py's HostConfig documentation <https://docker-py.readthedocs.io/en/1.10.4/hostconfig/>`_ for all the supported options.
 
 Setting up Volumes
 ..................

--- a/master/docs/relnotes/0.8.6.rst
+++ b/master/docs/relnotes/0.8.6.rst
@@ -184,7 +184,7 @@ Features
   all the triggered builds. This URL is displayed in the waterfall and build
   details. See :bug:`2170`.
 
-* The :src:`master/contrib/fakemaster.py` script allows you to run arbitrary commands on a slave by emulating a master.
+* The ``master/contrib/fakemaster.py`` script allows you to run arbitrary commands on a slave by emulating a master.
   See the file itself for documentation.
 
 * MailNotifier allows multiple notification modes in the same instance.  See

--- a/master/docs/relnotes/0.8.9.rst
+++ b/master/docs/relnotes/0.8.9.rst
@@ -178,7 +178,7 @@ Features
 
 * Added zsh and bash tab-completions support for 'buildbot' command.
 
-* An example of a declarative configuration is included in :src:`master/contrib/SimpleConfig.py`, with copious comments.
+* An example of a declarative configuration is included in ``master/contrib/SimpleConfig.py``, with copious comments.
 
 * Systemd unit files for Buildbot are available in the :src:`master/contrib/` directory.
 


### PR DESCRIPTION
Fixed `make docschecks` invocation.
Looks like currently `linkcheck` is not being run nor on Travis, nor on MetaBuildbot.
