### PR TITLE
Add `webhooks` to `buildbot.plugins`

### DIFF
--- a/master/buildbot/plugins/__init__.py
+++ b/master/buildbot/plugins/__init__.py
@@ -26,7 +26,7 @@ from buildbot.plugins.db import get_plugins
 
 __all__ = [
     'changes', 'schedulers', 'steps', 'util', 'reporters', 'statistics',
-    'worker', 'secrets',
+    'worker', 'secrets', 'webhooks',
     'buildslave',  # deprecated, use 'worker' instead.
 ]
 
@@ -39,6 +39,7 @@ steps = get_plugins('steps', IBuildStep)
 util = get_plugins('util', None)
 reporters = get_plugins('reporters', None)
 secrets = get_plugins('secrets', None)
+webhooks = get_plugins('webhooks', None)
 
 # For plugins that are not updated to the new worker names, plus fallback of
 # current Buildbot plugins for old configuration files.


### PR DESCRIPTION
According to the documentation we should be able to import `webhooks` from `buildbot.plugins`:

	http://docs.buildbot.net/0.9.10/manual/cfg-wwwhooks.html#custom-hooks
