### PR TITLE
checkPidFile: erase old pidfile if the process is not live anymore

### DIFF
--- a/master/buildbot/newsfragments/checkpidfile.bugfix
+++ b/master/buildbot/newsfragments/checkpidfile.bugfix
@@ -1,0 +1,1 @@
+Like for ``buildbot start``, ``buildbot upgrade-master`` will now erase an old pidfile if the process is not live anymore instead of just failing.

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 from future.builtins import range
 
 import copy
+import errno
 import os
 import stat
 import sys
@@ -42,6 +43,31 @@ def captureErrors(errors, msg):
         defer.returnValue(1)
 
 
+def checkPidFile(pidfile):
+    """ mostly comes from _twistd_unix.py which is not twisted public API :-/
+
+        except it returns an exception instead of exiting
+    """
+    if os.path.exists(pidfile):
+        try:
+            with open(pidfile) as f:
+                pid = int(f.read())
+        except ValueError:
+            raise ValueError('Pidfile %s contains non-numeric value' % pidfile)
+        try:
+            os.kill(pid, 0)
+        except OSError as why:
+            if why.errno == errno.ESRCH:
+                # The pid doesn't exist.
+                print('Removing stale pidfile %s' % pidfile)
+                os.remove(pidfile)
+            else:
+                raise OSError("Can't check status of PID %s from pidfile %s: %s" %
+                              (pid, pidfile, why[1]))
+        else:
+            raise AssertionError("'%s' exists - is this master still running?")
+
+
 def checkBasedir(config):
     if not config['quiet']:
         print("checking basedir")
@@ -52,9 +78,12 @@ def checkBasedir(config):
     if runtime.platformType != 'win32':  # no pids on win32
         if not config['quiet']:
             print("checking for running master")
+
         pidfile = os.path.join(config['basedir'], 'twistd.pid')
-        if os.path.exists(pidfile):
-            print("'%s' exists - is this master still running?" % (pidfile,))
+        try:
+            checkPidFile(pidfile)
+        except Exception as e:
+            print(str(e))
             return False
 
     tac = getConfigFromTac(config['basedir'])
@@ -168,8 +197,8 @@ class SubcommandOptions(usage.Options):
                 # pylint: disable=not-an-iterable
                 for optfile_name, option_name in self.buildbotOptions:
                     for i in range(len(op)):
-                        if (op[i][0] == option_name
-                                and optfile_name in optfile):
+                        if (op[i][0] == option_name and
+                                optfile_name in optfile):
                             op[i] = list(op[i])
                             op[i][2] = optfile[optfile_name]
         usage.Options.__init__(self, *args)

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -43,6 +43,10 @@ def captureErrors(errors, msg):
         defer.returnValue(1)
 
 
+class BusyError(RuntimeError):
+    pass
+
+
 def checkPidFile(pidfile):
     """ mostly comes from _twistd_unix.py which is not twisted public API :-/
 
@@ -65,7 +69,7 @@ def checkPidFile(pidfile):
                 raise OSError("Can't check status of PID %s from pidfile %s: %s" %
                               (pid, pidfile, why[1]))
         else:
-            raise AssertionError("'%s' exists - is this master still running?")
+            raise BusyError("'%s' exists - is this master still running?")
 
 
 def checkBasedir(config):

--- a/master/buildbot/test/unit/test_scripts_base.py
+++ b/master/buildbot/test/unit/test_scripts_base.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import errno
 import os
 import string
 import textwrap
@@ -320,10 +321,60 @@ class TestLoadConfig(dirs.DirsMixin, misc.StdoutAssertionsMixin,
     @skipUnlessPlatformIs('posix')
     def test_checkBasedir_active_pidfile(self):
         self.activeBasedir()
-        open(os.path.join('test', 'twistd.pid'), 'w').close()
+        # write our own pid in the file
+        with open(os.path.join('test', 'twistd.pid'), 'w') as f:
+            f.write(str(os.getpid()))
         rv = base.checkBasedir(mkconfig())
         self.assertFalse(rv)
         self.assertInStdout('still running')
+
+    @skipUnlessPlatformIs('posix')
+    def test_checkBasedir_bad_pidfile(self):
+        self.activeBasedir()
+        # write our own pid in the file
+        with open(os.path.join('test', 'twistd.pid'), 'w') as f:
+            f.write("xxx")
+        rv = base.checkBasedir(mkconfig())
+        self.assertFalse(rv)
+        self.assertInStdout('twistd.pid contains non-numeric value')
+
+    @skipUnlessPlatformIs('posix')
+    def test_checkBasedir_stale_pidfile(self):
+        """
+        Stale PID file is removed without causing a system exit.
+        """
+        self.activeBasedir()
+        # write our own pid in the file
+        pidfile = os.path.join('test', 'twistd.pid')
+        with open(pidfile, 'w') as f:
+            f.write(str(os.getpid() + 1))
+
+        def kill(pid, sig):
+            raise OSError(errno.ESRCH, "fake")
+        self.patch(os, "kill", kill)
+        rv = base.checkBasedir(mkconfig())
+        self.assertTrue(rv)
+        self.assertInStdout('Removing stale pidfile test')
+        self.assertFalse(os.path.exists(pidfile))
+
+    @skipUnlessPlatformIs('posix')
+    def test_checkBasedir_pidfile_kill_error(self):
+        """
+        if ping-killing the PID file does not work, we should error out.
+        """
+        self.activeBasedir()
+        # write our own pid in the file
+        pidfile = os.path.join('test', 'twistd.pid')
+        with open(pidfile, 'w') as f:
+            f.write(str(os.getpid() + 1))
+
+        def kill(pid, sig):
+            raise OSError(errno.EPERM, "fake")
+        self.patch(os, "kill", kill)
+        rv = base.checkBasedir(mkconfig())
+        self.assertFalse(rv)
+        self.assertInStdout('Can\'t check status of PID')
+        self.assertTrue(os.path.exists(pidfile))
 
     def test_checkBasedir_invalid_rotateLength(self):
         self.activeBasedir(extra_lines=['rotateLength="32"'])

--- a/master/buildbot/test/unit/test_scripts_base.py
+++ b/master/buildbot/test/unit/test_scripts_base.py
@@ -320,6 +320,9 @@ class TestLoadConfig(dirs.DirsMixin, misc.StdoutAssertionsMixin,
 
     @skipUnlessPlatformIs('posix')
     def test_checkBasedir_active_pidfile(self):
+        """
+        active PID file is giving error.
+        """
         self.activeBasedir()
         # write our own pid in the file
         with open(os.path.join('test', 'twistd.pid'), 'w') as f:
@@ -330,8 +333,10 @@ class TestLoadConfig(dirs.DirsMixin, misc.StdoutAssertionsMixin,
 
     @skipUnlessPlatformIs('posix')
     def test_checkBasedir_bad_pidfile(self):
+        """
+        corrupted PID file is giving error.
+        """
         self.activeBasedir()
-        # write our own pid in the file
         with open(os.path.join('test', 'twistd.pid'), 'w') as f:
             f.write("xxx")
         rv = base.checkBasedir(mkconfig())
@@ -344,7 +349,6 @@ class TestLoadConfig(dirs.DirsMixin, misc.StdoutAssertionsMixin,
         Stale PID file is removed without causing a system exit.
         """
         self.activeBasedir()
-        # write our own pid in the file
         pidfile = os.path.join('test', 'twistd.pid')
         with open(pidfile, 'w') as f:
             f.write(str(os.getpid() + 1))

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -539,6 +539,7 @@ persistant
 petmail
 Phantomjs
 phasis
+pidfile
 pids
 plaintext
 pluggable


### PR DESCRIPTION
Like for buildbot start, which uses twistd directly,

buildbot upgrade-master will now erase an old pidfile if the process is not live anymore instead of just failing.

This will make the ansible setup of metabuildbot more stable.
