### PR TITLE
Shell suppressions

### DIFF
--- a/master/buildbot/newsfragments/shell_suppressions.feature
+++ b/master/buildbot/newsfragments/shell_suppressions.feature
@@ -1,0 +1,1 @@
+added support for static suppressions parameter for shell commands

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -404,7 +404,7 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
     def __init__(self,
                  warningPattern=None, warningExtractor=None, maxWarnCount=None,
                  directoryEnterPattern=None, directoryLeavePattern=None,
-                 suppressionFile=None, **kwargs):
+                 suppressionFile=None, suppressionList=None, **kwargs):
         # See if we've been given a regular expression to use to match
         # warnings. If not, use a default that assumes any line with "warning"
         # present is a warning. This may lead to false positives in some cases.
@@ -416,6 +416,8 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
             self.directoryLeavePattern = directoryLeavePattern
         if suppressionFile:
             self.suppressionFile = suppressionFile
+        # self.suppressions is already taken, so use something else
+        self.suppressionList = suppressionList
         if warningExtractor:
             self.warningExtractor = warningExtractor
         else:
@@ -551,6 +553,8 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
         self.warnCount += 1
 
     def start(self):
+        if self.suppressionList is not None:
+            self.addSuppression(self.suppressionList)
         if self.suppressionFile is None:
             return ShellCommand.start(self)
         d = self.getFileContentFromWorker(

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -755,19 +755,27 @@ class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase,
             writer.remote_close()
             command.rc = 0
 
-        self.expectCommands(
-            # step will first get the remote suppressions file
-            Expect('uploadFile', dict(blocksize=32768, maxsize=None,
-                                      workersrc='supps', workdir='wkdir',
-                                      writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
-            + Expect.behavior(upload_behavior),
+        if supps_file is not None:
+            self.expectCommands(
+                # step will first get the remote suppressions file
+                Expect('uploadFile', dict(blocksize=32768, maxsize=None,
+                                          workersrc='supps', workdir='wkdir',
+                                          writer=ExpectRemoteRef(remotetransfer.StringFileWriter)))
+                + Expect.behavior(upload_behavior),
 
-            # and then run the command
-            ExpectShell(workdir='wkdir',
-                        command=["make"])
-            + ExpectShell.log('stdio', stdout=stdout)
-            + 0
-        )
+                # and then run the command
+                ExpectShell(workdir='wkdir',
+                            command=["make"])
+                + ExpectShell.log('stdio', stdout=stdout)
+                + 0
+            )
+        else:
+            self.expectCommands(
+                ExpectShell(workdir='wkdir',
+                            command=["make"])
+                + ExpectShell.log('stdio', stdout=stdout)
+                + 0
+            )
         if exp_exception:
             self.expectOutcome(result=EXCEPTION,
                                state_string="'make' (exception)")

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -927,6 +927,30 @@ class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase,
         return self.do_test_suppressions(step, '', stdout, 2,
                                          exp_warning_log)
 
+    def test_suppressions_suppressionsParameter(self):
+        def warningExtractor(step, line, match):
+            return line.split(':', 2)
+
+        supps = (
+                   ("abc.c", ".*", 100, 199),
+                   ("def.c", ".*", 22, 22),
+                )
+        step = shell.WarningCountingShellCommand(command=['make'],
+                                                 suppressionList=supps,
+                                                 warningExtractor=warningExtractor)
+        stdout = textwrap.dedent(u"""\
+            abc.c:99: warning: seen 1
+            abc.c:150: warning: unseen
+            def.c:22: warning: unseen
+            abc.c:200: warning: seen 2
+            """)
+        exp_warning_log = textwrap.dedent(u"""\
+            abc.c:99: warning: seen 1
+            abc.c:200: warning: seen 2
+            """)
+        return self.do_test_suppressions(step, None, stdout, 2,
+                                         exp_warning_log)
+
     def test_warnExtractFromRegexpGroups(self):
         step = shell.WarningCountingShellCommand(command=['make'])
         we = shell.WarningCountingShellCommand.warnExtractFromRegexpGroups

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -73,20 +73,21 @@ def _dict_diff(d1, d2):
 
 def _describe_cmd_difference(exp, command):
     if exp.args == command.args:
-        return
-
+        return ""
+    text = ""
     missing_in_exp, missing_in_cmd, diff = _dict_diff(exp.args, command.args)
     if missing_in_exp:
-        log.msg(
-            'Keys in cmd missing from expectation: {0}'.format(missing_in_exp))
+        text += (
+            'Keys in cmd missing from expectation: {0}\n'.format(missing_in_exp))
     if missing_in_cmd:
-        log.msg(
-            'Keys in expectation missing from command: {0}'.format(missing_in_cmd))
+        text += (
+            'Keys in expectation missing from command: {0}\n'.format(missing_in_cmd))
     if diff:
         formatted_diff = [
             '"{0}": expected {1!r}, got {2!r}'.format(*d) for d in diff]
-        log.msg('Key differences between expectation and command: {0}'.format(
+        text += ('Key differences between expectation and command: {0}\n'.format(
             '\n'.join(formatted_diff)))
+    return text
 
 
 class BuildStepMixin(object):
@@ -404,9 +405,9 @@ class BuildStepMixin(object):
             # first check any ExpectedRemoteReference instances
             exp_tup = (exp.remote_command, exp.args)
             if exp_tup != got:
-                _describe_cmd_difference(exp, command)
+                text = _describe_cmd_difference(exp, command)
                 raise AssertionError(
-                    "Command contents different from expected; see logs")
+                    "Command contents different from expected; " + text)
 
         if exp.shouldRunBehaviors():
             # let the Expect object show any behaviors that are required

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -1413,6 +1413,11 @@ For example:
 
 If no line number range is specified, the pattern matches the whole file; if only one number is given it matches only on that line.
 
+The ``suppressionList=`` argument can be specified as a list of four-tuples as addition or instead of ``suppressionFile=``.
+The tuple should be ``[ FILE-RE, WARNING-RE, START, END ]``.
+If ``FILE-RE`` is ``None``, then the suppression applies to any file.
+``START`` and ``END`` can be specified as in suppression file, or ``None``.
+
 The default warningPattern regexp only matches the warning text, so line numbers and file names are ignored.
 To enable line number and file name matching, provide a different regexp and provide a function (callable) as the argument of ``warningExtractor=``.
 The function is called with three arguments: the :class:`BuildStep` object, the line in the log file with the warning, and the ``SRE_Match`` object of the regexp search for ``warningPattern``.


### PR DESCRIPTION
This pull request adds support for `suppressions` parameter that contains static list of suppression tuplets.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation