### PR TITLE
Add unicode2NativeString()

### DIFF
--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -31,8 +31,8 @@ from buildbot.process.results import SKIPPED
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.reporters import http
-from buildbot.util import bytes2NativeString
 from buildbot.util import httpclientservice
+from buildbot.util import unicode2NativeString
 
 HOSTED_BASE_URL = 'https://api.github.com'
 
@@ -145,22 +145,14 @@ class GitHubStatusPush(http.HttpStatusPushBase):
         for sourcestamp in sourcestamps:
             sha = sourcestamp['revision']
             try:
-                repo_user = repoOwner.encode('utf-8')
-                repo_user = bytes2NativeString(repo_user, encoding='utf-8')
-                repo_name = repoName.encode('utf-8')
-                repo_name = bytes2NativeString(repo_name, encoding='utf-8')
-                sha = sha.encode('utf-8')
-                sha = bytes2NativeString(sha, encoding='utf-8')
-                state = state.encode('utf-8')
-                state = bytes2NativeString(state, encoding='utf-8')
-                target_url = build['url'].encode('utf-8')
-                target_url = bytes2NativeString(target_url, encoding='utf-8')
-                context = context.encode('utf-8')
-                context = bytes2NativeString(context, encoding='utf-8')
-                issue = issue.encode('utf-8')
-                issue = bytes2NativeString(issue, encoding='utf-8')
-                description = description.encode('utf-8')
-                description = bytes2NativeString(description, encoding='utf-8')
+                repo_user = unicode2NativeString(repoOwner)
+                repo_name = unicode2NativeString(repoName)
+                sha = unicode2NativeString(sha)
+                state = unicode2NativeString(state)
+                target_url = unicode2NativeString(build['url'])
+                context = unicode2NativeString(context)
+                issue = unicode2NativeString(issue)
+                description = unicode2NativeString(description)
                 yield self.createStatus(
                     repo_user=repo_user,
                     repo_name=repo_name,

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -31,8 +31,8 @@ from buildbot.process.results import SKIPPED
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.reporters import http
-from buildbot.util import bytes2NativeString
 from buildbot.util import httpclientservice
+from buildbot.util import unicode2NativeString
 
 HOSTED_BASE_URL = 'https://gitlab.com'
 
@@ -131,8 +131,7 @@ class GitLabStatusPush(http.HttpStatusPushBase):
         # retrieve project id via cache
         self.project_ids
         project_full_name = "%s%%2F%s" % (repoOwner, repoName)
-        project_full_name = project_full_name.encode("utf-8")
-        project_full_name = bytes2NativeString(project_full_name)
+        project_full_name = unicode2NativeString(project_full_name)
 
         if project_full_name not in self.project_ids:
             proj = yield self._http.get('/api/v3/projects/%s' % (project_full_name))
@@ -143,18 +142,12 @@ class GitLabStatusPush(http.HttpStatusPushBase):
         for sourcestamp in sourcestamps:
             sha = sourcestamp['revision']
             try:
-                branch = branch.encode('utf-8')
-                branch = bytes2NativeString(branch, encoding='utf-8')
-                sha = sha.encode('utf-8')
-                sha = bytes2NativeString(sha, encoding='utf-8')
-                state = state.encode('utf-8')
-                state = bytes2NativeString(state, encoding='utf-8')
-                target_url = build['url'].encode('utf-8')
-                target_url = bytes2NativeString(target_url, encoding='utf-8')
-                context = context.encode('utf-8')
-                context = bytes2NativeString(context, encoding='utf-8')
-                description = description.encode('utf-8')
-                description = bytes2NativeString(description, encoding='utf-8')
+                branch = unicode2NativeString(branch)
+                sha = unicode2NativeString(sha)
+                state = unicode2NativeString(state)
+                target_url = unicode2NativeString(build['url'])
+                context = unicode2NativeString(context)
+                description = unicode2NativeString(description)
                 res = yield self.createStatus(
                     project_id=proj_id,
                     branch=branch,

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -240,8 +240,8 @@ class SubcommandOptions(usage.Options):
             here = next
             toomany -= 1  # just in case
             if toomany == 0:
-                print ("I seem to have wandered up into the infinite glories "
-                       "of the heavens. Oops.")
+                print("I seem to have wandered up into the infinite glories "
+                      "of the heavens. Oops.")
                 break
 
         searchpath.append(home)

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -37,7 +37,7 @@ from buildbot.steps import shell
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import fakeprotocol
-from buildbot.util import bytes2NativeString
+from buildbot.util import unicode2NativeString
 from buildbot.worker.base import Worker
 
 
@@ -98,8 +98,7 @@ class Latin1ProducingCustomBuildStep(buildstep.BuildStep):
     @defer.inlineCallbacks
     def run(self):
         l = yield self.addLog('xx')
-        output_bytes = u'\N{CENT SIGN}'.encode('latin-1')
-        output_str = bytes2NativeString(output_bytes, encoding='latin-1')
+        output_str = unicode2NativeString(u'\N{CENT SIGN}', encoding='latin-1')
         yield l.addStdout(output_str)
         yield l.finish()
         defer.returnValue(results.SUCCESS)

--- a/master/buildbot/test/unit/test_util.py
+++ b/master/buildbot/test/unit/test_util.py
@@ -298,6 +298,15 @@ class Bytes2Unicode(unittest.TestCase):
             self.assertEqual(str, bytes)
 
 
+class Unicode2NativeString(unittest.TestCase):
+
+    def test_unicode2NativeString(self):
+        rv = util.unicode2NativeString(u'abcd')
+        self.assertEqual((rv, type(rv)), ('abcd', str))
+        rv = util.unicode2NativeString('efgh')
+        self.assertEqual((rv, type(rv)), ('efgh', str))
+
+
 class StringToBoolean(unittest.TestCase):
 
     def test_it(self):

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -239,7 +239,7 @@ def ascii2unicode(x, errors='strict'):
     return bytes2unicode(x, encoding='ascii', errors=errors)
 
 
-def bytes2NativeString(x, encoding='utf-8'):
+def bytes2NativeString(x, encoding='utf-8', errors='strict'):
     """
     Convert C{bytes} to a native C{str}.
 
@@ -258,7 +258,29 @@ def bytes2NativeString(x, encoding='utf-8'):
     if isinstance(x, bytes) and type("") != type(b""):
         # On Python 3 and higher, type("") != type(b"")
         # so we need to decode() to return a native string.
-        return x.decode(encoding)
+        return x.decode(encoding, errors)
+    return x
+
+
+def unicode2NativeString(x, encoding='utf-8', errors='strict'):
+    """
+    Convert C{unicode} to a native C{str}.
+
+    On Python 3 and higher, the unicode type is gone,
+    replaced by str.   In this case, do nothing
+    and just return the native string.
+
+    On Python 2 and lower, unicode and str are separate types.
+    In this case, encode() to return the native string.
+
+    @param x: a string of type C{unicode}
+    @param encoding: an optional codec, default: 'utf-8'
+    @return: a string of type C{str}
+    """
+    if isinstance(x, text_type) and type(u"") != type(""):
+        # On Python 2 and lower, type(u"") != type("")
+        # so we need to encode() to return a native string.
+        return x.encode(encoding, errors)
     return x
 
 


### PR DESCRIPTION
There are a few cases in the code where on Python 2
we want to convert a unicode string to a native string by calling encode().

For example:

```
u"some str".encode("utf-8")   -> "some str"
```

There are some cases where on Python 3, we really don't want bytes,
but we want a "native string".  For example, stdout/stderr must always take native string, not bytes.
