### PR TITLE
Add git to container

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -25,6 +25,7 @@ RUN \
     echo @testing http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
     apk add --no-cache \
+        git \
         python \
         py-pip \
         py-psycopg2 \


### PR DESCRIPTION
Following the tutorial at https://docs.buildbot.net/current/tutorial/docker.html if the container group is left to its own devices, it will report the following error because Git is not installed on the Alpine-based container:
```
buildbot_1  | 2017-02-21 14:07:30+0000 [-] while polling for changes
buildbot_1  |   Traceback (most recent call last):
buildbot_1  |     File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 393, in callback
buildbot_1  |       self._startRunCallbacks(result)
buildbot_1  |     File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 501, in _startRunCallbacks
buildbot_1  |       self._runCallbacks()
buildbot_1  |     File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 588, in _runCallbacks
buildbot_1  |       current.result = callback(current.result, *args, **kw)
buildbot_1  |     File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 1184, in gotResult
buildbot_1  |       _inlineCallbacks(r, g, deferred)
buildbot_1  |   --- <exception caught here> ---
buildbot_1  |     File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 1126, in _inlineCallbacks
buildbot_1  |       result = result.throwExceptionIntoGenerator(g)
buildbot_1  |     File "/usr/lib/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
buildbot_1  |       return g.throw(self.type, self.value, self.tb)
buildbot_1  |     File "/usr/lib/python2.7/site-packages/buildbot/changes/gitpoller.py", line 165, in poll
buildbot_1  |       yield self._dovccmd('init', ['--bare', self.workdir])
buildbot_1  |     File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 588, in _runCallbacks
buildbot_1  |       current.result = callback(current.result, *args, **kw)
buildbot_1  |     File "/usr/lib/python2.7/site-packages/buildbot/changes/gitpoller.py", line 368, in _convert_nonzero_to_failure
buildbot_1  |       % (command, args, path, self.repourl, code, stderr))
buildbot_1  |   exceptions.EnvironmentError: command init ['--bare', '/var/lib/buildbot/gitpoller-workdir'] in None on repourl git://github.com/buildbot/pyflakes.git failed with 
exit code 1: Upon execvpe git ['git', 'init', '--bare', '/var/lib/buildbot/gitpoller-workdir'] in environment id 140470394071592
buildbot_1  |   :Traceback (most recent call last):
buildbot_1  |     File "/usr/lib/python2.7/site-packages/twisted/internet/process.py", line 430, in _fork
buildbot_1  |       environment)
buildbot_1  |     File "/usr/lib/python2.7/site-packages/twisted/internet/process.py", line 508, in _execChild
buildbot_1  |       os.execvpe(executable, args, environment)
buildbot_1  |     File "/usr/lib/python2.7/os.py", line 355, in execvpe
buildbot_1  |       _execvpe(file, args, env)
buildbot_1  |     File "/usr/lib/python2.7/os.py", line 382, in _execvpe
buildbot_1  |       func(fullname, *argrest)
buildbot_1  |   OSError: [Errno 2] No such file or directory
```

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

👆 will address the above shortly, when I figure out where to add a test
