### PR TITLE
fixed pattern-based authz check

### DIFF
--- a/master/buildbot/test/unit/test_www_authz.py
+++ b/master/buildbot/test/unit/test_www_authz.py
@@ -150,7 +150,7 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_fnmatchPatternRoleCheck(self):
-        # set defaultDeny to True so action is denied if no match
+        # defaultDeny is True by default so action is denied if no match
         allow_rules = [
                         AnyEndpointMatcher(role="[a,b]dmin?")
         ]
@@ -160,17 +160,18 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
         yield self.assertUserAllowed("builds/13", "rebuild", {}, "homer")
 
         # check if action is denied
-        with self.assertRaises(authz.Forbidden):
+        with self.assertRaisesRegex(authz.Forbidden, '403 you need to have role .+'):
             yield self.assertUserAllowed("builds/13", "rebuild", {}, "nineuser")
 
-        with self.assertRaises(authz.Forbidden):
+        with self.assertRaisesRegex(authz.Forbidden, '403 you need to have role .+'):
             yield self.assertUserAllowed("builds/13", "rebuild", {}, "eightuser")
 
     @defer.inlineCallbacks
     def test_regexPatternRoleCheck(self):
         # change matcher
         self.authz.match = authz.reStrMatcher
-        # set defaultDeny to True so action is denied if no match
+
+        # defaultDeny is True by default so action is denied if no match
         allow_rules = [
             AnyEndpointMatcher(role="(admin|agent)s"),
         ]
@@ -181,15 +182,15 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
         yield self.assertUserAllowed("builds/13", "rebuild", {}, "bond")
 
         # check if action is denied
-        with self.assertRaises(authz.Forbidden):
+        with self.assertRaisesRegex(authz.Forbidden, '403 you need to have role .+'):
             yield self.assertUserAllowed("builds/13", "rebuild", {}, "nineuser")
 
-        with self.assertRaises(authz.Forbidden):
+        with self.assertRaisesRegex(authz.Forbidden, '403 you need to have role .+'):
             yield self.assertUserAllowed("builds/13", "rebuild", {}, "eightuser")
 
     @defer.inlineCallbacks
     def test_DefaultDenyFalseContinuesCheck(self):
-        # set defaultDeny to True in last rule so action is denied in this test
+        # defaultDeny is True in the last rule so action is denied in the last check
         allow_rules = [
             AnyEndpointMatcher(role="not-exists1", defaultDeny=False),
             AnyEndpointMatcher(role="not-exists2", defaultDeny=False),
@@ -199,12 +200,12 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
         self.setAllowRules(allow_rules)
 
         # check if action is denied and last check was exact against not-exist3
-        with self.assertRaisesRegex(authz.Forbidden, '.*not-exists3.*'):
+        with self.assertRaisesRegex(authz.Forbidden, '.+not-exists3.+'):
             yield self.assertUserAllowed("builds/13", "rebuild", {}, "nineuser")
 
     @defer.inlineCallbacks
     def test_DefaultDenyTrueStopsCheckIfFailed(self):
-        # set defaultDeny to True in last rule so action is denied in this test
+        # defaultDeny is True in the first rule so action is denied in the first check
         allow_rules = [
             AnyEndpointMatcher(role="not-exists1", defaultDeny=True),
             AnyEndpointMatcher(role="not-exists2", defaultDeny=False),
@@ -213,6 +214,6 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
 
         self.setAllowRules(allow_rules)
 
-        # check if action is denied and last check was exact against not-exist3
-        with self.assertRaisesRegex(authz.Forbidden, '.*not-exists1.*'):
+        # check if action is denied and last check was exact against not-exist1
+        with self.assertRaisesRegex(authz.Forbidden, '.+not-exists1.+'):
             yield self.assertUserAllowed("builds/13", "rebuild", {}, "nineuser")

--- a/master/buildbot/test/unit/test_www_authz.py
+++ b/master/buildbot/test/unit/test_www_authz.py
@@ -105,7 +105,7 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
         ])
 
     def setAllowRules(self, allow_rules):
-        # we should add links to autz and master instances in each new rule
+        # we should add links to authz and master instances in each new rule
         for r in allow_rules:
             r.setAuthz(self.authz)
 
@@ -152,7 +152,7 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
     def test_fnmatchPatternRoleCheck(self):
         # set defaultDeny to True so action is denied if no match
         allow_rules = [
-                        AnyEndpointMatcher(role="[a,b]dmin?", defaultDeny=True)
+                        AnyEndpointMatcher(role="[a,b]dmin?")
         ]
 
         self.setAllowRules(allow_rules)
@@ -172,7 +172,7 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
         self.authz.match = authz.reStrMatcher
         # set defaultDeny to True so action is denied if no match
         allow_rules = [
-            AnyEndpointMatcher(role="(admin|agent)s", defaultDeny=True),
+            AnyEndpointMatcher(role="(admin|agent)s"),
         ]
 
         self.setAllowRules(allow_rules)
@@ -199,7 +199,7 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
         self.setAllowRules(allow_rules)
 
         # check if action is denied and last check was exact against not-exist3
-        with self.assertRaisesRegexp(authz.Forbidden, '.*not-exists3.*'):
+        with self.assertRaisesRegex(authz.Forbidden, '.*not-exists3.*'):
             yield self.assertUserAllowed("builds/13", "rebuild", {}, "nineuser")
 
     @defer.inlineCallbacks
@@ -214,5 +214,5 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
         self.setAllowRules(allow_rules)
 
         # check if action is denied and last check was exact against not-exist3
-        with self.assertRaisesRegexp(authz.Forbidden, '.*not-exists1.*'):
+        with self.assertRaisesRegex(authz.Forbidden, '.*not-exists1.*'):
             yield self.assertUserAllowed("builds/13", "rebuild", {}, "nineuser")

--- a/master/buildbot/www/authz/authz.py
+++ b/master/buildbot/www/authz/authz.py
@@ -24,8 +24,8 @@ from twisted.web.error import Error
 from zope.interface import implementer
 
 from buildbot.interfaces import IConfigured
-from buildbot.www.authz.roles import RolesFromOwner
 from buildbot.util import unicode2bytes
+from buildbot.www.authz.roles import RolesFromOwner
 
 
 class Forbidden(Error):
@@ -97,6 +97,7 @@ class Authz(object):
                 if not rule.defaultDeny:
                     continue   # check next suitable rule if not denied
                 else:
-                    error_msg = unicode2bytes("you need to have role '%s'" % rule.role)
+                    error_msg = unicode2bytes(
+                        "you need to have role '%s'" % rule.role)
                     raise Forbidden(error_msg)
         defer.returnValue(None)

--- a/master/buildbot/www/authz/authz.py
+++ b/master/buildbot/www/authz/authz.py
@@ -25,6 +25,7 @@ from zope.interface import implementer
 
 from buildbot.interfaces import IConfigured
 from buildbot.www.authz.roles import RolesFromOwner
+from buildbot.util import unicode2bytes
 
 
 class Forbidden(Error):
@@ -96,6 +97,6 @@ class Authz(object):
                 if not rule.defaultDeny:
                     continue   # check next suitable rule if not denied
                 else:
-                    raise Forbidden(
-                        "you need to have role '%s'" % (rule.role,))
+                    error_msg = unicode2bytes("you need to have role '%s'" % rule.role)
+                    raise Forbidden(error_msg)
         defer.returnValue(None)

--- a/master/buildbot/www/authz/authz.py
+++ b/master/buildbot/www/authz/authz.py
@@ -89,10 +89,13 @@ class Authz(object):
                     if owner is not None:
                         roles.update(
                             self.getOwnerRolesFromUser(userDetails, owner))
-                if rule.role not in roles:
-                    if rule.defaultDeny:
-                        raise Forbidden(
-                            "you need to have role '%s'" % (rule.role,))
-                elif not rule.defaultDeny:
-                    defer.returnValue(None)
+                for role in roles:
+                    if self.match(role, rule.role):
+                        defer.returnValue(None)
+
+                if not rule.defaultDeny:
+                    continue   # check next suitable rule if not denied
+                else:
+                    raise Forbidden(
+                        "you need to have role '%s'" % (rule.role,))
         defer.returnValue(None)


### PR DESCRIPTION
Hello.

It seems that I have found couple of bugs in authz.
First, pattern-based roles checking didn't work as described in doc.
There was only simple check if rule's role in user's list of roles.

Second, authz check finished successfully if role had defaultDeny=False.
For example in tests ( buildbot.test.unit.test_www_authz ) all checks returned success.
Because first role to compare was
AnyEndpointMatcher(role="admins", defaultDeny=False)
So if user has not "admins" in his roles this check was successful too.

Please correct me if I'm wrong.