### PR TITLE
cleanup reclaim and unclaimexpire

### DIFF
--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -207,13 +207,6 @@ class BuildRequest(base.ResourceType):
                                         _reactor=_reactor)
 
     @base.updateMethod
-    def reclaimBuildRequests(self, brids, _reactor=reactor):
-        return self.callDbBuildRequests(brids,
-                                        self.master.db.buildrequests.reclaimBuildRequests,
-                                        event="update",
-                                        _reactor=_reactor)
-
-    @base.updateMethod
     @defer.inlineCallbacks
     def unclaimBuildRequests(self, brids):
         if brids:
@@ -255,11 +248,6 @@ class BuildRequest(base.ResourceType):
                 yield self.master.data.updates.maybeBuildsetComplete(bsid)
 
         defer.returnValue(True)
-
-    @base.updateMethod
-    @defer.inlineCallbacks
-    def unclaimExpiredRequests(self, old, _reactor=reactor):
-        yield self.master.db.buildrequests.unclaimExpiredRequests(old, _reactor=_reactor)
 
     @base.updateMethod
     @defer.inlineCallbacks

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -73,10 +73,6 @@ class LogRotation(object):
 class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
                   WorkerAPICompatMixin):
 
-    # frequency with which to reclaim running builds; this should be set to
-    # something fairly long, to avoid undue database load
-    RECLAIM_BUILD_INTERVAL = 10 * 60
-
     # multiplier on RECLAIM_BUILD_INTERVAL at which a build is considered
     # unclaimed; this should be at least 2 to avoid false positives
     UNCLAIMED_BUILD_FACTOR = 6

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -20,7 +20,6 @@ from future.utils import string_types
 import warnings
 import weakref
 
-from twisted.application import internet
 from twisted.application import service
 from twisted.internet import defer
 from twisted.python import log

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -64,7 +64,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
         warnings.warn("'Builder.expectations' is deprecated.")
         return None
 
-    def __init__(self, name, _addServices=True):
+    def __init__(self, name):
         service.MultiService.__init__(self)
         self.name = name
 
@@ -89,23 +89,6 @@ class Builder(util_service.ReconfigurableServiceMixin,
 
         self.config = None
         self.builder_status = None
-
-        if _addServices:
-            self.reclaim_svc = internet.TimerService(10 * 60,
-                                                     self.reclaimAllBuilds)
-            self.reclaim_svc.setServiceParent(self)
-
-            # update big status every 30 minutes, working around #1980
-            self.updateStatusService = internet.TimerService(30 * 60,
-                                                             self.updateBigStatus)
-            self.updateStatusService.setServiceParent(self)
-
-    def setServiceParent(self, parent):
-        # botmaster needs to set before setServiceParent which calls
-        # startService
-        for child in [self.reclaim_svc, self.updateStatusService]:
-            child.clock = parent.master.reactor
-        return service.MultiService.setServiceParent(self, parent)
 
     @defer.inlineCallbacks
     def reconfigServiceWithBuildbotConfig(self, new_config):
@@ -186,20 +169,6 @@ class Builder(util_service.ReconfigurableServiceMixin,
         else:
             defer.returnValue(None)
 
-    def reclaimAllBuilds(self):
-        brids = set()
-        for b in self.building:
-            brids.update([br.id for br in b.requests])
-        for b in self.old_building:
-            brids.update([br.id for br in b.requests])
-
-        if not brids:
-            return defer.succeed(None)
-
-        d = self.master.data.updates.reclaimBuildRequests(list(brids))
-        d.addErrback(log.err, 'while re-claiming running BuildRequests')
-        return d
-
     def getBuild(self, number):
         for b in self.building:
             if b.build_status and b.build_status.number == number:
@@ -260,8 +229,6 @@ class Builder(util_service.ReconfigurableServiceMixin,
         self.attaching_workers.remove(wfb)
         self.workers.append(wfb)
 
-        self.updateBigStatus()
-
         return self
 
     def _not_attached(self, why, worker):
@@ -290,22 +257,6 @@ class Builder(util_service.ReconfigurableServiceMixin,
 
         # inform the WorkerForBuilder that their worker went away
         wfb.detached()
-        self.updateBigStatus()
-
-    def updateBigStatus(self):
-        try:
-            # Catch exceptions here, since this is called in a LoopingCall.
-            if not self.builder_status:
-                return
-            if not self.workers:
-                self.builder_status.setBigState("offline")
-            elif self.building or self.old_building:
-                self.builder_status.setBigState("building")
-            else:
-                self.builder_status.setBigState("idle")
-        except Exception:
-            log.err(
-                None, "while trying to update status of builder '%s'" % (self.name,))
 
     def getAvailableWorkers(self):
         return [wfb for wfb in self.workers if wfb.isAvailable()]
@@ -338,9 +289,6 @@ class Builder(util_service.ReconfigurableServiceMixin,
 
         # append the build to self.building
         self.building.append(build)
-
-        # update the big status accordingly
-        self.updateBigStatus()
 
         # The worker is ready to go. workerforbuilder.buildStarted() sets its
         # state to BUILDING (so we won't try to use it for any other builds).
@@ -408,8 +356,6 @@ class Builder(util_service.ReconfigurableServiceMixin,
 
         if wfb.worker:
             wfb.worker.releaseLocks()
-
-        self.updateBigStatus()
 
     def _resubmit_buildreqs(self, build):
         brids = [br.id for br in build.requests]

--- a/master/buildbot/spec/types/buildrequest.raml
+++ b/master/buildbot/spec/types/buildrequest.raml
@@ -20,14 +20,6 @@ description: |
 
             Claim a list of buildrequests
 
-        .. py:method:: reclaimBuildRequests(brids, _reactor=twisted.internet.reactor)
-
-            :param list(integer) brids: list of buildrequest id to reclaim
-            :param twisted.internet.interfaces.IReactorTime _reactor: reactor used to get current time
-            :returns: (boolean) whether reclaim succeeded or not
-
-            Reclaim a list of buildrequests
-
         .. py:method:: unclaimBuildRequests(brids)
 
             :param list(integer) brids: list of buildrequest id to unclaim
@@ -42,14 +34,6 @@ description: |
             :param twisted.internet.interfaces.IReactorTime _reactor: reactor used to get current time, if ``complete_at`` is None
 
             Complete a list of buildrequest with the ``results`` status
-
-        .. py:method:: unclaimExpiredRequests(old, _reactor=twisted.internet.reactor)
-
-            :param integer old: time in seconds considered for getting unclaimed buildrequests
-            :param twisted.internet.interfaces.IReactorTime _reactor: reactor used to get current time
-
-            Unclaim the previously claimed buildrequests that are older than ``old`` seconds
-            and that were never completed
 
 properties:
     buildrequestid:

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -197,21 +197,6 @@ class FakeUpdates(service.AsyncService):
         defer.returnValue(True)
 
     @defer.inlineCallbacks
-    def reclaimBuildRequests(self, brids, _reactor=reactor):
-        validation.verifyType(self.testcase, 'brids', brids,
-                              validation.ListValidator(validation.IntValidator()))
-        if not brids:
-            defer.returnValue(True)
-            return
-        try:
-            yield self.master.db.buildrequests.reclaimBuildRequests(
-                brids=brids, _reactor=_reactor)
-        except AlreadyClaimedError:
-            defer.returnValue(False)
-        self.claimedBuildRequests.update(set(brids))
-        defer.returnValue(True)
-
-    @defer.inlineCallbacks
     def unclaimBuildRequests(self, brids):
         validation.verifyType(self.testcase, 'brids', brids,
                               validation.ListValidator(validation.IntValidator()))
@@ -227,11 +212,6 @@ class FakeUpdates(service.AsyncService):
         validation.verifyType(self.testcase, 'complete_at', complete_at,
                               validation.NoneOk(validation.DateTimeValidator()))
         return defer.succeed(True)
-
-    def unclaimExpiredRequests(self, old, _reactor=reactor):
-        validation.verifyType(
-            self.testcase, "old", old, validation.IntValidator())
-        return defer.succeed(None)
 
     def rebuildBuildrequest(self, buildrequest):
         return defer.succeed(None)

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1790,17 +1790,6 @@ class FakeBuildRequestsComponent(FakeDBComponent):
                                                   masterid=self.MASTER_ID, claimed_at=claimed_at)
         return defer.succeed(None)
 
-    def reclaimBuildRequests(self, brids, _reactor):
-        for brid in brids:
-            if brid in self.claims and self.claims[brid].masterid != self.db.master.masterid:
-                raise buildrequests.AlreadyClaimedError
-
-        # now that we've thrown any necessary exceptions, get started
-        for brid in brids:
-            self.claims[brid] = BuildRequestClaim(brid=brid,
-                                                  masterid=self.MASTER_ID, claimed_at=_reactor.seconds())
-        return defer.succeed(None)
-
     def unclaimBuildRequests(self, brids):
         for brid in brids:
             if brid in self.claims and self.claims[brid].masterid == self.db.master.masterid:
@@ -1822,17 +1811,6 @@ class FakeBuildRequestsComponent(FakeDBComponent):
             self.reqs[brid].results = results
             self.reqs[brid].complete_at = complete_at
         return defer.succeed(None)
-
-    def unclaimExpiredRequests(self, old, _reactor=reactor):
-        old_epoch = _reactor.seconds() - old
-
-        for br in itervalues(self.reqs):
-            if br.complete == 1:
-                continue
-
-            claim_row = self.claims.get(br.id)
-            if claim_row and claim_row.claimed_at < old_epoch:
-                del self.claims[br.id]
 
     def _brdictFromRow(self, row):
         return buildrequests.BuildRequestsConnectorComponent._brdictFromRow(row, self.MASTER_ID)

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -165,7 +165,7 @@ class RunSteps(unittest.TestCase):
         self.master.db.insertTestData([
             fakedb.Builder(id=80, name='test'), ])
 
-        self.builder = builder.Builder('test', _addServices=False)
+        self.builder = builder.Builder('test')
         self.builder._builderid = 80
         self.builder.master = self.master
         yield self.builder.startService()

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -55,7 +55,7 @@ class BuilderMixin(object):
         config_args.update(config_kwargs)
         self.builder_config = config.BuilderConfig(**config_args)
         self.bldr = builder.Builder(
-            self.builder_config.name, _addServices=False)
+            self.builder_config.name)
         self.bldr.master = self.master
         self.bldr.botmaster = self.master.botmaster
 
@@ -215,35 +215,6 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
     # other methods
 
     @defer.inlineCallbacks
-    def test_reclaimAllBuilds_empty(self):
-        yield self.makeBuilder()
-
-        # just to be sure this doesn't crash
-        yield self.bldr.reclaimAllBuilds()
-
-    @defer.inlineCallbacks
-    def test_reclaimAllBuilds(self):
-        yield self.makeBuilder()
-
-        def mkbld(brids):
-            bld = mock.Mock(name='Build')
-            bld.requests = []
-            for brid in brids:
-                br = mock.Mock(name='BuildRequest %d' % brid)
-                br.id = brid
-                bld.requests.append(br)
-            return bld
-
-        old = mkbld([15])  # keep a reference to the "old" build
-        self.bldr.old_building[old] = None
-        self.bldr.building.append(mkbld([10, 11, 12]))
-
-        yield self.bldr.reclaimAllBuilds()
-
-        self.assertEqual(self.master.data.updates.claimedBuildRequests,
-                         set([10, 11, 12, 15]))
-
-    @defer.inlineCallbacks
     def test_canStartBuild(self):
         yield self.makeBuilder()
 
@@ -325,7 +296,7 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
         self.factory = factory.BuildFactory()
         self.master = fakemaster.make_master(testcase=self, wantData=True)
         # only include the necessary required config, plus user-requested
-        self.bldr = builder.Builder('bldr', _addServices=False)
+        self.bldr = builder.Builder('bldr')
         self.bldr.master = self.master
         self.master.data.updates.findBuilderId = fbi = mock.Mock()
         fbi.return_value = defer.succeed(13)
@@ -348,7 +319,7 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
         self.assertIdentical(deprecated, builder.enforceChosenWorker)
 
     def test_attaching_workers_old_api(self):
-        bldr = builder.Builder('bldr', _addServices=False)
+        bldr = builder.Builder('bldr')
 
         with assertNotProducesWarnings(DeprecatedWorkerAPIWarning):
             new = bldr.attaching_workers
@@ -361,7 +332,7 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
         self.assertIdentical(new, old)
 
     def test_workers_old_api(self):
-        bldr = builder.Builder('bldr', _addServices=False)
+        bldr = builder.Builder('bldr')
 
         with assertNotProducesWarnings(DeprecatedWorkerAPIWarning):
             new = bldr.workers
@@ -374,7 +345,7 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
         self.assertIdentical(new, old)
 
     def test_canStartWithWorkerForBuilder_old_api(self):
-        bldr = builder.Builder('bldr', _addServices=False)
+        bldr = builder.Builder('bldr')
         bldr.config = mock.Mock()
         bldr.config.locks = []
 
@@ -388,7 +359,7 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
                 self.assertEqual(dummy, 'dummy')
 
     def test_addLatentWorker_old_api(self):
-        bldr = builder.Builder('bldr', _addServices=False)
+        bldr = builder.Builder('bldr')
 
         with assertProducesWarning(
                 DeprecatedWorkerNameWarning,
@@ -402,7 +373,7 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
                 self.assertTrue(method.called)
 
     def test_getAvailableWorkers_old_api(self):
-        bldr = builder.Builder('bldr', _addServices=False)
+        bldr = builder.Builder('bldr')
 
         with assertProducesWarning(
                 DeprecatedWorkerNameWarning,

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -658,7 +658,7 @@ class TestMaybeStartBuilds(TestBRDBase):
     def test_bldr_maybeStartBuild_fails_always(self):
         self.bldr.config.nextWorker = nth_worker(-1)
         # the builder fails to start the build; we'll see that the build
-        # was requested, but the brids will get reclaimed
+        # was requested, but the brids will get claimed again
 
         def maybeStartBuild(worker, builds):
             self.startedBuilds.append((worker.name, builds))
@@ -673,7 +673,7 @@ class TestMaybeStartBuilds(TestBRDBase):
                                 submitted_at=135000),
         ]
         yield self.do_test_maybeStartBuildsOnBuilder(rows=rows,
-                                                     # reclaimed so none taken!
+                                                     # claimed again so none taken!
                                                      exp_claims=[],
                                                      exp_builds=[
                                                          ('test-worker2', [10]), ('test-worker1', [11])])
@@ -682,7 +682,7 @@ class TestMaybeStartBuilds(TestBRDBase):
     def test_bldr_maybeStartBuild_fails_once(self):
         self.bldr.config.nextWorker = nth_worker(-1)
         # the builder fails to start the build; we'll see that the build
-        # was requested, but the brids will get reclaimed
+        # was requested, but the brids will get claimed again
 
         def maybeStartBuild(worker, builds, _fail=[False]):
             self.startedBuilds.append((worker.name, builds))
@@ -703,7 +703,7 @@ class TestMaybeStartBuilds(TestBRDBase):
 
         # first time around, only #11 stays claimed
         yield self.brd._maybeStartBuildsOnBuilder(self.bldr)
-        self.assertMyClaims([11])  # reclaimed so none taken!
+        self.assertMyClaims([11])  # claimed again so none taken!
         self.assertBuildsStarted(
             [('test-worker2', [10]), ('test-worker1', [11])])
 

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -154,10 +154,6 @@ buildrequests
 
         If ``claimed_at`` is not given, then the current time will be used.
 
-        As of 0.8.5, this method can no longer be used to re-claim build
-        requests.  All given ID's must be unclaimed.  Use
-        :py:meth:`reclaimBuildRequests` to reclaim.
-
         .. index:: single: MySQL; limitations
         .. index:: single: SQLite; limitations
 
@@ -168,20 +164,6 @@ buildrequests
             transactions (MySQL), this method will not properly roll back any
             partial claims made before an :py:exc:`AlreadyClaimedError` is
             generated.
-
-    .. py:method:: reclaimBuildRequests(brids)
-
-        :param brids: ids of buildrequests to reclaim
-        :type brids: list
-        :returns: Deferred
-        :raises: :py:exc:`AlreadyClaimedError`
-
-        Re-claim the given build requests, updating the timestamp, but checking
-        that the requests are owned by this master.  The resulting deferred will
-        fire normally on success, or fail with :py:exc:`AlreadyClaimedError` if
-        *any* of the build requests are already claimed by another master
-        instance, or don't exist.  In this case, none of the reclaims will take
-        effect.
 
     .. py:method:: unclaimBuildRequests(brids)
 
@@ -208,19 +190,6 @@ buildrequests
         instance.  This will fail with :py:exc:`NotClaimedError` if the build
         request is already completed or does not exist.  If ``complete_at`` is
         not given, the current time will be used.
-
-    .. py:method:: unclaimExpiredRequests(old)
-
-        :param old: number of seconds after which a claim is considered old
-        :type old: int
-        :returns: Deferred
-
-        Find any incomplete claimed builds which are older than ``old``
-        seconds, and clear their claim information.
-
-        This is intended to catch builds that were claimed by a master which
-        has since disappeared.  As a side effect, it will log a message if any
-        requests are unclaimed.
 
 builds
 ~~~~~~


### PR DESCRIPTION
This is not needed anymore in nine, as we now have master expiration, which does the same thing

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
