### PR TITLE
Skip invalid utf8 warnings on mysql

### DIFF
--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -76,7 +76,7 @@ def patch_mysqlclient_warnings():
 
     def patched_init(self, *args):
         if isinstance(args[0], int):
-            super(Warning, self).__init__(args[1], args[0], *args[2:])
+            super(Warning, self).__init__("{} {}".format(args[0], args[1]))
         else:
             super(Warning, self).__init__(*args)
     Warning.__init__ = patched_init

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -118,7 +118,7 @@ warnings.filterwarnings('ignore', "Not importing directory.*docker': missing __i
                         category=ImportWarning)
 
 # FIXME: needs to be sorted out (#3666)
-warnings.filterwarnings('ignore', "Invalid utf8 character string")
+warnings.filterwarnings('ignore', "1300 Invalid utf8 character string")
 
 # twisted.compat.execfile is using 'U' https://twistedmatrix.com/trac/ticket/9023
 warnings.filterwarnings('ignore', "'U' mode is deprecated", DeprecationWarning)


### PR DESCRIPTION
This is needed to fix this warning:

```
Traceback (most recent call last):
  File "/buildbot/buildbot-job/build/sandbox/local/lib/python2.7/site-packages/twisted/trial/_synctest.py", line 1049, in run
    warnings.warn_explicit(**w)
_mysql_exceptions.Warning: (u"Invalid utf8 character string: 'B30572'", 1300L)
buildbot.test.unit.test_scripts_cleanupdb.TestCleanupDb.test_cleanup
```

It turns out that the Warning is a tuple, of form tuple(u"Invalid utf8 character string: 'B30572'", 1300L).

In buildbot/__init__.py, the filterwarnings('ignore', 'Invalid utf8 character string')
can only work if Warning is a string.