### PR TITLE
gitlab hook: support merge_request events

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -556,6 +556,7 @@ gf
 gib
 giger
 github
+gitlab
 gitorious
 gmail
 gmt

--- a/master/buildbot/newsfragments/gitlabhook.feature
+++ b/master/buildbot/newsfragments/gitlabhook.feature
@@ -1,0 +1,2 @@
+Gitlab hook now supports the merge_request event to automatically build from a merge request.
+Note that the results will not properly displayed in merge_request UI due to https://gitlab.com/gitlab-org/gitlab-ce/issues/33293

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -30,7 +30,7 @@ from buildbot.www.hooks.gitlab import _HEADER_EVENT
 from buildbot.www.hooks.gitlab import _HEADER_GITLAB_TOKEN
 
 
-# Sample GITHUB commit payload from http://help.github.com/post-receive-hooks/
+# Sample GITLAB commit payload from https://docs.gitlab.com/ce/user/project/integrations/webhooks.html
 # Added "modified" and "removed", and change email
 gitJsonPayload = """
 {
@@ -113,6 +113,85 @@ gitJsonPayloadTag = """
    "total_commits_count": 2
 }
 """
+gitJsonPayloadMR = """
+{
+  "object_kind": "merge_request",
+  "user": {
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
+  },
+  "object_attributes": {
+    "id": 99,
+    "target_branch": "master",
+    "source_branch": "ms-viewport",
+    "source_project_id": 14,
+    "author_id": 51,
+    "assignee_id": 6,
+    "title": "MS-Viewport",
+    "created_at": "2013-12-03T17:23:34Z",
+    "updated_at": "2013-12-03T17:23:34Z",
+    "st_commits": null,
+    "st_diffs": null,
+    "milestone_id": null,
+    "state": "opened",
+    "merge_status": "unchecked",
+    "target_project_id": 14,
+    "iid": 1,
+    "description": "",
+    "source":{
+      "name":"Awesome Project",
+      "description":"Aut reprehenderit ut est.",
+      "web_url":"http://example.com/awesome_space/awesome_project",
+      "avatar_url":null,
+      "git_ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "git_http_url":"http://example.com/awesome_space/awesome_project.git",
+      "namespace":"Awesome Space",
+      "visibility_level":20,
+      "path_with_namespace":"awesome_space/awesome_project",
+      "default_branch":"master",
+      "homepage":"http://example.com/awesome_space/awesome_project",
+      "url":"http://example.com/awesome_space/awesome_project.git",
+      "ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "http_url":"http://example.com/awesome_space/awesome_project.git"
+    },
+    "target": {
+      "name":"Awesome Project",
+      "description":"Aut reprehenderit ut est.",
+      "web_url":"http://example.com/awesome_space/awesome_project",
+      "avatar_url":null,
+      "git_ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "git_http_url":"http://example.com/awesome_space/awesome_project.git",
+      "namespace":"Awesome Space",
+      "visibility_level":20,
+      "path_with_namespace":"awesome_space/awesome_project",
+      "default_branch":"master",
+      "homepage":"http://example.com/awesome_space/awesome_project",
+      "url":"http://example.com/awesome_space/awesome_project.git",
+      "ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "http_url":"http://example.com/awesome_space/awesome_project.git"
+    },
+    "last_commit": {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "message": "fixed readme",
+      "timestamp": "2012-01-03T23:36:29+02:00",
+      "url": "http://example.com/awesome_space/awesome_project/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "author": {
+        "name": "GitLab dev user",
+        "email": "gitlabdev@dv6700.(none)"
+      }
+    },
+    "work_in_progress": false,
+    "url": "http://example.com/diaspora/merge_requests/1",
+    "action": "open",
+    "assignee": {
+      "name": "User1",
+      "username": "user1",
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
+    }
+  }
+}
+"""
 
 
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
@@ -131,6 +210,18 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
             1323692851
         )
         self.assertEqual(change["branch"], "v1.0.0")
+
+    def check_changes_mr_event(self, r, project='', codebase=None):
+        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
+        change = self.changeHook.master.addedChanges[0]
+
+        self.assertEqual(change["repository"], "http://example.com/awesome_space/awesome_project.git")
+        self.assertEqual(
+            calendar.timegm(change["when_timestamp"].utctimetuple()),
+            1325626589
+        )
+        self.assertEqual(change["branch"], "refs/merge-requests/1/head")
+        self.assertEqual(change["category"], "merge_request")
 
     def check_changes_push_event(self, r, project='', codebase=None):
         self.assertEqual(len(self.changeHook.master.addedChanges), 2)
@@ -177,6 +268,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = FakeRequest(content=gitJsonPayload)
         self.request.uri = b"/change_hook/gitlab"
         self.request.method = b"POST"
+        self.request.received_headers[_HEADER_EVENT] = "Push Hook"
         res = yield self.request.test_render(self.changeHook)
         self.check_changes_push_event(res)
 
@@ -185,6 +277,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = FakeRequest(content=gitJsonPayload)
         self.request.uri = b"/change_hook/gitlab"
         self.request.args = {'project': ['MyProject']}
+        self.request.received_headers[_HEADER_EVENT] = "Push Hook"
         self.request.method = b"POST"
         res = yield self.request.test_render(self.changeHook)
         self.check_changes_push_event(res, project="MyProject")
@@ -194,6 +287,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = FakeRequest(content=gitJsonPayload)
         self.request.uri = b"/change_hook/gitlab"
         self.request.args = {'codebase': ['MyCodebase']}
+        self.request.received_headers[_HEADER_EVENT] = "Push Hook"
         self.request.method = b"POST"
         res = yield self.request.test_render(self.changeHook)
         self.check_changes_push_event(res, codebase="MyCodebase")
@@ -203,6 +297,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = FakeRequest(content=gitJsonPayloadTag)
         self.request.uri = b"/change_hook/gitlab"
         self.request.args = {'codebase': ['MyCodebase']}
+        self.request.received_headers[_HEADER_EVENT] = "Push Hook"
         self.request.method = b"POST"
         res = yield self.request.test_render(self.changeHook)
         self.check_changes_tag_event(res, codebase="MyCodebase")
@@ -211,6 +306,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = FakeRequest()
         self.request.uri = b"/change_hook/gitlab"
         self.request.method = b"POST"
+        self.request.received_headers[_HEADER_EVENT] = "Push Hook"
         d = self.request.test_render(self.changeHook)
 
         def check_changes(r):
@@ -231,6 +327,19 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(len(self.changeHook.master.addedChanges), 2)
         change = self.changeHook.master.addedChanges[0]
         self.assertEqual(change["properties"]["event"], "Push Hook")
+        self.assertEqual(change["category"], "Push Hook")
+
+    @defer.inlineCallbacks
+    def testGitWithChange_WithMR(self):
+        self.request = FakeRequest(content=gitJsonPayloadMR)
+        self.request.uri = b"/change_hook/gitlab"
+        self.request.args = {'codebase': ['MyCodebase']}
+        self.request.received_headers[_HEADER_EVENT] = "Merge Request Hook"
+        self.request.method = b"POST"
+        res = yield self.request.test_render(self.changeHook)
+        self.check_changes_mr_event(res, codebase="MyCodebase")
+        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(change["category"], "merge_request")
 
 
 class TestChangeHookConfiguredWithSecret(unittest.TestCase):
@@ -248,6 +357,7 @@ class TestChangeHookConfiguredWithSecret(unittest.TestCase):
         self.request.uri = b"/change_hook/gitlab"
         self.request.args = {'codebase': ['MyCodebase']}
         self.request.method = b"POST"
+        self.request.received_headers[_HEADER_EVENT] = "Push Hook"
         yield self.request.test_render(self.changeHook)
         expected = b'Invalid secret'
         self.assertEqual(self.request.written, expected)
@@ -257,6 +367,7 @@ class TestChangeHookConfiguredWithSecret(unittest.TestCase):
     def test_valid_secret(self):
         self.request = FakeRequest(content=gitJsonPayload)
         self.request.received_headers[_HEADER_GITLAB_TOKEN] = self._SECRET
+        self.request.received_headers[_HEADER_EVENT] = "Push Hook"
         self.request.uri = b"/change_hook/gitlab"
         self.request.method = b"POST"
         yield self.request.test_render(self.changeHook)


### PR DESCRIPTION
Gitlab hook now supports the merge_request event to automatically build from a merge request.

Note that the results will not properly displayed in merge_request UI due to https://gitlab.com/gitlab-org/gitlab-ce/issues/33293
