### PR TITLE
Add instance id to build properties

### DIFF
--- a/master/buildbot/newsfragments/ec2instanceid.feature
+++ b/master/buildbot/newsfragments/ec2instanceid.feature
@@ -1,0 +1,1 @@
+:py:class: `~buildbot.worker.ec2.EC2LatentWorker` now provides instance id as the `instance` property enabling use of the AWS toolkit.

--- a/master/buildbot/test/unit/test_worker_ec2.py
+++ b/master/buildbot/test/unit/test_worker_ec2.py
@@ -214,6 +214,7 @@ class TestEC2LatentWorker(unittest.TestCase):
         self.assertEqual(len(instances), 1)
         self.assertEqual(instances[0].id, instance_id)
         self.assertEqual(instances[0].tags, [])
+        self.assertEqual(instances[0].id, bs.properties.getProperty('instance'))
 
     @mock_ec2
     def test_start_instance_volumes_deprecated(self):

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -543,6 +543,7 @@ class EC2LatentWorker(AbstractLatentWorker):
             self.instance.reload()
 
         if self.instance.state['Name'] == RUNNING:
+            self.properties.setProperty("instance", self.instance.id, "Worker")
             self.output = self.instance.console_output().get('Output')
             minutes = duration // 60
             seconds = duration % 60


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

Note sure if this is a good idea or not. But, having the instance id is handy when attempting to run various ec2 related tools. Any thoughts?