### PR TITLE
Fixes for Python 3 compatibility with Gerrit

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -252,23 +252,23 @@ class GerritChangeSource(GerritChangeSourceBase):
 
         def __init__(self, change_source):
             self.change_source = change_source
-            self.data = ""
+            self.data = b""
 
         @defer.inlineCallbacks
         def outReceived(self, data):
             """Do line buffering."""
             self.data += data
-            lines = self.data.split("\n")
+            lines = self.data.split(b"\n")
             # last line is either empty or incomplete
             self.data = lines.pop(-1)
             for line in lines:
                 if self.change_source.debug:
-                    log.msg("gerrit: %s" % line)
+                    log.msg(b"gerrit: %s" % line)
                 yield self.change_source.lineReceived(line)
 
         def errReceived(self, data):
             if self.change_source.debug:
-                log.msg("gerrit stderr: %s" % data)
+                log.msg(b"gerrit stderr: %s" % data)
 
         def processEnded(self, status_object):
             self.change_source.streamProcessStopped()

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -37,6 +37,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.process.results import Results
 from buildbot.reporters import utils
+from buildbot.util import bytes2NativeString
 from buildbot.util import service
 
 # Cache the version that the gerrit server is running for this many seconds
@@ -203,16 +204,16 @@ class GerritStatusPush(service.BuildbotService):
             self.gerrit_version = None
 
         def outReceived(self, data):
-            vstr = "gerrit version "
+            vstr = b"gerrit version "
             if not data.startswith(vstr):
-                log.msg("Error: Cannot interpret gerrit version info:", data)
+                log.msg(b"Error: Cannot interpret gerrit version info: " + data)
                 return
-            vers = data[len(vstr):]
-            log.msg("gerrit version:", vers)
-            self.gerrit_version = LooseVersion(vers)
+            vers = data[len(vstr):].strip()
+            log.msg(b"gerrit version: " + vers)
+            self.gerrit_version = LooseVersion(bytes2NativeString(vers))
 
         def errReceived(self, data):
-            log.msg("gerriterr:", data)
+            log.msg(b"gerriterr: " + data)
 
         def processEnded(self, status_object):
             if status_object.value.exitCode:


### PR DESCRIPTION
Installed buildbot via pip with Python 3.5.2 on Ubuntu 16.04, but the Gerrit integration failed. These patches are needed to avoid crashes like:
```
        Traceback (most recent call last):
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/internet/process.py", line 295, in dataReceived
            self.proc.childDataReceived(self.name, data)
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/internet/process.py", line 961, in childDataReceived
            self.proto.childDataReceived(name, data)
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/internet/protocol.py", line 604, in childDataReceived
            self.outReceived(data)
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/internet/defer.py", line 1447, in unwindGenerator
            return _inlineCallbacks(None, gen, Deferred())
        --- <exception caught here> ---
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/internet/defer.py", line 1301, in _inlineCallbacks
            result = g.send(result)
          File "/home/buildbot/venv/lib/python3.5/site-packages/buildbot/changes/gerritchangesource.py", line 260, in outReceived
            self.data += data
        builtins.TypeError: Can't convert 'bytes' object to str implicitly
```
and
```
        Traceback (most recent call last):
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/python/log.py", line 103, in callWithLogger
            return callWithContext({"system": lp}, func, *args, **kw)
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/python/log.py", line 86, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/python/context.py", line 122, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/python/context.py", line 85, in callWithContext
            return func(*args,**kw)
        --- <exception caught here> ---
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/internet/posixbase.py", line 597, in _doReadOrWrite
            why = selectable.doRead()
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/internet/process.py", line 291, in doRead
            return fdesc.readFromFD(self.fd, self.dataReceived)
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/internet/fdesc.py", line 94, in readFromFD
            callback(output)
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/internet/process.py", line 295, in dataReceived
            self.proc.childDataReceived(self.name, data)
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/internet/process.py", line 961, in childDataReceived
            self.proto.childDataReceived(name, data)
          File "/home/buildbot/venv/lib/python3.5/site-packages/twisted/internet/protocol.py", line 604, in childDataReceived
            self.outReceived(data)
          File "/home/buildbot/venv/lib/python3.5/site-packages/buildbot/reporters/gerrit.py", line 207, in outReceived
            if not data.startswith(vstr):
        builtins.TypeError: startswith first arg must be bytes or a tuple of bytes, not str

```

Conversion to str seems more likely to be the right thing in this case than forcing everything to be bytes.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

