### PR TITLE
Fix GitPoller using peeled tags in the ls-remote output

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -135,7 +135,7 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         return str
 
     def _getBranches(self):
-        d = self._dovccmd('ls-remote', [self.repourl])
+        d = self._dovccmd('ls-remote', ['--refs', self.repourl])
 
         @d.addCallback
         def parseRemote(rows):

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -706,7 +706,7 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
     def test_poll_allBranches_single(self):
         self.expectCommands(
             gpo.Expect(b'git', b'init', b'--bare', b'gitpoller-work'),
-            gpo.Expect(b'git', b'ls-remote', self.REPOURL)
+            gpo.Expect(b'git', b'ls-remote', b'--refs', self.REPOURL)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
             gpo.Expect(b'git', b'fetch', self.REPOURL,
@@ -819,7 +819,7 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
     def test_poll_allBranches_multiple(self):
         self.expectCommands(
             gpo.Expect(b'git', b'init', b'--bare', b'gitpoller-work'),
-            gpo.Expect(b'git', b'ls-remote', self.REPOURL)
+            gpo.Expect(b'git', b'ls-remote', b'--refs', self.REPOURL)
             .stdout(b'\n'.join([
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
                 b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
@@ -920,7 +920,7 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
     def test_poll_callableFilteredBranches(self):
         self.expectCommands(
             gpo.Expect(b'git', b'init', b'--bare', b'gitpoller-work'),
-            gpo.Expect(b'git', b'ls-remote', self.REPOURL)
+            gpo.Expect(b'git', b'ls-remote', b'--refs', self.REPOURL)
             .stdout(b'\n'.join([
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\trefs/heads/master',
                 b'9118f4ab71963d23d02d4bdc54876ac8bf05acf2\trefs/heads/release',
@@ -1010,7 +1010,7 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
     def test_poll_branchFilter(self):
         self.expectCommands(
             gpo.Expect(b'git', b'init', b'--bare', b'gitpoller-work'),
-            gpo.Expect(b'git', b'ls-remote', self.REPOURL)
+            gpo.Expect(b'git', b'ls-remote', b'--refs', self.REPOURL)
             .stdout(b'\n'.join([
                 b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                 b'refs/pull/410/merge',
@@ -1190,7 +1190,7 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
     def test_poll_callableCategory(self):
         self.expectCommands(
             gpo.Expect(b'git', b'init', b'--bare', b'gitpoller-work'),
-            gpo.Expect(b'git', b'ls-remote', self.REPOURL)
+            gpo.Expect(b'git', b'ls-remote', b'--refs', self.REPOURL)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
                     b'refs/heads/master\n'),
             gpo.Expect(b'git', b'fetch', self.REPOURL,


### PR DESCRIPTION
While trying to use the [`only_tags`](http://docs.buildbot.net/current/manual/cfg-changesources.html#gitpoller) option of GitPoller, I ran into a strange issue as GitPoller was unable to detect new git tags and throw a [`GitError`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/changes/gitpoller.py#L37).

It appears that the GitPoller is parsing the output of `git ls-remove` in [`_getBranches`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/changes/gitpoller.py#L138) without using the option `--refs` which hides peeled tags and pseudorefs. In my case, [`_getBranches`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/changes/gitpoller.py#L138) was parsing both the lightweight and annotated refs of the same tag and passing both of them to [`git fetch`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/changes/gitpoller.py#L188) which raised an error 128.

Without using [`--refs`,](https://git-scm.com/docs/git-ls-remote.html#git-ls-remote---refs) with `git ls-remote`, [`_getBranches`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/changes/gitpoller.py#L138) returns the following result
```
da39a3ee5e6b4b0d3255bfef95601890afd80709	refs/tags/mytag
d74880752203616894cfb3db7ad644c086497992	refs/tags/mytag^{}
```
Note the `^{}` which indicates the annotated ref of the tag.

Using [`--refs`,](https://git-scm.com/docs/git-ls-remote.html#git-ls-remote---refs) we can hide peeled tags so [`_getBranches`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/changes/gitpoller.py#L138) returns the following result
```
da39a3ee5e6b4b0d3255bfef95601890afd80709	refs/tags/mytag
```
Which is the result expected. This PR fix this issue.

Regards,
