### PR TITLE
Improve Builder infrastructure for priority functions

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -165,6 +165,21 @@ class Builder(util_service.ReconfigurableServiceMixin,
         if unclaimed:
             unclaimed = sorted([brd['submitted_at'] for brd in unclaimed])
             defer.returnValue(unclaimed[0])
+
+    @defer.inlineCallbacks
+    def getNewestCompleteTime(self):
+        """Returns the complete_at of the latest completed build request for
+        this builder, or None if there are no such build requests.
+
+        @returns: datetime instance or None, via Deferred
+        """
+        bldrid = yield self.getBuilderId()
+        completed = yield self.master.data.get(
+            ('builders', bldrid, 'buildrequests'),
+            [resultspec.Filter('complete', 'eq', [False])],
+            order=['-complete_at'], limit=1)
+        if completed:
+            defer.returnValue(completed[0]['complete_at'])
         else:
             defer.returnValue(None)
 

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -175,6 +175,26 @@ A simple ``prioritizeBuilders`` implementation might look like this::
 
     c['prioritizeBuilders'] = prioritizeBuilders
 
+If the change frequency is higher than the turn-around of the builders,
+the following approach might be helpful:
+
+.. code-block:: python
+
+    def prioritizeBuilders(buildmaster, builders):
+        """Prioritize builders. First, prioritize inactive builders.
+        Second, consider the last time a job was completed (no job is infinite past).
+        Third, consider the time the oldest request has been queued.
+        This provides a simple round-robin scheme that works with collapsed builds."""
+
+        def isBuilding(b):
+            return bool(b.building) or bool(b.old_building)
+
+        builders.sort(key = lambda b: (isBuilding(b), b.getNewestCompleteTime(), b.getOldestRequestTime()))
+        return builders
+
+    c['prioritizeBuilders'] = prioritizeBuilders
+
+
 .. index:: Builds; priority
 
 .. _Build-Priority-Functions:


### PR DESCRIPTION
The default priority function sorts by `getOldestRequestTime` and that differs subtly from the documentation. If two requests are collapsed, the submission time of the winner stays, so with the default behavior, starvation can occur. The new `getNewestCompleteTime` can be used to avoid that by sorting on finished jobs instead, i.e. preferring the builder that has waited for the longest.

The second part cleans up `getOldestRequestTime` to better use the data layer, i.e. when many unclaimed builds are around.

Documentation changes can be done separately, including an example using gNCT.