### PR TITLE
Add basic authentication to BitbucketPullrequestPoller

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -37,7 +37,7 @@ from buildbot.util import epoch2datetime
 
 class BitbucketPullrequestPoller(base.PollingChangeSource):
 
-    compare_attrs = ("owner", "slug", "branch",
+    compare_attrs = ("owner", "slug", "branches",
                      "pollInterval", "useTimestamps",
                      "category", "project", "pollAtLaunch",
                      "username", "app_password")
@@ -45,7 +45,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
     db_class_name = 'BitbucketPullrequestPoller'
 
     def __init__(self, owner, slug,
-                 branch=None,
+                 branches=None,
                  pollInterval=10 * 60,
                  useTimestamps=True,
                  category=None,
@@ -59,7 +59,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
         self.agent = Agent(reactor)
         self.owner = owner
         self.slug = slug
-        self.branch = branch
+        self.branches = branches
         self.username = username
         self.app_password = app_password
         base.PollingChangeSource.__init__(
@@ -81,8 +81,8 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
 
     def describe(self):
         return "BitbucketPullrequestPoller watching the "\
-            "Bitbucket repository %s/%s, branch: %s" % (
-                self.owner, self.slug, self.branch)
+            "Bitbucket repository %s/%s, branches: %s" % (
+                self.owner, self.slug, self.branches)
 
     @deferredLocked('initLock')
     def poll(self):
@@ -94,7 +94,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
     def _getChanges(self):
         self.lastPoll = time.time()
         log.msg("BitbucketPullrequestPoller: polling "
-                "Bitbucket repository %s/%s, branch: %s" % (self.owner, self.slug, self.branch))
+                "Bitbucket repository %s/%s, branches: %s" % (self.owner, self.slug, self.branches))
         url = "https://bitbucket.org/api/2.0/repositories/%s/%s/pullrequests" % (
             self.owner, self.slug)
         return self._getPage(url)
@@ -113,7 +113,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
             revision = pr['source']['commit']['hash']
 
             # check branch
-            if not self.branch or branch in self.branch:
+            if not self.branches or branch in self.branches:
                 current = yield self._getCurrentRev(nr)
 
                 # compare _short_ hashes to check if the PR has been updated
@@ -206,7 +206,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
     def _getStateObjectId(self):
         # Return a deferred for object id in state db.
         return self.master.db.state.getObjectId(
-            '%s/%s#%s' % (self.owner, self.slug, self.branch), self.db_class_name)
+            '%s/%s#%s' % (self.owner, self.slug, self.branches), self.db_class_name)
 
     def _getPage(self, url):
         headers = None

--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -163,7 +163,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
                         comments=u'pull-request #%d: %s\n%s' % (
                             nr, title, prlink),
                         when_timestamp=datetime2epoch(updated),
-                        branch=self.branch,
+                        branch=ascii2unicode(branch),
                         category=self.category,
                         project=self.project,
                         repository=ascii2unicode(repo),

--- a/master/buildbot/newsfragments/bitbucketpullrequestpoller.bugfix
+++ b/master/buildbot/newsfragments/bitbucketpullrequestpoller.bugfix
@@ -1,0 +1,1 @@
+Added basic authentication to ``BitbucketPullrequestPoller``

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -974,6 +974,17 @@ The :bb:chsrc:`BitbucketPullrequestPoller` accepts the following arguments:
     Set encoding will be used to parse author's name and commit message.
     Default encoding is ``'utf-8'``.
 
+``username``
+    The username to authenticate with. This, together with app_password, allows the poller to access private repositories.
+
+``app_password``
+    The application password to authenticate with. This, together with username, allows the poller to access private repositories.
+    This is sent via basic HTTP(S) authentication.
+    To enable this, you need to go to your Bitbucket Settings -> App passwords.
+    Click "Create app password".
+    Give the new password a label, eg 'buildbot'.
+    Give the consumer Pull requests:Read access at least.
+
 A minimal configuration for the Bitbucket pull request poller might look like this:
 
 .. code-block:: python

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -941,7 +941,7 @@ The :bb:chsrc:`BitbucketPullrequestPoller` accepts the following arguments:
 ``slug``
     The name of the Bitbucket repository.
 
-``branch``
+``branches``
     A single branch or a list of branches which should be processed.
     If it is ``None`` (the default) all pull requests are used.
 


### PR DESCRIPTION
BitbucketPullrequestPoller was returning PRs for public repositories, but had no way of returning the private ones.
One way to do this is with OAuth2, but the easiest way is with an application password and the `Authorization` header.
In order to work correctly with HTTPS I had to change `client.getPage` for `agent.request`, as the former is [deprecated](https://twistedmatrix.com/trac/ticket/8960#ticket).

This PR also includes adding the correct branch info in the change.

## Unit tests and checkers
Most of the checkers failed with things unrelated to this PR:
* `flake8 --config=common/flake8rc` returned 47396 errors, but none from `bitbucket.py`
* `pylint --rcfile common/pylintrc buildbot worker` returned one error:

> Traceback (most recent call last):
>   File "/Users/vguzman/Development/fluendo-buildbot/buildbot-env/bin/pylint", line 11, in <module>
>     sys.exit(run_pylint())
>   File "/Users/vguzman/Development/fluendo-buildbot/buildbot-env/lib/python2.7/site-packages/pylint/__init__.py", line 13, in run_pylint
>     Run(sys.argv[1:])
>   File "/Users/vguzman/Development/fluendo-buildbot/buildbot-env/lib/python2.7/site-packages/pylint/lint.py", line 1268, in __init__
>     linter.load_config_file()
>   File "/Users/vguzman/Development/fluendo-buildbot/buildbot-env/lib/python2.7/site-packages/pylint/config.py", line 654, in load_config_file
>     self.global_set_option(option, value)
>   File "/Users/vguzman/Development/fluendo-buildbot/buildbot-env/lib/python2.7/site-packages/pylint/config.py", line 560, in global_set_option
>     self._all_options[opt].set_option(opt, value)
>   File "/Users/vguzman/Development/fluendo-buildbot/buildbot-env/lib/python2.7/site-packages/pylint/config.py", line 744, in set_option
>     value = _validate(value, optdict, optname)
>   File "/Users/vguzman/Development/fluendo-buildbot/buildbot-env/lib/python2.7/site-packages/pylint/config.py", line 217, in _validate
>     return _call_validator(_type, optdict, name, value)
>   File "/Users/vguzman/Development/fluendo-buildbot/buildbot-env/lib/python2.7/site-packages/pylint/config.py", line 198, in _call_validator
>     return VALIDATORS[opttype](optdict, option, value)
>   File "/Users/vguzman/Development/fluendo-buildbot/buildbot-env/lib/python2.7/site-packages/pylint/config.py", line 188, in <lambda>
>     'choice': lambda opt, name, value: _choice_validator(opt['choices'], name, value),
>   File "/Users/vguzman/Development/fluendo-buildbot/buildbot-env/lib/python2.7/site-packages/pylint/config.py", line 145, in _choice_validator
>     raise optparse.OptionValueError(msg % (name, value, choices))
> optparse.OptionValueError: option spelling-dict: invalid value: u'en_US', should be in ['']

In addition, trying to run the test that existed already (test_changes_bitbucket.py) with `$ trial master/buildbot/test/unit/test_changes_bitbucket.py ` returned `exceptions.ImportError: No module named test.util`

## Contributor Checklist:

* [] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
