### PR TITLE
grid_view: fix results filtering

### DIFF
--- a/www/grid_view/src/module/grid.controller.coffee
+++ b/www/grid_view/src/module/grid.controller.coffee
@@ -130,8 +130,8 @@ class Grid extends Controller
                     build = buildByReqID[req.buildrequestid]
                     unless build?
                         continue
-                    if !isNaN(@result) and !isNaN(build.results)
-                        if parseInt(build.results) != parseInt(@result)
+                    if @result? and @result != '' and !isNaN(@result)
+                        if build.results != parseInt(@result)
                             continue
                     builder = @builders.get(build.builderid)
                     unless @isBuilderDisplayed(builder)


### PR DESCRIPTION
When selecting 'Results=SUCCESS' and then 'Results=FAILURE', it works properly. But when going back to 'Results=(all)' nothing is displayed.

This is because `isNaN('')` returns `False`. Check explicitly if `@result` is set to a non-empty value before checking if it is set to a number.