### PR TITLE
Performance improvement for lineboundaries

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -921,6 +921,7 @@ parms
 parseable
 parsegotrevision
 parsejob
+partialLine
 passwd
 patchable
 patchid
@@ -1209,6 +1210,7 @@ spawnprocess
 specdir
 specfile
 specfiles
+splitted
 spulec
 sql
 sqlalchemy

--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -921,7 +921,6 @@ parms
 parseable
 parsegotrevision
 parsejob
-partialLine
 passwd
 patchable
 patchid
@@ -1210,7 +1209,7 @@ spawnprocess
 specdir
 specfile
 specfiles
-splitted
+split
 spulec
 sql
 sqlalchemy

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -67,6 +67,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
 
     # Postgres and MySQL will both allow bigger sizes than this.  The limit
     # for MySQL appears to be max_packet_size (default 1M).
+    # note that MAX_CHUNK_SIZE is equal to BUFFER_SIZE in buildbot_worker.runprocess
     MAX_CHUNK_SIZE = 65536  # a chunk may not be bigger than this
     MAX_CHUNK_LINES = 1000  # a chunk may not have more lines than this
     COMPRESSION_MODE = {"raw": {"id": 0, "dumps": lambda x: x, "read": lambda x: x},

--- a/master/buildbot/newsfragments/lineboundaryfinder.bugfix
+++ b/master/buildbot/newsfragments/lineboundaryfinder.bugfix
@@ -1,0 +1,1 @@
+Fix performance issue when remote command does not send any line boundary (:issue:`3517`)

--- a/master/buildbot/newsfragments/lineboundaryfinder.feature
+++ b/master/buildbot/newsfragments/lineboundaryfinder.feature
@@ -1,0 +1,2 @@
+Buildbot now tries harder at finding line boundaries.
+It nows support several cursor controlling ANSI sequences as well as use of lots of backspace to go back several characters.

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -311,10 +311,10 @@ class InheritBuildParameter(ChoiceStringParameter):
 
     def updateFromKwargs(self, master, properties, changes, kwargs, **unused):
         arg = kwargs.get(self.fullName, [""])[0]
-        splitted_arg = arg.split(" ")[0].split("/")
-        if len(splitted_arg) != 2:
+        split_arg = arg.split(" ")[0].split("/")
+        if len(split_arg) != 2:
             raise ValidationError("bad build: %s" % (arg))
-        builder, num = splitted_arg
+        builder, num = split_arg
         builder_status = master.status.getBuilder(builder)
         if not builder_status:
             raise ValidationError("unknown builder: %s in %s" % (builder, arg))

--- a/master/buildbot/test/unit/test_util_lineboundaries.py
+++ b/master/buildbot/test/unit/test_util_lineboundaries.py
@@ -139,7 +139,7 @@ class LBF(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_long_lines(self):
-        """long lines are splitted"""
+        """long lines are split"""
         for i in range(4):
             yield self.lbf.append('12' * 1000)
         # a split at 4096 + the remaining chars
@@ -147,7 +147,7 @@ class LBF(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_huge_lines(self):
-        """huge lines are splitted"""
+        """huge lines are split"""
         yield self.lbf.append('12' * 32768)
         yield self.lbf.flush()
         self.assertCallbacks([('12' * 2048 + '\n') * 16])

--- a/master/buildbot/util/lineboundaries.py
+++ b/master/buildbot/util/lineboundaries.py
@@ -50,8 +50,8 @@ class LineBoundaryFinder(object):
                     log.warn("Splitting long line: {line_start} {length} (not warning anymore for this log)",
                              line_start=self.partialLine[:30], length=len(self.partialLine))
                     self.warned = True
-                # switch the variables, and return previous partialLine,
-                # splitted every MAX_LINELENGTH plus a trailing \n
+                # switch the variables, and return previous _partialLine_,
+                # split every MAX_LINELENGTH plus a trailing \n
                 self.partialLine, text = text, self.partialLine
                 ret = []
                 while len(text) > self.MAX_LINELENGTH:


### PR DESCRIPTION
When a remotecommand sends huge lines, the LBF will eat the data until it finds a boundary.
This could cause a master to OOM if a malicious or buggy script send lots of data to stdout/err

We also add support for other line boundaries (ANSI cursor control and \b+)

fix for #3517 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
