### PR TITLE
Trigger step issue 3088

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -101,6 +101,7 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         # overall results, may downgrade after each step
         self.results = SUCCESS
         self.properties = properties.Properties()
+        self.nsteps = 0
 
     def setBuilder(self, builder):
         """
@@ -410,6 +411,7 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
 
             if self.useProgress:
                 step.setupProgress()
+        self.nsteps += len(steps)
         return steps
 
     def setupBuild(self):
@@ -492,7 +494,10 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         terminate = self.stepDone(results, step)  # interpret/merge results
         if terminate:
             self.terminate = True
-        return self.startNextStep()
+        if len(self.executedSteps) == self.nsteps:
+            return self.allStepsDone()
+        if self.steps:
+            return self.startNextStep()
 
     def stepDone(self, results, step):
         """This method is called when the BuildStep completes. It is passed a

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -102,6 +102,7 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         self.results = SUCCESS
         self.properties = properties.Properties()
         self.nsteps = 0
+        self.doneSteps = []
 
     def setBuilder(self, builder):
         """
@@ -494,7 +495,8 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         terminate = self.stepDone(results, step)  # interpret/merge results
         if terminate:
             self.terminate = True
-        if len(self.executedSteps) == self.nsteps:
+        self.doneSteps.append(step)
+        if len(self.doneSteps) == self.nsteps:
             return self.allStepsDone()
         if self.steps:
             return self.startNextStep()

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -319,6 +319,7 @@ class BuildStep(results.ResultComputingConfigMixin,
     rendered = False  # true if attributes are rendered
     _workdir = None
     _waitingForLocks = False
+    __mutex = defer.DeferredLock()
 
     def _run_finished_hook(self):
         return None  # override in tests
@@ -484,9 +485,11 @@ class BuildStep(results.ResultComputingConfigMixin,
     def addStep(self):
         # create and start the step, noting that the name may be altered to
         # ensure uniqueness
+        self.__mutex.acquire()
         self.stepid, self.number, self.name = yield self.master.data.updates.addStep(
             buildid=self.build.buildid,
             name=util.ascii2unicode(self.name))
+        self.__mutex.release()
         yield self.master.data.updates.startStep(self.stepid)
 
     @defer.inlineCallbacks

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -50,6 +50,7 @@ class Trigger(BuildStep):
 
     def __init__(self, schedulerNames=None, sourceStamp=None, sourceStamps=None,
                  updateSourceStamp=None, alwaysUseLatest=False,
+                 startNext=False,
                  waitForFinish=False, set_properties=None,
                  copy_properties=None, parent_relationship="Triggered from",
                  unimportantSchedulerNames=None, **kwargs):
@@ -86,6 +87,7 @@ class Trigger(BuildStep):
             self.updateSourceStamp = not (alwaysUseLatest or self.sourceStamps)
         self.alwaysUseLatest = alwaysUseLatest
         self.waitForFinish = waitForFinish
+        self.startNext = startNext
 
         if set_properties is None:
             set_properties = {}
@@ -226,6 +228,10 @@ class Trigger(BuildStep):
 
     @defer.inlineCallbacks
     def run(self):
+        # startNext and waitForFinish should be both true for this case
+        if self.startNext and self.waitForFinish and self.build.steps:
+            self.build.startNextStep()
+
         schedulers_and_props = yield self.getSchedulersAndProperties()
 
         schedulers_and_props_list = []


### PR DESCRIPTION
Hello,
this is PR for issue 3088 (trigger: combine waitForFinish and not waitForFinish behavior )

There is a draft version. I ran all tests, but haven't added any new.

The main idea is to start next step in build before scheduling child build from trigger.
So build is not blocked (it can execute next step) and build is waiting child build for finish.

There is one change in Build.addStep to prevent race conditions when build adds steps to DB. 
Race condition could be because addStep can be invoked simultaniosly in startNextStep() when step is finished and from trigger step in startNextStep() call.

Also there can be case when last step in parent build finished earlier then children.
Decision about finish of build was taken in Build.startNextStep. Build is finished If there is no next steps.
But it is not work in case that I have described. So I moved this check to Build._stepDone.
I also had to compare number of done steps with total amount of steps.
Build.executedSteps is updated before step is done. That's why I have added doneSteps list and update 
it when step is done for correct compare.

Maybe executedSteps can be updated when step is done? If so, doneSteps can be removed.

Does this solution look ok?
What tests I should add?  

