### PR TITLE
[www] Make it possible to cancel requests

### DIFF
--- a/www/base/guanlecoja/config.coffee
+++ b/www/base/guanlecoja/config.coffee
@@ -45,7 +45,7 @@ config =
                 version: "~3.1.1"
                 files: []
             'buildbot-data':
-                version: '~2.1.0'
+                version: '~2.2.0'
                 files: 'dist/buildbot-data.js'
 
         testdeps:

--- a/www/base/src/app/builders/log/logviewer/logpreview.directive.coffee
+++ b/www/base/src/app/builders/log/logviewer/logpreview.directive.coffee
@@ -11,6 +11,10 @@ class Logpreview extends Directive
             controller: ["$scope", ($scope) ->
 
                 @settings = bbSettingsService.getSettingsGroup("LogPreview")
+                pendingRequest = null
+                $scope.$on '$destroy', ->
+                    if pendingRequest
+                        pendingRequest.cancel()
                 loading = $sce.trustAs($sce.HTML, "...")
                 unwatch = $scope.$watch "logpreview.log", (n, o) =>
                     @log.lines = []
@@ -18,7 +22,8 @@ class Logpreview extends Directive
                         return
                     unwatch()
                     if @log.type == 'h'
-                        restService.get("logs/#{@log.logid}/contents").then (content) =>
+                        pendingRequest = restService.get("logs/#{@log.logid}/contents")
+                        pendingRequest.then (content) =>
                             @log.content = $sce.trustAs($sce.HTML, content.logchunks[0].content)
                     else
                         $scope.$watch "logpreview.log.num_lines", loadLines
@@ -52,9 +57,10 @@ class Logpreview extends Directive
                         number: offset + limit - 1
                     @log.lines.push(loading_element)
 
-                    restService.get("logs/#{@log.logid}/contents",
+                    pendingRequest = restService.get("logs/#{@log.logid}/contents",
                                     offset: offset,
-                                    limit: limit).then (content) =>
+                                    limit: limit)
+                    pendingRequest.then (content) =>
                         content = content.logchunks[0].content
                         lines = content.split("\n")
                         # there is a trailing '\n' generates an empty line in the end

--- a/www/data_module/guanlecoja/config.coffee
+++ b/www/data_module/guanlecoja/config.coffee
@@ -13,7 +13,7 @@ gulp.task "publish", ['default'], ->
     exec "git clone git@github.com:buildbot/buildbot-data-js.git"
     bower_json =
         name: "buildbot-data"
-        version: "2.1.0"
+        version: "2.2.0"
         main: ["buildbot-data.js"]
         moduleType: [],
         license: "MIT",

--- a/www/data_module/src/services/dataUtils/dataUtils.service.spec.coffee
+++ b/www/data_module/src/services/dataUtils/dataUtils.service.spec.coffee
@@ -53,10 +53,10 @@ describe 'Data utils service', ->
             expect(result.test("asd/1/new")).toBeTruthy()
 
             result = dataUtilsService.socketPathRE('asd/1/bnm/*/*').source
-            expect(result).toBe('^asd\\/1\\/bnm\\/[^/]+\\/[^/]+$')
+            expect(result).toBe('^asd\\/1\\/bnm\\/[^\\/]+\\/[^\\/]+$')
 
             result = dataUtilsService.socketPathRE('asd/1/*').source
-            expect(result).toBe('^asd\\/1\\/[^/]+$')
+            expect(result).toBe('^asd\\/1\\/[^\\/]+$')
 
 
     describe 'restPath(arg)', ->

--- a/www/data_module/src/services/rest/rest.service.coffee
+++ b/www/data_module/src/services/rest/rest.service.coffee
@@ -13,24 +13,32 @@ class Rest extends Service
                     .error (reason) -> reject(reason)
 
             get: (url, params = {}) ->
+                canceller = $q.defer()
                 config =
                     method: 'GET'
                     url: @parse(API, url)
                     params: params
                     headers:
                         'Accept': 'application/json'
+                    timeout: canceller.promise
 
-                @execute(config)
+                promise = @execute(config)
+                promise.cancel = canceller.resolve
+                return promise
 
             post: (url, data = {}) ->
+                canceller = $q.defer()
                 config =
                     method: 'POST'
                     url: @parse(API, url)
                     data: data
                     headers:
                         'Content-Type': 'application/json'
+                    timeout: canceller.promise
 
-                @execute(config)
+                promise = @execute(config)
+                promise.cancel = canceller.resolve
+                return promise
 
             parse: (args...) ->
                 args.join('/').replace(/\/\//, '/')

--- a/www/data_module/src/services/rest/rest.service.spec.coffee
+++ b/www/data_module/src/services/rest/rest.service.spec.coffee
@@ -75,3 +75,19 @@ describe 'Rest service', ->
         $httpBackend.flush()
         expect(gotResponse).not.toBeNull()
         expect(gotResponse).not.toEqual(response)
+
+    it 'should reject the promise when cancelled', inject ($rootScope) ->
+        $httpBackend.expectGET('/api/endpoint').respond({})
+
+        gotResponse = null
+        rejected = false
+        request = restService.get('endpoint')
+        request.then (response) ->
+            gotResponse = response
+        , (reason) ->
+            rejected = true
+
+        request.cancel()
+        $rootScope.$apply()
+        expect(gotResponse).toBeNull()
+        expect(rejected).toBe(true)

--- a/www/data_module/yarn.lock
+++ b/www/data_module/yarn.lock
@@ -2083,17 +2083,13 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@4.1.0:
+object-assign@4.1.0, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
 object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
-
-object-assign@^4.0.1, object-assign@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
 object-component@0.0.3:
   version "0.0.3"


### PR DESCRIPTION
Extends the RestService interface with a cancel method on pending requests. This fixes #3275 which should help with slow links/servers and larger logs. Additionally, it can be used to reduce data usage when the view is hidden anyway.

Implementation relies on timeout parameter of $http:
https://docs.angularjs.org/api/ng/service/$http
https://stackoverflow.com/questions/35375120/cancelling-ongoing-angular-http-requests-when-theres-a-new-request

If this looks good, please consider publishing an updated buildbot-data package with the first change before merging the second patch. Let me know if you prefer two PRs for this.

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

