### PR TITLE
allow github reporter to work with git@ urls

### DIFF
--- a/master/buildbot/newsfragments/github.feature
+++ b/master/buildbot/newsfragments/github.feature
@@ -1,0 +1,1 @@
+:py:class:`~buildbot.reporters.github.GitHubStatusPush` now support reporting to ssh style URLs, ie `git@github.com:Owner/RepoName.git`

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -33,6 +33,7 @@ from buildbot.process.results import WARNINGS
 from buildbot.reporters import http
 from buildbot.util import httpclientservice
 from buildbot.util import unicode2NativeString
+from buildbot.util.giturlparse import giturlparse
 
 HOSTED_BASE_URL = 'https://api.github.com'
 
@@ -136,12 +137,16 @@ class GitHubStatusPush(http.HttpStatusPushBase):
         else:
             issue = None
 
-        if project:
+        if "/" in project:
             repoOwner, repoName = project.split('/')
         else:
-            repo = sourcestamps[0]['repository'].split('/')[-2:]
-            repoOwner = repo[0]
-            repoName = '.'.join(repo[1].split('.')[:-1])
+            giturl = giturlparse(sourcestamps[0]['repository'])
+            repoOwner = giturl.owner
+            repoName = giturl.repo
+
+        if self.verbose:
+            log.msg("Updating github status: repoOwner={repoOwner}, repoName={repoName}".format(
+                repoOwner=repoOwner, repoName=repoName))
 
         for sourcestamp in sourcestamps:
             sha = sourcestamp['revision']

--- a/master/buildbot/test/unit/test_reporter_github.py
+++ b/master/buildbot/test/unit/test_reporter_github.py
@@ -31,6 +31,8 @@ from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake import fakemaster
 from buildbot.test.util.reporter import ReporterTestMixin
 
+URLtestcount = 0
+
 
 class TestGitHubStatusPush(unittest.TestCase, ReporterTestMixin):
     # project must be in the form <owner>/<project>
@@ -107,6 +109,110 @@ class TestGitHubStatusPush(unittest.TestCase, ReporterTestMixin):
     @defer.inlineCallbacks
     def test_empty(self):
         build = yield self.setupBuildResultsMin(SUCCESS)
+        build['complete'] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        build['complete'] = True
+        self.sp.buildFinished(("build", 20, "finished"), build)
+        build['results'] = FAILURE
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+
+class TestGitHubStatusPushURL(unittest.TestCase, ReporterTestMixin):
+    # project must be in the form <owner>/<project>
+    TEST_PROJECT = u'buildbot'
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        global URLtestcount
+        if (URLtestcount == 0):
+            ReporterTestMixin.TEST_REPO = u'https://github.com/buildbot1/buildbot1.git'
+        else:
+            ReporterTestMixin.TEST_REPO = u'git@github.com:buildbot2/buildbot2.git'
+        URLtestcount = 1
+
+        # ignore config error if txrequests is not installed
+        self.patch(config, '_errors', Mock())
+        self.master = fakemaster.make_master(testcase=self,
+                                             wantData=True, wantDb=True, wantMq=True)
+
+        yield self.master.startService()
+        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+            self.master, self,
+            HOSTED_BASE_URL, headers={
+                'Authorization': 'token XXYYZZ',
+                'User-Agent': 'Buildbot'
+            },
+            debug=None, verify=None)
+        sp = self.setService()
+        sp.sessionFactory = Mock(return_value=Mock())
+        yield sp.setServiceParent(self.master)
+
+    def setService(self):
+        self.sp = GitHubStatusPush('XXYYZZ')
+        return self.sp
+
+    def tearDown(self):
+        return self.master.stopService()
+
+    @defer.inlineCallbacks
+    def setupBuildResults(self, buildResults):
+        self.insertTestData([buildResults], buildResults)
+        build = yield self.master.data.get(("builds", 20))
+        defer.returnValue(build)
+
+    @defer.inlineCallbacks
+    def test_ssh(self):
+        build = yield self.setupBuildResults(SUCCESS)
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            'post',
+            '/repos/buildbot2/buildbot2/statuses/d34db33fd43db33f',
+            json={'state': 'pending',
+                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
+                  'description': 'Build started.', 'context': 'buildbot/Builder0'})
+        self._http.expect(
+            'post',
+            '/repos/buildbot2/buildbot2/statuses/d34db33fd43db33f',
+            json={'state': 'success',
+                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
+                  'description': 'Build done.', 'context': 'buildbot/Builder0'})
+        self._http.expect(
+            'post',
+            '/repos/buildbot2/buildbot2/statuses/d34db33fd43db33f',
+            json={'state': 'failure',
+                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
+                  'description': 'Build done.', 'context': 'buildbot/Builder0'})
+
+        build['complete'] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        build['complete'] = True
+        self.sp.buildFinished(("build", 20, "finished"), build)
+        build['results'] = FAILURE
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
+    def test_https(self):
+        build = yield self.setupBuildResults(SUCCESS)
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            'post',
+            '/repos/buildbot1/buildbot1/statuses/d34db33fd43db33f',
+            json={'state': 'pending',
+                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
+                  'description': 'Build started.', 'context': 'buildbot/Builder0'})
+        self._http.expect(
+            'post',
+            '/repos/buildbot1/buildbot1/statuses/d34db33fd43db33f',
+            json={'state': 'success',
+                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
+                  'description': 'Build done.', 'context': 'buildbot/Builder0'})
+        self._http.expect(
+            'post',
+            '/repos/buildbot1/buildbot1/statuses/d34db33fd43db33f',
+            json={'state': 'failure',
+                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
+                  'description': 'Build done.', 'context': 'buildbot/Builder0'})
+
         build['complete'] = False
         self.sp.buildStarted(("build", 20, "started"), build)
         build['complete'] = True


### PR DESCRIPTION
Allow GitHub to parse https:// and git@github.com:xxx style repository URLS correctly
Add some verbose messages that can be useful.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

