### PR TITLE
steps.shell.WarningCountingShellCommand: Make more parameters renderable

### DIFF
--- a/master/buildbot/newsfragments/WarningCountingShellCommand-renderables.feature
+++ b/master/buildbot/newsfragments/WarningCountingShellCommand-renderables.feature
@@ -1,0 +1,3 @@
+Make parameters for :py:class:`~buildbot.steps.shell.WarningCountingShellCommand` renderable.
+These are `suppressionList`, `warningPattern`, `directoryEnterPattern`, `directoryLeavePattern` and `maxWarnCount`. 
+

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -387,7 +387,14 @@ class Configure(ShellCommand):
 
 
 class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
-    renderables = ['suppressionFile']
+    renderables = [
+                    'suppressionFile',
+                    'suppressionList',
+                    'warningPattern',
+                    'directoryEnterPattern',
+                    'directoryLeavePattern',
+                    'maxWarnCount',
+    ]
 
     warnCount = 0
     warningPattern = '(?i).*warning[: ].*'


### PR DESCRIPTION
There is no reason these could be renderable, and it's useful to be able get some parameters from Properties.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
