### PR TITLE
add support for buildernames in REST api

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -108,8 +108,11 @@ class BuildNestingMixin(object):
         if 'buildid' in kwargs:
             defer.returnValue(kwargs['buildid'])
         else:
+            builderid = yield self.getBuilderId(kwargs)
+            if builderid is None:
+                return
             build = yield self.master.db.builds.getBuildByNumber(
-                builderid=kwargs['builderid'],
+                builderid=builderid,
                 number=kwargs['build_number'])
             if not build:
                 return
@@ -131,6 +134,12 @@ class BuildNestingMixin(object):
             if not dbdict:
                 return
             defer.returnValue(dbdict['id'])
+
+    def getBuilderId(self, kwargs):
+        if 'buildername' in kwargs:
+            return self.master.db.builders.findBuilderId(kwargs['buildername'], autoCreate=False)
+        else:
+            return defer.succeed(kwargs['builderid'])
 
 
 class ListResult(UserList):

--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -138,8 +138,7 @@ class BuildNestingMixin(object):
     def getBuilderId(self, kwargs):
         if 'buildername' in kwargs:
             return self.master.db.builders.findBuilderId(kwargs['buildername'], autoCreate=False)
-        else:
-            return defer.succeed(kwargs['builderid'])
+        return defer.succeed(kwargs['builderid'])
 
 
 class ListResult(UserList):

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -22,17 +22,21 @@ from buildbot.data import base
 from buildbot.data import types
 
 
-class BuilderEndpoint(base.Endpoint):
+class BuilderEndpoint(base.BuildNestingMixin, base.Endpoint):
 
     isCollection = False
     pathPatterns = """
         /builders/n:builderid
+        /builders/i:buildername
         /masters/n:masterid/builders/n:builderid
     """
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
-        builderid = kwargs['builderid']
+        builderid = yield self.getBuilderId(kwargs)
+        if builderid is None:
+            defer.returnValue(None)
+
         bdict = yield self.master.db.builders.getBuilder(builderid)
         if not bdict:
             defer.returnValue(None)

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -48,6 +48,8 @@ class LogEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
         /builds/n:buildid/steps/n:step_number/logs/i:log_slug
         /builders/n:builderid/builds/n:build_number/steps/i:step_name/logs/i:log_slug
         /builders/n:builderid/builds/n:build_number/steps/n:step_number/logs/i:log_slug
+        /builders/i:buildername/builds/n:build_number/steps/i:step_name/logs/i:log_slug
+        /builders/i:buildername/builds/n:build_number/steps/n:step_number/logs/i:log_slug
     """
 
     @defer.inlineCallbacks
@@ -77,6 +79,8 @@ class LogsEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
         /builds/n:buildid/steps/n:step_number/logs
         /builders/n:builderid/builds/n:build_number/steps/i:step_name/logs
         /builders/n:builderid/builds/n:build_number/steps/n:step_number/logs
+        /builders/i:buildername/builds/n:build_number/steps/i:step_name/logs
+        /builders/i:buildername/builds/n:build_number/steps/n:step_number/logs
     """
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -50,7 +50,9 @@ class StepEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
         /builds/n:buildid/steps/n:step_number
         /builders/n:builderid/builds/n:build_number/steps/i:step_name
         /builders/n:builderid/builds/n:build_number/steps/n:step_number
-    """
+        /builders/i:buildername/builds/n:build_number/steps/i:step_name
+        /builders/i:buildername/builds/n:build_number/steps/n:step_number
+        """
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
@@ -76,6 +78,7 @@ class StepsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
     pathPatterns = """
         /builds/n:buildid/steps
         /builders/n:builderid/builds/n:build_number/steps
+        /builders/i:buildername/builds/n:build_number/steps
     """
 
     @defer.inlineCallbacks

--- a/master/buildbot/db/base.py
+++ b/master/buildbot/db/base.py
@@ -65,7 +65,7 @@ class DBConnectorComponent(object):
                 % (col, col.type.length, value))
 
     def findSomethingId(self, tbl, whereclause, insert_values,
-                        _race_hook=None):
+                        _race_hook=None, autoCreate=True):
         def thd(conn, no_recurse=False):
             # try to find the master
             q = sa.select([tbl.c.id],
@@ -77,6 +77,9 @@ class DBConnectorComponent(object):
             # found it!
             if row:
                 return row.id
+
+            if not autoCreate:
+                return None
 
             _race_hook and _race_hook(conn)
 

--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -25,15 +25,16 @@ from buildbot.db import base
 
 class BuildersConnectorComponent(base.DBConnectorComponent):
 
-    def findBuilderId(self, name):
+    def findBuilderId(self, name, autoCreate=True):
         tbl = self.db.model.builders
+        name_hash = self.hashColumns(name)
         return self.findSomethingId(
             tbl=tbl,
-            whereclause=(tbl.c.name == name),
+            whereclause=(tbl.c.name_hash == name_hash),
             insert_values=dict(
                 name=name,
-                name_hash=self.hashColumns(name),
-            ))
+                name_hash=name_hash,
+            ), autoCreate=autoCreate)
 
     @defer.inlineCallbacks
     def updateBuilderInfo(self, builderid, description, tags):

--- a/master/buildbot/newsfragments/rest_buildernames.feature
+++ b/master/buildbot/newsfragments/rest_buildernames.feature
@@ -1,0 +1,2 @@
+added support for builder names in REST API.
+Note that those endpoints are not (yet) available from the UI, as the events are not sent to the endpoints with builder names.

--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -71,11 +71,11 @@ types:
     get:
         is:
         - bbget: {bbtype: builder}
-    /{builderid}:
+    /{builderid_or_buildername}:
         uriParameters:
-            builderid:
-                type: number
-                description: the ID of the builder
+            builderid_or_buildername:
+                type: number | identifier
+                description: the ID or name of the builder
         description: This path selects a builder by builderid
         get:
             is:

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -2369,10 +2369,12 @@ class FakeBuildersComponent(FakeDBComponent):
                 self.builders_tags.setdefault(row.builderid,
                                               []).append(row.tagid)
 
-    def findBuilderId(self, name, _reactor=reactor):
+    def findBuilderId(self, name, autoCreate=True, _reactor=reactor):
         for m in itervalues(self.builders):
             if m['name'] == name:
                 return defer.succeed(m['id'])
+        if not autoCreate:
+            return defer.succeed(None)
         id = len(self.builders) + 1
         self.builders[id] = dict(
             id=id,

--- a/master/buildbot/test/unit/test_data_builders.py
+++ b/master/buildbot/test/unit/test_data_builders.py
@@ -62,6 +62,14 @@ class BuilderEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             self.assertEqual(builder, None)
         return d
 
+    def test_get_missing_with_name(self):
+        d = self.callGet(('builders', 'builderc'))
+
+        @d.addCallback
+        def check(builder):
+            self.assertEqual(builder, None)
+        return d
+
     def test_get_existing_with_master(self):
         d = self.callGet(('masters', 13, 'builders', 2))
 

--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -46,7 +46,7 @@ class BuildEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def setUp(self):
         self.setUpEndpoint()
         self.db.insertTestData([
-            fakedb.Builder(id=77),
+            fakedb.Builder(id=77, name='builder77'),
             fakedb.Master(id=88),
             fakedb.Worker(id=13, name='wrk'),
             fakedb.Buildset(id=8822),
@@ -90,6 +90,12 @@ class BuildEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(build['buildid'], 15)
 
     @defer.inlineCallbacks
+    def test_get_buildername_number(self):
+        build = yield self.callGet(('builders', 'builder77', 'builds', 5))
+        self.validateData(build)
+        self.assertEqual(build['buildid'], 15)
+
+    @defer.inlineCallbacks
     def test_properties_injection(self):
         resultSpec = MockedResultSpec(
             filters=[resultspec.Filter('property', 'eq', [False])])
@@ -129,7 +135,8 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def setUp(self):
         self.setUpEndpoint()
         self.db.insertTestData([
-            fakedb.Builder(id=77),
+            fakedb.Builder(id=77, name='builder77'),
+            fakedb.Builder(id=78, name='builder78'),
             fakedb.Master(id=88),
             fakedb.Worker(id=13, name='wrk'),
             fakedb.Buildset(id=8822),
@@ -155,6 +162,12 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_get_builder(self):
         builds = yield self.callGet(('builders', 78, 'builds'))
+        [self.validateData(build) for build in builds]
+        self.assertEqual(sorted([b['number'] for b in builds]), [5])
+
+    @defer.inlineCallbacks
+    def test_get_buildername(self):
+        builds = yield self.callGet(('builders', 'builder78', 'builds'))
         [self.validateData(build) for build in builds]
         self.assertEqual(sorted([b['number'] for b in builds]), [5])
 

--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -96,6 +96,11 @@ class BuildEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(build['buildid'], 15)
 
     @defer.inlineCallbacks
+    def test_get_buildername_not_existing_number(self):
+        build = yield self.callGet(('builders', 'builder77_nope', 'builds', 5))
+        self.assertEqual(build, None)
+
+    @defer.inlineCallbacks
     def test_properties_injection(self):
         resultSpec = MockedResultSpec(
             filters=[resultspec.Filter('property', 'eq', [False])])

--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -177,10 +177,20 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(sorted([b['number'] for b in builds]), [5])
 
     @defer.inlineCallbacks
+    def test_get_buildername_not_existing(self):
+        builds = yield self.callGet(('builders', 'builder78_nope', 'builds'))
+        self.assertEqual(builds, [])
+
+    @defer.inlineCallbacks
     def test_get_buildrequest(self):
         builds = yield self.callGet(('buildrequests', 82, 'builds'))
         [self.validateData(build) for build in builds]
         self.assertEqual(sorted([b['number'] for b in builds]), [3, 4])
+
+    @defer.inlineCallbacks
+    def test_get_buildrequest_not_existing(self):
+        builds = yield self.callGet(('buildrequests', 899, 'builds'))
+        self.assertEqual(builds, [])
 
     @defer.inlineCallbacks
     def test_get_buildrequest_via_filter(self):

--- a/master/buildbot/test/unit/test_data_logs.py
+++ b/master/buildbot/test/unit/test_data_logs.py
@@ -36,7 +36,7 @@ class LogEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def setUp(self):
         self.setUpEndpoint()
         self.db.insertTestData([
-            fakedb.Builder(id=77),
+            fakedb.Builder(id=77, name='builder77'),
             fakedb.Master(id=88),
             fakedb.Worker(id=13, name='wrk'),
             fakedb.Buildset(id=8822),
@@ -94,6 +94,14 @@ class LogEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def test_get_by_builder_step_name(self):
         log = yield self.callGet(
             ('builders', '77', 'builds', 3, 'steps', 'make',
+             'logs', 'errors'))
+        self.validateData(log)
+        self.assertEqual(log['name'], u'errors')
+
+    @defer.inlineCallbacks
+    def test_get_by_buildername_step_name(self):
+        log = yield self.callGet(
+            ('builders', 'builder77', 'builds', 3, 'steps', 'make',
              'logs', 'errors'))
         self.validateData(log)
         self.assertEqual(log['name'], u'errors')

--- a/master/buildbot/test/unit/test_data_steps.py
+++ b/master/buildbot/test/unit/test_data_steps.py
@@ -107,6 +107,11 @@ class StepEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(step['stepid'], 71)
 
     @defer.inlineCallbacks
+    def test_get_missing_buildername_builder_number(self):
+        step = yield self.callGet(('builders', 'builder77_nope', 'builds', 7, 'steps', 1))
+        self.assertEqual(step, None)
+
+    @defer.inlineCallbacks
     def test_get_missing(self):
         step = yield self.callGet(('steps', 9999))
         self.assertEqual(step, None)

--- a/master/buildbot/test/unit/test_data_steps.py
+++ b/master/buildbot/test/unit/test_data_steps.py
@@ -41,7 +41,7 @@ class StepEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.setUpEndpoint()
         self.db.insertTestData([
             fakedb.Worker(id=47, name='linux'),
-            fakedb.Builder(id=77),
+            fakedb.Builder(id=77, name='builder77'),
             fakedb.Master(id=88),
             fakedb.Buildset(id=8822),
             fakedb.BuildRequest(id=82, buildsetid=8822),
@@ -95,6 +95,12 @@ class StepEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(step['stepid'], 71)
 
     @defer.inlineCallbacks
+    def test_get_existing_buildername_name(self):
+        step = yield self.callGet(('builders', 'builder77', 'builds', 7, 'steps', 'two'))
+        self.validateData(step)
+        self.assertEqual(step['stepid'], 71)
+
+    @defer.inlineCallbacks
     def test_get_existing_builder_number(self):
         step = yield self.callGet(('builders', 77, 'builds', 7, 'steps', 1))
         self.validateData(step)
@@ -115,7 +121,7 @@ class StepsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.setUpEndpoint()
         self.db.insertTestData([
             fakedb.Worker(id=47, name='linux'),
-            fakedb.Builder(id=77),
+            fakedb.Builder(id=77, name='builder77'),
             fakedb.Master(id=88),
             fakedb.Buildset(id=8822),
             fakedb.BuildRequest(id=82, buildsetid=8822),
@@ -146,6 +152,12 @@ class StepsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_get_builder(self):
         steps = yield self.callGet(('builders', 77, 'builds', 7, 'steps'))
+        [self.validateData(step) for step in steps]
+        self.assertEqual([s['number'] for s in steps], [0, 1, 2])
+
+    @defer.inlineCallbacks
+    def test_get_buildername(self):
+        steps = yield self.callGet(('builders', 'builder77', 'builds', 7, 'steps'))
         [self.validateData(step) for step in steps]
         self.assertEqual([s['number'] for s in steps], [0, 1, 2])
 

--- a/master/buildbot/test/unit/test_db_base.py
+++ b/master/buildbot/test/unit/test_db_base.py
@@ -140,6 +140,17 @@ class TestBaseAsConnectorComponent(unittest.TestCase,
                                active=1, last_active=1))
         self.assertEqual(id, 7)
 
+    @defer.inlineCallbacks
+    def test_findSomethingId_new_noCreate(self):
+        tbl = self.db.model.masters
+        hash = hashlib.sha1(b'somemaster').hexdigest()
+        id = yield self.db.base.findSomethingId(
+            tbl=self.db.model.masters,
+            whereclause=(tbl.c.name_hash == hash),
+            insert_values=dict(name='somemaster', name_hash=hash,
+                               active=1, last_active=1), autoCreate=False)
+        self.assertEqual(id, None)
+
 
 class TestCachedDecorator(unittest.TestCase):
 

--- a/master/buildbot/test/unit/test_db_builders.py
+++ b/master/buildbot/test/unit/test_db_builders.py
@@ -44,7 +44,7 @@ class Tests(interfaces.InterfaceTests):
 
     def test_signature_findBuilderId(self):
         @self.assertArgSpecMatches(self.db.builders.findBuilderId)
-        def findBuilderId(self, name):
+        def findBuilderId(self, name, autoCreate=True):
             pass
 
     def test_signature_addBuilderMaster(self):
@@ -100,6 +100,11 @@ class Tests(interfaces.InterfaceTests):
         self.assertEqual(builderdict,
                          dict(id=id, name='some:builder', tags=[],
                               masterids=[], description=None))
+
+    @defer.inlineCallbacks
+    def test_findBuilderId_new_no_autoCreate(self):
+        id = yield self.db.builders.findBuilderId('some:builder', autoCreate=False)
+        self.assertIsNone(id)
 
     @defer.inlineCallbacks
     def test_findBuilderId_exists(self):

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -1467,7 +1467,7 @@ builders
 
         Return the builder ID for the builder with this builder name.
         If such a builder is already in the database, this returns the ID.
-        If not and C{autoCreate} is True, the builder is added to the database.
+        If not and ``autoCreate`` is True, the builder is added to the database.
 
     .. py:method:: addBuilderMaster(builderid=None, masterid=None)
 
@@ -1555,8 +1555,8 @@ The DB Connector and Components
 
     .. py:method:: findSomethingId(self, tbl, whereclause, insert_values, _race_hook=None, autoCreate=True)
 
-        Find (using C{whereclause}) or add (using C{insert_values) a row to
-        C{table}, and return the resulting ID. If C{autoCreate} == False, we will not automatically insert the row.
+        Find (using ``whereclause``) or add (using ``insert_values``) a row to
+        ``table``, and return the resulting ID. If ``autoCreate`` == False, we will not automatically insert the row.
 
     .. py:method:: hashColumns(*args)
 

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -1457,15 +1457,17 @@ builders
     * ``name``  -- the builder name, a 20-character :ref:`identifier <type-identifier>`
     * ``masterids`` -- the IDs of the masters where this builder is configured (sorted by id)
 
-    .. py:method:: findBuilderId(name)
+    .. py:method:: findBuilderId(name, autoCreate=True)
 
         :param name: name of this builder
         :type name: 20-character :ref:`identifier <type-identifier>`
+        :param autoCreate: create automatically the builder if name not found
+        :type autoCreate: bool
         :returns: builder id via Deferred
 
         Return the builder ID for the builder with this builder name.
         If such a builder is already in the database, this returns the ID.
-        If not, the builder is added to the database.
+        If not and C{autoCreate} is True, the builder is added to the database.
 
     .. py:method:: addBuilderMaster(builderid=None, masterid=None)
 
@@ -1551,10 +1553,10 @@ The DB Connector and Components
         For use by subclasses to check that 'value' will fit in 'col', where 'col' is a table column from the model.
         Ignore this check for database engines that either provide this error themselves (postgres) or that do not enforce maximum-length restrictions (sqlite)
 
-    .. py:method:: findSomethingId(self, tbl, whereclause, insert_values, _race_hook=None)
+    .. py:method:: findSomethingId(self, tbl, whereclause, insert_values, _race_hook=None, autoCreate=True)
 
         Find (using C{whereclause}) or add (using C{insert_values) a row to
-        C{table}, and return the resulting ID.
+        C{table}, and return the resulting ID. If C{autoCreate} == False, we will not automatically insert the row.
 
     .. py:method:: hashColumns(*args)
 

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -1461,7 +1461,7 @@ builders
 
         :param name: name of this builder
         :type name: 20-character :ref:`identifier <type-identifier>`
-        :param autoCreate: create automatically the builder if name not found
+        :param autoCreate: automatically create the builder if name not found
         :type autoCreate: bool
         :returns: builder id via Deferred
 


### PR DESCRIPTION
Partial Fix for #3407 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
