### PR TITLE
gitlab hook: support proper scheme for mergerequest reporting

### DIFF
--- a/master/buildbot/newsfragments/gitlab_mergerequest.feature
+++ b/master/buildbot/newsfragments/gitlab_mergerequest.feature
@@ -1,0 +1,3 @@
+Gitlab merge request hook now create a change with repository to be the source repository and branch the source branch.
+Additional properties are created to point to destination branch and destination repository.
+This makes :bb:reporter:`GitlabReporter` push the correct status to Gitlab, so that pipeline report is visible in the merge request page.

--- a/master/buildbot/newsfragments/gitlab_mergerequest.feature
+++ b/master/buildbot/newsfragments/gitlab_mergerequest.feature
@@ -1,3 +1,3 @@
-Gitlab merge request hook now create a change with repository to be the source repository and branch the source branch.
+GitLab merge request hook now create a change with repository to be the source repository and branch the source branch.
 Additional properties are created to point to destination branch and destination repository.
-This makes :bb:reporter:`GitLabStatusPush` push the correct status to Gitlab, so that pipeline report is visible in the merge request page.
+This makes :bb:reporter:`GitLabStatusPush` push the correct status to GitLab, so that pipeline report is visible in the merge request page.

--- a/master/buildbot/newsfragments/gitlab_mergerequest.feature
+++ b/master/buildbot/newsfragments/gitlab_mergerequest.feature
@@ -1,3 +1,3 @@
 Gitlab merge request hook now create a change with repository to be the source repository and branch the source branch.
 Additional properties are created to point to destination branch and destination repository.
-This makes :bb:reporter:`GitlabReporter` push the correct status to Gitlab, so that pipeline report is visible in the merge request page.
+This makes :bb:reporter:`GitLabStatusPush` push the correct status to Gitlab, so that pipeline report is visible in the merge request page.

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -142,18 +142,18 @@ gitJsonPayloadMR = """
     "source":{
       "name":"Awesome Project",
       "description":"Aut reprehenderit ut est.",
-      "web_url":"http://example.com/awesome_space/awesome_project",
+      "web_url":"http://example.com/awesome_user/awesome_project",
       "avatar_url":null,
-      "git_ssh_url":"git@example.com:awesome_space/awesome_project.git",
-      "git_http_url":"http://example.com/awesome_space/awesome_project.git",
+      "git_ssh_url":"git@example.com:awesome_user/awesome_project.git",
+      "git_http_url":"http://example.com/awesome_user/awesome_project.git",
       "namespace":"Awesome Space",
       "visibility_level":20,
-      "path_with_namespace":"awesome_space/awesome_project",
+      "path_with_namespace":"awesome_user/awesome_project",
       "default_branch":"master",
-      "homepage":"http://example.com/awesome_space/awesome_project",
-      "url":"http://example.com/awesome_space/awesome_project.git",
-      "ssh_url":"git@example.com:awesome_space/awesome_project.git",
-      "http_url":"http://example.com/awesome_space/awesome_project.git"
+      "homepage":"http://example.com/awesome_user/awesome_project",
+      "url":"http://example.com/awesome_user/awesome_project.git",
+      "ssh_url":"git@example.com:awesome_user/awesome_project.git",
+      "http_url":"http://example.com/awesome_user/awesome_project.git"
     },
     "target": {
       "name":"Awesome Project",
@@ -215,12 +215,16 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(len(self.changeHook.master.addedChanges), 1)
         change = self.changeHook.master.addedChanges[0]
 
-        self.assertEqual(change["repository"], "http://example.com/awesome_space/awesome_project.git")
+        self.assertEqual(change["repository"],
+                         "http://example.com/awesome_user/awesome_project.git")
+        self.assertEqual(change['properties']["target_repository"],
+                         "http://example.com/awesome_space/awesome_project.git")
         self.assertEqual(
             calendar.timegm(change["when_timestamp"].utctimetuple()),
             1325626589
         )
-        self.assertEqual(change["branch"], "refs/merge-requests/1/head")
+        self.assertEqual(change["branch"], "ms-viewport")
+        self.assertEqual(change['properties']["target_branch"], 'master')
         self.assertEqual(change["category"], "merge_request")
 
     def check_changes_push_event(self, r, project='', codebase=None):

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -105,7 +105,7 @@ def _process_merge_request_change(payload, project, event, codebase=None):
     commit = attrs['last_commit']
     when_timestamp = dateparse(commit['timestamp'])
     # @todo provide and document a way to choose between http and ssh url
-    repo_url = attrs['target']['git_http_url']
+    repo_url = attrs['source']['git_http_url']
     changes = [{
         'author': '%s <%s>' % (commit['author']['name'],
                                commit['author']['email']),
@@ -113,13 +113,14 @@ def _process_merge_request_change(payload, project, event, codebase=None):
         'comments': "MR#{}: {}\n\n{}".format(attrs['iid'], attrs['title'], attrs['description']),
         'revision': commit['id'],
         'when_timestamp': when_timestamp,
-        'branch': "refs/merge-requests/{}/head".format(attrs['iid']),
-        'repository': repo_url.replace(":30302", ''),
+        'branch': attrs['source_branch'],
+        'repository': repo_url,
         'project': project,
         'category': event,
         'revlink': attrs['url'],
         'properties': {
             'target_branch': attrs['target_branch'],
+            'target_repository': attrs['target']['git_http_url'],
             'event': event,
         },
     }]

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -235,7 +235,7 @@ Several small utilities are available at the top-level :mod:`buildbot.util` pack
 
     This function is intended to help various components to parse git urls.
     It helps to find the ``<owner>/<repo>`` of a git repository url coming from a change, in order to call urls.
-    ``owner`` and ``repo`` is a common scheme for identifying git repository between various git hosting services like GitHub, Gitlab, BitBucket, etc.
+    ``owner`` and ``repo`` is a common scheme for identifying git repository between various git hosting services like GitHub, GitLab, BitBucket, etc.
     Each service have their own naming for similar things, but we choose to use the GitHub naming as a de-facto standard.
     To simplify implementation, the parser is accepting invalid urls, but it should always parse valid urls correctly.
     The unit tests in ``test_util_giturlparse.py`` is the references of what the parser is accepting.
@@ -270,11 +270,11 @@ Several small utilities are available at the top-level :mod:`buildbot.util` pack
 
     .. py:attribute:: owner
 
-        The owner of the repository (in case of Gitlab might be a nested group, i.e contain ``/``, e.g ``repo/subrepo/subsubrepo``)
+        The owner of the repository (in case of GitLab might be a nested group, i.e contain ``/``, e.g ``repo/subrepo/subsubrepo``)
 
     .. py:attribute:: repo
 
-        The owner of the repository (in case of Gitlab might be a nested group, i.e contain ``/``)
+        The owner of the repository (in case of GitLab might be a nested group, i.e contain ``/``)
 
 
 :py:mod:`buildbot.util.lru`

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -39,19 +39,19 @@ Core Features
 Components Bug fixes
 --------------------
 
-- Gitlab reporter now correctly sets the status to running instead of pending
+- GitLab reporter now correctly sets the status to running instead of pending
   when a build starts.
-- Gitlab reporter now correctly works when there are multiple codebase, and
+- GitLab reporter now correctly works when there are multiple codebase, and
   when the projects names contain url reserved characters.
-- Gitlab reporter now correctly reports the status even if there are several
-  sourcestamps. Better parsing of change repository in Gitlab reporter so that
-  it understands ssh urls and https url. Gitlab reporter do not use the project
+- GitLab reporter now correctly reports the status even if there are several
+  sourcestamps. Better parsing of change repository in GitLab reporter so that
+  it understands ssh urls and https url. GitLab reporter do not use the project
   field anymore to know the repository to push to.
 
 Components Features
 -------------------
 
-- Gitlab hook now supports the merge_request event to automatically build from
+- GitLab hook now supports the merge_request event to automatically build from
   a merge request. Note that the results will not properly displayed in
   merge_request UI due to https://gitlab.com/gitlab-org/gitlab-ce/issues/33293
 - Added a https://pushjet.io/ reporter as
@@ -159,7 +159,7 @@ Components Features
 - Changed :py:class:`~buildbot.www.oauth2.GitHubAuth` now supports GitHub
   Enterprise when setting new ``serverURL`` argument.
 - :bb:chsrc:`GitLab` now sets the ``event`` property
-  on each change to what the ``X-Gitlab-Event`` header contains.
+  on each change to what the ``X-GitLab-Event`` header contains.
 - :bb:chsrc:`GitHub` now process
   git tag push events
 - :bb:chsrc:`GitHub` now adds
@@ -346,7 +346,7 @@ Bug fixes
 - Fix :py:class:`~buildbot.www.oauth2.GitHubAuth` to retrieve all organizations
   instead of only those publicly available.
 - Fixed `ref` to point to `branch` instead of commit `sha` in
-  :py:class:`~buildbot.reporters.GitlabStatusPush`
+  :py:class:`~buildbot.reporters.GitLabStatusPush`
 - :bb:reporter:`IRC` :py:meth:`maybeColorize` is able to highlight single words
   and stop colorization at the end. The previous implementation only stopped
   colorization but not boldface.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -310,7 +310,7 @@ getters
 GiB
 github
 GitHub
-Gitlab
+GitLab
 Gitorious
 glMenuProvider
 google


### PR DESCRIPTION
This integrates with unchanged reporter and give following UI in gitlab:

![image](https://user-images.githubusercontent.com/109859/27136852-9cb17f54-511c-11e7-96b5-c7d59849382a.png)

![image](https://user-images.githubusercontent.com/109859/27136888-baed16f4-511c-11e7-8858-fc44a4c8474d.png)