### PR TITLE
Change REST API's __contains to OR behavior

### DIFF
--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -46,7 +46,7 @@ class FieldBase(object):
     plural_operators = {
         'eq': lambda d, v: d in v,
         'ne': lambda d, v: d not in v,
-        'contains': lambda d, v: set(v) <= set(d),
+        'contains': lambda d, v: len(set(v).intersection(set(d))) > 0,
     }
 
     def __init__(self, field, op, values):

--- a/master/buildbot/newsfragments/rest_contains.bugfix
+++ b/master/buildbot/newsfragments/rest_contains.bugfix
@@ -1,0 +1,1 @@
+Make REST API's filter __contains use OR connector rather than AND according to what the documentation suggests.

--- a/master/buildbot/newsfragments/rest_contains.doc
+++ b/master/buildbot/newsfragments/rest_contains.doc
@@ -1,0 +1,1 @@
+Improve documentation of REST API's __contains filter.

--- a/master/buildbot/test/unit/test_data_resultspec.py
+++ b/master/buildbot/test/unit/test_data_resultspec.py
@@ -76,6 +76,16 @@ class Filter(unittest.TestCase):
         self.assertEqual(list(f.apply(mklist('num', 5, 10, 15))),
                          mklist('num', 10, 15))
 
+    def test_contains(self):
+        f = resultspec.Filter('num', 'contains', [10])
+        self.assertEqual(list(f.apply(mklist('num', [5, 1], [10, 1], [15, 1]))),
+                         mklist('num', [10, 1]))
+
+    def test_contains_plural(self):
+        f = resultspec.Filter('num', 'contains', [10, 5])
+        self.assertEqual(list(f.apply(mklist('num', [5, 1], [10, 1], [15, 1]))),
+                         mklist('num', [5, 1], [10, 1]))
+
 
 class ResultSpec(unittest.TestCase):
 

--- a/master/docs/developer/rest.rst
+++ b/master/docs/developer/rest.rst
@@ -112,7 +112,8 @@ Filters can use any of the operators listed below, with query parameters of the 
 ``ge``
     select resources where the field's value is greater than or equal to ``{value}``
 ``contains``
-    select resources where the field's value contains ``{value}``
+    Select resources where the field's value contains ``{value}``.
+    If the parameter is provided multiple times, results containing at least one of the values are returned (so `foo__contains=x&foo__contains=y` would match resources where foo contains `x`, `y` or both).
 
 For example:
 


### PR DESCRIPTION
Created out of a discussion in #3526.
Fixes #3527.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
