### PR TITLE
Fix handle_deprec to pass through new value

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -459,16 +459,15 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
         kwargs['comments'] = comments
 
         def handle_deprec(oldname, newname):
-            if oldname not in kwargs:
-                return
-            old = kwargs.pop(oldname)
-            if old is not None:
-                if kwargs.get(newname) is None:
-                    log.msg("WARNING: change source is using deprecated "
-                            "addChange parameter '%s'" % oldname)
-                    return old
-                raise TypeError("Cannot provide '%s' and '%s' to addChange"
-                                % (oldname, newname))
+            if oldname in kwargs:
+                old = kwargs.pop(oldname)
+                if old is not None:
+                    if kwargs.get(newname) is None:
+                        log.msg("WARNING: change source is using deprecated "
+                                "addChange parameter '%s'" % oldname)
+                        return old
+                    raise TypeError("Cannot provide '%s' and '%s' to addChange"
+                                    % (oldname, newname))
             return kwargs.get(newname)
 
         kwargs['author'] = handle_deprec("who", "author")

--- a/master/buildbot/newsfragments/fix-handle-deprec.bugfix
+++ b/master/buildbot/newsfragments/fix-handle-deprec.bugfix
@@ -1,0 +1,1 @@
+Update old addChange method to accept the new chdict names if only the new name is present. Fixes :issue:`3191`.

--- a/master/buildbot/newsfragments/fix-handle-deprec.bugfix
+++ b/master/buildbot/newsfragments/fix-handle-deprec.bugfix
@@ -1,1 +1,1 @@
-Update old addChange method to accept the new chdict names if only the new name is present. Fixes :issue:`3191`.
+Update old ``addChange`` method to accept the new chdict names if only the new name is present. Fixes :issue:`3191`.

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -119,6 +119,14 @@ class OldTriggeringMethods(unittest.TestCase):
             kwargs=dict(when=892293875),
             exp_data_kwargs=dict(when_timestamp=892293875))
 
+    def test_addChange_args_new_and_old(self):
+        func = self.do_test_addChange_args
+        kwargs = dict(who='author',
+                      author='author'),
+        exp_data_kwargs = dict(author='author')
+        self.assertRaises(TypeError, func, kwargs=kwargs,
+                          exp_data_kwargs=exp_data_kwargs)
+
     def test_addChange_args_properties(self):
         # properties should not be qualified with a source
         return self.do_test_addChange_args(

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import datetime
 import os
 import signal
 
@@ -117,6 +118,12 @@ class OldTriggeringMethods(unittest.TestCase):
         # when should come through as when_timestamp, as a datetime
         return self.do_test_addChange_args(
             kwargs=dict(when=892293875),
+            exp_data_kwargs=dict(when_timestamp=892293875))
+
+    def test_addChange_args_when_timestamp(self):
+        # when_timestamp should come through as an epoch time.
+        return self.do_test_addChange_args(
+            kwargs=dict(when_timestamp=datetime.datetime(1998, 4, 11, 11, 24, 35)),
             exp_data_kwargs=dict(when_timestamp=892293875))
 
     def test_addChange_args_new_and_old(self):


### PR DESCRIPTION
* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

