### PR TITLE
Fix json.dumps() encoding error on Python 3

### DIFF
--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -133,7 +133,7 @@ def basicData(master):
         'plugins': plugins_uses,
         'db': master.config.db['db_url'].split("://")[0],
         'mq': master.config.mq['type'],
-        'www_plugins': master.config.www['plugins'].keys()
+        'www_plugins': list(master.config.www['plugins'].keys())
     }
 
 


### PR DESCRIPTION
This fixes an encoding error with json.dumps() on Python 3.

Fixes: https://github.com/buildbot/buildbot/issues/3052