### PR TITLE
[PY3] Fixed oauth2 expecting string instead of bytes

### DIFF
--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from future.moves.urllib.parse import parse_qs
 from future.moves.urllib.parse import urlencode
-from future.utils import binary_type
 from future.utils import iteritems
 
 import json
@@ -152,14 +151,13 @@ class OAuth2Auth(auth.AuthBase):
             response = requests.post(
                 url, data=data, auth=auth, verify=self.sslVerify)
             response.raise_for_status()
-            if isinstance(response.content, binary_type):
-                try:
-                    content = json.loads(response.content)
-                except ValueError:
-                    content = parse_qs(response.content)
-                    for k, v in iteritems(content):
-                        content[k] = v[0]
-            else:
+            try:
+                content = json.loads(response.content)
+            except ValueError:
+                content = parse_qs(response.content)
+                for k, v in iteritems(content):
+                    content[k] = v[0]
+            except TypeError:
                 content = response.content
 
             session = self.createSessionFromToken(content)

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -17,8 +17,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from future.moves.urllib.parse import parse_qs
 from future.moves.urllib.parse import urlencode
+from future.utils import binary_type
 from future.utils import iteritems
-from future.utils import string_types
 
 import json
 from posixpath import join
@@ -152,7 +152,7 @@ class OAuth2Auth(auth.AuthBase):
             response = requests.post(
                 url, data=data, auth=auth, verify=self.sslVerify)
             response.raise_for_status()
-            if isinstance(response.content, string_types):
+            if isinstance(response.content, binary_type):
                 try:
                     content = json.loads(response.content)
                 except ValueError:


### PR DESCRIPTION
requests always returns `bytes`, not `str`/`unicode` type
https://github.com/kennethreitz/requests/blob/master/requests/models.py#L816

Works fine on python 2 only because `string_types = basestring` and `basestring` is superclass of both `str` and `unicode`.
