### PR TITLE
build status_string: store meaningful status at the end of the build

### DIFF
--- a/master/buildbot/newsfragments/build_summary.feature
+++ b/master/buildbot/newsfragments/build_summary.feature
@@ -1,0 +1,2 @@
+Builds ``state_string`` is now automatically computed according to the :py:meth:`BuildStep.getResultSummary`,  :py:attr:`BuildStep.description` and ``updateBuildSummaryPolicy`` from :ref:`Buildstep-Common-Parameters`.
+This allows the dashboards and reporters to get a descent summary text of the build without fetching the steps.

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -533,7 +533,7 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         if isinstance(results, tuple):
             results, text = results
         assert isinstance(results, type(SUCCESS)), "got %r" % (results,)
-        summary = yield step.getResultSummary()
+        summary = yield step.getBuildResultSummary()
         if 'build' in summary:
             text = [summary['build']]
         log.msg(" step '%s' complete: %s (%s)" % (step.name, statusToString(results), text))

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -442,8 +442,9 @@ class BuildStep(results.ResultComputingConfigMixin,
 
         if self.results != SUCCESS:
             stepsumm += u' (%s)' % Results[self.results]
-
-        return {u'step': stepsumm}
+            return {u'step': stepsumm, u'build': stepsumm}
+        else:
+            return {u'step': stepsumm}
 
     @debounce.method(wait=1)
     @defer.inlineCallbacks

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -49,6 +49,7 @@ from buildbot.process import remotecommand
 from buildbot.process import results
 # (WithProperties used to be available in this module)
 from buildbot.process.properties import WithProperties
+from buildbot.process.results import ALL_RESULTS
 from buildbot.process.results import CANCELLED
 from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
@@ -293,6 +294,7 @@ class BuildStep(results.ResultComputingConfigMixin,
         'flunkOnFailure',
         'flunkOnWarnings',
         'haltOnFailure',
+        'updateBuildSummaryPolicy',
         'hideStepIf',
         'locks',
         'logEncoding',
@@ -308,6 +310,7 @@ class BuildStep(results.ResultComputingConfigMixin,
     description = None  # set this to a list of short strings to override
     descriptionDone = None  # alternate description when the step is complete
     descriptionSuffix = None  # extra information to append to suffix
+    updateBuildSummaryPolicy = None
     locks = []
     progressMetrics = ()  # 'time' is implicit
     useProgress = True  # set to False if step is really unpredictable
@@ -346,6 +349,21 @@ class BuildStep(results.ResultComputingConfigMixin,
         if isinstance(self.descriptionSuffix, str):
             self.descriptionSuffix = [self.descriptionSuffix]
 
+        if self.updateBuildSummaryPolicy is None:  # compute default value for updateBuildSummaryPolicy
+            self.updateBuildSummaryPolicy = [EXCEPTION, RETRY, CANCELLED]
+            if self.flunkOnFailure or self.haltOnFailure or self.warnOnFailure:
+                self.updateBuildSummaryPolicy.append(FAILURE)
+            if self.warnOnWarnings or self.flunkOnWarnings:
+                self.updateBuildSummaryPolicy.append(WARNINGS)
+            self.updateBuildSummaryPolicy
+        if self.updateBuildSummaryPolicy is False:
+            self.updateBuildSummaryPolicy = []
+        if self.updateBuildSummaryPolicy is True:
+            self.updateBuildSummaryPolicy = ALL_RESULTS
+        if not isinstance(self.updateBuildSummaryPolicy, list):
+            config.error("BuildStep updateBuildSummaryPolicy must be "
+                         "a list of result ids or boolean but it is %r" %
+                         (self.updateBuildSummaryPolicy,))
         self._acquiringLock = None
         self.stopped = False
         self.master = None
@@ -442,9 +460,15 @@ class BuildStep(results.ResultComputingConfigMixin,
 
         if self.results != SUCCESS:
             stepsumm += u' (%s)' % Results[self.results]
-            return {u'step': stepsumm, u'build': stepsumm}
-        else:
-            return {u'step': stepsumm}
+
+        return {u'step': stepsumm}
+
+    @defer.inlineCallbacks
+    def getBuildResultSummary(self):
+        summary = yield self.getResultSummary()
+        if self.results in self.updateBuildSummaryPolicy and u'build' not in summary and u'step' in summary:
+            summary[u'build'] = summary[u'step']
+        defer.returnValue(summary)
 
     @debounce.method(wait=1)
     @defer.inlineCallbacks

--- a/master/buildbot/process/results.py
+++ b/master/buildbot/process/results.py
@@ -17,7 +17,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from future.utils import lrange
 
-SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY, CANCELLED = lrange(7)
+ALL_RESULTS = lrange(7)
+SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY, CANCELLED = ALL_RESULTS
 Results = ["success", "warnings", "failure", "skipped", "exception", "retry", "cancelled"]
 
 

--- a/master/buildbot/test/integration/test_trigger.py
+++ b/master/buildbot/test/integration/test_trigger.py
@@ -26,7 +26,7 @@ from buildbot.test.util.integration import RunMasterBase
 # with two builders and a trigger step linking them
 
 expectedOutputRegex = \
-    r"""\*\*\* BUILD 1 \*\*\* ==> finished \(success\)
+    r"""\*\*\* BUILD 1 \*\*\* ==> build successful \(success\)
     \*\*\* STEP shell \*\*\* ==> 'echo hello' \(success\)
         log:stdio \({loglines}\)
     \*\*\* STEP trigger \*\*\* ==> triggered trigsched \(success\)
@@ -34,7 +34,7 @@ expectedOutputRegex = \
        url:success: build #1 \(http://localhost:8080/#builders/(1|2)/builds/1\)
     \*\*\* STEP shell_1 \*\*\* ==> 'echo world' \(success\)
         log:stdio \({loglines}\)
-\*\*\* BUILD 2 \*\*\* ==> finished \(success\)
+\*\*\* BUILD 2 \*\*\* ==> build successful \(success\)
     \*\*\* STEP shell \*\*\* ==> 'echo ola' \(success\)
         log:stdio \({loglines}\)
 """

--- a/master/buildbot/test/integration/test_try_client.py
+++ b/master/buildbot/test/integration/test_try_client.py
@@ -158,9 +158,7 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
             'Delivering job; comment= None',
             'job has been delivered',
             'All Builds Complete',
-            # XXX should be something like "build successful one two", but
-            # currently just drawn from the build status strings
-            'a: success (finished)',
+            'a: success (build successful)',
         ])
         buildsets = yield self.master.db.buildsets.getBuildsets()
         self.assertEqual(len(buildsets), 1)

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -88,16 +88,24 @@ class FakeRequest:
         return self.reason
 
 
-class FakeBuildStep:
+class FakeBuildStep(BuildStep):
 
     def __init__(self):
-        self.haltOnFailure = False
-        self.flunkOnWarnings = False
-        self.flunkOnFailure = True
-        self.warnOnWarnings = True
-        self.warnOnFailure = False
-        self.alwaysRun = False
-        self.name = 'fake'
+        BuildStep.__init__(
+            self, haltOnFailure=False, flunkOnWarnings=False, flunkOnFailure=True,
+            warnOnWarnings=True, warnOnFailure=False, alwaysRun=False, name='fake')
+        self._summary = {u'step': u'result', u'build': u'build result'}
+        self._expected_results = SUCCESS
+
+    def run(self):
+        return self._expected_results
+
+    def getResultSummary(self):
+        return self._summary
+
+    def interrupt(self, reason):
+        self.running = False
+        self.interrupted = reason
 
 
 class FakeBuilder:
@@ -195,27 +203,23 @@ class TestBuild(unittest.TestCase):
         self.workerforbuilder.ping = lambda: True
 
         self.build.setBuilder(self.builder)
+        self.build.text = []
+        self.build.buildid = 666
 
     def testRunSuccessfulBuild(self):
         b = self.build
 
-        step = Mock()
-        step.return_value = step
-        step.startStep.return_value = SUCCESS
+        step = FakeBuildStep()
         b.setStepFactories([FakeStepFactory(step)])
 
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
 
         self.assertEqual(b.results, SUCCESS)
-        self.assertIn(('startStep', (self.workerforbuilder.worker.conn,), {}),
-                      step.method_calls)
 
     def testStopBuild(self):
         b = self.build
 
-        step = Mock()
-        step.return_value = step
-        step.results = None
+        step = FakeBuildStep()
         b.setStepFactories([FakeStepFactory(step)])
 
         def startStep(*args, **kw):
@@ -228,7 +232,7 @@ class TestBuild(unittest.TestCase):
 
         self.assertEqual(b.results, CANCELLED)
 
-        self.assertIn(('interrupt', ('stop it',), {}), step.method_calls)
+        self.assertIn('stop it', step.interrupted)
 
     def testAlwaysRunStepStopBuild(self):
         """Test that steps marked with alwaysRun=True still get run even if
@@ -238,12 +242,10 @@ class TestBuild(unittest.TestCase):
         # the second one is marked with alwaysRun=True
         b = self.build
 
-        step1 = Mock()
-        step1.return_value = step1
+        step1 = FakeBuildStep()
         step1.alwaysRun = False
         step1.results = None
-        step2 = Mock()
-        step2.return_value = step2
+        step2 = FakeBuildStep()
         step2.alwaysRun = True
         step2.results = None
         b.setStepFactories([
@@ -256,7 +258,7 @@ class TestBuild(unittest.TestCase):
             b.stopBuild("stop it")
             return defer.succeed(SUCCESS)
         step1.startStep = startStep1
-        step1.stepDone.return_value = False
+        step1.stepDone = lambda: False
 
         step2Started = [False]
 
@@ -264,13 +266,13 @@ class TestBuild(unittest.TestCase):
             step2Started[0] = True
             return defer.succeed(SUCCESS)
         step2.startStep = startStep2
-        step1.stepDone.return_value = False
+        step1.stepDone = lambda: False
 
         d = b.startBuild(FakeBuildStatus(), self.workerforbuilder)
 
         def check(ign):
             self.assertEqual(b.results, CANCELLED)
-            self.assertIn(('interrupt', ('stop it',), {}), step1.method_calls)
+            self.assertIn('stop it', step1.interrupted)
             self.assertTrue(step2Started[0])
         d.addCallback(check)
         return d
@@ -361,16 +363,12 @@ class TestBuild(unittest.TestCase):
         real_lock.claim = claim
         b.setLocks([lock_access])
 
-        step = Mock()
-        step.return_value = step
-        step.startStep.return_value = SUCCESS
+        step = FakeBuildStep()
         b.setStepFactories([FakeStepFactory(step)])
 
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
 
         self.assertEqual(b.results, SUCCESS)
-        self.assertIn(('startStep', (self.workerforbuilder.worker.conn,), {}),
-                      step.method_calls)
         self.assertEqual(claimCount[0], 1)
 
     def testBuildLocksOrder(self):
@@ -407,9 +405,7 @@ class TestBuild(unittest.TestCase):
         fakeBuildAccess = lock.access('counting')
         realLock.claim(fakeBuild, fakeBuildAccess)
 
-        step = Mock()
-        step.return_value = step
-        step.startStep.return_value = SUCCESS
+        step = FakeBuildStep()
         eBuild.setStepFactories([FakeStepFactory(step)])
         cBuild.setStepFactories([FakeStepFactory(step)])
 
@@ -444,17 +440,13 @@ class TestBuild(unittest.TestCase):
         real_lock.claim = claim
         b.setLocks([lock_access])
 
-        step = Mock()
-        step.return_value = step
-        step.startStep.return_value = SUCCESS
+        step = FakeBuildStep()
         b.setStepFactories([FakeStepFactory(step)])
 
         real_lock.claim(Mock(), lock.access('counting'))
 
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
 
-        self.assertNotIn(('startStep', (self.workerforbuilder.worker.conn,), {}),
-                         step.method_calls)
         self.assertEqual(claimCount[0], 1)
         self.assertTrue(b.currentStep is None)
         self.assertTrue(b._acquiringLock is not None)
@@ -469,9 +461,7 @@ class TestBuild(unittest.TestCase):
             .getLock(self.workerforbuilder.worker)
         b.setLocks([lock_access])
 
-        step = Mock()
-        step.return_value = step
-        step.startStep.return_value = SUCCESS
+        step = FakeBuildStep()
         step.alwaysRun = False
         b.setStepFactories([FakeStepFactory(step)])
 
@@ -485,11 +475,8 @@ class TestBuild(unittest.TestCase):
 
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
 
-        self.assertNotIn(('startStep', (self.workerforbuilder.worker.conn,), {}),
-                         step.method_calls)
         self.assertTrue(b.currentStep is None)
         self.assertEqual(b.results, CANCELLED)
-        self.assertNotIn(('interrupt', ('stop it',), {}), step.method_calls)
 
     def testStopBuildWaitingForLocks_lostRemote(self):
         b = self.build
@@ -501,9 +488,7 @@ class TestBuild(unittest.TestCase):
             .getLock(self.workerforbuilder.worker)
         b.setLocks([lock_access])
 
-        step = Mock()
-        step.return_value = step
-        step.startStep.return_value = SUCCESS
+        step = FakeBuildStep()
         step.alwaysRun = False
         b.setStepFactories([FakeStepFactory(step)])
 
@@ -517,11 +502,8 @@ class TestBuild(unittest.TestCase):
 
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
 
-        self.assertNotIn(('startStep', (self.workerforbuilder.worker.conn,), {}),
-                         step.method_calls)
         self.assertTrue(b.currentStep is None)
         self.assertEqual(b.results, RETRY)
-        self.assertNotIn(('interrupt', ('stop it',), {}), step.method_calls)
         self.build.build_status.setText.assert_called_with(
             ["retry", "lost", "connection"])
         self.build.build_status.setResults.assert_called_with(RETRY)
@@ -557,127 +539,114 @@ class TestBuild(unittest.TestCase):
 
     def testStepDone(self):
         b = self.build
-        b.results = [SUCCESS]
         b.results = SUCCESS
         step = FakeBuildStep()
         terminate = b.stepDone(SUCCESS, step)
-        self.assertFalse(terminate)
+        self.assertFalse(terminate.result)
         self.assertEqual(b.results, SUCCESS)
 
     def testStepDoneHaltOnFailure(self):
         b = self.build
-        b.results = []
         b.results = SUCCESS
         step = FakeBuildStep()
         step.haltOnFailure = True
         terminate = b.stepDone(FAILURE, step)
-        self.assertTrue(terminate)
+        self.assertTrue(terminate.result)
         self.assertEqual(b.results, FAILURE)
 
     def testStepDoneHaltOnFailureNoFlunkOnFailure(self):
         b = self.build
-        b.results = []
         b.results = SUCCESS
         step = FakeBuildStep()
         step.flunkOnFailure = False
         step.haltOnFailure = True
         terminate = b.stepDone(FAILURE, step)
-        self.assertTrue(terminate)
+        self.assertTrue(terminate.result)
         self.assertEqual(b.results, SUCCESS)
 
     def testStepDoneFlunkOnWarningsFlunkOnFailure(self):
         b = self.build
-        b.results = []
         b.results = SUCCESS
         step = FakeBuildStep()
         step.flunkOnFailure = True
         step.flunkOnWarnings = True
         b.stepDone(WARNINGS, step)
         terminate = b.stepDone(FAILURE, step)
-        self.assertFalse(terminate)
+        self.assertFalse(terminate.result)
         self.assertEqual(b.results, FAILURE)
 
     def testStepDoneNoWarnOnWarnings(self):
         b = self.build
-        b.results = [SUCCESS]
         b.results = SUCCESS
         step = FakeBuildStep()
         step.warnOnWarnings = False
         terminate = b.stepDone(WARNINGS, step)
-        self.assertFalse(terminate)
+        self.assertFalse(terminate.result)
         self.assertEqual(b.results, SUCCESS)
 
     def testStepDoneWarnings(self):
         b = self.build
-        b.results = [SUCCESS]
         b.results = SUCCESS
         step = FakeBuildStep()
         terminate = b.stepDone(WARNINGS, step)
-        self.assertFalse(terminate)
+        self.assertFalse(terminate.result)
         self.assertEqual(b.results, WARNINGS)
 
     def testStepDoneFail(self):
         b = self.build
-        b.results = [SUCCESS]
         b.results = SUCCESS
         step = FakeBuildStep()
         terminate = b.stepDone(FAILURE, step)
-        self.assertFalse(terminate)
+        self.assertFalse(terminate.result)
         self.assertEqual(b.results, FAILURE)
 
     def testStepDoneFailOverridesWarnings(self):
         b = self.build
-        b.results = [SUCCESS, WARNINGS]
         b.results = WARNINGS
         step = FakeBuildStep()
         terminate = b.stepDone(FAILURE, step)
-        self.assertFalse(terminate)
+        self.assertFalse(terminate.result)
         self.assertEqual(b.results, FAILURE)
 
     def testStepDoneWarnOnFailure(self):
         b = self.build
-        b.results = [SUCCESS]
         b.results = SUCCESS
         step = FakeBuildStep()
         step.warnOnFailure = True
         step.flunkOnFailure = False
         terminate = b.stepDone(FAILURE, step)
-        self.assertFalse(terminate)
+        self.assertFalse(terminate.result)
         self.assertEqual(b.results, WARNINGS)
 
     def testStepDoneFlunkOnWarnings(self):
         b = self.build
-        b.results = [SUCCESS]
         b.results = SUCCESS
         step = FakeBuildStep()
         step.flunkOnWarnings = True
         terminate = b.stepDone(WARNINGS, step)
-        self.assertFalse(terminate)
+        self.assertFalse(terminate.result)
         self.assertEqual(b.results, FAILURE)
 
     def testStepDoneHaltOnFailureFlunkOnWarnings(self):
         b = self.build
-        b.results = [SUCCESS]
         b.results = SUCCESS
         step = FakeBuildStep()
         step.flunkOnWarnings = True
         self.haltOnFailure = True
         terminate = b.stepDone(WARNINGS, step)
-        self.assertFalse(terminate)
+        self.assertFalse(terminate.result)
         self.assertEqual(b.results, FAILURE)
 
     def testStepDoneWarningsDontOverrideFailure(self):
         b = self.build
-        b.results = [FAILURE]
         b.results = FAILURE
         step = FakeBuildStep()
         terminate = b.stepDone(WARNINGS, step)
-        self.assertFalse(terminate)
+        self.assertFalse(terminate.result)
         self.assertEqual(b.results, FAILURE)
 
     def testStepDoneRetryOverridesAnythingElse(self):
         b = self.build
-        b.results = [RETRY]
         b.results = RETRY
         step = FakeBuildStep()
         step.alwaysRun = True
@@ -685,7 +654,7 @@ class TestBuild(unittest.TestCase):
         b.stepDone(FAILURE, step)
         b.stepDone(SUCCESS, step)
         terminate = b.stepDone(EXCEPTION, step)
-        self.assertTrue(terminate)
+        self.assertTrue(terminate.result)
         self.assertEqual(b.results, RETRY)
 
     def test_getSummaryStatistic(self):
@@ -716,28 +685,26 @@ class TestBuild(unittest.TestCase):
         self.assertEqual(self.master.data.updates.properties,
                          [(43, u'foo', 'bar', u'test')])
 
-    def create_mock_steps(self, names):
+    def create_fake_steps(self, names):
         steps = []
 
-        def create_mock_step(name):
-            step = Mock()
-            step.return_value = step
-            step.startStep.return_value = SUCCESS
+        def create_fake_step(name):
+            step = FakeBuildStep()
             step.name = name
             return step
 
         for name in names:
-            step = create_mock_step(name)
+            step = create_fake_step(name)
             steps.append(step)
         return steps
 
     def testAddStepsAfterCurrentStep(self):
         b = self.build
 
-        steps = self.create_mock_steps(["a", "b", "c"])
+        steps = self.create_fake_steps(["a", "b", "c"])
 
         def startStepB(*args, **kw):
-            new_steps = self.create_mock_steps(["d", "e"])
+            new_steps = self.create_fake_steps(["d", "e"])
             b.addStepsAfterCurrentStep([FakeStepFactory(s) for s in new_steps])
             return SUCCESS
 
@@ -753,10 +720,10 @@ class TestBuild(unittest.TestCase):
     def testAddStepsAfterLastStep(self):
         b = self.build
 
-        steps = self.create_mock_steps(["a", "b", "c"])
+        steps = self.create_fake_steps(["a", "b", "c"])
 
         def startStepB(*args, **kw):
-            new_steps = self.create_mock_steps(["d", "e"])
+            new_steps = self.create_fake_steps(["d", "e"])
             b.addStepsAfterLastStep([FakeStepFactory(s) for s in new_steps])
             return SUCCESS
 
@@ -773,7 +740,7 @@ class TestBuild(unittest.TestCase):
         # if the step names are unique they should remain unchanged
         b = self.build
 
-        steps = self.create_mock_steps(["clone", "command", "clean"])
+        steps = self.create_fake_steps(["clone", "command", "clean"])
         b.setStepFactories([FakeStepFactory(s) for s in steps])
 
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
@@ -785,7 +752,7 @@ class TestBuild(unittest.TestCase):
     def testStepNamesDuplicate(self):
         b = self.build
 
-        steps = self.create_mock_steps(["stage", "stage", "stage"])
+        steps = self.create_fake_steps(["stage", "stage", "stage"])
         b.setStepFactories([FakeStepFactory(s) for s in steps])
 
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
@@ -797,10 +764,10 @@ class TestBuild(unittest.TestCase):
     def testStepNamesDuplicateAfterAdd(self):
         b = self.build
 
-        steps = self.create_mock_steps(["a", "b", "c"])
+        steps = self.create_fake_steps(["a", "b", "c"])
 
         def startStepB(*args, **kw):
-            new_steps = self.create_mock_steps(["c", "c"])
+            new_steps = self.create_fake_steps(["c", "c"])
             b.addStepsAfterCurrentStep([FakeStepFactory(s) for s in new_steps])
             return SUCCESS
 

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -782,8 +782,7 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
     def test_runRmdir(self):
         self.step.testMethod = lambda: self.step.runRmdir('/some/path')
         self.expectCommands(
-            Expect('rmdir', {'dir': '/some/path', 'logEnviron': False})
-            + 0,
+            Expect('rmdir', {'dir': '/some/path', 'logEnviron': False}) + 0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -793,8 +792,7 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
     def test_runMkdir(self):
         self.step.testMethod = lambda: self.step.runMkdir('/some/path')
         self.expectCommands(
-            Expect('mkdir', {'dir': '/some/path', 'logEnviron': False})
-            + 0,
+            Expect('mkdir', {'dir': '/some/path', 'logEnviron': False}) + 0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -804,8 +802,7 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
     def test_runMkdir_fails(self):
         self.step.testMethod = lambda: self.step.runMkdir('/some/path')
         self.expectCommands(
-            Expect('mkdir', {'dir': '/some/path', 'logEnviron': False})
-            + 1,
+            Expect('mkdir', {'dir': '/some/path', 'logEnviron': False}) + 1,
         )
         self.expectOutcome(result=FAILURE)
         yield self.runStep()
@@ -815,8 +812,7 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
         self.step.testMethod = lambda: self.step.runMkdir(
             '/some/path', abandonOnFailure=False)
         self.expectCommands(
-            Expect('mkdir', {'dir': '/some/path', 'logEnviron': False})
-            + 1,
+            Expect('mkdir', {'dir': '/some/path', 'logEnviron': False}) + 1,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -826,8 +822,8 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
     def test_pathExists(self):
         self.step.testMethod = lambda: self.step.pathExists('/some/path')
         self.expectCommands(
-            Expect('stat', {'file': '/some/path', 'logEnviron': False})
-            + 0,
+            Expect('stat', {'file': '/some/path', 'logEnviron': False}) +
+            0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -837,8 +833,7 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
     def test_pathExists_doesnt(self):
         self.step.testMethod = lambda: self.step.pathExists('/some/path')
         self.expectCommands(
-            Expect('stat', {'file': '/some/path', 'logEnviron': False})
-            + 1,
+            Expect('stat', {'file': '/some/path', 'logEnviron': False}) + 1,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -848,9 +843,9 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
     def test_pathExists_logging(self):
         self.step.testMethod = lambda: self.step.pathExists('/some/path')
         self.expectCommands(
-            Expect('stat', {'file': '/some/path', 'logEnviron': False})
-            + Expect.log('stdio', header='NOTE: never mind\n')
-            + 1,
+            Expect('stat', {'file': '/some/path', 'logEnviron': False}) +
+            Expect.log('stdio', header='NOTE: never mind\n') +
+            1,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -865,9 +860,9 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
             self.assertEqual(res, ["one.pyc", "two.pyc"])
         self.step.testMethod = testFunc
         self.expectCommands(
-            Expect('glob', {'path': '*.pyc', 'logEnviron': False})
-            + Expect.update('files', ["one.pyc", "two.pyc"])
-            + 0
+            Expect('glob', {'path': '*.pyc', 'logEnviron': False}) +
+            Expect.update('files', ["one.pyc", "two.pyc"]) +
+            0
         )
         self.expectOutcome(result=SUCCESS)
         return self.runStep()
@@ -875,9 +870,9 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
     def test_glob_empty(self):
         self.step.testMethod = lambda: self.step.runGlob("*.pyc")
         self.expectCommands(
-            Expect('glob', {'path': '*.pyc', 'logEnviron': False})
-            + Expect.update('files', [])
-            + 0
+            Expect('glob', {'path': '*.pyc', 'logEnviron': False}) +
+            Expect.update('files', []) +
+            0
         )
         self.expectOutcome(result=SUCCESS)
         return self.runStep()
@@ -885,8 +880,8 @@ class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
     def test_glob_fail(self):
         self.step.testMethod = lambda: self.step.runGlob("*.pyc")
         self.expectCommands(
-            Expect('glob', {'path': '*.pyc', 'logEnviron': False})
-            + 1
+            Expect('glob', {'path': '*.pyc', 'logEnviron': False}) +
+            1
         )
         self.expectOutcome(result=FAILURE)
         return self.runStep()
@@ -974,12 +969,12 @@ class TestShellMixin(steps.BuildStepMixin,
     def test_example(self):
         self.setupStep(ShellMixinExample(), wantDefaultWorkdir=False)
         self.expectCommands(
-            ExpectShell(workdir='build', command=['./cleanup.sh'])
-            + Expect.log('stdio', stderr="didn't go so well\n")
-            + 1,
+            ExpectShell(workdir='build', command=['./cleanup.sh']) +
+            Expect.log('stdio', stderr="didn't go so well\n") +
+            1,
             ExpectShell(workdir='build', command=['./cleanup.sh', '--force'],
-                        logEnviron=False)
-            + 0,
+                        logEnviron=False) +
+            0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -990,9 +985,9 @@ class TestShellMixin(steps.BuildStepMixin,
             logfiles={'cleanup': 'cleanup.log'}), wantDefaultWorkdir=False)
         self.expectCommands(
             ExpectShell(workdir='build', command=['./cleanup.sh'],
-                        logfiles={'cleanup': 'cleanup.log'})
-            + Expect.log('cleanup', stdout='cleaning\ncleaned\n')
-            + 0,
+                        logfiles={'cleanup': 'cleanup.log'}) +
+            Expect.log('cleanup', stdout='cleaning\ncleaned\n') +
+            0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -1004,8 +999,8 @@ class TestShellMixin(steps.BuildStepMixin,
         self.setupStep(ShellMixinExample(), wantDefaultWorkdir=False)
         self.build.workdir = '/alternate'
         self.expectCommands(
-            ExpectShell(workdir='/alternate', command=['./cleanup.sh'])
-            + 0,
+            ExpectShell(workdir='/alternate', command=['./cleanup.sh']) +
+            0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -1015,8 +1010,8 @@ class TestShellMixin(steps.BuildStepMixin,
         self.setupStep(ShellMixinExample(), wantDefaultWorkdir=False)
         self.build.workdir = lambda x: '/alternate'
         self.expectCommands(
-            ExpectShell(workdir='/alternate', command=['./cleanup.sh'])
-            + 0,
+            ExpectShell(workdir='/alternate', command=['./cleanup.sh']) +
+            0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -1027,8 +1022,8 @@ class TestShellMixin(steps.BuildStepMixin,
         self.build.workdir = properties.Property("myproperty")
         self.properties.setProperty("myproperty", "/myproperty", "test")
         self.expectCommands(
-            ExpectShell(workdir='/myproperty', command=['./cleanup.sh'])
-            + 0,
+            ExpectShell(workdir='/myproperty', command=['./cleanup.sh']) +
+            0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -1045,8 +1040,8 @@ class TestShellMixin(steps.BuildStepMixin,
         self.setupStep(ShellMixinExample(workdir='/alternate'))
         self.build.workdir = '/overridden'
         self.expectCommands(
-            ExpectShell(workdir='/alternate', command=['./cleanup.sh'])
-            + 0,
+            ExpectShell(workdir='/alternate', command=['./cleanup.sh']) +
+            0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -1060,8 +1055,8 @@ class TestShellMixin(steps.BuildStepMixin,
         self.setupStep(ShellMixinExample(workdir=rendered_workdir))
         self.build.workdir = '/overridden'
         self.expectCommands(
-            ExpectShell(workdir='/alternate', command=['./cleanup.sh'])
-            + 0,
+            ExpectShell(workdir='/alternate', command=['./cleanup.sh']) +
+            0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -1073,8 +1068,8 @@ class TestShellMixin(steps.BuildStepMixin,
             makeRemoteShellCommandKwargs={'workdir': '/alternate'},
             command=['foo', properties.Property('bar', 'BAR')]))
         self.expectCommands(
-            ExpectShell(workdir='/alternate', command=['foo', 'BAR'])
-            + 0,
+            ExpectShell(workdir='/alternate', command=['foo', 'BAR']) +
+            0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -1097,9 +1092,9 @@ class TestShellMixin(steps.BuildStepMixin,
         self.setupStep(ShellMixinExample(usePTY=False, interruptSignal='DIE'),
                        worker_version={'*': "1.1"}, wantDefaultWorkdir=False)
         self.expectCommands(
-            ExpectShell(workdir='build', command=['./cleanup.sh'])
+            ExpectShell(workdir='build', command=['./cleanup.sh']) +
             # note missing parameters
-            + 0,
+            0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -1112,9 +1107,9 @@ class TestShellMixin(steps.BuildStepMixin,
         self.setupStep(ShellMixinExample(usePTY=False, interruptSignal='DIE'),
                        worker_version={'*': "3.0"}, wantDefaultWorkdir=False)
         self.expectCommands(
-            ExpectShell(workdir='build', usePTY=False, command=['./cleanup.sh'])
+            ExpectShell(workdir='build', usePTY=False, command=['./cleanup.sh']) +
             # note missing parameters
-            + 0,
+            0,
         )
         self.expectOutcome(result=SUCCESS)
         yield self.runStep()
@@ -1126,8 +1121,8 @@ class TestShellMixin(steps.BuildStepMixin,
         self.setupStep(SimpleShellCommand(
             command=['foo', properties.Property('bar', 'BAR')]), wantDefaultWorkdir=False)
         self.expectCommands(
-            ExpectShell(workdir='build', command=['foo', 'BAR'])
-            + 0,
+            ExpectShell(workdir='build', command=['foo', 'BAR']) +
+            0,
         )
         self.expectOutcome(result=SUCCESS, state_string=u"'foo BAR'")
         yield self.runStep()

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -520,11 +520,21 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
         st.descriptionSuffix = ['bar', 'bar2']
         self.checkSummary(st.getResultSummary(), u'foo ing bar bar2')
 
+    @defer.inlineCallbacks
     def test_getResultSummary_descriptionSuffix_failure(self):
         st = buildstep.BuildStep()
         st.results = FAILURE
         st.description = 'fooing'
-        self.checkSummary(st.getResultSummary(), u'fooing (failure)', u'fooing (failure)')
+        self.checkSummary((yield st.getBuildResultSummary()), u'fooing (failure)', u'fooing (failure)')
+        self.checkSummary(st.getResultSummary(), u'fooing (failure)')
+
+    @defer.inlineCallbacks
+    def test_getResultSummary_descriptionSuffix_skipped(self):
+        st = buildstep.BuildStep()
+        st.results = SKIPPED
+        st.description = 'fooing'
+        self.checkSummary((yield st.getBuildResultSummary()), u'fooing (skipped)')
+        self.checkSummary(st.getResultSummary(), u'fooing (skipped)')
 
     # Test calling checkWorkerHasCommand() when worker have support for
     # requested remote command.

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -524,7 +524,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
         st = buildstep.BuildStep()
         st.results = FAILURE
         st.description = 'fooing'
-        self.checkSummary(st.getResultSummary(), u'fooing (failure)')
+        self.checkSummary(st.getResultSummary(), u'fooing (failure)', u'fooing (failure)')
 
     # Test calling checkWorkerHasCommand() when worker have support for
     # requested remote command.

--- a/master/docs/developer/cls-buildsteps.rst
+++ b/master/docs/developer/cls-buildsteps.rst
@@ -268,6 +268,15 @@ BuildStep
 
         New-style build steps should override this method to provide a more interesting summary than the default, or to provide any build summary information.
 
+
+    .. py:method:: getBuildResultSummary()
+
+        :returns: dictionary, optionally via Deferred
+
+        Returns a dictionary containing status information for a completed step.
+        This method calls :py:meth:`getResultSummary`, and automatically compute a ``build`` key from the ``step`` key according to the ``updateBuildSummaryPolicy``
+
+
     .. py:method:: describe(done=False)
 
         :param done: If true, the step is finished.

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -158,6 +158,23 @@ Arguments common to all :class:`BuildStep` subclasses:
     The character encoding to use to decode logs produced during the execution of this step.
     This overrides the default :bb:cfg:`logEncoding`; see :ref:`Log-Encodings`.
 
+.. index:: Buildstep Parameter; updateBuildSummaryPolicy
+
+``updateBuildSummaryPolicy``
+    The policy to use to propagate the step summary to the build summary.
+    If False, the build summary will never include step summary
+    If True, the build summary will always include step summary
+    If set to a list (e.g. ``[FAILURE, EXCEPTION]``), it will propagate if the step results id is present in that list.
+    If not set or None, the default is computed according to other BuildStep parameters using following algorithm::
+
+        self.updateBuildSummaryPolicy = [EXCEPTION, RETRY, CANCELLED]
+        if self.flunkOnFailure or self.haltOnFailure or self.warnOnFailure:
+            self.updateBuildSummaryPolicy.append(FAILURE)
+        if self.warnOnWarnings or self.flunkOnWarnings:
+            self.updateBuildSummaryPolicy.append(WARNINGS)
+
+    Note that in a custom step, if :py:meth:`BuildStep.getResultSummary` is overridden and setting the ``build`` summary, ``updateBuildSummaryPolicy`` is ignored and ``build`` summary will be used regardless.
+
 .. _Source-Checkout:
 
 Source Checkout


### PR DESCRIPTION
- add updateBuildSummaryPolicy so that all the steps will not pollute the build status
- rework the process_build unit test to remove a bit of mocking
