### PR TITLE
db/logs.py: Fix exception of compressing empty logs

### DIFF
--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -329,6 +329,8 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             q = sa.select([sa.func.sum(sa.func.length(tbl.c.content))])
             q = q.where(tbl.c.logid == logid)
             newsize = conn.execute(q).fetchone()[0]
+            if newsize is None:
+                newsize = totlength
             return totlength - newsize
 
         saved = yield self.db.pool.do(thdcompressLog)


### PR DESCRIPTION
We have running BuildBot with custom msbuild steps that logs warnings and errors into separate logfiles.
In case build finishes and log contains no line we see exception stack
trace below.
At the moment I don't have depth knowledge of BuildBot. It seems following patch could fix the problem.

[-] while compressing log 10 (ignored)
	Traceback (most recent call last):
	  File "c:\bb\bb-master\lib\site-packages\twisted\internet\defer.py", line 500, in errback
	    self._startRunCallbacks(fail)
	  File "c:\bb\bb-master\lib\site-packages\twisted\internet\defer.py", line 567, in _startRunCallbacks
	    self._runCallbacks()
	  File "c:\bb\bb-master\lib\site-packages\twisted\internet\defer.py", line 653, in _runCallbacks
	    current.result = callback(current.result, *args, **kw)
	  File "c:\bb\bb-master\lib\site-packages\twisted\internet\defer.py", line 1357, in gotResult
	    _inlineCallbacks(r, g, deferred)
	--- <exception caught here> ---
	  File "c:\bb\bb-master\lib\site-packages\twisted\internet\defer.py", line 1299, in _inlineCallbacks
	    result = result.throwExceptionIntoGenerator(g)
	  File "c:\bb\bb-master\lib\site-packages\twisted\python\failure.py", line 393, in throwExceptionIntoGenerator
	    return g.throw(self.type, self.value, self.tb)
	  File "c:\bb\bb-master\lib\site-packages\buildbot\db\logs.py", line 334, in compressLog
	    saved = yield self.db.pool.do(thdcompressLog)
	  File "c:\bb\bb-master\lib\site-packages\twisted\python\threadpool.py", line 250, in inContext
	    result = inContext.theWork()
	  File "c:\bb\bb-master\lib\site-packages\twisted\python\threadpool.py", line 266, in <lambda>
	    inContext.theWork = lambda: context.call(ctx, func, *args, **kw)
	  File "c:\bb\bb-master\lib\site-packages\twisted\python\context.py", line 122, in callWithContext
	    return self.currentContext().callWithContext(ctx, func, *args, **kw)
	  File "c:\bb\bb-master\lib\site-packages\twisted\python\context.py", line 85, in callWithContext
	    return func(*args,**kw)
	  File "c:\bb\bb-master\lib\site-packages\buildbot\db\pool.py", line 182, in __thd
	    rv = callable(arg, *args, **kwargs)
	  File "c:\bb\bb-master\lib\site-packages\buildbot\db\logs.py", line 332, in thdcompressLog
	    return totlength - newsize
	exceptions.TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

http://trac.buildbot.net/wiki/Development
And especially:
http://trac.buildbot.net/wiki/SubmittingPatches

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

