### PR TITLE
Renderable builder locks

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -38,6 +38,7 @@ from zope.interface import implementer
 from buildbot import interfaces
 from buildbot import locks
 from buildbot import util
+from buildbot.interfaces import IRenderable
 from buildbot.revlinks import default_revlink_matcher
 from buildbot.util import config as util_config
 from buildbot.util import identifiers as util_identifiers
@@ -911,7 +912,7 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
                 lock_dict[lock.name] = lock
 
         for b in self.builders:
-            if b.locks:
+            if b.locks and not IRenderable.providedBy(b.locks):
                 for lock in b.locks:
                     check_lock(lock)
 

--- a/master/buildbot/newsfragments/renderable_builder_locks.feature
+++ b/master/buildbot/newsfragments/renderable_builder_locks.feature
@@ -1,0 +1,1 @@
+Added support for renderable builder locks. Previously only steps could have renderable locks.

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -136,10 +136,14 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
     def getAllSourceStamps(self):
         return list(self.sources)
 
-    def allChanges(self):
-        for s in self.sources:
+    @staticmethod
+    def allChangesFromSources(sources):
+        for s in sources:
             for c in s.changes:
                 yield c
+
+    def allChanges(self):
+        return Build.allChangesFromSources(self.sources)
 
     def allFiles(self):
         # return a list of all source files that were changed
@@ -190,25 +194,23 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
         return self.workerforbuilder.worker.workername
     deprecatedWorkerClassMethod(locals(), getWorkerName)
 
-    def setupProperties(self):
-        props = interfaces.IProperties(self)
-
-        # give the properties a reference back to this build
-        props.build = self
+    @staticmethod
+    def setupProperties(props, requests, builder):
 
         # start with global properties from the configuration
-        props.updateFromProperties(self.master.config.properties)
+        props.updateFromProperties(builder.master.config.properties)
 
         # from the SourceStamps, which have properties via Change
-        for change in self.allChanges():
+        sources = requests[0].mergeSourceStampsWith(requests[1:])
+        for change in Build.allChangesFromSources(sources):
             props.updateFromProperties(change.properties)
 
         # and finally, get any properties from requests (this is the path
         # through which schedulers will send us properties)
-        for rq in self.requests:
+        for rq in requests:
             props.updateFromProperties(rq.properties)
 
-        self.builder.setupProperties(props)
+        builder.setupProperties(props)
 
     def setupOwnProperties(self):
         # now set some properties of our own, corresponding to the
@@ -225,19 +227,22 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
             props.setProperty("codebase", source.codebase, "Build")
             props.setProperty("project", source.project, "Build")
 
-    def setupWorkerForBuilder(self, workerforbuilder):
-        self.path_module = workerforbuilder.worker.path_module
+    @staticmethod
+    def setupWorkerProperties(props, builder, workerforbuilder):
+        path_module = workerforbuilder.worker.path_module
 
         # navigate our way back to the L{buildbot.worker.Worker}
         # object that came from the config, and get its properties
         worker_properties = workerforbuilder.worker.properties
-        self.getProperties().updateFromProperties(worker_properties)
+        props.updateFromProperties(worker_properties)
         if workerforbuilder.worker.worker_basedir:
-            builddir = self.path_module.join(
+            builddir = path_module.join(
                 bytes2NativeString(workerforbuilder.worker.worker_basedir),
-                bytes2NativeString(self.builder.config.workerbuilddir))
-            self.setProperty("builddir", builddir, "Worker")
+                bytes2NativeString(builder.config.workerbuilddir))
+            props.setProperty("builddir", builddir, "Worker")
 
+    def setupWorkerForBuilder(self, workerforbuilder):
+        self.path_module = workerforbuilder.worker.path_module
         self.workername = workerforbuilder.worker.workername
         self._registerOldWorkerAttr("workername")
         self.build_status.setWorkername(self.workername)

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -275,8 +275,8 @@ class Builder(util_service.ReconfigurableServiceMixin,
             # collect properties that would be set for a build if we
             # started it now and render locks using it
             props = Properties()
-            Build.setupProperties(props, buildrequests, self)
-            Build.setupWorkerProperties(props, self, workerforbuilder)
+            Build.setupPropertiesKnownBeforeBuildStarts(props, buildrequests,
+                                                        self, workerforbuilder)
             locks = yield props.render(locks)
 
         # Make sure we don't warn and throw an exception at the same time
@@ -307,8 +307,8 @@ class Builder(util_service.ReconfigurableServiceMixin,
         # give the properties a reference back to this build
         props.build = build
 
-        Build.setupProperties(props, build.requests, build.builder)
-        Build.setupWorkerProperties(props, build.builder, workerforbuilder)
+        Build.setupPropertiesKnownBeforeBuildStarts(
+            props, build.requests, build.builder, workerforbuilder)
 
         log.msg("starting build %s using worker %s" %
                 (build, workerforbuilder))

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -276,7 +276,15 @@ class Builder(util_service.ReconfigurableServiceMixin,
     def _startBuildFor(self, workerforbuilder, buildrequests):
         build = self.config.factory.newBuild(buildrequests)
         build.setBuilder(self)
-        build.setupProperties()
+
+        props = build.getProperties()
+
+        # give the properties a reference back to this build
+        props.build = build
+
+        Build.setupProperties(props, build.requests, build.builder)
+        Build.setupWorkerProperties(props, build.builder, workerforbuilder)
+
         log.msg("starting build %s using worker %s" %
                 (build, workerforbuilder))
 

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -270,7 +270,7 @@ class BasicBuildChooser(BuildChooserBase):
 
             self.workerpool.remove(worker)
 
-            canStart = yield self.bldr.canStartWithWorkerForBuilder(worker)
+            canStart = yield self.bldr.canStartWithWorkerForBuilder(worker, [buildrequest])
             if canStart:
                 defer.returnValue(worker)
                 return

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -374,7 +374,7 @@ class TestBuild(unittest.TestCase):
         b.getProperties = Mock()
         b.setProperty = Mock()
 
-        b.setupWorkerForBuilder(self.workerforbuilder)
+        b.setupWorkerBuildirProperty(self.workerforbuilder)
 
         expected_path = '/srv/buildbot/worker/test'
 

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -344,6 +344,7 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
 
         self.assertIdentical(new, old)
 
+    @defer.inlineCallbacks
     def test_canStartWithWorkerForBuilder_old_api(self):
         bldr = builder.Builder('bldr')
         bldr.config = mock.Mock()
@@ -355,7 +356,7 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
             with mock.patch(
                     'buildbot.process.build.Build.canStartWithWorkerForBuilder',
                     mock.Mock(return_value='dummy')):
-                dummy = bldr.canStartWithSlavebuilder(mock.Mock())
+                dummy = yield bldr.canStartWithSlavebuilder(mock.Mock(), mock.Mock())
                 self.assertEqual(dummy, 'dummy')
 
     def test_addLatentWorker_old_api(self):

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -433,13 +433,10 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
                 'buildbot.process.build.Build.canStartWithWorkerForBuilder',
                 mock.Mock(return_value='dummy')):
             with mock.patch(
-                    'buildbot.process.build.Build.setupProperties',
+                    'buildbot.process.build.Build.setupPropertiesKnownBeforeBuildStarts',
                     mock.Mock()):
-                with mock.patch(
-                        'buildbot.process.build.Build.setupWorkerProperties',
-                        mock.Mock()):
-                    dummy = yield bldr.canStartWithWorkerForBuilder(mock.Mock(), [mock.Mock()])
-                    self.assertEqual(dummy, 'dummy')
+                dummy = yield bldr.canStartWithWorkerForBuilder(mock.Mock(), [mock.Mock()])
+                self.assertEqual(dummy, 'dummy')
 
         self.assertTrue(renderedLocks[0])
 

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -138,7 +138,7 @@ class TestBRDBase(unittest.TestCase):
             reactor.callLater(0, d.callback, True)
             return d
         bldr.maybeStartBuild = maybeStartBuild
-        bldr.canStartWithWorkerForBuilder = lambda _: True
+        bldr.canStartWithWorkerForBuilder = lambda _, __: True
         bldr.getCollapseRequestsFn = lambda: False
 
         bldr.workers = []
@@ -516,7 +516,7 @@ class TestMaybeStartBuilds(TestBRDBase):
 
         workers_attempted = []
 
-        def _canStartWithWorkerForBuilder(workerforbuilder):
+        def _canStartWithWorkerForBuilder(workerforbuilder, buildrequests):
             workers_attempted.append(workerforbuilder.name)
             return True
         self.bldr.canStartWithWorkerForBuilder = _canStartWithWorkerForBuilder
@@ -573,7 +573,7 @@ class TestMaybeStartBuilds(TestBRDBase):
 
         workers_attempted = []
 
-        def _canStartWithWorkerForBuilder(workerforbuilder):
+        def _canStartWithWorkerForBuilder(workerforbuilder, buildrequests):
             workers_attempted.append(workerforbuilder.name)
             allowed = workerforbuilder.name in ['test-worker2', 'test-worker1']
             return defer.succeed(allowed)   # a deferred here!
@@ -621,7 +621,7 @@ class TestMaybeStartBuilds(TestBRDBase):
 
         workers_attempted = []
 
-        def _canStartWithWorkerForBuilder(workerforbuilder):
+        def _canStartWithWorkerForBuilder(workerforbuilder, buildrequests):
             workers_attempted.append(workerforbuilder.name)
             return (workerforbuilder.name == 'test-worker3')
         self.bldr.canStartWithWorkerForBuilder = _canStartWithWorkerForBuilder

--- a/master/docs/manual/cfg-builders.rst
+++ b/master/docs/manual/cfg-builders.rst
@@ -82,7 +82,14 @@ Other optional keys may be set on each ``BuilderConfig``:
     See :ref:`canStartBuild-Functions` for a concrete example.
 
 ``locks``
-    This argument specifies a list of locks that apply to this builder; see :ref:`Interlocks`.
+    A list of ``Locks`` (instances of :class:`buildbot.locks.WorkerLock` or :class:`buildbot.locks.MasterLock`) that should be acquired before starting a :class:`Build` from this :class:`Builder`.
+    Alternatively this could be a renderable that returns this list depending on properties of related to a build that is just about to be created.
+    This lets you defer picking the locks to acquire until it is known which :class:`Worker` a build would get assigned to.
+    The properties available to the renderable include all properties that are set to the build before its first step excluding the properties that come from the build itself and the ``builddir`` property that comes from worker.
+    The ``Locks`` will be released when the build is complete.
+    Note that this is a list of actual :class:`Lock` instances, not names.
+    Also note that all Locks must have unique names.
+    See :ref:`Interlocks`.
 
 ``env``
     A Builder may be given a dictionary of environment variables in this parameter.


### PR DESCRIPTION
Hi,

Currently step locks can be renderables whereas builder locks can't. This pull request implements renderable support for builder locks.

Could you please look and decide whether this PR is good in principle? I'd like not to spend time refining the PR if the implementation goes to completely wrong direction :-)

Currently there are no tests for the new functionality, some existing tests have been broken by changes of internal APIs and some other things are missing. These all will be fixed on the next iteration if you like the PR.

Thanks a lot for your time!