### PR TITLE
Try scheduler with SVN VCS fix.

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -163,14 +163,14 @@ class SVNExtractor(SourceStampExtractor):
         for line in res.split("\n"):
             m = re.search(r'^Status against revision:\s+(\d+)', line)
             if m:
-                self.baserev = int(m.group(1))
+                self.baserev = m.group(1)
                 return
         output(
             "Could not find 'Status against revision' in SVN output: %s" % res)
         sys.exit(1)
 
     def getPatch(self, res):
-        d = self.dovc(["diff", "-r%d" % self.baserev])
+        d = self.dovc(["diff", "-r%s" % self.baserev])
         d.addCallback(self.readPatch, self.patchlevel)
         return d
 

--- a/master/buildbot/newsfragments/tryscheduler.bugfix
+++ b/master/buildbot/newsfragments/tryscheduler.bugfix
@@ -1,0 +1,1 @@
+Fixed operation of the Try scheduler for a code checked out from Subversion.

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -15,9 +15,10 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import integer_types
 from future.utils import iteritems
 from future.utils import itervalues
-from future.utils import text_type
+from future.utils import string_types
 
 import calendar
 
@@ -138,7 +139,7 @@ class TempSourceStamp(object):
             result['patch_%s' % attr] = patch.get(attr)
 
         assert all(
-            isinstance(val, (text_type, type(None), int))
+            isinstance(val, string_types + integer_types + (type(None),))
             for attr, val in iteritems(result)
         ), result
         return result


### PR DESCRIPTION
This patch contains two fixes necessary to make in order to be able to use Try scheduler for Subversion code. The changes in `tryclient.py` are required to be able to submit patches at all. Without it, the build is not even started and `twistd.log` contains the following error:

<pre>
2017-10-06 11:33:29+0200 [-] Unhandled Error
        Traceback (most recent call last):
        Failure: twisted.internet.defer.FirstError: FirstError[#0, [Failure instance: Traceback: <type 'exceptions.TypeError'>: object of type 'int' has no len()
        /usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py:1386:_inlineCallbacks
        /usr/local/lib/python2.7/dist-packages/buildbot/db/buildsets.py:65:addBuildset
        /usr/local/lib/python2.7/dist-packages/buildbot/db/buildsets.py:63:toSsid
        /usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py:1532:unwindGenerator
        --- <exception caught here> ---
        /usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py:1386:_inlineCallbacks
        /usr/local/lib/python2.7/dist-packages/buildbot/db/sourcestamps.py:55:findSourceStampId
        /usr/local/lib/python2.7/dist-packages/buildbot/db/base.py:62:checkLength
        ]]
</pre>

The path in the `buildrequest.py` is needed in Python 2 as the type `path_body` element is `str` not `unicode` and the type of `path_level` is `long` not `int`.