### PR TITLE
Include white-listed event payload properties for GitHub push events

### DIFF
--- a/master/buildbot/changes/github.py
+++ b/master/buildbot/changes/github.py
@@ -42,7 +42,7 @@ link_urls = {
 
 
 class PullRequestMixin(object):
-    def extractProperties(self, pr_info):
+    def extractProperties(self, payload):
         def flatten(properties, base, info_dict):
             for k, v in iteritems(info_dict):
                 name = ".".join([base, k])
@@ -53,7 +53,7 @@ class PullRequestMixin(object):
                     properties[name] = v
 
         properties = {}
-        flatten(properties, "github", pr_info)
+        flatten(properties, "github", payload)
         return properties
 
 

--- a/master/buildbot/newsfragments/hooks-github-push-event-include-whilelisted-properties.feature
+++ b/master/buildbot/newsfragments/hooks-github-push-event-include-whilelisted-properties.feature
@@ -1,0 +1,1 @@
+The :py:class:`~buildbot.www.hooks.github.GitHubEventHandler` now allows the inclusion of white-listed properties for push events.


### PR DESCRIPTION
Include white-listed event payload properties for GitHub push events, similar to pull requests.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
