### PR TITLE
Don't Trim File input from textarea in FileField

### DIFF
--- a/www/base/src/app/common/directives/forcefields/filefield.tpl.jade
+++ b/www/base/src/app/common/directives/forcefields/filefield.tpl.jade
@@ -2,7 +2,7 @@ basefield
     label.control-label.col-sm-2(for="{{field.name}}")
         | {{field.label}}
     .col-sm-9
-        textarea.form-control(ng-if="field.safevalue !== false", rows="{{field.rows}}", ng-model="field.safevalue")
+        textarea.form-control(ng-if="field.safevalue !== false", rows="{{field.rows}}", ng-model="field.safevalue", ng-trim="false")
         label.control-label(ng-if="field.safevalue === false") {{field.value.length}} bytes file
     .col-sm-1
         input(type="file", id="file-{{field.name}}", style="display:none;", fileread="field.value")


### PR DESCRIPTION
Patch files can be very picky about lines. Best not autotrim them,

## Contributor Checklist:

* [ ] ~~I have updated the unit tests~~
* [ ] ~~I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)~~
* [ ] ~~I have updated the appropriate documentation~~
