### PR TITLE
Make UserPasswordAuth string casting aware of lists

### DIFF
--- a/master/buildbot/newsfragments/auth_regression.bugfix
+++ b/master/buildbot/newsfragments/auth_regression.bugfix
@@ -1,0 +1,1 @@
+Fixed a regression inn ``UserPasswordAuth`` where a list would create an error.

--- a/master/buildbot/test/unit/test_www_auth.py
+++ b/master/buildbot/test/unit/test_www_auth.py
@@ -176,6 +176,13 @@ class UserPasswordAuth(www.WwwTestMixin, unittest.TestCase):
         self.auth = auth.UserPasswordAuth(login)
         self.assertEqual(self.auth.checkers[0].users, correct_login)
 
+        login = [("user_string", "password"),
+                 ("user_bytes", b"password")]
+        correct_login = {b"user_string": b"password",
+                         b"user_bytes": b"password"}
+        self.auth = auth.UserPasswordAuth(login)
+        self.assertEqual(self.auth.checkers[0].users, correct_login)
+
 
 class LoginResource(www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
 

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -171,8 +171,10 @@ class HTPasswdAuth(TwistedICredAuthBase):
 class UserPasswordAuth(TwistedICredAuthBase):
 
     def __init__(self, users, **kwargs):
-        for user, password in users.items():
-            users[user] = unicode2bytes(password)
+        if isinstance(users, dict):
+            users = {user: unicode2bytes(pw) for user, pw in users.items()}
+        elif isinstance(users, list):
+            users = [(user, unicode2bytes(pw)) for user, pw in users]
         TwistedICredAuthBase.__init__(
             self,
             [DigestCredentialFactory(b"md5", b"buildbot"),


### PR DESCRIPTION
Signed-off-by: Morten Linderud <morten@linderud.pw>

Fixes a regression introduced inn #3295 (#3334) where it wouldn't accept lists with tuples


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
