### PR TITLE
virtualenv: upgrade setuptools to avoid errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ docker-buildbot-master-ubuntu:
 
 .venv:
 		virtualenv .venv
-		.venv/bin/pip install -U pip
+		.venv/bin/pip install -U pip setuptools
 		.venv/bin/pip install -e pkg \
 			-e 'master[tls,test,docs]' \
 			-e 'worker[test]' \


### PR DESCRIPTION
Fix the following error seen on debian 8 (jessie):

```
$ make virtualenv
[...]
error in buildbot setup command: 'extras_require' must be a
dictionary whose values are strings or lists of strings containing
valid project/version requirement specifiers.
```

The distro version of setuptools is old: 5.5.1, upgrading it in the virtualenv fixes the issue.