### PR TITLE
Obfuscated secrets

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -494,6 +494,7 @@ class BuildStep(results.ResultComputingConfigMixin,
             raise TypeError("step result string must be unicode (got %r)"
                             % (stepResult,))
         if self.stepid is not None:
+            stepResult = self.build.properties.cleanupTextFromSecrets(stepResult)
             yield self.master.data.updates.setStepStateString(self.stepid,
                                                               stepResult)
 

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -566,7 +566,7 @@ class Interpolate(util.ComparableMixin, object):
         return _thePropertyDict, prop, repl
 
     @staticmethod
-    def _parse_secrets(arg):
+    def _parse_secret(arg):
         try:
             secret, repl = arg.split(":", 1)
         except ValueError:

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -274,22 +274,24 @@ class RemoteCommand(base.RemoteCommandImpl, WorkerAPICompatMixin):
     @metrics.countMethod('RemoteCommand.remoteUpdate()')
     @defer.inlineCallbacks
     def remoteUpdate(self, update):
+        def cleanup(data):
+            return self.step.build.properties.cleanupTextFromSecrets(data)
         if self.debug:
             for k, v in iteritems(update):
                 log.msg("Update[%s]: %s" % (k, v))
         if "stdout" in update:
             # 'stdout': data
-            yield self.addStdout(update['stdout'])
+            yield self.addStdout(cleanup(update['stdout']))
         if "stderr" in update:
             # 'stderr': data
-            yield self.addStderr(update['stderr'])
+            yield self.addStderr(cleanup(update['stderr']))
         if "header" in update:
             # 'header': data
-            yield self.addHeader(update['header'])
+            yield self.addHeader(cleanup(update['header']))
         if "log" in update:
             # 'log': (logname, data)
             logname, data = update['log']
-            yield self.addToLog(logname, data)
+            yield self.addToLog(logname, cleanup(data))
         if "rc" in update:
             rc = self.rc = update['rc']
             log.msg("%s rc=%s" % (self, rc))

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -134,3 +134,4 @@ warnings.filterwarnings('ignore',
                         "deprecated, use Unicode filenames instead")
 # moto warning v1.0.0
 warnings.filterwarnings('ignore', "Flags not at the start of the expression")
+warnings.filterwarnings('ignore', "object() takes no parameters")

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -132,3 +132,5 @@ warnings.filterwarnings('ignore', r"inspect.getargspec\(\) is deprecated")
 warnings.filterwarnings('ignore',
                         "The Windows bytes API has been "
                         "deprecated, use Unicode filenames instead")
+# moto warning v1.0.0
+warnings.filterwarnings('ignore', "Flags not at the start of the expression")

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -134,4 +134,4 @@ warnings.filterwarnings('ignore',
                         "deprecated, use Unicode filenames instead")
 # moto warning v1.0.0
 warnings.filterwarnings('ignore', "Flags not at the start of the expression")
-warnings.filterwarnings('ignore', "object() takes no parameters")
+warnings.filterwarnings('ignore', r"object\(\) takes no parameters")

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -92,6 +92,7 @@ class FakeBuild(properties.PropertiesMixin):
             props = properties.Properties()
         props.build = self
         self.build_status.properties = props
+        self.properties = props
 
     def getSourceStamp(self, codebase):
         if codebase in self.sources:

--- a/master/buildbot/test/integration/test_integration_secrets.py
+++ b/master/buildbot/test/integration/test_integration_secrets.py
@@ -72,10 +72,10 @@ def masterConfig():
     f = BuildFactory()
     if os.name == "posix":
         f.addStep(steps.ShellCommand(command=Interpolate(
-            'echo %(secrets:foo)s | sed "s/bar/The password was there/"')))
+            'echo %(secret:foo)s | sed "s/bar/The password was there/"')))
     else:
         f.addStep(steps.ShellCommand(command=Interpolate(
-            'echo %(secrets:foo)s')))
+            'echo %(secret:foo)s')))
     c['builders'] = [
         BuilderConfig(name="testy",
                       workernames=["local1"],

--- a/master/buildbot/test/integration/test_integration_secrets.py
+++ b/master/buildbot/test/integration/test_integration_secrets.py
@@ -29,8 +29,11 @@ class SecretsConfig(RunMasterBase):
         yield self.setupConfig(masterConfig())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
-        res = yield self.checkBuildStepLogExist(build, "echo bar")
+        res = yield self.checkBuildStepLogExist(build, "echo <foo>")
         self.assertTrue(res)
+        # at this point, build contains all the log and steps info that is in the db
+        # we check that our secret is not in there!
+        self.assertNotIn("bar", repr(build))
 
     @defer.inlineCallbacks
     def test_secretReconfig(self):
@@ -41,9 +44,11 @@ class SecretsConfig(RunMasterBase):
         yield self.master.reconfig()
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
-        res = yield self.checkBuildStepLogExist(build, "echo different_value")
+        res = yield self.checkBuildStepLogExist(build, "echo <foo>")
         self.assertTrue(res)
-
+        # at this point, build contains all the log and steps info that is in the db
+        # we check that our secret is not in there!
+        self.assertNotIn("different_value", repr(build))
 
 # master configuration
 def masterConfig():

--- a/master/buildbot/test/integration/test_integration_secrets_with_vault.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault.py
@@ -51,7 +51,7 @@ class SecretsConfig(RunMasterBase):
         yield self.setupConfig(masterConfig())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
-        res = yield self.checkBuildStepLogExist(build, "echo word")
+        res = yield self.checkBuildStepLogExist(build, "echo <key>")
         self.assertTrue(res)
 
 

--- a/master/buildbot/test/integration/test_integration_secrets_with_vault.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault.py
@@ -72,7 +72,7 @@ def masterConfig():
     )]
 
     f = BuildFactory()
-    f.addStep(ShellCommand(command=[Interpolate('echo %(secrets:key)s')]))
+    f.addStep(ShellCommand(command=[Interpolate('echo %(secret:key)s')]))
 
     c['builders'] = [
         BuilderConfig(name="testy",

--- a/master/buildbot/test/unit/test_interpolate_secrets.py
+++ b/master/buildbot/test/unit/test_interpolate_secrets.py
@@ -33,12 +33,12 @@ class TestInterpolateSecrets(unittest.TestCase, ConfigErrorsMixin):
 
     @defer.inlineCallbacks
     def test_secret(self):
-        command = Interpolate("echo %(secrets:foo)s")
+        command = Interpolate("echo %(secret:foo)s")
         rendered = yield self.build.render(command)
         self.assertEqual(rendered, "echo bar")
 
     def test_secret_not_found(self):
-        command = Interpolate("echo %(secrets:fuo)s")
+        command = Interpolate("echo %(secret:fuo)s")
         self.assertFailure(self.build.render(command), defer.FirstError)
         self.flushLoggedErrors(defer.FirstError)
         self.flushLoggedErrors(KeyError)
@@ -51,7 +51,7 @@ class TestInterpolateSecretsNoService(unittest.TestCase, ConfigErrorsMixin):
         self.build = FakeBuildWithMaster(self.master)
 
     def test_secret(self):
-        command = Interpolate("echo %(secrets:fuo)s")
+        command = Interpolate("echo %(secret:fuo)s")
         self.assertFailure(self.build.render(command), defer.FirstError)
         self.flushLoggedErrors(defer.FirstError)
         self.flushLoggedErrors(KeyError)
@@ -71,7 +71,7 @@ class TestInterpolateSecretsHiddenSecrets(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_secret(self):
-        command = Interpolate("echo %(secrets:foo)s")
+        command = Interpolate("echo %(secret:foo)s")
         rendered = yield self.build.render(command)
         cleantext = self.build.build_status.properties.cleanupTextFromSecrets(rendered)
         self.assertEqual(cleantext, "echo <foo>")

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -406,6 +406,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
         step.master.reactor = self.clock
         step.stepid = 13
         step.step_status = mock.Mock()
+        step.build = fakebuild.FakeBuild()
         return step
 
     def test_updateSummary_running(self):


### PR DESCRIPTION
Completing @tardyp pull request [WIP] obfuscate secrets #3068

buildbot-worker has this support for obfuscating secrets from the list of commands but:

this works only for shell=False, list kinds ShellCommands
this works only for shell commands
this does not prevent secrets to leak in the logs
With this method, we prevent secrets to leak anywhere in the db

This method does not prevent secrets to leak in the twisted log of the worker
## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

