### PR TITLE
_wait_for_request() should be using request_status

### DIFF
--- a/master/buildbot/newsfragments/ec2_wait_for_request.bugfix
+++ b/master/buildbot/newsfragments/ec2_wait_for_request.bugfix
@@ -1,0 +1,1 @@
+_wait_for_request() would fail to format a log statement due to an invalid type being passed to log.msg (resulting in a broken build)

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -593,10 +593,10 @@ class EC2LatentWorker(AbstractLatentWorker):
             log.msg('%s %s spot request rejected, spot price too low' %
                     (self.__class__.__name__, self.workername))
             raise LatentWorkerFailedToSubstantiate(
-                request['SpotInstanceRequestId'], request.status)
+                request['SpotInstanceRequestId'], request_status)
         else:
             log.msg('%s %s failed to fulfill spot request %s with status %s' %
                     (self.__class__.__name__, self.workername,
                      request['SpotInstanceRequestId'], request_status))
             raise LatentWorkerFailedToSubstantiate(
-                request['SpotInstanceRequestId'], request.status)
+                request['SpotInstanceRequestId'], request_status)


### PR DESCRIPTION
_wait_for_request() is using request.status when it should be
using request_status instead. Otherwise an error will be raised
when the log message attempts to format request.status.

## Contributor Checklist:

* [x] I have updated the unit tests (nothing to update)
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
