### PR TITLE
fix default user info provider to None.

### DIFF
--- a/master/buildbot/newsfragments/default_userinfo.bugfix
+++ b/master/buildbot/newsfragments/default_userinfo.bugfix
@@ -1,0 +1,1 @@
+``OAuth`` Authentication are now working with :py:class:`RolesFromEmails`.

--- a/master/buildbot/test/unit/test_www_auth.py
+++ b/master/buildbot/test/unit/test_www_auth.py
@@ -75,6 +75,7 @@ class AuthBase(www.WwwTestMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_updateUserInfo(self):
+        self.auth.userInfoProvider = auth.UserInfoProviderBase()
         self.auth.userInfoProvider.getUserInfo = lambda un: {'info': un}
         self.req.session.user_info = {'username': 'elvira'}
         yield self.auth.updateUserInfo(self.req)

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -49,8 +49,6 @@ class AuthRootResource(resource.Resource):
 class AuthBase(config.ConfiguredMixin):
 
     def __init__(self, userInfoProvider=None):
-        if userInfoProvider is None:
-            userInfoProvider = UserInfoProviderBase()
         self.userInfoProvider = userInfoProvider
 
     def reconfigAuth(self, master, new_config):
@@ -104,6 +102,8 @@ class RemoteUserAuth(AuthBase):
 
     def __init__(self, header=None, headerRegex=None, **kwargs):
         AuthBase.__init__(self, **kwargs)
+        if self.userInfoProvider is None:
+            self.userInfoProvider = UserInfoProviderBase()
         if header is not None:
             self.header = header
         if headerRegex is not None:
@@ -145,6 +145,8 @@ class TwistedICredAuthBase(AuthBase):
 
     def __init__(self, credentialFactories, checkers, **kwargs):
         AuthBase.__init__(self, **kwargs)
+        if self.userInfoProvider is None:
+            self.userInfoProvider = UserInfoProviderBase()
         self.credentialFactories = credentialFactories
         self.checkers = checkers
 


### PR DESCRIPTION
fix #3177
We better set default user info provider to UserInfoProviderBase only if really needed.
