### PR TITLE
[RFC] janitorConfigurator (replacing logHorizon)

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -174,6 +174,8 @@ conchc
 config
 configfile
 configs
+configurators
+configurator
 conn
 contrib
 cors

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -201,8 +201,6 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
         self.titleURL = 'http://buildbot.net'
         self.buildbotURL = 'http://localhost:8080/'
         self.changeHorizon = None
-        self.logHorizon = None
-        self.buildHorizon = None
         self.logCompressionLimit = 4 * 1024
         self.logCompressionMethod = 'gz'
         self.logEncoding = 'utf-8'
@@ -262,6 +260,7 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
         "caches",
         "change_source",
         "codebaseGenerator",
+        "configurators"
         "changeCacheSize",
         "changeHorizon",
         'db',
@@ -319,6 +318,7 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
 
     @classmethod
     def loadFromDict(cls, config_dict, filename):
+        # warning, all of this is loaded from a thread
         global _errors
         _errors = errors = ConfigErrors()
 
@@ -338,6 +338,7 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
 
         # and defer the rest to sub-functions, for code clarity
         try:
+            config.run_configurators(filename, config_dict)
             config.load_global(filename, config_dict)
             config.load_validation(filename, config_dict)
             config.load_db(filename, config_dict)
@@ -360,7 +361,6 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
             config.check_locks()
             config.check_builders()
             config.check_status()
-            config.check_horizons()
             config.check_ports()
         finally:
             _errors = None
@@ -369,6 +369,10 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
             raise errors
 
         return config
+
+    def run_configurators(self, filename, config_dict):
+        for configurator in config_dict.get('configurators', []):
+            interfaces.IConfigurator(configurator).configure(config_dict)
 
     def load_global(self, filename, config_dict):
         def copy_param(name, alt_key=None,
@@ -418,16 +422,14 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
                 )
         copy_str_or_callable_param('buildbotNetUsageData')
 
+        for horizon in ('logHorizon', 'buildHorizon', 'eventHorizon'):
+            if horizon in config_dict:
+                warnDeprecated(
+                    '0.9.0',
+                    "NOTE: `{}` is deprecated and ignored "
+                    "They are replaced by util.JanitorConfigurator".format(horizon))
+
         copy_int_param('changeHorizon')
-        copy_int_param('logHorizon')
-        copy_int_param('buildHorizon')
-
-        if 'eventHorizon' in config_dict:
-            warnDeprecated(
-                '0.9.0',
-                '`eventHorizon` is deprecated and will be removed in a future version.',
-            )
-
         copy_int_param('logCompressionLimit')
 
         self.logCompressionMethod = config_dict.get(
@@ -926,14 +928,6 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
         for s in self.status:
             s.checkConfig(self.status)
 
-    def check_horizons(self):
-        if self.buildHorizon is not None:
-            log.msg("NOTE: `buildHorizon` and `logHorizon` are deprecated and ignored "
-                    "They are replaced by util.JanitorConfigurator")
-        if self.logHorizon is not None and self.buildHorizon is not None:
-            if self.logHorizon > self.buildHorizon:
-                error("logHorizon must be less than or equal to buildHorizon")
-
     def check_ports(self):
         ports = set()
         if self.protocols:
@@ -955,14 +949,6 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
             return
         if self.workers:
             error("workers are configured, but c['protocols'] not")
-
-    @property
-    def eventHorizon(self):
-        warnings.warn(
-            "`eventHorizon` is deprecated and will be removed in a future version.",
-            category=DeprecationWarning,
-        )
-        return 0
 
 
 class BuilderConfig(util_config.ConfiguredMixin, WorkerAPICompatMixin):

--- a/master/buildbot/configurators/__init__.py
+++ b/master/buildbot/configurators/__init__.py
@@ -1,0 +1,45 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+#
+from __future__ import absolute_import
+from __future__ import print_function
+
+""" This module holds configurators, which helps setup schedulers, builders, steps,
+    for a very specific purpose.
+    Higher level interfaces to buildbot configurations components.
+"""
+
+
+class ConfiguratorBase(object):
+    """
+        I provide base helper methods for configurators
+    """
+    def __init__(self, config_dict):
+        self.config_dict = c = config_dict
+        if 'schedulers' not in c:
+            c['schedulers'] = []
+        self.schedulers = c['schedulers']
+        if 'protocols' not in c:
+            c['protocols'] = {}
+        self.protocols = c['protocols']
+        if 'builders' not in c:
+            c['builders'] = []
+        self.builders = c['builders']
+        if 'workers' not in c and 'slaves' not in c:
+            c['workers'] = self.workers = []
+        elif 'slaves' in c:
+            self.workers = c['slaves']
+        elif 'workers' in c:
+            self.workers = c['workers']

--- a/master/buildbot/configurators/__init__.py
+++ b/master/buildbot/configurators/__init__.py
@@ -15,6 +15,8 @@
 #
 from __future__ import absolute_import
 from __future__ import print_function
+from zope.interface import implementer
+from buildbot.interfaces import IConfigurator
 
 """ This module holds configurators, which helps setup schedulers, builders, steps,
     for a very specific purpose.
@@ -22,11 +24,15 @@ from __future__ import print_function
 """
 
 
+@implementer(IConfigurator)
 class ConfiguratorBase(object):
     """
         I provide base helper methods for configurators
     """
-    def __init__(self, config_dict):
+    def __init__(self):
+        pass
+
+    def configure(self, config_dict):
         self.config_dict = c = config_dict
         if 'schedulers' not in c:
             c['schedulers'] = []

--- a/master/buildbot/configurators/janitor.py
+++ b/master/buildbot/configurators/janitor.py
@@ -1,0 +1,80 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+#
+from __future__ import absolute_import
+from __future__ import print_function
+
+import datetime
+
+from twisted.internet import defer
+
+from buildbot.config import BuilderConfig
+from buildbot.configurators import ConfiguratorBase
+from buildbot.process.buildstep import BuildStep
+from buildbot.process.factory import BuildFactory
+from buildbot.process.results import SUCCESS
+from buildbot.schedulers.timed import Nightly
+from buildbot.util import datetime2epoch
+from buildbot.worker.local import LocalWorker
+
+""" Janitor is a configurator which create a Janitor Builder with all needed Janitor steps
+"""
+
+JANITOR_NAME = "__Janitor"  # If you read this code, you may want to patch this name.
+
+
+def now():
+    """patchable now (datetime is not patchable as builtin)"""
+    return datetime.datetime.utcnow()
+
+
+class LogChunksJanitor(BuildStep):
+    name = 'LogChunksJanitor'
+    renderables = ["logHorizon"]
+
+    def __init__(self, logHorizon):
+        BuildStep.__init__(self)
+        self.logHorizon = logHorizon
+
+    @defer.inlineCallbacks
+    def run(self):
+        older_than_timestamp = datetime2epoch(now() - self.logHorizon)
+        deleted = yield self.master.db.logs.deleteOldLogChunks(older_than_timestamp)
+        self.descriptionDone = ["deleted", str(deleted), "logchunks"]
+        defer.returnValue(SUCCESS)
+
+
+class JanitorConfigurator(ConfiguratorBase):
+    def __init__(self, config_dict, logHorizon=None, hour=0, **kwargs):
+        if logHorizon is None:
+            return
+        ConfiguratorBase.__init__(self, config_dict)
+        nightly_kwargs = {}
+
+        # we take the defaults of Nightly, except for hour
+        for arg in ('minute', 'dayOfMonth', 'month', 'dayOfWeek'):
+            if arg in kwargs:
+                nightly_kwargs[arg] = kwargs[arg]
+
+        self.schedulers.append(Nightly(
+            name=JANITOR_NAME, builderNames=[JANITOR_NAME], hour=hour, **nightly_kwargs))
+
+        self.builders.append(BuilderConfig(
+            name=JANITOR_NAME, workername=JANITOR_NAME, factory=BuildFactory(steps=[
+                LogChunksJanitor(logHorizon=logHorizon)
+            ])
+        ))
+        self.protocols.setdefault('null', {})
+        self.workers.append(LocalWorker(JANITOR_NAME))

--- a/master/buildbot/configurators/janitor.py
+++ b/master/buildbot/configurators/janitor.py
@@ -57,10 +57,20 @@ class LogChunksJanitor(BuildStep):
 
 
 class JanitorConfigurator(ConfiguratorBase):
-    def __init__(self, config_dict, logHorizon=None, hour=0, **kwargs):
-        if logHorizon is None:
+    def __init__(self, logHorizon=None, hour=0, **kwargs):
+        ConfiguratorBase.__init__(self)
+        self.logHorizon = logHorizon
+        self.hour = hour
+        self.kwargs = kwargs
+
+    def configure(self, config_dict):
+        if self.logHorizon is None:
             return
-        ConfiguratorBase.__init__(self, config_dict)
+        logHorizon = self.logHorizon
+        hour = self.hour
+        kwargs = self.kwargs
+
+        ConfiguratorBase.configure(self, config_dict)
         nightly_kwargs = {}
 
         # we take the defaults of Nightly, except for hour

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -1103,7 +1103,7 @@ class IConfigurator(Interface):
         """
         Alter the buildbot config_dict, as defined in master.cfg
 
-        like the master.cfg, this is run from the a thread, so this can block, but this can't
+        like the master.cfg, this is run out of the main reactor thread, so this can block, but this can't
         call most Buildbot facilities.
 
         :returns: None

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -1095,3 +1095,16 @@ class IHttpResponse(Interface):
         """
     master = Attribute('code',
                        "http status code of the request's response (e.g 200)")
+
+
+class IConfigurator(Interface):
+
+    def configure(config_dict):
+        """
+        Alter the buildbot config_dict, as defined in master.cfg
+
+        like the master.cfg, this is run from the a thread, so this can block, but this can't
+        call most Buildbot facilities.
+
+        :returns: None
+        """

--- a/master/buildbot/newsfragments/configurator.feature
+++ b/master/buildbot/newsfragments/configurator.feature
@@ -1,0 +1,1 @@
+New :bb:cfg:`configurators` section, which can be used to create higher level configuration modules for Buildbot.

--- a/master/buildbot/newsfragments/janitor.feature
+++ b/master/buildbot/newsfragments/janitor.feature
@@ -1,0 +1,1 @@
+new :bb:cfg:`JanitorConfigurator` which can be used to create a builder which save disk space by removing old logs from the database.

--- a/master/buildbot/newsfragments/janitor.feature
+++ b/master/buildbot/newsfragments/janitor.feature
@@ -1,1 +1,1 @@
-new :bb:cfg:`JanitorConfigurator` which can be used to create a builder which save disk space by removing old logs from the database.
+New :bb:configurator:`JanitorConfigurator` which can be used to create a builder which save disk space by removing old logs from the database.

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -35,6 +35,7 @@ from twisted.trial import unittest
 from zope.interface import implementer
 
 from buildbot import config
+from buildbot import configurators
 from buildbot import interfaces
 from buildbot import locks
 from buildbot import revlinks
@@ -63,9 +64,6 @@ global_defaults = dict(
     title='Buildbot',
     titleURL='http://buildbot.net',
     buildbotURL='http://localhost:8080/',
-    changeHorizon=None,
-    logHorizon=None,
-    buildHorizon=None,
     logCompressionLimit=4096,
     logCompressionMethod='gz',
     logEncoding='utf-8',
@@ -372,7 +370,6 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
         self.assertTrue(rv.check_locks.called)
         self.assertTrue(rv.check_builders.called)
         self.assertTrue(rv.check_status.called)
-        self.assertTrue(rv.check_horizons.called)
         self.assertTrue(rv.check_ports.called)
 
     def test_preChangeGenerator(self):
@@ -484,7 +481,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
     def test_load_global_eventHorizon(self):
         with assertProducesWarning(
                 config.ConfigWarning,
-                message_pattern=r"`eventHorizon` is deprecated and will be removed in a future version."):
+                message_pattern=r"`eventHorizon` is deprecated and ignored"):
             self.do_test_load_global(
                 dict(eventHorizon=10))
 
@@ -495,12 +492,6 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                 message_pattern=r"`buildbotNetUsageData` is not configured and defaults to basic."):
             self.do_test_load_global(
                 dict())
-
-    def test_load_global_logHorizon(self):
-        self.do_test_load_global(dict(logHorizon=10), logHorizon=10)
-
-    def test_load_global_buildHorizon(self):
-        self.do_test_load_global(dict(buildHorizon=10), buildHorizon=10)
 
     def test_load_global_logCompressionLimit(self):
         self.do_test_load_global(dict(logCompressionLimit=10),
@@ -1057,6 +1048,16 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         errMsg += "object should be an instance of buildbot.util.service.BuildbotService"
         self.assertConfigError(self.errors, errMsg)
 
+    def test_load_configurators_norminal(self):
+
+        class MyConfigurator(configurators.ConfiguratorBase):
+
+            def configure(self, config_dict):
+                config_dict['foo'] = 'bar'
+        c = dict(configurators=[MyConfigurator()])
+        self.cfg.run_configurators(self.filename, c)
+        self.assertEqual(c['foo'], 'bar')
+
 
 class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
 
@@ -1252,13 +1253,6 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
 
         self.assertNoConfigErrors(self.errors)
         st.checkConfig.assert_called_once_with(self.cfg.status)
-
-    def test_check_horizons(self):
-        self.cfg.logHorizon = 100
-        self.cfg.buildHorizon = 50
-        self.cfg.check_horizons()
-
-        self.assertConfigError(self.errors, "logHorizon must be less")
 
     def test_check_ports_protocols_set(self):
         self.cfg.protocols = {"pb": {"port": 10}}

--- a/master/buildbot/test/unit/test_configurator_base.py
+++ b/master/buildbot/test/unit/test_configurator_base.py
@@ -1,0 +1,48 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from twisted.trial import unittest
+
+from buildbot.configurators import ConfiguratorBase
+from buildbot.test.util import configurators
+
+
+class ConfiguratorBaseTests(configurators.ConfiguratorMixin, unittest.SynchronousTestCase):
+    ConfiguratorClass = ConfiguratorBase
+
+    def test_basic(self):
+        self.setupConfigurator()
+        self.assertEqual(self.config_dict, {
+            'schedulers': [],
+            'protocols': {},
+            'workers': [],
+            'builders': []
+        })
+        self.assertEqual(self.configurator.workers, [])
+
+    def test_worker_vs_slaves(self):
+        """The base configurator uses the slaves config if it exists already"""
+        self.config_dict['slaves'] = [1]  # marker
+        self.setupConfigurator()
+        self.assertEqual(self.config_dict, {
+            'schedulers': [],
+            'slaves': [1],
+            'builders': [],
+            'protocols': {}
+        })
+        self.assertEqual(self.configurator.workers, [1])

--- a/master/buildbot/test/unit/test_janitor_configurator.py
+++ b/master/buildbot/test/unit/test_janitor_configurator.py
@@ -1,0 +1,89 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import datetime
+from datetime import timedelta
+
+import mock
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.configurators import janitor
+from buildbot.configurators.janitor import JanitorConfigurator
+from buildbot.configurators.janitor import LogChunksJanitor
+from buildbot.process.results import SUCCESS
+from buildbot.schedulers.timed import Nightly
+from buildbot.test.util import config as configmixin
+from buildbot.test.util import configurators
+from buildbot.test.util import steps
+from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.util import datetime2epoch
+from buildbot.worker.local import LocalWorker
+from buildbot.worker_transition import DeprecatedWorkerNameWarning
+
+
+class JanitorConfiguratorTests(configurators.ConfiguratorMixin, unittest.SynchronousTestCase):
+    ConfiguratorClass = JanitorConfigurator
+
+    def test_nothing(self):
+        self.setupConfigurator()
+        self.assertEqual(self.config_dict, {
+        })
+
+    def test_basic(self):
+        self.setupConfigurator(logHorizon=timedelta(weeks=1))
+        self.expectWorker("__Janitor", LocalWorker)
+        self.expectScheduler("__Janitor", Nightly)
+        self.expectBuilderHasSteps("__Janitor", [LogChunksJanitor])
+        self.expectNoConfigError()
+
+    def test_worker_vs_slaves(self):
+        """The base configurator uses the slaves config if it exists already"""
+        self.config_dict['slaves'] = []
+        self.setupConfigurator(logHorizon=timedelta(weeks=1))
+        self.expectWorker("__Janitor", LocalWorker)
+        self.expectScheduler("__Janitor", Nightly)
+        self.expectBuilderHasSteps("__Janitor", [LogChunksJanitor])
+        with assertProducesWarning(
+                DeprecatedWorkerNameWarning,
+                message_pattern=r"c\['slaves'\] key is deprecated, "
+                                r"use c\['workers'\] instead"):
+                self.expectNoConfigError()
+
+
+class LogChunksJanitorTests(steps.BuildStepMixin, unittest.TestCase, configmixin.ConfigErrorsMixin):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.setUpBuildStep()
+        self.patch(janitor, "now", lambda: datetime.datetime(year=2017, month=1, day=1))
+
+    def tearDown(self):
+        return self.tearDownBuildStep()
+
+    @defer.inlineCallbacks
+    def test_basic(self):
+        self.setupStep(
+            LogChunksJanitor(logHorizon=timedelta(weeks=1)))
+        self.master.db.logs.deleteOldLogChunks = mock.Mock(return_value=3)
+        self.expectOutcome(result=SUCCESS,
+                           state_string=u"deleted 3 logchunks")
+        yield self.runStep()
+        expected_timestamp = datetime2epoch(datetime.datetime(year=2016, month=12, day=25))
+        self.master.db.logs.deleteOldLogChunks.assert_called_with(expected_timestamp)

--- a/master/buildbot/test/unit/test_janitor_configurator.py
+++ b/master/buildbot/test/unit/test_janitor_configurator.py
@@ -25,6 +25,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.configurators import janitor
+from buildbot.configurators.janitor import JANITOR_NAME
 from buildbot.configurators.janitor import JanitorConfigurator
 from buildbot.configurators.janitor import LogChunksJanitor
 from buildbot.process.results import SUCCESS
@@ -48,18 +49,18 @@ class JanitorConfiguratorTests(configurators.ConfiguratorMixin, unittest.Synchro
 
     def test_basic(self):
         self.setupConfigurator(logHorizon=timedelta(weeks=1))
-        self.expectWorker("__Janitor", LocalWorker)
-        self.expectScheduler("__Janitor", Nightly)
-        self.expectBuilderHasSteps("__Janitor", [LogChunksJanitor])
+        self.expectWorker(JANITOR_NAME, LocalWorker)
+        self.expectScheduler(JANITOR_NAME, Nightly)
+        self.expectBuilderHasSteps(JANITOR_NAME, [LogChunksJanitor])
         self.expectNoConfigError()
 
     def test_worker_vs_slaves(self):
         """The base configurator uses the slaves config if it exists already"""
         self.config_dict['slaves'] = []
         self.setupConfigurator(logHorizon=timedelta(weeks=1))
-        self.expectWorker("__Janitor", LocalWorker)
-        self.expectScheduler("__Janitor", Nightly)
-        self.expectBuilderHasSteps("__Janitor", [LogChunksJanitor])
+        self.expectWorker(JANITOR_NAME, LocalWorker)
+        self.expectScheduler(JANITOR_NAME, Nightly)
+        self.expectBuilderHasSteps(JANITOR_NAME, [LogChunksJanitor])
         with assertProducesWarning(
                 DeprecatedWorkerNameWarning,
                 message_pattern=r"c\['slaves'\] key is deprecated, "

--- a/master/buildbot/test/util/configurators.py
+++ b/master/buildbot/test/util/configurators.py
@@ -31,7 +31,8 @@ class ConfiguratorMixin(object):
         self.config_dict = {}
 
     def setupConfigurator(self, *args, **kwargs):
-        self.configurator = self.ConfiguratorClass(self.config_dict, *args, **kwargs)
+        self.configurator = self.ConfiguratorClass(*args, **kwargs)
+        return self.configurator.configure(self.config_dict)
 
     def expectWorker(self, name, klass):
         if 'workers' in self.config_dict and 'slaves' in self.config_dict:

--- a/master/buildbot/test/util/configurators.py
+++ b/master/buildbot/test/util/configurators.py
@@ -1,0 +1,68 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from buildbot.config import MasterConfig
+
+
+class ConfiguratorMixin(object):
+
+    """
+    Support for testing configurators.
+
+    @ivar configurator: the configurator under test
+    @ivar config_dict: the config dict that the configurator is modifying
+    """
+    def setUp(self):
+        self.config_dict = {}
+
+    def setupConfigurator(self, *args, **kwargs):
+        self.configurator = self.ConfiguratorClass(self.config_dict, *args, **kwargs)
+
+    def expectWorker(self, name, klass):
+        if 'workers' in self.config_dict and 'slaves' in self.config_dict:
+            self.fail("both 'workers' and 'slaves' are in the config dict!")
+        for worker in self.config_dict.get('workers', []) + self.config_dict.get('slaves', []):
+            if isinstance(worker, klass) and worker.name == name:
+                return worker
+        self.fail("expected a worker named {} of class {}".format(name, klass))
+
+    def expectScheduler(self, name, klass):
+        for scheduler in self.config_dict['schedulers']:
+            if scheduler.name == name and isinstance(scheduler, klass):
+                return scheduler
+        self.fail("expected a scheduler named {} of class {}".format(name, klass))
+
+    def expectBuilder(self, name):
+        for builder in self.config_dict['builders']:
+            if builder.name == name:
+                return builder
+        self.fail("expected a builder named {}".format(name))
+
+    def expectBuilderHasSteps(self, name, step_classes):
+        builder = self.expectBuilder(name)
+        for step_class in step_classes:
+            found = [
+                step
+                for step in builder.factory.steps if step.factory == step_class
+            ]
+            if not found:
+                self.fail("expected a buildstep of {!r} in {}".format(step_class, name))
+
+    def expectNoConfigError(self):
+        config = MasterConfig()
+        config.loadFromDict(self.config_dict, "test")

--- a/master/docs/bbdocs/ext.py
+++ b/master/docs/bbdocs/ext.py
@@ -190,6 +190,7 @@ class BBDomain(Domain):
         'chsrc': ObjType('chsrc', 'chsrc'),
         'step': ObjType('step', 'step'),
         'reporter': ObjType('reporter', 'reporter'),
+        'configurator': ObjType('configurator', 'configurator'),
         'worker': ObjType('worker', 'worker'),
         'cmdline': ObjType('cmdline', 'cmdline'),
         'msg': ObjType('msg', 'msg'),
@@ -223,6 +224,11 @@ class BBDomain(Domain):
                                               indextemplates=[
                                                   'single: Reporter Targets; %s',
                                                   'single: %s Reporter Target',
+                                              ]),
+        'configurator': make_ref_target_directive('configurator',
+                                              indextemplates=[
+                                                  'single: Configurators; %s',
+                                                  'single: %s Configurators',
                                               ]),
         'worker': make_ref_target_directive('worker',
                                             indextemplates=[
@@ -294,6 +300,7 @@ class BBDomain(Domain):
         'chsrc': XRefRole(),
         'step': XRefRole(),
         'reporter': XRefRole(),
+        'configurator': XRefRole(),
         'worker': XRefRole(),
         'cmdline': XRefRole(),
         'msg': XRefRole(),
@@ -313,6 +320,7 @@ class BBDomain(Domain):
         make_index("chsrc", "Change Source Index"),
         make_index("step", "Build Step Index"),
         make_index("reporter", "Reporter Target Index"),
+        make_index("configurator", "Configurator Target Index"),
         make_index("worker", "Build Worker Index"),
         make_index("cmdline", "Command Line Index"),
         make_index("msg", "MQ Routing Key Index"),

--- a/master/docs/developer/classes.rst
+++ b/master/docs/developer/classes.rst
@@ -22,6 +22,7 @@ The sections contained here document classes that can be used or subclassed.
     cls-forcesched
     cls-irenderable
     cls-iproperties
+    cls-iconfigurator
     cls-resultspec
     cls-protocols
     cls-workermanager

--- a/master/docs/developer/cls-iconfigurator.rst
+++ b/master/docs/developer/cls-iconfigurator.rst
@@ -1,0 +1,16 @@
+.. index:: single: Configurator; IConfigurator
+
+``IConfigurator``
+=================
+
+.. class:: buildbot.interfaces.IConfigurator::
+
+    A configurator is an object which configures several components of Buildbot in a coherent manner.
+    This can be used to implement higher level configuration tools.
+
+    .. method:: configure(config_dict)
+
+       Alter the buildbot ``config_dict``, as defined in master.cfg
+
+       like the master.cfg, this is run from the a thread, so this can block, but this can't
+       call most Buildbot facilities.

--- a/master/docs/developer/cls-iconfigurator.rst
+++ b/master/docs/developer/cls-iconfigurator.rst
@@ -10,7 +10,7 @@
 
     .. method:: configure(config_dict)
 
-       Alter the buildbot ``config_dict``, as defined in master.cfg
+        Alter the buildbot ``config_dict``, as defined in master.cfg
 
-       like the master.cfg, this is run from the a thread, so this can block, but this can't
-       call most Buildbot facilities.
+        like the master.cfg, this is run out of the main reactor thread, so this can block, but this can't
+        call most Buildbot facilities.

--- a/master/docs/developer/config.rst
+++ b/master/docs/developer/config.rst
@@ -46,17 +46,6 @@ described in :ref:`developer-Reconfiguration`.
         The URL of this buildmaster, for use in constructing WebStatus URLs;
         from :bb:cfg:`buildbotURL`.
 
-    .. py:attribute:: changeHorizon
-
-        The current change horizon, from :bb:cfg:`changeHorizon`.
-
-    .. py:attribute:: logHorizon
-
-        The current log horizon, from :bb:cfg:`logHorizon`.
-
-    .. py:attribute:: buildHorizon
-
-        The current build horizon, from :bb:cfg:`buildHorizon`.
 
     .. py:attribute:: logCompressionLimit
 

--- a/master/docs/manual/cfg-configurators.rst
+++ b/master/docs/manual/cfg-configurators.rst
@@ -5,7 +5,7 @@ Configurators
 
 For advanced users or plugins writers, the 'configurators' key is available, and holds a list of :py:class:`buildbot.interfaces.IConfigurator`.
 Configurators will run after the master.cfg has been processed, and will modify the config dictionary.
-Configurator implementers should make sure that they are inter operable with each other, which means carefully modifying the config to avoid overriding a setting already made by the user or by another configurator.
+Configurator implementers should make sure that they are interoperable with each other, which means carefully modifying the config to avoid overriding a setting already made by the user or by another configurator.
 Configurators are run (thus prioritized) in the order of the 'configurators' list.
 
 .. bb:configurator:: JanitorConfigurator

--- a/master/docs/manual/cfg-configurators.rst
+++ b/master/docs/manual/cfg-configurators.rst
@@ -5,7 +5,7 @@ Configurators
 
 For advanced users or plugins writers, the 'configurators' key is available, and holds a list of :py:class:`buildbot.interfaces.IConfigurator`.
 Configurators will run after the master.cfg has been processed, and will modify the config dictionary.
-Configurator implementers should make sure that they are inter operable with each other, which means carefully modify the config to avoid overriding a setting already made by the user or by another configurator.
+Configurator implementers should make sure that they are inter operable with each other, which means carefully modifying the config to avoid overriding a setting already made by the user or by another configurator.
 Configurators are run (thus prioritized) in the order of the 'configurators' list.
 
 .. bb:configurator:: JanitorConfigurator
@@ -17,7 +17,7 @@ Buildbot stores historical information in its database.
 In a large installation, these can quickly consume disk space, yet in many cases developers never consult this historical information.
 
 :bb:configurator::`JanitorConfigurator` creates a builder and :bb:sched:`Nightly` scheduler which will regularly remove old information.
-At the moment it only supports cleaning of logs, but it will contain more feature as we implement them.
+At the moment it only supports cleaning of logs, but it will contain more features as we implement them.
 
 ::
 

--- a/master/docs/manual/cfg-configurators.rst
+++ b/master/docs/manual/cfg-configurators.rst
@@ -1,0 +1,43 @@
+.. bb:cfg:: configurators
+
+Configurators
+-------------
+
+For advanced users or plugins writers, the 'configurators' key is available, and holds a list of :py:class:`buildbot.interfaces.IConfigurator`.
+Configurators will run after the master.cfg has been processed, and will modify the config dictionary.
+Configurator implementers should make sure that they are inter operable with each other, which means carefully modify the config to avoid overriding a setting already made by the user or by another configurator.
+Configurators are run (thus prioritized) in the order of the 'configurators' list.
+
+.. bb:configurator:: JanitorConfigurator
+
+JanitorConfigurator
+~~~~~~~~~~~~~~~~~~~
+
+Buildbot stores historical information in its database.
+In a large installation, these can quickly consume disk space, yet in many cases developers never consult this historical information.
+
+:bb:configurator::`JanitorConfigurator` creates a builder and :bb:sched:`Nightly` scheduler which will regularly remove old information.
+At the moment it only supports cleaning of logs, but it will contain more feature as we implement them.
+
+::
+
+    from buildbot.plugins import util
+    from datetime import timedelta
+
+    # configure a janitor which will delete all logs older than one month, and will run on sundays at noon
+    c['configurators'] = [util.JanitorConfigurator(
+        logHorizon=timedelta(weeks=4),
+        hour=12,
+        dayOfWeek=6)]
+
+
+Parameters for :bb:configurator:`JanitorConfigurator` are:
+
+``logHorizon``
+    a ``timedelta`` object describing the minimum time for which the log data should be maintained
+
+``hour``, ``dayOfWeek``, ...
+    Arguments given to the :bb:sched::`Nightly` scheduler which is backing the JanitorConfigurator.
+    Determines when the cleanup will be done.
+    With this, you can configure it daily, weekly or even hourly if you wish.
+    You probably want to schedule it when Buildbot is less loaded.

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -273,41 +273,11 @@ It can also be overridden for a single log file by passing the ``logEncoding`` p
 Data Lifetime
 ~~~~~~~~~~~~~
 
-.. bb:cfg:: changeHorizon
-.. bb:cfg:: buildHorizon
-.. bb:cfg:: logHorizon
-.. bb:cfg:: JanitorConfigurator
-
 Horizons
 ++++++++
 
-::
-
-    from buildbot.plugins import util
-    from datetime import timedelta
-
-    # at the end of your master.cfg
-    # configure a janitor which will delete all logs older than one month, and will run on sundays at noon
-    util.JanitorConfigurator(c,
-        logHorizon=timedelta(weeks=4),
-        hour=12,
-        dayOfWeek=6)
-
-Buildbot stores historical information in its database.
-In a large installation, these can quickly consume disk space, yet in many cases developers never consult this historical information.
-
-Parameters for :bb:cfg:`JanitorConfigurator` are:
-
-``c``
-    The `BuildmasterConfig` config dictionary from your ``master.cfg``
-
-``logHorizon``
-    a ``timedelta`` object describing the minimum time for which the log data should be maintained
-
-``hour``, ``dayOfWeek``, ...
-    Arguments given to the :bb:sched::`Nightly` scheduler which is backing the JanitorConfigurator.
-    Determines when the cleanup will be done.
-    With this, you can configure it daily, weekly or even hourly if you wish.
+Previously Buildbot implemented a global configuration for horizons.
+Now it is implemented as an utility Builder, and shall be configured via :bb:configurator:`JanitorConfigurator`
 
 
 .. bb:cfg:: caches

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -276,27 +276,39 @@ Data Lifetime
 .. bb:cfg:: changeHorizon
 .. bb:cfg:: buildHorizon
 .. bb:cfg:: logHorizon
+.. bb:cfg:: JanitorConfigurator
 
 Horizons
 ++++++++
 
 ::
 
-    c['changeHorizon'] = 200
-    c['buildHorizon'] = 100
-    c['logHorizon'] = 40
-    c['buildCacheSize'] = 15
+    from buildbot.plugins import util
+    from datetime import timedelta
+
+    # at the end of your master.cfg
+    # configure a janitor which will delete all logs older than one month, and will run on sundays at noon
+    util.JanitorConfigurator(c,
+        logHorizon=timedelta(weeks=4),
+        hour=12,
+        dayOfWeek=6)
 
 Buildbot stores historical information in its database.
 In a large installation, these can quickly consume disk space, yet in many cases developers never consult this historical information.
 
-The :bb:cfg:`changeHorizon` key determines how many changes the master will keep a record of.
-One place these changes are displayed is on the waterfall page.
-This parameter defaults to 0, which means keep all changes indefinitely.
+Parameters for :bb:cfg:`JanitorConfigurator` are:
 
-The :bb:cfg:`buildHorizon` specifies the minimum number of builds for each builder which should be kept.
-The :bb:cfg:`logHorizon` gives the minimum number of builds for which logs should be maintained; this parameter must be less than or equal to :bb:cfg:`buildHorizon`.
-Builds older than :bb:cfg:`logHorizon` but not older than :bb:cfg:`buildHorizon` will maintain their overall status and the status of each step, but the logfiles will be deleted.
+``c``
+    The `BuildmasterConfig` config dictionary from your ``master.cfg``
+
+``logHorizon``
+    a ``timedelta`` object describing the minimum time for which the log data should be maintained
+
+``hour``, ``dayOfWeek``, ...
+    Arguments given to the :bb:sched::`Nightly` scheduler which is backing the JanitorConfigurator.
+    Determines when the cleanup will be done.
+    With this, you can configure it daily, weekly or even hourly if you wish.
+
 
 .. bb:cfg:: caches
 .. bb:cfg:: changeCacheSize

--- a/master/docs/manual/configuration.rst
+++ b/master/docs/manual/configuration.rst
@@ -27,3 +27,4 @@ The next section, :doc:`customization`, describes this approach, with frequent r
     cfg-wwwhooks
     cfg-services
     cfg-dbconfig
+    cfg-configurators

--- a/master/docs/manual/installation/nine-upgrade.rst
+++ b/master/docs/manual/installation/nine-upgrade.rst
@@ -197,6 +197,18 @@ Build History
 
 There is no support for importing build history from 0.8.x (where the history was stored on-disk in pickle files) into 0.9.x (where it is stored in the database).
 
+Data LifeTime
+-------------
+
+Buildbot Nine data being implemented fully in an SQL database, the ``buildHorizon`` feature had to be reworked.
+Instead of being number-of-things based, it is now time based.
+This makes more sense from a user perspective but makes it harder to predict the database average size.
+Please be careful to provision enough disk space for your database.
+
+The old ``c['logHorizon']`` way of configuring is not supported anymore.
+See :bb:cfg:`JanitorConfigurator` to learn how to configure.
+A new ``__Janitor`` builder will be created to help keep an eye on the cleanup activities.
+
 More Information
 ----------------
 

--- a/master/docs/manual/installation/nine-upgrade.rst
+++ b/master/docs/manual/installation/nine-upgrade.rst
@@ -206,7 +206,7 @@ This makes more sense from a user perspective but makes it harder to predict the
 Please be careful to provision enough disk space for your database.
 
 The old ``c['logHorizon']`` way of configuring is not supported anymore.
-See :bb:cfg:`JanitorConfigurator` to learn how to configure.
+See :bb:configurator:`JanitorConfigurator` to learn how to configure.
 A new ``__Janitor`` builder will be created to help keep an eye on the cleanup activities.
 
 More Information

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -167,6 +167,8 @@ Config
 configs
 Configs
 configurability
+configurator
+configurators
 contrib
 Contrib
 coolproject

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -361,6 +361,7 @@ inrepo
 inrepos
 interCaps
 internet
+interoperable
 ini
 intialization
 io

--- a/master/setup.py
+++ b/master/setup.py
@@ -165,6 +165,7 @@ setup_args = {
     'packages': [
         "buildbot",
         "buildbot.buildslave",
+        "buildbot.configurators",
         "buildbot.worker",
         "buildbot.worker.protocols",
         "buildbot.changes",


### PR DESCRIPTION
This is highly untested for now, but this is a change of the horizon interface I intend to introduce.

- old interface is number based, which will be quite painful to write efficient sql query.
- I personally prefer the timedelta interface, which I find more adapted to the CI job. I'd like to find some feedback on this if ppl agree or not according to their experience.

