### PR TITLE
Fix getBuildRequests results when using multiple sourcestamps

### DIFF
--- a/master/buildbot/newsfragments/duplicate-brid.bugfix
+++ b/master/buildbot/newsfragments/duplicate-brid.bugfix
@@ -1,0 +1,1 @@
+Fix duplicate build requests results in :py:class:`~buildbot.db.buildrequests.BuildRequestsConnectorComponent` when querying the database  (:issue:`3712`).

--- a/master/buildbot/test/unit/test_db_buildrequests.py
+++ b/master/buildbot/test/unit/test_db_buildrequests.py
@@ -319,6 +319,11 @@ class Tests(interfaces.InterfaceTests):
                                branch='branch_A', repository='repository_A'),
             fakedb.BuildsetSourceStamp(buildsetid=self.BSID + 3,
                                        sourcestampid=self.BSID + 3),
+            # multiple sourcestamps on the same buildset are possible
+            fakedb.SourceStamp(id=self.BSID + 4,
+                               branch='branch_B', repository='repository_B'),
+            fakedb.BuildsetSourceStamp(buildsetid=self.BSID + 3,
+                                       sourcestampid=self.BSID + 4),
         ])
         d.addCallback(lambda _:
                       self.db.buildrequests.getBuildRequests(**kwargs))


### PR DESCRIPTION
I recently faced a nasty bug when using multiple codebases. It appears that [`getBuildResquests`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/db/buildrequests.py#L84) returns build requests with the same `id` several times when using multiple codebases in the same build. After some debugging, I discovered that when you use several codebases (which generate several sourcestamps) in the build, `getBuildRequests` does not group them and thus returns several build requests with the same `id`.

As always, an example is more meaningful... Here, we have a buildrequest which use several sourcestamps. The SQL query used in `getBuildRequests` is generated in [`_saSelectQuery`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/db/buildrequests.py#L48) and join together several models including [`buildrequests`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/db/model.py#L73), [`buildset_sourcestamps`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/db/model.py#L451) and [`sourcestamps`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/db/model.py#L416). However, when using multiple sourcestamps, the join will duplicate the buildrequest and `getBuildRequests` will return them.

Here is the current SQL query result of a buildset which use two codebases:

```
id          buildsetid  builderid   priority    complete    results     submitted_at  complete_at  waited_for  brid        masterid    claimed_at  branch      repository  codebase    buildername
----------  ----------  ----------  ----------  ----------  ----------  ------------  -----------  ----------  ----------  ----------  ----------  ----------  ----------  ----------  -----------
435         331         40          0           1           0           1508832228    1508832236   1           435         1           1508832228                          production  sdk-android
435         331         40          0           1           0           1508832228    1508832236   1           435         1           1508832228                          internal    sdk-android
```

But if we perform a `GROUP BY buildrequests.id` on the query, we ensure that the same build request is not duplicated by the joined sourcestamps before returning the `getBuildRequests` result:

```
id          buildsetid  builderid   priority    complete    results     submitted_at  complete_at  waited_for  brid        masterid    claimed_at  branch      repository  codebase    buildername
----------  ----------  ----------  ----------  ----------  ----------  ------------  -----------  ----------  ----------  ----------  ----------  ----------  ----------  ----------  -----------
435         331         40          0           1           0           1508832228    1508832236   1           435         1           1508832228                          production  sdk-android
```

From my tests, it solves two bugs that I noticed:
* When using multiple codebases in your builset and a mailnotifier with the option `buildSetSummary=True`, buildbot was sending an email with the same text repeated within due to multiple buildrequests returned to the notifier [right here](https://github.com/buildbot/buildbot/blob/master/master/buildbot/reporters/utils.py#L54).
* When using multiple codebases in your builset and fetching the buidrequests on [http://localhost:8020/api/v2/buildrequests](http://localhost:8020/api/v2/buildrequests), the same buildrequests was returned several times. 