### PR TITLE
PY3: paths should be str not bytes (equality)

### DIFF
--- a/master/buildbot/newsfragments/py3_fixauthorization.bugfix
+++ b/master/buildbot/newsfragments/py3_fixauthorization.bugfix
@@ -1,0 +1,1 @@
+fix bytes vs string issue on python3 with authorization of rest endpoints.

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -657,7 +657,7 @@ class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
     def test_authz_forbidden(self):
 
         def deny(request, ep, action, options):
-            if b"test" in ep:
+            if "test" in ep:
                 raise authz.Forbidden("no no")
             return None
         self.master.www.assertUserAllowed = deny

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -884,7 +884,7 @@ class V2RootResource_JSONRPC2(www.WwwTestMixin, unittest.TestCase):
     def test_authz_forbidden(self):
 
         def deny(request, ep, action, options):
-            if b"13" in ep:
+            if "13" in ep:
                 raise authz.Forbidden("no no")
             return None
         self.master.www.assertUserAllowed = deny

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -126,10 +126,14 @@ class V2RootResource(resource.Resource):
     # enable reconfigResource calls
     needsReconfig = True
 
-    def getEndpoint(self, request):
+    @defer.inlineCallbacks
+    def getEndpoint(self, request, method, params):
         # note that trailing slashes are not allowed
         request_postpath = [bytes2NativeString(p) for p in request.postpath]
-        return self.master.data.getEndpoint(tuple(request_postpath))
+        yield self.master.www.assertUserAllowed(request, request_postpath,
+                                                method, params)
+        ret = yield self.master.data.getEndpoint(tuple(request_postpath))
+        defer.returnValue(ret)
 
     @contextmanager
     def handleErrors(self, writeError):
@@ -228,15 +232,12 @@ class V2RootResource(resource.Resource):
         with self.handleErrors(writeError):
             method, id, params = self.decodeJsonRPC2(request)
             jsonRpcReply['id'] = id
-            request_postpath = tuple([bytes2NativeString(p) for p in request.postpath])
-            yield self.master.www.assertUserAllowed(request, request_postpath,
-                                                    method, params)
+            ep, kwargs = yield self.getEndpoint(request, method, params)
             userinfos = self.master.www.getUserInfos(request)
             if 'anonymous' in userinfos and userinfos['anonymous']:
                 owner = "anonymous"
             else:
                 owner = userinfos['email']
-            ep, kwargs = self.getEndpoint(request)
             params['owner'] = owner
 
             result = yield ep.control(method, params, kwargs)
@@ -374,9 +375,7 @@ class V2RootResource(resource.Resource):
             request.write(data)
 
         with self.handleErrors(writeError):
-            yield self.master.www.assertUserAllowed(request, tuple(request.postpath), request.method, {})
-
-            ep, kwargs = self.getEndpoint(request)
+            ep, kwargs = yield self.getEndpoint(request, request.method, {})
 
             rspec = self.decodeResultSpec(request, ep)
             data = yield ep.get(rspec, kwargs)

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -228,7 +228,8 @@ class V2RootResource(resource.Resource):
         with self.handleErrors(writeError):
             method, id, params = self.decodeJsonRPC2(request)
             jsonRpcReply['id'] = id
-            yield self.master.www.assertUserAllowed(request, tuple(request.postpath),
+            request_postpath = tuple([bytes2NativeString(p) for p in request.postpath])
+            yield self.master.www.assertUserAllowed(request, request_postpath,
                                                     method, params)
             userinfos = self.master.www.getUserInfos(request)
             if 'anonymous' in userinfos and userinfos['anonymous']:


### PR DESCRIPTION
Twisted reads paths as bytes (and rightly so), but buildbot codebase
(at least matchers) expect them to be unicode strings and equality
doesn't work between bytes and str

