### PR TITLE
GH OAuth: Use read-only scopes

### DIFF
--- a/master/buildbot/newsfragments/github_access_permissions.bugfix
+++ b/master/buildbot/newsfragments/github_access_permissions.bugfix
@@ -1,0 +1,1 @@
+Fix issue with buildbot requesting too many permissions from GitHub's OAuth

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -94,12 +94,13 @@ class OAuth2Auth(www.WwwTestMixin, unittest.TestCase):
         res = yield self.githubAuth.getLoginURL('http://redir')
         exp = ("https://github.com/login/oauth/authorize?client_id=ghclientID&"
                "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
-               "scope=user&state=redirect%3Dhttp%253A%252F%252Fredir")
+               "scope=user%3Aemail+read%3Aorg&"
+               "state=redirect%3Dhttp%253A%252F%252Fredir")
         self.assertEqual(res, exp)
         res = yield self.githubAuth.getLoginURL(None)
         exp = ("https://github.com/login/oauth/authorize?client_id=ghclientID&"
                "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
-               "scope=user")
+               "scope=user%3Aemail+read%3Aorg")
         self.assertEqual(res, exp)
 
     @defer.inlineCallbacks

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -193,7 +193,7 @@ class GitHubAuth(OAuth2Auth):
     name = "GitHub"
     faIcon = "fa-github"
     authUri = 'https://github.com/login/oauth/authorize'
-    authUriAdditionalParams = {'scope': 'user'}
+    authUriAdditionalParams = {'scope': 'user:email read:org'}
     tokenUri = 'https://github.com/login/oauth/access_token'
     resourceEndpoint = 'https://api.github.com'
 


### PR DESCRIPTION
Before, Buildbot would require Read/Write permissions from the user,
which are too many permissions that could be abused by buildbot.

This commit ensures that buildbot only needs read permissions.

![see](http://i.imgur.com/3ikb04Y.png)

If I read https://developer.github.com/v3/oauth/#scopes correctly, `user:email` should be enough to access all email addresses. Adding `read:org`, would allow seeing 'private' orgs for that user.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

