### PR TITLE
steps: add assert renderable step to master steps

### DIFF
--- a/master/buildbot/newsfragments/process_property.feature
+++ b/master/buildbot/newsfragments/process_property.feature
@@ -1,0 +1,1 @@
+The class :py:class:`~buildbot.process.properties.Property` now allows being used with Python built in comparators. It will return a Renderable which executes the comparison.

--- a/master/buildbot/newsfragments/steps_master_assert.feature
+++ b/master/buildbot/newsfragments/steps_master_assert.feature
@@ -1,0 +1,1 @@
+New build step :py:class:`~buildbot.steps.master.Assert` Tests a renderable or constant if it evaluates to true. It will succeed or fail to step according to the result.

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -213,6 +213,23 @@ class SetProperties(BuildStep):
         return defer.succeed(SUCCESS)
 
 
+class Assert(BuildStep):
+    name = 'Assert'
+    description = ['Checking..']
+    descriptionDone = ["checked"]
+    renderables = ['check']
+
+    def __init__(self, check, **kwargs):
+        BuildStep.__init__(self, **kwargs)
+        self.check = check
+        self.descriptionDone = ["checked {}".format(repr(self.check))]
+
+    def run(self):
+        if self.check:
+            return defer.succeed(SUCCESS)
+        return defer.succeed(FAILURE)
+
+
 class LogRenderable(BuildStep):
     name = 'LogRenderable'
     description = ['Logging']

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -1232,6 +1232,62 @@ class TestProperty(unittest.TestCase):
                       ["string", "bla", "string", "bla"])
         return d
 
+    @defer.inlineCallbacks
+    def testCompEq(self):
+        self.props.setProperty("do-tests", "string", "scheduler")
+        result = yield self.build.render(Property("do-tests") == "string")
+        self.assertEqual(result, True)
+
+    @defer.inlineCallbacks
+    def testCompNe(self):
+        self.props.setProperty("do-tests", "not-string", "scheduler")
+        result = yield self.build.render(Property("do-tests") != "string")
+        self.assertEqual(result, True)
+
+    @defer.inlineCallbacks
+    def testCompLt(self):
+        self.props.setProperty("do-tests", 1, "scheduler")
+        result = yield self.build.render(Property("do-tests") < 2)
+        self.assertEqual(result, True)
+
+    @defer.inlineCallbacks
+    def testCompLe(self):
+        self.props.setProperty("do-tests", 1, "scheduler")
+        result = yield self.build.render(Property("do-tests") <= 2)
+        self.assertEqual(result, True)
+
+    @defer.inlineCallbacks
+    def testCompGt(self):
+        self.props.setProperty("do-tests", 3, "scheduler")
+        result = yield self.build.render(Property("do-tests") > 2)
+        self.assertEqual(result, True)
+
+    @defer.inlineCallbacks
+    def testCompGe(self):
+        self.props.setProperty("do-tests", 3, "scheduler")
+        result = yield self.build.render(Property("do-tests") >= 2)
+        self.assertEqual(result, True)
+
+    @defer.inlineCallbacks
+    def testStringCompEq(self):
+        self.props.setProperty("do-tests", "string", "scheduler")
+        test_string = "string"
+        result = yield self.build.render(test_string == Property("do-tests"))
+        self.assertEqual(result, True)
+
+    @defer.inlineCallbacks
+    def testIntCompLe(self):
+        self.props.setProperty("do-tests", 1, "scheduler")
+        test_int = 1
+        result = yield self.build.render(test_int <= Property("do-tests"))
+        self.assertEqual(result, True)
+
+    @defer.inlineCallbacks
+    def testPropCompGe(self):
+        self.props.setProperty("do-tests", 1, "scheduler")
+        result = yield self.build.render(Property("do-tests") >= Property("do-tests"))
+        self.assertEqual(result, True)
+
 
 class TestRenderableAdapters(unittest.TestCase):
 

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -2344,6 +2344,15 @@ LogRenderable
 This build step takes content which can be renderable and logs it in a pretty-printed format.
 It can be useful for debugging properties during a build.
 
+.. bb:step:: Assert
+
+Assert
+++++++
+
+.. py:class:: buildbot.steps.master.Assert
+
+This build step takes a Renderable or constant passed in as first argument. It will test if the expression evaluates to ``True`` and succeed the step or fail the step otherwise.
+
 .. index:: Properties; from steps
 
 .. _Setting-Properties:

--- a/master/setup.py
+++ b/master/setup.py
@@ -270,7 +270,7 @@ setup_args = {
                 'HTTPStep', 'POST', 'GET', 'PUT', 'DELETE', 'HEAD',
                 'OPTIONS']),
             ('buildbot.steps.master', [
-                'MasterShellCommand', 'SetProperty', 'SetProperties', 'LogRenderable']),
+                'MasterShellCommand', 'SetProperty', 'SetProperties', 'LogRenderable', "Assert"]),
             ('buildbot.steps.maxq', ['MaxQ']),
             ('buildbot.steps.mswin', ['Robocopy']),
             ('buildbot.steps.mtrlogobserver', ['MTR']),


### PR DESCRIPTION
This step allows to assert an user created expression. It supports renderables, callables and constant values. (But constant values don't make sense to me).
Unit tests should cover every code path.

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

