### PR TITLE
make db.getObjectId accept very large object names

### DIFF
--- a/master/buildbot/db/base.py
+++ b/master/buildbot/db/base.py
@@ -64,6 +64,12 @@ class DBConnectorComponent(object):
                 "value for column %s is greater than max of %d characters: %s"
                 % (col, col.type.length, value))
 
+    def ensureLength(self, col, value):
+        assert col.type.length, "column %s does not have a length" % (col,)
+        if value and len(value) > col.type.length:
+            value = value[:col.type.length / 2] + hashlib.sha1(value).hexdigest()[:col.type.length / 2]
+        return value
+
     def findSomethingId(self, tbl, whereclause, insert_values,
                         _race_hook=None, autoCreate=True):
         def thd(conn, no_recurse=False):

--- a/master/buildbot/db/base.py
+++ b/master/buildbot/db/base.py
@@ -22,6 +22,8 @@ import itertools
 
 import sqlalchemy as sa
 
+from buildbot.util import unicode2bytes
+
 
 class DBConnectorComponent(object):
     # A fixed component of the DBConnector, handling one particular aspect of
@@ -67,7 +69,7 @@ class DBConnectorComponent(object):
     def ensureLength(self, col, value):
         assert col.type.length, "column %s does not have a length" % (col,)
         if value and len(value) > col.type.length:
-            value = value[:col.type.length / 2] + hashlib.sha1(value).hexdigest()[:col.type.length / 2]
+            value = value[:col.type.length // 2] + hashlib.sha1(unicode2bytes(value)).hexdigest()[:col.type.length // 2]
         return value
 
     def findSomethingId(self, tbl, whereclause, insert_values,

--- a/master/buildbot/db/state.py
+++ b/master/buildbot/db/state.py
@@ -52,7 +52,7 @@ class StateConnectorComponent(base.DBConnectorComponent):
     def thdGetObjectId(self, conn, name, class_name):
         objects_tbl = self.db.model.objects
 
-        self.checkLength(objects_tbl.c.name, name)
+        name = self.ensureLength(objects_tbl.c.name, name)
         self.checkLength(objects_tbl.c.class_name, class_name)
 
         def select():
@@ -132,7 +132,7 @@ class StateConnectorComponent(base.DBConnectorComponent):
         except (TypeError, ValueError):
             raise TypeError("Error encoding JSON for %r" % (value,))
 
-        self.checkLength(object_state_tbl.c.name, name)
+        name = self.ensureLength(object_state_tbl.c.name, name)
 
         def update():
             q = object_state_tbl.update(

--- a/master/buildbot/newsfragments/3449.bugfix
+++ b/master/buildbot/newsfragments/3449.bugfix
@@ -1,0 +1,1 @@
+Fix bug where object names could not be larger than 150 characters (:issue:`3449`)

--- a/master/buildbot/test/unit/test_db_base.py
+++ b/master/buildbot/test/unit/test_db_base.py
@@ -49,6 +49,15 @@ class TestBase(unittest.TestCase):
         self.assertRaises(RuntimeError, lambda:
                           self.comp.checkLength(self.tbl.c.str32, "long string" * 5))
 
+    def test_ensureLength_ok(self):
+        v = self.comp.ensureLength(self.tbl.c.str32, "short string")
+        self.assertEqual(v, "short string")
+
+    def test_ensureLength_long(self):
+        v = self.comp.ensureLength(self.tbl.c.str32, "short string" * 5)
+        self.assertEqual(v, "short stringshordacf5a81f8ae3873")
+        self.comp.checkLength(self.tbl.c.str32, v)
+
     def test_checkLength_text(self):
         self.assertRaises(AssertionError, lambda:
                           self.comp.checkLength(self.tbl.c.txt, "long string" * 5))

--- a/master/buildbot/test/unit/test_db_state.py
+++ b/master/buildbot/test/unit/test_db_state.py
@@ -86,6 +86,23 @@ class TestStateConnectorComponent(
         d.addCallback(check)
         return d
 
+    def test_getObjectId_new_big_name(self):
+        d = self.db.state.getObjectId('someobj' * 150, 'someclass')
+        expn = 'someobj' * 9 + 's132bf9b89b0cdbc040d1ebc69e0dbee85dff720a'
+
+        def check(objectid):
+            self.assertNotEqual(objectid, None)
+
+            def thd(conn):
+                q = self.db.model.objects.select()
+                rows = conn.execute(q).fetchall()
+                self.assertEqual(
+                    [(r.id, r.name, r.class_name) for r in rows],
+                    [(objectid, expn, 'someclass')])
+            return self.db.pool.do(thd)
+        d.addCallback(check)
+        return d
+
     def test_getState_missing(self):
         d = self.db.state.getState(10, 'nosuch')
         return self.assertFailure(d, KeyError)

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -468,11 +468,12 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
             for n in added_names:
                 child = new_by_name[n]
                 # setup service's objectid
-                class_name = '%s.%s' % (child.__class__.__module__,
-                                        child.__class__.__name__)
-                objectid = yield self.master.db.state.getObjectId(
-                    child.name, class_name)
-                child.objectid = objectid
+                if hasattr(child, 'objectid'):
+                    class_name = '%s.%s' % (child.__class__.__module__,
+                                            child.__class__.__name__)
+                    objectid = yield self.master.db.state.getObjectId(
+                        child.name, class_name)
+                    child.objectid = objectid
                 yield defer.maybeDeferred(child.setServiceParent, self)
 
         # As the services that were just added got


### PR DESCRIPTION
We just hash the object name if it is too large for the column

We also as an optimization only calculate the object id if it is needed by the subclass

fix for #3449

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
