### PR TITLE
cmake: allow renderables in definition/options

### DIFF
--- a/master/buildbot/newsfragments/cmake_renderable.bugfix
+++ b/master/buildbot/newsfragments/cmake_renderable.bugfix
@@ -1,0 +1,1 @@
+Allow renderables in options and definitions of  step ``CMake``. Currently only dicts and lists with renderables inside are allowed.

--- a/master/buildbot/steps/cmake.py
+++ b/master/buildbot/steps/cmake.py
@@ -20,6 +20,7 @@ from future.utils import iteritems
 from twisted.internet import defer
 
 from buildbot import config
+from buildbot.interfaces import IRenderable
 from buildbot.process.buildstep import BuildStep
 from buildbot.process.buildstep import ShellMixin
 
@@ -47,12 +48,14 @@ class CMake(ShellMixin, BuildStep):
         self.path = path
         self.generator = generator
 
-        if not (definitions is None or isinstance(definitions, dict)):
-            config.error('definitions must be a dictionary')
+        if not (definitions is None or isinstance(definitions, dict)
+                or IRenderable.providedBy(definitions)):
+            config.error('definitions must be a dictionary or implement IRenderable')
         self.definitions = definitions
 
-        if not (options is None or isinstance(options, (list, tuple))):
-            config.error('options must be a list or a tuple')
+        if not (options is None or isinstance(options, (list, tuple))
+                or IRenderable.providedBy(options)):
+            config.error('options must be a list, a tuple or implement IRenderable')
         self.options = options
 
         self.cmake = cmake

--- a/master/buildbot/test/unit/test_steps_cmake.py
+++ b/master/buildbot/test/unit/test_steps_cmake.py
@@ -104,6 +104,14 @@ class TestCMake(BuildStepMixin, TestCase):
         self.properties.setProperty('b', b_value, source='test')
         self.expect_and_run_command('-D%s=%s' % ('a', b_value))
 
+    def test_definitions_renderable(self):
+        b_value = 'real_b'
+
+        definitions = Property('b')
+        self.setupStep(CMake(definitions=definitions))
+        self.properties.setProperty('b', {'a': b_value}, source='test')
+        self.expect_and_run_command('-D%s=%s' % ('a', b_value))
+
     def test_generator(self):
         generator = 'Ninja'
 


### PR DESCRIPTION
Allows putting in real renderables in the CMake step.

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)