### PR TITLE
REST API: Allow selecting fields and ordering descending at the same time

### DIFF
--- a/master/buildbot/newsfragments/filter-and-sort-desc.bugfix
+++ b/master/buildbot/newsfragments/filter-and-sort-desc.bugfix
@@ -1,0 +1,1 @@
+When using REST API it is now possible to filter and sort in descending order at the same time.

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -462,6 +462,32 @@ class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
                                   total=8, orderSignificant=True)
 
     @defer.inlineCallbacks
+    def test_api_collection_filter_and_order(self):
+        yield self.render_resource(self.rsrc, '/test?field=info&order=info')
+        self.assertRestCollection(typeName='tests',
+                                  items=sorted(list([{'info': v['info']}
+                                                     for v in itervalues(endpoint.testData)]),
+                                               key=lambda v: v['info']),
+                                  total=8, orderSignificant=True)
+
+    @defer.inlineCallbacks
+    def test_api_collection_order_desc(self):
+        yield self.render_resource(self.rsrc, '/test?order=-info')
+        self.assertRestCollection(typeName='tests',
+                                  items=sorted(list(itervalues(endpoint.testData)),
+                                               key=lambda v: v['info'], reverse=True),
+                                  total=8, orderSignificant=True)
+
+    @defer.inlineCallbacks
+    def test_api_collection_filter_and_order_desc(self):
+        yield self.render_resource(self.rsrc, '/test?field=info&order=-info')
+        self.assertRestCollection(typeName='tests',
+                                  items=sorted(list([{'info': v['info']}
+                                                     for v in itervalues(endpoint.testData)]),
+                                               key=lambda v: v['info'], reverse=True),
+                                  total=8, orderSignificant=True)
+
+    @defer.inlineCallbacks
     def test_api_collection_order_on_unselected(self):
         yield self.render_resource(self.rsrc, '/test?field=id&order=info')
         self.assertRestError(message="cannot order on un-selected fields",

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -305,7 +305,7 @@ class V2RootResource(resource.Resource):
         # if ordering or filtering is on a field that's not in fields, bail out
         if fields:
             fieldsSet = set(fields)
-            if order and set(order) - fieldsSet:
+            if order and set([o.lstrip('-') for o in order]) - fieldsSet:
                 raise BadRequest("cannot order on un-selected fields")
             for filter in filters:
                 if filter.field not in fieldsSet:


### PR DESCRIPTION
REST API allows to specify fields to return (via "field=" query param(s)) and sorting order (via "order=" query param(s)); it also requires that order fields are present in fields list. When order is descending field name in "order=" param is to be prepended with "-", and this expression is an invalid field name which cannot be found in fields list (note that prepending "-" to field name in "field=" param is prohibited).

Strip leading "-" from order fields when checking whether all order fields are also present in fields list. This would allow specifying fields to return and sort in descending order at the same time.