### PR TITLE
www: fix timestamp insertion for scripts.js

### DIFF
--- a/www/base/src/app/layout.jade
+++ b/www/base/src/app/layout.jade
@@ -13,7 +13,7 @@ html.no-js(xmlns:ng='http://angularjs.org', xmlns:app='ignored', ng-app="app")
         block content
         block footer
 
-    script(src="scripts.js?_#{(new Date()).getTime()}")
+    script(src="scripts.js?_" + (new Date()).getTime())
     | {% for app in config.plugins -%}
     script(src="{{app}}/scripts.js")
     link(rel='stylesheet', href='{{app}}/styles.css')

--- a/www/md_base/src/app/index.jade
+++ b/www/md_base/src/app/index.jade
@@ -24,7 +24,7 @@ html(ng-app="app", ng-controller="appController as app")
         md-content.main-content.md-padding(flex, ui-view, ng-class="app.view.classname")
           h1 Hello buildbot!
 
-      script(src="scripts.js?_#{(new Date()).getTime()}")
+      script(src="scripts.js?_" + (new Date()).getTime())
       | {% for app in config.plugins %}
       script(src="{{app}}/scripts.js")
       link(rel='stylesheet', href='{{app}}/styles.css')


### PR DESCRIPTION
Attribute interpolation syntax has changed, adjust accordingly to
prevent the code from being shown literally.  See
https://pugjs.org/language/attributes.html

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

