### PR TITLE
http_status_push: fix issue with datetime not json encodable

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -369,6 +369,7 @@ jobfiles
 jobid
 joe
 json
+jsonable
 jsonapi
 json'd
 jsonrc

--- a/master/buildbot/newsfragments/http_status_push.bugfix
+++ b/master/buildbot/newsfragments/http_status_push.bugfix
@@ -1,0 +1,1 @@
+Fix issue with :bb:reporter:`HttpStatusPush` raising datetime is not JSON serializable error.

--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 from future.utils import iteritems
 
 import abc
+import copy
 
 from twisted.internet import defer
 from twisted.python import log
@@ -42,6 +43,7 @@ class HttpStatusPushBase(service.BuildbotService):
         yield service.BuildbotService.reconfigService(self)
 
         self.builders = builders
+        self.neededDetails = copy.copy(self.neededDetails)
         for k, v in iteritems(kwargs):
             if k.startswith("want"):
                 self.neededDetails[k] = v

--- a/master/buildbot/test/fake/httpclientservice.py
+++ b/master/buildbot/test/fake/httpclientservice.py
@@ -27,6 +27,7 @@ from zope.interface import implementer
 from buildbot.interfaces import IHttpResponse
 from buildbot.util import httpclientservice
 from buildbot.util import service
+from buildbot.util import toJson
 from buildbot.util import unicode2bytes
 from buildbot.util.logger import Logger
 
@@ -35,6 +36,7 @@ log = Logger()
 
 @implementer(IHttpResponse)
 class ResponseWrapper(object):
+
     def __init__(self, code, content):
         self._content = content
         self._code = code
@@ -101,7 +103,7 @@ class HTTPClientService(service.SharedService):
             return ValueError("content and content_json cannot be both specified")
 
         if content_json is not None:
-            content = jsonmodule.dumps(content_json)
+            content = jsonmodule.dumps(content_json, default=toJson)
 
         self._expected.append(dict(
             method=method, ep=ep, params=params, data=data, json=json, code=code,
@@ -116,6 +118,9 @@ class HTTPClientService(service.SharedService):
         if not self.quiet:
             log.debug("{method} {ep} {params!r} <- {data!r}",
                       method=method, ep=ep, params=params, data=data or json)
+        if json is not None:
+            # ensure that the json is really jsonable
+            jsonmodule.dumps(json, default=toJson)
         if not self._expected:
             raise AssertionError(
                 "Not expecting a request, while we got: "


### PR DESCRIPTION
add more unit tests to make sure our httpclientservice detects json encoding issues

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)

