### PR TITLE
Latent Worker Stops when it cannot Substantiate

### DIFF
--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -59,6 +59,9 @@ deprecatedWorkerModuleAttribute(
 class LatentWorkerFailedToSubstantiate(Exception):
     pass
 
+class LatentWorkerCannotSubstantiate(Exception):
+    pass
+
 
 deprecatedWorkerModuleAttribute(
     locals(), LatentWorkerFailedToSubstantiate,

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -59,6 +59,7 @@ deprecatedWorkerModuleAttribute(
 class LatentWorkerFailedToSubstantiate(Exception):
     pass
 
+
 class LatentWorkerCannotSubstantiate(Exception):
     pass
 

--- a/master/buildbot/newsfragments/latent_worker_stop_retry.feature
+++ b/master/buildbot/newsfragments/latent_worker_stop_retry.feature
@@ -1,0 +1,1 @@
+Latent Workers will no longer continually retry if they cannot substantiate

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -327,6 +327,8 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
             yield self.buildPreparationFailure(ready_or_failure, "worker_prepare")
             if self.stopped:
                 self.buildFinished(["worker", "cancelled"], self.results)
+            elif ready_or_failure.check([interfaces.LatentWorkerCannotToSubstantiate]):
+                self.buildFinished(["worker", "cannot", "substanciate"], EXCEPTION)
             else:
                 self.buildFinished(["worker", "not", "available"], RETRY)
             return

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -327,7 +327,7 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
             yield self.buildPreparationFailure(ready_or_failure, "worker_prepare")
             if self.stopped:
                 self.buildFinished(["worker", "cancelled"], self.results)
-            elif ready_or_failure.check([interfaces.LatentWorkerFailedToSubstantiate]):
+            elif isinstance(ready_or_failure, Failure) and ready_or_failure.check(interfaces.LatentWorkerCannotSubstantiate):
                 self.buildFinished(["worker", "cannot", "substantiate"], EXCEPTION)
             else:
                 self.buildFinished(["worker", "not", "available"], RETRY)

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -327,8 +327,8 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
             yield self.buildPreparationFailure(ready_or_failure, "worker_prepare")
             if self.stopped:
                 self.buildFinished(["worker", "cancelled"], self.results)
-            elif ready_or_failure.check([interfaces.LatentWorkerCannotToSubstantiate]):
-                self.buildFinished(["worker", "cannot", "substanciate"], EXCEPTION)
+            elif ready_or_failure.check([interfaces.LatentWorkerFailedToSubstantiate]):
+                self.buildFinished(["worker", "cannot", "substantiate"], EXCEPTION)
             else:
                 self.buildFinished(["worker", "not", "available"], RETRY)
             return

--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -32,9 +32,9 @@ from buildbot.interfaces import LatentWorkerSubstantiatiationCancelled
 from buildbot.process.buildstep import BuildStep
 from buildbot.process.factory import BuildFactory
 from buildbot.process.results import CANCELLED
+from buildbot.process.results import EXCEPTION
 from buildbot.process.results import RETRY
 from buildbot.process.results import SUCCESS
-from buildbot.process.results import EXCEPTION
 from buildbot.test.fake.latent import LatentController
 from buildbot.test.fake.reactor import NonThreadPool
 from buildbot.test.fake.reactor import TestReactor

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -27,8 +27,8 @@ from twisted.internet import threads
 from twisted.python import log
 
 from buildbot import config
-from buildbot.interfaces import LatentWorkerFailedToSubstantiate
 from buildbot.interfaces import LatentWorkerCannotSubstantiate
+from buildbot.interfaces import LatentWorkerFailedToSubstantiate
 from buildbot.util import unicode2bytes
 from buildbot.worker import AbstractLatentWorker
 

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -28,6 +28,7 @@ from twisted.python import log
 
 from buildbot import config
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate
+from buildbot.interfaces import LatentWorkerCannotSubstantiate
 from buildbot.util import unicode2bytes
 from buildbot.worker import AbstractLatentWorker
 
@@ -241,7 +242,7 @@ class DockerLatentWorker(DockerBaseWorker):
 
         if (not self._image_exists(docker_client, image)):
             log.msg("Image '%s' not found" % image)
-            raise LatentWorkerFailedToSubstantiate(
+            raise LatentWorkerCannotSubstantiate(
                 'Image "%s" not found on docker host.' % image
             )
 


### PR DESCRIPTION
This PR adds in a feature that will keep Latent Workers from continually retrying when buildrequest errors, such as a docker image cannot be found. 

Fixes #3572 

Examples include:
* Docker Image not existing



## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
