### PR TITLE
Correction of cfg-www.rst documentation

### DIFF
--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -744,7 +744,7 @@ More complex config with separation per branch:
             # defaultDeny=False: if user does not have the admin role, we continue parsing rules
             util.AnyEndpointMatcher(role="admins", defaultDeny=False),
 
-            StopBuildEndpointMatcher(role="owner"),
+            util.StopBuildEndpointMatcher(role="owner"),
 
             # *-try groups can start "try" builds
             util.ForceBuildEndpointMatcher(builder="try", role="*-try"),


### PR DESCRIPTION
change StopBuildEndpointMatcher(role="owner") to
util.StopBuildEndpointMatcher(role="owner")

issue ref: #3043

Signed-off-by: desurd <david.desurmont@gmail.com>

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

http://trac.buildbot.net/wiki/Development
And especially:
http://trac.buildbot.net/wiki/SubmittingPatches

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

