### PR TITLE
Fix non ascii payload handling in base web hook

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -52,7 +52,7 @@ from buildbot.process.users.manager import UserManagerManager
 from buildbot.schedulers.manager import SchedulerManager
 from buildbot.secrets.manager import SecretManager
 from buildbot.status.master import Status
-from buildbot.util import ascii2unicode
+from buildbot.util import bytes2unicode
 from buildbot.util import check_functional_environment
 from buildbot.util import datetime2epoch
 from buildbot.util import service
@@ -477,12 +477,12 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
         for k in ('comments', 'author', 'revision', 'branch', 'category',
                   'revlink', 'repository', 'codebase', 'project'):
             if k in kwargs:
-                kwargs[k] = ascii2unicode(kwargs[k])
+                kwargs[k] = bytes2unicode(kwargs[k])
         if kwargs.get('files'):
-            kwargs['files'] = [ascii2unicode(f)
+            kwargs['files'] = [bytes2unicode(f)
                                for f in kwargs['files']]
         if kwargs.get('properties'):
-            kwargs['properties'] = dict((ascii2unicode(k), v)
+            kwargs['properties'] = dict((bytes2unicode(k), v)
                                         for k, v in iteritems(kwargs['properties']))
 
         # pass the converted call on to the data API

--- a/master/buildbot/newsfragments/base-hook-non-ascii.bugfix
+++ b/master/buildbot/newsfragments/base-hook-non-ascii.bugfix
@@ -1,0 +1,1 @@
+Fix non ascii payload handling in base web hook (:issue:`3321`).

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 # This file is part of Buildbot.  Buildbot is free software: you can
 # redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation, version 2.
@@ -113,6 +114,16 @@ class OldTriggeringMethods(unittest.TestCase):
         return self.do_test_addChange_args(
             kwargs=dict(who='me'),
             exp_data_kwargs=dict(author='me'))
+
+    def test_addChange_args_cyrillic(self):
+        return self.do_test_addChange_args(
+            kwargs=dict(who=b'\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82',
+                        files=[b'\xd0\xbd\xd0\xb5'],
+                        properties={b'\xd1\x80\xd0\xb0\xd0\xb1\xd0\xbe\xd1\x82\xd0\xb0\xd0\xb5\xd1\x82':
+                                    'a'}),
+            exp_data_kwargs=dict(author=u'привет',
+                                 files=[u'не'],
+                                 properties={u'работает': 'a'}))
 
     def test_addChange_args_when(self):
         # when should come through as when_timestamp, as a datetime


### PR DESCRIPTION
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)

closes #3321
