### PR TITLE
Fix for SVN.purge fails when modified files contain non-ascii characters

### DIFF
--- a/master/buildbot/newsfragments/3576.bugfix
+++ b/master/buildbot/newsfragments/3576.bugfix
@@ -1,0 +1,1 @@
+Fix for SVN.purge fails when modified files contain non-ascii characters (:issue:`3576`)

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -32,7 +32,8 @@ from buildbot.config import ConfigErrors
 from buildbot.process import buildstep
 from buildbot.process import remotecommand
 from buildbot.steps.source.base import Source
-from buildbot.util import unicode2bytes
+from buildbot.util import unicode2NativeString
+
 
 class SVN(Source):
 
@@ -353,7 +354,7 @@ class SVN(Source):
         def parseAndRemove(stdout):
             files = []
             for filename in self.getUnversionedFiles(stdout, self.keep_on_purge):
-                filename = unicode2bytes(self.build.path_module.join(self.workdir, filename))
+                filename = unicode2NativeString(self.build.path_module.join(self.workdir, filename))
                 files.append(filename)
             if not files:
                 d = defer.succeed(0)

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -32,7 +32,7 @@ from buildbot.config import ConfigErrors
 from buildbot.process import buildstep
 from buildbot.process import remotecommand
 from buildbot.steps.source.base import Source
-
+from buildbot.util import unicode2bytes
 
 class SVN(Source):
 
@@ -353,7 +353,7 @@ class SVN(Source):
         def parseAndRemove(stdout):
             files = []
             for filename in self.getUnversionedFiles(stdout, self.keep_on_purge):
-                filename = self.build.path_module.join(self.workdir, filename)
+                filename = unicode2bytes(self.build.path_module.join(self.workdir, filename))
                 files.append(filename)
             if not files:
                 d = defer.succeed(0)

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -353,7 +353,7 @@ class SVN(Source):
         def parseAndRemove(stdout):
             files = []
             for filename in self.getUnversionedFiles(stdout, self.keep_on_purge):
-                filename = self.workdir + '/' + str(filename)
+                filename = self.build.path_module.join(self.workdir, filename)
                 files.append(filename)
             if not files:
                 d = defer.succeed(0)

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # This file is part of Buildbot.  Buildbot is free software: you can
 # redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation, version 2.
@@ -2041,7 +2042,7 @@ class TestGetUnversionedFiles(unittest.TestCase):
         """
         unversioned_files = list(svn.SVN.getUnversionedFiles(svn_st_xml, []))
         self.assertEqual(
-            ["Path/To/Content/Developers/François"], unversioned_files)
+            [u"Path/To/Content/Developers/François"], unversioned_files)
 
 
 

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -47,7 +47,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                     <wc-status props="none" item="unversioned">
                     </wc-status>
                 </entry>
-                <entry path="svn_external_path/unversioned_file2">
+                <entry path="svn_external_path/unversioned_file2_uniçode">
                     <wc-status props="none" item="unversioned">
                     </wc-status>
                 </entry>
@@ -894,7 +894,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                               stdout=self.svn_st_xml)
             + 0,
             Expect('rmdir', {'dir':
-                             ['wkdir/svn_external_path/unversioned_file2'],
+                             ['wkdir/svn_external_path/unversioned_file2_uniçode'],
                              'logEnviron': True,
                              'timeout': 1200})
             + 0,
@@ -1091,7 +1091,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                              'timeout': 1200})
             + 0,
             Expect('rmdir', {'dir':
-                             'wkdir/svn_external_path/unversioned_file2',
+                             'wkdir/svn_external_path/unversioned_file2_uniçode',
                              'logEnviron': True,
                              'timeout': 1200})
             + 0,
@@ -1140,7 +1140,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,
             Expect('rmdir', {'dir':
                              ['wkdir/svn_external_path/unversioned_file1',
-                              'wkdir/svn_external_path/unversioned_file2'],
+                              'wkdir/svn_external_path/unversioned_file2_uniçode'],
                              'logEnviron': True,
                              'timeout': 1200})
             + 0,
@@ -1308,7 +1308,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                               stdout=self.svn_st_xml)
             + 0,
             Expect('rmdir', dict(dir=['wkdir/svn_external_path/unversioned_file1',
-                                      'wkdir/svn_external_path/unversioned_file2'],
+                                      'wkdir/svn_external_path/unversioned_file2_uniçode'],
                                  logEnviron=True,
                                  timeout=1200))
             + 0,
@@ -1383,7 +1383,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                               stdout=self.svn_st_xml)
             + 0,
             Expect('rmdir', dict(dir=['wkdir/svn_external_path/unversioned_file1',
-                                      'wkdir/svn_external_path/unversioned_file2'],
+                                      'wkdir/svn_external_path/unversioned_file2_uniçode'],
                                  logEnviron=True,
                                  timeout=1200))
             + 0,
@@ -1841,7 +1841,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                               stdout=self.svn_st_xml)
             + 0,
             Expect('rmdir', {'dir':
-                             ['wkdir/svn_external_path/unversioned_file2'],
+                             ['wkdir/svn_external_path/unversioned_file2_uniçode'],
                              'logEnviron': True,
                              'timeout': 1200})
             + 1,
@@ -2024,6 +2024,25 @@ class TestGetUnversionedFiles(unittest.TestCase):
         unversioned_files = list(svn.SVN.getUnversionedFiles(svn_st_xml, []))
         self.assertEqual(
             ["svn_external_path/unversioned_file"], unversioned_files)
+
+    def test_getUnversionedFiles_unicode(self):
+        svn_st_xml = """<?xml version="1.0"?>
+        <status>
+            <target path=".">
+                <entry
+                   path="Path/To/Content/Developers/François">
+                    <wc-status
+                       item="unversioned"
+                       props="none">
+                    </wc-status>
+                </entry>
+            </target>
+        </status>
+        """
+        unversioned_files = list(svn.SVN.getUnversionedFiles(svn_st_xml, []))
+        self.assertEqual(
+            ["Path/To/Content/Developers/François"], unversioned_files)
+
 
 
 class TestSvnUriCanonicalize(unittest.TestCase):

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -2045,7 +2045,6 @@ class TestGetUnversionedFiles(unittest.TestCase):
             [u"Path/To/Content/Developers/François"], unversioned_files)
 
 
-
 class TestSvnUriCanonicalize(unittest.TestCase):
     # svn.SVN.svnUriCanonicalize() test method factory
     #


### PR DESCRIPTION
fixes #3576


* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
