### PR TITLE
twisted.mail.smtp.ESMTPSenderFactory fix for Python 3.

### DIFF
--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -328,7 +328,7 @@ class MailNotifier(NotifierBase):
 
         s = unicode2bytes(s)
         sender_factory = ESMTPSenderFactory(
-            self.smtpUser, self.smtpPassword,
+            unicode2bytes(self.smtpUser), unicode2bytes(self.smtpPassword),
             self.fromaddr, recipients, BytesIO(s),
             result, requireTransportSecurity=self.useTls,
             requireAuthentication=useAuth)


### PR DESCRIPTION
For twisted.mail.smtp.ESMTPSenderFactory, ensure username and password are bytes.

This fixes Python 3.
