### PR TITLE
Turn 022 to 0o22

### DIFF
--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -113,7 +113,7 @@ class CreateWorkerOptions(MakerBase):
          "Interval at which keepalives should be sent (in seconds)"],
         ["umask", None, "None",
          "controls permissions of generated files. "
-         "Use --umask=022 to be world-readable"],
+         "Use --umask=0o22 to be world-readable"],
         ["maxdelay", None, 300,
          "Maximum time between connection attempts"],
         ["numcpus", None, "None",

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -199,7 +199,7 @@ class CreateWorkerOptions(MakerBase):
             raise usage.UsageError("log-count parameter needs to be a number"
                                    " or None")
 
-        if not re.match(r'^\d+$', self['umask']) and \
+        if not re.match(r'^(0o)?\d+$', self['umask']) and \
                 self['umask'] != 'None':
             raise usage.UsageError("umask parameter needs to be a number"
                                    " or None")

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -166,7 +166,7 @@ class CreateWorkerOptions(MakerBase):
             port = int(port)
         except ValueError:
             raise usage.UsageError("invalid master port '%s', "
-                                   "needs to be an number" % port)
+                                   "needs to be a number" % port)
 
         return master, port
 
@@ -191,22 +191,22 @@ class CreateWorkerOptions(MakerBase):
             try:
                 self[argument] = int(self[argument])
             except ValueError:
-                raise usage.UsageError("%s parameter needs to be an number"
+                raise usage.UsageError("%s parameter needs to be a number"
                                        % argument)
 
         if not re.match(r'^\d+$', self['log-count']) and \
                 self['log-count'] != 'None':
-            raise usage.UsageError("log-count parameter needs to be an number"
+            raise usage.UsageError("log-count parameter needs to be a number"
                                    " or None")
 
         if not re.match(r'^\d+$', self['umask']) and \
                 self['umask'] != 'None':
-            raise usage.UsageError("umask parameter needs to be an number"
+            raise usage.UsageError("umask parameter needs to be a number"
                                    " or None")
 
         if not re.match(r'^\d+$', self['numcpus']) and \
                 self['numcpus'] != 'None':
-            raise usage.UsageError("numcpus parameter needs to be an number"
+            raise usage.UsageError("numcpus parameter needs to be a number"
                                    " or None")
 
         if self['allow-shutdown'] not in [None, 'signal', 'file']:

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -205,32 +205,32 @@ class TestCreateWorkerOptions(OptionsMixin, unittest.TestCase):
 
     def test_inv_keepalive(self):
         self.assertRaisesRegex(usage.UsageError,
-                               "keepalive parameter needs to be an number",
+                               "keepalive parameter needs to be a number",
                                self.parse, "--keepalive=X", *self.req_args)
 
     def test_inv_maxdelay(self):
         self.assertRaisesRegex(usage.UsageError,
-                               "maxdelay parameter needs to be an number",
+                               "maxdelay parameter needs to be a number",
                                self.parse, "--maxdelay=X", *self.req_args)
 
     def test_inv_log_size(self):
         self.assertRaisesRegex(usage.UsageError,
-                               "log-size parameter needs to be an number",
+                               "log-size parameter needs to be a number",
                                self.parse, "--log-size=X", *self.req_args)
 
     def test_inv_log_count(self):
         self.assertRaisesRegex(usage.UsageError,
-                               "log-count parameter needs to be an number or None",
+                               "log-count parameter needs to be a number or None",
                                self.parse, "--log-count=X", *self.req_args)
 
     def test_inv_numcpus(self):
         self.assertRaisesRegex(usage.UsageError,
-                               "numcpus parameter needs to be an number or None",
+                               "numcpus parameter needs to be a number or None",
                                self.parse, "--numcpus=X", *self.req_args)
 
     def test_inv_umask(self):
         self.assertRaisesRegex(usage.UsageError,
-                               "umask parameter needs to be an number or None",
+                               "umask parameter needs to be a number or None",
                                self.parse, "--umask=X", *self.req_args)
 
     def test_inv_allow_shutdown(self):
@@ -276,7 +276,7 @@ class TestCreateWorkerOptions(OptionsMixin, unittest.TestCase):
         opts = runner.CreateWorkerOptions()
         self.assertRaisesRegex(usage.UsageError,
                                "invalid master port 'apple', "
-                               "needs to be an number",
+                               "needs to be a number",
                                opts.validateMasterArgument, "host:apple")
 
     def test_validateMasterArgument_ok(self):

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -179,14 +179,14 @@ class TestCreateWorkerOptions(OptionsMixin, unittest.TestCase):
         self.patch(runner.MakerBase, "postOptions", mock.Mock())
 
         opts = self.parse("--force", "--relocatable", "--no-logrotate",
-                          "--keepalive=4", "--umask=022",
+                          "--keepalive=4", "--umask=0o22",
                           "--maxdelay=3", "--numcpus=4", "--log-size=2", "--log-count=1",
                           "--allow-shutdown=file", *self.req_args)
         self.assertOptions(opts,
                            {"force": True,
                             "relocatable": True,
                             "no-logrotate": True,
-                            "umask": "022",
+                            "umask": "0o22",
                             "maxdelay": 3,
                             "numcpus": "4",
                             "log-size": 2,


### PR DESCRIPTION
Python 3 doesn't support 022 as an octal number, instead requiring the
number to be 0o22. Python 2.7 supports that syntax too. Switch the three
locations to using the 0o prefix.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

