### PR TITLE
RETRY should be 5 and CANCELLED 6

### DIFF
--- a/master/docs/developer/results.rst
+++ b/master/docs/developer/results.rst
@@ -35,12 +35,12 @@ external tools, so the values are fixed.
 
 .. py:data:: RETRY
 
-    Value: 4; color: purple; a run that should be retried, usually due to a
+    Value: 5; color: purple; a run that should be retried, usually due to a
     worker disconnection.
 
 .. py:data:: CANCELLED
 
-    Value: 5; color: pink; a run that was cancelled by the user.
+    Value: 6; color: pink; a run that was cancelled by the user.
 
 .. py:data:: Results
 


### PR DESCRIPTION
Value 4 is duplicated, and as in the code RETRY should be 5 and CANCELLED 6

https://github.com/buildbot/buildbot/blob/858a282942fa5875bc6142b2970765d6196cb4de/www/md_base/src/app/common/common.constant.coffee#L14

https://github.com/buildbot/buildbot/blob/858a282942fa5875bc6142b2970765d6196cb4de/www/base/src/app/common/common.constant.coffee#L44

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

http://trac.buildbot.net/wiki/Development
And especially:
http://trac.buildbot.net/wiki/SubmittingPatches

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

