### PR TITLE
Fix ShellArg arguments being rendered only once

### DIFF
--- a/master/buildbot/newsfragments/shellarg_rendering.bugfix
+++ b/master/buildbot/newsfragments/shellarg_rendering.bugfix
@@ -1,0 +1,1 @@
+Fix bug when :py:class:`~buildbot.steps.shellsequence.ShellArg` arguments were rendered only once during an instance's lifetime.

--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -25,6 +25,7 @@ from buildbot import config
 from buildbot.process import buildstep
 from buildbot.process import results
 
+import copy
 
 class ShellArg(results.ResultComputingConfigMixin):
     publicAttributes = (
@@ -63,10 +64,11 @@ class ShellArg(results.ResultComputingConfigMixin):
 
     @defer.inlineCallbacks
     def getRenderingFor(self, build):
+        rv = copy.copy(self)
         for p_attr in self.publicAttributes:
             res = yield build.render(getattr(self, p_attr))
-            setattr(self, p_attr, res)
-        defer.returnValue(self)
+            setattr(rv, p_attr, res)
+        defer.returnValue(rv)
 
 
 class ShellSequence(buildstep.ShellMixin, buildstep.BuildStep):

--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -18,6 +18,8 @@ from __future__ import print_function
 from future.utils import iteritems
 from future.utils import string_types
 
+import copy
+
 from twisted.internet import defer
 from twisted.python import log
 
@@ -25,7 +27,6 @@ from buildbot import config
 from buildbot.process import buildstep
 from buildbot.process import results
 
-import copy
 
 class ShellArg(results.ResultComputingConfigMixin):
     publicAttributes = (


### PR DESCRIPTION
ShellArg arguments were rendered only once, the first time the object
was rendered. All subsequent renderings of a ShellArg instance, i.e. all
subsequent calls to the getRenderingFor() method of the instance,
computed always the same values for its arguments.

This happened because the first time a ShellArg instance was rendered it
substituted it's attributes (even the renderable ones) with their renderings.

For example in the following code snippet: 

```
f = util.BuildFactory()
f.addStep(steps.ShellSequence(
    commands=[
        util.ShellArg(
            command=[
                "echo",
                util.Interpolate("Build number: %(prop:buildnumber)s")
            ],
            logfile="stdio")
    ]))
```

The output of the echo command is the same for every build. It is the number of the first build ran with the the builder using this build factory, when the ShellArg() instance was first rendered.

The fix changes the getRenderingFor() method of ShellArg() to return a rendered copy of itself instead of substituting its own attributes. 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
