### PR TITLE
Restrict Twisted version to < 16.0

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -439,7 +439,7 @@ if 'a' in version or 'b' in version:
 if sys.version_info[0] >= 3:
     twisted_ver = ">= 17.5.0"
 else:
-    twisted_ver = ">= 14.0.1"
+    twisted_ver = ">= 14.0.1, <16.0"
 autobahn_ver = ">= 0.16.0"
 txaio_ver = ">= 2.2.2"
 


### PR DESCRIPTION
This should fix #3160, at least until Buildbot is updated to use the new Manhole API in Conch.

* https://irclogs.jackgrigg.com/irc.freenode.net/buildbot/2017-04-28
* https://stackoverflow.com/a/40870636/6461688
* https://twistedmatrix.com/trac/ticket/8229

## Contributor Checklist:

* [x] ~~I have updated the unit tests~~ N/A
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
