### PR TITLE
Bitbucket-Authorization and branch bug - flake8 warning repair

### DIFF
--- a/common/porttostable.py
+++ b/common/porttostable.py
@@ -32,7 +32,7 @@ for pr in to_port['items']:
                 continue
             if 'fatal: bad object' in e.output:
                 continue
-            print("cannot automatically cherry-pick", pr['number'], c['sha'], title,e.output)
+            print("cannot automatically cherry-pick", pr['number'], c['sha'], title, e.output)
         else:
-            summary += "\n#{number}: {title}".format(number=pr['number'], title=title , **c)
+            summary += "\n#{number}: {title}".format(number=pr['number'], title=title, **c)
 print(summary)

--- a/master/setup.py
+++ b/master/setup.py
@@ -131,6 +131,7 @@ def define_plugin_entries(groups):
 
     return result
 
+
 __file__ = inspect.getframeinfo(inspect.currentframe()).filename
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as long_d_f:

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -42,6 +42,8 @@ def listdir(path):
     if "node_modules" in l:
         l.remove("node_modules")
     return l
+
+
 os.listdir = listdir
 
 

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -136,7 +136,7 @@ else:
 try:
     # If setuptools is installed, then we'll add setuptools-specific arguments
     # to the setup args.
-    import setuptools  # @UnusedImport
+    import setuptools  # @UnusedImport # noqa F401
 except ImportError:
     pass
 else:


### PR DESCRIPTION
Two changes for bitbucket.py

- Support authorization for bitbucket through the use of self.authHeader
- fix a bug _processChanges which was using the cached default branch, rather than the branch in the current pull request.

master/buildbot/changes/bitbucket.py

Next address flake8 warnings.

flake8 warnings generated by
 -   worker/setup.py
 -   common/porttostable.py
 -   master/setup.py
 -   worker/setup.py

./worker/setup.py:139:5: F401 'setuptools' imported but unused
    import setuptools  # @UnusedImport
    ^

./common/porttostable.py:35:84: E231 missing whitespace after ','
            print("cannot automatically cherry-pick", pr['number'], c['sha'], title,e.output)
                                                                                   ^

./common/porttostable.py:37:86: E203 whitespace before ','
            summary += "\n#{number}: {title}".format(number=pr['number'], title=title , **c)

./pkg/buildbot_pkg.py:45:1: E305 expected 2 blank lines after class or function definition, found 0
os.listdir = listdir

./master/setup.py:134:1: E305 expected 2 blank lines after class or function definition, found 1
__file__ = inspect.getframeinfo(inspect.currentframe()).filename
^

## Contributor Checklist:
* [X] I fixed a bug.
* [-] I have updated the unit tests
* [-] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [-] I have updated the appropriate documentation
