### PR TITLE
fix issue with ws reconnection logic breaks oauth connection sequence.

### DIFF
--- a/master/buildbot/newsfragments/firefoxoauth.bugfix
+++ b/master/buildbot/newsfragments/firefoxoauth.bugfix
@@ -1,0 +1,1 @@
+Fix issue with oauth sequence not working with Firefox (:issue:`3306`)

--- a/www/base/src/app/app.run.coffee
+++ b/www/base/src/app/app.run.coffee
@@ -27,7 +27,11 @@ class ReconnectingListener extends Run
                     $interval.cancel(interval)
                     interval = null
                     hasBeenConnected = true
-                    socketService.socket.onclose = ->
+                    socketService.socket.onclose = (evt) ->
+                        # ignore if we are navigating away from buildbot
+                        # see https://github.com/buildbot/buildbot/issues/3306
+                        if evt.code <= 1001  # CLOSE_GOING_AWAY or CLOSE_NORMAL
+                            return
                         reconnecting = true
                         $rootScope.$apply ->
                             # send event to connectionstatus directive


### PR DESCRIPTION
When browsing away from the page, Firefox sends the onclose event for the websocket, which eventually triggers a reload of the page.
This races with the oauth connection sequence.
As the browser do not get a document for a while during that sequence, javascript continues to run, and eventually reload the page, cancelling the oauth redirection sequence

fix for #3306 

## Contributor Checklist:

* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)

