### PR TITLE
Fix exception in worker service startup on Windows

### DIFF
--- a/master/buildbot/newsfragments/worker_windows_service.bugfix
+++ b/master/buildbot/newsfragments/worker_windows_service.bugfix
@@ -1,0 +1,1 @@
+Fix buildbot worker startup when running as worker/windows_service

--- a/worker/buildbot_worker/scripts/windows_service.py
+++ b/worker/buildbot_worker/scripts/windows_service.py
@@ -234,7 +234,7 @@ class BBService(win32serviceutil.ServiceFramework):
             hstop = self.hWaitStop
 
             cmd = '{0} --spawn {1} start --nodaemon {2}'.format(
-                self.runner_prefix, hstop, bbdir)
+                self.runner_prefix, int(hstop), bbdir)
             # print "cmd is", cmd
             h, t, output = self.createProcess(cmd)
             child_infos.append((bbdir, h, t, output))


### PR DESCRIPTION
BuildBot for directory 'd:\\bbw\\worker' terminated with exit code 1.
Traceback (most recent call last):
  File "d:\bbw\lib\site-packages\buildbot_worker\scripts\windows_service.py", line 561, in <module>
    HandleCommandLine()
  File "d:\bbw\lib\site-packages\buildbot_worker\scripts\windows_service.py", line 554, in HandleCommandLine
    _RunChild(DetermineRunner(sys.argv[5]))
  File "d:\bbw\lib\site-packages\buildbot_worker\scripts\windows_service.py", line 493, in _RunChild
    args=(int(sys.argv[1]), )
ValueError: invalid literal for int() with base 10: '<PyHANDLE:424>'

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

http://trac.buildbot.net/wiki/Development
And especially:
http://trac.buildbot.net/wiki/SubmittingPatches

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
