### PR TITLE
Match ex.remoteType if it is bytes or unicode.

### DIFF
--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -117,7 +117,8 @@ def _wrapRemoteException():
     try:
         yield
     except pb.RemoteError as ex:
-        if ex.remoteType == 'twisted.spread.flavors.NoSuchMethod':
+        if ex.remoteType in (b'twisted.spread.flavors.NoSuchMethod',
+                             u'twisted.spread.flavors.NoSuchMethod'):
             raise _NoSuchMethod(ex)
         else:
             raise


### PR DESCRIPTION
This fixes an interop problem between
a Python 3 master running buildbot 0.9 and
a Python 2 slave running buildbot 0.8.
