### PR TITLE
Doc: fixing Apache websocket example 

### DIFF
--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -564,6 +564,9 @@ To run with Apache2, you'll need `mod_proxy_wstunnel <https://httpd.apache.org/d
 
 Here is a configuration that is known to work (Apache 2.4.10 / Debian 8 and Apache 2.4.25 / Debian 9), directly at the top of the domain.
 
+If you want to add access control directives, just put them in a
+``<Location />``.
+
 .. code-block:: none
 
 

--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -562,7 +562,7 @@ Here is an nginx configuration that is known to work (nginx 1.6.2):
 
 To run with Apache2, you'll need `mod_proxy_wstunnel <https://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html>`_ in addition to `mod_proxy_http <https://httpd.apache.org/docs/2.4/mod/mod_proxy_http.html>`_. Serving HTTPS (`mod_ssl <https://httpd.apache.org/docs/2.4/mod/mod_ssl.html>`_) is advised to prevent issues with enterprise proxies (see :ref:`SSE`), even if you don't need the encryption itself.
 
-Here is a configuration that is known to work (Apache 2.4.10 / Debian 8), directly at the top of the domain.
+Here is a configuration that is known to work (Apache 2.4.10 / Debian 8 and Apache 2.4.25 / Debian 9), directly at the top of the domain.
 
 .. code-block:: none
 
@@ -571,12 +571,9 @@ Here is a configuration that is known to work (Apache 2.4.10 / Debian 8), direct
         ServerName buildbot.example
         ServerAdmin webmaster@buildbot.example
 
-        <Location /ws>
-          ProxyPass ws://127.0.0.1:8020/ws
-          ProxyPassReverse ws://127.0.0.1:8020/ws
-        </Location>
-
-        ProxyPass /ws !
+        # replace with actual port of your Buildbot master
+        ProxyPass ws://127.0.0.1:8020/ws
+        ProxyPassReverse ws://127.0.0.1:8020/ws
         ProxyPass / http://127.0.0.1:8020/
         ProxyPassReverse / http://127.0.0.1:8020/
 


### PR DESCRIPTION
Hello,
after upgrading one of my masters to Debian 9 (Stretch) I found the Apache configuration to be broken, here's an updated working one.

Regards