### PR TITLE
Move lint to bbtravis

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -97,9 +97,8 @@ install:
                   mysqlclient \
                   psycopg2 \
                   pg8000 \
-                  codecov
-
-      if [ $TESTS = trial -o $TESTS = coverage -o $TESTS = py3 ]; then pip install buildbot_www; fi
+                  codecov \
+                  buildbot_www
 
       if [ $TESTS = lint ]; then pip install -e './master[docs,test]'; fi
       # until towncrier toml is released, we need to fetch from git :-/

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -91,7 +91,6 @@ install:
       fi
       if [ $TWISTED != latest -a  $TWISTED != trunk ]; then pip install Twisted==$TWISTED ; fi
       if [ $SQLALCHEMY != latest ]; then pip install sqlalchemy==$SQLALCHEMY; fi
-      if [ $TESTS = trial -o $TESTS = coverage -o $TESTS = lint -o $TESTS = js -o $TESTS = py3 ]; then
       pip install -e pkg \
                   -e 'master[tls,test]' \
                   -e 'worker[test]' \
@@ -99,9 +98,6 @@ install:
                   psycopg2 \
                   pg8000 \
                   codecov
-      fi
-
-      if [ $TESTS = trial_worker ]; then pip install -e 'worker[test]'; fi
 
       if [ $TESTS = trial -o $TESTS = coverage -o $TESTS = py3 ]; then pip install buildbot_www; fi
 

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -77,6 +77,8 @@ matrix:
     # python 3 tests
     - python: "3.5"
       env: TWISTED=trunk SQLALCHEMY=latest TESTS=py3
+    - python: "3.5"
+      env: TWISTED=trunk SQLALCHEMY=latest TESTS=flake8
 
 # Dependencies installation commands
 install:

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -13,6 +13,8 @@ env:
   matrix:
   # lint, docs and coverage first as they're more likely to find issues
   - TWISTED=latest SQLALCHEMY=latest TESTS=lint
+  - TWISTED=latest SQLALCHEMY=latest TESTS=flake8
+  - TWISTED=latest SQLALCHEMY=latest TESTS=isort
   - TWISTED=latest SQLALCHEMY=latest TESTS=docs
   - TWISTED=latest SQLALCHEMY=latest TESTS=coverage
 
@@ -100,7 +102,7 @@ install:
                   codecov \
                   buildbot_www
 
-      if [ $TESTS = lint ]; then pip install -e './master[docs,test]'; fi
+      if [ $TESTS = lint -o $TESTS = flake8 -o $TESTS = isort ]; then pip install -e './master[docs,test]'; fi
       # until towncrier toml is released, we need to fetch from git :-/
       if [ $TESTS = docs ]; then pip install -e './master[docs]' 'git+https://github.com/tardyp/towncrier'; fi
 
@@ -152,11 +154,11 @@ script:
     cmd: make pylint
 
   - title: flake8
-    condition: TESTS == "lint"
+    condition: TESTS == "flake8"
     cmd: make flake8
 
   - title: isort
-    condition: TESTS == "lint"
+    condition: TESTS == "isort"
     cmd: isort --check -df `git ls-files |grep '.py$'`
 
   # Build documentation

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -101,8 +101,9 @@ install:
                   mysqlclient \
                   psycopg2 \
                   pg8000 \
-                  codecov \
-                  buildbot_www
+                  codecov
+      # install buildbot_www from pip in order to run the www tests
+      pip install buildbot_www
 
       if [ $TESTS = lint -o $TESTS = flake8 -o $TESTS = isort ]; then pip install -e './master[docs,test]'; fi
       # until towncrier toml is released, we need to fetch from git :-/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ python:
   - "2.7"
 
 env:
-  # lint, docs and coverage first as they're more likely to find issues
-  - TWISTED=latest SQLALCHEMY=latest TESTS=lint
   # Configuration when SQLite database is persistent between running tests
   # (by default in other tests in-memory SQLite database is used which is
   # recreated for each test).
@@ -82,7 +80,7 @@ install:
   # Install mysqlclient for tests that uses real MySQL
   # Install psycopg2 and pg8000 for tests that uses real PostgreSQL
   - |
-      if [ $TESTS = trial -o $TESTS = coverage -o $TESTS = lint -o $TESTS = js ]; then
+      if [ $TESTS = trial -o $TESTS = coverage -o $TESTS = js ]; then
       pip install -e pkg \
                   -e 'master[tls,test]' \
                   -e 'worker[test]' \
@@ -102,7 +100,6 @@ install:
 
   - "pip install -e worker future"
 
-  - "if [ $TESTS = lint -o $TESTS = flake8 ]; then pip install 'flake8~=2.6.0' ; fi"
   # Install sphinx so that pylint will be able to import it
   - "if [ $TESTS = lint ]; then  pip install sphinx ; fi"
   # Install docs dependencies for running the tests
@@ -132,10 +129,6 @@ script:
   # run tests under coverage for latest only (it's slower..)
   - "if [ $TESTS = coverage ]; then coverage run --rcfile=.coveragerc $(which trial) --reporter=text --rterrors buildbot.test buildbot_worker.test ; fi"
 
-  # Run additional tests in their separate job
-  - "if [ $TESTS = lint ]; then make pylint ; fi"
-  - "if [ $TESTS = lint -o $TESTS = flake8 ]; then make flake8; fi"
-  - "if [ $TESTS = lint ]; then isort --check -df `git ls-files |grep '.py$'` ; fi"
   # Build documentation
   - "if [ $TESTS = docs ]; then make docs ; fi"
   # Run spell checker on documentation


### PR DESCRIPTION
Move lint to bbtravis.
The travis builds are getting longer and longer, so shuffle things around
to try to optimize things.