### PR TITLE
Setup Docker Latent Worker to autopull image based on config

### DIFF
--- a/master/buildbot/newsfragments/docker_autopull.feature
+++ b/master/buildbot/newsfragments/docker_autopull.feature
@@ -1,0 +1,1 @@
+Added autopull for Docker images based on config. (:issue:`3071`)

--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -28,6 +28,7 @@ class Client(object):
         self.call_args_create_host_config = []
         self.called_class_name = None
         self._images = [{'RepoTags': ['busybox:latest', 'worker:latest']}]
+        self._pullable = ['alpine:latest']
         self._containers = {}
 
     def images(self):
@@ -50,6 +51,10 @@ class Client(object):
             for line in logs:
                 yield line
             self._images.append({'RepoTags': [tag + ':latest']})
+
+    def pull(self, image, *args, **kwargs):
+        if image in self._pullable:
+            self._images.append({'RepoTags': [image]})
 
     def containers(self, filters=None, *args, **kwargs):
         if filters is not None:

--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -220,6 +220,12 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase):
         id, name = self.successResultOf(bs.start_instance(self.build))
         self.assertEqual(name, 'customworker')
 
+    def test_start_instance_noimage_pull(self):
+        bs = self.setupWorker(
+            'bot', 'pass', 'tcp://1234:2375', 'alpine:latest', autopull=True)
+        id, name = self.successResultOf(bs.start_instance(self.build))
+        self.assertEqual(name, 'alpine:latest')
+
     def test_start_instance_noimage_renderabledockerfile(self):
         bs = self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'customworker',

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -117,7 +117,7 @@ class DockerLatentWorker(DockerBaseWorker):
 
     def checkConfig(self, name, password, docker_host, image=None, command=None,
                     volumes=None, dockerfile=None, version=None, tls=None, followStartupLogs=False,
-                    masterFQDN=None, hostconfig=None, **kwargs):
+                    masterFQDN=None, hostconfig=None, autopull=False, **kwargs):
 
         DockerBaseWorker.checkConfig(self, name, password, image, masterFQDN, **kwargs)
 

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -225,6 +225,10 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     (optional)
     Extra host configuration parameters passed as a dictionary used to create HostConfig object. See `docker-py's HostConfig documentation <https://docker-py.readthedocs.io/en/1.10.4/hostconfig/>`_ for all the supported options.
 
+``autopull``
+    (optional, defaults to false)
+    Automatically pulls image if requested image is not on docker host.
+
 Setting up Volumes
 ..................
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -37,6 +37,7 @@ authz
 autoconf
 autodetected
 automake
+autopull
 autoreconf
 backend
 backends


### PR DESCRIPTION
Added automatic pulling of docker images by setting require config.
The setting is `autopull` and is set to false by default, keeping the original workflow.

Closes #3071.
Starts #3572 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
