### PR TITLE
[docs]: fix usage of name->label in codebaseParameter

### DIFF
--- a/master/docs/manual/cfg-schedulers.rst
+++ b/master/docs/manual/cfg-schedulers.rst
@@ -909,7 +909,7 @@ What you need in your config file is something like::
         codebases=[
             util.CodebaseParameter(
                 "",
-                name="Main repository",
+                label="Main repository",
                 # will generate a combo box
                 branch=util.ChoiceStringParameter(
                     name="branch",


### PR DESCRIPTION
* [x] I have updated the appropriate documentation

Fix forceScheduler example. Since codebase parameter is subclass of nestedparameter, we *can* use `name` there, but **it should be done carefully** and in most of cases it doesn't needed and lead to #3479
