### PR TITLE
Support auth token _get_commit_msg

### DIFF
--- a/master/buildbot/newsfragments/githubhookauth
+++ b/master/buildbot/newsfragments/githubhookauth
@@ -1,0 +1,1 @@
+:py:class:`~buildbot.www.hooks.github.GitHubEventHandler` now supports authentication for GitHub instances that do not allow anonymous access

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -858,6 +858,38 @@ class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase):
         self._check_pull_request_no_skip(gitJsonPayloadPullRequest)
 
 
+class TestChangeHookConfiguredWithAuth(unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        _token = '7e076f41-b73a-4045-a817'
+        self.changeHook = _prepare_github_change_hook(
+            strict=False, token=_token)
+        self.master = self.changeHook.master
+        fake_headers =  {'User-Agent': 'Buildbot',
+                'Authorization': 'token ' + _token }
+        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+            self.master, self, 'https://api.github.com', headers=fake_headers,
+            debug=False, verify=False)
+        yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.master.stopService()
+
+    @defer.inlineCallbacks
+    def _check_pull_request(self, payload):
+        self.request = _prepare_request(b'pull_request', payload)
+        yield self.request.test_render(self.changeHook)
+        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
+
+    def test_pull_request(self):
+        api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+
+        self._http.expect('get', api_endpoint, content_json=gitJsonPayloadCommit)
+        self._check_pull_request(gitJsonPayloadPullRequest)
+
+
 class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase):
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -888,6 +888,39 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase):
         self._check_pull_request(gitJsonPayloadPullRequest)
 
 
+class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        _token = '7e076f41-b73a-4045-a817'
+        self.changeHook = _prepare_github_change_hook(
+            strict=False, github_api_endpoint='https://black.magic.io',
+            token=_token)
+        self.master = self.changeHook.master
+        fake_headers =  {'User-Agent': 'Buildbot',
+                'Authorization': 'token ' + _token }
+        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+            self.master, self, 'https://black.magic.io', headers=fake_headers,
+            debug=False, verify=False)
+        yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.master.stopService()
+
+    @defer.inlineCallbacks
+    def _check_pull_request(self, payload):
+        self.request = _prepare_request(b'pull_request', payload)
+        yield self.request.test_render(self.changeHook)
+        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
+
+    def test_pull_request(self):
+        api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+
+        self._http.expect('get', api_endpoint, content_json=gitJsonPayloadCommit)
+        self._check_pull_request(gitJsonPayloadPullRequest)
+
+
 class TestChangeHookConfiguredWithStrict(unittest.TestCase):
 
     _SECRET = 'somethingreallysecret'

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -505,7 +505,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.changeHook = _prepare_github_change_hook(
             strict=False, github_property_whitelist=["github.*"])
         self.master = self.changeHook.master
-        fake_headers =  {'User-Agent': 'Buildbot'}
+        fake_headers = {'User-Agent': 'Buildbot'}
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
             self.master, self, 'https://api.github.com', headers=fake_headers,
             debug=False, verify=False)
@@ -866,8 +866,8 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase):
         self.changeHook = _prepare_github_change_hook(
             strict=False, token=_token)
         self.master = self.changeHook.master
-        fake_headers =  {'User-Agent': 'Buildbot',
-                'Authorization': 'token ' + _token }
+        fake_headers = {'User-Agent': 'Buildbot',
+                'Authorization': 'token ' + _token}
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
             self.master, self, 'https://api.github.com', headers=fake_headers,
             debug=False, verify=False)
@@ -897,7 +897,7 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase):
         self.changeHook = _prepare_github_change_hook(
             strict=False, github_api_endpoint='https://black.magic.io')
         self.master = self.changeHook.master
-        fake_headers =  {'User-Agent': 'Buildbot'}
+        fake_headers = {'User-Agent': 'Buildbot'}
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
             self.master, self, 'https://black.magic.io', headers=fake_headers,
             debug=False, verify=False)
@@ -929,8 +929,8 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase):
             strict=False, github_api_endpoint='https://black.magic.io',
             token=_token)
         self.master = self.changeHook.master
-        fake_headers =  {'User-Agent': 'Buildbot',
-                'Authorization': 'token ' + _token }
+        fake_headers = {'User-Agent': 'Buildbot',
+                'Authorization': 'token ' + _token}
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
             self.master, self, 'https://black.magic.io', headers=fake_headers,
             debug=False, verify=False)

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -505,8 +505,9 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.changeHook = _prepare_github_change_hook(
             strict=False, github_property_whitelist=["github.*"])
         self.master = self.changeHook.master
+        fake_headers =  {'User-Agent': 'Buildbot'}
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
-            self.master, self, 'https://api.github.com',
+            self.master, self, 'https://api.github.com', headers=fake_headers,
             debug=False, verify=False)
         yield self.master.startService()
 
@@ -785,8 +786,9 @@ class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase):
         self.changeHook = _prepare_github_change_hook(
             strict=False, skips=[r'\[ *bb *skip *\]'])
         self.master = self.changeHook.master
+        fake_headers = {'User-Agent': 'Buildbot'}
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
-            self.master, self, 'https://api.github.com',
+            self.master, self, 'https://api.github.com', headers=fake_headers,
             debug=False, verify=False)
         yield self.master.startService()
 
@@ -863,8 +865,9 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase):
         self.changeHook = _prepare_github_change_hook(
             strict=False, github_api_endpoint='https://black.magic.io')
         self.master = self.changeHook.master
+        fake_headers =  {'User-Agent': 'Buildbot'}
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
-            self.master, self, 'https://black.magic.io',
+            self.master, self, 'https://black.magic.io', headers=fake_headers,
             debug=False, verify=False)
         yield self.master.startService()
 

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -48,10 +48,12 @@ class GitHubEventHandler(PullRequestMixin):
                  master=None,
                  skips=None,
                  github_api_endpoint=None,
+                 token=None,
                  debug=False,
                  verify=False):
         self._secret = secret
         self._strict = strict
+        self._token = token
         self._codebase = codebase
         self.github_property_whitelist = github_property_whitelist
         self.skips = skips
@@ -209,9 +211,15 @@ class GitHubEventHandler(PullRequestMixin):
         :param repo: the repo full name, ``{owner}/{project}``.
             e.g. ``buildbot/buildbot``
         '''
+        headers = {
+            'User-Agent': 'Buildbot'
+        }
+        if self._token:
+            headers['Authorization'] = 'token ' + self._token
+
         url = '/repos/{}/commits/{}'.format(repo, sha)
         http = yield httpclientservice.HTTPClientService.getService(
-            self.master, self.github_api_endpoint,
+            self.master, self.github_api_endpoint, headers=headers,
             debug=self.debug, verify=self.verify)
         res = yield http.get(url)
         data = yield res.json()
@@ -313,6 +321,7 @@ class GitHubHandler(BaseHookHandler):
             'github_property_whitelist': options.get('github_property_whitelist', None),
             'skips': options.get('skips', None),
             'github_api_endpoint': options.get('github_api_endpoint', None) or 'https://api.github.com',
+            'token': options.get('token', None),
             'debug': options.get('debug', None) or False,
             'verify': options.get('verify', None) or False,
         }

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -128,6 +128,9 @@ The GitHub hook has the following parameters:
     If you have a self-host GitHub Enterprise installation, please set
     this url properly.
 
+``token``
+    If your GitHub or GitHub Enterprise instance does not allow anonymous communication, you need to provide an access token.  Instructions can be found here <https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/>
+
 The simplest way to use GitHub hook is as follows:
 
 .. code-block:: python


### PR DESCRIPTION
https://github.com/buildbot/buildbot/pull/3443 introduced the `_get_commit_msg` function, that interacts with the github api. This breaks the use of github event hook on any GitHub instances that enforce authentication. Add support for auth token