### PR TITLE
Fix renderability of a build step name

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -41,6 +41,7 @@ from zope.interface import implementer
 from buildbot import config
 from buildbot import interfaces
 from buildbot import util
+from buildbot.interfaces import IRenderable
 from buildbot.interfaces import WorkerTooOldError
 from buildbot.process import log as plog
 from buildbot.process import logobserver
@@ -339,8 +340,9 @@ class BuildStep(results.ResultComputingConfigMixin,
                          % (self.__class__, list(kwargs)))
         self._pendingLogObservers = []
 
-        if not isinstance(self.name, str):
-            config.error("BuildStep name must be a string: %r" % (self.name,))
+        if not isinstance(self.name, str) and not IRenderable.providedBy(self.name):
+            config.error("BuildStep name must be a string or a renderable object: "
+                         "%r" % (self.name,))
 
         if isinstance(self.description, str):
             self.description = [self.description]

--- a/master/buildbot/test/unit/test_steps_renderable.py
+++ b/master/buildbot/test/unit/test_steps_renderable.py
@@ -1,0 +1,46 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from twisted.trial import unittest
+
+from buildbot.process.buildstep import BuildStep
+from buildbot.process.properties import Interpolate
+from buildbot.test.util import config as configmixin
+from buildbot.test.util import steps
+
+
+class TestBuildStep(BuildStep):
+    def run(self):
+        self.setProperty('name', self.name)
+        return 0
+
+
+class TestBuildStepNameIsRenderable(steps.BuildStepMixin, unittest.TestCase, configmixin.ConfigErrorsMixin):
+
+    def setUp(self):
+        return self.setUpBuildStep()
+
+    def tearDown(self):
+        return self.tearDownBuildStep()
+
+    def test_name_is_renderable(self):
+        step = TestBuildStep(name=Interpolate('%(kw:foo)s', foo='bar'))
+        self.setupStep(step)
+        self.expectProperty('name', 'bar')
+        self.expectOutcome(0)
+        return self.runStep()


### PR DESCRIPTION
According to the [documentation](http://docs.buildbot.net/current/manual/cfg-buildsteps.html#common-parameters), a build step name may be a renderable object. But if I pass an Interpolate instance as the name argument I will get configuration error that says "BuildStep name must be a string". 
## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation