### PR TITLE
Perforce bytes fix

### DIFF
--- a/master/buildbot/newsfragments/perforce.bugfix
+++ b/master/buildbot/newsfragments/perforce.bugfix
@@ -1,0 +1,1 @@
+Fix the Perforce build step on Python 3 (:issue:`3493`)

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from future.utils import iteritems
-from future.utils import string_types
+from future.utils import text_type
 
 from twisted.internet import defer
 from twisted.internet import error
@@ -360,7 +360,7 @@ class RemoteShellCommand(RemoteCommand):
         if decodeRC is None:
             decodeRC = {0: SUCCESS}
         self.command = command  # stash .command, set it later
-        if isinstance(self.command, string_types):
+        if isinstance(self.command, (text_type, bytes)):
             # Single string command doesn't support obfuscation.
             self.fake_command = command
         else:

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -21,8 +21,6 @@ from future.utils import text_type
 import os
 import pprint
 import re
-from builtins import bytes
-from builtins import str
 
 from twisted.internet import defer
 from twisted.internet import error

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from future.utils import iteritems
-from future.utils import string_types
+from future.utils import text_type
 
 import os
 import pprint
@@ -85,7 +85,7 @@ class MasterShellCommand(BuildStep):
         # render properties
         command = self.command
         # set up argv
-        if isinstance(command, (str, bytes)):
+        if isinstance(command, (text_type, bytes)):
             if runtime.platformType == 'win32':
                 # allow %COMSPEC% to have args
                 argv = os.environ['COMSPEC'].split()
@@ -108,7 +108,7 @@ class MasterShellCommand(BuildStep):
 
         self.stdio_log = stdio_log = self.addLog("stdio")
 
-        if isinstance(command, str):
+        if isinstance(command, (text_type, bytes)):
             stdio_log.addHeader(command.strip() + "\n\n")
         else:
             stdio_log.addHeader(" ".join(command) + "\n\n")
@@ -139,7 +139,7 @@ class MasterShellCommand(BuildStep):
             newenv = {}
             for key, v in iteritems(env):
                 if v is not None:
-                    if not isinstance(v, string_types):
+                    if not isinstance(v, (text_type, bytes)):
                         raise RuntimeError("'env' values must be strings or "
                                            "lists; key '%s' is incorrect" % (key,))
                     newenv[key] = p.sub(subst, env[key])

--- a/worker/buildbot_worker/test/unit/test_util.py
+++ b/worker/buildbot_worker/test/unit/test_util.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 # This file is part of Buildbot.  Buildbot is free software: you can
 # redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation, version 2.
@@ -68,16 +69,30 @@ class TestObfuscated(unittest.TestCase):
 
     def testObfuscatedCommand(self):
         cmd = ['echo', util.Obfuscated('password', '*******')]
+        cmd_bytes = [b'echo', util.Obfuscated(b'password', b'*******')]
+        cmd_unicode = [u'echo', util.Obfuscated(u'password', u'привет')]
 
         self.assertEqual(
             ['echo', 'password'], util.Obfuscated.get_real(cmd))
         self.assertEqual(
             ['echo', '*******'], util.Obfuscated.get_fake(cmd))
+        self.assertEqual(
+            [b'echo', b'password'], util.Obfuscated.get_real(cmd_bytes))
+        self.assertEqual(
+            [b'echo', b'*******'], util.Obfuscated.get_fake(cmd_bytes))
+        self.assertEqual(
+            [u'echo', u'password'], util.Obfuscated.get_real(cmd_unicode))
+        self.assertEqual(
+            [u'echo', u'привет'], util.Obfuscated.get_fake(cmd_unicode))
 
     def testObfuscatedNonString(self):
         cmd = ['echo', 1]
+        cmd_bytes = [b'echo', 2]
+        cmd_unicode = [u'привет', 3]
         self.assertEqual(['echo', '1'], util.Obfuscated.get_real(cmd))
-        self.assertEqual(['echo', '1'], util.Obfuscated.get_fake(cmd))
+        self.assertEqual([b'echo', '2'], util.Obfuscated.get_fake(cmd_bytes))
+        self.assertEqual([u'привет', u'3'],
+                         util.Obfuscated.get_fake(cmd_unicode))
 
     def testObfuscatedNonList(self):
         cmd = 1

--- a/worker/buildbot_worker/util/__init__.py
+++ b/worker/buildbot_worker/util/__init__.py
@@ -13,7 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
-from future.utils import string_types
+from future.utils import text_type
 
 import itertools
 import textwrap
@@ -70,7 +70,7 @@ class Obfuscated(object):
 
     @staticmethod
     def to_text(s):
-        if isinstance(s, string_types):
+        if isinstance(s, (text_type, bytes)):
             return s
         return str(s)
 


### PR DESCRIPTION
Fix a case where the Perforce step was passing bytes all the way down
to RemoteCommand.  `buildbot_worker.util.__init__.Obfuscated(b"something")` was returning a string `"b'something'"` instead of `b"something"` which was causing things to break.

Fixes #3493