### PR TITLE
Minor fix : On rebuild, giturl is empty. Don't backtrace out

### DIFF
--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -141,6 +141,8 @@ class GitHubStatusPush(http.HttpStatusPushBase):
             repoOwner, repoName = project.split('/')
         else:
             giturl = giturlparse(sourcestamps[0]['repository'])
+            if not giturl:
+                return
             repoOwner = giturl.owner
             repoName = giturl.repo
 


### PR DESCRIPTION
After https://github.com/buildbot/buildbot/pull/3148 merged, the fix in https://github.com/buildbot/buildbot/pull/2724 needs to extended a bit