### PR TITLE
worker: fix cancellation error in missing timer if it is already called

### DIFF
--- a/master/buildbot/newsfragments/missing_timer.bugfix
+++ b/master/buildbot/newsfragments/missing_timer.bugfix
@@ -1,0 +1,1 @@
+Fix issue with ``DelayedCalled`` already called, and worker missing notification email never received.

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -57,7 +57,8 @@ class FakeUpdates(service.AsyncService):
         self.stepStateString = {}  # { stepid : string }
         self.stepUrls = {}  # { stepid : [(name,url)] }
         self.properties = []
-    # extra assertions
+        self.missingWorkers = []
+        # extra assertions
 
     def assertProperties(self, sourced, properties):
         self.testcase.assertIsInstance(properties, dict)
@@ -437,6 +438,9 @@ class FakeUpdates(service.AsyncService):
     def deconfigureAllWorkersForMaster(self, masterid):
         return self.master.db.workers.deconfigureAllWorkersForMaster(
             masterid=masterid)
+
+    def workerMissing(self, workerid, masterid, last_connection, notify):
+        self.missingWorkers.append((workerid, masterid, last_connection, notify))
 
 
 class FakeDataConnector(service.AsyncMultiService):

--- a/master/buildbot/test/unit/test_worker_base.py
+++ b/master/buildbot/test/unit/test_worker_base.py
@@ -321,7 +321,7 @@ class TestAbstractWorker(unittest.TestCase):
                             missing_timeout=3600)
         bs.parent = mock.Mock()
         bs.startMissingTimer()
-        self.assertEqual(bs.missing_timer, None)
+        self.assertNotEqual(bs.missing_timer, None)
 
     def test_missing_timer(self):
         bs = ConcreteWorker('bot', 'pass',
@@ -506,6 +506,14 @@ class TestAbstractWorker(unittest.TestCase):
         yield worker.shutdownRequested()
         self.assertEqual(worker.worker_status.getGraceful(), True)
 
+    @defer.inlineCallbacks
+    def test_missing_timer_missing(self):
+        worker = self.createWorker(attached=False, missing_timeout=1)
+        yield worker.startService()
+        self.assertNotEqual(worker.missing_timer, None)
+        yield self.clock.advance(1)
+        self.assertEqual(worker.missing_timer, None)
+        self.assertEqual(len(self.master.data.updates.missingWorkers), 1)
 
 class TestAbstractLatentWorker(unittest.SynchronousTestCase):
 

--- a/master/buildbot/test/unit/test_worker_base.py
+++ b/master/buildbot/test/unit/test_worker_base.py
@@ -320,6 +320,7 @@ class TestAbstractWorker(unittest.TestCase):
         bs = ConcreteWorker('bot', 'pass',
                             missing_timeout=3600)
         bs.parent = mock.Mock()
+        bs.running = True
         bs.startMissingTimer()
         self.assertNotEqual(bs.missing_timer, None)
 
@@ -328,6 +329,7 @@ class TestAbstractWorker(unittest.TestCase):
                             notify_on_missing=['abc'],
                             missing_timeout=100)
         bs.parent = mock.Mock()
+        bs.running = True
         bs.startMissingTimer()
         self.assertNotEqual(bs.missing_timer, None)
         bs.stopMissingTimer()
@@ -514,6 +516,16 @@ class TestAbstractWorker(unittest.TestCase):
         yield self.clock.advance(1)
         self.assertEqual(worker.missing_timer, None)
         self.assertEqual(len(self.master.data.updates.missingWorkers), 1)
+
+    @defer.inlineCallbacks
+    def test_missing_timer_stopped(self):
+        worker = self.createWorker(attached=False, missing_timeout=1)
+        yield worker.startService()
+        self.assertNotEqual(worker.missing_timer, None)
+        yield worker.stopService()
+        self.assertEqual(worker.missing_timer, None)
+        self.assertEqual(len(self.master.data.updates.missingWorkers), 0)
+
 
 class TestAbstractLatentWorker(unittest.SynchronousTestCase):
 

--- a/master/buildbot/test/unit/test_worker_local.py
+++ b/master/buildbot/test/unit/test_worker_local.py
@@ -76,6 +76,7 @@ class TestLocalWorker(unittest.TestCase):
         # make sure that we can provide an absolute path
         self.assertEqual(
             old.remote_worker.bot.basedir, os.path.abspath('custom'))
+        yield old.stopService()
 
     @defer.inlineCallbacks
     def test_workerinfo(self):
@@ -87,3 +88,4 @@ class TestLocalWorker(unittest.TestCase):
         yield wrk.startService()
         info = yield wrk.conn.remoteGetWorkerInfo()
         self.assertIn("worker_commands", info)
+        yield wrk.stopService()

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -302,7 +302,8 @@ class AbstractWorker(service.BuildbotService, object):
 
     def stopMissingTimer(self):
         if self.missing_timer:
-            self.missing_timer.cancel()
+            if self.missing_timer.active():
+                self.missing_timer.cancel()
             self.missing_timer = None
 
     def isConnected(self):
@@ -314,7 +315,7 @@ class AbstractWorker(service.BuildbotService, object):
         if not self.parent:
             return
         last_connection = time.ctime(time.time() - self.missing_timeout)
-        yield self.master.data.updates.workerMissing(
+        self.master.data.updates.workerMissing(
             workerid=self.workerid,
             masterid=self.master.masterid,
             last_connection=last_connection,

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -55,6 +55,7 @@ class AbstractWorker(service.BuildbotService, object):
     quarantine_timer = None
     quarantine_timeout = quarantine_initial_timeout = 10
     quarantine_max_timeout = 60 * 60
+    start_missing_on_startup = True
 
     def checkConfig(self, name, password, max_builds=None,
                     notify_on_missing=None,
@@ -220,12 +221,15 @@ class AbstractWorker(service.BuildbotService, object):
     @defer.inlineCallbacks
     def startService(self):
         self.updateLocks()
-        self.startMissingTimer()
         self.workerid = yield self.master.data.updates.findWorkerId(
             self.name)
 
         yield self._getWorkerInfo()
         yield service.BuildbotService.startService(self)
+
+        # startMissingTimer wants the service to be running to really start
+        if self.start_missing_on_startup:
+            self.startMissingTimer()
 
     @defer.inlineCallbacks
     def reconfigService(self, name, password, max_builds=None,
@@ -295,7 +299,7 @@ class AbstractWorker(service.BuildbotService, object):
         yield service.BuildbotService.stopService(self)
 
     def startMissingTimer(self):
-        if self.missing_timeout and self.parent:
+        if self.missing_timeout and self.parent and self.running:
             self.stopMissingTimer()  # in case it's already running
             self.missing_timer = self.master.reactor.callLater(self.missing_timeout,
                                                                self._missing_timer_fired)

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -295,7 +295,7 @@ class AbstractWorker(service.BuildbotService, object):
         yield service.BuildbotService.stopService(self)
 
     def startMissingTimer(self):
-        if self.notify_on_missing and self.missing_timeout and self.parent:
+        if self.missing_timeout and self.parent:
             self.stopMissingTimer()  # in case it's already running
             self.missing_timer = self.master.reactor.callLater(self.missing_timeout,
                                                                self._missing_timer_fired)

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -102,11 +102,7 @@ class AbstractLatentWorker(AbstractWorker):
             self._setBuildWaitTimer()
             return defer.succeed(True)
         if not self._substantiation_notifier:
-            if self.parent and not self.missing_timer:
-                # start timer.  if timer times out, fail deferred
-                self.missing_timer = self.master.reactor.callLater(
-                    self.missing_timeout,
-                    self._substantiation_failed, defer.TimeoutError())
+            self.startMissingTimer()
             self.substantiation_build = build
             # if substantiate fails synchronously we need to have the deferred
             # ready to be notified
@@ -138,8 +134,7 @@ class AbstractLatentWorker(AbstractWorker):
             return result
 
         def clean_up(failure):
-            if self.missing_timer is not None:
-                self.missing_timer.cancel()
+            self.stopMissingTimer()
             self._substantiation_failed(failure)
             # swallow the failure as it is given to notified
             return None
@@ -181,8 +176,11 @@ class AbstractLatentWorker(AbstractWorker):
             d = self._substantiate(self.substantiation_build)
             d.addErrback(log.err, 'while re-substantiating')
 
-    def _substantiation_failed(self, failure):
+    def _missing_timer_fired(self):
         self.missing_timer = None
+        return self._substantiation_failed(defer.TimeoutError())
+
+    def _substantiation_failed(self, failure):
         if self.substantiation_build:
             self.substantiation_build = None
             self._substantiation_notifier.notify(failure)
@@ -270,9 +268,7 @@ class AbstractLatentWorker(AbstractWorker):
             yield AbstractWorker.disconnect(self)
             return
 
-        if self.missing_timer:
-            self.missing_timer.cancel()
-            self.missing_timer = None
+        self.stopMissingTimer()
 
         # if master is stopping, we will never achieve consistent state, as workermanager
         # wont accept new connection

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -46,6 +46,7 @@ class AbstractLatentWorker(AbstractWorker):
     substantiation_build = None
     insubstantiating = False
     build_wait_timer = None
+    start_missing_on_startup = False
 
     def checkConfig(self, name, password,
                     build_wait_timeout=60 * 10,


### PR DESCRIPTION
Just a small fix to catch the error and to allow workers from attaching if missing_timeout is specified.
Otherwise I get:
```
2017-01-30 18:50:08-0800 [-] worker Ubuntu_14_04_64_0 cannot attach
        Traceback (most recent call last):
        Failure: twisted.internet.error.AlreadyCalled: Tried to cancel an already-called event.
```


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

