### PR TITLE
Fix wrong GerritStatusPush.name attribute

### DIFF
--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -509,3 +509,18 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
         self.patch(reactor, 'spawnProcess', spawnProcess)
         gsp.callWithVersion(lambda: self.assertEqual(
             gsp.gerrit_version, LooseVersion('2.14')))
+
+    def test_name_as_class_attribute(self):
+        class FooStatusPush(GerritStatusPush):
+            name = 'foo'
+
+        reporter = FooStatusPush('gerrit.server.com', 'password')
+        self.assertEqual(reporter.name, 'foo')
+
+    def test_name_as_kwarg(self):
+        reporter = GerritStatusPush('gerrit.server.com', 'password', name='foo')
+        self.assertEqual(reporter.name, 'foo')
+
+    def test_default_name(self):
+        reporter = GerritStatusPush('gerrit.server.com', 'password')
+        self.assertEqual(reporter.name, 'GerritStatusPush')

--- a/master/buildbot/test/unit/test_www_hooks_poller.py
+++ b/master/buildbot/test/unit/test_www_hooks_poller.py
@@ -50,10 +50,10 @@ class TestPollingChangeHook(unittest.TestCase):
             dialects={'poller': options}, master=master)
         master.change_svc = ChangeManager()
         yield master.change_svc.setServiceParent(master)
-        self.changesrc = self.Subclass("example", 21)
+        self.changesrc = self.Subclass(21, name='example')
         yield self.changesrc.setServiceParent(master.change_svc)
 
-        self.otherpoller = self.Subclass("otherpoller", 22)
+        self.otherpoller = self.Subclass(22, name="otherpoller")
         yield self.otherpoller.setServiceParent(master.change_svc)
 
         anotherchangesrc = base.ChangeSource(name='notapoller')

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -212,9 +212,8 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
                 pass
         yield AsyncMultiService.startService(self)
 
-    def checkConfig(self, name=None, *args, **kwargs):
-        if name is not None:
-            self.name = ascii2unicode(name)
+    def checkConfig(self, *args, **kwargs):
+        return defer.succeed(True)
 
     def reconfigService(self, name=None, *args, **kwargs):
         return defer.succeed(None)


### PR DESCRIPTION
I have following buildbot configuration:
```python
class FooStatusPush(GerritStatusPush):
    name = 'foo'

class BarStatusPush(GerritStatusPush):
   name = 'bar'

config['services'].extend([
    FooStatusPush(server_url, username, etc...),
    BarStatusPush(server_url, username, etc...),
])
```

It used to work for me, but after update to version 0.9.7 it have broken.
After some investigations I have found out that problem was in [`BuildbotService.checkConfig`](https://github.com/buildbot/buildbot/blob/v0.9.7/master/buildbot/util/service.py#L216) method.
It takes the first constructor argument (which is a Gerrit server name) and assignes it to the name attribute. If I have several reporters defined in my configuration with the same Gerrit server only one of them will work eventually, because all of them will have the same name.
## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation
