### PR TITLE
waterfall: prevent tooltip from flashing in Firefox

### DIFF
--- a/www/waterfall_view/src/styles/styles.less
+++ b/www/waterfall_view/src/styles/styles.less
@@ -219,3 +219,7 @@
     }
   }
 }
+
+.svg-tooltip {
+  pointer-events: none;
+}


### PR DESCRIPTION
Cherry-picked from https://github.com/buildbot/buildbot/pull/3296 by @Lekensteyn 