### PR TITLE
Fix GerritVerifyStatusPush()'s request body to match Gerrit's expectations

### DIFF
--- a/master/buildbot/newsfragments/reporters-gerrit-verify-status.bugfix
+++ b/master/buildbot/newsfragments/reporters-gerrit-verify-status.bugfix
@@ -1,0 +1,2 @@
+The GerritVerifyStatusPush has been fixed to send a request body that's properly formatted to Gerrit. This error was
+previously ignored because the http reponse code sent by Gerrit was not being checked.

--- a/master/buildbot/reporters/gerrit_verify_status.py
+++ b/master/buildbot/reporters/gerrit_verify_status.py
@@ -136,6 +136,8 @@ class GerritVerifyStatusPush(http.HttpStatusPushBase):
         if duration is not None:
             payload['duration'] = duration
 
+        payload = {'verifications': {name: payload}}
+
         if self._verbose:
             log.debug(
                 'Sending Gerrit status for {change_id}/{revision_id}: data={data}',

--- a/master/buildbot/reporters/gerrit_verify_status.py
+++ b/master/buildbot/reporters/gerrit_verify_status.py
@@ -233,7 +233,10 @@ class GerritVerifyStatusPush(http.HttpStatusPushBase):
                 # The verify-status plugin will return 204 NO CONTENT
                 # on success.
                 if response.code != http_client.NO_CONTENT:
-                    body = yield response.text()
+                    try:
+                        body = yield response.text()
+                    except AttributeError:
+                        body = yield response.content()
                     raise ValueError('Expected 204 NO CONTENT. Response was %s: %s' % (response.code, body))
 
             except Exception:


### PR DESCRIPTION

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation (no change)
