### PR TITLE
Do not compare the string-encoded JSON sent to sendMessage().

### DIFF
--- a/master/buildbot/test/unit/test_www_ws.py
+++ b/master/buildbot/test/unit/test_www_ws.py
@@ -23,6 +23,7 @@ from mock import Mock
 from twisted.trial import unittest
 
 from buildbot.test.util import www
+from buildbot.util import bytes2NativeString
 from buildbot.www import ws
 
 
@@ -35,54 +36,60 @@ class WsResource(www.WwwTestMixin, unittest.TestCase):
         self.gotMsg = []
         self.proto.sendMessage = Mock(spec=self.proto.sendMessage)
 
+    def assert_called_with_json(self, obj, expected_json):
+        jsonArg = obj.call_args[0][0]
+        jsonArg = bytes2NativeString(jsonArg)
+        actual_json = json.loads(jsonArg)
+        self.assertEqual(actual_json, expected_json)
+
     def test_ping(self):
         self.proto.onMessage(json.dumps(dict(cmd="ping", _id=1)), False)
-        self.proto.sendMessage.assert_called_with(
-            '{"msg":"pong","code":200,"_id":1}')
+        self.assert_called_with_json(self.proto.sendMessage,
+            {"msg": "pong", "code": 200, "_id": 1})
 
     def test_bad_cmd(self):
         self.proto.onMessage(json.dumps(dict(cmd="poing", _id=1)), False)
-        self.proto.sendMessage.assert_called_with(
-            '{"_id":1,"code":404,"error":"no such command \'poing\'"}')
+        self.assert_called_with_json(self.proto.sendMessage,
+            {"_id": 1, "code": 404, "error": "no such command 'poing'"})
 
     def test_no_cmd(self):
         self.proto.onMessage(json.dumps(dict(_id=1)), False)
-        self.proto.sendMessage.assert_called_with(
-            '{"_id":null,"code":400,"error":"no \'cmd\' in websocket frame"}')
+        self.assert_called_with_json(self.proto.sendMessage,
+            {"_id": None, "code": 400, "error": "no 'cmd' in websocket frame"})
 
     def test_no_id(self):
         self.proto.onMessage(json.dumps(dict(cmd="ping")), False)
-        self.proto.sendMessage.assert_called_with(
-            '{"_id":null,"code":400,"error":"no \'_id\' in websocket frame"}')
+        self.assert_called_with_json(self.proto.sendMessage,
+            {"_id": None, "code": 400, "error": "no '_id' in websocket frame"})
 
     def test_startConsuming(self):
         self.proto.onMessage(
             json.dumps(dict(cmd="startConsuming", path="builds/*/*", _id=1)), False)
-        self.proto.sendMessage.assert_called_with(
-            '{"msg":"OK","code":200,"_id":1}')
+        self.assert_called_with_json(self.proto.sendMessage,
+            {"msg": "OK", "code": 200, "_id": 1})
         self.master.mq.verifyMessages = False
         self.master.mq.callConsumer(("builds", "1", "new"), {"buildid": 1})
-        self.proto.sendMessage.assert_called_with(
-            '{"k":"builds/1/new","m":{"buildid":1}}')
+        self.assert_called_with_json(self.proto.sendMessage,
+            {"k": "builds/1/new", "m": {"buildid": 1}})
 
     def test_startConsumingBadPath(self):
         self.proto.onMessage(
             json.dumps(dict(cmd="startConsuming", path={}, _id=1)), False)
-        self.proto.sendMessage.assert_called_with(
-            '{"_id":1,"code":400,"error":"invalid path format \'{}\'"}')
+        self.assert_called_with_json(self.proto.sendMessage,
+            {"_id": 1, "code": 400, "error": "invalid path format '{}'"})
 
     def test_stopConsumingNotRegistered(self):
         self.proto.onMessage(
             json.dumps(dict(cmd="stopConsuming", path="builds/*/*", _id=1)), False)
-        self.proto.sendMessage.assert_called_with(
-            '{"_id":1,"code":400,"error":"path was not consumed \'builds/*/*\'"}')
+        self.assert_called_with_json(self.proto.sendMessage,
+            {"_id": 1, "code": 400, "error": "path was not consumed \'builds/*/*\'"})
 
     def test_stopConsuming(self):
         self.proto.onMessage(
             json.dumps(dict(cmd="startConsuming", path="builds/*/*", _id=1)), False)
-        self.proto.sendMessage.assert_called_with(
-            '{"msg":"OK","code":200,"_id":1}')
+        self.assert_called_with_json(self.proto.sendMessage,
+            {"msg": "OK", "code": 200, "_id": 1})
         self.proto.onMessage(
             json.dumps(dict(cmd="stopConsuming", path="builds/*/*", _id=2)), False)
-        self.proto.sendMessage.assert_called_with(
-            '{"msg":"OK","code":200,"_id":2}')
+        self.assert_called_with_json(self.proto.sendMessage,
+            {"msg": "OK", "code": 200, "_id": 2})


### PR DESCRIPTION
On Python 3, this is bytes, not str, and the order of items
in the string is different.
Instead, decode the string-encoded JSON sent to sendMessage()
into an actual dictionary, and compare that.
