### PR TITLE
master: replace most str occurences by string_types

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -477,7 +477,7 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
         protocols = config_dict.get('protocols', {})
         if isinstance(protocols, dict):
             for proto, options in iteritems(protocols):
-                if not isinstance(proto, str):
+                if not isinstance(proto, string_types):
                     error("c['protocols'] keys must be strings")
                 if not isinstance(options, dict):
                     error("c['protocols']['%s'] must be a dict" % proto)
@@ -1028,7 +1028,7 @@ class BuilderConfig(util_config.ConfiguredMixin, WorkerAPICompatMixin):
 
         # workernames can be a single worker name or a list, and should also
         # include workername, if given
-        if isinstance(workernames, str):
+        if isinstance(workernames, string_types):
             workernames = [workernames]
         if workernames:
             if not isinstance(workernames, list):
@@ -1038,7 +1038,7 @@ class BuilderConfig(util_config.ConfiguredMixin, WorkerAPICompatMixin):
             workernames = []
 
         if workername:
-            if not isinstance(workername, str):
+            if not isinstance(workername, string_types):
                 error("builder '%s': workername must be a string" % (name,))
             workernames = workernames + [workername]
         if not workernames:
@@ -1069,13 +1069,13 @@ class BuilderConfig(util_config.ConfiguredMixin, WorkerAPICompatMixin):
             warnDeprecated("0.9", "builder '%s': builder categories are "
                                   "deprecated and should be replaced with "
                                   "'tags=[cat]'" % (name,))
-            if not isinstance(category, str):
+            if not isinstance(category, string_types):
                 error("builder '%s': category must be a string" % (name,))
             tags = [category]
         if tags:
             if not isinstance(tags, list):
                 error("builder '%s': tags must be a list" % (name,))
-            bad_tags = any((tag for tag in tags if not isinstance(tag, str)))
+            bad_tags = any((tag for tag in tags if not isinstance(tag, string_types)))
             if bad_tags:
                 error(
                     "builder '%s': tags list contains something that is not a string" % (name,))

--- a/master/buildbot/mq/simple.py
+++ b/master/buildbot/mq/simple.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import string_types
 
 import pprint
 
@@ -47,7 +48,7 @@ class SimpleMQ(service.ReconfigurableServiceMixin, base.MQBase):
                 qref.invoke(routingKey, data)
 
     def startConsuming(self, callback, filter, persistent_name=None):
-        if any(not isinstance(k, str) and k is not None for k in filter):
+        if any(not isinstance(k, string_types) and k is not None for k in filter):
             raise AssertionError("%s is not a filter" % (filter,))
         if persistent_name:
             if persistent_name in self.persistent_qrefs:

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -336,14 +336,14 @@ class BuildStep(results.ResultComputingConfigMixin,
                          % (self.__class__, list(kwargs)))
         self._pendingLogObservers = []
 
-        if not isinstance(self.name, str):
+        if not isinstance(self.name, string_types):
             config.error("BuildStep name must be a string: %r" % (self.name,))
 
-        if isinstance(self.description, str):
+        if isinstance(self.description, string_types):
             self.description = [self.description]
-        if isinstance(self.descriptionDone, str):
+        if isinstance(self.descriptionDone, string_types):
             self.descriptionDone = [self.descriptionDone]
-        if isinstance(self.descriptionSuffix, str):
+        if isinstance(self.descriptionSuffix, string_types):
             self.descriptionSuffix = [self.descriptionSuffix]
 
         self._acquiringLock = None

--- a/master/buildbot/process/factory.py
+++ b/master/buildbot/process/factory.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import string_types
 
 import warnings
 
@@ -123,7 +124,7 @@ class GNUAutoconf(BuildFactory):
             # we either need to wind up with a string (which will be
             # space-split), or with a list of strings (which will not). The
             # list of strings is the preferred form.
-            if isinstance(configure, str):
+            if isinstance(configure, string_types):
                 if configureFlags:
                     assert " " not in configure  # please use list instead
                     command = [configure] + configureFlags

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from future.utils import itervalues
+from future.utils import string_types
 from future.utils import text_type
 
 import re
@@ -51,7 +52,7 @@ class Log(object):
         then we return a new lambda, s.decode().
         If cfg is already a lambda or function, then we return that.
         """
-        if isinstance(cfg, (bytes, str)):
+        if isinstance(cfg, string_types):
             return lambda s: s.decode(cfg, 'replace')
         else:
             return cfg

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -129,7 +129,7 @@ class MailNotifier(service.BuildbotService):
             config.error("extraRecipients must be a list or tuple")
         else:
             for r in extraRecipients:
-                if not isinstance(r, str) or not VALID_EMAIL.search(r):
+                if not isinstance(r, string_types) or not VALID_EMAIL.search(r):
                     config.error(
                         "extra recipient %r is not a valid email" % (r,))
 

--- a/master/buildbot/revlinks.py
+++ b/master/buildbot/revlinks.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.utils import text_type
+from future.utils import string_types
 
 import re
 
@@ -23,7 +23,7 @@ import re
 class RevlinkMatch(object):
 
     def __init__(self, repo_urls, revlink):
-        if isinstance(repo_urls, str) or isinstance(repo_urls, text_type):
+        if isinstance(repo_urls, string_types):
             repo_urls = [repo_urls]
         self.repo_urls = [re.compile(url) for url in repo_urls]
         self.revlink = revlink

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from future.builtins import range
+from future.utils import string_types
 
 import copy
 import errno
@@ -92,13 +93,13 @@ def checkBasedir(config):
 
     tac = getConfigFromTac(config['basedir'])
     if tac:
-        if isinstance(tac.get('rotateLength', 0), str):
+        if isinstance(tac.get('rotateLength', 0), string_types):
             print("ERROR: rotateLength is a string, it should be a number")
             print("ERROR: Please, edit your buildbot.tac file and run again")
             print(
                 "ERROR: See http://trac.buildbot.net/ticket/2588 for more details")
             return False
-        if isinstance(tac.get('maxRotatedFiles', 0), str):
+        if isinstance(tac.get('maxRotatedFiles', 0), string_types):
             print("ERROR: maxRotatedFiles is a string, it should be a number")
             print("ERROR: Please, edit your buildbot.tac file and run again")
             print(

--- a/master/buildbot/secrets/providers/vault.py
+++ b/master/buildbot/secrets/providers/vault.py
@@ -18,6 +18,7 @@ vault based providers
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import string_types
 
 from twisted.internet import defer
 
@@ -34,9 +35,9 @@ class HashiCorpVaultSecretProvider(SecretProviderBase):
     name = 'SecretInVault'
 
     def checkConfig(self, vaultServer=None, vaultToken=None, secretsmount=None):
-        if not isinstance(vaultServer, str):
+        if not isinstance(vaultServer, string_types):
             config.error("vaultServer must be a string while it is %s" % (type(vaultServer,)))
-        if not isinstance(vaultToken, str):
+        if not isinstance(vaultToken, string_types):
             config.error("vaultToken must be a string while it is %s" % (type(vaultToken,)))
 
     @defer.inlineCallbacks

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -108,7 +108,7 @@ class MasterShellCommand(BuildStep):
 
         self.stdio_log = stdio_log = self.addLog("stdio")
 
-        if isinstance(command, str):
+        if isinstance(command, string_types):
             stdio_log.addHeader(command.strip() + "\n\n")
         else:
             stdio_log.addHeader(" ".join(command) + "\n\n")

--- a/master/buildbot/steps/package/rpm/rpmspec.py
+++ b/master/buildbot/steps/package/rpm/rpmspec.py
@@ -20,6 +20,7 @@ library to populate parameters from and rpmspec file into a memory structure
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import string_types
 
 import re
 
@@ -59,7 +60,7 @@ class RpmSpec(ShellCommand):
         """
         # If we are given a string, open it up else assume it's something we
         # can call read on.
-        if isinstance(self.specfile, str):
+        if isinstance(self.specfile, string_types):
             f = open(self.specfile, 'r')
         else:
             f = self.specfile

--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -19,6 +19,7 @@ BuildSteps that are specific to the Twisted source tree
 from __future__ import absolute_import
 from __future__ import print_function
 from future.builtins import range
+from future.utils import string_types
 
 import re
 
@@ -291,7 +292,7 @@ class Trial(ShellCommand):
         if python:
             self.python = python
         if self.python is not None:
-            if isinstance(self.python, str):
+            if isinstance(self.python, string_types):
                 self.python = [self.python]
             for s in self.python:
                 if " " in s:
@@ -318,14 +319,14 @@ class Trial(ShellCommand):
             self.testpath = testpath
         if self.testpath is UNSPECIFIED:
             raise ValueError("You must specify testpath= (it can be None)")
-        assert isinstance(self.testpath, str) or self.testpath is None
+        assert isinstance(self.testpath, string_types) or self.testpath is None
 
         if reactor is not UNSPECIFIED:
             self.reactor = reactor
 
         if tests is not None:
             self.tests = tests
-        if isinstance(self.tests, str):
+        if isinstance(self.tests, string_types):
             self.tests = [self.tests]
         if testChanges is not None:
             self.testChanges = testChanges
@@ -386,7 +387,7 @@ class Trial(ShellCommand):
                 # this bit produces a list, which can be used
                 # by buildbot_worker.runprocess.RunProcess
                 ppath = e.get('PYTHONPATH', self.testpath)
-                if isinstance(ppath, str):
+                if isinstance(ppath, string_types):
                     ppath = [ppath]
                 if self.testpath not in ppath:
                     ppath.insert(0, self.testpath)

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -492,7 +492,7 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
         # Now compile a regular expression from whichever warning pattern we're
         # using
         wre = self.warningPattern
-        if isinstance(wre, str):
+        if isinstance(wre, string_types):
             wre = re.compile(wre)
 
         directoryEnterRe = self.directoryEnterPattern

--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from future.utils import iteritems
+from future.utils import string_types
 
 from twisted.internet import defer
 from twisted.python import log
@@ -50,7 +51,7 @@ class ShellArg(results.ResultComputingConfigMixin):
             config.error("%s is an invalid command, "
                          "it must be a string or a list" % (self.command,))
         if isinstance(self.command, list):
-            if not all([isinstance(x, str) for x in self.command]):
+            if not all([isinstance(x, string_types) for x in self.command]):
                 config.error("%s must only have strings in it" %
                              (self.command,))
         runConfParams = [(p_attr, getattr(self, p_attr))

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import string_types
 
 from twisted.python import log
 
@@ -169,7 +170,7 @@ class Source(LoggingBuildStep, CompositeStepMixin):
             source = self.__class__.__name__
 
         if self.codebase != '':
-            assert not isinstance(self.getProperty(name, None), str), \
+            assert not isinstance(self.getProperty(name, None), string_types), \
                 "Sourcestep %s has a codebase, other sourcesteps don't" \
                 % self.name
             property_dict = self.getProperty(name, {})

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import string_types
 
 import stat
 
@@ -58,7 +59,7 @@ class SetPropertiesFromEnv(WorkerBuildStep):
         environ = self.worker.worker_environ
         variables = self.variables
         log = []
-        if isinstance(variables, str):
+        if isinstance(variables, string_types):
             variables = [self.variables]
         for variable in variables:
             key = variable

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -218,7 +218,7 @@ def encodeString(s, encoding='utf-8'):
 
 
 def none_or_str(x):
-    if x is not None and not isinstance(x, str):
+    if x is not None and not isinstance(x, string_types):
         return str(x)
     return x
 

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from future.utils import itervalues
+from future.utils import string_types
 
 import time
 
@@ -107,11 +108,11 @@ class AbstractWorker(service.BuildbotService, object):
 
         if notify_on_missing is None:
             notify_on_missing = []
-        if isinstance(notify_on_missing, str):
+        if isinstance(notify_on_missing, string_types):
             notify_on_missing = [notify_on_missing]
         self.notify_on_missing = notify_on_missing
         for i in notify_on_missing:
-            if not isinstance(i, str):
+            if not isinstance(i, string_types):
                 config.error(
                     'notify_on_missing arg %r is not a string' % (i,))
 

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from future.utils import string_types
 
 import hashlib
 import json
@@ -68,7 +69,7 @@ class DockerBaseWorker(AbstractLatentWorker):
         # container is almost immediate, we can afford doing so for each build.
         if 'build_wait_timeout' not in kwargs:
             kwargs['build_wait_timeout'] = 0
-        if image is not None and not isinstance(image, str):
+        if image is not None and not isinstance(image, string_types):
             if not hasattr(image, 'getRenderingFor'):
                 config.error("image must be a string")
 
@@ -133,7 +134,7 @@ class DockerLatentWorker(DockerBaseWorker):
         # Renderables can be direct volumes definition or list member
         if isinstance(volumes, list):
             for volume_string in (volumes or []):
-                if not isinstance(volume_string, str):
+                if not isinstance(volume_string, string_types):
                     continue
                 try:
                     bind, volume = volume_string.split(":", 1)

--- a/master/docs/developer/py3-compat.rst
+++ b/master/docs/developer/py3-compat.rst
@@ -153,13 +153,17 @@ After:
 
 .. code-block:: python
 
-    from builtins import str
+    from future.utils import text_type, string_types
     unicode_s = u"this is a unicode string"
     byte_s = b"this is a bytestring"
 
-    if(isinstance(unicode_s, str)):
+    if(isinstance(unicode_s, string_types)):
         print("This line will print")
-    if(isinstance(byte_s, str):
+    if(isinstance(byte_s, string_types)):
+        print("This line will print")
+    if(isinstance(unicode_s, text_type)):
+        print("This line will print")
+    if(isinstance(byte_s, text_type):
         print("this line will not print")
 
 


### PR DESCRIPTION
When configuring some services in `master.cfg` with:

```python
from __future__ import unicode_literals
from buildbot.plugins.db import steps
b = steps.ShellCommand(
    name='do stuff',
    command=['stuff'],
)
```

there are errors with python 2:

```
BuildStep name must be a string: u'do stuff'
```

`BuildStep` is only an example, there are other constructors that do not accept unicode strings.

Since almost all internal API work on unicode strings, replace most checks that a variable is a string by testing if it is an instance of `string_types` (from `future.utils`).

## Contributor Checklist:

* [x] I have updated the appropriate documentation