### PR TITLE
Fix exception in case of compressing empty logs

### DIFF
--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -286,6 +286,10 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                 numchunks += 1
             rows.close()
 
+            if totlength == 0:
+                # empty log
+                return 0
+
             if todo_numchunks > 1 or (force and todo_numchunks):
                 # last chunk group
                 todo_gather_list.append((todo_first_line, todo_last_line))

--- a/master/buildbot/newsfragments/db_compress_empty_log.bugfix
+++ b/master/buildbot/newsfragments/db_compress_empty_log.bugfix
@@ -1,0 +1,1 @@
+Fix issue with compressing empty log

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -523,6 +523,7 @@ class RealTests(Tests):
         logdict = yield self.db.logs.getLog(201)
         self.assertEqual(logdict, None)
 
+
 class TestFakeDB(unittest.TestCase, Tests):
 
     def setUp(self):

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -518,10 +518,27 @@ class RealTests(Tests):
         return self.do_addLogLines_huge_log(NUM_CHUNKS=3000, chunk=u'\N{SNOWMAN}\n' * 50)
 
     @defer.inlineCallbacks
-    def test_compressEmptyLog(self):
+    def test_compressLog_non_existing_log(self):
         yield self.db.logs.compressLog(201)
         logdict = yield self.db.logs.getLog(201)
         self.assertEqual(logdict, None)
+
+    @defer.inlineCallbacks
+    def test_compressLog_empty_log(self):
+        yield self.insertTestData(self.backgroundData + [
+            fakedb.Log(id=201, stepid=101, name=u'stdio', slug=u'stdio',
+                       complete=1, num_lines=0, type=u's'),
+        ])
+        yield self.db.logs.compressLog(201)
+        logdict = yield self.db.logs.getLog(201)
+        self.assertEqual(logdict, {
+            'stepid': 101,
+            'num_lines': 0,
+            'name': u'stdio',
+            'id': 201,
+            'type': u's',
+            'slug': u'stdio',
+            'complete': True})
 
 
 class TestFakeDB(unittest.TestCase, Tests):

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -517,6 +517,11 @@ class RealTests(Tests):
     def test_addLogLines_huge_log_lots_snowmans(self):
         return self.do_addLogLines_huge_log(NUM_CHUNKS=3000, chunk=u'\N{SNOWMAN}\n' * 50)
 
+    @defer.inlineCallbacks
+    def test_compressEmptyLog(self):
+        yield self.db.logs.compressLog(201)
+        logdict = yield self.db.logs.getLog(201)
+        self.assertEqual(logdict, None)
 
 class TestFakeDB(unittest.TestCase, Tests):
 


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

