### PR TITLE
Fix issue when several mail notifiers are used with same parameters, …

### DIFF
--- a/master/buildbot/newsfragments/mailnotifier_modes.bugfix
+++ b/master/buildbot/newsfragments/mailnotifier_modes.bugfix
@@ -1,0 +1,1 @@
+Fix issue when several mail notifiers are used with same parameters, but different modes (:issue:`3398`).

--- a/master/buildbot/reporters/notifier.py
+++ b/master/buildbot/reporters/notifier.py
@@ -80,6 +80,7 @@ class NotifierBase(service.BuildbotService):
                 self.name += "_schedulers_" + "+".join(schedulers)
             if branches is not None:
                 self.name += "_branches_" + "+".join(branches)
+            self.name += "_".join(mode)
 
         if '\n' in subject:
             config.error(


### PR DESCRIPTION
…but different modes

fixes #3398


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
