### PR TITLE
Builders UI: Load builds based on tags filter

### DIFF
--- a/master/buildbot/newsfragments/builders_fetchlimit_configurable.feature
+++ b/master/buildbot/newsfragments/builders_fetchlimit_configurable.feature
@@ -1,0 +1,1 @@
+Make maximum number of builds fetched on the builders page configurable.

--- a/master/buildbot/newsfragments/lazy_load_builds.feature
+++ b/master/buildbot/newsfragments/lazy_load_builds.feature
@@ -1,0 +1,1 @@
+On 'Builders' page reload builds when tags change.

--- a/www/base/src/app/builders/builders.controller.coffee
+++ b/www/base/src/app/builders/builders.controller.coffee
@@ -21,6 +21,8 @@ class Builders extends Controller
         $scope.$watch('settings', ->
             bbSettingsService.save()
         , true)
+        buildFetchLimit = $scope.settings.buildFetchLimit.value
+
         $scope.getAllTags = ->
             all_tags = []
             for builder in $scope.builders
@@ -116,7 +118,7 @@ class Builders extends Controller
             builderIds = filteredBuilds.map (builder) -> builder.builderid
             builderIds = [] if builderIds.length == $scope.builders.length
 
-            builds = data.getBuilds(limit: 200, order: '-started_at', builderid__eq: builderIds)
+            builds = data.getBuilds(limit: buildFetchLimit, order: '-started_at', builderid__eq: builderIds)
             dataGrouperService.groupBy($scope.builders, workers, 'builderid', 'workers', 'configured_on')
             dataGrouperService.groupBy($scope.builders, builds, 'builderid', 'builds')
 

--- a/www/base/src/app/builders/builders.route.coffee
+++ b/www/base/src/app/builders/builders.route.coffee
@@ -35,4 +35,9 @@ class State extends Config
                 name:'show_old_builders'
                 caption:'Show old builders'
                 default_value: false
+            ,
+                type:'integer'
+                name:'buildFetchLimit'
+                caption:'Maximum number of builds to fetch'
+                default_value: 200
             ]

--- a/www/data_module/src/services/data/collection/dataquery.service.coffee
+++ b/www/data_module/src/services/data/collection/dataquery.service.coffee
@@ -24,9 +24,10 @@ class DataQuery extends Factory
 
 
             isFiltered: (v) ->
-                cmp = false
+                cmpByOp = {}
                 for fieldAndOperator, value of @filters
                     [field, operator] = fieldAndOperator.split('__')
+                    cmp = false
                     switch operator
                         when 'ne' then cmp = v[field] != value
                         when 'lt' then cmp = v[field] <  value
@@ -35,11 +36,16 @@ class DataQuery extends Factory
                         when 'ge' then cmp = v[field] >= value
                         else cmp = v[field] == value or
                             (angular.isArray(v[field]) and value in v[field]) or
+                            (angular.isArray(value) and value.length == 0) or
+                            (angular.isArray(value) and v[field] in value) or
                             # private fields added by the data service
                             v["_#{field}"] == value or
-                            (angular.isArray(v["_#{field}"]) and value in v["_#{field}"])
-                    if !cmp then return false
-                 return true
+                            (angular.isArray(v["_#{field}"]) and value in v["_#{field}"]) or
+                            (angular.isArray(value) and v["_#{field}"] in value)
+                    cmpByOp[fieldAndOperator] = cmpByOp[fieldAndOperator] || cmp
+                for own op, v of cmpByOp
+                    return false if !v
+                return true
 
             filter: (array) ->
                 i = 0

--- a/www/data_module/src/services/data/collection/dataquery.service.spec.coffee
+++ b/www/data_module/src/services/data/collection/dataquery.service.spec.coffee
@@ -69,6 +69,16 @@ describe 'dataquery service', ->
             expect(result).toContain(testArray[1])
             expect(result).toContain(testArray[2])
 
+        it 'should filter the array (two eq)', ->
+            result = wrappedDataQuery.filter(testArray, 'buildid__eq': [1, 2])
+            expect(result.length).toBe(2)
+            expect(result).toContain(testArray[1])
+            expect(result).toContain(testArray[2])
+
+        it 'should treat empty eq criteria as no restriction' ->
+            result = wrappedDataQuery.filter(testArray, 'buildid__eq': [])
+            expect(result.length).toBe(3)
+
         it 'should filter the array (ne - not equal)', ->
             result = wrappedDataQuery.filter(testArray, 'complete__ne': true)
             expect(result.length).toBe(1)


### PR DESCRIPTION
On large buildbot instances (>400 builders) it depends on luck for which builders a build is shown (because only 200 builds are fetched). When drilling down into the list by filtering for a tag (project in our case) it might well be that no builds are shown for the visible builders.

Increasing the amount of loaded builds is not an option, as the resulting JSON would be too large and performance is already an issue.

This solution reloads builds when tag filtering changes. Additionally, the request for builds asks the REST API to filter the builds by builderid (which is possible with the fixes of #3526).

Drawbacks:
- every change in the tags filter sends a new request to the server (should not happen too often in usual usage)
- changing the tags filter removes the builds and readds them, which can be a visible appearance, disappearance

I could add an option to enable this new behavior (disabled by default) so that large buildbot instances can have the advantages while smaller instances are not affected.

## Contributor Checklist:

* ~I have updated the unit tests~ necessary?
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* ~I have updated the appropriate documentation~ - no documentation affected to my knowledge
