### PR TITLE
add stopService in test_worker_docker to properly cleanup everything

### DIFF
--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -40,6 +40,7 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase):
         master = fakemaster.make_master(testcase=self, wantData=True)
         worker.setServiceParent(master)
         self.successResultOf(master.startService())
+        self.addCleanup(master.stopService)
         return worker
 
     def setUp(self):


### PR DESCRIPTION
I am not sure exactly why but the precommit tests pass but not the post commit.

and I can't reproduce issue as well :-/