### PR TITLE
Add dummy primary keys in tables lacking them

### DIFF
--- a/master/buildbot/db/migrate_utils.py
+++ b/master/buildbot/db/migrate_utils.py
@@ -31,6 +31,7 @@ def test_unicode(migrate_engine):
 
     test_unicode = sautils.Table(
         'test_unicode', submeta,
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
         sa.Column('u', sa.Unicode(length=100)),
         sa.Column('b', sa.LargeBinary),
     )

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -105,9 +105,9 @@ class Model(base.DBConnectorComponent):
     buildrequest_claims = sautils.Table(
         'buildrequest_claims', metadata,
         sa.Column('brid', sa.Integer, sa.ForeignKey('buildrequests.id'),
-                  nullable=False),
+                  primary_key=True),
         sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
-                  index=True, nullable=True),
+                  index=True, nullable=False),
         sa.Column('claimed_at', sa.Integer, nullable=False),
     )
 
@@ -117,8 +117,8 @@ class Model(base.DBConnectorComponent):
     build_properties = sautils.Table(
         'build_properties', metadata,
         sa.Column('buildid', sa.Integer, sa.ForeignKey('builds.id'),
-                  nullable=False),
-        sa.Column('name', sa.String(256), nullable=False),
+                  primary_key=True),
+        sa.Column('name', sa.String(256), primary_key=True),
         # JSON encoded value
         sa.Column('value', sa.Text, nullable=False),
         sa.Column('source', sa.String(256), nullable=False),
@@ -185,10 +185,11 @@ class Model(base.DBConnectorComponent):
 
     logchunks = sautils.Table(
         'logchunks', metadata,
-        sa.Column('logid', sa.Integer, sa.ForeignKey('logs.id')),
+        sa.Column('logid', sa.Integer, sa.ForeignKey('logs.id'),
+                  primary_key=True),
         # 0-based line number range in this chunk (inclusive); note that for
         # HTML logs, this counts lines of HTML, not lines of rendered output
-        sa.Column('first_line', sa.Integer, nullable=False),
+        sa.Column('first_line', sa.Integer, primary_key=True),
         sa.Column('last_line', sa.Integer, nullable=False),
         # log contents, including a terminating newline, encoded in utf-8 or,
         # if 'compressed' is not 0, compressed with gzip, bzip2 or lz4
@@ -202,8 +203,8 @@ class Model(base.DBConnectorComponent):
     buildset_properties = sautils.Table(
         'buildset_properties', metadata,
         sa.Column('buildsetid', sa.Integer, sa.ForeignKey('buildsets.id'),
-                  nullable=False),
-        sa.Column('property_name', sa.String(256), nullable=False),
+                  primary_key=True),
+        sa.Column('property_name', sa.String(256), primary_key=True),
         # JSON-encoded tuple of (value, source)
         sa.Column('property_value', sa.Text, nullable=False),
     )
@@ -304,6 +305,7 @@ class Model(base.DBConnectorComponent):
     # Files touched in changes
     change_files = sautils.Table(
         'change_files', metadata,
+        sa.Column('changefileid', sa.Integer, primary_key=True, autoincrement=True),
         sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
                   nullable=False),
         sa.Column('filename', sa.String(1024), nullable=False),
@@ -313,8 +315,8 @@ class Model(base.DBConnectorComponent):
     change_properties = sautils.Table(
         'change_properties', metadata,
         sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
-                  nullable=False),
-        sa.Column('property_name', sa.String(256), nullable=False),
+                  primary_key=True),
+        sa.Column('property_name', sa.String(256), primary_key=True),
         # JSON-encoded tuple of (value, source)
         sa.Column('property_value', sa.Text, nullable=False),
     )
@@ -325,10 +327,10 @@ class Model(base.DBConnectorComponent):
     change_users = sautils.Table(
         "change_users", metadata,
         sa.Column("changeid", sa.Integer, sa.ForeignKey('changes.changeid'),
-                  nullable=False),
+                  primary_key=True),
         # uid for the author of the change with the given changeid
         sa.Column("uid", sa.Integer, sa.ForeignKey('users.uid'),
-                  nullable=False),
+                  primary_key=True),
     )
 
     # Changes to the source code, produced by ChangeSources
@@ -498,8 +500,10 @@ class Model(base.DBConnectorComponent):
     # the change.
     scheduler_changes = sautils.Table(
         'scheduler_changes', metadata,
-        sa.Column('schedulerid', sa.Integer, sa.ForeignKey('schedulers.id')),
-        sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid')),
+        sa.Column('schedulerid', sa.Integer, sa.ForeignKey('schedulers.id'),
+                  primary_key=True),
+        sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
+                  primary_key=True),
         # true (nonzero) if this change is important to this scheduler
         sa.Column('important', sa.Integer),
     )
@@ -571,9 +575,9 @@ class Model(base.DBConnectorComponent):
         "object_state", metadata,
         # object for which this value is set
         sa.Column("objectid", sa.Integer, sa.ForeignKey('objects.id'),
-                  nullable=False),
+                  primary_key=True),
         # name for this value (local to the object)
-        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("name", sa.String(length=255), primary_key=True),
         # value, as a JSON string
         sa.Column("value_json", sa.Text, nullable=False),
     )
@@ -603,10 +607,10 @@ class Model(base.DBConnectorComponent):
         "users_info", metadata,
         # unique user id number
         sa.Column("uid", sa.Integer, sa.ForeignKey('users.uid'),
-                  nullable=False),
+                  primary_key=True),
 
         # type of user attribute, such as 'git'
-        sa.Column("attr_type", sa.String(128), nullable=False),
+        sa.Column("attr_type", sa.String(128), primary_key=True),
 
         # data for given user attribute, such as a commit string or password
         sa.Column("attr_data", sa.String(128), nullable=False),


### PR DESCRIPTION
Some tables from migrate_utils.py and model.py don't have a primary
key. Because of that some RDBMS complain when executing...

  buildbot upgrade-master /path/to/master/directory/

Having primary keys in tables is highly recommended [1], so let's fix
that issue by adding some dummy ones.

1: https://stackoverflow.com/questions/840162/should-each-and-every-table-have-a-primary-key

Signed-off-by: Vicente Olivert Riera <Vincent.Riera@imgtec.com>