### PR TITLE
git: use `checkout -B` rather than `branch -M`

### DIFF
--- a/master/buildbot/newsfragments/git_checkout.bugfix
+++ b/master/buildbot/newsfragments/git_checkout.bugfix
@@ -1,0 +1,1 @@
+The ``git`` source step now uses `git checkout -B` rather than `git branch -M` to create local branches

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -421,7 +421,7 @@ class Git(Source):
         # Rename the branch if needed.
         if res == RC_SUCCESS and self.branch != 'HEAD':
             # Ignore errors
-            yield self._dovccmd(['branch', '-M', self.branch], abandonOnFailure=False)
+            yield self._dovccmd(['checkout', '-B', self.branch], abandonOnFailure=False)
 
         defer.returnValue(res)
 

--- a/master/buildbot/test/unit/test_steps_source_gerrit.py
+++ b/master/buildbot/test/unit/test_steps_source_gerrit.py
@@ -65,7 +65,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'branch', '-M', 'gerrit_branch'])
+                        command=['git', 'checkout', '-B', 'gerrit_branch'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
@@ -109,7 +109,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'branch', '-M', 'refs/changes/34/1234/567'])
+                        command=['git', 'checkout', '-B', 'refs/changes/34/1234/567'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -381,7 +381,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'branch', '-M', 'test-branch'])
+                        command=['git', 'checkout', '-B', 'test-branch'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
@@ -897,7 +897,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'branch', '-M', 'test-branch'])
+                        command=['git', 'checkout', '-B', 'test-branch'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
@@ -1350,7 +1350,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'branch', '-M', 'test-branch'])
+                        command=['git', 'checkout', '-B', 'test-branch'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])

--- a/master/buildbot/test/unit/test_steps_source_github.py
+++ b/master/buildbot/test/unit/test_steps_source_github.py
@@ -59,7 +59,7 @@ class TestGitHub(test_steps_source_git.TestGit):
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'branch', '-M', 'refs/pull/1234/merge'])
+                        command=['git', 'checkout', '-B', 'refs/pull/1234/merge'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
@@ -103,7 +103,7 @@ class TestGitHub(test_steps_source_git.TestGit):
                         command=['git', 'reset', '--hard', '12345678', '--'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'branch', '-M', 'refs/pull/1234/head'])
+                        command=['git', 'checkout', '-B', 'refs/pull/1234/head'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])


### PR DESCRIPTION
Some projects require local branches to exist (namely `master`) in order
to run their tests. The rename step takes away the `master` branch from
the checkout on the build machine and can cause tests to fail. Rather
than renaming the current branch, checkout a new branch, overwriting any
branch of the previous name.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

Not sure if there's relevant documentation as to how the local branch gets made anywhere or not.