### PR TITLE
Fix GNUAutoconf factory.

### DIFF
--- a/master/buildbot/process/factory.py
+++ b/master/buildbot/process/factory.py
@@ -86,24 +86,29 @@ class BuildFactory(util.ComparableMixin):
 # BuildFactory subclasses for common build tools
 
 
+class _DefaultCommand(object):
+    # Used to indicate a default command to the step.
+    pass
+
+
 class GNUAutoconf(BuildFactory):
 
     def __init__(self, source, configure="./configure",
                  configureEnv=None,
                  configureFlags=None,
                  reconf=None,
-                 compile=None,
-                 test=None,
-                 distcheck=None):
+                 compile=_DefaultCommand,
+                 test=_DefaultCommand,
+                 distcheck=_DefaultCommand):
         if configureEnv is None:
             configureEnv = {}
         if configureFlags is None:
             configureFlags = []
-        if compile is None:
+        if compile is _DefaultCommand:
             compile = ["make", "all"]
-        if test is None:
+        if test is _DefaultCommand:
             test = ["make", "check"]
-        if distcheck is None:
+        if distcheck is _DefaultCommand:
             distcheck = ["make", "distcheck"]
 
         BuildFactory.__init__(self, [source])

--- a/master/buildbot/test/unit/test_process_factory.py
+++ b/master/buildbot/test/unit/test_process_factory.py
@@ -122,6 +122,7 @@ class TestGNUAutoconf(TestBuildFactory):
     def test_init(self):
         # actual initialization is already done by setUp
         configurePresent = False
+        compilePresent = False
         checkPresent = False
         distcheckPresent = False
         for step in self.factory.steps:
@@ -130,6 +131,8 @@ class TestGNUAutoconf(TestBuildFactory):
             # the following checks are rather hairy and should be
             # rewritten less implementation dependent.
             try:
+                if step.buildStep().command == ['make', 'all']:
+                    compilePresent = True
                 if step.buildStep().command == ['make', 'check']:
                     checkPresent = True
                 if step.buildStep().command == ['make', 'distcheck']:
@@ -138,8 +141,23 @@ class TestGNUAutoconf(TestBuildFactory):
                 pass
 
         self.assertTrue(configurePresent)
+        self.assertTrue(compilePresent)
         self.assertTrue(checkPresent)
         self.assertTrue(distcheckPresent)
+
+    def test_init_none(self):
+        """Default steps can be uninitialized by setting None"""
+
+        self.factory = GNUAutoconf(source=BuildStep(), compile=None, test=None,
+                                   distcheck=None)
+        for step in self.factory.steps:
+            try:
+                cmd = step.buildStep().command
+                self.assertNotIn(cmd, [['make', 'all'], ['make', 'check'],
+                                 ['make', 'distcheck']],
+                                 "Build step %s should not be present." % cmd)
+            except(AttributeError, KeyError):
+                pass
 
     def test_init_reconf(self):
         # test reconf = True


### PR DESCRIPTION
The GNUAutoconf factory execute by default a sequence of compile,
test, and distcheck, but one is supposed to disable any of them by
setting None. Currently it doesn't work though.

This change fix the issue so that these steps may be disabled.

## Contributor Checklist:

* [x] I have updated the unit tests

