### PR TITLE
configure pyup to update only every week

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,4 @@
+# update schedule, default is not set
+# the bot will visit the repo once and bundle all updates in a single PR for the given
+# day/week/month
+schedule: "every week" # allowed ["every day", "every week", "every two weeks", "every month"]


### PR DESCRIPTION
70% of our PRs are now from pyup. this is a bit too much.
We only need to update every once in a while