### PR TITLE
Secrets examples fixed

### DIFF
--- a/master/buildbot/newsfragments/secrets_fix.bugfix
+++ b/master/buildbot/newsfragments/secrets_fix.bugfix
@@ -1,0 +1,1 @@
+corrected the example code for using secrets in all documentation, made changes to all secrets plugin to be imported and used.

--- a/master/buildbot/plugins/__init__.py
+++ b/master/buildbot/plugins/__init__.py
@@ -26,7 +26,7 @@ from buildbot.plugins.db import get_plugins
 
 __all__ = [
     'changes', 'schedulers', 'steps', 'util', 'reporters', 'statistics',
-    'worker',
+    'worker', 'secrets',
     'buildslave',  # deprecated, use 'worker' instead.
 ]
 
@@ -38,6 +38,7 @@ schedulers = get_plugins('schedulers', IScheduler)
 steps = get_plugins('steps', IBuildStep)
 util = get_plugins('util', None)
 reporters = get_plugins('reporters', None)
+secrets = get_plugins('secrets', None)
 
 # For plugins that are not updated to the new worker names, plus fallback of
 # current Buildbot plugins for old configuration files.

--- a/master/docs/developer/secrets.rst
+++ b/master/docs/developer/secrets.rst
@@ -49,7 +49,7 @@ File provider
 
 .. code-block:: python
 
-    c['secretsProviders'] = [util.SecretInAFile(dirname="/path/toSecretsFiles")]
+    c['secretsProviders'] = [secrets.SecretInAFile(dirname="/path/toSecretsFiles")]
 
 In the master configuration the provider is instantiated through a Buildbot service secret manager with the file directory path.
 File secrets provider reads the file named by the key wanted by Buildbot and returns the contained text value (removing trailing newlines if present).
@@ -60,7 +60,7 @@ Vault provider
 
 .. code-block:: python
 
-    c['secretsProviders'] = [util.SecretInVault(vaultToken=open('VAULT_TOKEN').read(),
+    c['secretsProviders'] = [secrets.SecretInVault(vaultToken=open('VAULT_TOKEN').read(),
                                                 vaultServer="http://localhost:8200"
                                                 )]
 

--- a/master/docs/manual/secretsmanagement.rst
+++ b/master/docs/manual/secretsmanagement.rst
@@ -42,7 +42,7 @@ The following example shows a basic usage of secrets in Buildbot.
 
     # First we declare that the secrets are stored in a directory of the filesystem
     # each file contain one secret identified by the filename
-    c['secretsProviders'] = [util.SecretInAFile(dirname="/path/toSecretsFiles")]
+    c['secretsProviders'] = [secrets.SecretInAFile(dirname="/path/toSecretsFiles")]
 
     # then in a buildfactory:
 
@@ -59,7 +59,7 @@ SecretInAFile
 
 .. code-block:: python
 
-    c['secretsProviders'] = [util.SecretInAFile(dirname="/path/toSecretsFiles")]
+    c['secretsProviders'] = [secrets.SecretInAFile(dirname="/path/toSecretsFiles")]
 
 In the passed directory, every file contains a secret identified by the filename.
 
@@ -79,7 +79,7 @@ SecretInVault
 
 .. code-block:: python
 
-    c['secretsProviders'] = [util.SecretInVault(
+    c['secretsProviders'] = [secrets.SecretInVault(
                             vaultToken=open('VAULT_TOKEN').read(),
                             vaultServer="http://localhost:8200"
     )]


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

This fork started off as a simple documentation fix, both the User Manual and the Developer Documentation referenced util.SecretInAFile in stead of the secrets.SecretInAFile.

Once that change had been made, CheckConfig showed different errors indicating that the secrets module were never imported, changes made to master/builbot/plugins/__init__.py fix that issue.

14 unittests are currently failing _(skips=118, errors=14, successes=4977)_, however, the same set of 14 files are also failing on master so I don't believe my changes have had an impact.