### PR TITLE
Running with --nodaemon and pid files

### DIFF
--- a/master/buildbot/newsfragments/nodaemon-pidfile.bugfix
+++ b/master/buildbot/newsfragments/nodaemon-pidfile.bugfix
@@ -1,0 +1,1 @@
+Add empty pidfile option to master and worker start script when --nodaemon option is on. (:issue:`3012`).

--- a/master/buildbot/newsfragments/nodaemon-pidfile.bugfix
+++ b/master/buildbot/newsfragments/nodaemon-pidfile.bugfix
@@ -1,1 +1,1 @@
-Add empty pidfile option to master and worker start script when --nodaemon option is on. (:issue:`3012`).
+Add empty pidfile option to master and worker start script when `--nodaemon` option is on. (:issue:`3012`).

--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -84,9 +84,14 @@ def launchNoDaemon(config):
 
     argv = ["twistd",
             "--no_save",
-            '--nodaemon',
+            "--nodaemon",
             "--logfile=twistd.log",  # windows doesn't use the same default
             "--python=buildbot.tac"]
+
+    if platformType != 'win32':
+        # windows doesn't use pidfile option.
+        argv.extend(["--pidfile="])
+
     sys.argv = argv
 
     # this is copied from bin/twistd. twisted-2.0.0 through 2.4.0 use

--- a/worker/buildbot_worker/scripts/start.py
+++ b/worker/buildbot_worker/scripts/start.py
@@ -131,7 +131,11 @@ def launch(nodaemon):
             "--logfile=twistd.log",  # windows doesn't use the same default
             "--python=buildbot.tac"]
     if nodaemon:
-        argv.extend(['--nodaemon'])
+        argv.extend(["--nodaemon"])
+        if platformType != 'win32':
+            # windows doesn't use pidfile option.
+            argv.extend(["--pidfile="])
+
     sys.argv = argv
 
     # this is copied from bin/twistd. twisted-2.0.0 through 2.4.0 use


### PR DESCRIPTION
Add empty pidfile option to master and worker start script when `--nodaemon` option is on. 
Fixes #3012 