### PR TITLE
RolesFromDomain: fix typo in documentation and add entry_point information

### DIFF
--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -820,7 +820,7 @@ You can grant roles from groups information provided by the Auth plugins, or if 
     ex::
 
         roleMatchers=[
-          util.RolesFromDomains(admins=["gmail.com"])
+          util.RolesFromDomain(admins=["gmail.com"])
         ]
 
 .. py:class:: buildbot.www.authz.roles.RolesFromOwner(roledict)

--- a/master/setup.py
+++ b/master/setup.py
@@ -399,7 +399,8 @@ setup_args = {
             ('buildbot.www.authz', [
                 'Authz', 'fnmatchStrMatcher', 'reStrMatcher']),
             ('buildbot.www.authz.roles', [
-                'RolesFromEmails', 'RolesFromGroups', 'RolesFromOwner', 'RolesFromUsername']),
+                'RolesFromEmails', 'RolesFromGroups', 'RolesFromOwner', 'RolesFromUsername',
+                'RolesFromDomain']),
             ('buildbot.www.authz.endpointmatchers', [
                 'AnyEndpointMatcher', 'StopBuildEndpointMatcher', 'ForceBuildEndpointMatcher',
                 'RebuildBuildEndpointMatcher', 'AnyControlEndpointMatcher', 'EnableSchedulerEndpointMatcher']),


### PR DESCRIPTION
Fix typo in documentation for RolesFromDomain made in #3423. Add entry_points so we can use class.