### PR TITLE
Nightly: use serviceid instead of objectid for classification

### DIFF
--- a/master/buildbot/newsfragments/README.txt
+++ b/master/buildbot/newsfragments/README.txt
@@ -10,5 +10,6 @@ towncrier has a few standard types of news fragments, signified by the file exte
 The core of the filename can be the fixed issue number of any unique text relative to your work.
 Buildbot project does not require a tracking ticket to be made for each contribution even if this is appreciated.
 
-Please point to the bug using syntax: (:bug:`NNN`)
+Please point to the trac bug using syntax: (:bug:`NNN`)
+Please point to the github bug using syntax: (:issue:`NNN`)
 please point to classes using syntax: :py:class:`~buildbot.reporters.http.HttpStatusBase`

--- a/master/buildbot/newsfragments/nightly.bugfix
+++ b/master/buildbot/newsfragments/nightly.bugfix
@@ -1,0 +1,1 @@
+Fix issue with :bb:sched::`Nightly` change classification raising foreign key exceptions (:issue:`3021`)

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -102,7 +102,7 @@ class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
                                              change_filter=self.change_filter,
                                              onlyImportant=self.onlyImportant)
         else:
-            yield self.master.db.schedulers.flushChangeClassifications(self.objectid)
+            yield self.master.db.schedulers.flushChangeClassifications(self.serviceid)
 
     @defer.inlineCallbacks
     def deactivate(self):
@@ -134,7 +134,7 @@ class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
             return defer.succeed(None)  # don't care about this change
 
         d = self.master.db.schedulers.classifyChanges(
-            self.objectid, {change.number: important})
+            self.serviceid, {change.number: important})
 
         if self.createAbsoluteSourceStamps:
             d.addCallback(lambda _: self.recordChange(change))
@@ -151,7 +151,7 @@ class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
 
         # use the collected changes to start a build
         scheds = self.master.db.schedulers
-        classifications = yield scheds.getChangeClassifications(self.objectid)
+        classifications = yield scheds.getChangeClassifications(self.serviceid)
 
         # if onlyIfChanged is True, then we will skip this build if no
         # important changes have occurred since the last invocation
@@ -167,7 +167,7 @@ class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
             max_changeid = changeids[-1]  # (changeids are sorted)
             yield self.addBuildsetForChanges(reason=self.reason,
                                              changeids=changeids)
-            yield scheds.flushChangeClassifications(self.objectid,
+            yield scheds.flushChangeClassifications(self.serviceid,
                                                     less_than=max_changeid + 1)
         else:
             # There are no changes, but onlyIfChanged is False, so start

--- a/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
@@ -193,13 +193,13 @@ class Nightly(scheduler.SchedulerMixin, unittest.TestCase):
                                    minute=[10, 20, 21, 40, 50, 51])
 
         # add a change classification
-        self.db.schedulers.fakeClassifications(self.OBJECTID, {19: True})
+        self.db.schedulers.fakeClassifications(self.SCHEDULERID, {19: True})
 
         yield sched.activate()
 
         # check that the classification has been flushed, since this
         # invocation has not requested onlyIfChanged
-        self.db.schedulers.assertClassifications(self.OBJECTID, {})
+        self.db.schedulers.assertClassifications(self.SCHEDULERID, {})
 
         self.clock.advance(0)  # let it get set up
         while self.clock.seconds() < self.localtime_offset + 30 * 60:

--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -148,7 +148,8 @@ intersphinx_mapping = {
 extlinks = {
     'pull': ('https://github.com/buildbot/buildbot/pull/%s', 'pull request '),
     'issue': ('https://github.com/buildbot/buildbot/issue/%s', 'issue # '),
-    'bug': ('http://trac.buildbot.net/ticket/%s', 'bug #'),  # deprecated. Use issue instead, and point to GH
+    # deprecated. Use issue instead, and point to Github
+    'bug': ('http://trac.buildbot.net/ticket/%s', 'bug #'),
     # Renders as link with whole url, e.g.
     #   :src-link:`master`
     # renders as

--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -146,8 +146,9 @@ intersphinx_mapping = {
 }
 
 extlinks = {
-    'bug': ('http://trac.buildbot.net/ticket/%s', 'bug #'),
     'pull': ('https://github.com/buildbot/buildbot/pull/%s', 'pull request '),
+    'issue': ('https://github.com/buildbot/buildbot/issue/%s', 'issue # '),
+    'bug': ('http://trac.buildbot.net/ticket/%s', 'bug #'),  # deprecated. Use issue instead, and point to GH
     # Renders as link with whole url, e.g.
     #   :src-link:`master`
     # renders as


### PR DESCRIPTION
fixes https://github.com/buildbot/buildbot/issues/3021

serviceid is pointing to the schedulerid, and is the id required for classification, while objectid is for the state table
this is the same fix as http://trac.buildbot.net/ticket/3532.
I did grep for other use of xxxChangeClassifications to find the same bug class, but it seems nightly is the only remaining
