### PR TITLE
Hook plugins

### DIFF
--- a/master/buildbot/newsfragments/hooksplugin.feature
+++ b/master/buildbot/newsfragments/hooksplugin.feature
@@ -1,2 +1,2 @@
 The :ref:`Change-Hooks` system is now integrated in the :ref:`Plugins` system, making it easier to subclass hooks.
-There is still the need to refactor hook by hook to allow better customizability.
+There is still the need to re-factor hook by hook to allow better customizability.

--- a/master/buildbot/newsfragments/hooksplugin.feature
+++ b/master/buildbot/newsfragments/hooksplugin.feature
@@ -1,0 +1,2 @@
+The :ref:`Change-Hooks` system is now integrated in the :ref:`Plugins` system, making it easier to subclass hooks.
+There is still the need to refactor hook by hook to allow better customizability.

--- a/master/buildbot/test/unit/test_changes_github.py
+++ b/master/buildbot/test/unit/test_changes_github.py
@@ -133,8 +133,8 @@ gitJsonUserPage_missingEmail = """
 }"""
 
 
-_CT_ENCODED = 'application/x-www-form-urlencoded'
-_CT_JSON = 'application/json'
+_CT_ENCODED = b'application/x-www-form-urlencoded'
+_CT_JSON = b'application/json'
 
 _GH_PARSED_PROPS = {
     'github.head.sha': '4c9a7f03e04e551a5e012064b581577f949dd3a4',

--- a/master/buildbot/test/unit/test_www_hooks_bitbucket.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucket.py
@@ -196,7 +196,7 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
         yield request.test_render(self.change_hook)
 
         self.assertEqual(len(self.change_hook.master.addedChanges), 0)
-        self.assertEqual(request.written, b'no changes found')
+        self.assertEqual(request.written, b'no change found')
 
     @inlineCallbacks
     def testMercurialWithChange(self):
@@ -246,7 +246,7 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
         yield request.test_render(self.change_hook)
 
         self.assertEqual(len(self.change_hook.master.addedChanges), 0)
-        self.assertEqual(request.written, b'no changes found')
+        self.assertEqual(request.written, b'no change found')
 
     @inlineCallbacks
     def testWithNoJson(self):

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -386,8 +386,9 @@ gitJsonPayloadEmpty = """
 """
 
 _HEADER_CT = 'Content-Type'
-_CT_ENCODED = 'application/x-www-form-urlencoded'
-_CT_JSON = 'application/json'
+_CT_ENCODED = b'application/x-www-form-urlencoded'
+_CT_JSON = b'application/json'
+
 
 def _prepare_github_change_hook(**params):
     return ChangeHookResource(dialects={
@@ -459,9 +460,9 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
             _HEADER_CT: bad_content_type
         })
         yield self.request.test_render(self.changeHook)
-        expected = b'Unknown content type: ' + bad_content_type
+        expected = b'Unknown content type: '
         self.assertEqual(len(self.changeHook.master.addedChanges), 0)
-        self.assertEqual(self.request.written, expected)
+        self.assertIn(expected, self.request.written)
 
     @defer.inlineCallbacks
     def _check_ping(self, payload):

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -618,7 +618,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def _check_git_with_no_changes(self, payload):
         self.request = _prepare_request('push', payload)
         yield self.request.test_render(self.changeHook)
-        expected = b"no changes found"
+        expected = b"no change found"
         self.assertEqual(len(self.changeHook.master.addedChanges), 0)
         self.assertEqual(self.request.written, expected)
 
@@ -632,7 +632,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def _check_git_with_non_branch_changes(self, payload):
         self.request = _prepare_request('push', payload)
         yield self.request.test_render(self.changeHook)
-        expected = b"no changes found"
+        expected = b"no change found"
         self.assertEqual(len(self.changeHook.master.addedChanges), 0)
         self.assertEqual(self.request.written, expected)
 

--- a/master/buildbot/test/unit/test_www_hooks_poller.py
+++ b/master/buildbot/test/unit/test_www_hooks_poller.py
@@ -69,7 +69,7 @@ class TestPollingChangeHook(unittest.TestCase):
     @defer.inlineCallbacks
     def test_no_args(self):
         yield self.setUpRequest({})
-        self.assertEqual(self.request.written, b"no changes found")
+        self.assertEqual(self.request.written, b"no change found")
         self.assertEqual(self.changesrc.called, True)
         self.assertEqual(self.otherpoller.called, True)
 
@@ -94,7 +94,7 @@ class TestPollingChangeHook(unittest.TestCase):
     @defer.inlineCallbacks
     def test_trigger_poll(self):
         yield self.setUpRequest({"poller": ["example"]})
-        self.assertEqual(self.request.written, b"no changes found")
+        self.assertEqual(self.request.written, b"no change found")
         self.assertEqual(self.changesrc.called, True)
         self.assertEqual(self.otherpoller.called, False)
 
@@ -110,13 +110,13 @@ class TestPollingChangeHook(unittest.TestCase):
     @defer.inlineCallbacks
     def test_allowlist_allow(self):
         yield self.setUpRequest({"poller": ["example"]}, options={"allowed": ["example"]})
-        self.assertEqual(self.request.written, b"no changes found")
+        self.assertEqual(self.request.written, b"no change found")
         self.assertEqual(self.changesrc.called, True)
         self.assertEqual(self.otherpoller.called, False)
 
     @defer.inlineCallbacks
     def test_allowlist_all(self):
         yield self.setUpRequest({}, options={"allowed": ["example"]})
-        self.assertEqual(self.request.written, b"no changes found")
+        self.assertEqual(self.request.written, b"no change found")
         self.assertEqual(self.changesrc.called, True)
         self.assertEqual(self.otherpoller.called, False)

--- a/master/buildbot/www/change_hook.py
+++ b/master/buildbot/www/change_hook.py
@@ -25,7 +25,6 @@ import re
 
 from twisted.internet import defer
 from twisted.python import log
-from twisted.python.failure import Failure
 from twisted.web import server
 
 from buildbot.plugins.db import get_plugins

--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -24,58 +24,66 @@ from __future__ import print_function
 import json
 
 
-def getChanges(request, options=None):
-    """
-    Consumes a naive build notification (the default for now)
-    basically, set POST variables to match commit object parameters:
-    revision, revlink, comments, branch, who, files, links
+class BaseHookHandler(object):
+    def __init__(self, master, options):
+        self.master = master
+        self.options = options
 
-    files, links and properties will be de-json'd, the rest are interpreted as strings
-    """
-
-    def firstOrNothing(value):
+    def getChanges(self, request):
         """
-        Small helper function to return the first value (if value is a list)
-        or return the whole thing otherwise
+        Consumes a naive build notification (the default for now)
+        basically, set POST variables to match commit object parameters:
+        revision, revlink, comments, branch, who, files, links
+
+        files, links and properties will be de-json'd, the rest are interpreted as strings
         """
-        if (isinstance(value, type([]))):
-            return value[0]
-        return value
 
-    args = request.args
-    # first, convert files, links and properties
-    files = None
-    if args.get(b'files'):
-        files = json.loads(args.get(b'files')[0])
-    else:
-        files = []
+        def firstOrNothing(value):
+            """
+            Small helper function to return the first value (if value is a list)
+            or return the whole thing otherwise
+            """
+            if (isinstance(value, type([]))):
+                return value[0]
+            return value
 
-    properties = None
-    if args.get(b'properties'):
-        properties = json.loads(args.get(b'properties')[0])
-    else:
-        properties = {}
+        args = request.args
+        # first, convert files, links and properties
+        files = None
+        if args.get(b'files'):
+            files = json.loads(args.get(b'files')[0])
+        else:
+            files = []
 
-    revision = firstOrNothing(args.get(b'revision'))
-    when = firstOrNothing(args.get(b'when'))
-    if when is not None:
-        when = float(when)
-    author = firstOrNothing(args.get(b'author'))
-    if not author:
-        author = firstOrNothing(args.get(b'who'))
-    comments = firstOrNothing(args.get(b'comments'))
-    if isinstance(comments, bytes):
-        comments = comments.decode('utf-8')
-    branch = firstOrNothing(args.get(b'branch'))
-    category = firstOrNothing(args.get(b'category'))
-    revlink = firstOrNothing(args.get(b'revlink'))
-    repository = firstOrNothing(args.get(b'repository'))
-    project = firstOrNothing(args.get(b'project'))
-    codebase = firstOrNothing(args.get(b'codebase'))
+        properties = None
+        if args.get(b'properties'):
+            properties = json.loads(args.get(b'properties')[0])
+        else:
+            properties = {}
 
-    chdict = dict(author=author, files=files, comments=comments,
-                  revision=revision, when=when,
-                  branch=branch, category=category, revlink=revlink,
-                  properties=properties, repository=repository,
-                  project=project, codebase=codebase)
-    return ([chdict], None)
+        revision = firstOrNothing(args.get(b'revision'))
+        when = firstOrNothing(args.get(b'when'))
+        if when is not None:
+            when = float(when)
+        author = firstOrNothing(args.get(b'author'))
+        if not author:
+            author = firstOrNothing(args.get(b'who'))
+        comments = firstOrNothing(args.get(b'comments'))
+        if isinstance(comments, bytes):
+            comments = comments.decode('utf-8')
+        branch = firstOrNothing(args.get(b'branch'))
+        category = firstOrNothing(args.get(b'category'))
+        revlink = firstOrNothing(args.get(b'revlink'))
+        repository = firstOrNothing(args.get(b'repository'))
+        project = firstOrNothing(args.get(b'project'))
+        codebase = firstOrNothing(args.get(b'codebase'))
+
+        chdict = dict(author=author, files=files, comments=comments,
+                      revision=revision, when=when,
+                      branch=branch, category=category, revlink=revlink,
+                      properties=properties, repository=repository,
+                      project=project, codebase=codebase)
+        return ([chdict], None)
+
+
+base = BaseHookHandler  # alternate name for buildbot plugin

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -24,147 +24,151 @@ from dateutil.parser import parse as dateparse
 from twisted.python import log
 
 from buildbot.util import bytes2NativeString
+from buildbot.www.hooks.base import BaseHookHandler
 
 _HEADER_EVENT = b'X-Gitlab-Event'
 _HEADER_GITLAB_TOKEN = b'X-Gitlab-Token'
 
 
-def _process_change(payload, user, repo, repo_url, project, event,
-                    codebase=None):
-    """
-    Consumes the JSON as a python object and actually starts the build.
+class GitLabHandler(BaseHookHandler):
 
-    :arguments:
-        payload
-            Python Object that represents the JSON sent by GitLab Service
-            Hook.
-    """
-    changes = []
-    refname = payload['ref']
+    def _process_change(self, payload, user, repo, repo_url, project, event,
+                        codebase=None):
+        """
+        Consumes the JSON as a python object and actually starts the build.
 
-    # We only care about regular heads or tags
-    match = re.match(r"^refs/(heads|tags)/(.+)$", refname)
-    if not match:
-        log.msg("Ignoring refname `%s': Not a branch" % refname)
+        :arguments:
+            payload
+                Python Object that represents the JSON sent by GitLab Service
+                Hook.
+        """
+        changes = []
+        refname = payload['ref']
+
+        # We only care about regular heads or tags
+        match = re.match(r"^refs/(heads|tags)/(.+)$", refname)
+        if not match:
+            log.msg("Ignoring refname `%s': Not a branch" % refname)
+            return changes
+
+        branch = match.group(2)
+        if payload.get('deleted'):
+            log.msg("Branch `%s' deleted, ignoring" % branch)
+            return changes
+
+        for commit in payload['commits']:
+            if not commit.get('distinct', True):
+                log.msg('Commit `%s` is a non-distinct commit, ignoring...' %
+                        (commit['id'],))
+                continue
+
+            files = []
+            for kind in ('added', 'modified', 'removed'):
+                files.extend(commit.get(kind, []))
+
+            when_timestamp = dateparse(commit['timestamp'])
+
+            log.msg("New revision: %s" % commit['id'][:8])
+
+            change = {
+                'author': '%s <%s>' % (commit['author']['name'],
+                                       commit['author']['email']),
+                'files': files,
+                'comments': commit['message'],
+                'revision': commit['id'],
+                'when_timestamp': when_timestamp,
+                'branch': branch,
+                'revlink': commit['url'],
+                'repository': repo_url,
+                'project': project,
+                'category': event,
+                'properties': {
+                    'event': event,
+                },
+            }
+
+            if codebase is not None:
+                change['codebase'] = codebase
+
+            changes.append(change)
+
         return changes
 
-    branch = match.group(2)
-    if payload.get('deleted'):
-        log.msg("Branch `%s' deleted, ignoring" % branch)
-        return changes
+    def _process_merge_request_change(self, payload, project, event, codebase=None):
+        """
+        Consumes the merge_request JSON as a python object and turn it into a buildbot change.
 
-    for commit in payload['commits']:
-        if not commit.get('distinct', True):
-            log.msg('Commit `%s` is a non-distinct commit, ignoring...' %
-                    (commit['id'],))
-            continue
-
-        files = []
-        for kind in ('added', 'modified', 'removed'):
-            files.extend(commit.get(kind, []))
-
+        :arguments:
+            payload
+                Python Object that represents the JSON sent by GitLab Service
+                Hook.
+        """
+        attrs = payload['object_attributes']
+        commit = attrs['last_commit']
         when_timestamp = dateparse(commit['timestamp'])
-
-        log.msg("New revision: %s" % commit['id'][:8])
-
-        change = {
+        # @todo provide and document a way to choose between http and ssh url
+        repo_url = attrs['source']['git_http_url']
+        changes = [{
             'author': '%s <%s>' % (commit['author']['name'],
                                    commit['author']['email']),
-            'files': files,
-            'comments': commit['message'],
+            'files': [],  # @todo use rest API
+            'comments': "MR#{}: {}\n\n{}".format(attrs['iid'], attrs['title'], attrs['description']),
             'revision': commit['id'],
             'when_timestamp': when_timestamp,
-            'branch': branch,
-            'revlink': commit['url'],
+            'branch': attrs['source_branch'],
             'repository': repo_url,
             'project': project,
             'category': event,
+            'revlink': attrs['url'],
             'properties': {
+                'target_branch': attrs['target_branch'],
+                'target_repository': attrs['target']['git_http_url'],
                 'event': event,
             },
-        }
-
+        }]
         if codebase is not None:
-            change['codebase'] = codebase
+            changes[0]['codebase'] = codebase
+        return changes
 
-        changes.append(change)
+    def getChanges(self, request):
+        """
+        Reponds only to POST events and starts the build process
 
-    return changes
+        :arguments:
+            request
+                the http request object
+        """
+        expected_secret = isinstance(self.options, dict) and self.options.get('secret')
+        if expected_secret:
+            received_secret = request.getHeader(_HEADER_GITLAB_TOKEN)
+            if received_secret != expected_secret:
+                raise ValueError("Invalid secret")
+        try:
+            payload = json.load(request.content)
+        except Exception as e:
+            raise ValueError("Error loading JSON: " + str(e))
+        event_type = request.getHeader(_HEADER_EVENT)
+        event_type = bytes2NativeString(event_type)
+        # newer version of gitlab have a object_kind parameter,
+        # which allows not to use the http header
+        event_type = payload.get('object_kind', event_type)
+        project = request.args.get('project', [''])[0]
+        codebase = request.args.get('codebase', [None])[0]
+        if event_type in ("push", "tag_push", "Push Hook"):
+            user = payload['user_name']
+            repo = payload['repository']['name']
+            repo_url = payload['repository']['url']
+            changes = self._process_change(
+                payload, user, repo, repo_url, project, event_type, codebase=codebase)
+        elif event_type == 'merge_request':
+            changes = self._process_merge_request_change(
+                payload, project, event_type, codebase=codebase)
+        else:
+            changes = []
+        if changes:
+            log.msg("Received {} changes from {} gitlab event".format(
+                len(changes), event_type))
+        return (changes, 'git')
 
 
-def _process_merge_request_change(payload, project, event, codebase=None):
-    """
-    Consumes the merge_request JSON as a python object and turn it into a buildbot change.
-
-    :arguments:
-        payload
-            Python Object that represents the JSON sent by GitLab Service
-            Hook.
-    """
-    attrs = payload['object_attributes']
-    commit = attrs['last_commit']
-    when_timestamp = dateparse(commit['timestamp'])
-    # @todo provide and document a way to choose between http and ssh url
-    repo_url = attrs['source']['git_http_url']
-    changes = [{
-        'author': '%s <%s>' % (commit['author']['name'],
-                               commit['author']['email']),
-        'files': [],  # @todo use rest API
-        'comments': "MR#{}: {}\n\n{}".format(attrs['iid'], attrs['title'], attrs['description']),
-        'revision': commit['id'],
-        'when_timestamp': when_timestamp,
-        'branch': attrs['source_branch'],
-        'repository': repo_url,
-        'project': project,
-        'category': event,
-        'revlink': attrs['url'],
-        'properties': {
-            'target_branch': attrs['target_branch'],
-            'target_repository': attrs['target']['git_http_url'],
-            'event': event,
-        },
-    }]
-    if codebase is not None:
-        changes[0]['codebase'] = codebase
-    return changes
-
-
-def getChanges(request, options=None):
-    """
-    Reponds only to POST events and starts the build process
-
-    :arguments:
-        request
-            the http request object
-    """
-    expected_secret = isinstance(options, dict) and options.get('secret')
-    if expected_secret:
-        received_secret = request.getHeader(_HEADER_GITLAB_TOKEN)
-        if received_secret != expected_secret:
-            raise ValueError("Invalid secret")
-    try:
-        payload = json.load(request.content)
-    except Exception as e:
-        raise ValueError("Error loading JSON: " + str(e))
-    event_type = request.getHeader(_HEADER_EVENT)
-    event_type = bytes2NativeString(event_type)
-    # newer version of gitlab have a object_kind parameter,
-    # which allows not to use the http header
-    event_type = payload.get('object_kind', event_type)
-    project = request.args.get('project', [''])[0]
-    codebase = request.args.get('codebase', [None])[0]
-    if event_type in ("push", "tag_push", "Push Hook"):
-        user = payload['user_name']
-        repo = payload['repository']['name']
-        repo_url = payload['repository']['url']
-        changes = _process_change(
-            payload, user, repo, repo_url, project, event_type, codebase=codebase)
-    elif event_type == 'merge_request':
-        changes = _process_merge_request_change(
-            payload, project, event_type, codebase=codebase)
-    else:
-        changes = []
-    if changes:
-        log.msg("Received {} changes from {} gitlab event".format(
-            len(changes), event_type))
-    return (changes, 'git')
+gitlab = GitLabHandler

--- a/master/buildbot/www/hooks/gitorious.py
+++ b/master/buildbot/www/hooks/gitorious.py
@@ -18,63 +18,64 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import json
 import re
 
 from dateutil.parser import parse as dateparse
 
 from twisted.python import log
 
-try:
-    import json
-    assert json
-except ImportError:
-    import simplejson as json
+from buildbot.www.hooks.base import BaseHookHandler
 
 
-def getChanges(request, options=None):
-    payload = json.loads(request.args['payload'][0])
-    user = payload['repository']['owner']['name']
-    repo = payload['repository']['name']
-    repo_url = payload['repository']['url']
-    project = payload['project']['name']
+class GitoriousHandler(BaseHookHandler):
 
-    changes = process_change(payload, user, repo, repo_url, project)
-    log.msg("Received %s changes from gitorious" % len(changes))
-    return (changes, 'git')
+    def getChanges(self, request):
+        payload = json.loads(request.args['payload'][0])
+        user = payload['repository']['owner']['name']
+        repo = payload['repository']['name']
+        repo_url = payload['repository']['url']
+        project = payload['project']['name']
+
+        changes = self.process_change(payload, user, repo, repo_url, project)
+        log.msg("Received %s changes from gitorious" % len(changes))
+        return (changes, 'git')
+
+    def process_change(self, payload, user, repo, repo_url, project):
+        changes = []
+        newrev = payload['after']
+
+        branch = payload['ref']
+        if re.match(r"^0*$", newrev):
+            log.msg("Branch `%s' deleted, ignoring" % branch)
+            return []
+        else:
+            for commit in payload['commits']:
+                files = []
+                # Gitorious doesn't send these, maybe later
+                # if 'added' in commit:
+                #     files.extend(commit['added'])
+                # if 'modified' in commit:
+                #     files.extend(commit['modified'])
+                # if 'removed' in commit:
+                #     files.extend(commit['removed'])
+                when_timestamp = dateparse(commit['timestamp'])
+
+                log.msg("New revision: %s" % commit['id'][:8])
+                changes.append({
+                    'author': '%s <%s>' % (commit['author']['name'],
+                                           commit['author']['email']),
+                    'files': files,
+                    'comments': commit['message'],
+                    'revision': commit['id'],
+                    'when_timestamp': when_timestamp,
+                    'branch': branch,
+                    'revlink': commit['url'],
+                    'repository': repo_url,
+                    'project': project
+                })
+
+        return changes
 
 
-def process_change(payload, user, repo, repo_url, project):
-    changes = []
-    newrev = payload['after']
-
-    branch = payload['ref']
-    if re.match(r"^0*$", newrev):
-        log.msg("Branch `%s' deleted, ignoring" % branch)
-        return []
-    else:
-        for commit in payload['commits']:
-            files = []
-            # Gitorious doesn't send these, maybe later
-            # if 'added' in commit:
-            #     files.extend(commit['added'])
-            # if 'modified' in commit:
-            #     files.extend(commit['modified'])
-            # if 'removed' in commit:
-            #     files.extend(commit['removed'])
-            when_timestamp = dateparse(commit['timestamp'])
-
-            log.msg("New revision: %s" % commit['id'][:8])
-            changes.append({
-                'author': '%s <%s>' % (commit['author']['name'],
-                                       commit['author']['email']),
-                'files': files,
-                'comments': commit['message'],
-                'revision': commit['id'],
-                'when_timestamp': when_timestamp,
-                'branch': branch,
-                'revlink': commit['url'],
-                'repository': repo_url,
-                'project': project
-            })
-
-    return changes
+gitorious = GitoriousHandler

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -303,3 +303,32 @@ Note that as before, not using ``change_hook_auth`` can expose you to security r
 .. note::
 
     Web hooks are only available for local Gitorious installations, since this feature is not offered as part of Gitorious.org yet.
+
+
+Custom Hooks
+++++++++++++
+
+Custom hooks are supported via the :ref:`Plugins` mechanism.
+You can subclass any of the available hook handler class available in :py:mod:`buildbot.www.hooks` and register it in the plugin system, via a custom python module.
+For convenience, you ca also use the generic option ``custom_class`` e.g:
+
+.. code-block:: python
+
+    from buildbot.plugins import webhooks
+    class CustomBase(webhooks.base):
+        def getChanges(self, request):
+            args = request.args
+            chdict = dict(
+                          revision=args.get(b'revision'),
+                          repository=args.get(b'repository'),
+                          project=args.get(b'project'),
+                          codebase=args.get(b'codebase'))
+            return ([chdict], None)
+
+    c['www'] = dict(...,
+        change_hook_dialects={
+            'base' : {
+                'custom_class': CustomBase,
+            },
+        },
+    )

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -192,6 +192,7 @@ cronjob
 crontab
 css
 csv
+customizability
 cvs
 CVS
 cvsmodule

--- a/master/setup.py
+++ b/master/setup.py
@@ -397,6 +397,14 @@ setup_args = {
             ('buildbot.www.authz.endpointmatchers', [
                 'AnyEndpointMatcher', 'StopBuildEndpointMatcher', 'ForceBuildEndpointMatcher',
                 'RebuildBuildEndpointMatcher', 'AnyControlEndpointMatcher', 'EnableSchedulerEndpointMatcher']),
+        ]),
+        ('buildbot.webhooks', [
+            ('buildbot.www.hooks.base', ['base']),
+            ('buildbot.www.hooks.bitbucket', ['bitbucket']),
+            ('buildbot.www.hooks.github', ['github']),
+            ('buildbot.www.hooks.gitlab', ['gitlab']),
+            ('buildbot.www.hooks.gitorious', ['gitorious']),
+            ('buildbot.www.hooks.poller', ['poller']),
         ])
     ]), {
         'console_scripts': [


### PR DESCRIPTION
This is a refactor to make the hook system integrated to the plugin system.
This will allow better customizability, and switch the api to an autodiscovery based on twisted.python.reflect.namedModule to our plugin system.

We also change the API to a single function to a class that can potentially store cache.
The classes have access to self.master, but the getChange function cannot return deferred. This has to be done in a follow up PR.


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the master/buildbot/newsfragment directory (and read the README.txt in that directory)
* [x] I have updated the appropriate documentation

