### PR TITLE
Change tuple to list, and fix logic error which should use '<' operator.

### DIFF
--- a/master/buildbot/test/unit/test_process_remotecommand.py
+++ b/master/buildbot/test/unit/test_process_remotecommand.py
@@ -166,7 +166,7 @@ class TestRunCommand(unittest.TestCase, Tests):
             return '2.16'
 
         def workerVersionIsOlderThan(command, minversion):
-            return ('2', '16') > minversion.split('.')
+            return ['2', '16'] < minversion.split('.')
 
         step = mock.Mock()
         step.workerVersionIsOlderThan = workerVersionIsOlderThan


### PR DESCRIPTION
Fixes Python 3 error:
TypeError: '>' not supported between instances of 'tuple' and 'list'
