### PR TITLE
Replace platform.linux_distribution() with distro.linux_distribution().

### DIFF
--- a/.py3.notworking.txt
+++ b/.py3.notworking.txt
@@ -6,9 +6,6 @@ buildbot.test.integration.test_try_client.Schedulers.test_userpass_list_builders
 buildbot.test.integration.test_try_client.Schedulers.test_userpass_no_wait
 buildbot.test.integration.test_try_client.Schedulers.test_userpass_wait
 buildbot.test.integration.test_www.Www.test_masters
-buildbot.test.unit.test_buildbot_net_usage_data.Tests.test_basic
-buildbot.test.unit.test_buildbot_net_usage_data.Tests.test_custom
-buildbot.test.unit.test_buildbot_net_usage_data.Tests.test_full
 buildbot.test.unit.test_data_properties.Properties.test_setBuildProperties
 buildbot.test.unit.test_process_users_manual.TestCommandlineUserManagerPerspective.test_perspective_commandline_get_format
 buildbot.test.unit.test_reporter_github.TestGitHubStatusPush.test_basic

--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -43,9 +43,26 @@ PHONE_HOME_URL = "https://events.buildbot.net/events/phone_home"
 
 
 def get_distro():
-    for distro in ('linux_distribution', 'mac_ver', 'win32_ver', 'java_ver'):
-        if hasattr(platform, distro):
-            return "{}:{}".format(distro, getattr(platform, distro)())
+    try:
+        from distro import linux_distribution
+    except ImportError:
+        linux_distribution = None
+
+    system = platform.system()
+    if system == "Linux":
+        dist = linux_distribution()
+        return "{}:{}".format(dist[0], dist[1])
+    elif system == "Windows":
+        dist = platform.win32_ver()
+        return "{}:{}".format(dist[0], dist[1])
+    elif system == "Java":
+        dist = platform.java_ver()
+        return "{}:{}".format(dist[0], dist[1])
+    elif system == "Darwin":
+        dist = platform.mac_ver()
+        return "{}".format(dist[0])
+    else:
+        return ":".join(platform.uname()[0:1])
 
 
 def getName(obj):

--- a/master/setup.py
+++ b/master/setup.py
@@ -444,6 +444,7 @@ setup_args['install_requires'] = [
     'txaio ' + txaio_ver,
     'autobahn ' + autobahn_ver,
     'PyJWT',
+    'distro'
 ]
 
 # Unit test dependencies.


### PR DESCRIPTION
platform.linux_distribution() is deprecated in Python 3.

In https://bugs.python.org/issue1322 , it is mentioned that the distro package should be used instead.