### PR TITLE
fix hyper instabilities

### DIFF
--- a/master/buildbot/test/fake/hyper.py
+++ b/master/buildbot/test/fake/hyper.py
@@ -44,7 +44,12 @@ class Client(object):
 
     def containers(self, filters=None, *args, **kwargs):
         if filters is not None:
-            return [c for c in self._containers.values() if c['name'] == filters['name']]
+            def match(name, names):
+                for n in names:
+                    if name in n:
+                        return True
+                return False
+            return [c for c in self._containers.values() if match(filters['name'], c['Names'])]
         return self._containers.values()
 
     def create_container(self, image, name=None, *args, **kwargs):
@@ -55,7 +60,9 @@ class Client(object):
                 raise Exception("cannot create with same name")
         ret = {'Id': '8a61192da2b3bb2d922875585e29b74ec0dc4e0117fcbf84c962204e97564cd7',
                'Warnings': None}
-        self._containers[ret['Id']] = {'started': False, 'image': image, 'Id': ret['Id'], "name": name}
+        self._containers[ret['Id']] = {
+            'started': False, 'image': image, 'Id': ret['Id'], "Names": ["/" + name]
+        }
         return ret
 
     def remove_container(self, id, **kwargs):


### PR DESCRIPTION
hyper filtering will match 'hyper12" if you search for 'hyper1' !

0 % hyper ps -f name=buildbot6ad783-hyper1
CONTAINER ID        IMAGE                  COMMAND                  CREATED             STATUS              PORTS               NAMES                    PUBLIC IP
5edca06defbf        buildbot/metabbotcfg   "/usr/local/bin/dumb-"   6 minutes ago       Up 6 minutes                            buildbot6ad783-hyper10
61930db1ebe6        buildbot/metabbotcfg   "/usr/local/bin/dumb-"   6 minutes ago       Up 5 minutes                            buildbot6ad783-hyper17
5a089dbacf61        buildbot/metabbotcfg   "/usr/local/bin/dumb-"   6 minutes ago       Up 6 minutes                            buildbot6ad783-hyper19

we also ignore 'Conflict operation on container' but I think those are related to the previous issue
