### PR TITLE
Fixed buildbot master not start error in docker

### DIFF
--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -69,7 +69,11 @@ def checkPidFile(pidfile):
                 raise OSError("Can't check status of PID {} from pidfile {}: {}".format(
                     pid, pidfile, why))
         else:
-            raise BusyError("'{}' exists - is this master still running?".format(pidfile))
+            # No exception if pid equal ppid, fixed it.
+            if pid == os.getppid():
+                os.remove(pidfile)
+            else:
+                raise BusyError("'{}' exists - is this master still running?".format(pidfile))
 
 
 def checkBasedir(config):


### PR DESCRIPTION
I'm running buildbot in docker with volumes(`-v /path/to/buildbot:/var/lib/buildbot`). The PID not change in container everytime, and the removing pid logic not enough when **the pid equal to ppid**. It's always try starting in looping.
```
checking basedir
checking for running master
'/var/lib/buildbot/twistd.pid' exists - is this master still running?
Can't upgrade master yet. Waiting for database ready?
```


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
