### PR TITLE
test_checkconfig: always create different config dir

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -246,6 +246,7 @@ erroring
 errortoo
 et
 exe
+execfile
 executables
 exe's
 expanduser

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -119,3 +119,6 @@ warnings.filterwarnings('ignore', "Not importing directory.*docker': missing __i
 
 # FIXME: needs to be sorted out (#3666)
 warnings.filterwarnings('ignore', "Invalid utf8 character string")
+
+# twisted.compat.execfile is using 'U' https://twistedmatrix.com/trac/ticket/9023
+warnings.filterwarnings('ignore', "'U' mode is deprecated", DeprecationWarning)

--- a/master/buildbot/test/unit/test_scripts_checkconfig.py
+++ b/master/buildbot/test/unit/test_scripts_checkconfig.py
@@ -35,7 +35,9 @@ from buildbot.test.util import dirs
 class TestConfigLoader(dirs.DirsMixin, unittest.TestCase):
 
     def setUp(self):
-        return self.setUpDirs('configdir')
+        # config dir must be unique so that the python runtime does not optimize its list of module
+        self.configdir = self.mktemp()
+        return self.setUpDirs(self.configdir)
 
     def tearDown(self):
         return self.tearDownDirs()
@@ -44,17 +46,17 @@ class TestConfigLoader(dirs.DirsMixin, unittest.TestCase):
 
     def do_test_load(self, config='', other_files={},
                      stdout_re=None, stderr_re=None):
-        configFile = os.path.join('configdir', 'master.cfg')
+        configFile = os.path.join(self.configdir, 'master.cfg')
         with open(configFile, "w") as f:
             f.write(config)
         for filename, contents in iteritems(other_files):
             if isinstance(filename, type(())):
-                fn = os.path.join('configdir', *filename)
+                fn = os.path.join(self.configdir, *filename)
                 dn = os.path.dirname(fn)
                 if not os.path.isdir(dn):
                     os.makedirs(dn)
             else:
-                fn = os.path.join('configdir', filename)
+                fn = os.path.join(self.configdir, filename)
             with open(fn, "w") as f:
                 f.write(contents)
 
@@ -63,7 +65,7 @@ class TestConfigLoader(dirs.DirsMixin, unittest.TestCase):
         stderr = sys.stderr = NativeStringIO()
         try:
             checkconfig._loadConfig(
-                basedir='configdir', configFile="master.cfg", quiet=False)
+                basedir=self.configdir, configFile="master.cfg", quiet=False)
         finally:
             sys.stdout, sys.stderr = old_stdout, old_stderr
         if stdout_re:


### PR DESCRIPTION
fix for python3

It looks like python3 added some optimization for the import method.

both tests are importing files from _trialtemp/configdir , but between the two tests, the list available modules actually change.

In the second test however, if you run from within the same python runtime, then python won't look again at the directory, and thus wont see it has changed since last time.
So it will not find the new module. If we change 'configdir' with mkstemp, then it will work.

also remove a warning from https://twistedmatrix.com/trac/ticket/9023#ticket
