### PR TITLE
Fix bug in github status code

### DIFF
--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -110,6 +110,9 @@ class GitHubStatusPush(http.HttpStatusPushBase):
 
         context = yield props.render(self.context)
 
+        if not build['buildset'].get('sourcestamps'):
+            return
+
         sourcestamps = build['buildset']['sourcestamps']
         project = sourcestamps[0]['project']
 


### PR DESCRIPTION
When a force scheduler is used, sourcestamps are missing and this
code block throws an exception along these lines :
```
2017-02-03 21:55:39+0000 [-] while invoking <bound method GitHubStatusPush.buildFinished of <buildbot.reporters.github.GitHubStatusPush object at 0x7f1c9b419ad0>>
        Traceback (most recent call last):
          File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 1184, in gotResult
            _inlineCallbacks(r, g, deferred)
          File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 1128, in _inlineCallbacks
            result = g.send(result)
          File "/usr/lib/python2.7/site-packages/buildbot/reporters/http.py", line 79, in getMoreInfoAndSend
            yield self.send(build)
          File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 1274, in unwindGenerator
            return _inlineCallbacks(None, gen, Deferred())
        --- <exception caught here> ---
          File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 1128, in _inlineCallbacks
            result = g.send(result)
          File "/usr/lib/python2.7/site-packages/buildbot/reporters/github.py", line 115, in send
            repoName = '.'.join(repo[1].split('.')[:-1])
        exceptions.IndexError: list index out of range
```