### PR TITLE
grid_view: display most recent changes on the left

### DIFF
--- a/smokes/e2e/pages/settings.coffee
+++ b/smokes/e2e/pages/settings.coffee
@@ -67,4 +67,13 @@ class SettingsPage extends BasePage
         maxBuilderForm = @getItem("Console", "changeLimit")
         expect(maxBuilderForm.getAttribute('value')).toEqual(maxBuildersVar)
 
+    changeShowWorkerBuilders: (showWorkerBuildersVar) ->
+        showWorkerBuildersForm = @getItem("Workers", "showWorkerBuilders")
+        showWorkerBuildersForm.isSelected().then (checked) ->
+            showWorkerBuildersForm.click() if checked != showWorkerBuildersVar
+
+    checkShowWorkerBuilders: (showWorkerBuildersVar) ->
+        showWorkerBuildersForm = @getItem("Workers", "showWorkerBuilders")
+        expect(showWorkerBuildersForm.isSelected()).toEqual(showWorkerBuildersVar)
+
 module.exports = SettingsPage

--- a/smokes/e2e/worker.scenarios.coffee
+++ b/smokes/e2e/worker.scenarios.coffee
@@ -3,17 +3,23 @@
 # to use previous and next link
 
 workerPage = require('./pages/worker.coffee')
+settingsPage = require('./pages/settings.coffee')
 
 describe('', () ->
     worker = null
     builder = null
+    settings = null
 
     beforeEach(() ->
         worker = new workerPage('runtests')
+        settings = new settingsPage('runtests')
     )
 
     describe 'check worker page', () ->
         it 'should navigate to the worker page, check the one builder inside', () ->
+            settings.goSettings()
+            settings.changeShowWorkerBuilders(true)
+            settings.checkShowWorkerBuilders(true)
             worker.goWorker()
             worker.checkWorkerPage()
             worker.checkHrefPresent()
@@ -22,6 +28,9 @@ describe('', () ->
 
     describe 'check worker page', () ->
         it 'should navigate to the worker page, check the one builder inside', () ->
+            settings.goSettings()
+            settings.changeShowWorkerBuilders(true)
+            settings.checkShowWorkerBuilders(true)
             worker.goWorker()
             worker.checkWorkerPage()
             worker.checkHrefPresent()

--- a/www/base/src/app/workers/workers.route.coffee
+++ b/www/base/src/app/workers/workers.route.coffee
@@ -33,4 +33,9 @@ class State extends Config
                 name:'show_old_workers'
                 caption:'Show old workers'
                 default_value: false
+            ,
+                type:'bool'
+                name:'showWorkerBuilders'
+                caption:'Show list of builders for each worker (can take a lot of time)'
+                default_value: false
             ]

--- a/www/base/src/app/workers/workers.tpl.jade
+++ b/www/base/src/app/workers/workers.tpl.jade
@@ -5,7 +5,7 @@
                 th Masters
                 th WorkerName
                 th Recent Builds
-                th Builders
+                th(ng-if="settings.showWorkerBuilders.value") Builders
                 th(ng-repeat="info in worker_infos") {{ capitalize(info) }}
                     
             tr(ng-repeat='worker in workers | orderBy: ["-num_connections", "name"]',
@@ -25,7 +25,7 @@
                         a(ui-sref='build({builder: build.builderid, build: build.number})')
                             span.badge-status(ng-class="results2class(build, 'pulse')")
                               | {{ builders.get(build.builderid).name }}/{{ build.number }}
-                td
+                td(ng-if="settings.showWorkerBuilders.value")
                     ul.list-inline
                         li(ng-repeat='builder in getUniqueBuilders(worker) | orderBy: ["name"]')
                             a(ui-sref="builder({builder: builder.builderid})")

--- a/www/grid_view/src/module/grid.controller.coffee
+++ b/www/grid_view/src/module/grid.controller.coffee
@@ -31,7 +31,7 @@ class Grid extends Controller
         @rightToLeft = settings.rightToLeft.value
 
         @buildsets = @data.getBuildsets(
-            limit: @changeFetchLimit
+            limit: @buildFetchLimit
             order: '-bsid'
         )
         @changes = @data.getChanges(

--- a/www/grid_view/src/module/grid.controller.coffee
+++ b/www/grid_view/src/module/grid.controller.coffee
@@ -28,6 +28,7 @@ class Grid extends Controller
         @changeFetchLimit = settings.changeFetchLimit.value
         @buildFetchLimit = settings.buildFetchLimit.value
         @compactChanges = settings.compactChanges.value
+        @rightToLeft = settings.rightToLeft.value
 
         @buildsets = @data.getBuildsets(
             limit: @changeFetchLimit
@@ -92,9 +93,14 @@ class Grid extends Controller
 
         # only keep the @revisionLimit most recent changes for display
         changes = (change for own cid, change of changes)
-        changes.sort((a, b) -> a.changeid - b.changeid)
-        if changes.length > @revisionLimit
-            changes = changes.slice(changes.length - @revisionLimit)
+        if @rightToLeft
+            changes.sort((a, b) -> b.changeid - a.changeid)
+            if changes.length > @revisionLimit
+                changes = changes.slice(0, @revisionLimit)
+        else
+            changes.sort((a, b) -> a.changeid - b.changeid)
+            if changes.length > @revisionLimit
+                changes = changes.slice(changes.length - @revisionLimit)
         @$scope.changes = changes
 
         @$scope.branches = (br for br of branches)

--- a/www/grid_view/src/module/main.module.coffee
+++ b/www/grid_view/src/module/main.module.coffee
@@ -58,6 +58,11 @@ class State extends Config
                     caption: 'Hide avatar and time ago from change details'
                     defaultValue: true
                 ,
+                    type: 'bool'
+                    name: 'rightToLeft'
+                    caption: 'Show most recent changes on the left'
+                    defaultValue: true
+                ,
                     type: 'integer'
                     name: 'revisionLimit'
                     caption: 'Maximum number of revisions to display'


### PR DESCRIPTION
Add a new setting allowing to change the ordering of changes. By default, most recent changes are displayed on the left (older ones on the right).