### PR TITLE
support cancel build during prepare worker

### DIFF
--- a/master/buildbot/newsfragments/stop_build_during_latent_worker_substantiate.bugfix
+++ b/master/buildbot/newsfragments/stop_build_during_latent_worker_substantiate.bugfix
@@ -1,0 +1,1 @@
+now if you stop build during latent worker substantiating, the build result will be cancelled instead of retry.

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -326,7 +326,7 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         if ready_or_failure is not True:
             yield self.buildPreparationFailure(ready_or_failure, "worker_prepare")
             if self.stopped:
-                self.buildFinished(["worker", "cancelled"], CANCELLED)
+                self.buildFinished(["worker", "cancelled"], self.results)
             else:
                 self.buildFinished(["worker", "not", "available"], RETRY)
             return

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -325,7 +325,10 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         # If it returns failure then we don't start a new build.
         if ready_or_failure is not True:
             yield self.buildPreparationFailure(ready_or_failure, "worker_prepare")
-            self.buildFinished(["worker", "not", "available"], RETRY)
+            if self.stopped:
+                self.buildFinished(["worker", "cancelled"], CANCELLED)
+            else:
+                self.buildFinished(["worker", "not", "available"], RETRY)
             return
 
         # ping the worker to make sure they're still there. If they've

--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -541,7 +541,7 @@ class Tests(SynchronousTestCase):
         self.assertEqual(builds[1]['results'], SUCCESS)
 
     @defer.inlineCallbacks
-    def test_build_cancelled_when_build_stopped_during_substantiation(self):
+    def test_build_stop_with_cancelled_during_substantiation(self):
         """
         If a build is stopping during latent worker substantiating, the build becomes cancelled
         """
@@ -559,11 +559,48 @@ class Tests(SynchronousTestCase):
             'multiMaster': True,
         }
         master = self.getMaster(config_dict)
-        builder_id = self.successResultOf(
-            master.data.updates.findBuilderId('testy'))
+        builder = master.botmaster.builders['testy']
+        builder_id = self.successResultOf(builder.getBuilderId())
 
         # Trigger a buildrequest
         self.createBuildrequest(master, [builder_id])
+
+        # Stop the build
+        build = builder.getBuild(0)
+        build.stopBuild('no reason', results=CANCELLED)
+
+        # Indicate that the worker can't start an instance.
+        controller.start_instance(False)
+
+        dbdict = yield master.db.builds.getBuildByNumber(builder_id, 1)
+        self.assertEqual(CANCELLED, dbdict['results'])
+        controller.auto_stop(True)
+        self.flushLoggedErrors(LatentWorkerFailedToSubstantiate)
+
+    @defer.inlineCallbacks
+    def test_build_stop_with_retry_during_substantiation(self):
+        """
+        If master is shutting down during latent worker substantiating, the build becomes retry.
+        """
+        controller = LatentController('local')
+        config_dict = {
+            'builders': [
+                BuilderConfig(name="testy",
+                              workernames=["local"],
+                              factory=BuildFactory(),
+                              ),
+            ],
+            'workers': [controller.worker],
+            'protocols': {'null': {}},
+            # Disable checks about missing scheduler.
+            'multiMaster': True,
+        }
+        master = self.getMaster(config_dict)
+        builder = master.botmaster.builders['testy']
+        builder_id = self.successResultOf(builder.getBuilderId())
+
+        # Trigger a buildrequest
+        _, brids = self.createBuildrequest(master, [builder_id])
 
         unclaimed_build_requests = []
         self.successResultOf(master.mq.startConsuming(
@@ -571,13 +608,17 @@ class Tests(SynchronousTestCase):
             ('buildrequests', None, 'unclaimed')))
 
         # Stop the build
-        master.mq.produce(("control", "builds", '1', 'stop'),
-                          dict(reason='no reason'))
+        build = builder.getBuild(0)
+        build.stopBuild('no reason', results=RETRY)
 
         # Indicate that the worker can't start an instance.
         controller.start_instance(False)
 
         dbdict = yield master.db.builds.getBuildByNumber(builder_id, 1)
-        self.assertEqual(CANCELLED, dbdict['results'])
+        self.assertEqual(RETRY, dbdict['results'])
+        self.assertEqual(
+            set(brids),
+            set([req['buildrequestid'] for req in unclaimed_build_requests]),
+        )
         controller.auto_stop(True)
         self.flushLoggedErrors(LatentWorkerFailedToSubstantiate)

--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -30,7 +30,8 @@ from buildbot.interfaces import LatentWorkerFailedToSubstantiate
 from buildbot.interfaces import LatentWorkerSubstantiatiationCancelled
 from buildbot.process.buildstep import BuildStep
 from buildbot.process.factory import BuildFactory
-from buildbot.process.results import RETRY, CANCELLED
+from buildbot.process.results import CANCELLED
+from buildbot.process.results import RETRY
 from buildbot.process.results import SUCCESS
 from buildbot.test.fake.latent import LatentController
 from buildbot.test.fake.reactor import NonThreadPool

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -252,7 +252,6 @@ class TestBuild(unittest.TestCase):
 
         d = defer.Deferred()
         self.workerforbuilder.prepare = lambda _: d
-
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
         b.stopBuild('Cancel Build', CANCELLED)
         d.callback(False)
@@ -266,7 +265,6 @@ class TestBuild(unittest.TestCase):
 
         d = defer.Deferred()
         self.workerforbuilder.prepare = lambda _: d
-        
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
         b.stopBuild('Cancel Build', RETRY)
         d.callback(False)

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -234,6 +234,30 @@ class TestBuild(unittest.TestCase):
 
         self.assertIn('stop it', step.interrupted)
 
+    def testBuildRetryWhenWorkerPrepareReturnFalse(self):
+        b = self.build
+
+        step = FakeBuildStep()
+        b.setStepFactories([FakeStepFactory(step)])
+
+        self.workerforbuilder.prepare = lambda _: False
+        b.startBuild(FakeBuildStatus(), self.workerforbuilder)
+        self.assertEqual(b.results, RETRY)
+
+    def testBuildCancelledWhenWorkerPrepareReturnFalseBecauseBuildStop(self):
+        b = self.build
+
+        step = FakeBuildStep()
+        b.setStepFactories([FakeStepFactory(step)])
+
+        def prepare(build):
+            build.stopped = True # simulate stopBuild
+            return False
+
+        self.workerforbuilder.prepare = prepare
+        b.startBuild(FakeBuildStatus(), self.workerforbuilder)
+        self.assertEqual(b.results, CANCELLED)
+
     def testAlwaysRunStepStopBuild(self):
         """Test that steps marked with alwaysRun=True still get run even if
         the build is stopped."""

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -251,7 +251,7 @@ class TestBuild(unittest.TestCase):
         b.setStepFactories([FakeStepFactory(step)])
 
         def prepare(build):
-            build.stopped = True # simulate stopBuild
+            build.stopped = True  # simulate stopBuild
             return False
 
         self.workerforbuilder.prepare = prepare


### PR DESCRIPTION
In latent worker scenario, depending on the actual latent implementation, worker prepare may take a long time. 
In that case, it's desirable to cancel a build during prepare worker. 
In latent worker implementation, I can add logic to check build.stopped status, and cancel preparation. But when the prepare returns false, the code here will always start a new build to retry which defeats the stop build purpose.
The change here is to really cancel the build if the build has been marked stopped.

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

http://trac.buildbot.net/wiki/Development
And especially:
http://trac.buildbot.net/wiki/SubmittingPatches

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
