### PR TITLE
Fix example which fails with "trial pyflakes"

### DIFF
--- a/master/buildbot/scripts/sample.cfg
+++ b/master/buildbot/scripts/sample.cfg
@@ -27,11 +27,11 @@ c['protocols'] = {'pb': {'port': 9989}}
 ####### CHANGESOURCES
 
 # the 'change_source' setting tells the buildmaster how it should find out
-# about source code changes.  Here we point to the buildbot clone of pyflakes.
+# about source code changes.  Here we point to the buildbot version of a python hello-world project.
 
 c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
-        'git://github.com/buildbot/pyflakes.git',
+        'git://github.com/buildbot/hello-world.git',
         workdir='gitpoller-workdir', branch='master',
         pollinterval=300))
 
@@ -58,9 +58,9 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 # check out the source
-factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
+factory.addStep(steps.Git(repourl='git://github.com/buildbot/hello-world.git', mode='incremental'))
 # run the tests (note that this will require that 'trial' is installed)
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+factory.addStep(steps.ShellCommand(command=["trial", "hello"],
                                    env={"PYTHONPATH": "."}))
 
 c['builders'] = []
@@ -82,8 +82,8 @@ c['services'] = []
 # the 'title' string will appear at the top of this buildbot installation's
 # home pages (linked to the 'titleURL').
 
-c['title'] = "Pyflakes"
-c['titleURL'] = "https://launchpad.net/pyflakes"
+c['title'] = "Hello World CI"
+c['titleURL'] = "https://buildbot.github.io/hello-world/"
 
 # the 'buildbotURL' string should point to the location where the buildbot's
 # internal web server is visible. This typically uses the port number set in

--- a/master/buildbot/scripts/sample.cfg
+++ b/master/buildbot/scripts/sample.cfg
@@ -60,7 +60,8 @@ factory = util.BuildFactory()
 # check out the source
 factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
 # run the tests (note that this will require that 'trial' is installed)
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"]))
+factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+                                   env={"PYTHONPATH": "."}))
 
 c['builders'] = []
 c['builders'].append(

--- a/master/buildbot/test/integration/test_configs.py
+++ b/master/buildbot/test/integration/test_configs.py
@@ -178,7 +178,7 @@ c['protocols'] = {'pb': {'port': 9989}}
 
 c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
-        'git://github.com/buildbot/pyflakes.git',
+        'git://github.com/buildbot/hello-world.git',
         workdir='gitpoller-workdir', branch='master',
         pollinterval=300))
 
@@ -193,7 +193,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
                             builderNames=["runtests"]))
 
 factory = util.BuildFactory()
-factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
+factory.addStep(steps.Git(repourl='git://github.com/buildbot/hello-world.git', mode='incremental'))
 factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
                                    env={"PYTHONPATH": "."}))
 
@@ -230,7 +230,7 @@ c['protocols'] = {'pb': {'port': 9989}}
 
 c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
-        'git://github.com/buildbot/pyflakes.git',
+        'git://github.com/buildbot/hello-world.git',
         workdir='gitpoller-workdir', branch='master',
         pollinterval=300))
 
@@ -245,7 +245,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
                             builderNames=["runtests"]))
 
 factory = util.BuildFactory()
-factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
+factory.addStep(steps.Git(repourl='git://github.com/buildbot/hello-world.git', mode='incremental'))
 factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
                                    env={"PYTHONPATH": "."}))
 

--- a/master/buildbot/test/integration/test_configs.py
+++ b/master/buildbot/test/integration/test_configs.py
@@ -194,7 +194,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 factory.addStep(steps.Git(repourl='git://github.com/buildbot/hello-world.git', mode='incremental'))
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+factory.addStep(steps.ShellCommand(command=["trial", "hello"],
                                    env={"PYTHONPATH": "."}))
 
 c['builders'] = []
@@ -246,7 +246,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 factory.addStep(steps.Git(repourl='git://github.com/buildbot/hello-world.git', mode='incremental'))
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+factory.addStep(steps.ShellCommand(command=["trial", "hello"],
                                    env={"PYTHONPATH": "."}))
 
 c['builders'] = []

--- a/master/buildbot/test/integration/test_configs.py
+++ b/master/buildbot/test/integration/test_configs.py
@@ -194,7 +194,8 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"]))
+factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+                                   env={"PYTHONPATH": "."}))
 
 c['builders'] = []
 c['builders'].append(
@@ -245,7 +246,8 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"]))
+factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+                                   env={"PYTHONPATH": "."}))
 
 c['builders'] = []
 c['builders'].append(

--- a/master/buildbot/test/integration/test_worker_transition.py
+++ b/master/buildbot/test/integration/test_worker_transition.py
@@ -66,7 +66,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 factory.addStep(steps.Git(repourl='git://github.com/buildbot/hello-world.git', mode='incremental'))
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+factory.addStep(steps.ShellCommand(command=["trial", "hello"],
                                    env={"PYTHONPATH": "."}))
 
 c['builders'] = []
@@ -111,7 +111,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 factory.addStep(steps.Git(repourl='git://github.com/buildbot/hello-world.git', mode='incremental'))
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+factory.addStep(steps.ShellCommand(command=["trial", "hello"],
                                    env={"PYTHONPATH": "."}))
 
 c['builders'] = []

--- a/master/buildbot/test/integration/test_worker_transition.py
+++ b/master/buildbot/test/integration/test_worker_transition.py
@@ -50,7 +50,7 @@ c['protocols'] = {'pb': {'port': 'tcp:0'}}
 
 c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
-        'git://github.com/buildbot/pyflakes.git',
+        'git://github.com/buildbot/hello-world.git',
         workdir='gitpoller-workdir', branch='master',
         pollinterval=300))
 
@@ -65,7 +65,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
                             builderNames=["runtests"]))
 
 factory = util.BuildFactory()
-factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
+factory.addStep(steps.Git(repourl='git://github.com/buildbot/hello-world.git', mode='incremental'))
 factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
                                    env={"PYTHONPATH": "."}))
 
@@ -95,7 +95,7 @@ c['protocols'] = {'pb': {'port': 'tcp:0'}}
 
 c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
-        'git://github.com/buildbot/pyflakes.git',
+        'git://github.com/buildbot/hello-world.git',
         workdir='gitpoller-workdir', branch='master',
         pollinterval=300))
 
@@ -110,7 +110,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
                             builderNames=["runtests"]))
 
 factory = util.BuildFactory()
-factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
+factory.addStep(steps.Git(repourl='git://github.com/buildbot/hello-world.git', mode='incremental'))
 factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
                                    env={"PYTHONPATH": "."}))
 

--- a/master/buildbot/test/integration/test_worker_transition.py
+++ b/master/buildbot/test/integration/test_worker_transition.py
@@ -66,7 +66,8 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"]))
+factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+                                   env={"PYTHONPATH": "."}))
 
 c['builders'] = []
 c['builders'].append(
@@ -110,7 +111,8 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 factory.addStep(steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental'))
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"]))
+factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+                                   env={"PYTHONPATH": "."}))
 
 c['builders'] = []
 c['builders'].append(

--- a/master/docs/manual/cfg-global.rst
+++ b/master/docs/manual/cfg-global.rst
@@ -245,7 +245,7 @@ This setting has no impact on status plugins, and merely affects the required di
 The :bb:cfg:`logCompressionMethod` controls what type of compression is used for build logs.
 The default is 'gz', and the other valid option are 'raw' (no compression), 'gz' or 'lz4' (required lz4 package).
 
-Please find below some stats extracted from 50x "Pyflakes" runs (results may differ according to log type).
+Please find below some stats extracted from 50x "trial Pyflakes" runs (results may differ according to log type).
 
 .. csv-table:: Space saving details
    :header: "compression", "raw log size", "compressed log size", "space saving", "compression speed"

--- a/master/docs/manual/cfg-intro.rst
+++ b/master/docs/manual/cfg-intro.rst
@@ -41,7 +41,7 @@ For the configurations described in this section, a detailed knowledge of Python
 Python comments start with a hash character ``#``, tuples are defined with ``(parenthesis, pairs)``, and lists (arrays) are defined with ``[square, brackets]``.
 Tuples and lists are mostly interchangeable.
 Dictionaries (data structures which map *keys* to *values*) are defined with curly braces: ``{'key1': value1, 'key2': value2}``.
-Function calls (and object instantiation) can use named parameters, like ``steps.ShellCommand(command=["trial", "pyflakes"])``.
+Function calls (and object instantiation) can use named parameters, like ``steps.ShellCommand(command=["trial", "hello"])``.
 
 The config file starts with a series of ``import`` statements, which make various kinds of :class:`Step`\s and :class:`Status` targets available for later use.
 The main ``BuildmasterConfig`` dictionary is created, then it is populated with a variety of keys, described section-by-section in subsequent chapters.

--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -85,12 +85,12 @@ Now that buildbot is installed, it's time to create the master:
 .. code-block:: bash
 
   buildbot create-master master
- 
+
 Buildbot's activity is controlled by a configuration file.
 We will use the sample configuration file unchanged:
 
 .. code-block:: bash
- 
+
   mv master/master.cfg.sample master/master.cfg
 
 Finally, start the master:
@@ -116,7 +116,7 @@ Creating a worker
 -----------------
 
 The worker will be executing the commands sent by the master.
-In this tutorial, we are using the pyflakes project as an example.
+In this tutorial, we are using the buildbot/hello-world project as an example.
 As a consequence of this, your worker will need access to the git_ command in order to checkout some code.
 Be sure that it is installed, or the builds will fail.
 
@@ -198,7 +198,7 @@ Click on the `Waterfall Display link <http://localhost:8010/#/waterfall>`_ and y
 .. image:: _images/waterfall-empty.png
    :alt: empty waterfall.
 
-Your master is now quietly waiting for new commits to Pyflakes.
+Your master is now quietly waiting for new commits to hello-world.
 This doesn't happen very often though.
 In the next section, we'll see how to manually start a build.
 

--- a/master/docs/tutorial/tour.rst
+++ b/master/docs/tutorial/tour.rst
@@ -43,10 +43,10 @@ Now, look for the section marked *PROJECT IDENTITY* which reads::
   # the 'title' string will appear at the top of this buildbot installation's
   # home pages (linked to the 'titleURL').
 
-  c['title'] = "Pyflakes"
-  c['titleURL'] = "http://divmod.org/trac/wiki/DivmodPyflakes"
+  c['title'] = "Hello World CI"
+  c['titleURL'] = "https://buildbot.github.io/hello-world/"
 
-If you want, you can change either of these links to anything you want to see what happens when you change them. 
+If you want, you can change either of these links to anything you want to see what happens when you change them.
 
 After making a change go into the terminal and type:
 
@@ -93,8 +93,8 @@ Open up the config again and introduce a syntax error by removing the first sing
 
 .. code-block:: none
 
-  c[title'] = "Pyflakes
-  c[titleURL'] = "http://divmod.org/trac/wiki/DivmodPyflakes"
+  c[title'] = "Hello World CI"
+  c[titleURL'] = "https://buildbot.github.io/hello-world/"
 
 This creates a Python ``SyntaxError``.
 Now go ahead and reconfig the buildmaster:
@@ -324,14 +324,14 @@ To set this up, add the following lines to master.cfg::
 
 Then you can submit changes using the :bb:cmdline:`try` command.
 
-Let's try this out by making a one-line change to pyflakes, say, to make it trace the tree by default:
+Let's try this out by making a one-line change to hello-world, say, to make it trace the tree by default:
 
 .. code-block:: bash
 
-  git clone git://github.com/buildbot/pyflakes.git pyflakes-git
-  cd pyflakes-git/pyflakes
-  $EDITOR checker.py
-  # change "traceTree = False" on line 185 to "traceTree = True"
+  git clone git://github.com/buildbot/hello-world.git hello-world-git
+  cd hello-world-git/hello
+  $EDITOR __init__.py
+  # change 'return "hello " + who' on line 6 to 'return "greets " + who'
 
 Then run buildbot's ``try`` command as follows:
 

--- a/smokes/e2e/hook.scenarios.coffee
+++ b/smokes/e2e/hook.scenarios.coffee
@@ -19,7 +19,7 @@ describe 'change hook', () ->
                 $.post('change_hook/base', {
                     comments:'sd',
                     project:'pyflakes'
-                    repository:'git://github.com/buildbot/pyflakes.git'
+                    repository:'git://github.com/buildbot/hello-world.git'
                     author:'foo <foo@bar.com>'
                     revision: 'HEAD'
                     branch:'master'

--- a/smokes/master.cfg
+++ b/smokes/master.cfg
@@ -34,7 +34,7 @@ c['protocols'] = {'pb': {'port': 9989}}
 # about source code changes.  Here we point to the buildbot clone of pyflakes.
 c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
-        'https://github.com/buildbot/pyflakes.git',
+        'https://github.com/buildbot/hello-world.git',
         workdir='gitpoller-workdir', branch='master',
         pollinterval=300))
 
@@ -60,13 +60,13 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 factory = util.BuildFactory()
 # check out the source
-factory.addStep(steps.Git(repourl='https://github.com/buildbot/pyflakes.git', mode='incremental'))
+factory.addStep(steps.Git(repourl='https://github.com/buildbot/hello-world.git', mode='incremental'))
 factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
                                    env={"PYTHONPATH": "."}))
 
 slowfactory = util.BuildFactory()
 #check out the source
-slowfactory.addStep(steps.Git(repourl='https://github.com/buildbot/pyflakes.git', mode='incremental'))
+slowfactory.addStep(steps.Git(repourl='https://github.com/buildbot/hello-world.git', mode='incremental'))
 slowfactory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
                                        env={"PYTHONPATH": "."}))
 slowfactory.addStep(steps.ShellCommand(command=["sleep", "10"]))

--- a/smokes/master.cfg
+++ b/smokes/master.cfg
@@ -61,15 +61,14 @@ c['schedulers'].append(schedulers.ForceScheduler(
 factory = util.BuildFactory()
 # check out the source
 factory.addStep(steps.Git(repourl='https://github.com/buildbot/pyflakes.git', mode='incremental'))
-# run the tests (note that this will not actually run the tests are they do not work with py3)
-factory.addStep(steps.ShellCommand(command=["echo", "trial", "pyflakes"]))
-
+factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+                                   env={"PYTHONPATH": "."}))
 
 slowfactory = util.BuildFactory()
 #check out the source
 slowfactory.addStep(steps.Git(repourl='https://github.com/buildbot/pyflakes.git', mode='incremental'))
-# run the tests (note that this will not actually run the tests are they do not work with py3)
-slowfactory.addStep(steps.ShellCommand(command=["echo", "trial", "pyflakes"]))
+slowfactory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+                                       env={"PYTHONPATH": "."}))
 slowfactory.addStep(steps.ShellCommand(command=["sleep", "10"]))
 
 

--- a/smokes/master.cfg
+++ b/smokes/master.cfg
@@ -61,13 +61,13 @@ c['schedulers'].append(schedulers.ForceScheduler(
 factory = util.BuildFactory()
 # check out the source
 factory.addStep(steps.Git(repourl='https://github.com/buildbot/hello-world.git', mode='incremental'))
-factory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+factory.addStep(steps.ShellCommand(command=["trial", "hello"],
                                    env={"PYTHONPATH": "."}))
 
 slowfactory = util.BuildFactory()
 #check out the source
 slowfactory.addStep(steps.Git(repourl='https://github.com/buildbot/hello-world.git', mode='incremental'))
-slowfactory.addStep(steps.ShellCommand(command=["trial", "pyflakes"],
+slowfactory.addStep(steps.ShellCommand(command=["trial", "hello"],
                                        env={"PYTHONPATH": "."}))
 slowfactory.addStep(steps.ShellCommand(command=["sleep", "10"]))
 


### PR DESCRIPTION
When calling "trial pyflakes", add current directory to PYTHONPATH.

This is required in Twisted 16.6.0 and higher.

See:
https://stackoverflow.com/questions/42425901/twisted-trial-pythonpath-and-sys-path

In Twisted 16.4.0 and higher, trial does not add the pwd to PYTHONPATH.

A user is required to either:
  1.  Properly install their package via setup.py and then run trial
  2.  Explicitly add '.' to PYTHONPATH.

The decision was made to keep this new behavior:
https://twistedmatrix.com/pipermail/twisted-python/2017-February/031145.html