### PR TITLE
Add primary keys in tables lacking them

### DIFF
--- a/master/buildbot/db/migrate/versions/050_add_change_files_changefileid.py
+++ b/master/buildbot/db/migrate/versions/050_add_change_files_changefileid.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot. Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import sqlalchemy as sa
+
+from buildbot.util import sautils
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+    change_files_table = sautils.Table('change_files', metadata, autoload=True)
+    changefileid = sa.Column('changefileid', sa.Integer, nullable=True)
+    changefileid.create(change_files_table)

--- a/master/buildbot/db/migrate/versions/051_add_missing_pk_columns.py
+++ b/master/buildbot/db/migrate/versions/051_add_missing_pk_columns.py
@@ -1,0 +1,38 @@
+# This file is part of Buildbot. Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import sqlalchemy as sa
+
+from buildbot.util import sautils
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+    # Add buildset_properties.buildsetpropertyid column
+    buildset_properties_table = sautils.Table('buildset_properties', metadata, autoload=True)
+    buildsetpropertyid = sa.Column('buildsetpropertyid', sa.Integer, nullable=True)
+    buildsetpropertyid.create(buildset_properties_table)
+    # Add change_properties.changepropertyid column
+    change_properties_table = sautils.Table('change_properties', metadata, autoload=True)
+    changepropertyid = sa.Column('changepropertyid', sa.Integer, nullable=True)
+    changepropertyid.create(change_properties_table)
+    # Add build_properties.buildpropertyid column
+    build_properties_table = sautils.Table('build_properties', metadata, autoload=True)
+    buildpropertyid = sa.Column('buildpropertyid', sa.Integer, nullable=True)
+    buildpropertyid.create(build_properties_table)

--- a/master/buildbot/db/migrate_utils.py
+++ b/master/buildbot/db/migrate_utils.py
@@ -31,6 +31,7 @@ def test_unicode(migrate_engine):
 
     test_unicode = sautils.Table(
         'test_unicode', submeta,
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
         sa.Column('u', sa.Unicode(length=100)),
         sa.Column('b', sa.LargeBinary),
     )

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -105,9 +105,9 @@ class Model(base.DBConnectorComponent):
     buildrequest_claims = sautils.Table(
         'buildrequest_claims', metadata,
         sa.Column('brid', sa.Integer, sa.ForeignKey('buildrequests.id'),
-                  nullable=False),
+                  primary_key=True),
         sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
-                  index=True, nullable=True),
+                  index=True, nullable=False),
         sa.Column('claimed_at', sa.Integer, nullable=False),
     )
 
@@ -116,6 +116,8 @@ class Model(base.DBConnectorComponent):
     # This table contains the build properties
     build_properties = sautils.Table(
         'build_properties', metadata,
+        sa.Column('buildpropertyid', sa.Integer, primary_key=True,
+                  autoincrement=True),
         sa.Column('buildid', sa.Integer, sa.ForeignKey('builds.id'),
                   nullable=False),
         sa.Column('name', sa.String(256), nullable=False),
@@ -185,10 +187,11 @@ class Model(base.DBConnectorComponent):
 
     logchunks = sautils.Table(
         'logchunks', metadata,
-        sa.Column('logid', sa.Integer, sa.ForeignKey('logs.id')),
+        sa.Column('logid', sa.Integer, sa.ForeignKey('logs.id'),
+                  primary_key=True),
         # 0-based line number range in this chunk (inclusive); note that for
         # HTML logs, this counts lines of HTML, not lines of rendered output
-        sa.Column('first_line', sa.Integer, nullable=False),
+        sa.Column('first_line', sa.Integer, primary_key=True),
         sa.Column('last_line', sa.Integer, nullable=False),
         # log contents, including a terminating newline, encoded in utf-8 or,
         # if 'compressed' is not 0, compressed with gzip, bzip2 or lz4
@@ -201,6 +204,8 @@ class Model(base.DBConnectorComponent):
     # This table contains input properties for buildsets
     buildset_properties = sautils.Table(
         'buildset_properties', metadata,
+        sa.Column('buildsetpropertyid', sa.Integer, primary_key=True,
+                  autoincrement=True),
         sa.Column('buildsetid', sa.Integer, sa.ForeignKey('buildsets.id'),
                   nullable=False),
         sa.Column('property_name', sa.String(256), nullable=False),
@@ -304,6 +309,7 @@ class Model(base.DBConnectorComponent):
     # Files touched in changes
     change_files = sautils.Table(
         'change_files', metadata,
+        sa.Column('changefileid', sa.Integer, primary_key=True, autoincrement=True),
         sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
                   nullable=False),
         sa.Column('filename', sa.String(1024), nullable=False),
@@ -312,6 +318,8 @@ class Model(base.DBConnectorComponent):
     # Properties for changes
     change_properties = sautils.Table(
         'change_properties', metadata,
+        sa.Column('changepropertyid', sa.Integer, primary_key=True,
+                  autoincrement=True),
         sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
                   nullable=False),
         sa.Column('property_name', sa.String(256), nullable=False),
@@ -325,10 +333,10 @@ class Model(base.DBConnectorComponent):
     change_users = sautils.Table(
         "change_users", metadata,
         sa.Column("changeid", sa.Integer, sa.ForeignKey('changes.changeid'),
-                  nullable=False),
+                  primary_key=True),
         # uid for the author of the change with the given changeid
         sa.Column("uid", sa.Integer, sa.ForeignKey('users.uid'),
-                  nullable=False),
+                  primary_key=True),
     )
 
     # Changes to the source code, produced by ChangeSources
@@ -498,8 +506,10 @@ class Model(base.DBConnectorComponent):
     # the change.
     scheduler_changes = sautils.Table(
         'scheduler_changes', metadata,
-        sa.Column('schedulerid', sa.Integer, sa.ForeignKey('schedulers.id')),
-        sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid')),
+        sa.Column('schedulerid', sa.Integer, sa.ForeignKey('schedulers.id'),
+                  primary_key=True),
+        sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
+                  primary_key=True),
         # true (nonzero) if this change is important to this scheduler
         sa.Column('important', sa.Integer),
     )
@@ -571,9 +581,9 @@ class Model(base.DBConnectorComponent):
         "object_state", metadata,
         # object for which this value is set
         sa.Column("objectid", sa.Integer, sa.ForeignKey('objects.id'),
-                  nullable=False),
+                  primary_key=True),
         # name for this value (local to the object)
-        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("name", sa.String(length=255), primary_key=True),
         # value, as a JSON string
         sa.Column("value_json", sa.Text, nullable=False),
     )
@@ -603,10 +613,10 @@ class Model(base.DBConnectorComponent):
         "users_info", metadata,
         # unique user id number
         sa.Column("uid", sa.Integer, sa.ForeignKey('users.uid'),
-                  nullable=False),
+                  primary_key=True),
 
         # type of user attribute, such as 'git'
-        sa.Column("attr_type", sa.String(128), nullable=False),
+        sa.Column("attr_type", sa.String(128), primary_key=True),
 
         # data for given user attribute, such as a commit string or password
         sa.Column("attr_data", sa.String(128), nullable=False),

--- a/master/buildbot/test/unit/test_db_migrate_versions_050_add_missing_pk_columns.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_050_add_missing_pk_columns.py
@@ -1,0 +1,253 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import sqlalchemy as sa
+
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_thd(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        patches = sautils.Table(
+            'patches', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('patchlevel', sa.Integer, nullable=False),
+            sa.Column('patch_base64', sa.Text, nullable=False),
+            sa.Column('patch_author', sa.Text, nullable=False),
+            sa.Column('patch_comment', sa.Text, nullable=False),
+            sa.Column('subdir', sa.Text),
+        )
+        patches.create()
+        conn.execute(patches.insert(), [
+            dict(id=0, patchlevel=0, patch_base64='dummy', patch_author='dummy', patch_comment='dummy')])
+
+        sourcestamps = sautils.Table(
+            'sourcestamps', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('ss_hash', sa.String(40), nullable=False),
+            sa.Column('branch', sa.String(256)),
+            sa.Column('revision', sa.String(256)),
+            sa.Column('patchid', sa.Integer, sa.ForeignKey('patches.id')),
+            sa.Column('repository', sa.String(length=512), nullable=False,
+                      server_default=''),
+            sa.Column('codebase', sa.String(256), nullable=False,
+                      server_default=sa.DefaultClause("")),
+            sa.Column('project', sa.String(length=512), nullable=False,
+                      server_default=''),
+            sa.Column('created_at', sa.Integer, nullable=False),
+        )
+        sourcestamps.create()
+        conn.execute(sourcestamps.insert(), [
+            dict(id=0, ss_hash='dummy', patchid=0, created_at=0)])
+
+        changes = sautils.Table(
+            'changes', metadata,
+            sa.Column('changeid', sa.Integer, primary_key=True),
+            sa.Column('author', sa.String(255), nullable=False),
+            sa.Column('comments', sa.Text, nullable=False),
+            sa.Column('branch', sa.String(255)),
+            sa.Column('revision', sa.String(255)),  # CVS uses NULL
+            sa.Column('revlink', sa.String(256)),
+            sa.Column('when_timestamp', sa.Integer, nullable=False),
+            sa.Column('category', sa.String(255)),
+            sa.Column('repository', sa.String(length=512), nullable=False,
+                      server_default=''),
+            sa.Column('codebase', sa.String(256), nullable=False,
+                      server_default=sa.DefaultClause("")),
+            sa.Column('project', sa.String(length=512), nullable=False,
+                      server_default=''),
+            sa.Column('sourcestampid', sa.Integer,
+                       sa.ForeignKey('sourcestamps.id')),
+            sa.Column('parent_changeids', sa.Integer, sa.ForeignKey(
+                      'changes.changeid'), nullable=True),
+        )
+        changes.create()
+        conn.execute(changes.insert(), [
+            dict(changeid=0, author='dummy', comments='dummy', when_timestamp=0, parent_changeids=0)])
+
+        builders = sautils.Table(
+            'builders', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('name', sa.Text, nullable=False),
+            sa.Column('description', sa.Text, nullable=True),
+            sa.Column('name_hash', sa.String(40), nullable=False),
+        )
+        builders.create()
+        conn.execute(builders.insert(), [
+            dict(id=0, name='dummy', name_hash='dummy')])
+
+        buildrequests = sautils.Table(
+            'buildrequests', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('buildsetid', sa.Integer, sa.ForeignKey("buildsets.id"),
+                      nullable=False),
+            sa.Column('builderid', sa.Integer, sa.ForeignKey('builders.id'),
+                      nullable=False),
+            sa.Column('priority', sa.Integer, nullable=False,
+                      server_default=sa.DefaultClause("0")),
+            sa.Column('complete', sa.Integer,
+                      server_default=sa.DefaultClause("0")),
+            sa.Column('results', sa.SmallInteger),
+            sa.Column('submitted_at', sa.Integer, nullable=False),
+            sa.Column('complete_at', sa.Integer),
+            sa.Column('waited_for', sa.SmallInteger,
+                      server_default=sa.DefaultClause("0")),
+        )
+        buildrequests.create()
+        conn.execute(buildrequests.insert(), [
+            dict(id=0, buildsetid=0, builderid=0, submitted_at=0)])
+
+        workers = sautils.Table(
+            "workers", metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.String(50), nullable=False),
+            sa.Column("info", JsonObject, nullable=False),
+        )
+        workers.create()
+        conn.execute(workers.insert(), [
+            dict(id=0, name='dummy', info={'dummy':0})])
+
+        masters = sautils.Table(
+            "masters", metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('name', sa.Text, nullable=False),
+            sa.Column('name_hash', sa.String(40), nullable=False),
+            sa.Column('active', sa.Integer, nullable=False),
+            sa.Column('last_active', sa.Integer, nullable=False),
+        )
+        masters.create()
+        conn.execute(masters.insert(), [
+            dict(id=0, name='dummy', name_hash='dummy', active=0, last_active=0)])
+
+        builds = sautils.Table(
+            'builds', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('number', sa.Integer, nullable=False),
+            sa.Column('builderid', sa.Integer, sa.ForeignKey('builders.id')),
+            sa.Column('buildrequestid', sa.Integer,
+                      sa.ForeignKey(
+                          'buildrequests.id', use_alter=True, name='buildrequestid'),
+                      nullable=False),
+            sa.Column('workerid', sa.Integer, sa.ForeignKey('workers.id')),
+            sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
+                      nullable=False),
+            sa.Column('started_at', sa.Integer, nullable=False),
+            sa.Column('complete_at', sa.Integer),
+            sa.Column('state_string', sa.Text, nullable=False),
+            sa.Column('results', sa.Integer),
+        )
+        builds.create()
+        conn.execute(builds.insert(), [
+            dict(id=0, number=0, builderid=0, buildrequestid=0, wokerid=0, masterid=0, started_at=0, state_string='dummy')])
+
+        buildsets = sautils.Table(
+            'buildsets', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('external_idstring', sa.String(256)),
+            sa.Column('reason', sa.String(256)),
+            sa.Column('submitted_at', sa.Integer, nullable=False),
+            sa.Column('complete', sa.SmallInteger, nullable=False,
+                      server_default=sa.DefaultClause("0")),
+            sa.Column('complete_at', sa.Integer),
+            sa.Column('results', sa.SmallInteger),
+            sa.Column('parent_buildid', sa.Integer,
+                      sa.ForeignKey('builds.id', use_alter=True, name='parent_buildid')),
+            sa.Column('parent_relationship', sa.Text),
+        )
+        buildsets.create()
+        conn.execute(buildsets.insert(), [
+            dict(id=0, submitted_at=0, complete=0 , parent_buildid=0)])
+
+        change_files = sautils.Table(
+            'change_files', metadata,
+            sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
+                      nullable=False),
+            sa.Column('filename', sa.String(1024), nullable=False),
+        )
+        change_files.create()
+        conn.execute(change_files.insert(), [
+            dict(changeid=0, filename='foo')])
+
+        buildset_properties = sautils.Table(
+            'buildset_properties', metadata,
+            sa.Column('buildsetid', sa.Integer, sa.ForeignKey('buildsets.id'),
+                      nullable=False),
+            sa.Column('property_name', sa.String(256), nullable=False),
+            sa.Column('property_value', sa.Text, nullable=False),
+        )
+        buildset_properties.create()
+        conn.execute(buildset_properties.insert(), [
+            dict(buildsetid=0, property_name='foo', property_value='bar')])
+
+        build_properties = sautils.Table(
+            'build_properties', metadata,
+            sa.Column('buildid', sa.Integer, sa.ForeignKey('builds.id'),
+                      nullable=False),
+            sa.Column('name', sa.String(256), nullable=False),
+            sa.Column('value', sa.Text, nullable=False),
+            sa.Column('source', sa.String(256), nullable=False),
+        )
+        build_properties.create()
+        conn.execute(build_properties.insert(), [
+            dict(buildid=0, name='foo', value='bar', source='baz')])
+
+        change_properties = sautils.Table(
+            'change_properties', metadata,
+            sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
+                      nullable=False),
+            sa.Column('property_name', sa.String(256), nullable=False),
+            sa.Column('property_value', sa.Text, nullable=False),
+        )
+        change_properties.create()
+        conn.execute(change_properties.insert(), [
+            dict(changeid=0, property_name='foo', property_value='bar')])
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            change_files = sautils.Table('change_files', metadata, autoload=True)
+            self.assertIsInstance(change_files.c.changefileid.type, sa.Integer)
+
+            buildset_properties = sautils.Table('buildset_properties', metadata, autoload=True)
+            self.assertIsInstance(buildset_properties.c.buildsetpropertyid.type, sa.Integer)
+
+            build_properties = sautils.Table('build_properties', metadata, autoload=True)
+            self.assertIsInstance(build_properties.c.buildpropertyid.type, sa.Integer)
+
+            change_properties = sautils.Table('change_properties', metadata, autoload=True)
+            self.assertIsInstance(change_properties.c.changepropertyid.type, sa.Integer)
+
+        return self.do_test_migration(49, 50, setup_thd, verify_thd)


### PR DESCRIPTION
Some tables from migrate_utils.py and model.py don't have a primary
key. Because of that some RDBMS complain when executing...

  buildbot upgrade-master /path/to/master/directory/

Having primary keys in tables is highly recommended [1], so let's fix
that issue by adding them.

1: https://stackoverflow.com/questions/840162/should-each-and-every-table-have-a-primary-key

Signed-off-by: Vicente Olivert Riera <Vincent.Riera@imgtec.com>