### PR TITLE
Fix documentation for log obfuscation in new-style build steps.

### DIFF
--- a/master/buildbot/newsfragments/log_obfuscating.doc
+++ b/master/buildbot/newsfragments/log_obfuscating.doc
@@ -1,0 +1,1 @@
+Fixed documentation regarding log obfuscation for passwords

--- a/master/buildbot/newsfragments/log_obfuscating.doc
+++ b/master/buildbot/newsfragments/log_obfuscating.doc
@@ -1,1 +1,1 @@
-Fixed documentation regarding log obfuscation for passwords
++Fixed documentation regarding log obfuscation for passwords.

--- a/master/docs/developer/cls-remotecommands.rst
+++ b/master/docs/developer/cls-remotecommands.rst
@@ -196,7 +196,9 @@ RemoteCommand
     Most of the constructor arguments are sent directly to the worker; see :ref:`shell-command-args` for the details of the formats.
     The ``collectStdout`` parameter is as described for the parent class.
 
-    If shell command contains passwords they can be hidden from log files by passing them as tuple in command argument.
+    If shell command contains passwords, they can be hidden from log files by using :doc:`../manual/secretsmanagement`.
+    This is the recommended procedure for new-style build steps. For legacy build steps password were hidden from the
+    log file by passing them as tuple in command argument.
     Eg. ``['print', ('obfuscated', 'password', 'dummytext')]`` is logged as ``['print', 'dummytext']``.
 
     This class is used by the :bb:step:`ShellCommand` step, and by steps that run multiple customized shell commands.


### PR DESCRIPTION
As requested in #3510 a documentation fix for obfuscating passwords in log files when using new-style build steps.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
