### PR TITLE
don't error in case buildbot takes too long to stop

### DIFF
--- a/smokes/run.sh
+++ b/smokes/run.sh
@@ -27,6 +27,7 @@ else
     ./node_modules/protractor/bin/webdriver-manager update
     ./node_modules/protractor/bin/protractor protractor.conf.js
 fi
+set +e
 buildbot stop workdir
 buildbot-worker stop workdir/worker
 rm -rf workdir


### PR DESCRIPTION
This makes spurious fails in the CI.
