### PR TITLE
Import future.moves.urllib.error explicitly

### DIFF
--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -21,8 +21,8 @@ urllib2 supports http_proxy already urllib2 is blocking and thus everything is d
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.moves.urllib import request as urllib_request
 from future.moves.urllib import error as urllib_error
+from future.moves.urllib import request as urllib_request
 
 import hashlib
 import inspect

--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -21,8 +21,8 @@ urllib2 supports http_proxy already urllib2 is blocking and thus everything is d
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.moves import urllib
 from future.moves.urllib import request as urllib_request
+from future.moves.urllib import error as urllib_error
 
 import hashlib
 import inspect
@@ -167,7 +167,7 @@ def computeUsageData(master):
 
 
 def _sendWithUrlib(url, data):
-    data = json.dumps(data)
+    data = json.dumps(data).encode()
     clen = len(data)
     req = urllib_request.Request(url, data, {
         'Content-Type': 'application/json',
@@ -175,7 +175,7 @@ def _sendWithUrlib(url, data):
     })
     try:
         f = urllib_request.urlopen(req)
-    except urllib.error.URLError:
+    except urllib_error.URLError:
         return None
     res = f.read()
     f.close()

--- a/master/buildbot/newsfragments/urllib-error-import.bugfix
+++ b/master/buildbot/newsfragments/urllib-error-import.bugfix
@@ -1,0 +1,3 @@
+Make future.moves.urllib.error.URLError available in buildbot_net_usage_data
+module.  Fixes an exception found in buildbot_net_usage_data._sendWithUrlib
+when running through the tutorial using Python 3.

--- a/master/buildbot/newsfragments/urllib-error-import.bugfix
+++ b/master/buildbot/newsfragments/urllib-error-import.bugfix
@@ -1,4 +1,4 @@
-Make :py:class:`future.moves.urllib.error.URLError` available in
-:py:module:`buildbot_net_usage_data` module.  Fixes an exception found in
-:py:function:`buildbot_net_usage_data._sendWithUrlib` when running through the
+Make :py:class:`future.moves.urllib.error.URLError` available in the
+:py:mod:`buildbot_net_usage_data` module.  Fixes an exception found in
+:py:func:`~buildbot_net_usage_data._sendWithUrlib` when running through the
 tutorial using Python 3.

--- a/master/buildbot/newsfragments/urllib-error-import.bugfix
+++ b/master/buildbot/newsfragments/urllib-error-import.bugfix
@@ -1,3 +1,4 @@
-Make future.moves.urllib.error.URLError available in buildbot_net_usage_data
-module.  Fixes an exception found in buildbot_net_usage_data._sendWithUrlib
-when running through the tutorial using Python 3.
+Make :py:class:`future.moves.urllib.error.URLError` available in
+:py:module:`buildbot_net_usage_data` module.  Fixes an exception found in
+:py:function:`buildbot_net_usage_data._sendWithUrlib` when running through the
+tutorial using Python 3.

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -133,7 +133,8 @@ class Tests(unittest.TestCase):
         self.assertEqual(len(open_url), 1)
         self.assertEqual(open_url[0].request.args,
                          ('https://events.buildbot.net/events/phone_home',
-                          '{"foo": "bar"}', {'Content-Length': 14, 'Content-Type': 'application/json'}))
+                          b'{"foo": "bar"}',
+                          {'Content-Length': 14, 'Content-Type': 'application/json'}))
 
     def test_real(self):
         if "TEST_BUILDBOTNET_USAGEDATA" not in os.environ:


### PR DESCRIPTION
## Contributor Checklist:

* [*] I have updated the unit tests
* [*] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [n/a] I have updated the appropriate documentation
* [*] I ran `trial buildbot.test buildbot_worker.test` using Python 2
* [*] I ran `trial buildbot.test buildbot_worker.test` using Python 3

There are some flake8 and pylint checks that don't pass, but they don't appear to be related to the files I've touched.