### PR TITLE
allow `json` as parameter of HTTPStep

### DIFF
--- a/master/buildbot/newsfragments/http_step.bugfix
+++ b/master/buildbot/newsfragments/http_step.bugfix
@@ -1,0 +1,1 @@
+Fix :py:class:`~buildbot.steps.http.HTTPStep` to accept ``json`` as keyword argument.

--- a/master/buildbot/steps/http.py
+++ b/master/buildbot/steps/http.py
@@ -66,7 +66,7 @@ class HTTPStep(BuildStep):
     name = 'HTTPStep'
     description = 'Requesting'
     descriptionDone = 'Requested'
-    requestsParams = ["params", "data", "headers",
+    requestsParams = ["params", "data", "json", "headers",
                       "cookies", "files", "auth",
                       "timeout", "allow_redirects", "proxies",
                       "hooks", "stream", "verify", "cert"]

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -2830,7 +2830,9 @@ The parameters are the following:
     Dictionary of headers to send.
 
 ``other params``
-    Any other keywords supported by the ``requests`` api can be passed to this step
+    Any other keywords supported by the ``requests``
+    `api <http://docs.python-requests.org/en/master/api/#main-interface>`_
+    can be passed to this step.
 
     .. note::
 


### PR DESCRIPTION
ref: http://docs.python-requests.org/en/master/api/#main-interface
