### PR TITLE
Fix 'reconfig master causes worker lost' error

### DIFF
--- a/master/buildbot/newsfragments/3392.bugfix
+++ b/master/buildbot/newsfragments/3392.bugfix
@@ -1,0 +1,1 @@
+Fix 'reconfig master causes worker lost' error (:issue:`3392`).

--- a/master/buildbot/test/unit/test_db_workers.py
+++ b/master/buildbot/test/unit/test_db_workers.py
@@ -525,6 +525,29 @@ class Tests(interfaces.InterfaceTests):
                                 key=configuredOnKey))
 
     @defer.inlineCallbacks
+    def test_workerReConfigured_should_not_affect_other_worker(self):
+        yield self.insertTestData(self.baseRows + self.multipleMasters)
+
+        # should remove all the builders in master 11
+        yield self.db.workers.workerConfigured(
+            workerid=30, masterid=11, builderids=[])
+
+        w = yield self.db.workers.getWorker(30)
+        x1 = sorted(w['configured_on'], key=configuredOnKey)
+        x2 = sorted([{'builderid': 20, 'masterid': 10},
+                     {'builderid': 21, 'masterid': 10}],
+                    key=configuredOnKey)
+        self.assertEqual(x1, x2)
+
+        # ensure worker 31 is not affected (see GitHub issue#3392)
+        w = yield self.db.workers.getWorker(31)
+        x1 = sorted(w['configured_on'], key=configuredOnKey)
+        x2 = sorted([{'builderid': 20, 'masterid': 11},
+                     {'builderid': 22, 'masterid': 11}],
+                    key=configuredOnKey)
+        self.assertEqual(x1, x2)
+
+    @defer.inlineCallbacks
     def test_workerUnconfigured(self):
         yield self.insertTestData(self.baseRows + self.multipleMasters)
 


### PR DESCRIPTION
This commit fixed the issue: https://github.com/buildbot/buildbot/issues/3392

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
