### PR TITLE
GerritStatusPush: allow to expose logs

### DIFF
--- a/master/buildbot/newsfragments/gerritstatuspushlogs.feature
+++ b/master/buildbot/newsfragments/gerritstatuspushlogs.feature
@@ -1,0 +1,1 @@
+Allow to expose logs to summary callback of GerritStatusPush.

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -148,12 +148,15 @@ class GerritStatusPush(service.BuildbotService):
     startArg = None
     summaryCB = None
     summaryArg = None
+    wantSteps = False
+    wantLogs = False
     _gerrit_notify = None
 
     def reconfigService(self, server, username, reviewCB=DEFAULT_REVIEW,
                         startCB=None, port=29418, reviewArg=None,
                         startArg=None, summaryCB=DEFAULT_SUMMARY, summaryArg=None,
-                        identity_file=None, builders=None, notify=None):
+                        identity_file=None, builders=None, notify=None,
+                        wantSteps=False, wantLogs=False):
 
         # If neither reviewCB nor summaryCB were specified, default to sending
         # out "summary" reviews. But if we were given a reviewCB and only a
@@ -181,6 +184,8 @@ class GerritStatusPush(service.BuildbotService):
         self.summaryArg = summaryArg
         self.builders = builders
         self._gerrit_notify = notify
+        self.wantSteps = wantSteps
+        self.wantLogs = wantLogs
 
     def _gerritCmd(self, *args):
         '''Construct a command as a list of strings suitable for
@@ -315,7 +320,8 @@ class GerritStatusPush(service.BuildbotService):
             return
         bsid = msg['bsid']
         res = yield utils.getDetailsForBuildset(
-            self.master, bsid, wantProperties=True)
+            self.master, bsid, wantProperties=True,
+            wantSteps=self.wantSteps, wantLogs=self.wantLogs)
         builds = res['builds']
         buildset = res['buildset']
         self.sendBuildSetSummary(buildset, builds)

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -803,6 +803,13 @@ GerritStatusPush can send a separate review for each build that completes, or a 
                   The possible values for `notify` can be found in your version of the
                   Gerrit documentation for the `gerrit review` command.
 
+   :param wantSteps: (optional, defaults to False) Extends the given ``build`` object with information about steps of the build.
+                     Use it only when necessary as this increases the overhead in term of CPU and memory on the master.
+
+   :param wantLogs: (optional, default to False) Extends the steps of the given ``build`` object with the full logs of the build.
+                    This requires ``wantSteps`` to be True.
+                    Use it only when mandatory as this increases the overhead in term of CPU and memory on the master greatly.
+
 .. note::
 
    By default, a single summary review is sent; that is, a default :py:func:`summaryCB` is provided, but no :py:func:`reviewCB` or :py:func:`startCB`.


### PR DESCRIPTION
Adds `wantsSteps` and `wantsLogs` similar to how it is done for MailNotifier.

* ~I have updated the unit tests~ necessary?
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
