### PR TITLE
Builders GUI fixes

### DIFF
--- a/www/base/src/app/builders/builders.controller.coffee
+++ b/www/base/src/app/builders/builders.controller.coffee
@@ -1,6 +1,6 @@
 class Builders extends Controller
     constructor: ($scope, $log, dataService, resultsService, bbSettingsService, $stateParams,
-        $location, dataGrouperService) ->
+        $location, dataGrouperService, $rootScope) ->
         # make resultsService utilities available in the template
         _.mixin($scope, resultsService)
         $scope.connected2class = (worker) ->
@@ -31,15 +31,20 @@ class Builders extends Controller
             all_tags.sort()
             return all_tags
 
-        $scope.tags_filter = $location.search()["tags"]
-        $scope.tags_filter ?= []
-        if not angular.isArray($scope.tags_filter)
-            $scope.tags_filter = [$scope.tags_filter]
+        updateTagsFilterFromLocation = () ->
+            $scope.tags_filter = $location.search()["tags"]
+            $scope.tags_filter ?= []
+            if not angular.isArray($scope.tags_filter)
+                $scope.tags_filter = [$scope.tags_filter]
+
+        updateTagsFilterFromLocation()
 
         $scope.$watch  "tags_filter", (tags, old) ->
             if old?
                 $location.search("tags", tags)
         , true
+
+        $rootScope.$on '$locationChangeSuccess', updateTagsFilterFromLocation
 
         $scope.isBuilderFiltered = (builder, index) ->
 

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -74,6 +74,9 @@
   }
 }
 
+.label {
+  cursor: pointer
+}
 
 .no-select {
   -webkit-touch-callout: none;


### PR DESCRIPTION
Two small fixes in the Builders view:
- use 'pointer' cursor style for tags #3473 
- update tag filter when using the browser's back button #3474 

## Contributor Checklist:

* I have updated the unit tests =>  minor patch
* I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory) =>  minor patch
* I have updated the appropriate documentation =>  minor patch
