### PR TITLE
Transform arguments from bytes to strings.

### DIFF
--- a/master/buildbot/newsfragments/gitlab-args.bugfix
+++ b/master/buildbot/newsfragments/gitlab-args.bugfix
@@ -1,0 +1,1 @@
+Arguments passed to GitLab push notifications now work with Python 3.  Fixes (:issue:`3720`).

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -280,7 +280,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def testGitWithChange_WithProjectToo(self):
         self.request = FakeRequest(content=gitJsonPayload)
         self.request.uri = b"/change_hook/gitlab"
-        self.request.args = {'project': ['MyProject']}
+        self.request.args = {b'project': [b'MyProject']}
         self.request.received_headers[_HEADER_EVENT] = b"Push Hook"
         self.request.method = b"POST"
         res = yield self.request.test_render(self.changeHook)
@@ -290,7 +290,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def testGitWithChange_WithCodebaseToo(self):
         self.request = FakeRequest(content=gitJsonPayload)
         self.request.uri = b"/change_hook/gitlab"
-        self.request.args = {'codebase': ['MyCodebase']}
+        self.request.args = {b'codebase': [b'MyCodebase']}
         self.request.received_headers[_HEADER_EVENT] = b"Push Hook"
         self.request.method = b"POST"
         res = yield self.request.test_render(self.changeHook)
@@ -300,7 +300,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def testGitWithChange_WithPushTag(self):
         self.request = FakeRequest(content=gitJsonPayloadTag)
         self.request.uri = b"/change_hook/gitlab"
-        self.request.args = {'codebase': ['MyCodebase']}
+        self.request.args = {b'codebase': [b'MyCodebase']}
         self.request.received_headers[_HEADER_EVENT] = b"Push Hook"
         self.request.method = b"POST"
         res = yield self.request.test_render(self.changeHook)
@@ -337,7 +337,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def testGitWithChange_WithMR(self):
         self.request = FakeRequest(content=gitJsonPayloadMR)
         self.request.uri = b"/change_hook/gitlab"
-        self.request.args = {'codebase': ['MyCodebase']}
+        self.request.args = {b'codebase': [b'MyCodebase']}
         self.request.received_headers[_HEADER_EVENT] = b"Merge Request Hook"
         self.request.method = b"POST"
         res = yield self.request.test_render(self.changeHook)
@@ -359,7 +359,7 @@ class TestChangeHookConfiguredWithSecret(unittest.TestCase):
     def test_missing_secret(self):
         self.request = FakeRequest(content=gitJsonPayloadTag)
         self.request.uri = b"/change_hook/gitlab"
-        self.request.args = {'codebase': ['MyCodebase']}
+        self.request.args = {b'codebase': [b'MyCodebase']}
         self.request.method = b"POST"
         self.request.received_headers[_HEADER_EVENT] = b"Push Hook"
         yield self.request.test_render(self.changeHook)

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -154,8 +154,10 @@ class GitLabHandler(BaseHookHandler):
         # newer version of gitlab have a object_kind parameter,
         # which allows not to use the http header
         event_type = payload.get('object_kind', event_type)
-        project = request.args.get('project', [''])[0]
-        codebase = request.args.get('codebase', [None])[0]
+        project = request.args.get(b'project', [''])[0]
+        project = bytes2unicode(project)
+        codebase = request.args.get(b'codebase', [None])[0]
+        codebase = bytes2unicode(codebase)
         if event_type in ("push", "tag_push", "Push Hook"):
             user = payload['user_name']
             repo = payload['repository']['name']


### PR DESCRIPTION
This change works for me locally. Transform bytes in rest args to normal strings. Fixes #3720.
