### PR TITLE
Hot fixes for grid_view plugin

### DIFF
--- a/www/grid_view/src/module/grid.controller.coffee
+++ b/www/grid_view/src/module/grid.controller.coffee
@@ -28,6 +28,7 @@ class Grid extends Controller
         @changeFetchLimit = settings.changeFetchLimit.value
         @buildFetchLimit = settings.buildFetchLimit.value
         @compactChanges = settings.compactChanges.value
+        @rightToLeft = settings.rightToLeft.value
 
         @buildsets = @data.getBuildsets(
             limit: @changeFetchLimit
@@ -44,6 +45,7 @@ class Grid extends Controller
         )
         @builds = @data.getBuilds(
             limit: @buildFetchLimit
+            order: '-buildrequestid'
         )
 
         @buildsets.onChange = @changes.onChange = @builders.onChange = \
@@ -65,31 +67,41 @@ class Grid extends Controller
         if not @dataReady()
             return
 
-        changesByBSID = {}
-        @$scope.changes = []
+        changes = {}
         branches = {}
 
+        # map changes by source stamp id
         changesBySSID = {}
         for c in @changes
             changesBySSID[c.sourcestamp.ssid] = c
+            c.buildsets = {}  # there can be multiple buildsets by change
 
+        # associate buildsets to each change and remember existing branches
         for bset in @buildsets
             change = changesBySSID[_.last(bset.sourcestamps).ssid]
             unless change?
                 continue
-            change.bsid = bset.bsid
+
+            change.buildsets[bset.bsid] = bset
             change.branch ?= 'master'
             branches[change.branch] = true
 
-            if @$scope.changes.length > @revisionLimit
-                continue
             if @branch and change.branch != @branch
                 continue
 
-            @$scope.changes.push(change)
-            changesByBSID[bset.bsid] = change
+            changes[change.changeid] = change
 
-        @$scope.changes.sort((a, b) -> a.bsid - b.bsid)
+        # only keep the @revisionLimit most recent changes for display
+        changes = (change for own cid, change of changes)
+        if @rightToLeft
+            changes.sort((a, b) -> b.changeid - a.changeid)
+            if changes.length > @revisionLimit
+                changes = changes.slice(0, @revisionLimit)
+        else
+            changes.sort((a, b) -> a.changeid - b.changeid)
+            if changes.length > @revisionLimit
+                changes = changes.slice(changes.length - @revisionLimit)
+        @$scope.changes = changes
 
         @$scope.branches = (br for br of branches)
 
@@ -106,20 +118,21 @@ class Grid extends Controller
         buildersById = {}
         # find builds for the selected changes and associate them to builders
         for c in @$scope.changes
-            requests = requestsByBSID[c.bsid]
-            unless requests?
-                continue
-            for req in requests
-                build = buildByReqID[req.buildrequestid]
-                unless build?
+            for own bsid, bset of c.buildsets
+                requests = requestsByBSID[bsid]
+                unless requests?
                     continue
-                builder = @builders.get(build.builderid)
-                unless @isBuilderDisplayed(builder)
-                    continue
-                buildersById[builder.builderid] = builder
-                builder.builds[c.bsid] = build
+                for req in requests
+                    build = buildByReqID[req.buildrequestid]
+                    unless build?
+                        continue
+                    builder = @builders.get(build.builderid)
+                    unless @isBuilderDisplayed(builder)
+                        continue
+                    buildersById[builder.builderid] = builder
+                    builder.builds[c.changeid] = build
 
-        @$scope.builders = (buildersById[i] for i of buildersById)
+        @$scope.builders = (builder for own i, builder of buildersById)
 
     changeBranch: (branch) =>
         @branch = branch

--- a/www/grid_view/src/module/grid.controller.coffee
+++ b/www/grid_view/src/module/grid.controller.coffee
@@ -32,23 +32,18 @@ class Grid extends Controller
         @buildsets = @data.getBuildsets(
             limit: @changeFetchLimit
             order: '-bsid'
-            property: ['bsid', 'sourcestamps']
         )
         @changes = @data.getChanges(
             limit: @changeFetchLimit
             order: '-changeid'
         )
-        @builders = @data.getBuilders(
-            property: ['builderid', 'name']
-        )
+        @builders = @data.getBuilders()
         @buildrequests = @data.getBuildrequests(
             limit: @buildFetchLimit
             order: '-buildrequestid'
-            property: ['buildrequestid', 'buildsetid', 'builderid']
         )
         @builds = @data.getBuilds(
             limit: @buildFetchLimit
-            order: '-buildrequestid'
         )
 
         @buildsets.onChange = @changes.onChange = @builders.onChange = \

--- a/www/grid_view/src/module/grid.controller.coffee
+++ b/www/grid_view/src/module/grid.controller.coffee
@@ -28,7 +28,6 @@ class Grid extends Controller
         @changeFetchLimit = settings.changeFetchLimit.value
         @buildFetchLimit = settings.buildFetchLimit.value
         @compactChanges = settings.compactChanges.value
-        @rightToLeft = settings.rightToLeft.value
 
         @buildsets = @data.getBuildsets(
             limit: @changeFetchLimit
@@ -93,14 +92,9 @@ class Grid extends Controller
 
         # only keep the @revisionLimit most recent changes for display
         changes = (change for own cid, change of changes)
-        if @rightToLeft
-            changes.sort((a, b) -> b.changeid - a.changeid)
-            if changes.length > @revisionLimit
-                changes = changes.slice(0, @revisionLimit)
-        else
-            changes.sort((a, b) -> a.changeid - b.changeid)
-            if changes.length > @revisionLimit
-                changes = changes.slice(changes.length - @revisionLimit)
+        changes.sort((a, b) -> a.changeid - b.changeid)
+        if changes.length > @revisionLimit
+            changes = changes.slice(changes.length - @revisionLimit)
         @$scope.changes = changes
 
         @$scope.branches = (br for br of branches)

--- a/www/grid_view/src/module/grid.tpl.jade
+++ b/www/grid_view/src/module/grid.tpl.jade
@@ -30,7 +30,7 @@
                             | {{ C.tags.length }} tags
                     span(ng-show="C.tags.length > 0")
                         span.label.label-danger.clickable(ng-click="C.resetTags()", uib-tooltip="Reset tags filter") x
-                th.change(ng-repeat="ch in changes")
+                th.change(ng-repeat="ch in changes track by ch.changeid")
                     changedetails(change="ch", compact="C.compactChanges")
         tbody
             tr(ng-repeat="b in builders | orderBy: 'name'")
@@ -41,7 +41,7 @@
                     span(ng-repeat="tag in b.tags")
                         span.builder-tag.label(ng-click="C.toggleTag(tag)", ng-class="C.isTagToggled(tag) ? 'label-success': 'label-default'")
                             | {{ tag }}
-                td(ng-repeat="ch in changes")
-                    a(ng-if="b.builds[ch.bsid]", ui-sref="build({builder: b.builderid, build: b.builds[ch.bsid].number})")
-                        span.badge-status(ng-class="results2class(b.builds[ch.bsid], 'pulse')")
-                            | {{ b.builds[ch.bsid].number }}
+                td(ng-repeat="ch in changes track by ch.changeid")
+                    a(ng-if="b.builds[ch.changeid]", ui-sref="build({builder: b.builderid, build: b.builds[ch.changeid].number})")
+                        span.badge-status(ng-class="results2class(b.builds[ch.changeid], 'pulse')")
+                            | {{ b.builds[ch.changeid].number }}

--- a/www/grid_view/src/module/main.module.coffee
+++ b/www/grid_view/src/module/main.module.coffee
@@ -41,7 +41,7 @@ class State extends Config
                 name: 'grid'
                 controller: 'gridController'
                 controllerAs: 'C'
-                templateUrl: 'buildbot_grid_view/views/grid.html'
+                templateUrl: 'grid_view/views/grid.html'
                 url: '/grid?branch&tag'
                 reloadOnSearch: false
                 data:

--- a/www/grid_view/src/module/main.module.coffee
+++ b/www/grid_view/src/module/main.module.coffee
@@ -58,6 +58,11 @@ class State extends Config
                     caption: 'Hide avatar and time ago from change details'
                     defaultValue: true
                 ,
+                    type: 'bool'
+                    name: 'rightToLeft'
+                    caption: 'Show most recent changes on the left'
+                    defaultValue: true
+                ,
                     type: 'integer'
                     name: 'revisionLimit'
                     caption: 'Maximum number of revisions to display'

--- a/www/grid_view/src/module/main.module.coffee
+++ b/www/grid_view/src/module/main.module.coffee
@@ -58,11 +58,6 @@ class State extends Config
                     caption: 'Hide avatar and time ago from change details'
                     defaultValue: true
                 ,
-                    type: 'bool'
-                    name: 'rightToLeft'
-                    caption: 'Show most recent changes on the left'
-                    defaultValue: true
-                ,
                     type: 'integer'
                     name: 'revisionLimit'
                     caption: 'Maximum number of revisions to display'

--- a/www/grid_view/src/styles/styles.less
+++ b/www/grid_view/src/styles/styles.less
@@ -23,5 +23,6 @@
     .builder-tag {
         margin-right: 0.3em;
         margin-left: 0.3em;
+        cursor: pointer;
     }
 }


### PR DESCRIPTION
When using trigger buildsteps, there can be multiple buildsets for the same change object.

Modify the code so that builds are identified by change id.