### PR TITLE
Fix ChangesEndpoint get doesn't limit results

### DIFF
--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -85,7 +85,7 @@ class ChangesEndpoint(FixerMixin, base.Endpoint):
         else:
             # this special case is useful and implemented by the dbapi
             # so give it a boost
-            if (resultSpec.order == ['-changeid'] and resultSpec.limit and
+            if (resultSpec.order == ('-changeid',) and resultSpec.limit and
                     resultSpec.offset is None):
                 changes = yield self.master.db.changes.getRecentChanges(resultSpec.limit)
             else:

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -296,7 +296,7 @@ class ResultSpec(object):
                 log.msg("Warning: limited data api query is not backed by db because of following filters",
                         unmatched_filters, unmatched_order)
             self.filters = unmatched_filters
-            self.order = unmatched_order
+            self.order = tuple(unmatched_order)
             return query, None
         count_query = sa.select([sa.func.count()]).select_from(query.alias('query'))
         self.order = None

--- a/master/buildbot/test/unit/test_data_changes.py
+++ b/master/buildbot/test/unit/test_data_changes.py
@@ -99,7 +99,7 @@ class ChangesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_getRecentChanges(self):
-        resultSpec = resultspec.ResultSpec(limit=1, order=['-changeid'])
+        resultSpec = resultspec.ResultSpec(limit=1, order=('-changeid',))
         changes = yield self.callGet(('changes',), resultSpec=resultSpec)
 
         self.validateData(changes[0])
@@ -108,7 +108,7 @@ class ChangesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_getChangesOtherOrder(self):
-        resultSpec = resultspec.ResultSpec(limit=1, order=['-when_time_stamp'])
+        resultSpec = resultspec.ResultSpec(limit=1, order=('-when_time_stamp',))
         changes = yield self.callGet(('changes',), resultSpec=resultSpec)
 
         # limit not implemented for other order
@@ -117,7 +117,7 @@ class ChangesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_getChangesOtherOffset(self):
         resultSpec = resultspec.ResultSpec(
-            limit=1, offset=1, order=['-changeid'])
+            limit=1, offset=1, order=('-changeid',))
         changes = yield self.callGet(('changes',), resultSpec=resultSpec)
 
         # limit not implemented for other offset


### PR DESCRIPTION
I have encountered that BuildBot is hanging if I visit the Last Changes page in web UI.
It turned out that when ChangesEndpoint.get method tries to determine which one to use - `db.changes.getRecentChanges` or  `db.changes.getChanges` it compares tuple and list and makes the wrong decision and makes try to return all the changes.

It looks like the bug was introduced in [this](https://github.com/buildbot/buildbot/commit/6d0ebb56175beaa8a3776a071a23a7d0b6f37088#diff-bcc309a389ecb20d626f59e7a656dd48R273) commit. 
## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

