### PR TITLE
remote_read() returns bytes, but we need to pass str to json.loads()

### DIFF
--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -42,6 +42,7 @@ from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.util import steps
 from buildbot.test.util.warnings import assertNotProducesWarnings
 from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.util import bytes2NativeString
 from buildbot.util import unicode2bytes
 from buildbot.worker_transition import DeprecatedWorkerAPIWarning
 from buildbot.worker_transition import DeprecatedWorkerNameWarning
@@ -1098,6 +1099,7 @@ class TestJSONPropertiesDownload(unittest.TestCase):
                 self.assertEqual(kwargs['workerdest'], 'props.json')
                 reader = kwargs['reader']
                 data = reader.remote_read(100)
+                data = bytes2NativeString(data)
                 actualJson = json.loads(data)
                 expectedJson = dict(sourcestamps=[ss.asDict()], properties={'key1': 'value1'})
                 self.assertEqual(actualJson, expectedJson)
@@ -1129,6 +1131,7 @@ class TestJSONPropertiesDownload(unittest.TestCase):
                 self.assertEqual(kwargs['slavedest'], 'props.json')
                 reader = kwargs['reader']
                 data = reader.remote_read(100)
+                data = bytes2NativeString(data)
                 actualJson = json.loads(data)
                 expectedJson = dict(sourcestamps=[ss.asDict()], properties={'key1': 'value1'})
                 self.assertEqual(actualJson, expectedJson)


### PR DESCRIPTION
This fixes errors on Python 3:

```
[ERROR]
Traceback (most recent call last):
  File "/buildbot/buildbot-job/build/master/buildbot/test/unit/test_data_types.py", line 54, in test_validate
    errors = list(self.ty.validate(repr(o), o))
  File "/buildbot/buildbot-job/build/master/buildbot/data/types.py", line 255, in validate
    json.loads(propval)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
builtins.TypeError: the JSON object must be str, not 'bytes'
```