### PR TITLE
Fix regression in oath2 github v3 handling

### DIFF
--- a/master/buildbot/newsfragments/oauth2.bugfix
+++ b/master/buildbot/newsfragments/oauth2.bugfix
@@ -1,0 +1,1 @@
+Fix regression in GithHub oauth2 v3 api

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -248,7 +248,7 @@ class GitHubAuth(OAuth2Auth):
                 config.error(
                     'Retrieving team membership information using GitHubAuth is only '
                     'possible using GitHub api v4.')
-            self.apiResourceEndpoint = '{0}/api/v3'.format(self.serverURL)
+            self.resourceEndpoint = '{0}/api/v3'.format(self.serverURL)
         else:
             self.apiResourceEndpoint = '{0}/graphql'.format(self.serverURL)
         if getTeamsMembership:


### PR DESCRIPTION
## Remove this paragraph
Fix regression in GitHub auth2 v3 

http://trac.buildbot.net/wiki/Development
And especially:
http://trac.buildbot.net/wiki/SubmittingPatches

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
