### PR TITLE
treq *must* be passed bytes, but json.loads() and json.dumps() can only work with str

### DIFF
--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -29,6 +29,7 @@ from buildbot import config
 from buildbot.interfaces import IHttpResponse
 from buildbot.util import service
 from buildbot.util import toJson
+from buildbot.util import unicode2bytes
 from buildbot.util.logger import Logger
 
 try:
@@ -90,7 +91,8 @@ class HTTPClientService(service.SharedService):
     MAX_THREADS = 5
 
     def __init__(self, base_url, auth=None, headers=None):
-        assert not base_url.endswith("/"), "baseurl should not end with /: " + base_url
+        assert not base_url.endswith(
+            "/"), "baseurl should not end with /: " + base_url
         service.SharedService.__init__(self)
         self._base_url = base_url
         self._auth = auth
@@ -112,7 +114,8 @@ class HTTPClientService(service.SharedService):
                 from_module, HTTPClientService.TREQ_PROS_AND_CONS))
 
     def startService(self):
-        # treq only supports basicauth, so we force txrequests if the auth is something else
+        # treq only supports basicauth, so we force txrequests if the auth is
+        # something else
         if self._auth is not None and not isinstance(self._auth, tuple):
             self.PREFER_TREQ = False
         if txrequests is not None and not self.PREFER_TREQ:
@@ -148,9 +151,10 @@ class HTTPClientService(service.SharedService):
         # for txrequests and treq
         json = kwargs.pop('json', None)
         if isinstance(json, dict):
-            data = jsonmodule.dumps(json, default=toJson)
+            jsonStr = jsonmodule.dumps(json, default=toJson)
+            jsonBytes = unicode2bytes(jsonStr)
             kwargs['headers']['Content-Type'] = 'application/json'
-            kwargs['data'] = data
+            kwargs['data'] = jsonBytes
 
         return url, kwargs
 
@@ -171,7 +175,8 @@ class HTTPClientService(service.SharedService):
     def _doTReq(self, method, ep, **kwargs):
         url, kwargs = self._prepareRequest(ep, kwargs)
         # treq requires header values to be an array
-        kwargs['headers'] = dict([(k, [v]) for k, v in kwargs['headers'].items()])
+        kwargs['headers'] = dict([(k, [v])
+                                  for k, v in kwargs['headers'].items()])
         kwargs['agent'] = self._agent
 
         d = getattr(treq, method)(url, **kwargs)


### PR DESCRIPTION
This fixes tests on Python 3.

This fixes regression on Python 3 introduced by https://github.com/buildbot/buildbot/pull/2712