### PR TITLE
Webpack support for building UI plugins

### DIFF
--- a/master/docs/developer/www-base-app.rst
+++ b/master/docs/developer/www-base-app.rst
@@ -29,7 +29,7 @@ On top of Angular we use nodeJS tools to ease development
 
 * gulp buildsystem, seemlessly build the app, can watch files for modification, rebuild and reload browser in dev mode.
   In production mode, the buildsystem minifies html, css and js, so that the final app is only 3 files to download (+img).
-* alternatively webpack build system can be used for the sam puproses as gulp (in UI extensions)
+* alternatively webpack build system can be used for the same purposes as gulp (in UI extensions)
 * `coffeescript <http://coffeescript.org/>`_, a very expressive langage, preventing some of the major traps of JS.
 * `pug template langage  (aka jade) <https://pugjs.org/>`_, adds syntax sugar and readbility to angular html templates.
 * `Bootstrap <http://getbootstrap.com/>`_ is a css library providing know good basis for our styles.
@@ -70,7 +70,7 @@ Typical plugin source code layout is:
     MANIFEST.in                  # needed by setup.py for sdist generation. You need to adapt this file to match the name of your plugin
 
 Alternatively it is possible to use webpack instead of gulp so `gulpfile.js` shall be replaced with `webpack.config.js` (with proper code inside of course).
-When `gulpfile.js` found, guld is used even `webpack.config.js` is defined.
+When `gulpfile.js` found, gulp is used even `webpack.config.js` is defined.
 
 Plugins are packaged as python entry-points for the ``buildbot.www`` namespace.
 The python part is defined in the `buildbot.www.plugin` module.

--- a/master/docs/developer/www-base-app.rst
+++ b/master/docs/developer/www-base-app.rst
@@ -29,6 +29,7 @@ On top of Angular we use nodeJS tools to ease development
 
 * gulp buildsystem, seemlessly build the app, can watch files for modification, rebuild and reload browser in dev mode.
   In production mode, the buildsystem minifies html, css and js, so that the final app is only 3 files to download (+img).
+* alternatively webpack build system can be used for the sam puproses as gulp (in UI extensions)
 * `coffeescript <http://coffeescript.org/>`_, a very expressive langage, preventing some of the major traps of JS.
 * `pug template langage  (aka jade) <https://pugjs.org/>`_, adds syntax sugar and readbility to angular html templates.
 * `Bootstrap <http://getbootstrap.com/>`_ is a css library providing know good basis for our styles.
@@ -67,6 +68,9 @@ Typical plugin source code layout is:
     package.json                 # declares npm dependency. normallly, only guanlecoja is needed. Typically, no change needed
     gulpfile.js                  # entrypoint for gulp, should be a one line call to guanlecoja. Typically, no change needed
     MANIFEST.in                  # needed by setup.py for sdist generation. You need to adapt this file to match the name of your plugin
+
+Alternatively it is possible to use webpack instead of gulp so `gulpfile.js` shall be replaced with `webpack.config.js` (with proper code inside of course).
+When `gulpfile.js` found, guld is used even `webpack.config.js` is defined.
 
 Plugins are packaged as python entry-points for the ``buildbot.www`` namespace.
 The python part is defined in the `buildbot.www.plugin` module.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -861,6 +861,7 @@ warningPattern
 webapp
 webdav
 webhook
+webpack
 webserver
 websocket
 websvn

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -156,6 +156,26 @@ class BuildJsCommand(distutils.cmd.Command):
                     level=distutils.log.INFO)
                 subprocess.call(command, shell=shell)
 
+        elif os.path.exists("webpack.config.js"):
+            npm_version = check_output("npm -v")
+            assert npm_version != "", "need nodejs and npm installed in current PATH"
+            assert LooseVersion(npm_version) >= LooseVersion(
+                "1.4"), "npm < 1.4 (%s)" % (npm_version)
+
+            npm_install_cmd = ['npm', 'install']
+            npm_build_cmd = ['npm', 'run', 'build']
+
+            if os.name == 'nt':
+                shell = True
+            else:
+                shell = False
+
+            for command in [npm_install_cmd, npm_build_cmd]:
+                self.announce(
+                    'Running command: %s' % str(" ".join(command)),
+                    level=distutils.log.INFO)
+                subprocess.call(command, shell=shell)
+
         self.copy_tree(os.path.join(package, 'static'), os.path.join(
             "build", "lib", package, "static"))
 

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -138,7 +138,7 @@ class BuildJsCommand(distutils.cmd.Command):
             assert npm_version != "", "need nodejs and npm installed in current PATH"
             assert LooseVersion(npm_version) >= LooseVersion(
                 "1.4"), "npm < 1.4 (%s)" % (npm_version)
-            
+
             commands = []
 
             # if we find yarn, then we use it as it is much faster

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -130,7 +130,7 @@ class BuildJsCommand(distutils.cmd.Command):
         if self.already_run:
             return
         package = self.distribution.packages[0]
-        if os.path.exists("gulpfile.js"):
+        if os.path.exists("gulpfile.js") or os.path.exists("webpack.config.js"):
             yarn_version = check_output("yarn --version")
             npm_version = check_output("npm -v")
             print("yarn:", yarn_version, "npm: ", npm_version)
@@ -138,39 +138,26 @@ class BuildJsCommand(distutils.cmd.Command):
             assert npm_version != "", "need nodejs and npm installed in current PATH"
             assert LooseVersion(npm_version) >= LooseVersion(
                 "1.4"), "npm < 1.4 (%s)" % (npm_version)
+            
+            commands = []
+
             # if we find yarn, then we use it as it is much faster
             if yarn_version != "":
-                npm_cmd = ['yarn', 'install']
+                commands.append(['yarn', 'install'])
             else:
-                npm_cmd = ['npm', 'install']
-            gulp_cmd = [os.path.join(npm_bin, "gulp"), 'prod', '--notests']
+                commands.append(['npm', 'install'])
+
+            if os.path.exists("gulpfile.js"):
+                commands.append([os.path.join(npm_bin, "gulp"), 'prod', '--notests'])
+            elif os.path.exists("webpack.config.js"):
+                commands.append([os.path.join(npm_bin, "webpack"), '-p'])
 
             if os.name == 'nt':
                 shell = True
             else:
                 shell = False
 
-            for command in [npm_cmd, gulp_cmd]:
-                self.announce(
-                    'Running command: %s' % str(" ".join(command)),
-                    level=distutils.log.INFO)
-                subprocess.call(command, shell=shell)
-
-        elif os.path.exists("webpack.config.js"):
-            npm_version = check_output("npm -v")
-            assert npm_version != "", "need nodejs and npm installed in current PATH"
-            assert LooseVersion(npm_version) >= LooseVersion(
-                "1.4"), "npm < 1.4 (%s)" % (npm_version)
-
-            npm_install_cmd = ['npm', 'install']
-            npm_build_cmd = ['npm', 'run', 'build']
-
-            if os.name == 'nt':
-                shell = True
-            else:
-                shell = False
-
-            for command in [npm_install_cmd, npm_build_cmd]:
+            for command in commands:
                 self.announce(
                     'Running command: %s' % str(" ".join(command)),
                     level=distutils.log.INFO)


### PR DESCRIPTION
This is extension of setup (build) system for plugins to be able to use webpack instead of gulp.
Change is backward compatible, 

## Contributor Checklist:

* [N/A] I have updated the unit tests
* [N/A] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [X] I have updated the appropriate documentation

