### PR TITLE
Fix secrets file permissions when downloaded to worker

### DIFF
--- a/master/buildbot/newsfragments/secrets_perms.bugfix
+++ b/master/buildbot/newsfragments/secrets_perms.bugfix
@@ -1,0 +1,1 @@
+Fix secrets downloaded to worker with too wide permissions

--- a/master/buildbot/steps/download_secret_to_worker.py
+++ b/master/buildbot/steps/download_secret_to_worker.py
@@ -15,6 +15,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import stat
+
 from twisted.internet import defer
 
 from buildbot.process.buildstep import FAILURE
@@ -39,7 +41,7 @@ class DownloadSecretsToWorker(BuildStep, CompositeStepMixin):
             if not isinstance(path, str):
                 raise ValueError("Secret path %s is not a string" % path)
             self.secret_to_be_interpolated = secretvalue
-            res = yield self.downloadFileContentToWorker(path, self.secret_to_be_interpolated)
+            res = yield self.downloadFileContentToWorker(path, self.secret_to_be_interpolated, mode=stat.S_IRUSR | stat.S_IWUSR)
             result = worst_status(result, res)
         defer.returnValue(result)
 

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -325,14 +325,14 @@ class CompositeStepMixin():
                                      evaluateCommand=commandComplete)
     deprecatedWorkerClassMethod(locals(), getFileContentFromWorker)
 
-    def downloadFileContentToWorker(self, workerdest, strfile, abandonOnFailure=False):
+    def downloadFileContentToWorker(self, workerdest, strfile, abandonOnFailure=False, mode=None):
         self.checkWorkerHasCommand("downloadFile")
         fileReader = remotetransfer.StringFileReader(strfile)
         # default arguments
         args = {
             'workdir': self.workdir,
             'maxsize': None,
-            'mode': None,
+            'mode': mode,
             'reader': fileReader,
             'blocksize': 32 * 1024,
         }

--- a/master/buildbot/test/unit/test_download_secret_to_worker.py
+++ b/master/buildbot/test/unit/test_download_secret_to_worker.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
+import stat
 
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
@@ -48,7 +49,7 @@ class TestDownloadFileSecretToWorkerCommand(steps.BuildStepMixin, unittest.TestC
                                      (os.path.join(self.temp_path, "pathB"), "something more")]))
         args1 = {
                     'maxsize': None,
-                    'mode': None,
+                    'mode': stat.S_IRUSR | stat.S_IWUSR,
                     'reader': ExpectRemoteRef(remotetransfer.StringFileReader),
                     'blocksize': 32 * 1024,
                     'workerdest': os.path.join(self.temp_path, "pathA"),
@@ -56,7 +57,7 @@ class TestDownloadFileSecretToWorkerCommand(steps.BuildStepMixin, unittest.TestC
                     }
         args2 = {
                     'maxsize': None,
-                    'mode': None,
+                    'mode': stat.S_IRUSR | stat.S_IWUSR,
                     'reader': ExpectRemoteRef(remotetransfer.StringFileReader),
                     'blocksize': 32 * 1024,
                     'workerdest': os.path.join(self.temp_path, "pathB"),

--- a/master/buildbot/test/unit/test_steps_worker.py
+++ b/master/buildbot/test/unit/test_steps_worker.py
@@ -503,6 +503,26 @@ class TestCompositeStepMixin(steps.BuildStepMixin, unittest.TestCase):
         self.expectOutcome(result=SUCCESS)
         return self.runStep()
 
+    def test_downloadFileContentToWorkerWithFilePermissions(self):
+        @defer.inlineCallbacks
+        def testFunc(x):
+            res = yield x.downloadFileContentToWorker("/path/dest1", "file text", mode=stat.S_IRUSR)
+            self.assertEqual(res, None)
+
+        exp_args = {'maxsize': None,
+                    'workdir': 'wkdir',
+                    'mode': stat.S_IRUSR,
+                    'reader': ExpectRemoteRef(remotetransfer.FileReader),
+                    'blocksize': 32768,
+                    'workerdest': '/path/dest1'}
+
+        self.setupStep(CompositeUser(testFunc))
+        self.expectCommands(
+            Expect('downloadFile', exp_args)
+        )
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
 
 class TestWorkerTransition(unittest.TestCase):
 


### PR DESCRIPTION
Secrets downloaded to the worker are using default permissions, meaning that they are readable by other users. This doesn't work well with sending for example ssh keys, (~/.ssh/id_rsa).
The patch forces all secrets to only allow read and write (not execute) by current owner.
Let me know if a more comprehensive solution like allow setting file permissions in the config is needed.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
