### PR TITLE
add tweaks to allow buildbot to start and stop nicely on win32

### DIFF
--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -114,8 +114,12 @@ def launch(config):
             "--python=buildbot.tac"]
 
     # ProcessProtocol just ignores all output
-    reactor.spawnProcess(
+    proc = reactor.spawnProcess(
         protocol.ProcessProtocol(), sys.executable, argv, env=os.environ)
+
+    if platformType == "win32":
+        with open("twistd.pid", "w") as pidfile:
+            pidfile.write("{0}".format(proc.pid))
 
 
 def start(config):

--- a/master/buildbot/scripts/stop.py
+++ b/master/buildbot/scripts/stop.py
@@ -22,6 +22,8 @@ import os
 import signal
 import time
 
+from twisted.python.runtime import platformType
+
 from buildbot.scripts import base
 
 
@@ -51,7 +53,7 @@ def stop(config, signame="TERM", wait=None):
     try:
         os.kill(pid, signum)
     except OSError as e:
-        if e.errno != errno.ESRCH:
+        if e.errno != errno.ESRCH and platformType != "win32":
             raise
         else:
             if not config['quiet']:


### PR DESCRIPTION
This adds some small tweak to allow the same 
```python
buildbot start
buildbot stop
buildbot restart
```
commands to work on windows as it does on posix systems

http://trac.buildbot.net/wiki/Development
And especially:
http://trac.buildbot.net/wiki/SubmittingPatches

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

