### PR TITLE
Give renderables in reporters access to master singleton

### DIFF
--- a/master/buildbot/newsfragments/reporters_master_singleton.feature
+++ b/master/buildbot/newsfragments/reporters_master_singleton.feature
@@ -1,0 +1,1 @@
+Give reporters access to master single in renderables. This allows access to build logs amongst other things

--- a/master/buildbot/reporters/bitbucketserver.py
+++ b/master/buildbot/reporters/bitbucketserver.py
@@ -75,6 +75,8 @@ class BitbucketServerStatusPush(http.HttpStatusPushBase):
     @defer.inlineCallbacks
     def send(self, build):
         props = Properties.fromDict(build['properties'])
+        props.master = self.master
+
         results = build['results']
         if build['complete']:
             state = SUCCESSFUL if results == SUCCESS else FAILED

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -103,6 +103,7 @@ class GitHubStatusPush(http.HttpStatusPushBase):
     @defer.inlineCallbacks
     def send(self, build):
         props = Properties.fromDict(build['properties'])
+        props.master = self.master
 
         if build['complete']:
             state = {

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -119,6 +119,7 @@ class GitLabStatusPush(http.HttpStatusPushBase):
     @defer.inlineCallbacks
     def send(self, build):
         props = Properties.fromDict(build['properties'])
+        props.master = self.master
 
         if build['complete']:
             state = {

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -236,6 +236,7 @@ class MailNotifier(NotifierBase):
             extraHeaders = self.extraHeaders
             if len(builds) == 1:
                 props = Properties.fromDict(builds[0]['properties'])
+                props.master = self.master
                 extraHeaders = yield props.render(extraHeaders)
 
             for k, v in iteritems(extraHeaders):

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -682,6 +682,8 @@ class Contact(service.AsyncService):
             return
 
         properties = Properties()
+        properties.master = self.master
+
         if props:
             # split props into name:value dict
             pdict = {}


### PR DESCRIPTION
Also needs build props to actually be able to address steps

This works to get build step output in GitHubCommentPush, but via a complicated renderer. I'm wondering if there's
some variation of getDetailsForBuildset that should be used instead.

Fixes #3082 @tardyp 