### PR TITLE
Fix issue with windows's sys.executable contains spaces

### DIFF
--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -490,7 +490,9 @@ class RunProcess(object):
                 argv = os.environ['COMSPEC'].split()
                 if '/c' not in argv:
                     argv += ['/c']
-                argv += list(self.command)
+                cmd_list = list(self.command)
+                cmd_list[0] = shell_quote(cmd_list[0], self.builder.unicode_encoding)
+                argv += list(cmd_list)
                 self.using_comspec = True
             else:
                 argv = self.command

--- a/worker/buildbot_worker/test/unit/test_util.py
+++ b/worker/buildbot_worker/test/unit/test_util.py
@@ -99,6 +99,21 @@ class TestObfuscated(unittest.TestCase):
         self.assertEqual(1, util.Obfuscated.get_real(cmd))
         self.assertEqual(1, util.Obfuscated.get_fake(cmd))
 
+    def testObfuscatedQuotedCmdForWin(self):
+        cmd = "c:\\test program\\test.exe -p use_parameter"
+        self.assertEqual('"c:\\test program\\test.exe" -p use_parameter',
+                         util.Obfuscated.quoted_cmd(cmd))
+
+    def testObfuscatedQuotedCmdForMultiSpacePath(self):
+        cmd = "c:\\test program\\sub folder\\test.exe -p use_parameter"
+        self.assertEqual('"c:\\test program\\sub folder\\test.exe" -p use_parameter',
+                         util.Obfuscated.quoted_cmd(cmd))
+
+    def testObfuscatedQuotedCmdForListCmd(self):
+        cmd = ["c:\\test program\\sub folder\\test.exe", '-p', 'use_parameter']
+        self.assertEqual(['"c:\\test program\\sub folder\\test.exe"', '-p', 'use_parameter'],
+                         util.Obfuscated.quoted_cmd(cmd))
+
 
 class TestRewrap(unittest.TestCase):
 


### PR DESCRIPTION
This 'fixes' Issue #3733.  

Though I'm not sure I'm going about in the right manner. 