### PR TITLE
[WIP] logviewer: add more control on the scroll position

### DIFF
--- a/www/base/src/app/builders/log/log.controller.coffee
+++ b/www/base/src/app/builders/log/log.controller.coffee
@@ -1,18 +1,21 @@
 class Log extends Controller
     constructor: ($scope, dataService, dataUtilsService, $stateParams, glBreadcrumbService) ->
         data = dataService.open().closeOnDestroy($scope)
+        $scope.jumpToLine = "end"
+        if $stateParams.jump_to_line?
+            $scope.jumpToLine = $stateParams.jump_to_line
         builderid = dataUtilsService.numberOrString($stateParams.builder)
         buildnumber = dataUtilsService.numberOrString($stateParams.build)
         stepnumber = dataUtilsService.numberOrString($stateParams.step)
         slug = $stateParams.log
-        data.getBuilders(builderid).then (builders) ->
-            $scope.builder = builder = builders[0]
-            builder.getBuilds(buildnumber).then (builds) ->
-                $scope.build = build = builds[0]
-                build.getSteps(stepnumber).then (steps) ->
-                    $scope.step = step = steps[0]
-                    step.getLogs(slug).then (logs) ->
-                        $scope.log = log = logs[0]
+        data.getBuilders(builderid).onNew = (builder) ->
+            $scope.builder = builder = builder
+            builder.getBuilds(buildnumber).onNew = (build) ->
+                $scope.build = build
+                build.getSteps(stepnumber).onNew = (step) ->
+                    $scope.step = step
+                    step.getLogs(slug).onNew = (log) ->
+                        $scope.log = log
                         glBreadcrumbService.setBreadcrumb [
                                 caption: "Builders"
                                 sref: "builders"

--- a/www/base/src/app/builders/log/log.route.coffee
+++ b/www/base/src/app/builders/log/log.route.coffee
@@ -14,7 +14,7 @@ class State extends Config
             controller: "#{name}Controller"
             templateUrl: "views/#{name}.html"
             name: name
-            url: '/builders/:builder/builds/:build/steps/:step/logs/:log'
+            url: '/builders/:builder/builds/:build/steps/:step/logs/:log?jump_to_line'
             data: cfg
 
         $stateProvider.state(state)

--- a/www/base/src/app/builders/log/log.tpl.jade
+++ b/www/base/src/app/builders/log/log.tpl.jade
@@ -1,1 +1,1 @@
-logviewer(log="log")
+logviewer(log="log", jump-to-line="jumpToLine")

--- a/www/base/src/app/builders/log/logviewer/logviewer.directive.coffee
+++ b/www/base/src/app/builders/log/logviewer/logviewer.directive.coffee
@@ -6,9 +6,14 @@ class Logviewer extends Directive
         directive = ->
             data = null
             self =
-            num_lines: 0
-            auto_scroll: true
 
+            toggleAutoScroll: ->
+                if self.scope.jumpToLine == "end"
+                    self.scope.jumpToLine = "none"
+                    self.scope.scroll_position = null
+                else
+                    self.scope.jumpToLine = "end"
+                    self.scope.scroll_position = self.scope.log.num_lines
             setHeight: (elm) ->
                 height = $window.height() - elm.offset().top
                 elm.css({height: height + "px"})
@@ -22,6 +27,11 @@ class Logviewer extends Directive
                         if log.type == 'h'
                             restService.get("logs/#{log.logid}/contents").then (content) ->
                                 self.scope.content = $sce.trustAs($sce.HTML, content.logchunks[0].content)
+                self.scope.$watch "log.num_lines", (n, o) ->
+                    if self.scope.jumpToLine == "end"
+                        self.scope.scroll_position = n
+                    else if self.scope.jumpToLine != "none"
+                        self.scope.scroll_position = self.scope.jumpToLine
 
             lines:
                 get: (index, count) ->
@@ -78,7 +88,7 @@ class Logviewer extends Directive
             replace: true
             transclude: true
             restrict: 'E'
-            scope: {log:"="}
+            scope: {log:"=", jumpToLine:"="}
             templateUrl: "views/logviewer.html"
             controller: ["$scope", ($scope) ->
                 self = directive()

--- a/www/base/src/app/builders/log/logviewer/logviewer.tpl.jade
+++ b/www/base/src/app/builders/log/logviewer/logviewer.tpl.jade
@@ -1,5 +1,7 @@
 .container.logcontainer
   .row.logoptions
+    a.btn.btn-default(title="scroll to end", ng-click="logviewer.toggleAutoScroll()", ng-class="{active: jumpToLine=='end'}")
+        i.fa.fa-angle-double-down
     a.btn.btn-default(download="{{log.name}}", title="download log as file", ng-href="{{raw_url}}")
         i.fa.fa-download
     a.btn.btn-default(title="load all data for use with browser search tool",
@@ -7,7 +9,7 @@
         i.fa(ng-class="loadAll && isLoading ? 'fa-spin fa-spinner': 'fa-search'")
   pre.row.log(ng-show="log.type!='h'", scroll-viewport)
     span(ng-if="log.type=='s' || log.type=='t'")
-        div(scroll="line in lines", scroll-position="log.num_lines", load-all="loadAll", is-loading="isLoading", total-size="log.num_lines", style="height:18px")
+        div(scroll="line in lines", scroll-position="scroll_position", load-all="loadAll", is-loading="isLoading", total-size="log.num_lines", style="height:18px")
             span.no-wrap(data-linenumber-content="{{::$index}}", class="{{::line.class}}") {{::line.content}}
   div.panel(ng-if="log.type=='h'", ng-class="log.name=='err.html' && 'panel-danger' || 'panel-default'")
     div.panel-heading

--- a/www/base/src/app/builders/log/logviewer/scrollviewport.directive.coffee
+++ b/www/base/src/app/builders/log/logviewer/scrollviewport.directive.coffee
@@ -238,7 +238,7 @@ class Scroll extends Directive
                         $timeout ->
                             viewport.scrollTop(pos * rowHeight)
                             maybeUpdateView()
-                        , 500
+                        , 100
 
 
                     $(window).bind 'resize', maybeUpdateView


### PR DESCRIPTION
add scroll_to_line query argument to the main route:
- "end" : always scroll to end of log, even when it is running (the default)
- "none": dont scroll (effectively stay at line 0)
- <number>: scroll to line number


* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
