### PR TITLE
Fixed a deadlock bug related to distinct but equal BuildSteps

### DIFF
--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -42,6 +42,10 @@ class BsProps(dict):
     pass
 
 
+class AlreadyCompleteError(RuntimeError):
+    pass
+
+
 class BuildsetsConnectorComponent(base.DBConnectorComponent):
     # Documentation is in developer/db.rst
 
@@ -149,7 +153,8 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
                                complete_at=complete_at)
 
             if res.rowcount != 1:
-                raise KeyError
+                # happens when two buildrequests finish at the same time
+                raise AlreadyCompleteError()
         return self.db.pool.do(thd)
 
     def getBuildset(self, bsid):

--- a/master/buildbot/db/pool.py
+++ b/master/buildbot/db/pool.py
@@ -28,6 +28,7 @@ from twisted.python import log
 from twisted.python import threadpool
 
 from buildbot.db.buildrequests import AlreadyClaimedError
+from buildbot.db.buildsets import AlreadyCompleteError
 from buildbot.db.changesources import ChangeSourceAlreadyClaimedError
 from buildbot.db.schedulers import SchedulerAlreadyClaimedError
 from buildbot.process import metrics
@@ -203,7 +204,7 @@ class DBThreadPool(object):
                     continue
                 # AlreadyClaimedError are normal especially in a multimaster
                 # configuration
-                except (AlreadyClaimedError, ChangeSourceAlreadyClaimedError, SchedulerAlreadyClaimedError):
+                except (AlreadyClaimedError, ChangeSourceAlreadyClaimedError, SchedulerAlreadyClaimedError, AlreadyCompleteError):
                     raise
                 except Exception as e:
                     log.err(e, 'Got fatal Exception on DB')

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -85,7 +85,7 @@ class BaseLock:
 
         # Find all waiters ahead of the requester in the wait queue
         for idx, waiter in enumerate(self.waiting):
-            if waiter[0] == requester:
+            if waiter[0] is requester:
                 w_index = idx
                 break
         else:
@@ -167,7 +167,7 @@ class BaseLock:
         d = defer.Deferred()
 
         # Are we already in the wait queue?
-        w = [i for i, w in enumerate(self.waiting) if w[0] == owner]
+        w = [i for i, w in enumerate(self.waiting) if w[0] is owner]
         if w:
             self.waiting[w[0]] = (owner, access, d)
         else:
@@ -178,7 +178,7 @@ class BaseLock:
         debuglog("%s stopWaitingUntilAvailable(%s)" % (self, owner))
         assert isinstance(access, LockAccess)
         assert (owner, access, d) in self.waiting
-        self.waiting = [w for w in self.waiting if w[0] != owner]
+        self.waiting = [w for w in self.waiting if w[0] is not owner]
 
     def isOwner(self, owner, access):
         return (owner, access) in self.owners

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -107,7 +107,7 @@ class BaseLock:
 
         assert isinstance(access, LockAccess)
         assert access.mode in ['counting', 'exclusive']
-        self.waiting = [w for w in self.waiting if w[0] != owner]
+        self.waiting = [w for w in self.waiting if w[0] is not owner]
         self.owners.append((owner, access))
         debuglog(" %s is claimed '%s'" % (self, access.mode))
 

--- a/master/buildbot/newsfragments/buildsets.bugfix
+++ b/master/buildbot/newsfragments/buildsets.bugfix
@@ -1,0 +1,1 @@
+Fixed KeyError in the log when two buildrequests of the same buildset are finished at the same time (:issue:`3591`)

--- a/master/buildbot/newsfragments/locks.bugfix
+++ b/master/buildbot/newsfragments/locks.bugfix
@@ -1,0 +1,1 @@
+Fixed deadlock issue, when locks are taken at least 3 times by the 3 Buildstep with same configuration (:issue:`3650`)

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -35,9 +35,9 @@ from twisted.internet import reactor
 
 from buildbot.data import resultspec
 from buildbot.db import buildrequests
+from buildbot.db import buildsets
 from buildbot.db import changesources
 from buildbot.db import schedulers
-from buildbot.db import buildsets
 from buildbot.test.util import validation
 from buildbot.util import bytes2NativeString
 from buildbot.util import datetime2epoch

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -37,6 +37,7 @@ from buildbot.data import resultspec
 from buildbot.db import buildrequests
 from buildbot.db import changesources
 from buildbot.db import schedulers
+from buildbot.db import buildsets
 from buildbot.test.util import validation
 from buildbot.util import bytes2NativeString
 from buildbot.util import datetime2epoch
@@ -1321,7 +1322,7 @@ class FakeBuildsetsComponent(FakeDBComponent):
     def completeBuildset(self, bsid, results, complete_at=None,
                          _reactor=reactor):
         if bsid not in self.buildsets or self.buildsets[bsid]['complete']:
-            raise KeyError
+            raise buildsets.AlreadyCompleteError()
         self.buildsets[bsid]['results'] = results
         self.buildsets[bsid]['complete'] = 1
         self.buildsets[bsid]['complete_at'] = \

--- a/master/buildbot/test/integration/test_integration_locks.py
+++ b/master/buildbot/test/integration/test_integration_locks.py
@@ -1,0 +1,92 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from twisted.internet import defer
+from twisted.internet import reactor
+
+from buildbot.process.buildstep import BuildStep
+from buildbot.test.util.integration import RunMasterBase
+
+
+class LockedStep(BuildStep):
+    locks_steps = []  # class variable
+
+    def run(self):
+        self.locks_steps.append(self)
+        self.d = defer.Deferred()
+        return self.d
+
+
+class ShellMaster(RunMasterBase):
+
+    @defer.inlineCallbacks
+    def test_shell(self):
+        yield self.setupConfig(masterConfig())
+
+        # there is no event that is sent *after* the lock, so no way to
+        # reliabily synchronize without polling :-(
+        def unlockStep():
+            for l in LockedStep.locks_steps:
+                if not l.d.called:
+                    l.d.callback(0)
+            if len(LockedStep.locks_steps) < 3:
+                reactor.callLater(.3, unlockStep)
+        reactor.callLater(.3, unlockStep)
+
+        change = dict(branch="master",
+                      files=["foo.c"],
+                      author="me@foo.com",
+                      comments="good stuff",
+                      revision="HEAD",
+                      project="none"
+                      )
+
+        yield self.doForceBuild(useChange=change)
+        LockedStep.locks_steps = []
+
+
+# master configuration
+def masterConfig():
+    c = {}
+    from buildbot.config import BuilderConfig
+    from buildbot.process.factory import BuildFactory
+    from buildbot.plugins import schedulers
+    from buildbot.plugins import util
+    lock = util.MasterLock("lock")
+
+    c['schedulers'] = [
+        schedulers.AnyBranchScheduler(
+            name="sched",
+            builderNames=["testy", "testy2", "testy3"]),
+        ]
+    f = BuildFactory()
+    lockstep = LockedStep(locks=[lock.access('exclusive')])
+    f.addStep(lockstep)
+    # assert lockstep._factory.buildStep() == lockstep._factory.buildStep()
+    c['builders'] = [
+        BuilderConfig(name="testy",
+                      workernames=["local1"],
+                      factory=f),
+        BuilderConfig(name="testy2",
+                      workernames=["local1"],
+                      factory=f),
+        BuilderConfig(name="testy3",
+              workernames=["local1"],
+              factory=f)]
+
+    return c

--- a/master/buildbot/test/integration/test_integration_locks.py
+++ b/master/buildbot/test/integration/test_integration_locks.py
@@ -39,7 +39,7 @@ class ShellMaster(RunMasterBase):
         yield self.setupConfig(masterConfig())
 
         # there is no event that is sent *after* the lock, so no way to
-        # reliabily synchronize without polling :-(
+        # reliably synchronize without polling :-(
         def unlockStep():
             for l in LockedStep.locks_steps:
                 if not l.d.called:

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -321,14 +321,14 @@ class Tests(interfaces.InterfaceTests):
         d.addCallback(lambda _:
                       self.db.buildsets.completeBuildset(bsid=92, results=6,
                                                          _reactor=self.clock))
-        return self.assertFailure(d, KeyError)
+        return self.assertFailure(d, buildsets.AlreadyCompleteError)
 
     def test_completeBuildset_missing(self):
         d = self.insert_test_getBuildsets_data()
         d.addCallback(lambda _:
                       self.db.buildsets.completeBuildset(bsid=93, results=6,
                                                          _reactor=self.clock))
-        return self.assertFailure(d, KeyError)
+        return self.assertFailure(d, buildsets.AlreadyCompleteError)
 
     def test_completeBuildset(self):
         d = self.insert_test_getBuildsets_data()


### PR DESCRIPTION
If a build factory has a buildstep with a lock, this will trigger a deadlock whenever 3 or more builds of this factory are started at the same time. The main reason is that BaseLock uses the == operator to compare the owners of a given lock. But if owners are BuildSteps, it doesn't work because they inherit from ComparableMixin (#d6c6b550), so two distinct BuildStep objects sharing the same properties will be considered as equal, although they are distinct Python objects: `b0 == b1` but `b0 is not b1`. Because of this, the first two buildsteps acquiring the lock were able to complete, but then the `waiting` list was empty and the remaining buildsteps were waiting forever. It was not possible to stop them with the `Stop` button of the web interface; only a master restart stopped them.
We use the `is` operator instead of `==` to fix this.