### PR TITLE
reporters.gitlab: Use correct codes

### DIFF
--- a/master/buildbot/newsfragments/gitlab-reporters.bugfix
+++ b/master/buildbot/newsfragments/gitlab-reporters.bugfix
@@ -1,0 +1,1 @@
+Fix :class:`reporters.gitlab` to use correct commit status codes.

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -68,8 +68,8 @@ class GitLabStatusPush(http.HttpStatusPushBase):
         :param project_id: Project ID from GitLab
         :param branch: Branch name to create the status for.
         :param sha: Full sha to create the status for.
-        :param state: one of the following 'pending', 'success', 'error'
-                      or 'failure'.
+        :param state: one of the following 'pending', 'success', 'failed'
+                      or 'cancelled'.
         :param target_url: Target url to associate with this status.
         :param description: Short description of the status.
         :param context: Context of the result
@@ -126,10 +126,10 @@ class GitLabStatusPush(http.HttpStatusPushBase):
                 WARNINGS: 'success',
                 FAILURE: 'failed',
                 SKIPPED: 'success',
-                EXCEPTION: 'error',
+                EXCEPTION: 'failed',
                 RETRY: 'pending',
-                CANCELLED: 'error'
-            }.get(build['results'], 'error')
+                CANCELLED: 'cancelled'
+            }.get(build['results'], 'failed')
             description = yield props.render(self.endDescription)
         else:
             state = 'running'


### PR DESCRIPTION
`error` is not specified as valid status, use failed and cancelled instead.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
