### PR TITLE
authz: fix AnyControlEndpointMatcher

### DIFF
--- a/master/buildbot/newsfragments/anycontrol_endpointmatcher.bugfix
+++ b/master/buildbot/newsfragments/anycontrol_endpointmatcher.bugfix
@@ -1,0 +1,1 @@
+:py:class:`buildbot.www.authz.endpointmatchers.AnyControlEndpointMatcher` now actually doesn't match `GET` requests. Before it would act like an `AnyEndpointMatcher` since the `GET` had a different case.

--- a/master/buildbot/test/unit/test_www_endpointmatchers.py
+++ b/master/buildbot/test/unit/test_www_endpointmatchers.py
@@ -80,8 +80,13 @@ class AnyControlEndpointMatcher(EndpointBase):
         return endpointmatchers.AnyControlEndpointMatcher(role="foo")
 
     @defer.inlineCallbacks
-    def test_get(self):
+    def test_default_action(self):
         ret = yield self.matcher.match(("foo", "bar"))
+        self.assertMatch(ret)
+
+    @defer.inlineCallbacks
+    def test_get(self):
+        ret = yield self.matcher.match(("foo", "bar"), action="GET")
         self.assertNotMatch(ret)
 
     @defer.inlineCallbacks

--- a/master/buildbot/www/authz/endpointmatchers.py
+++ b/master/buildbot/www/authz/endpointmatchers.py
@@ -109,8 +109,8 @@ class AnyControlEndpointMatcher(EndpointMatcherBase):
     def __init__(self, **kwargs):
         EndpointMatcherBase.__init__(self, **kwargs)
 
-    def match(self, ep, action="get", options=None):
-        if action != "get":
+    def match(self, ep, action="", options=None):
+        if action != "GET":
             return defer.succeed(Match(self.master))
         return defer.succeed(None)
 

--- a/master/buildbot/www/authz/endpointmatchers.py
+++ b/master/buildbot/www/authz/endpointmatchers.py
@@ -22,6 +22,7 @@ import inspect
 from twisted.internet import defer
 
 from buildbot.data.exceptions import InvalidPathError
+from buildbot.util import bytes2NativeString
 
 
 class EndpointMatcherBase(object):
@@ -110,7 +111,7 @@ class AnyControlEndpointMatcher(EndpointMatcherBase):
         EndpointMatcherBase.__init__(self, **kwargs)
 
     def match(self, ep, action="", options=None):
-        if action != "GET":
+        if bytes2NativeString(action).lower() != "get":
             return defer.succeed(Match(self.master))
         return defer.succeed(None)
 


### PR DESCRIPTION
* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)

Fixes serious bug in the AnyControlEndpointMatcher and fixes the unit test. Please don't test against default values in unit tests. Otherwise we wouldn't need them :) real world values we need :)
In this case we always get a uppercase `GET` and match against a lowercase `get` which conveniently was our default value for action.