### PR TITLE
buildrequest: optimize the query to find oldest buildrequest time.

### DIFF
--- a/master/buildbot/newsfragments/distributor.bugfix
+++ b/master/buildbot/newsfragments/distributor.bugfix
@@ -1,1 +1,1 @@
-Improve buildrequest distributor to ensure all builders are processed. With previous version, builder list could be reprioritized, while running the distributor, meaning some builders would never be run in case of master high load. (:issue:`3661`)
+Improve buildrequest distributor to ensure all builders are processed. With previous version, builder list could be re-prioritized, while running the distributor, meaning some builders would never be run in case of master high load. (:issue:`3661`)

--- a/master/buildbot/newsfragments/distributor.bugfix
+++ b/master/buildbot/newsfragments/distributor.bugfix
@@ -1,0 +1,1 @@
+Improve buildrequest distributor to ensure all builders are processed. With previous version, builder list could be reprioritized, while running the distributor, meaning some builders would never be run in case of master high load. (:issue:`3661`)

--- a/master/buildbot/newsfragments/getOldersBuildrequest.bugfix
+++ b/master/buildbot/newsfragments/getOldersBuildrequest.bugfix
@@ -1,1 +1,1 @@
-Improve ``getOldestRequestTimeOptim`` function of buildrequest distributor to to sorting and paging in the database layer.
+Improve ``getOldestRequestTime`` function of buildrequest distributor to do sorting and paging in the database layer.

--- a/master/buildbot/newsfragments/getOldersBuildrequest.bugfix
+++ b/master/buildbot/newsfragments/getOldersBuildrequest.bugfix
@@ -1,0 +1,1 @@
+Improve ``getOldestRequestTimeOptim`` function of buildrequest distributor to to sorting and paging in the database layer.

--- a/master/buildbot/newsfragments/p4pollertzexception
+++ b/master/buildbot/newsfragments/p4pollertzexception
@@ -1,1 +1,0 @@
-When p4poller's server_tz string is set, but the dateutil cannot resolve it to a valid timezone offset, p4poller now throws an exception instead of continuing with UTC zone.

--- a/master/buildbot/newsfragments/twisted-17.9.0.bugfix
+++ b/master/buildbot/newsfragments/twisted-17.9.0.bugfix
@@ -1,1 +1,0 @@
-Twisted 17.9.0 is now the minimum dependency when using Python 3.  Fixes (:issue:`3319`), (:issue:`3375`), (:issue:`3633`).

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -163,10 +163,10 @@ class Builder(util_service.ReconfigurableServiceMixin,
         bldrid = yield self.getBuilderId()
         unclaimed = yield self.master.data.get(
             ('builders', bldrid, 'buildrequests'),
-            [resultspec.Filter('claimed', 'eq', [False])])
+            [resultspec.Filter('claimed', 'eq', [False])],
+            order=['submitted_at'], limit=1)
         if unclaimed:
-            unclaimed = sorted([brd['submitted_at'] for brd in unclaimed])
-            defer.returnValue(unclaimed[0])
+            defer.returnValue(unclaimed[0]['submitted_at'])
 
     @defer.inlineCallbacks
     def getNewestCompleteTime(self):

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -490,6 +490,7 @@ class BuildRequestDistributor(service.AsyncMultiService):
                     self.activity_lock.release()
                     break
                 # take that builder list, and run it until the end
+                # we make a copy of it, as it could be modified meanwhile
                 pending_builders = copy.copy(self._pending_builders)
                 self._pending_builders = []
                 self.pending_builders_lock.release()


### PR DESCRIPTION
as reported by nbjoerg on IRC, this method does not use the ordering and limiting of dataapi, which can lead to strong innefficiency if there are lots of pending buildrequests.
