### PR TITLE
Remove __future__.with_statement

### DIFF
--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -19,7 +19,6 @@
 
 from __future__ import division
 from __future__ import print_function
-from __future__ import with_statement
 
 import os
 import re

--- a/master/buildbot/scripts/cleanupdb.py
+++ b/master/buildbot/scripts/cleanupdb.py
@@ -16,7 +16,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from __future__ import with_statement
 
 import os
 import sys

--- a/worker/buildbot_worker/__init__.py
+++ b/worker/buildbot_worker/__init__.py
@@ -20,7 +20,6 @@
 
 from __future__ import division
 from __future__ import print_function
-from __future__ import with_statement
 
 import os
 import re


### PR DESCRIPTION
The with statement has been a default part of Python since 2.6

See:
https://docs.python.org/2/library/__future__.html
