### PR TITLE
fix wamp connector

### DIFF
--- a/master/buildbot/mq/connector.py
+++ b/master/buildbot/mq/connector.py
@@ -30,7 +30,7 @@ class MQConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         },
         'wamp': {
             'class': "buildbot.mq.wamp.WampMQ",
-            'keys': set(["router_url", "debug", "realm", "debug_websockets", "debug_lowlevel"]),
+            'keys': set(["router_url", "realm", "wamp_debug_level"]),
         },
     }
     name = 'mq'

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -23,7 +23,6 @@ import textwrap
 
 import mock
 
-from autobahn.wamp.types import EventDetails
 from autobahn.wamp.types import SubscribeOptions
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -31,6 +30,11 @@ from twisted.trial import unittest
 from buildbot.mq import wamp
 from buildbot.test.fake import fakemaster
 from buildbot.wamp import connector
+
+
+class FakeEventDetails(object):
+    def __init__(self, topic):
+        self.topic = topic
 
 
 class ComparableSubscribeOptions(SubscribeOptions):
@@ -67,7 +71,7 @@ class FakeWampConnector(object):
         # make sure the topic is compatible with what was subscribed
         assert self.topic_match(topic)
         self.last_data = data
-        details = EventDetails(1, topic=topic)
+        details = FakeEventDetails(topic=topic)
         self.qref_cb(json.loads(json.dumps(data)), details=details)
 
 

--- a/master/buildbot/wamp/connector.py
+++ b/master/buildbot/wamp/connector.py
@@ -47,7 +47,7 @@ class MasterService(ApplicationSession, service.AsyncMultiService):
         for handler in [self] + self.services:
             yield self.register(handler)
             yield self.subscribe(handler)
-        yield self.publish("org.buildbot.%s.connected" % (self.master.masterid))
+        yield self.publish(u"org.buildbot.%s.connected" % (self.master.masterid))
         self.parent.service = self
         self.parent.serviceDeferred.callback(self)
 

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -129,7 +129,7 @@ Wamp
 
     c['mq'] = {
         'type' : 'wamp',
-        'router_url': 'ws://localhost:8080',
+        'router_url': 'ws://localhost:8080/ws',
         'realm': 'realm1',
         'wamp_debug_level' : 'error' # valid are: none, critical, error, warn, info, debug, trace
     }


### PR DESCRIPTION
autobahn's EventDetails constructor is not public API, and has changed in last version.
We fix the unit tests to use a Fake instead of the real object.

Also fix the config parsing for debug_level
