### PR TITLE
Make Gerrit Change Source and Reporter PATH Aware

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -19,6 +19,7 @@ from future.utils import iteritems
 
 import datetime
 import json
+import os
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -313,7 +314,8 @@ class GerritChangeSource(GerritChangeSourceBase):
             args = args + ['-i', self.identity_file]
         self.process = reactor.spawnProcess(
             self.LocalPP(self), "ssh",
-            ["ssh"] + args + ["gerrit", "stream-events"])
+            ["ssh"] + args + ["gerrit", "stream-events"],
+            env={'PATH': os.environ.get('PATH', '')})
 
     def activate(self):
         self.wantProcess = True

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -19,7 +19,6 @@ from future.utils import iteritems
 
 import datetime
 import json
-import os
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -314,8 +313,7 @@ class GerritChangeSource(GerritChangeSourceBase):
             args = args + ['-i', self.identity_file]
         self.process = reactor.spawnProcess(
             self.LocalPP(self), "ssh",
-            ["ssh"] + args + ["gerrit", "stream-events"],
-            env={'PATH': os.environ.get('PATH', '')})
+            ["ssh"] + args + ["gerrit", "stream-events"], env=None)
 
     def activate(self):
         self.wantProcess = True

--- a/master/buildbot/newsfragments/gerrit_changesource_reporter.bugfix
+++ b/master/buildbot/newsfragments/gerrit_changesource_reporter.bugfix
@@ -1,1 +1,1 @@
-Gerrit Chage Source and Reporter now use the system PATH variable to find the ssh binary.
+Gerrit Change Source and Reporter now use the system PATH variable to find the ssh binary.

--- a/master/buildbot/newsfragments/gerrit_changesource_reporter.bugfix
+++ b/master/buildbot/newsfragments/gerrit_changesource_reporter.bugfix
@@ -1,0 +1,1 @@
+Gerrit Chage Source and Reporter now use the system PATH variable to find the ssh binary.

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 from future.builtins import range
 from future.utils import iteritems
 
-import os
 import time
 import warnings
 from distutils.version import LooseVersion
@@ -240,8 +239,7 @@ class GerritStatusPush(service.BuildbotService):
         callback = lambda gerrit_version: self.processVersion(
             gerrit_version, func)
 
-        self.spawnProcess(self.VersionPP(callback), command[0], command,
-                          env={'PATH': os.environ.get('PATH', '')})
+        self.spawnProcess(self.VersionPP(callback), command[0], command, env=None)
 
     class LocalPP(ProcessProtocol):
 
@@ -426,8 +424,7 @@ class GerritStatusPush(service.BuildbotService):
 
         command.append(revision)
         command = [str(s) for s in command]
-        self.spawnProcess(self.LocalPP(self), command[0], command,
-                          env={'PATH': os.environ.get('PATH', '')})
+        self.spawnProcess(self.LocalPP(self), command[0], command, env=None)
 
     def spawnProcess(self, *arg, **kw):
         reactor.spawnProcess(*arg, **kw)

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 from future.builtins import range
 from future.utils import iteritems
 
+import os
 import time
 import warnings
 from distutils.version import LooseVersion
@@ -239,7 +240,8 @@ class GerritStatusPush(service.BuildbotService):
         callback = lambda gerrit_version: self.processVersion(
             gerrit_version, func)
 
-        self.spawnProcess(self.VersionPP(callback), command[0], command)
+        self.spawnProcess(self.VersionPP(callback), command[0], command,
+                          env={'PATH': os.environ.get('PATH', '')})
 
     class LocalPP(ProcessProtocol):
 
@@ -424,7 +426,8 @@ class GerritStatusPush(service.BuildbotService):
 
         command.append(revision)
         command = [str(s) for s in command]
-        self.spawnProcess(self.LocalPP(self), command[0], command)
+        self.spawnProcess(self.LocalPP(self), command[0], command,
+                          env={'PATH': os.environ.get('PATH', '')})
 
     def spawnProcess(self, *arg, **kw):
         reactor.spawnProcess(*arg, **kw)

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -19,7 +19,6 @@ from future.builtins import range
 
 import warnings
 
-from mock import ANY
 from mock import Mock
 from mock import call
 
@@ -451,14 +450,14 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
         gsp.spawnProcess = lambda _, *a, **k: spawnSkipFirstArg(*a, **k)
         yield gsp.sendCodeReview("project", "revision", {"message": "bla", "labels": {'Verified': 1}})
         spawnSkipFirstArg.assert_called_once_with(
-            'ssh', ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'version'], env={'PATH': ANY})
+            'ssh', ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'version'], env=None)
         gsp.processVersion("2.6", lambda: None)
         spawnSkipFirstArg = Mock()
         yield gsp.sendCodeReview("project", "revision", {"message": "bla", "labels": {'Verified': 1}})
         spawnSkipFirstArg.assert_called_once_with(
             'ssh',
             ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'review',
-             '--project project', "--message 'bla'", '--label Verified=1', 'revision'], env={'PATH': ANY})
+             '--project project', "--message 'bla'", '--label Verified=1', 'revision'], env=None)
 
         # <=2.5 uses other syntax
         gsp.processVersion("2.4", lambda: None)
@@ -467,7 +466,7 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
         spawnSkipFirstArg.assert_called_once_with(
             'ssh',
             ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'review', '--project project',
-             "--message 'bla'", '--verified 1', 'revision'], env={'PATH': ANY})
+             "--message 'bla'", '--verified 1', 'revision'], env=None)
 
         # now test the notify argument, even though _gerrit_notify
         # is private, work around that
@@ -479,7 +478,7 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
             'ssh',
             ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'review',
              '--project project', '--notify OWNER', "--message 'bla'", '--label Verified=1', 'revision'],
-            env={'PATH': ANY})
+            env=None)
 
         # gerrit versions <= 2.5 uses other syntax
         gsp.processVersion('2.4', lambda: None)
@@ -489,4 +488,4 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
             'ssh',
             ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'review', '--project project', '--notify OWNER',
              "--message 'bla'", '--verified 1', 'revision'],
-            env={'PATH': ANY})
+            env=None)

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -19,6 +19,7 @@ from future.builtins import range
 
 import warnings
 
+from mock import ANY
 from mock import Mock
 from mock import call
 
@@ -450,14 +451,14 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
         gsp.spawnProcess = lambda _, *a, **k: spawnSkipFirstArg(*a, **k)
         yield gsp.sendCodeReview("project", "revision", {"message": "bla", "labels": {'Verified': 1}})
         spawnSkipFirstArg.assert_called_once_with(
-            'ssh', ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'version'])
+            'ssh', ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'version'], env={'PATH': ANY})
         gsp.processVersion("2.6", lambda: None)
         spawnSkipFirstArg = Mock()
         yield gsp.sendCodeReview("project", "revision", {"message": "bla", "labels": {'Verified': 1}})
         spawnSkipFirstArg.assert_called_once_with(
             'ssh',
             ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'review',
-             '--project project', "--message 'bla'", '--label Verified=1', 'revision'])
+             '--project project', "--message 'bla'", '--label Verified=1', 'revision'], env={'PATH': ANY})
 
         # <=2.5 uses other syntax
         gsp.processVersion("2.4", lambda: None)
@@ -466,7 +467,7 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
         spawnSkipFirstArg.assert_called_once_with(
             'ssh',
             ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'review', '--project project',
-             "--message 'bla'", '--verified 1', 'revision'])
+             "--message 'bla'", '--verified 1', 'revision'], env={'PATH': ANY})
 
         # now test the notify argument, even though _gerrit_notify
         # is private, work around that
@@ -477,7 +478,8 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
         spawnSkipFirstArg.assert_called_once_with(
             'ssh',
             ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'review',
-             '--project project', '--notify OWNER', "--message 'bla'", '--label Verified=1', 'revision'])
+             '--project project', '--notify OWNER', "--message 'bla'", '--label Verified=1', 'revision'],
+            env={'PATH': ANY})
 
         # gerrit versions <= 2.5 uses other syntax
         gsp.processVersion('2.4', lambda: None)
@@ -486,4 +488,5 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
         spawnSkipFirstArg.assert_called_once_with(
             'ssh',
             ['ssh', 'user@serv', '-p', '29418', 'gerrit', 'review', '--project project', '--notify OWNER',
-             "--message 'bla'", '--verified 1', 'revision'])
+             "--message 'bla'", '--verified 1', 'revision'],
+            env={'PATH': ANY})


### PR DESCRIPTION
Without these changes these processes would not look
into PATH for the ssh binary, which is a problem
for operating systems that don't store the
ssh binary in the usual locations.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

