### PR TITLE
Process changes from git tag push events

### DIFF
--- a/master/buildbot/newsfragments/www_hooks_github.feature
+++ b/master/buildbot/newsfragments/www_hooks_github.feature
@@ -1,1 +1,1 @@
-:py:class: `~buildbot.www.hooks.github.GitHubEventHandler` now process git tag push events
+:py:class: `~buildbot.status.web.hooks.github.GitHubEventHandler` now process git tag push events

--- a/master/buildbot/newsfragments/www_hooks_github.feature
+++ b/master/buildbot/newsfragments/www_hooks_github.feature
@@ -1,0 +1,1 @@
+:py:class: `~buildbot.www.hooks.github.GitHubEventHandler` now process git tag push events

--- a/master/buildbot/newsfragments/www_hooks_gitlab.feature
+++ b/master/buildbot/newsfragments/www_hooks_gitlab.feature
@@ -1,0 +1,1 @@
+:py:class: `~buildbot.www.hooks.gitlab` now process git tag push events

--- a/master/buildbot/newsfragments/www_hooks_gitlab.feature
+++ b/master/buildbot/newsfragments/www_hooks_gitlab.feature
@@ -1,1 +1,1 @@
-:py:class: `~buildbot.www.hooks.gitlab` now process git tag push events
+:py:class: `~buildbot.status.web.hooks.gitlab` now process git tag push events

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -903,6 +903,7 @@ class BuildStep(results.ResultComputingConfigMixin,
             desc += self.descriptionSuffix
         return desc
 
+
 components.registerAdapter(
     BuildStep._getStepFactory,
     BuildStep, interfaces.IBuildStepFactory)

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -83,6 +83,54 @@ gitJsonPayload = """
 }
 """
 
+gitJsonPayloadTag = """
+{
+  "before": "5aef35982fb2d34e9d9d4502f6ede1072793222d",
+  "repository": {
+    "url": "http://github.com/defunkt/github",
+    "html_url": "http://github.com/defunkt/github",
+    "name": "github",
+    "full_name": "defunkt/github",
+    "description": "You're lookin' at it.",
+    "watchers": 5,
+    "forks": 2,
+    "private": 1,
+    "owner": {
+      "email": "fred@flinstone.org",
+      "name": "defunkt"
+    }
+  },
+  "commits": [
+    {
+      "id": "41a212ee83ca127e3c8cf465891ab7216a705f59",
+      "distinct": true,
+      "url": "http://github.com/defunkt/github/commit/41a212ee83ca127e3c8cf465891ab7216a705f59",
+      "author": {
+        "email": "fred@flinstone.org",
+        "name": "Fred Flinstone"
+      },
+      "message": "okay i give in",
+      "timestamp": "2008-02-15T14:57:17-08:00",
+      "added": ["filepath.rb"]
+    },
+    {
+      "id": "de8251ff97ee194a289832576287d6f8ad74e3d0",
+      "url": "http://github.com/defunkt/github/commit/de8251ff97ee194a289832576287d6f8ad74e3d0",
+      "author": {
+        "email": "fred@flinstone.org",
+        "name": "Fred Flinstone"
+      },
+      "message": "update pricing a tad",
+      "timestamp": "2008-02-15T14:36:34-08:00",
+      "modified": ["modfile"],
+      "removed": ["removedFile"]
+    }
+  ],
+  "after": "de8251ff97ee194a289832576287d6f8ad74e3d0",
+  "ref": "refs/tags/v1.0.0"
+}
+"""
+
 gitJsonPayloadNonBranch = """
 {
   "before": "5aef35982fb2d34e9d9d4502f6ede1072793222d",
@@ -347,6 +395,17 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
     def test_ping_json(self):
         self._check_ping('{}')
+
+    @defer.inlineCallbacks
+    def test_git_with_push_tag(self):
+        self.request = _prepare_request('push', gitJsonPayloadTag)
+        yield self.request.test_render(self.changeHook)
+
+        self.assertEqual(len(self.changeHook.master.addedChanges), 2)
+        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(change["author"],
+                         "Fred Flinstone <fred@flinstone.org>")
+        self.assertEqual(change["branch"], "v1.0.0")
 
     # Test 'base' hook with attributes. We should get a json string
     # representing a Change object as a dictionary. All values show be set.

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -112,6 +112,7 @@ gitJsonPayloadTag = """
 }
 """
 
+
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
     def setUp(self):

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -68,7 +68,49 @@ gitJsonPayload = """
   "total_commits_count": 2
 }
 """
-
+gitJsonPayloadTag = """
+{
+  "object_kind": "tag_push",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "82b3d5ae55f7080f1e6022629cdb57bfae7cccc7",
+  "ref": "refs/tags/v1.0.0",
+  "checkout_sha": "82b3d5ae55f7080f1e6022629cdb57bfae7cccc7",
+  "user_id": 1,
+  "user_name": "John Smith",
+  "repository":{
+    "name": "Example",
+    "url": "git@localhost:diaspora.git",
+    "description": "",
+    "homepage": "http://example.com/jsmith/example",
+    "git_http_url":"http://example.com/jsmith/example.git",
+    "git_ssh_url":"git@example.com:jsmith/example.git",
+    "visibility_level":0
+  },
+   "commits": [
+     {
+       "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+       "message": "Update Catalan translation to e38cb41.",
+       "timestamp": "2011-12-12T14:27:31+02:00",
+       "url": "http://localhost/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+       "author": {
+         "name": "Jordi Mallach",
+         "email": "jordi@softcatala.org"
+       }
+     },
+     {
+       "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+       "message": "fixed readme",
+       "timestamp": "2012-01-03T23:36:29+02:00",
+       "url": "http://localhost/diaspora/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+       "author": {
+         "name": "GitLab dev user",
+         "email": "gitlabdev@dv6700.(none)"
+       }
+     }
+   ],
+   "total_commits_count": 2
+}
+"""
 
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
@@ -76,7 +118,18 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'gitlab': True}, master=fakeMasterForHooks())
 
-    def check_changes(self, r, project='', codebase=None):
+    def check_changes_tag_event(self, r, project='', codebase=None):
+        self.assertEqual(len(self.changeHook.master.addedChanges), 2)
+        change = self.changeHook.master.addedChanges[0]
+
+        self.assertEqual(change["repository"], "git@localhost:diaspora.git")
+        self.assertEqual(
+            calendar.timegm(change["when_timestamp"].utctimetuple()),
+            1323692851
+        )
+        self.assertEqual(change["branch"], "v1.0.0")
+
+    def check_changes_push_event(self, r, project='', codebase=None):
         self.assertEqual(len(self.changeHook.master.addedChanges), 2)
         change = self.changeHook.master.addedChanges[0]
 
@@ -114,6 +167,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(change.get("project"), project)
         self.assertEqual(change.get("codebase"), codebase)
 
+
     # Test 'base' hook with attributes. We should get a json string representing
     # a Change object as a dictionary. All values show be set.
     @defer.inlineCallbacks
@@ -122,7 +176,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request.uri = "/change_hook/gitlab"
         self.request.method = "POST"
         res = yield self.request.test_render(self.changeHook)
-        self.check_changes(res)
+        self.check_changes_push_event(res)
 
     @defer.inlineCallbacks
     def testGitWithChange_WithProjectToo(self):
@@ -131,7 +185,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request.args = {'project': ['MyProject']}
         self.request.method = "POST"
         res = yield self.request.test_render(self.changeHook)
-        self.check_changes(res, project="MyProject")
+        self.check_changes_push_event(res, project="MyProject")
 
     @defer.inlineCallbacks
     def testGitWithChange_WithCodebaseToo(self):
@@ -140,7 +194,16 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request.args = {'codebase': ['MyCodebase']}
         self.request.method = "POST"
         res = yield self.request.test_render(self.changeHook)
-        self.check_changes(res, codebase="MyCodebase")
+        self.check_changes_push_event(res, codebase="MyCodebase")
+
+    @defer.inlineCallbacks
+    def testGitWithChange_WithPushTag(self):
+        self.request = FakeRequest(content=gitJsonPayloadTag)
+        self.request.uri = "/change_hook/gitlab"
+        self.request.args = {'codebase': ['MyCodebase']}
+        self.request.method = "POST"
+        res = yield self.request.test_render(self.changeHook)
+        self.check_changes_tag_event(res, codebase="MyCodebase")
 
     def testGitWithNoJson(self):
         self.request = FakeRequest()

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -167,7 +167,6 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(change.get("project"), project)
         self.assertEqual(change.get("codebase"), codebase)
 
-
     # Test 'base' hook with attributes. We should get a json string representing
     # a Change object as a dictionary. All values show be set.
     @defer.inlineCallbacks

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -178,13 +178,13 @@ class GitHubEventHandler(object):
         changes = []
         refname = payload['ref']
 
-        # We only care about regular heads, i.e. branches
-        match = re.match(r"^refs/heads/(.+)$", refname)
+        # We only care about regular heads or tags
+        match = re.match(r"^refs/(heads|tags)/(.+)$", refname)
         if not match:
             log.msg("Ignoring refname `{}': Not a branch".format(refname))
             return changes
 
-        branch = match.group(1)
+        branch = match.group(2)
         if payload.get('deleted'):
             log.msg("Branch `{}' deleted, ignoring".format(branch))
             return changes

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -36,13 +36,13 @@ def _process_change(payload, user, repo, repo_url, project, codebase=None):
     changes = []
     refname = payload['ref']
 
-    # We only care about regular heads, i.e. branches
-    match = re.match(r"^refs/heads/(.+)$", refname)
+    # We only care about regular heads or tags
+    match = re.match(r"^refs/(heads|tags)/(.+)$", refname)
     if not match:
         log.msg("Ignoring refname `%s': Not a branch" % refname)
         return changes
 
-    branch = match.group(1)
+    branch = match.group(2)
     if payload.get('deleted'):
         log.msg("Branch `%s' deleted, ignoring" % branch)
         return changes

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -150,7 +150,7 @@ The parameters are:
                 ...))
 
 :guilabel:`Which events would you like to trigger this webhook?`
-    Leave the default -- ``Just the push event`` -- other kind of events are not currently supported.
+    Leave the default -- ``Just the push [tag]  events`` -- other kind of events are not currently supported.
 
 And then press the ``Add Webhook`` button.
 


### PR DESCRIPTION
Hello,
since GitLab/GitHUB has webhooks for git tag push events and now in master branch we have in the GitPoller polling from tags i believe it is reasonable to process this events ( tag push ) and in webhooks.
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

