### PR TITLE
Secret returned by files provider. The secret is stored in files.

### DIFF
--- a/master/buildbot/secrets/providers/file.py
+++ b/master/buildbot/secrets/providers/file.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 import os
 
 from buildbot import config
-from buildbot.secrets.provider.base import SecretProviderBase
+from buildbot.secrets.providers.base import SecretProviderBase
 
 
 class SecretInAFile(SecretProviderBase):

--- a/master/buildbot/secrets/providers/file.py
+++ b/master/buildbot/secrets/providers/file.py
@@ -34,7 +34,7 @@ class SecretInAFile(SecretProviderBase):
     def checkFileIsReadOnly(self, dirname, secretfile):
         filepath = os.path.join(dirname, secretfile)
         obs_stat = stat.S_IMODE(os.stat(filepath).st_mode)
-        if (obs_stat & 0o77) != 0 and os.name=="posix":
+        if (obs_stat & 0o77) != 0 and os.name == "posix":
             config.error("Permissions %s on file %s are too open."
                          " It is required that your secret files are NOT"
                          " accessible by others!" % (oct(obs_stat),

--- a/master/buildbot/secrets/providers/file.py
+++ b/master/buildbot/secrets/providers/file.py
@@ -1,0 +1,49 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+"""
+file based provider
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+
+from buildbot import config
+from buildbot.secrets.provider.base import SecretProviderBase
+
+
+class SecretInAFile(SecretProviderBase):
+    """
+    secret is stored in a separate file under the given directory name
+    """
+    name = "SecretInAFile"
+
+    def checkConfig(self, name, dirname):
+        if dirname is None:
+            config.error("directory name could not be empty")
+
+    def reconfigService(self, name, dirname):
+        self._dirname = dirname
+
+    def get(self, entry):
+        """
+        get the value from the file identified by 'entry'
+        """
+        filename = os.path.join(self._dirname, entry)
+        assert os.path.isfile(filename), \
+            'File {} does not exist'.format(filename)
+        with open(filename) as source:
+            secret = source.read().strip()
+        return secret

--- a/master/buildbot/secrets/providers/file.py
+++ b/master/buildbot/secrets/providers/file.py
@@ -34,7 +34,7 @@ class SecretInAFile(SecretProviderBase):
     def checkFileIsReadOnly(self, dirname, secretfile):
         filepath = os.path.join(dirname, secretfile)
         obs_stat = stat.S_IMODE(os.stat(filepath).st_mode)
-        if (obs_stat & 0o77) != 0:
+        if (obs_stat & 0o77) != 0 and os.name=="posix":
             config.error("Permissions %s on file %s are too open."
                          " It is required that your secret files are NOT"
                          " accessible by others!" % (oct(obs_stat),

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -64,6 +64,8 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
         self.assertEqual(self.srvfile._dirname, self.tmp_dir)
 
     def testCheckConfigErrorSecretInAFileService(self):
+        if not os.name == "posix":
+            return
         file_path_not_readable, filepath = self.createFileTemp(self.tmp_dir,
                                                                "tempfile2.txt")
         os.chmod(filepath, stat.S_IRGRP)

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -46,7 +46,7 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
         filetmp, self.filepath = self.createFileTemp(self.tmp_dir,
                                                      "tempfile.txt",
                                                      text="key value")
-        os.chmod(self.filepath, stat.S_IRWXU)
+        os.chmod(self.filepath, 0o700)
         self.srvfile = SecretInAFile(self.tmp_dir)
         yield self.srvfile.startService()
 

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -18,8 +18,6 @@ from __future__ import print_function
 
 import os
 import stat
-from tempfile import mkdtemp
-from tempfile import mkstemp
 
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -50,8 +48,8 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
     def setUp(self):
         self.tmp_dir = self.createTempDir("temp")
         filetmp, self.filepath = self.createFileTemp(self.tmp_dir,
-                                                "tempfile.txt",
-                                                text="key value")
+                                                     "tempfile.txt",
+                                                     text="key value")
         os.chmod(self.filepath, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
         self.srvfile = SecretInAFile(self.tmp_dir)
         yield self.srvfile.startService()

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -34,9 +34,7 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
         tempdir.createDirectory()
         return tempdir.path
 
-    def createFileTemp(self, tempdir, filename, text=None):
-        if text is None:
-            text = ""
+    def createFileTemp(self, tempdir, filename, text=""):
         file_path = os.path.join(tempdir, filename)
         filetmp = open(file_path, 'w')
         with open(file_path, 'w') as filetmp:
@@ -56,6 +54,11 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def tearDown(self):
         yield self.srvfile.stopService()
+        # windows requires to close all existing open temp files not closed by
+        # open method
+        for tempfile in os.listdir(self.tmp_dir):
+            with open(os.path.join(self.tmp_dir, tempfile), 'w') as filetmp:
+                filetmp.close()
 
     def testCheckConfigSecretInAFileService(self):
         self.assertEqual(self.srvfile.name, "SecretInAFile")

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -17,6 +17,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
+import stat
+from tempfile import mkdtemp
 from tempfile import mkstemp
 
 from twisted.internet import defer
@@ -28,32 +30,77 @@ from buildbot.test.util.config import ConfigErrorsMixin
 
 class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
 
+    def createTempDir(self, dirname):
+        tempdir = self.mktemp()
+        basedir = os.path.dirname(tempdir)
+        tempdir = os.path.join(basedir, "temp")
+        os.mkdir(tempdir)
+        return tempdir
+
+    def createFileTemp(self, tempdir, filename, text=None):
+        file_path = os.path.join(tempdir, filename)
+        filetmp = open(file_path, 'w')
+        with open(file_path, 'w') as filetmp:
+            if text:
+                filetmp.write(text)
+            filetmp.close()
+        return filetmp, file_path
+
     @defer.inlineCallbacks
     def setUp(self):
-        self.srvfile = SecretInAFile("name", "/path/todirname")
+        self.tmp_dir = self.createTempDir("temp")
+        filetmp, self.filepath = self.createFileTemp(self.tmp_dir,
+                                                "tempfile.txt",
+                                                text="key value")
+        os.chmod(self.filepath, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+        self.srvfile = SecretInAFile(self.tmp_dir)
         yield self.srvfile.startService()
 
     @defer.inlineCallbacks
     def tearDown(self):
+        os.remove(self.filepath)
         yield self.srvfile.stopService()
 
     def testCheckConfigSecretInAFileService(self):
         self.assertEqual(self.srvfile.name, "SecretInAFile")
-        self.assertEqual(self.srvfile._dirname, "/path/todirname")
+        self.assertEqual(self.srvfile._dirname, self.tmp_dir)
 
     def testCheckConfigErrorSecretInAFileService(self):
-        self.assertRaisesConfigError("directory name could not be empty",
-         lambda: self.srvfile.checkConfig("name2", None))
+        file_path_not_readable, filepath = self.createFileTemp(self.tmp_dir,
+                                                               "tempfile2.txt")
+        os.chmod(filepath, stat.S_IWRITE)
+        expctd_msg_error = "the file tempfile2.txt is not read-only for user"
+        self.assertRaisesConfigError(expctd_msg_error,
+                                     lambda: self.srvfile.checkConfig(self.tmp_dir))
+        os.remove(filepath)
+
+    @defer.inlineCallbacks
+    def testCheckConfigfileExtension(self):
+        file_suffix, filepath = self.createFileTemp(self.tmp_dir,
+                                                    "tempfile2.ini",
+                                                    text="test suffix")
+        file_not_suffix, filepath2 = self.createFileTemp(self.tmp_dir,
+                                                         "tempfile2.txt",
+                                                         text="some text")
+        os.chmod(filepath, stat.S_IREAD)
+        os.chmod(filepath2, stat.S_IREAD)
+        yield self.srvfile.reconfigService(self.tmp_dir, suffix=".ini")
+        self.assertEqual(self.srvfile.get("tempfile2.ini"), "test suffix")
+        self.assertEqual(self.srvfile.get("tempfile2.txt"), None)
+        os.remove(filepath)
+        os.remove(filepath2)
 
     @defer.inlineCallbacks
     def testReconfigSecretInAFileService(self):
-        yield self.srvfile.reconfigService("name2", "/path/todirname2")
+        otherdir = self.createTempDir("temp2")
+        yield self.srvfile.reconfigService(otherdir)
         self.assertEqual(self.srvfile.name, "SecretInAFile")
-        self.assertEqual(self.srvfile._dirname, "/path/todirname2")
+        self.assertEqual(self.srvfile._dirname, otherdir)
 
-    def testGetFile(self):
-        (fd, name) = mkstemp()
-        os.write(fd, 'key value')
-        value = self.srvfile.get(name)
+    def testGetSecretInFile(self):
+        value = self.srvfile.get("tempfile.txt")
         self.assertEqual(value, "key value")
-        os.close(fd)
+
+    def testGetSecretInFileNotFound(self):
+        value = self.srvfile.get("tempfile2.txt")
+        self.assertEqual(value, None)

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -1,0 +1,59 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+from tempfile import mkstemp
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.secrets.providers.file import SecretInAFile
+from buildbot.test.util.config import ConfigErrorsMixin
+
+
+class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.srvfile = SecretInAFile("name", "/path/todirname")
+        yield self.srvfile.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.srvfile.stopService()
+
+    def testCheckConfigSecretInAFileService(self):
+        self.assertEqual(self.srvfile.name, "SecretInAFile")
+        self.assertEqual(self.srvfile._dirname, "/path/todirname")
+
+    def testCheckConfigErrorSecretInAFileService(self):
+        self.assertRaisesConfigError("directory name could not be empty",
+         lambda: self.srvfile.checkConfig("name2", None))
+
+    @defer.inlineCallbacks
+    def testReconfigSecretInAFileService(self):
+        yield self.srvfile.reconfigService("name2", "/path/todirname2")
+        self.assertEqual(self.srvfile.name, "SecretInAFile")
+        self.assertEqual(self.srvfile._dirname, "/path/todirname2")
+
+    def testGetFile(self):
+        (fd, name) = mkstemp()
+        os.write(fd, 'key value')
+        value = self.srvfile.get(name)
+        self.assertEqual(value, "key value")
+        os.close(fd)

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -36,7 +36,6 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
 
     def createFileTemp(self, tempdir, filename, text=""):
         file_path = os.path.join(tempdir, filename)
-        filetmp = open(file_path, 'w')
         with open(file_path, 'w') as filetmp:
             filetmp.write(text)
         return filetmp, file_path

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -35,11 +35,12 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
         return tempdir.path
 
     def createFileTemp(self, tempdir, filename, text=None):
+        if text is None:
+            text = ""
         file_path = os.path.join(tempdir, filename)
         filetmp = open(file_path, 'w')
         with open(file_path, 'w') as filetmp:
-            if text:
-                filetmp.write(text)
+            filetmp.write(text)
         return filetmp, file_path
 
     @defer.inlineCallbacks
@@ -64,7 +65,9 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
         file_path_not_readable, filepath = self.createFileTemp(self.tmp_dir,
                                                                "tempfile2.txt")
         os.chmod(filepath, stat.S_IRGRP)
-        expctd_msg_error = "the file tempfile2.txt is not user readable only"
+        expctd_msg_error = "Permissions 040 on file tempfile2.txt are too " \
+                           "open. It is required that your secret files are" \
+                           " NOT accessible by others!"
         self.assertRaisesConfigError(expctd_msg_error,
                                      lambda: self.srvfile.checkConfig(self.tmp_dir))
         os.remove(filepath)

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -67,7 +67,7 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
         file_path_not_readable, filepath = self.createFileTemp(self.tmp_dir,
                                                                "tempfile2.txt")
         os.chmod(filepath, stat.S_IRGRP)
-        expctd_msg_error = "Permissions 040 on file tempfile2.txt are too " \
+        expctd_msg_error = " on file tempfile2.txt are too " \
                            "open. It is required that your secret files are" \
                            " NOT accessible by others!"
         self.assertRaisesConfigError(expctd_msg_error,

--- a/master/docs/developer/secrets.rst
+++ b/master/docs/developer/secrets.rst
@@ -1,10 +1,11 @@
 .. _secrets:
 
+=======
 Secrets
--------
+=======
 
 SecretDetails
-`````````````
+=============
 
 A secret is identified by a couple (key, value).
 
@@ -23,7 +24,8 @@ Each parameter value could be returned by a function (source(), value(), key()).
 ``Secrets`` returned by the secrets manager are stored in a ``SecretDetails`` object.
 
 Secrets manager
-```````````````
+===============
+
 The secret manager is a Buildbot service, providing a get method API to retrieve a secret value.
 
 .. code-block:: python
@@ -39,3 +41,19 @@ The manager calls the get method of the configured provider and returns a ``Secr
   c['secretsProviders'] = [SecretsProviderOne(params), SecretsProviderTwo(params)]
 
 If more than one provider is defined in the configuration, the manager returns the first value found.
+
+Secrets providers
+=================
+
+The secrets providers are implementing the specific getters, related to the storage chosen.
+
+File provider
+`````````````
+
+.. code-block:: python
+
+    c['secretsManagers'] = [util.SecretInFile(directory="/path/toSecretsFiles"]
+
+In the master configuration the provider is instantiated through a Buildbot service secret manager with the file directory path.
+File secrets provider reads the file named by the key wanted by Buildbot and returns the contained text value.
+The provider SecretInFile allows Buildbot to read secrets in the secret directory.


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

