### PR TITLE
introduce logchunk deletion db API

### DIFF
--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -348,7 +348,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
     def deleteOldLogChunks(self, older_than_timestamp):
         def thddeleteOldLogs(conn):
             model = self.db.model
-            res = conn.execute("SELECT count(*) from `logchunks`")
+            res = conn.execute(sa.select([sa.func.count(model.logchunks.c.content)]))
             count1 = res.fetchone()[0]
             res.close()
             # join the step and log tables
@@ -372,7 +372,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                 .where(model.logchunks.c.logid.in_(q))
             )
             res.close()
-            res = conn.execute("SELECT count(*) from `logchunks`")
+            res = conn.execute(sa.select([sa.func.count(model.logchunks.c.content)]))
             count2 = res.fetchone()[0]
             res.close()
             return count1 - count2

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -353,6 +353,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             res.close()
 
             # update log types older than timestamps
+            # we do it first to avoid having UI discrepancy
             res = conn.execute(
                 model.logs.update()
                 .where(model.logs.c.stepid.in_(
@@ -362,10 +363,10 @@ class LogsConnectorComponent(base.DBConnectorComponent):
             )
             res.close()
 
-            # query all logs older than timestamps
+            # query all logs with type 'd' and delete their chunks.
             q = sa.select([model.logs.c.id])
-            q = q.select_from(model.logs.join(model.steps, model.steps.c.id == model.logs.c.stepid))
-            q = q.where(model.steps.c.started_at < older_than_timestamp)
+            q = q.select_from(model.logs)
+            q = q.where(model.logs.c.type == 'd')
 
             # delete their logchunks
             res = conn.execute(

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -179,7 +179,7 @@ class Model(base.DBConnectorComponent):
         sa.Column('stepid', sa.Integer, sa.ForeignKey('steps.id')),
         sa.Column('complete', sa.SmallInteger, nullable=False),
         sa.Column('num_lines', sa.Integer, nullable=False),
-        # 's' = stdio, 't' = text, 'h' = html
+        # 's' = stdio, 't' = text, 'h' = html, 'd' = deleted
         sa.Column('type', sa.String(1), nullable=False),
     )
 

--- a/master/buildbot/spec/types/logchunk.raml
+++ b/master/buildbot/spec/types/logchunk.raml
@@ -14,6 +14,7 @@ description: |
      * ``t`` -- text, a simple sequence of lines of text
      * ``s`` -- stdio, like text but with each line tagged with a stream
      * ``h`` -- HTML, represented as plain text
+     * ``d`` -- Deleted, logchunks for this log have been deleted by the Janitor
 
     In the stream type, each line is prefixed by a character giving the stream type for that line.
     The types are ``i`` for input, ``o`` for stdout, ``e`` for stderr, and ``h`` for header.

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -2201,6 +2201,11 @@ class FakeLogsComponent(FakeDBComponent):
     def compressLog(self, logid, force=False):
         return defer.succeed(None)
 
+    def deleteOldLogChunks(self, older_than_timestamp):
+        # not implemented
+        self._deleted = older_than_timestamp
+        return defer.succeed(1)
+
 
 class FakeUsersComponent(FakeDBComponent):
 

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -551,7 +551,7 @@ class RealTests(Tests):
         yield self.insertTestData(self.backgroundData)
         logids = []
         for stepid in (101, 102):
-            for i in xrange(stepid):
+            for i in range(stepid):
                 logid = yield self.db.logs.addLog(
                     stepid=stepid, name=u'another' + str(i), slug=u'another' + str(i), type=u's')
                 yield self.db.logs.appendLog(logid, u'xyz\n')

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -36,7 +36,8 @@ from buildbot.util import unicode2bytes
 
 
 class Tests(interfaces.InterfaceTests):
-
+    TIMESTAMP_STEP101 = 100000
+    TIMESTAMP_STEP102 = 200000
     backgroundData = [
         fakedb.Worker(id=47, name='linux'),
         fakedb.Buildset(id=20),
@@ -45,8 +46,8 @@ class Tests(interfaces.InterfaceTests):
         fakedb.Master(id=88),
         fakedb.Build(id=30, buildrequestid=41, number=7, masterid=88,
                      builderid=88, workerid=47),
-        fakedb.Step(id=101, buildid=30, number=1, name='one'),
-        fakedb.Step(id=102, buildid=30, number=2, name='two'),
+        fakedb.Step(id=101, buildid=30, number=1, name='one', started_at=TIMESTAMP_STEP101),
+        fakedb.Step(id=102, buildid=30, number=2, name='two', started_at=TIMESTAMP_STEP102),
     ]
 
     testLogLines = [
@@ -138,6 +139,11 @@ class Tests(interfaces.InterfaceTests):
     def test_signature_compressLog(self):
         @self.assertArgSpecMatches(self.db.logs.compressLog)
         def compressLog(self, logid, force=False):
+            pass
+
+    def test_signature_deleteOldLogChunks(self):
+        @self.assertArgSpecMatches(self.db.logs.deleteOldLogChunks)
+        def deleteOldLogChunks(self, older_than_timestamp):
             pass
 
     # method tests
@@ -539,6 +545,34 @@ class RealTests(Tests):
             'type': u's',
             'slug': u'stdio',
             'complete': True})
+
+    @defer.inlineCallbacks
+    def test_deleteOldLogChunks_basic(self):
+        yield self.insertTestData(self.backgroundData)
+        logids = []
+        for stepid in (101, 102):
+            for i in xrange(stepid):
+                logid = yield self.db.logs.addLog(
+                    stepid=stepid, name=u'another' + str(i), slug=u'another' + str(i), type=u's')
+                yield self.db.logs.appendLog(logid, u'xyz\n')
+                logids.append(logid)
+
+        deleted_chunks = yield self.db.logs.deleteOldLogChunks(
+            (self.TIMESTAMP_STEP102 + self.TIMESTAMP_STEP101) / 2)
+        self.assertEqual(deleted_chunks, 101)
+        deleted_chunks = yield self.db.logs.deleteOldLogChunks(
+            self.TIMESTAMP_STEP102 + self.TIMESTAMP_STEP101)
+        self.assertEqual(deleted_chunks, 102)
+        deleted_chunks = yield self.db.logs.deleteOldLogChunks(
+            self.TIMESTAMP_STEP102 + self.TIMESTAMP_STEP101)
+        self.assertEqual(deleted_chunks, 0)
+        for logid in logids:
+            logdict = yield self.db.logs.getLog(logid)
+            self.assertEqual(logdict['type'], 'd')
+
+            # we make sure we can still getLogLines, it will just return empty value
+            lines = yield self.db.logs.getLogLines(logid, 0, logdict['num_lines'])
+            self.assertEqual(lines, '')
 
 
 class TestFakeDB(unittest.TestCase, Tests):

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -550,6 +550,16 @@ logs
         It should only be called for finished logs.
         This method may take some time to complete.
 
+    .. py:method:: deleteOldLogChunks(older_than_timestamp)
+
+        :param integer older_than_timestamp: the logs whose step's ``started_at`` is older than ``older_than_timestamp`` will be deleted.
+        :returns: Deferred
+
+        Delete old logchunks (helper for the ``logHorizon`` policy).
+        Old logs have their logchunks deleted from the database, but they keep their ``num_lines`` metadata.
+        They have their types changed to 'd', so that the UI can display something meaningful.
+
+
 buildsets
 ~~~~~~~~~
 


### PR DESCRIPTION
The largest part of buildbot db is storing the logchunks.
for the first version of the Janitor, we will be deleting only the old logchunks to keep as much metadata as possible

build/steps/logs will be managed in a second step

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have updated the appropriate documentation

