### PR TITLE
Use context managers to plug leaks of open file handles.

### DIFF
--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -64,8 +64,9 @@ class MaildirSource(MaildirService, util.ComparableMixin):
 
         @d.addCallback
         def parse_file(_):
-            f = self.moveToCurDir(filename)
-            return self.parse_file(f, self.prefix)
+            with self.moveToCurDir(filename) as f:
+                parsedFile = self.parse_file(f, self.prefix)
+            return parsedFile
 
         @d.addCallback
         def add_change(chtuple):

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -75,8 +75,9 @@ class JobdirService(MaildirService):
         MaildirService.__init__(self, basedir)
 
     def messageReceived(self, filename):
-        f = self.moveToCurDir(filename)
-        return self.scheduler.handleJobFile(filename, f)
+        with self.moveToCurDir(filename) as f:
+            rv = self.scheduler.handleJobFile(filename, f)
+        return rv
 
 
 class Try_Jobdir(TryBase):

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -102,7 +102,8 @@ def isBuildmasterDir(dir):
 
     buildbot_tac = os.path.join(dir, "buildbot.tac")
     try:
-        contents = open(buildbot_tac).read()
+        with open(buildbot_tac) as f:
+            contents = f.read()
     except IOError as exception:
         print_error("error reading '%s': %s" %
                     (buildbot_tac, exception.strerror))
@@ -122,7 +123,8 @@ def getConfigFromTac(basedir, quiet=False):
         # relocatable buildmasters
         tacGlobals = {'__file__': tacFile}
         try:
-            exec(open(tacFile).read(), tacGlobals)
+            with open(tacFile) as f:
+                exec(f.read(), tacGlobals)
         except Exception:
             if not quiet:
                 traceback.print_exc()

--- a/master/buildbot/test/unit/test_scripts_create_master.py
+++ b/master/buildbot/test/unit/test_scripts_create_master.py
@@ -104,12 +104,14 @@ class TestCreateMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
         self.tearDownDirs()
 
     def assertInTacFile(self, str):
-        self.assertIn(str,
-                      open(os.path.join('test', 'buildbot.tac'), 'rt').read())
+        with open(os.path.join('test', 'buildbot.tac'), 'rt') as f:
+            content = f.read()
+        self.assertIn(str, content)
 
     def assertNotInTacFile(self, str):
-        self.assertNotIn(str,
-                         open(os.path.join('test', 'buildbot.tac'), 'rt').read())
+        with open(os.path.join('test', 'buildbot.tac'), 'rt') as f:
+            content = f.read()
+        self.assertNotIn(str, content)
 
     def assertDBSetup(self, basedir=None, db_url='sqlite:///state.sqlite',
                       verbose=True):

--- a/master/buildbot/test/unit/test_util_maildir.py
+++ b/master/buildbot/test/unit/test_util_maildir.py
@@ -91,7 +91,8 @@ class TestMaildirService(dirs.DirsMixin, unittest.TestCase):
         newfile = os.path.join(self.newdir, "newmsg")
         open(tmpfile, "w").close()
         os.rename(tmpfile, newfile)
-        self.svc.moveToCurDir("newmsg")
+        f = self.svc.moveToCurDir("newmsg")
+        f.close()
         self.assertEqual([os.path.exists(os.path.join(d, "newmsg"))
                           for d in (self.newdir, self.curdir, self.tmpdir)],
                          [False, True, False])

--- a/master/contrib/hgbuildbot.py
+++ b/master/contrib/hgbuildbot.py
@@ -174,7 +174,9 @@ def hook(ui, repo, hooktype, node=None, source=None, **kwargs):
             ui.write('* Virtualenv "%s" does not exist.\n' % venv)
         else:
             activate_this = os.path.join(venv, "bin/activate_this.py")
-            exec(open(activate_this).read(), dict(__file__=activate_this))
+            with open(activate_this) as f:
+                activateThisScript = f.read()
+            exec(activateThisScript, dict(__file__=activate_this))
 
     # - auth
     username = ui.config('hgbuildbot', 'user')

--- a/master/contrib/run_maxq.py
+++ b/master/contrib/run_maxq.py
@@ -41,7 +41,8 @@ for testlist in files:
         print("running test", test)
 
         try:
-            exec(open(test).read(), globals().copy())
+            with open(test) as f:
+                exec(f.read(), globals().copy())
 
         except Exception:
             ei = sys.exc_info()

--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -87,7 +87,8 @@ if 'VERSION' in os.environ:
     version = os.environ['VERSION']
 else:
     gl = {'__file__': '../buildbot/__init__.py'}
-    exec(open('../buildbot/__init__.py').read(), gl)
+    with open('../buildbot/__init__.py') as f:
+        exec(f.read(), gl)
     version = gl['version']
 # The full version, including alpha/beta/rc tags.
 release = version

--- a/master/setup.py
+++ b/master/setup.py
@@ -89,10 +89,12 @@ class our_sdist(sdist):
         # ensure that NEWS has a copy of the latest release notes, with the
         # proper version substituted
         src_fn = os.path.join('docs', 'relnotes/index.rst')
-        src = open(src_fn).read()
+        with open(src_fn) as f:
+            src = f.read()
         src = src.replace('|version|', version)
         dst_fn = os.path.join(base_dir, 'NEWS')
-        open(dst_fn, 'w').write(src)
+        with open(dst_fn, 'w') as f:
+            f.write(src)
 
 
 def define_plugin_entry(name, module_name):

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -54,7 +54,8 @@ def getVersion(init_file):
     try:
         cwd = os.path.dirname(os.path.abspath(init_file))
         fn = os.path.join(cwd, 'VERSION')
-        version = open(fn).read().strip()
+        with open(fn) as f:
+            version = f.read().strip()
         return version
     except IOError:
         pass

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -315,7 +315,8 @@ class BotBase(service.MultiService):
             for f in os.listdir(basedir):
                 filename = os.path.join(basedir, f)
                 if os.path.isfile(filename):
-                    files[f] = open(filename, "r").read()
+                    with open(filename, "r") as fin:
+                        files[f] = fin.read()
         if not self.numcpus:
             try:
                 self.numcpus = multiprocessing.cpu_count()
@@ -386,6 +387,7 @@ class WorkerBase(service.MultiService):
             hostname = socket.getfqdn()
 
         try:
-            open(filename, "w").write("%s\n" % hostname)
+            with open(filename, "w") as f:
+                f.write("%s\n" % hostname)
         except Exception:
             log.msg("failed - ignoring")

--- a/worker/buildbot_worker/commands/base.py
+++ b/worker/buildbot_worker/commands/base.py
@@ -412,10 +412,13 @@ class SourceBaseCommand(Command):
         @returns: source data
         @raises: IOError if the file does not exist
         """
-        return open(self.sourcedatafile, "r").read()
+        with open(self.sourcedatafile, "r") as f:
+            sourceData = f.read()
+        return sourceData
 
     def writeSourcedata(self, res):
-        open(self.sourcedatafile, "w").write(self.sourcedata)
+        with open(self.sourcedatafile, "w") as f:
+            f.write(self.sourcedata)
         return res
 
     def sourcedirIsUpdateable(self):

--- a/worker/buildbot_worker/scripts/base.py
+++ b/worker/buildbot_worker/scripts/base.py
@@ -26,7 +26,8 @@ def isWorkerDir(dir):
 
     buildbot_tac = os.path.join(dir, "buildbot.tac")
     try:
-        contents = open(buildbot_tac).read()
+        with open(buildbot_tac) as f:
+            contents = f.read()
     except IOError as exception:
         print_error("error reading '%s': %s" %
                     (buildbot_tac, exception.strerror))

--- a/worker/buildbot_worker/scripts/create_worker.py
+++ b/worker/buildbot_worker/scripts/create_worker.py
@@ -115,7 +115,8 @@ def _makeBuildbotTac(basedir, tac_file_contents, quiet):
 
     if os.path.exists(tacfile):
         try:
-            oldcontents = open(tacfile, "rt").read()
+            with open(tacfile, "rt") as f:
+                oldcontents = f.read()
         except IOError as exception:
             raise CreateWorkerError("error reading %s: %s" %
                                     (tacfile, exception.strerror))
@@ -132,9 +133,8 @@ def _makeBuildbotTac(basedir, tac_file_contents, quiet):
         tacfile = os.path.join(basedir, "buildbot.tac.new")
 
     try:
-        f = open(tacfile, "wt")
-        f.write(tac_file_contents)
-        f.close()
+        with open(tacfile, "wt") as f:
+            f.write(tac_file_contents)
         os.chmod(tacfile, 0o600)
     except IOError as exception:
         raise CreateWorkerError("could not write %s: %s" %

--- a/worker/buildbot_worker/test/unit/test_bot_Worker.py
+++ b/worker/buildbot_worker/test/unit/test_bot_Worker.py
@@ -151,8 +151,9 @@ class TestWorker(misc.PatcherMixin, unittest.TestCase):
                                  "testy", "westy", self.basedir,
                                  keepalive=0, umask=0o22)
         self.worker.recordHostname(self.basedir)
-        self.assertEqual(open(os.path.join(self.basedir, "twistd.hostname")).read().strip(),
-                         'test-hostname.domain.com')
+        with open(os.path.join(self.basedir, "twistd.hostname")) as f:
+            twistdHostname = f.read().strip()
+        self.assertEqual(twistdHostname, 'test-hostname.domain.com')
 
     def test_recordHostname_getfqdn(self):
         def missing():
@@ -164,8 +165,9 @@ class TestWorker(misc.PatcherMixin, unittest.TestCase):
                                  "testy", "westy", self.basedir,
                                  keepalive=0, umask=0o22)
         self.worker.recordHostname(self.basedir)
-        self.assertEqual(open(os.path.join(self.basedir, "twistd.hostname")).read().strip(),
-                         'test-hostname.domain.com')
+        with open(os.path.join(self.basedir, "twistd.hostname")) as f:
+            twistdHostname = f.read().strip()
+        self.assertEqual(twistdHostname, 'test-hostname.domain.com')
 
     def test_worker_graceful_shutdown(self):
         """Test that running the build worker's gracefulShutdown method results

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -422,7 +422,9 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
             ])
             datafile = os.path.join(self.basedir, 'data')
             self.assertTrue(os.path.exists(datafile))
-            self.assertEqual(open(datafile, mode="rb").read(), test_data)
+            with open(datafile, mode="rb") as f:
+                datafileContent = f.read()
+            self.assertEqual(datafileContent, test_data)
             if runtime.platformType != 'win32':
                 self.assertEqual(os.stat(datafile).st_mode & 0o777, 0o777)
         d.addCallback(check)
@@ -449,7 +451,9 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
             ])
             datafile = os.path.join(self.basedir, 'workdir', 'subdir', 'data')
             self.assertTrue(os.path.exists(datafile))
-            self.assertEqual(open(datafile, mode="rb").read(), test_data)
+            with open(datafile, mode="rb") as f:
+                datafileContent = f.read()
+            self.assertEqual(datafileContent, test_data)
         d.addCallback(check)
         return d
 

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -477,7 +477,8 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         for pidfile in self.pidfiles:
             if not os.path.exists(pidfile):
                 continue
-            pid = open(pidfile).read()
+            with open(pidfile) as f:
+                pid = f.read()
             if not pid:
                 return
             pid = int(pid)

--- a/worker/buildbot_worker/test/util/misc.py
+++ b/worker/buildbot_worker/test/util/misc.py
@@ -112,13 +112,16 @@ class FileIOMixin(object):
         @param file_contents: contents that will be returned by file object's
                               read() method
         """
-        # create mocked file object that returns 'file_contents' on read()
-        # and tracks any write() calls
-        self.fileobj = mock.Mock()
-        self.fileobj.read = mock.Mock(return_value=file_contents)
-        self.fileobj.write = mock.Mock()
+        # Use mock.mock_open() to create a substitute for
+        # open().
+        fakeOpen = mock.mock_open(read_data=file_contents)
 
-        # patch open() to return mocked object
+        # When fakeOpen() is called, it returns a Mock
+        # that has these methods: read(), write(), __enter__(), __exit__().
+        # read() will always return the value of the 'file_contents variable.
+        self.fileobj = fakeOpen()
+
+        # patch open() to always return our Mock file object
         self.open = mock.Mock(return_value=self.fileobj)
         self.patch(builtins, "open", self.open)
 
@@ -131,7 +134,14 @@ class FileIOMixin(object):
         @param strerror: exception's strerror value
         @param filename: exception's filename value
         """
-        self.open = mock.Mock(side_effect=IOError(errno, strerror, filename))
+        # Use mock.mock_open() to create a substitute for
+        # open().
+        fakeOpen = mock.mock_open()
+
+        # Add side_effect so that calling fakeOpen() will always
+        # raise an IOError.
+        fakeOpen.side_effect = IOError(errno, strerror, filename)
+        self.open = fakeOpen
         self.patch(builtins, "open", self.open)
 
     def setUpReadError(self, errno=errno.EIO, strerror="dummy-msg",
@@ -144,9 +154,19 @@ class FileIOMixin(object):
         @param filename: exception's filename value
 
         """
-        self.fileobj = mock.Mock()
-        self.fileobj.read = mock.Mock(side_effect=IOError(errno, strerror,
-                                                          filename))
+        # Use mock.mock_open() to create a substitute for
+        # open().
+        fakeOpen = mock.mock_open()
+
+        # When fakeOpen() is called, it returns a Mock
+        # that has these methods: read(), write(), __enter__(), __exit__().
+        self.fileobj = fakeOpen()
+
+        # Add side_effect so that calling read() will always
+        # raise an IOError.
+        self.fileobj.read.side_effect = IOError(errno, strerror, filename)
+
+        # patch open() to always return our Mock file object
         self.open = mock.Mock(return_value=self.fileobj)
         self.patch(builtins, "open", self.open)
 
@@ -159,9 +179,19 @@ class FileIOMixin(object):
         @param strerror: exception's strerror value
         @param filename: exception's filename value
         """
-        self.fileobj = mock.Mock()
-        self.fileobj.write = mock.Mock(side_effect=IOError(errno, strerror,
-                                                           filename))
+        # Use mock.mock_open() to create a substitute for
+        # open().
+        fakeOpen = mock.mock_open()
+
+        # When fakeOpen() is called, it returns a Mock
+        # that has these methods: read(), write(), __enter__(), __exit__().
+        self.fileobj = fakeOpen()
+
+        # Add side_effect so that calling write() will always
+        # raise an IOError.
+        self.fileobj.write.side_effect = IOError(errno, strerror, filename)
+
+        # patch open() to always return our Mock file object
         self.open = mock.Mock(return_value=self.fileobj)
         self.patch(builtins, "open", self.open)
 

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -43,7 +43,8 @@ class our_install_data(install_data):
         install_data.run(self)
         # ensure there's a buildbot_worker/VERSION file
         fn = os.path.join(self.install_dir, 'buildbot_worker', 'VERSION')
-        open(fn, 'w').write(version)
+        with open(fn, 'w') as f:
+            f.write(version)
         self.outfiles.append(fn)
 
 
@@ -58,10 +59,12 @@ class our_sdist(sdist):
         # ensure that NEWS has a copy of the latest release notes, copied from
         # the master tree, with the proper version substituted
         src_fn = os.path.join('..', 'master', 'docs', 'relnotes/index.rst')
-        src = open(src_fn).read()
+        with open(src_fn) as f:
+            src = f.read()
         src = src.replace('|version|', version)
         dst_fn = os.path.join(base_dir, 'NEWS')
-        open(dst_fn, 'w').write(src)
+        with open(dst_fn, 'w') as f:
+            f.write(src)
 
 setup_args = {
     'name': "buildbot-worker",


### PR DESCRIPTION
Fixes this warning on Python 3:
    builtins.ResourceWarning: unclosed file
