### PR TITLE
Handle Docker images with no tags in DockerLatentWorker

### DIFF
--- a/master/buildbot/newsfragments/fix-dockerWithNoneTags.bugfix
+++ b/master/buildbot/newsfragments/fix-dockerWithNoneTags.bugfix
@@ -1,0 +1,1 @@
+:py:class:`~buildbot.worker.docker.DockerLatentWorker`: ``_image_exists`` does not raise anymore if it encounters an image with ``<none>`` tag

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -191,7 +191,7 @@ class DockerLatentWorker(DockerBaseWorker):
     def _image_exists(self, client, name):
         # Make sure the image exists
         for image in client.images():
-            for tag in image['RepoTags']:
+            for tag in image['RepoTags'] or []:
                 if ':' in name and tag == name:
                     return True
                 if tag.startswith(name + ':'):


### PR DESCRIPTION
When checking if the requestes image exists (in _image_exists), an exception
(NoneType is not iterable) was raised in case any Docker image on the system
has a '<none>' tag. This commits prevents this exception from being raised.