### PR TITLE
Fix name management in NotifierBase

### DIFF
--- a/master/buildbot/newsfragments/3450.bugfix
+++ b/master/buildbot/newsfragments/3450.bugfix
@@ -1,0 +1,1 @@
+Fix bug where notifier names could not be overridden (:issue:`3450`)

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -95,17 +95,18 @@ class MailNotifier(NotifierBase):
                     messageFormatter=None, extraHeaders=None,
                     addPatch=True, useTls=False, useSmtps=False,
                     smtpUser=None, smtpPassword=None, smtpPort=25,
-                    name=None, schedulers=None, branches=None,
+                    schedulers=None, branches=None,
                     watchedWorkers='all', messageFormatterMissingWorker=None):
         if ESMTPSenderFactory is None:
             config.error("twisted-mail is not installed - cannot "
                          "send mail")
 
-        super(MailNotifier, self).checkConfig(mode, tags, builders,
-                                              buildSetSummary, messageFormatter,
-                                              subject, addLogs, addPatch,
-                                              name, schedulers, branches,
-                                              watchedWorkers, messageFormatterMissingWorker)
+        super(MailNotifier, self).checkConfig(
+            mode=mode, tags=tags, builders=builders,
+            buildSetSummary=buildSetSummary, messageFormatter=messageFormatter,
+            subject=subject, addLogs=addLogs, addPatch=addPatch,
+            schedulers=schedulers, branches=branches,
+            watchedWorkers=watchedWorkers, messageFormatterMissingWorker=messageFormatterMissingWorker)
 
         if extraRecipients is None:
             extraRecipients = []
@@ -138,16 +139,15 @@ class MailNotifier(NotifierBase):
                         messageFormatter=None, extraHeaders=None,
                         addPatch=True, useTls=False, useSmtps=False,
                         smtpUser=None, smtpPassword=None, smtpPort=25,
-                        name=None, schedulers=None, branches=None,
+                        schedulers=None, branches=None,
                         watchedWorkers='all', messageFormatterMissingWorker=None):
 
-        super(MailNotifier, self).reconfigService(mode, tags, builders,
-                                                  buildSetSummary,
-                                                  messageFormatter,
-                                                  subject,
-                                                  addLogs, addPatch,
-                                                  name, schedulers, branches,
-                                                  watchedWorkers, messageFormatterMissingWorker)
+        super(MailNotifier, self).reconfigService(
+            mode=mode, tags=tags, builders=builders,
+            buildSetSummary=buildSetSummary, messageFormatter=messageFormatter,
+            subject=subject, addLogs=addLogs, addPatch=addPatch,
+            schedulers=schedulers, branches=branches,
+            watchedWorkers=watchedWorkers, messageFormatterMissingWorker=messageFormatterMissingWorker)
         if extraRecipients is None:
             extraRecipients = []
         self.extraRecipients = extraRecipients

--- a/master/buildbot/reporters/notifier.py
+++ b/master/buildbot/reporters/notifier.py
@@ -36,7 +36,7 @@ ENCODING = 'utf-8'
 
 
 class NotifierBase(service.BuildbotService):
-
+    name = None
     __meta__ = abc.ABCMeta
 
     possible_modes = ("change", "failing", "passing", "problem", "warnings",
@@ -58,7 +58,7 @@ class NotifierBase(service.BuildbotService):
                     buildSetSummary=False, messageFormatter=None,
                     subject="Buildbot %(result)s in %(title)s on %(builder)s",
                     addLogs=False, addPatch=False,
-                    name=None, schedulers=None, branches=None,
+                    schedulers=None, branches=None,
                     watchedWorkers=None, messageFormatterMissingWorker=None):
 
         for m in self.computeShortcutModes(mode):
@@ -69,8 +69,7 @@ class NotifierBase(service.BuildbotService):
                 else:
                     config.error(
                         "mode %s is not a valid mode" % (m,))
-
-        if name is None:
+        if self.name is None:
             self.name = self.__class__.__name__
             if tags is not None:
                 self.name += "_tags_" + "+".join(tags)
@@ -101,7 +100,7 @@ class NotifierBase(service.BuildbotService):
                         buildSetSummary=False, messageFormatter=None,
                         subject="Buildbot %(result)s in %(title)s on %(builder)s",
                         addLogs=False, addPatch=False,
-                        name=None, schedulers=None, branches=None,
+                        schedulers=None, branches=None,
                         watchedWorkers=None, messageFormatterMissingWorker=None):
 
         self.mode = self.computeShortcutModes(mode)

--- a/master/buildbot/reporters/pushjet.py
+++ b/master/buildbot/reporters/pushjet.py
@@ -48,14 +48,14 @@ class PushjetNotifier(NotifierBase):
                     tags=None, builders=None,
                     buildSetSummary=False, messageFormatter=None,
                     subject="Buildbot %(result)s in %(title)s on %(builder)s",
-                    name=None, schedulers=None, branches=None,
+                    schedulers=None, branches=None,
                     levels=None, base_url='https://api.pushjet.io',
                     watchedWorkers=None, messageFormatterMissingWorker=None):
 
         super(PushjetNotifier, self).checkConfig(mode, tags, builders,
                                                  buildSetSummary, messageFormatter,
                                                  subject, False, False,
-                                                 name, schedulers,
+                                                 schedulers,
                                                  branches, watchedWorkers)
 
         httpclientservice.HTTPClientService.checkAvailable(self.__class__.__name__)
@@ -66,7 +66,7 @@ class PushjetNotifier(NotifierBase):
                         tags=None, builders=None,
                         buildSetSummary=False, messageFormatter=None,
                         subject="Buildbot %(result)s in %(title)s on %(builder)s",
-                        name=None, schedulers=None, branches=None,
+                        schedulers=None, branches=None,
                         levels=None, base_url='https://api.pushjet.io',
                         watchedWorkers=None, messageFormatterMissingWorker=None):
 
@@ -79,7 +79,7 @@ class PushjetNotifier(NotifierBase):
         super(PushjetNotifier, self).reconfigService(mode, tags, builders,
                                                      buildSetSummary, messageFormatter,
                                                      subject, False, False,
-                                                     name, schedulers, branches,
+                                                     schedulers, branches,
                                                      watchedWorkers, messageFormatterMissingWorker)
         self.secret = secret
         if levels is None:

--- a/master/buildbot/reporters/pushover.py
+++ b/master/buildbot/reporters/pushover.py
@@ -52,14 +52,14 @@ class PushoverNotifier(NotifierBase):
                     tags=None, builders=None,
                     buildSetSummary=False, messageFormatter=None,
                     subject="Buildbot %(result)s in %(title)s on %(builder)s",
-                    name=None, schedulers=None, branches=None,
+                    schedulers=None, branches=None,
                     priorities=None, otherParams=None,
                     watchedWorkers=None, messageFormatterMissingWorker=None):
 
         super(PushoverNotifier, self).checkConfig(mode, tags, builders,
                                                   buildSetSummary, messageFormatter,
                                                   subject, False, False,
-                                                  name, schedulers,
+                                                  schedulers,
                                                   branches, watchedWorkers)
 
         httpclientservice.HTTPClientService.checkAvailable(self.__class__.__name__)
@@ -74,7 +74,7 @@ class PushoverNotifier(NotifierBase):
                         tags=None, builders=None,
                         buildSetSummary=False, messageFormatter=None,
                         subject="Buildbot %(result)s in %(title)s on %(builder)s",
-                        name=None, schedulers=None, branches=None,
+                        schedulers=None, branches=None,
                         priorities=None, otherParams=None,
                         watchedWorkers=None, messageFormatterMissingWorker=None):
 
@@ -87,7 +87,7 @@ class PushoverNotifier(NotifierBase):
         super(PushoverNotifier, self).reconfigService(mode, tags, builders,
                                                       buildSetSummary, messageFormatter,
                                                       subject, False, False,
-                                                      name, schedulers, branches,
+                                                      schedulers, branches,
                                                       watchedWorkers, messageFormatterMissingWorker)
         self.user_key = user_key
         self.api_token = api_token

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -59,7 +59,6 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase, NotifierTestMixin):
         yield mn.startService()
         defer.returnValue(mn)
 
-
     @defer.inlineCallbacks
     def test_change_name(self):
         mn = yield self.setupMailNotifier('from@example.org', name="custom_name")

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -59,6 +59,12 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase, NotifierTestMixin):
         yield mn.startService()
         defer.returnValue(mn)
 
+
+    @defer.inlineCallbacks
+    def test_change_name(self):
+        mn = yield self.setupMailNotifier('from@example.org', name="custom_name")
+        self.assertEqual(mn.name, "custom_name")
+
     @defer.inlineCallbacks
     def do_test_createEmail_cte(self, funnyChars, expEncoding):
         _, builds = yield self.setupBuildResults(SUCCESS)


### PR DESCRIPTION
Name is automatically managed by buildbot service and is not passed to
checkConfig/reconfigureService, so that the notifier name is never
actually overriden

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
