### PR TITLE
Fix case in "c['BuildbotURL'] is misconfigured to ..." message

### DIFF
--- a/www/base/src/app/home/home.tpl.jade
+++ b/www/base/src/app/home/home.tpl.jade
@@ -1,7 +1,7 @@
 .container
   .row(ng-if="config.buildbotURL != baseurl")
       .alert.alert-danger Warning: 
-          | c['BuildbotURL'] is misconfigured to
+          | c['buildbotURL'] is misconfigured to
           pre {{config.buildbotURL}}
           | Should be:
           pre {{baseurl}}


### PR DESCRIPTION
A rather trivial change, but it confused me when I added the key stated to the configuration and it lead to an "Unknown BuildmasterConfig key BuildbotURL" error.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

(I haven't done any of these, but this change is about as trivial as it gets.)
