### PR TITLE
pylintrc: customize error messages

### DIFF
--- a/common/pylintrc
+++ b/common/pylintrc
@@ -149,6 +149,9 @@ disable=
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
+# Change the default error message template.
+msg-template={path}:{line} {msg} [{symbol}]
+
 # Include message's id in output
 include-ids=yes
 


### PR DESCRIPTION
Default messages are displayed like this:

```
************* Module buildbot.worker.base
E:110,41: Undefined variable 'string_types' (undefined-variable)
E:114,33: Undefined variable 'string_types' (undefined-variable)
```

This requires users to convert the module name to an actual python file to locate and fix the error.

Change the default message template to something like this:

```
************* Module buildbot.worker.base
buildbot/worker/base.py:110 Undefined variable 'string_types' [undefined-variable]
buildbot/worker/base.py:114 Undefined variable 'string_types' [undefined-variable]
```

See https://pylint.readthedocs.io/en/latest/user_guide/output.html for more details on message formatting.