### PR TITLE
console_view: match forced builds on got_revision if possible (#3363)

### DIFF
--- a/www/console_view/src/module/main.module.coffee
+++ b/www/console_view/src/module/main.module.coffee
@@ -103,8 +103,10 @@ class Console extends Controller
         @sortBuildersByTags(@all_builders)
 
         @changesBySSID ?= {}
+        @changesByRevision ?= {}
         for change in @changes
             @changesBySSID[change.sourcestamp.ssid] = change
+            @changesByRevision[change.revision] = change
             @populateChange(change)
 
 
@@ -271,13 +273,17 @@ class Console extends Controller
             rev = build.properties.got_revision[0]
             # got_revision can be per codebase or just the revision string
             if typeof(rev) == "string"
-                change = @makeFakeChange("", rev, build.started_at)
+                change = @changesByRevision[rev]
+                if not change?
+                    change = @makeFakeChange("", rev, build.started_at)
             else
                 for codebase, revision of rev
-                    change = @makeFakeChange(codebase, revision, build.started_at)
+                    change = @changesByRevision[rev]
+                    if not change?
+                        change = @makeFakeChange(codebase, revision, build.started_at)
 
         if not change?
-            change = @makeFakeChange("unknown codebase", "unknown revision")
+            change = @makeFakeChange("unknown codebase", "unknown revision", build.started_at)
 
         change.buildersById[build.builderid].builds.push(build)
 


### PR DESCRIPTION
This is a quick implementation of what was discussed here: https://github.com/buildbot/buildbot/issues/3363#issuecomment-336092464

**Before:** 

---

![buildbot-issue-before](https://user-images.githubusercontent.com/7168263/31544866-241706e4-b01d-11e7-92d6-9b69a70da25e.png)

---

Both builds 140 and 141 are building the same `got_revision`. 

140 is triggered by a `SingleBranchScheduler`
141 is triggered by a `ForceScheduler`

**After:**

---

![buildbot-issue-after](https://user-images.githubusercontent.com/7168263/31544900-57ce9218-b01d-11e7-84a5-cc6aeb59c7eb.png)

---
Both builds are properly grouped under the same `change`.

There may be better ways to do this, it's just a try. 