### PR TITLE
Fix to support multiple gerrit codebases (issue #3460)

### DIFF
--- a/master/buildbot/newsfragments/multiple-gerrit-repos.bugfix
+++ b/master/buildbot/newsfragments/multiple-gerrit-repos.bugfix
@@ -1,0 +1,1 @@
+Fix the Gerrit source step in the presence of multiple gerrit repos (:issue:`3460`).

--- a/master/buildbot/newsfragments/multiple-gerrit-repos.bugfix
+++ b/master/buildbot/newsfragments/multiple-gerrit-repos.bugfix
@@ -1,1 +1,1 @@
-Fix the Gerrit source step in the presence of multiple gerrit repos (:issue:`3460`).
+Fix the Gerrit source step in the presence of multiple Gerrit repos (:issue:`3460`).

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -389,8 +389,9 @@ class GerritStatusPush(service.BuildbotService):
         if getProperty(build, "event.change.id") is not None:
             project = getProperty(build, "event.change.project")
             codebase = getProperty(build, "codebase")
-            revision = getProperty(
-                build, "got_revision") or getProperty(build, "revision")
+            revision = (getProperty(build, "event.patchSet.revision") or
+                        getProperty(build, "got_revision") or
+                        getProperty(build, "revision"))
 
             if isinstance(revision, dict):
                 # in case of the revision is a codebase revision, we just take

--- a/master/buildbot/steps/source/gerrit.py
+++ b/master/buildbot/steps/source/gerrit.py
@@ -26,7 +26,15 @@ class Gerrit(Git):
 
     def startVC(self, branch, revision, patch):
         gerrit_branch = None
-        if self.build.hasProperty("event.patchSet.ref"):
+
+        changed_project = self.build.getProperty('event.change.project')
+        if (not self.sourcestamp or (self.sourcestamp.project !=
+                                     changed_project)):
+            # If we don't have a sourcestamp, or the project is  wrong, this
+            # isn't the repo that's changed.  Drop through and check out the
+            # head of the given branch
+            pass
+        elif self.build.hasProperty("event.patchSet.ref"):
             gerrit_branch = self.build.getProperty("event.patchSet.ref")
             self.updateSourceProperty("gerrit_branch", gerrit_branch)
         else:


### PR DESCRIPTION
- Adds a check to the gerrit source step that this codebase is the one that
  has been changed
- Allows gerrit reporter to use the gerrit event.patchset.revision as its
  revision.  This allows for the possibility that the gerrit startVC has not
  yet been executed when a failure occurs, and so got_revision will not be
  set


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [-] I have updated the appropriate documentation
