### PR TITLE
Waterfall fixes

### DIFF
--- a/master/buildbot/newsfragments/waterfall_view.bugfix
+++ b/master/buildbot/newsfragments/waterfall_view.bugfix
@@ -1,0 +1,1 @@
+Fix waterfall scrolling and zooming in current browsers

--- a/www/waterfall_view/src/module/main.module.coffee
+++ b/www/waterfall_view/src/module/main.module.coffee
@@ -104,12 +104,12 @@ class Waterfall extends Controller
 
             @$window.onkeydown = (e) =>
                 # +
-                if e.keyIdentifier is 'U+002B'
+                if e.key is '+'
                     e.preventDefault()
                     @incrementScaleFactor()
                     @render()
                 # -
-                if e.keyIdentifier is 'U+002D'
+                if e.key is '-'
                     e.preventDefault()
                     @decrementScaleFactor()
                     @render()

--- a/www/waterfall_view/src/module/main.module.coffee
+++ b/www/waterfall_view/src/module/main.module.coffee
@@ -88,15 +88,15 @@ class Waterfall extends Controller
             angular.element(@$window).bind 'resize', => @render()
 
             # Update view on data change
-            loadingMore = false
+            @loadingMore = false
             @builds.onChange = @builders.onChange = @renderNewData
 
 
             # Lazy load builds on scroll
             containerParent = @container.node().parentNode
             onScroll = =>
-                if not loadingMore and @getHeight() - containerParent.scrollTop < 1000
-                    loadingMore = true
+                if not @loadingMore and @getHeight() - containerParent.scrollTop < 1000
+                    @loadingMore = true
                     @loadMore()
 
             # Bind scroll event listener
@@ -138,8 +138,8 @@ class Waterfall extends Controller
         @buildLimit = @builds.length + @c.limit
         builds = @dataAccessor.getBuilds({limit: @buildLimit, order: '-complete_at'})
         builds.onChange = (builds) =>
-            @$scope.builds.close()  # force close the old collection's auto-update
-            @$scope.builds = builds
+            @builds.close()  # force close the old collection's auto-update
+            @builds = builds
             # renders the new data
             builds.onChange = @renderNewData
             builds.onChange()
@@ -502,7 +502,7 @@ class Waterfall extends Controller
         @groups = @dataProcessorService.getGroups(@builders, @builds, @c.threshold)
         @dataProcessorService.addStatus(@builders)
         @render()
-        loadingMore = false
+        @loadingMore = false
 
     ###
     # Render the waterfall view


### PR DESCRIPTION
Updates to make waterfall view work in current Chrome. I wasn't able to test this in other browsers, according to MDN should be a change for better.
- Zooming used deprecated attributes of KeyboardEvent, the old one is not working anymore with any current browser, the new one should be pretty well supported
- Fixed scoping issue in handler responsible for fetching additional data while scrolling

## Contributor Checklist:

* [ ] I have updated the unit tests
 - no tests for waterfall view
* [X] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory
* [ ] I have updated the appropriate documentation
 - no functionality changes
