### PR TITLE
fix vacuum for python 3.6

### DIFF
--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -76,6 +76,9 @@ class SqlLiteStrategy(Strategy):
         # try to enable WAL logging
         if u.database:
             def connect_listener(connection, record):
+                # default for PY2, not anymore for PY3, and cause issue with VACUUM
+                # (it thinks it is in a transaction while it is not)
+                connection.isolation_level = None
                 connection.execute("pragma checkpoint_fullfsync = off")
 
             sa.event.listen(engine.pool, 'connect', connect_listener)

--- a/master/buildbot/scripts/cleanupdb.py
+++ b/master/buildbot/scripts/cleanupdb.py
@@ -58,9 +58,8 @@ def doCleanupDatabase(config, master_cfg):
 
         # sqlite vacuum function rebuild the whole database to claim
         # free disk space back
-        def thd(engine):
-            r = engine.execute("vacuum;")
-            r.close()
+        def thd(conn):
+            conn.execute("vacuum;").close()
         yield db.pool.do(thd)
 
 


### PR DESCRIPTION
Changed in version 3.6: sqlite3 used to implicitly commit an open transaction before DDL statements. This is no longer the case.

I removed all the actions of the cleanupdb command, and sqlite3 still think I am in a transaction.
looking at Connection.in_transaction, it returns False.

So I am not sure if it is a bug or something outside of my understanding.
