### PR TITLE
Render secrets during service reconfiguration

### DIFF
--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -454,6 +454,29 @@ class _SecretRenderer(object):
         defer.returnValue(secret_detail.value)
 
 
+class Secret(_SecretRenderer):
+
+    def __repr__(self):
+        return "Secret({0})".format(self.secretKey)
+
+    def __init__(self, secretKey):
+        self.secretKey = secretKey
+
+    @defer.inlineCallbacks
+    def getRenderingFor(self, master):
+        secretsSrv = master.namedServices.get("secrets")
+        if not secretsSrv:
+            error_message = "secrets service not started, need to configure" \
+                            " SecretManager in c['services'] to use 'secrets'" \
+                            "in Interpolate"
+            raise KeyError(error_message)
+        credsservice = master.namedServices['secrets']
+        secret_detail = yield credsservice.get(self.secretKey)
+        if secret_detail is None:
+            raise KeyError("secret key %s is not found in any provider" % self.secretKey)
+        defer.returnValue(secret_detail.value)
+
+
 class _SecretIndexer(object):
 
     def __contains__(self, password):

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -68,6 +68,17 @@ class Properties(util.ComparableMixin):
         self._used_secrets = {}
         if kwargs:
             self.update(kwargs, "TEST")
+        self._master = None
+
+    @property
+    def master(self):
+        if self.build is not None:
+            return self.build.master
+        return self._master
+
+    @master.setter
+    def master(self, value):
+        self._master = value
 
     @classmethod
     def fromDict(cls, propDict):
@@ -463,14 +474,14 @@ class Secret(_SecretRenderer):
         self.secretKey = secretKey
 
     @defer.inlineCallbacks
-    def getRenderingFor(self, master):
-        secretsSrv = master.namedServices.get("secrets")
+    def getRenderingFor(self, props):
+        secretsSrv = props.master.namedServices.get("secrets")
         if not secretsSrv:
             error_message = "secrets service not started, need to configure" \
                             " SecretManager in c['services'] to use 'secrets'" \
                             "in Interpolate"
             raise KeyError(error_message)
-        credsservice = master.namedServices['secrets']
+        credsservice = props.master.namedServices['secrets']
         secret_detail = yield credsservice.get(self.secretKey)
         if secret_detail is None:
             raise KeyError("secret key %s is not found in any provider" % self.secretKey)

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -93,6 +93,7 @@ class FakeBuild(properties.PropertiesMixin):
         props.build = self
         self.build_status.properties = props
         self.properties = props
+        self.master = None
 
     def getSourceStamp(self, codebase):
         if codebase in self.sources:

--- a/master/buildbot/test/unit/test_secret_rendered_service.py
+++ b/master/buildbot/test/unit/test_secret_rendered_service.py
@@ -1,0 +1,64 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.secrets.manager import SecretManager
+from buildbot.test.fake import fakemaster
+from buildbot.test.fake.fakebuild import FakeBuild
+from buildbot.test.fake.secrets import FakeSecretStorage
+from buildbot.test.util.config import ConfigErrorsMixin
+from buildbot.util.service import BuildbotService
+
+
+class FakeBuildWithMaster(FakeBuild):
+
+    def __init__(self, master):
+        super(FakeBuildWithMaster, self).__init__()
+        self.master = master
+
+
+class FakeServiceUsingSecrets(BuildbotService):
+
+    name = "FakeServiceUsingSecrets"
+    render_secrets = ["secret_to_render"]
+
+    @defer.inlineCallbacks
+    def reconfigService(self, secret):
+        self.secret_to_render = secret
+        yield self.configureService()
+
+    def returnRenderedSecrets(self, secretKey):
+        try:
+            return getattr(self, secretKey)
+        except Exception:
+            raise Exception
+
+
+class TestRenderSecrets(unittest.TestCase):
+
+    def setUp(self):
+        self.master = fakemaster.make_master()
+        fakeStorageService = FakeSecretStorage()
+        fakeStorageService.reconfigService(secretdict={"foo": "bar",
+                                                       "other": "value"})
+        self.secretsrv = SecretManager()
+        self.secretsrv.services = [fakeStorageService]
+        self.secretsrv.setServiceParent(self.master)
+        self.srvtest = FakeServiceUsingSecrets(["foo", "other"])
+        self.srvtest.setServiceParent(self.master)
+
+    @defer.inlineCallbacks
+    def test_secret_rendered(self):
+        yield self.srvtest.reconfigService(["foo", "other"])
+        self.assertEqual("bar", self.srvtest.returnRenderedSecrets("foo"))
+
+    @defer.inlineCallbacks
+    def test_secret_rendered_not_found(self):
+        yield self.assertFailure(self.srvtest.reconfigService(["more"]), KeyError)
+
+    @defer.inlineCallbacks
+    def test_secret_render_no_secretkey(self):
+        yield self.srvtest.reconfigService(["foo", "other"])
+        self.assertRaises(Exception, self.srvtest.returnRenderedSecrets, "more")

--- a/master/buildbot/test/unit/test_secret_rendered_service.py
+++ b/master/buildbot/test/unit/test_secret_rendered_service.py
@@ -14,7 +14,7 @@ from buildbot.util.service import BuildbotService
 class FakeServiceUsingSecrets(BuildbotService):
 
     name = "FakeServiceUsingSecrets"
-    renderables = ["foo", "bar", "secret"]
+    secrets = ["foo", "bar", "secret"]
 
     def reconfigService(self, *args, **kwargs):
         self.kwargs = kwargs

--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -39,6 +39,7 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase):
         self.patch(dockerworker, 'docker', docker)
         worker = dockerworker.DockerLatentWorker(*args, **kwargs)
         master = fakemaster.make_master(testcase=self, wantData=True)
+        fakemaster.master = master
         worker.setServiceParent(master)
         self.successResultOf(master.startService())
         self.addCleanup(master.stopService)

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -28,8 +28,7 @@ from twisted.python import reflect
 from twisted.python.reflect import accumulateClassList
 
 from buildbot import util
-from buildbot.process.properties import PropertiesMixin
-from buildbot.process.properties import Secret
+from buildbot.process.properties import Properties
 from buildbot.util import ascii2unicode
 from buildbot.util import config
 from buildbot.util import unicode2bytes
@@ -193,30 +192,34 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
                 'args': self._config_args,
                 'kwargs': self._config_kwargs}
 
+    @defer.inlineCallbacks
     def reconfigServiceWithSibling(self, sibling):
         # only reconfigure if sibling is configured differently.
         # sibling == self is using ComparableMixin's implementation
         # only compare compare_attrs
         if self.configured and sibling == self:
-            return defer.succeed(None)
+            defer.returnValue(None)
         self.configured = True
-        return self.reconfigService(*sibling._config_args,
-                                    **sibling._config_kwargs)
+        # render renderables in parallel
+        p = Properties()
+        p.master = self.master
+        # render renderables in parallel
+        renderables = []
+        kwargs = {}
+        accumulateClassList(self.__class__, 'renderables', renderables)
+        for k, v in sibling._config_kwargs.items():
+            if k in renderables:
+                value = yield p.render(v)
+                setattr(self, k, value)
+                kwargs.update({k: value})
+            else:
+                kwargs.update({k: v})
+        d = yield self.reconfigService(*sibling._config_args,
+                                       **sibling._config_kwargs)
+        defer.returnValue(d)
 
     @defer.inlineCallbacks
     def configureService(self):
-        # render renderables in parallel
-        render_secrets = []
-        accumulateClassList(self.__class__, 'render_secrets', render_secrets)
-
-        def setRenderableSecret(res, attr):
-            setattr(self, attr, res)
-
-        for r_secret in render_secrets:
-            for secretkey in getattr(self, r_secret):
-                res_value = yield Secret(secretkey).getRenderingFor(self.master)
-                setRenderableSecret(res_value, secretkey)
-        self.rendered = True
         # reconfigServiceWithSibling with self, means first configuration
         d = yield self.reconfigServiceWithSibling(self)
         defer.returnValue(d)

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -28,7 +28,6 @@ from twisted.python import reflect
 from twisted.python.reflect import accumulateClassList
 
 from buildbot import util
-from buildbot.process.properties import Properties
 from buildbot.util import ascii2unicode
 from buildbot.util import config
 from buildbot.util import unicode2bytes
@@ -201,6 +200,8 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
             defer.returnValue(None)
         self.configured = True
         # render renderables in parallel
+        # Properties import to resolve cyclic import issue
+        from buildbot.process.properties import Properties
         p = Properties()
         p.master = self.master
         # render renderables in parallel

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -205,11 +205,11 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
         p = Properties()
         p.master = self.master
         # render renderables in parallel
-        renderables = []
+        secrets = []
         kwargs = {}
-        accumulateClassList(self.__class__, 'renderables', renderables)
+        accumulateClassList(self.__class__, 'secrets', secrets)
         for k, v in sibling._config_kwargs.items():
-            if k in renderables:
+            if k in secrets:
                 value = yield p.render(v)
                 setattr(self, k, value)
                 kwargs.update({k: value})
@@ -219,11 +219,9 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
                                        **sibling._config_kwargs)
         defer.returnValue(d)
 
-    @defer.inlineCallbacks
     def configureService(self):
         # reconfigServiceWithSibling with self, means first configuration
-        d = yield self.reconfigServiceWithSibling(self)
-        defer.returnValue(d)
+        return self.reconfigServiceWithSibling(self)
 
     @defer.inlineCallbacks
     def startService(self):


### PR DESCRIPTION
Secret is rendered when the service reconfig function is called like renderables are during build start.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
