### PR TITLE
Get rid of __cmp__() and implement all 6 rich comparison operators.

### DIFF
--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -142,16 +142,23 @@ class Change:
             self.when, self.category, self.project, self.repository,
             self.codebase)
 
-    def __cmp__(self, other):
-        # NOTE: __cmp__() and cmp() are gone on Python 3,
-        #       in favor of __le__ and __eq__().
-        return self.number - other.number
-
     def __eq__(self, other):
         return self.number == other.number
 
+    def __ne__(self, other):
+        return self.number != other.number
+
     def __lt__(self, other):
         return self.number < other.number
+
+    def __le__(self, other):
+        return self.number <= other.number
+
+    def __gt__(self, other):
+        return self.number > other.number
+
+    def __ge__(self, other):
+        return self.number >= other.number
 
     def asText(self):
         data = ""

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -117,21 +117,41 @@ class Row(object):
         # make the values appear as attributes
         self.__dict__.update(self.values)
 
-    def __cmp__(self, other):
-        # NOTE: __cmp__() and cmp() are gone on Python 3,
-        #       in favor of __le__ and __eq__().
-        return cmp(self.__class__, other.__class__) \
-            or cmp(self.values, other.values)
-
     def __eq__(self, other):
-        return (self.__class__ == other.__class__ and
-                self.values == other.values)
+        if self.__class__ != other.__class__:
+            return False
+        else:
+            return self.values == other.values
+
+    def __ne__(self, other):
+        if self.__class__ != other.__class__:
+            return True
+        else:
+            return self.values != other.values
 
     def __lt__(self, other):
         if self.__class__ != other.__class__:
             raise TypeError("Cannot compare {} and {}".format(
                 self.__class__, other.__class__))
         return self.values < other.values
+
+    def __le__(self, other):
+        if self.__class__ != other.__class__:
+            raise TypeError("Cannot compare {} and {}".format(
+                self.__class__, other.__class__))
+        return self.values <= other.values
+
+    def __gt__(self, other):
+        if self.__class__ != other.__class__:
+            raise TypeError("Cannot compare {} and {}".format(
+                self.__class__, other.__class__))
+        return self.values > other.values
+
+    def __ge__(self, other):
+        if self.__class__ != other.__class__:
+            raise TypeError("Cannot compare {} and {}".format(
+                self.__class__, other.__class__))
+        return self.values >= other.values
 
     def __repr__(self):
         return '%s(**%r)' % (self.__class__.__name__, self.values)

--- a/master/buildbot/test/unit/test_changes_changes.py
+++ b/master/buildbot/test/unit/test_changes_changes.py
@@ -63,6 +63,36 @@ class Change(unittest.TestCase):
             revision=u'deadbeef'))
         self.change23.number = 23
 
+        self.change24 = changes.Change(**dict(
+            category='devel',
+            repository=u'git://warner',
+            codebase=u'mainapp',
+            who=u'dustin',
+            when=266738405,
+            comments=u'fix whitespace again',
+            project=u'Buildbot',
+            branch=u'warnerdb',
+            revlink=u'http://warner/0e92a098c',
+            properties={'notest': "no"},
+            files=[u'master/README.txt', u'worker/README.txt'],
+            revision=u'deadbeef'))
+        self.change24.number = 24
+
+        self.change25 = changes.Change(**dict(
+            category='devel',
+            repository=u'git://warner',
+            codebase=u'mainapp',
+            who=u'dustin',
+            when=266738406,
+            comments=u'fix whitespace again',
+            project=u'Buildbot',
+            branch=u'warnerdb',
+            revlink=u'http://warner/0e92a098d',
+            properties={'notest': "no"},
+            files=[u'master/README.txt', u'worker/README.txt'],
+            revision=u'deadbeef'))
+        self.change25.number = 25
+
     @defer.inlineCallbacks
     def test_fromChdict(self):
         # get a real honest-to-goodness chdict from the fake db
@@ -149,3 +179,13 @@ class Change(unittest.TestCase):
 
     def test_getLogs(self):
         self.assertEqual(self.change23.getLogs(), {})
+
+    def test_compare(self):
+        self.assertEqual(self.change23, self.change23)
+        self.assertNotEqual(self.change24, self.change23)
+        self.assertGreater(self.change24, self.change23)
+        self.assertGreaterEqual(self.change24, self.change23)
+        self.assertGreaterEqual(self.change24, self.change24)
+        self.assertLessEqual(self.change24, self.change24)
+        self.assertLessEqual(self.change23, self.change24)
+        self.assertLess(self.change23, self.change25)

--- a/master/buildbot/test/unit/test_util_ComparableMixin.py
+++ b/master/buildbot/test/unit/test_util_ComparableMixin.py
@@ -72,7 +72,28 @@ class ComparableMixin(unittest.TestCase):
         self.assertEqual(self.f123, another_f123)
 
     def test_ne_importantDifferences(self):
-        assert self.f123 != self.f134
+        self.assertNotEqual(self.f123, self.f134)
 
     def test_ne_differentClasses(self):
-        assert self.f123 != self.b123
+        self.assertNotEqual(self.f123, self.b123)
+
+    def test_compare(self):
+         self.assertEqual(self.f123, self.f123)
+         self.assertNotEqual(self.b223, self.b213)
+         self.assertGreater(self.b223, self.b213)
+
+         # Different classes
+         self.assertFalse(self.b223 > self.f123)
+
+         self.assertGreaterEqual(self.b223, self.b213)
+         self.assertGreaterEqual(self.b223, self.b223)
+
+         # Different classes
+         self.assertFalse(self.f123 >= self.b123)
+
+         self.assertLess(self.b213, self.b223)
+         self.assertLessEqual(self.b213, self.b223)
+         self.assertLessEqual(self.b213, self.b213)
+
+         # Different classes
+         self.assertFalse(self.f123 <= self.b123)

--- a/master/buildbot/test/unit/test_util_ComparableMixin.py
+++ b/master/buildbot/test/unit/test_util_ComparableMixin.py
@@ -78,22 +78,22 @@ class ComparableMixin(unittest.TestCase):
         self.assertNotEqual(self.f123, self.b123)
 
     def test_compare(self):
-         self.assertEqual(self.f123, self.f123)
-         self.assertNotEqual(self.b223, self.b213)
-         self.assertGreater(self.b223, self.b213)
+        self.assertEqual(self.f123, self.f123)
+        self.assertNotEqual(self.b223, self.b213)
+        self.assertGreater(self.b223, self.b213)
 
-         # Different classes
-         self.assertFalse(self.b223 > self.f123)
+        # Different classes
+        self.assertFalse(self.b223 > self.f123)
 
-         self.assertGreaterEqual(self.b223, self.b213)
-         self.assertGreaterEqual(self.b223, self.b223)
+        self.assertGreaterEqual(self.b223, self.b213)
+        self.assertGreaterEqual(self.b223, self.b223)
 
-         # Different classes
-         self.assertFalse(self.f123 >= self.b123)
+        # Different classes
+        self.assertFalse(self.f123 >= self.b123)
 
-         self.assertLess(self.b213, self.b223)
-         self.assertLessEqual(self.b213, self.b223)
-         self.assertLessEqual(self.b213, self.b213)
+        self.assertLess(self.b213, self.b223)
+        self.assertLessEqual(self.b213, self.b223)
+        self.assertLessEqual(self.b213, self.b213)
 
-         # Different classes
-         self.assertFalse(self.f123 <= self.b123)
+        # Different classes
+        self.assertFalse(self.f123 <= self.b123)

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -129,27 +129,6 @@ class ComparableMixin(object):
                 [getattr(self, name, self._None) for name in compare_attrs]
         return hash(tuple(map(str, alist)))
 
-    def __cmp__(self, them):
-        # NOTE: __cmp__() and cmp() are gone on Python 3,
-        #       in favor of __le__ and __eq__().
-        result = cmp(type(self), type(them))
-        if result:
-            return result
-
-        result = cmp(self.__class__, them.__class__)
-        if result:
-            return result
-
-        compare_attrs = []
-        reflect.accumulateClassList(
-            self.__class__, 'compare_attrs', compare_attrs)
-
-        self_list = [getattr(self, name, self._None)
-                     for name in compare_attrs]
-        them_list = [getattr(them, name, self._None)
-                     for name in compare_attrs]
-        return cmp(self_list, them_list)
-
     def _cmp_common(self, them):
         if type(self) != type(them):
             return (False, None, None)
@@ -173,11 +152,35 @@ class ComparableMixin(object):
             return False
         return self_list == them_list
 
+    def __ne__(self, them):
+        (isComparable, self_list, them_list) = self._cmp_common(them)
+        if not isComparable:
+            return True
+        return self_list != them_list
+
     def __lt__(self, them):
         (isComparable, self_list, them_list) = self._cmp_common(them)
         if not isComparable:
             return False
         return self_list < them_list
+
+    def __le__(self, them):
+        (isComparable, self_list, them_list) = self._cmp_common(them)
+        if not isComparable:
+            return False
+        return self_list <= them_list
+
+    def __gt__(self, them):
+        (isComparable, self_list, them_list) = self._cmp_common(them)
+        if not isComparable:
+            return False
+        return self_list > them_list
+
+    def __ge__(self, them):
+        (isComparable, self_list, them_list) = self._cmp_common(them)
+        if not isComparable:
+            return False
+        return self_list >= them_list
 
     def getConfigDict(self):
         compare_attrs = []


### PR DESCRIPTION
This makes things consistent between Python 2 and Python 3,
where `__cmp__()` is gone.

I tried using @functools.total_ordering, but for the ComparableMixin and fakedb, it
didn't work due to the "interesting" logic in those.  To be safe, I just implemented
all 6 comparison operators, and it worked out.