### PR TITLE
Replace python3-ldap with its successor ldap3.

### DIFF
--- a/master/buildbot/newsfragments/replace_ldap3.feature
+++ b/master/buildbot/newsfragments/replace_ldap3.feature
@@ -1,0 +1,1 @@
+The :py:class:`~buildbot.www.ldapuserinfo.LdapUserInfo` now uses the python3-ldap successor ldap3.

--- a/master/buildbot/newsfragments/replace_ldap3.feature
+++ b/master/buildbot/newsfragments/replace_ldap3.feature
@@ -1,1 +1,1 @@
-The :py:class:`~buildbot.www.ldapuserinfo.LdapUserInfo` now uses the python3-ldap successor ldap3.
+The :py:class:`~buildbot.www.ldapuserinfo.LdapUserInfo` now uses the python3-ldap successor ldap3 (:issue:`3530`).

--- a/master/buildbot/test/unit/test_www_ldapuserinfo.py
+++ b/master/buildbot/test/unit/test_www_ldapuserinfo.py
@@ -44,7 +44,7 @@ class CommonTestCase(unittest.TestCase):
 
     """Common fixture for all ldapuserinfo tests
 
-    we completely fake the python3-ldap module, so no need to require
+    we completely fake the ldap3 module, so no need to require
     it to run the unit tests
     """
 

--- a/master/buildbot/www/ldapuserinfo.py
+++ b/master/buildbot/www/ldapuserinfo.py
@@ -71,20 +71,19 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
         netloc = server.netloc.split(":")
         # define the server and the connection
         s = ldap3.Server(netloc[0], port=int(netloc[1]), use_ssl=server.scheme == 'ldaps',
-                         get_info=ldap3.GET_ALL_INFO)
+                         get_info=ldap3.ALL)
 
-        auth = ldap3.AUTH_SIMPLE
+        auth = ldap3.SIMPLE
         if self.bindUser is None and self.bindPw is None:
-            auth = ldap3.AUTH_ANONYMOUS
+            auth = ldap3.ANONYMOUS
 
-        c = ldap3.Connection(s, auto_bind=True, client_strategy=ldap3.STRATEGY_SYNC,
+        c = ldap3.Connection(s, auto_bind=True, client_strategy=ldap3.SYNC,
                              user=self.bindUser, password=self.bindPw,
                              authentication=auth)
         return c
 
     def search(self, c, base, filterstr='f', attributes=None):
-        c.search(
-            base, filterstr, ldap3.SEARCH_SCOPE_WHOLE_SUBTREE, attributes=attributes)
+        c.search(base, filterstr, ldap3.SUBTREE, attributes=attributes)
         return c.response
 
     def getUserInfo(self, username):

--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -529,11 +529,11 @@ Example::
 
 .. note::
 
-            In order to use this module, you need to install the ``python3-ldap`` module (and an old version of ``pyASN1``, see :issue:`3530`):
+            In order to use this module, you need to install the ``ldap3`` module:
 
             .. code-block:: bash
 
-                pip install pyASN1==0.1.9 python3-ldap
+                pip install ldap3
 
 In the case of oauth2 authentications, you have to pass the userInfoProvider as keyword argument::
 


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

As discussed in #3530, I replaced python3-ldap with ldap3. I couldn't afford more time to rework the module, so I simply replaced the python3-ldap dependencies.
Do you have any special upgrade warning/procedure to inform people that they have to change their environment?

Btw I observed a significant performance increase after replacing the library.

fixes  #3530