### PR TITLE
Fix integration secret tests with vault instance

### DIFF
--- a/master/buildbot/test/integration/test_integration_secrets_with_vault.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault.py
@@ -35,13 +35,12 @@ class SecretsConfig(RunMasterBase):
         rv = os.system("docker run -d -e SKIP_SETCAP=yes -e "
                        "'VAULT_DEV_ROOT_TOKEN_ID=my_vaulttoken' -e 'VAULT_TOKEN=my_vaulttoken'"
                        " --name=vault_for_buildbot -p 8200:8200 vault")
-
         if rv != 0:
             raise SkipTest(
                 "Vault integration need docker environment to be setup")
-
-        os.system("docker exec vault_for_buildbot "
-                  "vault write -address 'http://localhost:8200' secret/key value=word")
+        os.system("docker exec -it vault_for_buildbot /bin/sh -c "
+                  "'export VAULT_ADDR=http://127.0.0.1:8200/\n"
+                  "vault write secret/key value=word'")
 
     def tearDown(self):
         os.system("docker rm -f vault_for_buildbot")


### PR DESCRIPTION
Integration tests are working with a vault instance. The instance needs to know what is the instance address in the environment variable list.

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
