### PR TITLE
Fix issue with log viewer not properly rendering color codes

### DIFF
--- a/master/buildbot/newsfragments/ansicode.bugfix
+++ b/master/buildbot/newsfragments/ansicode.bugfix
@@ -1,0 +1,1 @@
+Fix issue with log viewer not properly rendering color codes.

--- a/www/base/src/app/common/services/ansicodes/ansicodes.service.coffee
+++ b/www/base/src/app/common/services/ansicodes/ansicodes.service.coffee
@@ -53,7 +53,7 @@ class ansicodesService extends Factory('common')
                         css_classes[fgbg[ansi_classes[0]] + '-' + ansi_classes[2]] = true
                 else
                     for i in ansi_classes
-                        if i == '39' # color reset code
+                        if i == '39' or i == '0' # "color reset" code and "all attributes off" code
                             css_classes = {}
                         else
                             css_classes[i] = true

--- a/www/base/src/app/common/services/ansicodes/ansicodes.service.spec.coffee
+++ b/www/base/src/app/common/services/ansicodes/ansicodes.service.spec.coffee
@@ -46,6 +46,16 @@ describe 'ansicode service', ->
             {class: 'ansi1 ansi36', text: 'DEBUG [plugin]: '},
             {class: '', text: 'Loading plugin karma-jasmine.'}]
 
+    it 'should provide correct split_ansi_line for reset codes', ->
+        # code sequence from protractor
+        ret = ansicodesService.splitAnsiLine("\x1b[32m.\x1b[0m\x1b[31mF\x1b[0m\x1b[32m.\x1b[39m\x1b[32m.\x1b[0m")
+        expect(ret).toEqual [
+            {class: "ansi32", text: "."},
+            {class: "ansi31", text: "F"},
+            {class: "ansi32", text: "."},
+            {class: "ansi32", text: "."},
+         ]
+
     it 'should provide correct split_ansi_line for 256 colors', ->
         ret = ansicodesService.splitAnsiLine("\x1b[48;5;71mDEBUG \x1b[38;5;72m[plugin]: \x1b[39mLoading plugin karma-jasmine.")
         expect(ret).toEqual [


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)

