### PR TITLE
forcescheduler: fix error when builder names is unicode

### DIFF
--- a/master/buildbot/newsfragments/forcesched-unicode-builderNames.bugfix
+++ b/master/buildbot/newsfragments/forcesched-unicode-builderNames.bugfix
@@ -1,0 +1,1 @@
+Passing ``unicode`` ``builderNames`` to :bb:sched:`ForceScheduler` no longer causes an error.

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -644,7 +644,7 @@ class ForceScheduler(base.BaseScheduler):
             config.error("ForceScheduler name must be an identifier: %r" %
                          name)
 
-        if not self.checkIfListOfType(builderNames, str):
+        if not self.checkIfListOfType(builderNames, string_types):
             config.error("ForceScheduler '%s': builderNames must be a list of strings: %r" %
                          (name, builderNames))
 

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -609,6 +609,9 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                                      lambda: ForceScheduler(name='testsched', builderNames=[1234],
                                                             codebases=['bar'], username="foo"))
 
+    def test_listofunicode_builderNames(self):
+        ForceScheduler(name='testsched', builderNames=[u'a', u'b'])
+
     def test_listofmixed_builderNames(self):
         self.assertRaisesConfigError("ForceScheduler 'testsched': builderNames must be a list of strings:",
                                      lambda: ForceScheduler(name='testsched',


### PR DESCRIPTION
The `BuilderConfig.name` attribute [is forced to unicode](https://github.com/buildbot/buildbot/blob/master/master/buildbot/config.py#L1016), `ForceScheduler` should accept `unicode` as valid in the `builderNames` list.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

