### PR TITLE
Fix 'referenced before assignment' error

### DIFF
--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -192,6 +192,7 @@ class Trigger(BuildStep):
     @defer.inlineCallbacks
     def worstStatus(self, overall_results, rclist, unimportant_brids):
         for was_cb, results in rclist:
+            brids_dict = {}
             if isinstance(results, tuple):
                 results, brids_dict = results
 


### PR DESCRIPTION
When I interrupted a build triggered by Trigger step and it was waiting for available worker
I have got the following traceback:
```
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 588, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 1184, in gotResult
    _inlineCallbacks(r, g, deferred)
  File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 1126, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/usr/lib64/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
--- <exception caught here> ---
  File "/usr/lib/python2.7/site-packages/buildbot/process/buildstep.py", line 572, in startStep
    self.results = yield self.run()
  File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 1126, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/usr/lib64/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/usr/lib/python2.7/site-packages/buildbot/steps/trigger.py", line 311, in run
    results = yield self.worstStatus(results, rclist, unimportant_brids)
  File "/usr/lib64/python2.7/site-packages/twisted/internet/defer.py", line 1128, in _inlineCallbacks
    result = g.send(result)
  File "/usr/lib/python2.7/site-packages/buildbot/steps/trigger.py", line 205, in worstStatus
    if set(unimportant_brids).issuperset(set(brids_dict.values())):
exceptions.UnboundLocalError: local variable 'brids_dict' referenced before assignment
```

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation