### PR TITLE
Minor nit : fix pylint warnings

### DIFF
--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -39,7 +39,7 @@ from buildbot.www.hooks.github import GitHubEventHandler
 # Sample GITHUB commit payload from http://help.github.com/post-receive-hooks/
 # Added "modified" and "removed", and change email
 # Added "head_commit"
-#   https://developer.github.com/v3/activity/events/types/#webhook-payload-example-26
+#   https://developer.github.com/v3/activity/events/types/#webhook-payload-example-26 # pylint: disable=wrong-spelling-in-comment
 gitJsonPayload = b"""
 {
   "before": "5aef35982fb2d34e9d9d4502f6ede1072793222d",

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -30,7 +30,7 @@ from buildbot.www.hooks.gitlab import _HEADER_EVENT
 from buildbot.www.hooks.gitlab import _HEADER_GITLAB_TOKEN
 
 
-# Sample GITLAB commit payload from https://docs.gitlab.com/ce/user/project/integrations/webhooks.html
+# Sample GITLAB commit payload from https://docs.gitlab.com/ce/user/project/integrations/webhooks.html # pylint: disable=wrong-spelling-in-comment
 # Added "modified" and "removed", and change email
 gitJsonPayload = b"""
 {

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -253,7 +253,7 @@ class GitHubAuth(OAuth2Auth):
         else:
             self.apiResourceEndpoint = self.serverURL + '/graphql'
         if getTeamsMembership:
-            # GraphQL name aliases must comply with /^[_a-zA-Z][_a-zA-Z0-9]*$/
+            # GraphQL name aliases must comply with /^[_a-zA-Z][_a-zA-Z0-9]*$/ # pylint: disable=wrong-spelling-in-comment
             self._orgname_slug_sub_re = re.compile(r'[^_a-zA-Z0-9]')
             self.getUserTeamsGraphqlTplC = jinja2.Template(
                 self.getUserTeamsGraphqlTpl.strip())


### PR DESCRIPTION
Fixes the following, although I think the CI already ignores this : 
```
************* Module buildbot.www.oauth2
buildbot/www/oauth2.py:256 Wrong spelling of a word 'zA' in a comment:
# GraphQL name aliases must comply with /^[_a-zA-Z][_a-zA-Z0-9]*$/
                                              ^^
Did you mean: 'z' or 'a' or 'zag' or 'zap'? [wrong-spelling-in-comment]
buildbot/www/oauth2.py:256 Wrong spelling of a word 'zA' in a comment:
# GraphQL name aliases must comply with /^[_a-zA-Z][_a-zA-Z0-9]*$/
                                              ^^
Did you mean: 'z' or 'a' or 'zag' or 'zap'? [wrong-spelling-in-comment]
************* Module buildbot.test.unit.test_www_hooks_github
buildbot/test/unit/test_www_hooks_github.py:42 Wrong spelling of a word 'webhook' in a comment:
#   https://developer.github.com/v3/activity/events/types/#webhook-payload-example-26
                                                           ^^^^^^^
Did you mean: 'web hook' or 'web-hook' or 'Hooke' or 'Windhoek'? [wrong-spelling-in-comment]
************* Module buildbot.test.unit.test_www_hooks_gitlab
buildbot/test/unit/test_www_hooks_gitlab.py:33 Wrong spelling of a word 'ce' in a comment:
# Sample GITLAB commit payload from https://docs.gitlab.com/ce/user/project/integrations/webhooks.html
                                                            ^^
Did you mean: 'Ce' or 'cw' or 'c' or 'e'? [wrong-spelling-in-comment]
buildbot/test/unit/test_www_hooks_gitlab.py:33 Wrong spelling of a word 'webhooks' in a comment:
# Sample GITLAB commit payload from https://docs.gitlab.com/ce/user/project/integrations/webhooks.html
                                                                                         ^^^^^^^^
Did you mean: 'web hooks' or 'web-hooks' or 'shooks' or 'hooks'? [wrong-spelling-in-comment]
```