### PR TITLE
P4poller throws exception when server_tz string is not successfully resolved to a timezone offset

### DIFF
--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -157,7 +157,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
         self.ticket_login_interval = ticket_login_interval
         self.server_tz = dateutil.tz.gettz(server_tz) if server_tz else None
         if server_tz != None and self.server_tz == None:
-            raise P4PollerError("Failed to get timezone from server_tz string '{}'".format( server_tz))
+            raise P4PollerError("Failed to get timezone from server_tz string '{}'".format(server_tz))
 
         self._ticket_passwd = None
         self._ticket_login_counter = 0

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -157,7 +157,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
         self.ticket_login_interval = ticket_login_interval
         self.server_tz = dateutil.tz.gettz(server_tz) if server_tz else None
         if server_tz != None and self.server_tz == None:
-            raise P4PollerError("Failed to get timezone from server_tz string '%s'" % server_tz)
+            raise P4PollerError("Failed to get timezone from server_tz string '{}'".format( server_tz) )
 
         self._ticket_passwd = None
         self._ticket_login_counter = 0

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -156,6 +156,8 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
         self.use_tickets = use_tickets
         self.ticket_login_interval = ticket_login_interval
         self.server_tz = dateutil.tz.gettz(server_tz) if server_tz else None
+        if server_tz != None and self.server_tz == None:
+            raise P4PollerError( "Failed to get timezone from server_tz string '%s'" % server_tz)
 
         self._ticket_passwd = None
         self._ticket_login_counter = 0

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -157,7 +157,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
         self.ticket_login_interval = ticket_login_interval
         self.server_tz = dateutil.tz.gettz(server_tz) if server_tz else None
         if server_tz != None and self.server_tz == None:
-            raise P4PollerError("Failed to get timezone from server_tz string '{}'".format( server_tz) )
+            raise P4PollerError("Failed to get timezone from server_tz string '{}'".format( server_tz))
 
         self._ticket_passwd = None
         self._ticket_login_counter = 0

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -157,7 +157,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
         self.ticket_login_interval = ticket_login_interval
         self.server_tz = dateutil.tz.gettz(server_tz) if server_tz else None
         if server_tz != None and self.server_tz == None:
-            raise P4PollerError( "Failed to get timezone from server_tz string '%s'" % server_tz)
+            raise P4PollerError("Failed to get timezone from server_tz string '%s'" % server_tz)
 
         self._ticket_passwd = None
         self._ticket_login_counter = 0

--- a/master/buildbot/newsfragments/p4pollertzexception
+++ b/master/buildbot/newsfragments/p4pollertzexception
@@ -1,0 +1,1 @@
+When p4poller's server_tz string is set, but the dateutil cannot resolve it to a valid timezone offset, p4poller now throws an exception instead of continuing with UTC zone.


### PR DESCRIPTION
I hit the case where I set a timezone and thought it was working, but spent some time figuring out why it wasn't and what the correct string for my location was.

## Contributor Checklist:

* [] I have updated the unit tests
* [X ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [X ] I have updated the appropriate documentation

