### PR TITLE
dataBuffer must be bytes

### DIFF
--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -167,7 +167,7 @@ class Connection(base.Connection, pb.Avatar):
             # loseConnection) somehow prevents the notifyOnDisconnect
             # handlers from being run. Bummer.
             tport.offset = 0
-            tport.dataBuffer = ""
+            tport.dataBuffer = b""
         except Exception:
             # however, these hacks are pretty internal, so don't blow up if
             # they fail or are unavailable


### PR DESCRIPTION
dataBuffer must be bytes, because twisted.internet.abstract.FileDescr…iptor.dataBuffer must be bytes

This fixes some tests in Python 3
