### PR TITLE
db: fix issue with db being closed by wrong thread

### DIFF
--- a/.py3.notworking.txt
+++ b/.py3.notworking.txt
@@ -19,6 +19,7 @@ buildbot.test.unit.test_db_pool.Basic.test_persistence_across_invocations
 buildbot.test.unit.test_db_pool.BasicWithDebug.test_do
 buildbot.test.unit.test_db_pool.BasicWithDebug.test_do_error
 buildbot.test.unit.test_db_pool.BasicWithDebug.test_do_exception
+buildbot.test.unit.test_pbmanager.TestPBManager.test_register_unregister
 buildbot.test.unit.test_process_buildstep.TestBuildStep.testcheckWorkerHasCommandTooOld
 buildbot.test.unit.test_process_users_manual.TestCommandlineUserManagerPerspective.test_perspective_commandline_get_format
 buildbot.test.unit.test_reporter_github.TestGitHubStatusPush.test_basic

--- a/master/buildbot/db/pool.py
+++ b/master/buildbot/db/pool.py
@@ -32,6 +32,7 @@ from buildbot.db.changesources import ChangeSourceAlreadyClaimedError
 from buildbot.db.schedulers import SchedulerAlreadyClaimedError
 from buildbot.process import metrics
 
+
 # set this to True for *very* verbose query debugging output; this can
 # be monkey-patched from master.cfg, too:
 #     from buildbot.db import pool
@@ -145,8 +146,8 @@ class DBThreadPool(object):
 
     def _stop(self):
         self._stop_evt = None
+        threads.deferToThreadPool(self.reactor, self._pool, self.engine.dispose)
         self._pool.stop()
-        self.engine.dispose()
         self.running = False
 
     def shutdown(self):

--- a/master/buildbot/newsfragments/db_shutdown.bugfix
+++ b/master/buildbot/newsfragments/db_shutdown.bugfix
@@ -1,0 +1,1 @@
+Fix issue with db being closed by wrong thread


### PR DESCRIPTION
Fixed an issue reported by @rodrigc on users@bb.net `threads and SQLite problem`.
Problem was that `self.engine.dispose()` was called by the parent thread and not the thread pool.