### PR TITLE
py3.6 compatible test for test_default_origin

### DIFF
--- a/.py3.notworking.txt
+++ b/.py3.notworking.txt
@@ -1,2 +1,0 @@
-buildbot.test.unit.test_www_rest.V2RootResource.test_default_origin
-


### PR DESCRIPTION
in:
https://github.com/python/cpython/commit/bd48d27944453ad83d3ce37b2c867fa0d59a1c15

Python changed the implementation of fnmatch so that it generates a slightly different regex

So we change the test to actually test the functionality, and not depend on the regex generated
