### PR TITLE
changes: add additional information to properties in GitHubPullrequestPoller

### DIFF
--- a/master/buildbot/changes/github.py
+++ b/master/buildbot/changes/github.py
@@ -105,6 +105,7 @@ class GitHubPullrequestPoller(base.ReconfigurablePollingChangeSource,
         self.branches = branches
         self.project = project
         self.pollInterval = pollInterval
+        self.pollAtLaunch = pollAtLaunch
         self.repository_type = link_urls[repository_type]
         self.magic_link = magic_link
 
@@ -219,7 +220,7 @@ class GitHubPullrequestPoller(base.ReconfigurablePollingChangeSource,
                         failures[0].raiseException()
                 [files, email] = [r[1] for r in results]
 
-                if email is not None or email is not "null":
+                if email is not None and email is not "null":
                     author += " <" + str(email) + ">"
 
                 # emit the change

--- a/master/buildbot/newsfragments/changes_github.bugfix
+++ b/master/buildbot/newsfragments/changes_github.bugfix
@@ -1,0 +1,1 @@
+``pollAtLaunch`` of the :bb:chsrc:`GitHubPullrequestPoller` now works as expected. Also the author email won't be displayed as None

--- a/master/buildbot/newsfragments/chg_sources_github.feature
+++ b/master/buildbot/newsfragments/chg_sources_github.feature
@@ -1,1 +1,1 @@
- :bb:chsrc:`GitHubPullrequestPoller` now adds additional information about the pull request to properties.
+ :bb:chsrc:`GitHubPullrequestPoller` now adds additional information about the pull request to properties. The property argument is removed and is populated with the repository full name.

--- a/master/buildbot/newsfragments/chg_sources_github.feature
+++ b/master/buildbot/newsfragments/chg_sources_github.feature
@@ -1,0 +1,1 @@
+ :bb:chsrc:`GitHubPullrequestPoller` now adds additional information about the pull request to properties.

--- a/master/buildbot/newsfragments/www_hooks_github_pull.feature
+++ b/master/buildbot/newsfragments/www_hooks_github_pull.feature
@@ -1,0 +1,1 @@
+:py:class: `~buildbot.status.web.hooks.github.GitHubEventHandler` now adds more information about the pull request to the properties. This syncs features with GitHubPullrequestPoller

--- a/master/buildbot/test/unit/test_changes_github.py
+++ b/master/buildbot/test/unit/test_changes_github.py
@@ -67,6 +67,7 @@ gitJsonPayloadSinglePullrequest = """
     }
   },
   "merged": false,
+  "commits": 42,
   "mergeable": true,
   "mergeable_state": "clean",
   "merged_by": null

--- a/master/buildbot/test/unit/test_changes_github.py
+++ b/master/buildbot/test/unit/test_changes_github.py
@@ -184,6 +184,13 @@ class TestGitHubPullrequestPoller(changesource.ChangeSourceMixin,
         yield self.changesource.setServiceParent(self.master)
         yield self.attachChangeSource(self.changesource)
 
+    def assertDictSubset(self, expected_dict, response_dict):
+        expected = {}
+        for key in expected_dict.keys():
+            self.assertIn(key, set(response_dict.keys()))
+            expected[key] = response_dict[key]
+        self.assertDictEqual(expected_dict, expected)
+
     @defer.inlineCallbacks
     def test_describe(self):
         yield self.newChangeSource('defunkt', 'defunkt')
@@ -239,7 +246,8 @@ class TestGitHubPullrequestPoller(changesource.ChangeSourceMixin,
         self.assertEqual(change['repository'],
                          'https://github.com/defunkt/buildbot.git')
         self.assertEqual(change['files'], ['README.md'])
-        self.assertDictContainsSubset(_GH_PARSED_PROPS, change['properties'])
+
+        self.assertDictSubset(_GH_PARSED_PROPS, change['properties'])
         self.assertEqual(change["comments"],
                          "GitHub Pull Request #4242 (42 commits)\n"
                          "Update the README with new information\n"
@@ -297,7 +305,7 @@ class TestGitHubPullrequestPoller(changesource.ChangeSourceMixin,
         self.assertEqual(change['repository'],
                          'https://github.com/defunkt/buildbot.git')
         self.assertEqual(change['files'], ['README.md'])
-        self.assertDictContainsSubset(_GH_PARSED_PROPS, change['properties'])
+        self.assertDictSubset(_GH_PARSED_PROPS, change['properties'])
         self.assertEqual(change["comments"],
                          "GitHub Pull Request #4242 (42 commits)\n"
                          "Update the README with new information\n"
@@ -380,7 +388,7 @@ class TestGitHubPullrequestPoller(changesource.ChangeSourceMixin,
         self.assertEqual(change['repository'],
                          'https://github.com/buildbot/buildbot.git')
         self.assertEqual(change['files'], ['README.md'])
-        self.assertDictContainsSubset(_GH_PARSED_PROPS, change['properties'])
+        self.assertDictSubset(_GH_PARSED_PROPS, change['properties'])
         self.assertEqual(change["comments"],
                          "GitHub Pull Request #4242 (42 commits)\n"
                          "Update the README with new information\n"
@@ -420,7 +428,7 @@ class TestGitHubPullrequestPoller(changesource.ChangeSourceMixin,
         self.assertEqual(change['repository'],
                          'https://github.com/defunkt/buildbot.git')
         self.assertEqual(change['files'], ['README.md'])
-        self.assertDictContainsSubset(_GH_PARSED_PROPS, change['properties'])
+        self.assertDictSubset(_GH_PARSED_PROPS, change['properties'])
         self.assertEqual(change["comments"],
                          "GitHub Pull Request #4242 (42 commits)\n"
                          "Update the README with new information\n"

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -436,6 +436,13 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def setUp(self):
         self.changeHook = _prepare_github_change_hook(strict=False, github_property_whitelist=["github.*"])
 
+    def assertDictSubset(self, expected_dict, response_dict):
+        expected = {}
+        for key in expected_dict.keys():
+            self.assertIn(key, set(response_dict.keys()))
+            expected[key] = response_dict[key]
+        self.assertDictEqual(expected_dict, expected)
+
     @defer.inlineCallbacks
     def test_unknown_event(self):
         bad_event = b'whatever'
@@ -655,7 +662,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(change["branch"], "refs/pull/50/merge")
         self.assertEqual(change["revlink"],
                          "https://github.com/defunkt/github/pull/50")
-        self.assertDictContainsSubset(gitPRproperties, change["properties"])
+        self.assertDictSubset(gitPRproperties, change["properties"])
 
     def test_git_with_pull_encoded(self):
         self._check_git_with_pull([gitJsonPayloadPullRequest])

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -346,6 +346,21 @@ gitJsonPayloadPullRequest = """
 }
 """
 
+gitPRproperties = {
+    'github.head.sha': '05c588ba8cd510ecbe112d020f215facb17817a7',
+    'github.state': 'open',
+    'github.base.repo.full_name': 'defunkt/github',
+    'github.number': 50,
+    'github.base.ref': 'master',
+    'github.base.sha': '69a8b72e2d3d955075d47f03d902929dcaf74034',
+    'github.head.repo.full_name': 'defunkt/github',
+    'github.merged_at': None,
+    'github.head.ref': 'changes',
+    'github.closed_at': None,
+    'github.title': 'Update the README with new information',
+    'event': 'pull_request'
+}
+
 gitJsonPayloadEmpty = """
 {
   "before": "5aef35982fb2d34e9d9d4502f6ede1072793222d",
@@ -419,7 +434,7 @@ def _prepare_request(event, payload, _secret=None, headers=None):
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
     def setUp(self):
-        self.changeHook = _prepare_github_change_hook(strict=False)
+        self.changeHook = _prepare_github_change_hook(strict=False, github_property_whitelist=["github.*"])
 
     @defer.inlineCallbacks
     def test_unknown_event(self):
@@ -634,11 +649,13 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(change["revision"],
                          '05c588ba8cd510ecbe112d020f215facb17817a7')
         self.assertEqual(change["comments"],
-                         "GitHub Pull Request #50 (1 commit)")
+                         "GitHub Pull Request #50 (1 commit)\n"
+                         "Update the README with new information\n"
+                         "This is a pretty simple change that we need to pull into master.")
         self.assertEqual(change["branch"], "refs/pull/50/merge")
         self.assertEqual(change["revlink"],
                          "https://github.com/defunkt/github/pull/50")
-        self.assertEqual(change["properties"]["event"], "pull_request")
+        self.assertDictContainsSubset(gitPRproperties, change["properties"])
 
     def test_git_with_pull_encoded(self):
         self._check_git_with_pull([gitJsonPayloadPullRequest])

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -917,7 +917,8 @@ The :bb:chsrc:`GitHubPullrequestPoller` accepts the following arguments:
 ``magic_link``
    Set to `True` if the changes should contain ``refs/pulls/<PR #>/merge`` in the `branch` property and a link to the base `repository` in the repository property. These properties can be used by the :bb:step:`GitHub` source to pull from the special branch in the base repository. Default is `False`.
 
-
+``github_property_whitelist``
+   A list of ``fnmatch`` expressions which match against the flattened pull request information JSON prefixed with ``github``. For example ``github.number`` represents the pull request number. Available entries can be looked up in the GitHub API Documentation or by examining the data returned for a pull request by the API.
 
 .. bb:chsrc:: BitbucketPullrequestPoller
 


### PR DESCRIPTION
I want to checkout if this would have chances to get included into the main tree once I'm done refining it. 
Basically I'd like to extract more information from the PR and add it to the properties which then can be used in the builders.

Yes, no? Or in a different way?