### PR TITLE
Fix test_steps_source_svn on Python 3

### DIFF
--- a/.py3.notworking.txt
+++ b/.py3.notworking.txt
@@ -13,7 +13,6 @@ buildbot.test.unit.test_schedulers_trysched.Try_Jobdir.test_parseJob_v5
 buildbot.test.unit.test_schedulers_trysched.Try_Jobdir.test_parseJob_v5_invalid_json
 buildbot.test.unit.test_schedulers_trysched.Try_Jobdir.test_parseJob_v5_no_builders
 buildbot.test.unit.test_schedulers_trysched.Try_Jobdir.test_parseJob_v5_no_properties
-buildbot.test.unit.test_steps_source_svn.TestSvnUriCanonicalize.test_quote_funny_chars
 buildbot.test.unit.test_www_config.IndexResource.test_render
 buildbot.test.unit.test_www_rest.V2RootResource_REST.test_api_collection
 buildbot.test.unit.test_www_rest.V2RootResource_REST.test_api_collection_fields

--- a/master/buildbot/compat.py
+++ b/master/buildbot/compat.py
@@ -1,0 +1,30 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+from future.moves.urllib.parse import quote
+from future.utils import PY3
+
+
+def urlquote(*args, **kwargs):
+    new_kwargs = dict(kwargs)
+    if not PY3:
+        new_kwargs = dict(kwargs)
+        if 'encoding' in new_kwargs:
+            del new_kwargs['encoding']
+        if 'errors' in kwargs:
+            del new_kwargs['errors']
+    return quote(*args, **new_kwargs)

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.moves.urllib.parse import quote as urlquote
 from future.moves.urllib.parse import unquote as urlunquote
 from future.moves.urllib.parse import urlparse
 from future.moves.urllib.parse import urlunparse
@@ -28,6 +27,7 @@ from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log
 
+from buildbot.compat import urlquote
 from buildbot.config import ConfigErrors
 from buildbot.process import buildstep
 from buildbot.process import remotecommand
@@ -428,7 +428,7 @@ class SVN(Source):
                         'svn': '3690'}
 
         relative_schemes = ['http', 'https', 'svn']
-        quote = lambda uri: urlquote(uri, "!$&'()*+,-./:=@_~")
+        quote = lambda uri: urlquote(uri, "!$&'()*+,-./:=@_~", encoding="latin-1")
 
         if len(uri) == 0 or uri == '/':
             return uri


### PR DESCRIPTION
I tried various combinations to get this test to work on Python 2 and Python 3,
but due to some corner cases where "somestring" is unicode on Python 3,
and bytes on Python 2, and the bytes in this testcase can't be decoded as ASCII,
I couldn't get this to work any other way.