### PR TITLE
hooks: accept unicode in PR comments

### DIFF
--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -150,7 +150,6 @@ class GitHubEventHandler(PullRequestMixin):
 
         properties = self.extractProperties(payload['pull_request'])
         properties.update({'event': event})
-
         change = {
             'revision': payload['pull_request']['head']['sha'],
             'when_timestamp': dateparse(payload['pull_request']['created_at']),
@@ -161,7 +160,7 @@ class GitHubEventHandler(PullRequestMixin):
             'category': 'pull',
             # TODO: Get author name based on login id using txgithub module
             'author': payload['sender']['login'],
-            'comments': 'GitHub Pull Request #{0} ({1} commit{2})\n{3}\n{4}'.format(
+            'comments': u'GitHub Pull Request #{0} ({1} commit{2})\n{3}\n{4}'.format(
                 number, commits, 's' if commits != 1 else '', title, comments),
             'properties': properties,
         }


### PR DESCRIPTION
convert string in format to unicode so unicode characters in PR comments are handled properly and don't generate a silent error