### PR TITLE
Add a GitTagPoller that polls for new tags in a git repo

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -56,7 +56,7 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                  category=None, project=None,
                  pollinterval=-2, fetch_refspec=None,
                  encoding='utf-8', name=None, pollAtLaunch=False,
-                 buildPushesWithNoCommits=False):
+                 buildPushesWithNoCommits=False, only_tags=False):
 
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
@@ -72,12 +72,17 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         if project is None:
             project = ''
 
+        if only_tags and (branch or branches):
+            config.error("GitPoller: can't specify only_tags and branch/branches")
         if branch and branches:
             config.error("GitPoller: can't specify both branch and branches")
         elif branch:
             branches = [branch]
         elif not branches:
-            branches = ['master']
+            if only_tags:
+                branches = lambda ref: ref.startswith('refs/tags/')
+            else:
+                branches = ['master']
 
         self.repourl = repourl
         self.branches = branches

--- a/master/buildbot/newsfragments/gitpoller_onlytags.feature
+++ b/master/buildbot/newsfragments/gitpoller_onlytags.feature
@@ -1,0 +1,1 @@
+:py:class: `~buildbot.changes.GitPoller` now supports polling tags in a git repository.

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -1330,10 +1330,24 @@ class TestGitPollerConstructor(unittest.TestCase, config.ConfigErrorsMixin):
         poller = gitpoller.GitPoller("/tmp/git.git", branches=True)
         self.assertEqual(poller.branches, True)
 
+    def test_only_tags_True(self):
+        poller = gitpoller.GitPoller("/tmp/git.git", only_tags=True)
+        self.assertIsNotNone(poller.branches)
+
     def test_branches_andBranch(self):
         self.assertRaisesConfigError("can't specify both branch and branches",
                                      lambda: gitpoller.GitPoller("/tmp/git.git",
                                                                  branch='bad', branches=['listy']))
+
+    def test_branches_and_only_tags(self):
+        self.assertRaisesConfigError("can't specify only_tags and branch/branches",
+                                     lambda: gitpoller.GitPoller("/tmp/git.git",
+                                                                 only_tags=True, branches=['listy']))
+
+    def test_branch_and_only_tags(self):
+        self.assertRaisesConfigError("can't specify only_tags and branch/branches",
+                                     lambda: gitpoller.GitPoller("/tmp/git.git",
+                                                                 only_tags=True, branch='bad'))
 
     def test_gitbin_default(self):
         poller = gitpoller.GitPoller("/tmp/git.git")

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -775,6 +775,9 @@ It accepts the following arguments:
     If this is a relative path, it will be interpreted relative to the master's basedir.
     Multiple Git pollers can share the same directory.
 
+``only_tags``
+    Determines if the GitPoller should poll for new tags in the git repository.
+
 A configuration for the Git poller might look like this:
 
 .. code-block:: python


### PR DESCRIPTION
Create a new change source called the GitTagPoller
which polls a git repository for new tags. Many projects
tag new builds and may wish to build new releases that get
tagged.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

Another WIP pull request. Again, not sure how useful this would be. I find it useful to build tagged releases. Thoughts are welcome. If it would be useful, I'll add tests, etc.