### PR TITLE
Look for the repr() output for unicode string in log file.

### DIFF
--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -268,7 +268,7 @@ class RunSteps(unittest.TestCase):
             # instant step
             u'Observer saw []\n' if slowDB else
             # 'Observer saw [\'stdout\\n\', \'\\xe2\\x98\\x83\\n\']',
-            u'Observer saw [u\'stdout\\n\', u\'\\u2603\\n\']\n',
+            u'Observer saw [' + repr(u'stdout\n') + u", " + repr(u"\u2603\n") + u"]\n"
         })
 
     def test_OldStyleCustomBuildStep(self):

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -391,7 +391,7 @@ class SetPropertyFromCommand(steps.BuildStepMixin, unittest.TestCase):
         self.expectOutcome(result=SUCCESS,
                            state_string="property 'res' set")
         self.expectProperty("res", "abcdef")  # note: stripped
-        self.expectLogfile('property changes', r"res: u'abcdef'")
+        self.expectLogfile('property changes', r"res: " + repr(u'abcdef'))
         return self.runStep()
 
     def test_renderable_workdir(self):
@@ -406,7 +406,7 @@ class SetPropertyFromCommand(steps.BuildStepMixin, unittest.TestCase):
         self.expectOutcome(result=SUCCESS,
                            state_string="property 'res' set")
         self.expectProperty("res", "abcdef")  # note: stripped
-        self.expectLogfile('property changes', r"res: u'abcdef'")
+        self.expectLogfile('property changes', r"res: " + repr(u'abcdef'))
         return self.runStep()
 
     def test_run_property_no_strip(self):
@@ -421,7 +421,7 @@ class SetPropertyFromCommand(steps.BuildStepMixin, unittest.TestCase):
         self.expectOutcome(result=SUCCESS,
                            state_string="property 'res' set")
         self.expectProperty("res", "\n\nabcdef\n")
-        self.expectLogfile('property changes', r"res: u'\n\nabcdef\n'")
+        self.expectLogfile('property changes', r"res: " + repr(u'\n\nabcdef\n'))
         return self.runStep()
 
     def test_run_failure(self):


### PR DESCRIPTION
On Python 2, repr(u'abcdef') returns "u'abcdef'"
while on Python 3 it returns "'abcdef'".
