### PR TITLE
Make gulp "processindex" command work under Windows

### DIFF
--- a/master/buildbot/newsfragments/README.txt
+++ b/master/buildbot/newsfragments/README.txt
@@ -1,5 +1,7 @@
 This is the directory for news fragments used by towncrier: https://github.com/hawkowl/towncrier
 
+You create a news fragment in this directory when you make a change, and the file gets removed from this directory when the news is published.
+
 towncrier has a few standard types of news fragments, signified by the file extension. These are:
 
 .feature: Signifying a new feature.

--- a/master/buildbot/newsfragments/gulp_processindex_windows.bugfix
+++ b/master/buildbot/newsfragments/gulp_processindex_windows.bugfix
@@ -1,0 +1,1 @@
+Make gulp "processindex" command work under Windows (was failing due to single-quoted file path on command line)

--- a/master/buildbot/newsfragments/gulp_processindex_windows.bugfix
+++ b/master/buildbot/newsfragments/gulp_processindex_windows.bugfix
@@ -1,1 +1,1 @@
-Make gulp "processindex" command work under Windows (was failing due to single-quoted file path on command line).
+     Fix Windows compatibility with frontend development tool ``gulp dev proxy`` (:issue:`3359`)

--- a/master/buildbot/newsfragments/gulp_processindex_windows.bugfix
+++ b/master/buildbot/newsfragments/gulp_processindex_windows.bugfix
@@ -1,1 +1,1 @@
-Make gulp "processindex" command work under Windows (was failing due to single-quoted file path on command line)
+Make gulp "processindex" command work under Windows (was failing due to single-quoted file path on command line).

--- a/www/base/guanlecoja/config.coffee
+++ b/www/base/guanlecoja/config.coffee
@@ -59,7 +59,7 @@ config =
 gulp.task 'processindex', ['index'], ->
     indexpath = path.join(config.dir.build, 'index.html')
     gulp.src ""
-        .pipe shell("buildbot processwwwindex -i '#{indexpath}'")
+        .pipe shell("buildbot processwwwindex -i \"#{indexpath}\"")
 
 gulp.task 'proxy', ['processindex'], ->
     # this is a task for developing, it proxy api request to http://nine.buildbot.net


### PR DESCRIPTION
ProcessIndex command was using single quotes around the index.html file
path, need double quotes to work on Windows.   Tested double quotes
under Ubuntu and still worked there.

## Contributor Checklist:

* [N/A -- if someone had ever run this under windows, it would have caught the problem] I have updated the unit tests
* [ YES ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [N/A -- was not documented to begin with] I have updated the appropriate documentation
