### PR TITLE
Replace Python 3 generator expressions with lists

### DIFF
--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -143,8 +143,10 @@ class BuildRequestsEndpoint(Db2DataMixin, base.Endpoint):
             claimed=claimed,
             bsid=bsid,
             resultSpec=resultSpec)
-        defer.returnValue(
-            [(yield self.db2data(br)) for br in buildrequests])
+        results = []
+        for br in buildrequests:
+            results.append((yield self.db2data(br)))
+        defer.returnValue(results)
 
 
 class BuildRequest(base.ResourceType):

--- a/master/buildbot/data/buildsets.py
+++ b/master/buildbot/data/buildsets.py
@@ -152,9 +152,11 @@ class Buildset(base.ResourceType):
 
         # get each of the sourcestamps for this buildset (sequentially)
         bsdict = yield self.master.db.buildsets.getBuildset(bsid)
-        sourcestamps = [
-            (yield self.master.data.get(('sourcestamps', str(ssid)))).copy()
-            for ssid in bsdict['sourcestamps']]
+        sourcestamps = []
+        for ssid in bsdict['sourcestamps']:
+            sourcestamps.append(
+                (yield self.master.data.get(('sourcestamps', str(ssid)))).copy()
+            )
 
         # notify about the component build requests
         brResource = self.master.data.getResourceType("buildrequest")
@@ -222,10 +224,13 @@ class Buildset(base.ResourceType):
         # get the sourcestamps for the message
         # get each of the sourcestamps for this buildset (sequentially)
         bsdict = yield self.master.db.buildsets.getBuildset(bsid)
-        sourcestamps = [
-            copy.deepcopy((yield self.master.data.get(
-                ('sourcestamps', str(ssid)))))
-            for ssid in bsdict['sourcestamps']]
+        sourcestamps = []
+        for ssid in bsdict['sourcestamps']:
+            sourcestamps.append(
+                copy.deepcopy(
+                    (yield self.master.data.get(('sourcestamps', str(ssid))))
+                )
+            )
 
         msg = dict(
             bsid=bsid,

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -90,8 +90,10 @@ class ChangesEndpoint(FixerMixin, base.Endpoint):
                 changes = yield self.master.db.changes.getRecentChanges(resultSpec.limit)
             else:
                 changes = yield self.master.db.changes.getChanges()
-        changes = [(yield self._fixChange(ch)) for ch in changes]
-        defer.returnValue(changes)
+        results = []
+        for ch in changes:
+            results.append((yield self._fixChange(ch)))
+        defer.returnValue(results)
 
 
 class Change(base.ResourceType):

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -86,7 +86,10 @@ class LogsEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
             defer.returnValue([])
             return
         logs = yield self.master.db.logs.getLogs(stepid=stepid)
-        defer.returnValue([(yield self.db2data(dbdict)) for dbdict in logs])
+        results = []
+        for dbdict in logs:
+            results.append((yield self.db2data(dbdict)))
+        defer.returnValue(results)
 
 
 class Log(base.ResourceType):

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -87,7 +87,10 @@ class StepsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
             if buildid is None:
                 return
         steps = yield self.master.db.steps.getSteps(buildid=buildid)
-        defer.returnValue([(yield self.db2data(dbdict)) for dbdict in steps])
+        results = []
+        for dbdict in steps:
+            results.append((yield self.db2data(dbdict)))
+        defer.returnValue(results)
 
 
 class Step(base.ResourceType):

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1213,7 +1213,10 @@ class FakeSourceStampsComponent(FakeDBComponent):
         breq = yield self.db.buildrequests.getBuildRequest(build['buildrequestid'])
         bset = yield self.db.buildsets.getBuildset(breq['buildsetid'])
 
-        defer.returnValue([(yield self.getSourceStamp(ssid)) for ssid in bset['sourcestamps']])
+        results = []
+        for ssid in bset['sourcestamps']:
+            results.append((yield self.getSourceStamp(ssid)))
+        defer.returnValue(results)
 
 
 class FakeBuildsetsComponent(FakeDBComponent):


### PR DESCRIPTION
@exarkun explained this here: http://twistedmatrix.com/pipermail/twisted-python/2017-January/031104.html

```
On Python 2, [(yield self.db2data(br)) for br in buildrequests] is a list comprehension.  It will have len(buildrequests) elements and each will be the value sent back in to the generator via the yield expression.

On Python 3, the same expression is a list of one element which is a generator expression.

This form is much clearer, I think, and behaves as intended on both versions of Python:

    results = []
    for br in buildrequests:
        results.append((yield self.db2data(br)))
    defer.returnValue(results)
```

Thanks to @exarkun for the explanation.