### PR TITLE
Fix traceback in buildbot/db/logs.py

### DIFF
--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -328,7 +328,8 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             # calculate how many bytes we saved
             q = sa.select([sa.func.sum(sa.func.length(tbl.c.content))])
             q = q.where(tbl.c.logid == logid)
-            newsize = conn.execute(q).fetchone()[0]
+            # if fetchone()[0] is None, then set it to 0  # pylint:disable=wrong-spelling-in-comment
+            newsize = conn.execute(q).fetchone()[0] or 0
             return totlength - newsize
 
         saved = yield self.db.pool.do(thdcompressLog)


### PR DESCRIPTION
This traceback was triggered by a custom LogLineObserver class traceback.
This is likely a corner case.  But none the less, this code change should
prevent further tracebacks and the log system from also failing.

2017-03-06 21:36:39+0000 [-] Got fatal Exception on DB
        Traceback (most recent call last):
        Failure: exceptions.TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'

2017-03-06 21:36:39+0000 [-] while compressing log 1456 (ignored)
        Traceback (most recent call last):
          File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 434, in errback
            self._startRunCallbacks(fail)
          File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 501, in _startRunCallbacks
            self._runCallbacks()
          File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 588, in _runCallbacks
            current.result = callback(current.result, *args, **kw)
          File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 1184, in gotResult
            _inlineCallbacks(r, g, deferred)
        --- <exception caught here> ---
          File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 1126, in _inlineCallbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/usr/lib64/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "/usr/lib64/python2.7/site-packages/buildbot/db/logs.py", line 334, in compressLog
            saved = yield self.db.pool.do(thdcompressLog)
          File "/usr/lib64/python2.7/site-packages/twisted/python/threadpool.py", line 246, in inContext
            result = inContext.theWork()
          File "/usr/lib64/python2.7/site-packages/twisted/python/threadpool.py", line 262, in <lambda>
            inContext.theWork = lambda: context.call(ctx, func, *args, **kw)
          File "/usr/lib64/python2.7/site-packages/twisted/python/context.py", line 118, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/usr/lib64/python2.7/site-packages/twisted/python/context.py", line 81, in callWithContext
            return func(*args,**kw)
          File "/usr/lib64/python2.7/site-packages/buildbot/db/pool.py", line 182, in __thd
            rv = callable(arg, *args, **kwargs)
          File "/usr/lib64/python2.7/site-packages/buildbot/db/logs.py", line 332, in thdcompressLog
            return totlength - newsize
        exceptions.TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'


## Contributor Checklist:

* [ *] I have updated the unit tests
* [ *] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [*] I have updated the appropriate documentation

NOTE:  I didn't have enough info about what fetchone() returns to know if a specific check needs to be done to detect a Nonetype condition or not.  This was a simple solution.  Please regard this as a starting point.  I can update it to do a specific check if you prefer.