### PR TITLE
source: fix different url parsing in python2/python3

### DIFF
--- a/master/buildbot/compat.py
+++ b/master/buildbot/compat.py
@@ -1,0 +1,24 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+from future.moves.urllib.parse import quote
+from future.utils import PY3
+
+if PY3:
+    urlquote = lambda string: quote(string, encoding='latin')
+else:
+    urlquote = quote

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.moves.urllib.parse import quote as urlquote
 from future.moves.urllib.parse import unquote as urlunquote
 from future.moves.urllib.parse import urlparse
 from future.moves.urllib.parse import urlunparse
@@ -28,6 +27,7 @@ from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import log
 
+from buildbot.compat import urlquote
 from buildbot.config import ConfigErrors
 from buildbot.process import buildstep
 from buildbot.process import remotecommand
@@ -35,7 +35,6 @@ from buildbot.steps.source.base import Source
 
 
 class SVN(Source):
-
     """I perform Subversion checkout/update operations."""
 
     name = 'svn'
@@ -426,7 +425,6 @@ class SVN(Source):
         default_port = {'http': '80',
                         'https': '443',
                         'svn': '3690'}
-
         relative_schemes = ['http', 'https', 'svn']
         quote = lambda uri: urlquote(uri, "!$&'()*+,-./:=@_~")
 
@@ -455,8 +453,7 @@ class SVN(Source):
                 if last_path == path:
                     break
                 last_path = path
-
-        path = quote(urlunquote(path))
+        path = urlquote(urlunquote(path))
         canonical_uri = urlunparse(
             (scheme, authority, path, parameters, query, fragment))
         if canonical_uri == '/':


### PR DESCRIPTION
* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation