### PR TITLE
master/MANIFEST.in: Add missing docs files for sphinx docs generation

### DIFF
--- a/master/MANIFEST.in
+++ b/master/MANIFEST.in
@@ -18,8 +18,11 @@ include docs/manual/_images/*.png
 include docs/manual/_images/*.txt
 include docs/manual/_images/icon.blend
 include docs/manual/_images/Makefile
+include docs/manual/installation/*.rst
 include docs/bbdocs/*.py
 include docs/developer/*
+include docs/developer/_images/*
+
 include docs/relnotes/*
 
 include buildbot/scripts/sample.cfg


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

Above does not apply for this patch