### PR TITLE
logpreview: allow logpreviews to be collapsed

### DIFF
--- a/www/base/guanlecoja/config.coffee
+++ b/www/base/guanlecoja/config.coffee
@@ -45,7 +45,7 @@ config =
                 version: "~3.1.1"
                 files: []
             'buildbot-data':
-                version: '~2.1.0'
+                version: '~2.2.0'
                 files: 'dist/buildbot-data.js'
 
         testdeps:

--- a/www/base/src/app/builders/log/logviewer/logpreview.directive.coffee
+++ b/www/base/src/app/builders/log/logviewer/logpreview.directive.coffee
@@ -11,6 +11,10 @@ class Logpreview extends Directive
             controller: ["$scope", ($scope) ->
 
                 @settings = bbSettingsService.getSettingsGroup("LogPreview")
+                pendingRequest = null
+                $scope.$on '$destroy', ->
+                    if pendingRequest
+                        pendingRequest.cancel()
                 loading = $sce.trustAs($sce.HTML, "...")
                 unwatch = $scope.$watch "logpreview.log", (n, o) =>
                     @log.lines = []
@@ -18,7 +22,8 @@ class Logpreview extends Directive
                         return
                     unwatch()
                     if @log.type == 'h'
-                        restService.get("logs/#{@log.logid}/contents").then (content) =>
+                        pendingRequest = restService.get("logs/#{@log.logid}/contents")
+                        pendingRequest.then (content) =>
                             @log.content = $sce.trustAs($sce.HTML, content.logchunks[0].content)
                     else
                         $scope.$watch "logpreview.log.num_lines", loadLines
@@ -52,9 +57,10 @@ class Logpreview extends Directive
                         number: offset + limit - 1
                     @log.lines.push(loading_element)
 
-                    restService.get("logs/#{@log.logid}/contents",
+                    pendingRequest = restService.get("logs/#{@log.logid}/contents",
                                     offset: offset,
-                                    limit: limit).then (content) =>
+                                    limit: limit)
+                    pendingRequest.then (content) =>
                         content = content.logchunks[0].content
                         lines = content.split("\n")
                         # there is a trailing '\n' generates an empty line in the end

--- a/www/base/src/app/builders/log/logviewer/logpreview.directive.coffee
+++ b/www/base/src/app/builders/log/logviewer/logpreview.directive.coffee
@@ -4,7 +4,7 @@ class Logpreview extends Directive
             replace: true
             transclude: true
             restrict: 'E'
-            scope: {log:"<", buildnumber:"<", builderid:"<", step:"<"},
+            scope: {log:"<", fulldisplay:"<", buildnumber:"<", builderid:"<", step:"<"},
             templateUrl: "views/logpreview.html"
             controllerAs: "logpreview"
             bindToController: true

--- a/www/base/src/app/builders/log/logviewer/logpreview.tpl.jade
+++ b/www/base/src/app/builders/log/logviewer/logpreview.tpl.jade
@@ -2,7 +2,9 @@ div.logpreview.panel(ng-class="logpreview.log.name=='err.html' && 'panel-danger'
   div.panel-heading
     .panel-title
       .flex-row
-        div.flex-grow-3 {{logpreview.log.name}}
+        div.flex-grow-3(ng-click="logpreview.fulldisplay=!logpreview.fulldisplay")
+          i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':logpreview.fulldisplay}")
+          | #{' '} {{logpreview.log.name}}
         div.flex-grow-1
             div.pull-right
                 a(ui-sref="log({builder:logpreview.builderid, build:logpreview.buildnumber, step: logpreview.step.number, log:logpreview.log.slug})")
@@ -11,7 +13,8 @@ div.logpreview.panel(ng-class="logpreview.log.name=='err.html' && 'panel-danger'
                 a.btn.btn-default.btn-xs(ng-href="api/v2/logs/{{logpreview.log.logid}}/raw", description="download log")
                   i.fa.fa-download
                   | #{' '} download
-  pre.select-content.log(ng-show="logpreview.log.type!='h'")
-    div(ng-repeat="line in logpreview.log.lines", style="height:18px")
-        span.no-wrap(data-linenumber-content="{{line.number}}", class="{{line.class}}", ng-bind-html="line.content")
-  div.panel-body(ng-if="logpreview.log.type=='h'", ng-bind-html="logpreview.log.content")
+  div(ng-show="logpreview.fulldisplay")
+    pre.select-content.log(ng-show="logpreview.log.type!='h'")
+      div(ng-repeat="line in logpreview.log.lines", style="height:18px")
+          span.no-wrap(data-linenumber-content="{{line.number}}", class="{{line.class}}", ng-bind-html="line.content")
+    div.panel-body(ng-if="logpreview.log.type=='h'", ng-bind-html="logpreview.log.content")

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -50,5 +50,6 @@
             buildrequestsummary(style="margin-left:30px;margin-top:8px",buildrequestid='buildsummary.getBuildRequestIDFromURL(url.url)')
         div.anim-stepdetails(ng-if="step.fulldisplay")
           logpreview(ng-repeat="log in step.logs", log="log",
+                     fulldisplay="step.logs.length == 1",
                      builderid="buildsummary.build.builderid", buildnumber="buildsummary.build.number",
                      step="step")

--- a/www/data_module/guanlecoja/config.coffee
+++ b/www/data_module/guanlecoja/config.coffee
@@ -13,7 +13,7 @@ gulp.task "publish", ['default'], ->
     exec "git clone git@github.com:buildbot/buildbot-data-js.git"
     bower_json =
         name: "buildbot-data"
-        version: "2.1.0"
+        version: "2.2.0"
         main: ["buildbot-data.js"]
         moduleType: [],
         license: "MIT",

--- a/www/data_module/src/services/dataUtils/dataUtils.service.spec.coffee
+++ b/www/data_module/src/services/dataUtils/dataUtils.service.spec.coffee
@@ -53,10 +53,10 @@ describe 'Data utils service', ->
             expect(result.test("asd/1/new")).toBeTruthy()
 
             result = dataUtilsService.socketPathRE('asd/1/bnm/*/*').source
-            expect(result).toBe('^asd\\/1\\/bnm\\/[^/]+\\/[^/]+$')
+            expect(result).toBe('^asd\\/1\\/bnm\\/[^\\/]+\\/[^\\/]+$')
 
             result = dataUtilsService.socketPathRE('asd/1/*').source
-            expect(result).toBe('^asd\\/1\\/[^/]+$')
+            expect(result).toBe('^asd\\/1\\/[^\\/]+$')
 
 
     describe 'restPath(arg)', ->

--- a/www/data_module/src/services/rest/rest.service.coffee
+++ b/www/data_module/src/services/rest/rest.service.coffee
@@ -13,24 +13,32 @@ class Rest extends Service
                     .error (reason) -> reject(reason)
 
             get: (url, params = {}) ->
+                canceller = $q.defer()
                 config =
                     method: 'GET'
                     url: @parse(API, url)
                     params: params
                     headers:
                         'Accept': 'application/json'
+                    timeout: canceller.promise
 
-                @execute(config)
+                promise = @execute(config)
+                promise.cancel = canceller.resolve
+                return promise
 
             post: (url, data = {}) ->
+                canceller = $q.defer()
                 config =
                     method: 'POST'
                     url: @parse(API, url)
                     data: data
                     headers:
                         'Content-Type': 'application/json'
+                    timeout: canceller.promise
 
-                @execute(config)
+                promise = @execute(config)
+                promise.cancel = canceller.resolve
+                return promise
 
             parse: (args...) ->
                 args.join('/').replace(/\/\//, '/')

--- a/www/data_module/src/services/rest/rest.service.spec.coffee
+++ b/www/data_module/src/services/rest/rest.service.spec.coffee
@@ -75,3 +75,19 @@ describe 'Rest service', ->
         $httpBackend.flush()
         expect(gotResponse).not.toBeNull()
         expect(gotResponse).not.toEqual(response)
+
+    it 'should reject the promise when cancelled', inject ($rootScope) ->
+        $httpBackend.expectGET('/api/endpoint').respond({})
+
+        gotResponse = null
+        rejected = false
+        request = restService.get('endpoint')
+        request.then (response) ->
+            gotResponse = response
+        , (reason) ->
+            rejected = true
+
+        request.cancel()
+        $rootScope.$apply()
+        expect(gotResponse).toBeNull()
+        expect(rejected).toBe(true)

--- a/www/data_module/yarn.lock
+++ b/www/data_module/yarn.lock
@@ -2083,17 +2083,13 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@4.1.0:
+object-assign@4.1.0, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
 object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
-
-object-assign@^4.0.1, object-assign@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
 object-component@0.0.3:
   version "0.0.3"


### PR DESCRIPTION
Make log previews collapsable, useful when you want a summary of the log (number of lines) while reviewing the results of another step.

Additionally, collapse previews by default when when multiple logs are available (stdio, warnings).
___
![screencast (1.2MIB)](https://cloud.githubusercontent.com/assets/164530/26521469/48ff2e2e-42e9-11e7-800d-6996ca8cd160.gif)
___
Not sure how to write a test (spec) file for this usability feature, but manual verification resulted in the following:
1. Finished builds with one preview are expanded.
2. Finished builds with multiple previews are collapsed.
3. (observation:) The collapses state of the preview is not remembered (implementation detail of how the Logpreview component is removed when the step is collapsed).
4. Live builds also start expanded, but as soon as the second log is added in a step, both are collapsed.

Another possible (unimplemented) option would be not to fetch the log contents until it is expanded, saving a request.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

