### PR TITLE
doc/customization: add example for BuilderConfig.canStartBuild

### DIFF
--- a/master/docs/manual/cfg-builders.rst
+++ b/master/docs/manual/cfg-builders.rst
@@ -79,6 +79,8 @@ Other optional keys may be set on each ``BuilderConfig``:
     The function should return ``True`` if the combination is acceptable, or ``False`` otherwise.
     This function can optionally return a Deferred which should fire with the same results.
 
+    See :ref:`canStartBuild-Functions` for a concrete example.
+
 ``locks``
     This argument specifies a list of locks that apply to this builder; see :ref:`Interlocks`.
 


### PR DESCRIPTION
Add an example to execute remote commands on a worker in the `BuilderConfig.canStartBuild` callback function.

## Contributor Checklist:

* [x] I have updated the appropriate documentation

