### PR TITLE
[WIP] obfuscate secrets

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -469,6 +469,7 @@ class BuildStep(results.ResultComputingConfigMixin,
             raise TypeError("step result string must be unicode (got %r)"
                             % (stepResult,))
         if self.stepid is not None:
+            stepResult = self.build.properties.cleanupTextFromSecrets(stepResult)
             yield self.master.data.updates.setStepStateString(self.stepid,
                                                               stepResult)
 

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -274,22 +274,24 @@ class RemoteCommand(base.RemoteCommandImpl, WorkerAPICompatMixin):
     @metrics.countMethod('RemoteCommand.remoteUpdate()')
     @defer.inlineCallbacks
     def remoteUpdate(self, update):
+        def cleanup(data):
+            return self.step.build.properties.cleanupTextFromSecrets(data)
         if self.debug:
             for k, v in iteritems(update):
                 log.msg("Update[%s]: %s" % (k, v))
         if "stdout" in update:
             # 'stdout': data
-            yield self.addStdout(update['stdout'])
+            yield self.addStdout(cleanup(update['stdout']))
         if "stderr" in update:
             # 'stderr': data
-            yield self.addStderr(update['stderr'])
+            yield self.addStderr(cleanup(update['stderr']))
         if "header" in update:
             # 'header': data
-            yield self.addHeader(update['header'])
+            yield self.addHeader(cleanup(update['header']))
         if "log" in update:
             # 'log': (logname, data)
             logname, data = update['log']
-            yield self.addToLog(logname, data)
+            yield self.addToLog(logname, cleanup(data))
         if "rc" in update:
             rc = self.rc = update['rc']
             log.msg("%s rc=%s" % (self, rc))

--- a/master/buildbot/test/integration/test_integration_secrets.py
+++ b/master/buildbot/test/integration/test_integration_secrets.py
@@ -29,8 +29,11 @@ class SecretsConfig(RunMasterBase):
         yield self.setupConfig(masterConfig())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
-        res = yield self.checkBuildStepLogExist(build, "echo bar")
+        res = yield self.checkBuildStepLogExist(build, "echo <foo>")
         self.assertTrue(res)
+        # at this point, build contains all the log and steps info that is in the db
+        # we check that our secret is not in there!
+        self.assertNotIn("bar", repr(build))
 
     @defer.inlineCallbacks
     def test_secretReconfig(self):
@@ -41,9 +44,11 @@ class SecretsConfig(RunMasterBase):
         yield self.master.reconfig()
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
-        res = yield self.checkBuildStepLogExist(build, "echo different_value")
+        res = yield self.checkBuildStepLogExist(build, "echo <foo>")
         self.assertTrue(res)
-
+        # at this point, build contains all the log and steps info that is in the db
+        # we check that our secret is not in there!
+        self.assertNotIn("different_value", repr(build))
 
 # master configuration
 def masterConfig():


### PR DESCRIPTION
buildbot-worker has this support for obfuscating secrets from the list of commands but:
- this works only for shell=False, list kinds ShellCommands
- this works only for shell commands
- this does not prevent secrets to leak in the logs

With this method, we prevent secrets to leak anywhere in the db

This method does not prevent secrets to leak in the twisted log of the worker

