### PR TITLE
Waterfall GUI fixes

### DIFF
--- a/www/waterfall_view/src/module/main.module.coffee
+++ b/www/waterfall_view/src/module/main.module.coffee
@@ -305,8 +305,8 @@ class Waterfall extends Controller
         # Rotate text
         xAxisSelect.selectAll('text')
             .style('text-anchor', 'start')
-            .attr('transform', 'translate(0, -5) rotate(-25)')
-            .attr('dy', '.75em')
+            .attr('transform', 'translate(0, -16) rotate(-25)')
+            .attr('dy', '0.75em')
             .each(link)
 
         # Rotate tick lines

--- a/www/waterfall_view/src/module/scale/scale.service.coffee
+++ b/www/waterfall_view/src/module/scale/scale.service.coffee
@@ -47,4 +47,5 @@ class ScaleService extends Factory
             getBuilderName: (builders) ->
                 @d3.scale.ordinal()
                     .domain(builders.map (builder) -> builder.builderid)
-                    .range(builders.map (builder) -> builder.name)
+                    .range(builders.map (builder) -> builder.name
+                                   .sort (name1, name2) -> name1.localeCompare name2)

--- a/www/waterfall_view/src/styles/styles.less
+++ b/www/waterfall_view/src/styles/styles.less
@@ -70,7 +70,7 @@
             }
 
             line {
-              stroke-width: 4px;
+              stroke-width: 20px;
             }
           }
         }


### PR DESCRIPTION
Two small fixes in the Waterfall view:
- Increase size of build status indicators #3475 
  ![spectacle s12143](https://user-images.githubusercontent.com/6429953/28855627-8b2a7d5a-7703-11e7-9453-ee99db368056.png)

- sort x axis by locale (`b C m Z` instead of `C Z b m`)

## Contributor Checklist:

* I have updated the unit tests => minor patch
* I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory) => minor patch
* I have updated the appropriate documentation => minor patch
