### PR TITLE
steps: make SetProperty property renderable

### DIFF
--- a/master/buildbot/newsfragments/set_property.feature
+++ b/master/buildbot/newsfragments/set_property.feature
@@ -1,1 +1,1 @@
-``value`` argument in SetPropery is now renderable.
+``property`` argument in SetPropery is now renderable.

--- a/master/buildbot/newsfragments/set_property.feature
+++ b/master/buildbot/newsfragments/set_property.feature
@@ -1,0 +1,1 @@
+``value`` argument in SetPropery is now renderable.

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -181,7 +181,7 @@ class SetProperty(BuildStep):
     name = 'SetProperty'
     description = ['Setting']
     descriptionDone = ['Set']
-    renderables = ['value']
+    renderables = ['property', 'value']
 
     def __init__(self, property, value, **kwargs):
         BuildStep.__init__(self, **kwargs)


### PR DESCRIPTION
there is no reason we can't have value a renderable, make setting properties more flexible.


* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)