### PR TITLE
worker: close file handle in FileUpload

### DIFF
--- a/.py3.notworking.txt
+++ b/.py3.notworking.txt
@@ -1,8 +1,6 @@
 buildbot.test.integration.test_URLs.UrlForBuildMaster.test_url
 buildbot.test.integration.test_latent.Tests.test_failed_ping_get_requeued
 buildbot.test.integration.test_latent.Tests.test_failed_sendBuilderList_get_requeued
-buildbot.test.integration.test_transfer.TransferStepsMasterNull.test_transfer
-buildbot.test.integration.test_transfer.TransferStepsMasterPb.test_transfer
 buildbot.test.integration.test_trigger.TriggeringMaster.test_trigger
 buildbot.test.integration.test_try_client.Schedulers.test_jobdir_no_wait
 buildbot.test.integration.test_try_client.Schedulers.test_jobdir_wait

--- a/master/buildbot/newsfragments/fileupload_close.bugfix
+++ b/master/buildbot/newsfragments/fileupload_close.bugfix
@@ -1,0 +1,1 @@
+Fix issue with buildbot_worker not closing file handles when using the transfer steps


### PR DESCRIPTION
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)