### PR TITLE
SecretInAFile: strip newlines by default

### DIFF
--- a/master/buildbot/secrets/providers/file.py
+++ b/master/buildbot/secrets/providers/file.py
@@ -48,7 +48,7 @@ class SecretInAFile(SecretProviderBase):
                 if secretfile.endswith(suffix):
                     self.checkFileIsReadOnly(dirname, secretfile)
 
-    def loadSecrets(self, dirname, suffixes):
+    def loadSecrets(self, dirname, suffixes, strip):
         secrets = {}
         for secretfile in os.listdir(dirname):
             secretvalue = None
@@ -58,22 +58,25 @@ class SecretInAFile(SecretProviderBase):
                         secretvalue = source.read()
                     if suffix:
                         secretfile = secretfile[:-len(suffix)]
+                    if strip:
+                        secretvalue = secretvalue.rstrip("\r\n")
                     secrets[secretfile] = secretvalue
         return secrets
 
-    def checkConfig(self, dirname, suffixes=None):
+    def checkConfig(self, dirname, suffixes=None, strip=True):
         self._dirname = dirname
         if suffixes is None:
             suffixes = [""]
         self.checkSecretDirectoryIsAvailableAndReadable(dirname,
                                                         suffixes=suffixes)
 
-    def reconfigService(self, dirname, suffixes=None):
+    def reconfigService(self, dirname, suffixes=None, strip=True):
         self._dirname = dirname
         self.secrets = {}
         if suffixes is None:
             suffixes = [""]
-        self.secrets = self.loadSecrets(self._dirname, suffixes=suffixes)
+        self.secrets = self.loadSecrets(self._dirname, suffixes=suffixes,
+                                        strip=strip)
 
     def get(self, entry):
         """

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -46,7 +46,7 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
         self.tmp_dir = self.createTempDir("temp")
         filetmp, self.filepath = self.createFileTemp(self.tmp_dir,
                                                      "tempfile.txt",
-                                                     text="key value")
+                                                     text="key value\n")
         self.srvfile = SecretInAFile(self.tmp_dir)
         yield self.srvfile.startService()
 
@@ -107,3 +107,9 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
     def testGetSecretInFileNotFound(self):
         value = self.srvfile.get("tempfile2.txt")
         self.assertEqual(value, None)
+
+    @defer.inlineCallbacks
+    def testGetSecretInFileNoStrip(self):
+        yield self.srvfile.reconfigService(self.tmp_dir, strip=False)
+        value = self.srvfile.get("tempfile.txt")
+        self.assertEqual(value, "key value\n")

--- a/master/docs/developer/secrets.rst
+++ b/master/docs/developer/secrets.rst
@@ -49,10 +49,10 @@ File provider
 
 .. code-block:: python
 
-    c['secretsProviders'] = [util.SecretInAFile(dirname="/path/toSecretsFiles"]
+    c['secretsProviders'] = [util.SecretInAFile(dirname="/path/toSecretsFiles")]
 
 In the master configuration the provider is instantiated through a Buildbot service secret manager with the file directory path.
-File secrets provider reads the file named by the key wanted by Buildbot and returns the contained text value.
+File secrets provider reads the file named by the key wanted by Buildbot and returns the contained text value (removing trailing newlines if present).
 SecretInAFile provider allows Buildbot to read secrets in the secret directory.
 
 Vault provider

--- a/master/docs/manual/secretsmanagement.rst
+++ b/master/docs/manual/secretsmanagement.rst
@@ -42,7 +42,7 @@ The following example shows a basic usage of secrets in Buildbot.
 
     # First we declare that the secrets are stored in a directory of the filesystem
     # each file contain one secret identified by the filename
-    c['secretsProviders'] = [util.SecretInAFile(dirname="/path/toSecretsFiles"]
+    c['secretsProviders'] = [util.SecretInAFile(dirname="/path/toSecretsFiles")]
 
     # then in a buildfactory:
 
@@ -59,11 +59,20 @@ SecretInAFile
 
 .. code-block:: python
 
-    c['secretsProviders'] = [util.SecretInAFile(dirname="/path/toSecretsFiles"]
+    c['secretsProviders'] = [util.SecretInAFile(dirname="/path/toSecretsFiles")]
 
 In the passed directory, every file contains a secret identified by the filename.
 
 e.g: a file ``user`` contains the text ``pa$$w0rd``.
+
+Arguments:
+
+``dirname``
+  (required) Absolute path to directory containing the files with a secret.
+
+``strip``
+  (optional) if ``True`` (the default), trailing newlines are removed from the
+  file contents.
 
 SecretInVault
 `````````````


### PR DESCRIPTION
The secrets provider can be used to read passwords which likely do not
have trailing newlines. Strip them by default, this makes it easier
when editing via vim or using a command like `echo sikrit > foo`.

Add a strip option just in case you want to override this behavior. Note
that for some reason "\r" are converted to newlines anyway, so perhaps
this option can just be removed completely.

Fixes https://github.com/buildbot/buildbot/issues/3178

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

