### PR TITLE
Remove RUN_FLAKY_TESTS requirements for a few tests.

### DIFF
--- a/master/buildbot/test/integration/test_trigger.py
+++ b/master/buildbot/test/integration/test_trigger.py
@@ -20,7 +20,6 @@ from io import StringIO
 
 from twisted.internet import defer
 
-from buildbot.test.util.decorators import flaky
 from buildbot.test.util.integration import RunMasterBase
 
 

--- a/master/buildbot/test/integration/test_trigger.py
+++ b/master/buildbot/test/integration/test_trigger.py
@@ -44,7 +44,6 @@ expectedOutput = """\
 
 class TriggeringMaster(RunMasterBase):
 
-    @flaky(bugNumber=3339)
     @defer.inlineCallbacks
     def test_trigger(self):
         yield self.setupConfig(masterConfig())

--- a/master/buildbot/test/unit/test_schedulers_triggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_triggerable.py
@@ -169,7 +169,6 @@ class Triggerable(scheduler.SchedulerMixin, unittest.TestCase):
         sched = self.makeScheduler(reason="Because I said so")
         self.assertEqual(sched.reason, "Because I said so")
 
-    @flaky(bugNumber=3339)
     def test_trigger(self):
         sched = self.makeScheduler(codebases={'cb': {'repository': 'r'}})
         # no subscription should be in place yet

--- a/master/buildbot/test/unit/test_schedulers_triggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_triggerable.py
@@ -29,7 +29,6 @@ from buildbot.schedulers import triggerable
 from buildbot.test.fake import fakedb
 from buildbot.test.util import interfaces
 from buildbot.test.util import scheduler
-from buildbot.test.util.decorators import flaky
 
 
 class TriggerableInterfaceTest(unittest.TestCase, interfaces.InterfaceTests):


### PR DESCRIPTION
Unicode fixes for Python 3 have fixed these tests on Python 2.

Fixes: #3339