### PR TITLE
Remove unnecessary unicode/bytes encoding from p4 modules

### DIFF
--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -234,15 +234,6 @@ class P4(Source):
             command.extend(self.p4extra_args)
 
         command.extend(doCommand)
-
-        def encodeArg(arg):
-            if isinstance(arg, tuple):
-                # If a tuple, then the second element is the argument that will
-                # be used when executing the command.
-                return (arg[0], util.encodeString(arg[1]), arg[2])
-            return util.encodeString(arg)
-
-        command = [encodeArg(c) for c in command]
         return command
 
     def _dovccmd(self, command, collectStdout=False, initialStdin=None):

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -25,7 +25,6 @@ from twisted.python import log
 
 from buildbot import config
 from buildbot import interfaces
-from buildbot import util
 from buildbot.interfaces import WorkerTooOldError
 from buildbot.process import buildstep
 from buildbot.process.properties import Interpolate

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -348,7 +348,6 @@ class P4(Source):
                     client_spec += "\t%s%s/...%s %s//%s/%s/...%s\n" % (qa, k, qa,
                                                                        qb, self.p4client, v, qb)
 
-        client_spec = client_spec.encode('utf-8')  # resolve unicode issues
         if debug_logging:
             log.msg(client_spec)
 

--- a/master/buildbot/test/unit/test_steps_source_p4.py
+++ b/master/buildbot/test/unit/test_steps_source_p4.py
@@ -32,7 +32,6 @@ from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import sourcesteps
 from buildbot.test.util.properties import ConstantRenderable
-from buildbot.util import unicode2bytes
 
 _is_windows = (platform.system() == 'Windows')
 
@@ -120,7 +119,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',  # defaults to this, only changes if it has a copy mode.
@@ -128,20 +126,20 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,  # expected exit status
 
             ExpectShell(workdir='wkdir',
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', b'user',
-                                 b'-P', ('obfuscated', b'pass', 'XXXXXX'),
-                                 b'-c', b'p4_client1', b'client', b'-i'],
+                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
+                                 '-P', ('obfuscated', 'pass', 'XXXXXX'),
+                                 '-c', 'p4_client1', 'client', '-i'],
                         initialStdin=client_spec)
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', b'user',
-                                 b'-P', ('obfuscated', b'pass', 'XXXXXX'),
-                                 b'-c', b'p4_client1', b'sync', b'//depot...@100'])
+                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
+                                 '-P', ('obfuscated', 'pass', 'XXXXXX'),
+                                 '-c', 'p4_client1', 'sync', '//depot...@100'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', b'user',
-                                 b'-P', ('obfuscated', b'pass', 'XXXXXX'),
-                                 b'-c', b'p4_client1', b'changes', b'-m1', b'#have'])
+                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
+                                 '-P', ('obfuscated', 'pass', 'XXXXXX'),
+                                 '-c', 'p4_client1', 'changes', '-m1', '#have'])
             + ExpectShell.log('stdio',
                               stdout="Change 100 on 2013/03/21 by user@machine \'duh\'")
             + 0,
@@ -161,22 +159,22 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
 
             ExpectShell(workdir=workdir,
                         timeout=timeout,
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', b'user',
-                                 b'-P', ('obfuscated', b'pass', 'XXXXXX'),
-                                 b'-c', b'p4_client1', b'client', b'-i'],
+                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
+                                 '-P', ('obfuscated', 'pass', 'XXXXXX'),
+                                 '-c', 'p4_client1', 'client', '-i'],
                         initialStdin=client_stdin,)
             + 0,
             ExpectShell(workdir=workdir,
                         timeout=timeout,
-                        command=([b'p4', b'-p', b'localhost:12000', b'-u', b'user',
-                                  b'-P', ('obfuscated', b'pass', 'XXXXXX'), b'-c', b'p4_client1']
-                                 + extra_args + [b'sync']))
+                        command=(['p4', '-p', 'localhost:12000', '-u', 'user',
+                                  '-P', ('obfuscated', 'pass', 'XXXXXX'), '-c', 'p4_client1']
+                                 + extra_args + ['sync']))
             + 0,
             ExpectShell(workdir=workdir,
                         timeout=timeout,
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', b'user',
-                                 b'-P', ('obfuscated', b'pass', 'XXXXXX'),
-                                 b'-c', b'p4_client1', b'changes', b'-m1', b'#have'])
+                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
+                                 '-P', ('obfuscated', 'pass', 'XXXXXX'),
+                                 '-c', 'p4_client1', 'changes', '-m1', '#have'])
             + ExpectShell.log('stdio',
                               stdout="Change 100 on 2013/03/21 by user@machine \'duh\'")
             + 0,
@@ -210,7 +208,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._incremental(client_stdin=client_spec)
 
     def test_mode_incremental_p4base_with_no_branch(self):
@@ -238,7 +235,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._incremental(client_stdin=client_spec)
 
     def test_mode_incremental_p4base_with_p4extra_views(self):
@@ -272,7 +268,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         \t-//depot/trunk/doc/... //p4_client1/doc/...
         \t"-//depot/trunk/white space/..." "//p4_client1/white space/..."
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._incremental(client_stdin=client_spec)
 
     def test_mode_incremental_p4viewspec(self):
@@ -304,7 +299,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         \t"//depot/white space/..." "//p4_client1/white space/..."
         \t"-//depot/white space/excluded/..." "//p4_client1/white space/excluded/..."
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._incremental(client_stdin=client_spec)
 
     def test_mode_incremental_p4viewspec_suffix(self):
@@ -338,7 +332,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         \t"//depot/white space/..." "//p4_client1/white space/..."
         \t"-//depot/white space/excluded/..." "//p4_client1/white space/excluded/..."
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._incremental(client_stdin=client_spec)
 
     def test_mode_incremental_p4client_spec_options(self):
@@ -367,7 +360,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._incremental(client_stdin=client_spec)
 
     def test_mode_incremental_parent_workdir(self):
@@ -396,7 +388,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._incremental(client_stdin=client_spec, workdir='../another_wkdir')
 
     def test_mode_incremental_p4extra_args(self):
@@ -425,8 +416,7 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
-        self._incremental(client_stdin=client_spec, extra_args=[b'-Zproxyload'])
+        self._incremental(client_stdin=client_spec, extra_args=['-Zproxyload'])
 
     def test_mode_incremental_timeout(self):
         self.setupStep(P4(p4port='localhost:12000', mode='incremental',
@@ -454,17 +444,16 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._incremental(client_stdin=client_spec, timeout=60 * 60)
 
-    def _full(self, client_stdin='', p4client=b'p4_client1', p4user=b'user',
+    def _full(self, client_stdin='', p4client='p4_client1', p4user='user',
               workdir='wkdir', extra_args=None, obfuscated_pass=True):
         if extra_args is None:
             extra_args = []
         if obfuscated_pass:
-            expected_pass = ('obfuscated', b'pass', 'XXXXXX')
+            expected_pass = ('obfuscated', 'pass', 'XXXXXX')
         else:
-            expected_pass = b'pass'
+            expected_pass = 'pass'
 
         self.expectCommands(
             ExpectShell(workdir=workdir,
@@ -472,30 +461,30 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
             + 0,  # expected exit status
 
             ExpectShell(workdir=workdir,
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', p4user,
-                                 b'-P', expected_pass,
-                                 b'-c', p4client, b'client', b'-i'],
+                        command=['p4', '-p', 'localhost:12000', '-u', p4user,
+                                 '-P', expected_pass,
+                                 '-c', p4client, 'client', '-i'],
                         initialStdin=client_stdin)
             + 0,
             ExpectShell(workdir=workdir,
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', p4user,
-                                 b'-P', expected_pass, b'-c', p4client]
+                        command=['p4', '-p', 'localhost:12000', '-u', p4user,
+                                 '-P', expected_pass, '-c', p4client]
                         + extra_args
-                        + [b'sync', b'#none'])
+                        + ['sync', '#none'])
             + 0,
 
             Expect('rmdir', {'dir': workdir, 'logEnviron': True})
             + 0,
 
             ExpectShell(workdir=workdir,
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', p4user,
-                                 b'-P', expected_pass, b'-c', p4client]
-                        + extra_args + [b'sync'])
+                        command=['p4', '-p', 'localhost:12000', '-u', p4user,
+                                 '-P', expected_pass, '-c', p4client]
+                        + extra_args + ['sync'])
             + 0,
             ExpectShell(workdir=workdir,
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', p4user,
-                                 b'-P', expected_pass, b'-c', p4client,
-                                 b'changes', b'-m1', b'#have'])
+                        command=['p4', '-p', 'localhost:12000', '-u', p4user,
+                                 '-P', expected_pass, '-c', p4client,
+                                 'changes', '-m1', '#have'])
             + ExpectShell.log('stdio',
                               stdout="Change 100 on 2013/03/21 by user@machine \'duh\'")
             + 0,
@@ -529,7 +518,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
 
         View:
         \t//depot/trunk/... //p4_client1/...\n''' % root_dir)
-        client_stdin = unicode2bytes(client_stdin)
         self._full(client_stdin=client_stdin)
 
     def test_mode_full_p4base_not_obfuscated(self):
@@ -558,7 +546,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
 
         View:
         \t//depot/trunk/... //p4_client1/...\n''' % root_dir)
-        client_stdin = unicode2bytes(client_stdin)
         self._full(client_stdin=client_stdin, obfuscated_pass=False)
 
     def test_mode_full_p4base_with_no_branch(self):
@@ -586,7 +573,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._full(client_stdin=client_spec)
 
     def test_mode_full_p4viewspec(self):
@@ -620,7 +606,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         \t"//depot/main/white space/..." "//p4_client1/white space/..."
         \t"-//depot/main/white space/excluded/..." "//p4_client1/white space/excluded/..."
         ''' % root_dir)
-        client_stdin = unicode2bytes(client_stdin)
         self._full(client_stdin=client_stdin)
 
     def test_mode_full_renderable_p4base(self):
@@ -650,8 +635,7 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
 
         View:
         \t//depot/release/1.0/... //p4_client2/...\n''' % root_dir)
-        client_stdin = unicode2bytes(client_stdin)
-        self._full(client_stdin=client_stdin, p4client=b'p4_client2')
+        self._full(client_stdin=client_stdin, p4client='p4_client2')
 
     def test_mode_full_renderable_p4client(self):
         # Note that the config check skips checking p4base if it's a renderable
@@ -680,9 +664,8 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
 
         View:
         \t//depot/trunk/... //p4_client_render/...\n''' % root_dir)
-        client_stdin = unicode2bytes(client_stdin)
 
-        self._full(client_stdin=client_stdin, p4client=b'p4_client_render')
+        self._full(client_stdin=client_stdin, p4client='p4_client_render')
 
     def test_mode_full_renderable_p4branch(self):
         # Note that the config check skips checking p4base if it's a renderable
@@ -711,7 +694,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
 
         View:
         \t//depot/render_branch/... //p4_client1/...\n''' % root_dir)
-        client_stdin = unicode2bytes(client_stdin)
 
         self._full(client_stdin=client_stdin)
 
@@ -742,9 +724,8 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
 
         View:
         \t//depot/render_trunk/... //p4_client1/...\n''' % root_dir)
-        client_stdin = unicode2bytes(client_stdin)
 
-        self._full(client_stdin=client_stdin, p4user=b'different_user')
+        self._full(client_stdin=client_stdin, p4user='different_user')
 
     def test_mode_full_p4viewspec_suffix(self):
         self.setupStep(P4(p4port='localhost:12000', mode='full',
@@ -777,7 +758,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         \t"//depot/trunk/white space/..." "//p4_client1/white space/..."
         \t"-//depot/trunk/white space/excluded/..." "//p4_client1/white space/excluded/..."
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._full(client_stdin=client_spec)
 
     def test_mode_full_p4client_spec_options(self):
@@ -806,7 +786,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._full(client_stdin=client_spec)
 
     def test_mode_full_parent_workdir(self):
@@ -835,7 +814,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
         self._full(client_stdin=client_spec, workdir='../another_wkdir')
 
     def test_mode_full_p4extra_args(self):
@@ -864,8 +842,7 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
-        self._full(client_stdin=client_spec, extra_args=[b'-Zproxyload'])
+        self._full(client_stdin=client_spec, extra_args=['-Zproxyload'])
 
     def test_worker_connection_lost(self):
         self.setupStep(P4(p4port='localhost:12000', mode='incremental',
@@ -907,7 +884,6 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
         View:
         \t//depot/trunk/... //p4_client1/...
         ''' % root_dir)
-        client_spec = unicode2bytes(client_spec)
 
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['p4', '-V'])
@@ -916,23 +892,23 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
             # This is the extra step that gets run when using tickets,
             # and the password is not passed anymore after that.
             ExpectShell(workdir='wkdir',
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', b'user',
-                                 b'-c', b'p4_client1', b'login'],
+                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
+                                 '-c', 'p4_client1', 'login'],
                         initialStdin='pass\n')
             + 0,
 
             ExpectShell(workdir='wkdir',
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', b'user',
-                                 b'-c', b'p4_client1', b'client', b'-i'],
+                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
+                                 '-c', 'p4_client1', 'client', '-i'],
                         initialStdin=client_spec)
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=([b'p4', b'-p', b'localhost:12000', b'-u', b'user',
-                                  b'-c', b'p4_client1', b'sync']))
+                        command=(['p4', '-p', 'localhost:12000', '-u', 'user',
+                                  '-c', 'p4_client1', 'sync']))
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=[b'p4', b'-p', b'localhost:12000', b'-u', b'user',
-                                 b'-c', b'p4_client1', b'changes', b'-m1', b'#have'])
+                        command=['p4', '-p', 'localhost:12000', '-u', 'user',
+                                 '-c', 'p4_client1', 'changes', '-m1', '#have'])
             + ExpectShell.log('stdio',
                               stdout="Change 100 on 2013/03/21 by user@machine \'duh\'")
             + 0,


### PR DESCRIPTION
@sphet noticed in https://github.com/buildbot/buildbot/issues/3493#issuecomment-320105740 that encodeArg() in the P4 code probably doesn't belong.

I looked at it, and he was right.  It isn't necessary, because the command is encoded to bytes much later on in https://github.com/buildbot/buildbot/blob/master/worker/buildbot_worker/runprocess.py#L328