### PR TITLE
EC2LatentSlave: spot request state bugfixes and adding tag support

### DIFF
--- a/master/buildbot/newsfragments/ec2_latent_worker.bugfix
+++ b/master/buildbot/newsfragments/ec2_latent_worker.bugfix
@@ -1,0 +1,3 @@
+_wait_for_request() would fail to format a log statement due to an invalid type being passed to log.msg (resulting in a broken build)
+_wait_for_request() could leave a spot request open if it entered the capacity-oversubscribed or capacity-not-available states
+Tags are now applies to spot instances too

--- a/master/buildbot/newsfragments/ec2_wait_for_request.bugfix
+++ b/master/buildbot/newsfragments/ec2_wait_for_request.bugfix
@@ -1,1 +1,0 @@
-_wait_for_request() would fail to format a log statement due to an invalid type being passed to log.msg (resulting in a broken build)


### PR DESCRIPTION
This PR makes a couple of minor bugfixes:

*  Ensure that if the spot request enters the `capacity-not-available` or `capacity-oversubscribed` states that the request is closed by `_wait_for_request()`. The master would already skip to the next worker but it wouldn't close the spot request (which won't expire and counts against a region level limit)
* Create a `_tag_instance()` function and call this for both on demand and spot instances.  Previously spot instances didn't receive tags passed to `__init__()`.

## Contributor Checklist:

* [x] I have updated the unit tests (nothing to update)
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
