### PR TITLE
Customizable FileUpload step description and url text.

### DIFF
--- a/master/buildbot/newsfragments/FileUploadDescriptionAndURLText.feature
+++ b/master/buildbot/newsfragments/FileUploadDescriptionAndURLText.feature
@@ -1,0 +1,2 @@
+:py:class: `~buildbot.steps.transfer.FileUpload` now supports setting the url title text that is visible in the web UI.
+:py:class: `~buildbot.steps.transfer.FileUpload` now supports custom `description` and `descriptionDone` text.

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -182,6 +182,28 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
             self.assertEqual(srctimestamp[1], desttimestamp[1])
         return d
 
+    def testDescriptionDone(self):
+        self.setupStep(
+            transfer.FileUpload(workersrc=__file__, masterdest=self.destfile, url="http://server/file",
+                descriptionDone="Test File Uploaded"))
+
+        self.step.addURL = Mock()
+
+        self.expectCommands(
+            Expect('uploadFile', dict(
+                workersrc=__file__, workdir='wkdir',
+                blocksize=16384, maxsize=None, keepstamp=False,
+                writer=ExpectRemoteRef(remotetransfer.FileWriter)))
+            + Expect.behavior(uploadString("Hello world!"))
+            + 0)
+
+        self.expectOutcome(
+            result=SUCCESS,
+            state_string="Test File Uploaded")
+
+        d = self.runStep()
+        return d
+
     def testURL(self):
         self.setupStep(
             transfer.FileUpload(workersrc=__file__, masterdest=self.destfile, url="http://server/file"))
@@ -206,6 +228,32 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
         def checkURL(_):
             self.step.addURL.assert_called_once_with(
                 os.path.basename(self.destfile), "http://server/file")
+        return d
+
+    def testURLText(self):
+        self.setupStep(
+            transfer.FileUpload(workersrc=__file__, masterdest=self.destfile, url="http://server/file", urlText="testfile"))
+
+        self.step.addURL = Mock()
+
+        self.expectCommands(
+            Expect('uploadFile', dict(
+                workersrc=__file__, workdir='wkdir',
+                blocksize=16384, maxsize=None, keepstamp=False,
+                writer=ExpectRemoteRef(remotetransfer.FileWriter)))
+            + Expect.behavior(uploadString("Hello world!"))
+            + 0)
+
+        self.expectOutcome(
+            result=SUCCESS,
+            state_string="uploading %s" % os.path.basename(__file__))
+
+        d = self.runStep()
+
+        @d.addCallback
+        def checkURL(_):
+            self.step.addURL.assert_called_once_with(
+                "testfile", "http://server/file")
         return d
 
     def testFailure(self):

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -2134,6 +2134,8 @@ The ``url=`` argument allows you to specify an url that will be displayed in the
 The title of the url will be the name of the item transferred (directory for :class:`DirectoryUpload` or file for :class:`FileUpload`).
 This allows the user to add a link to the uploaded item if that one is uploaded to an accessible place.
 
+For :bb:step:`FileUpload`, the ``urlText=`` argument allows you to specify the url title that will be displayed in the web UI.
+
 .. bb:step:: DirectoryUpload
 
 Transfering Directories


### PR DESCRIPTION
When specifying a url for the FileUpload build step,
the link text would be the filename provided as part
of the masterdest path. In some cases, this is
undesirable. Instead, allow for a url text to be
provided which will be used in place of the
filename in the waterfall view. Also, allow for
the description to be customizable as well.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

This is mainly a WIP pull request. I'll update the unit tests, news, and documentation if necessary if you feel this is a good idea.
