### PR TITLE
docs: fix port numbers in docker tutorial

### DIFF
--- a/master/docs/tutorial/docker.rst
+++ b/master/docs/tutorial/docker.rst
@@ -64,12 +64,12 @@ Building and running Buildbot
   docker-compose up
 
 
-You should now be able to go to http://localhost:8010 and see a web page similar to:
+You should now be able to go to http://localhost:8080 and see a web page similar to:
 
 .. image:: _images/index.png
    :alt: index page
 
-Click on the `Waterfall Display link <http://localhost:8010/#/waterfall>`_ and you get this:
+Click on the `Waterfall Display link <http://localhost:8080/#/waterfall>`_ and you get this:
 
 .. image:: _images/waterfall-empty.png
    :alt: empty waterfall.


### PR DESCRIPTION
Either we fix the portnumbers here in the docs or we fix the example config in buildbot/buildbot-docker-example-config. 
Since the config is using `8080` and the tutorial tells to use `8010`

* [x] I have updated the appropriate documentation

