### PR TITLE
order worker jobs by buildid, to show active builds in the summary

### DIFF
--- a/www/base/src/app/workers/workers.tpl.jade
+++ b/www/base/src/app/workers/workers.tpl.jade
@@ -21,7 +21,7 @@
                     a(ui-sref='worker({worker: worker.workerid})')
                         | {{worker.name}}
                 td
-                    span(ng-repeat="build in worker.builds | orderBy : '-number' |limitTo: '7' ")
+                    span(ng-repeat="build in worker.builds | orderBy : '-buildid' |limitTo: '7' ")
                         a(ui-sref='build({builder: build.builderid, build: build.number})')
                             span.badge-status(ng-class="results2class(build, 'pulse')")
                               | {{ builders.get(build.builderid).name }}/{{ build.number }}


### PR DESCRIPTION
The number of builds shown in the summary is still limited to 7.

Resolves https://github.com/buildbot/buildbot/issues/3168