### PR TITLE
BuildbotService.__init__() pop() -> get() name

### DIFF
--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -171,7 +171,7 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
     objectid = None
 
     def __init__(self, *args, **kwargs):
-        name = kwargs.pop("name", None)
+        name = kwargs.get("name", None)
         if name is not None:
             self.name = ascii2unicode(name)
         self.checkConfig(*args, **kwargs)


### PR DESCRIPTION
`kwargs.pop("name", None)` entirely prevented `name` from descending onto subclasses' positional argument.

For example:
```python
>>> worker.Worker(name='example', password='example')
...
builtins.TypeError: checkConfig() missing 1 required positional argument: 'name'
```
