### PR TITLE
schedulers: make builderNames renderable

### DIFF
--- a/master/buildbot/newsfragments/renderable_builderNames.feature
+++ b/master/buildbot/newsfragments/renderable_builderNames.feature
@@ -1,0 +1,1 @@
+The :ref:`Schedulers` ``builderNames`` parameter can now be a :class:`~IRenderable` object that will render to a list of builder names.

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -69,6 +69,8 @@ class Properties(util.ComparableMixin):
         if kwargs:
             self.update(kwargs, "TEST")
         self._master = None
+        self._sourcestamps = None
+        self._changes = None
 
     @property
     def master(self):
@@ -79,6 +81,40 @@ class Properties(util.ComparableMixin):
     @master.setter
     def master(self, value):
         self._master = value
+
+    @property
+    def sourcestamps(self):
+        if self.build is not None:
+            return [b.asSSDict() for b in self.build.getAllSourceStamps()]
+        elif self._sourcestamps is not None:
+            return self._sourcestamps
+        raise AttributeError('neither build nor _sourcestamps are set')
+
+    @sourcestamps.setter
+    def sourcestamps(self, value):
+        self._sourcestamps = value
+
+    @property
+    def changes(self):
+        if self.build is not None:
+            return [c.asChDict() for c in self.build.allChanges()]
+        elif self._changes is not None:
+            return self._changes
+        raise AttributeError('neither build nor _changes are set')
+
+    @changes.setter
+    def changes(self, value):
+        self._changes = value
+
+    @property
+    def files(self):
+        if self.build is not None:
+            return self.build.allFiles()
+        files = []
+        # self.changes, not self._changes to raise AttributeError if unset
+        for chdict in self.changes:
+            files.extend(chdict['files'])
+        return files
 
     @classmethod
     def fromDict(cls, propDict):

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import itervalues
 
 import posixpath
 
@@ -100,8 +101,20 @@ class FakeBuild(properties.PropertiesMixin):
             return self.sources[codebase]
         return None
 
+    def getAllSourceStamps(self):
+        return list(itervalues(self.sources))
+
+    def allChanges(self):
+        for s in itervalues(self.sources):
+            for c in s.changes:
+                yield c
+
     def allFiles(self):
-        return []
+        files = []
+        for c in self.allChanges():
+            for f in c.files:
+                files.append(f)
+        return files
 
     def getBuilder(self):
         return self.builder

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1154,6 +1154,17 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.cfg.check_single_master()
         self.assertConfigError(self.errors, "have no schedulers to drive them")
 
+    def test_check_single_master_renderable_builderNames(self):
+        self.setup_basic_attrs()
+        b3 = mock.Mock()
+        b3.name = 'b3'
+        self.cfg.builders.append(b3)
+        sch2 = mock.Mock()
+        sch2.listBuilderNames = lambda: properties.Interpolate('%(prop:foo)s')
+        self.cfg.schedulers['sch2'] = sch2
+        self.cfg.check_single_master()
+        self.assertNoConfigErrors(self.errors)
+
     def test_check_schedulers_unknown_builder(self):
         self.setup_basic_attrs()
         del self.cfg.builders[1]  # remove b2, leaving b1
@@ -1165,6 +1176,15 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.setup_basic_attrs()
         del self.cfg.builders[1]  # remove b2, leaving b1
         self.cfg.multiMaster = True
+        self.cfg.check_schedulers()
+        self.assertNoConfigErrors(self.errors)
+
+    def test_check_schedulers_renderable_builderNames(self):
+        self.setup_basic_attrs()
+        sch2 = mock.Mock()
+        sch2.listBuilderNames = lambda: properties.Interpolate('%(prop:foo)s')
+        self.cfg.schedulers['sch2'] = sch2
+
         self.cfg.check_schedulers()
         self.assertNoConfigErrors(self.errors)
 

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -27,6 +27,8 @@ from zope.interface import implementer
 
 from buildbot.interfaces import IProperties
 from buildbot.interfaces import IRenderable
+from buildbot.process.buildrequest import TempChange
+from buildbot.process.buildrequest import TempSourceStamp
 from buildbot.process.properties import FlattenList
 from buildbot.process.properties import Interpolate
 from buildbot.process.properties import Properties
@@ -1036,6 +1038,30 @@ class TestProperties(unittest.TestCase):
 
     def test_getBuild(self):
         self.assertIdentical(self.props.getBuild(), self.props.build)
+
+    def test_unset_sourcestamps(self):
+        self.assertRaises(AttributeError, lambda: self.props.sourcestamps)
+
+    def test_unset_changes(self):
+        self.assertRaises(AttributeError, lambda: self.props.changes)
+        self.assertRaises(AttributeError, lambda: self.props.files)
+
+    def test_build_attributes(self):
+        build = FakeBuild(self.props)
+        change = TempChange({'author': 'me', 'files': ['main.c']})
+        ss = TempSourceStamp({'branch': 'master'})
+        ss.changes = [change]
+        build.sources[''] = ss
+        self.assertEqual(self.props.sourcestamps[0]['branch'], 'master')
+        self.assertEqual(self.props.changes[0]['author'], 'me')
+        self.assertEqual(self.props.files[0], 'main.c')
+
+    def test_own_attributes(self):
+        self.props.sourcestamps = [{'branch': 'master'}]
+        self.props.changes = [{'author': 'me', 'files': ['main.c']}]
+        self.assertEqual(self.props.sourcestamps[0]['branch'], 'master')
+        self.assertEqual(self.props.changes[0]['author'], 'me')
+        self.assertEqual(self.props.files[0], 'main.c')
 
     def test_render(self):
         @implementer(IRenderable)

--- a/master/docs/manual/cmdline.rst
+++ b/master/docs/manual/cmdline.rst
@@ -325,7 +325,7 @@ Darcs
 
 Git
     ``git branch -v`` lists all the branches available in the local repository along with the revision ID it points to and a short summary of the last commit.
-    The line containing the currently checked out branch begins with "* " (star and space) while all the others start with "  " (two spaces).
+    The line containing the currently checked out branch begins with "\* " (star and space) while all the others start with "  " (two spaces).
     :command:`try` scans for this line and extracts the branch name and revision from it.
     Then it generates a diff against the base revision.
 


### PR DESCRIPTION
Add a new `builderFilter` parameter to all schedulers. This callback allows to dynamically select which builders get scheduled when this scheduler is triggered. By default, all builders in `builderNames` are
scheduled.