### PR TITLE
db: allow using in-memory sqlite uri

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ docker-buildbot-master-ubuntu:
 
 $(VENV_NAME):
 	virtualenv -p $(VENV_PY_VERSION) $(VENV_NAME)
-	$(VENV_NAME)/bin/pip install -U pip
+	$(VENV_NAME)/bin/pip install -U pip setuptools
 	$(VENV_NAME)/bin/pip install -e pkg \
 		-e 'master[tls,test,docs]' \
 		-e 'worker[test]' \

--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -127,6 +127,11 @@ class DBConnector(WorkerAPICompatMixin, service.ReconfigurableServiceMixin,
 
         # make sure the db is up to date, unless specifically asked not to
         if check_version:
+            if db_url == 'sqlite://':
+                # Using in-memory database. Since it is reset after each process
+                # restart, `buildbot upgrade-master` cannot be used (data is not
+                # persistent). Upgrade model here to allow startup to continue.
+                self.model.upgrade()
             current = yield self.model.is_current()
             if not current:
                 for l in upgrade_message.format(basedir=self.master.basedir).split('\n'):

--- a/master/buildbot/test/unit/test_db_connector.py
+++ b/master/buildbot/test/unit/test_db_connector.py
@@ -92,6 +92,9 @@ class DBConnector(db.RealDatabaseMixin, unittest.TestCase):
         return d
 
     def test_setup_check_version_bad(self):
+        if self.db_url == 'sqlite://':
+            raise unittest.SkipTest(
+                'sqlite in-memory model is always upgraded at connection')
         d = self.startService(check_version=True)
         return self.assertFailure(d, exceptions.DatabaseNotReadyError)
 


### PR DESCRIPTION
When using an in-memory sqlite database (`db_url='sqlite://'`), everything is reset at each process restart. This causes the following error:

```
Setting up database with URL 'sqlite:'
The Buildmaster database needs to be upgraded before this version of
buildbot can run.  Use the following command-line

    buildbot upgrade-master ...

to upgrade the database, and try starting the buildmaster again.  You may
want to make a backup of your buildmaster before doing so.
```

Since there is no data persistence, the upgrade-master command would work but everything would be lost when restarting the server.

Handle this special case and initialize the db model at database connection to allow startup to continue.

See the following links for more details:

https://sqlite.org/inmemorydb.html
http://docs.sqlalchemy.org/en/latest/core/engines.html#sqlite