### PR TITLE
Force UserPasswordAuth passwords into bytes

### DIFF
--- a/master/buildbot/newsfragments/auth-incompatability-python3.bugfix
+++ b/master/buildbot/newsfragments/auth-incompatability-python3.bugfix
@@ -1,0 +1,1 @@
+Fix incompatibility issue of ``UserPasswordAuth`` with python 3.

--- a/master/buildbot/test/unit/test_www_auth.py
+++ b/master/buildbot/test/unit/test_www_auth.py
@@ -166,6 +166,17 @@ class TwistedICredAuthBase(www.WwwTestMixin, unittest.TestCase):
         self.assertIsInstance(rsrc, HTTPAuthSessionWrapper)
 
 
+class UserPasswordAuth(www.WwwTestMixin, unittest.TestCase):
+
+    def test_passwordStringToBytes(self):
+        login = {"user_string": "password",
+                 "user_bytes": b"password"}
+        correct_login = {b"user_string": b"password",
+                         b"user_bytes": b"password"}
+        self.auth = auth.UserPasswordAuth(login)
+        self.assertEqual(self.auth.checkers[0].users, correct_login)
+
+
 class LoginResource(www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
 
     @defer.inlineCallbacks

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -32,6 +32,7 @@ from zope.interface import implementer
 
 from buildbot.util import bytes2NativeString
 from buildbot.util import config
+from buildbot.util import unicode2bytes
 from buildbot.www import resource
 
 
@@ -170,6 +171,8 @@ class HTPasswdAuth(TwistedICredAuthBase):
 class UserPasswordAuth(TwistedICredAuthBase):
 
     def __init__(self, users, **kwargs):
+        for user, password in users.items():
+            users[user] = unicode2bytes(password)
         TwistedICredAuthBase.__init__(
             self,
             [DigestCredentialFactory(b"md5", b"buildbot"),


### PR DESCRIPTION
Signed-off-by: Morten Linderud <morten@linderud.pw>

Fixes the below error when passwords are not passed as bytes on Python3.*
```
2017-06-04 22:24:40+0200 [_GenericHTTPChannelProtocol,240,127.0.0.1] HTTPAuthSessionWrapper.getChildWithDefault encountered unexpected error
	Traceback (most recent call last):
	  File "/usr/local/lib/python3.5/dist-packages/Twisted-17.1.0.dev0-py3.5-linux-x86_64.egg/twisted/web/_auth/wrapper.py", line 162, in _login
	    d = self._portal.login(credentials, None, IResource)
	  File "/usr/local/lib/python3.5/dist-packages/Twisted-17.1.0.dev0-py3.5-linux-x86_64.egg/twisted/cred/portal.py", line 119, in login
	    return maybeDeferred(self.checkers[i].requestAvatarId, credentials
	  File "/usr/local/lib/python3.5/dist-packages/Twisted-17.1.0.dev0-py3.5-linux-x86_64.egg/twisted/internet/defer.py", line 150, in maybeDeferred
	    result = f(*args, **kw)
	  File "/usr/local/lib/python3.5/dist-packages/Twisted-17.1.0.dev0-py3.5-linux-x86_64.egg/twisted/cred/checkers.py", line 97, in requestAvatarId
	    self.users[credentials.username]).addCallback(
	--- <exception caught here> ---
	  File "/usr/local/lib/python3.5/dist-packages/Twisted-17.1.0.dev0-py3.5-linux-x86_64.egg/twisted/internet/defer.py", line 150, in maybeDeferred
	    result = f(*args, **kw)
	  File "/usr/local/lib/python3.5/dist-packages/Twisted-17.1.0.dev0-py3.5-linux-x86_64.egg/twisted/cred/credentials.py", line 157, in checkPassword
	    calcHA1(algo, self.username, self.realm, password, nonce, cnonce),
	  File "/usr/local/lib/python3.5/dist-packages/Twisted-17.1.0.dev0-py3.5-linux-x86_64.egg/twisted/cred/_digest.py", line 65, in calcHA1
	    m.update(pszPassword)
	builtins.TypeError: Unicode-objects must be encoded before hashing
```

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [ ] I have updated the appropriate documentation

