### PR TITLE
fix py3 issue with locale check

### DIFF
--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -32,7 +32,9 @@ import sqlalchemy as sa
 from twisted.python import reflect
 from twisted.python import usage
 
+import buildbot
 from buildbot.scripts import base
+from buildbot.util import check_functional_environment
 
 # Note that the terms 'options' and 'config' are used interchangeably here - in
 # fact, they are interchanged several times.  Caveat legator.
@@ -744,6 +746,7 @@ class Options(usage.Options):
 
 def run():
     config = Options()
+    check_functional_environment(buildbot.config)
     try:
         config.parseOptions(sys.argv[1:])
     except usage.error as e:

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -416,11 +416,11 @@ def asyncSleep(delay):
 def check_functional_environment(config):
     try:
         locale.getdefaultlocale()
-    except KeyError:
+    except (KeyError, ValueError) as e:
         config.error("\n".join([
             "Your environment has incorrect locale settings. This means python cannot handle strings safely.",
             " Please check 'LANG', 'LC_CTYPE', 'LC_ALL' and 'LANGUAGE'"
-            " are either unset or set to a valid locale.",
+            " are either unset or set to a valid locale.", str(e)
         ]))
 
 


### PR DESCRIPTION
py3 raise ValueError instead of KeyError when locale is not set properly.
While we are at it, we do the locale check very early.
