### PR TITLE
Docker Latent Worker: Always Pull

### DIFF
--- a/master/buildbot/newsfragments/docker_alwaysPull.feature
+++ b/master/buildbot/newsfragments/docker_alwaysPull.feature
@@ -1,0 +1,1 @@
+Added flag to Docker Latent Worker to always pull images

--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -27,8 +27,9 @@ class Client(object):
         self.call_args_create_container = []
         self.call_args_create_host_config = []
         self.called_class_name = None
-        self._images = [{'RepoTags': ['busybox:latest', 'worker:latest']}]
-        self._pullable = ['alpine:latest']
+        self._images = [{'RepoTags': ['busybox:latest', 'worker:latest', 'tester:latest']}]
+        self._pullable = ['alpine:latest', 'tester:latest']
+        self._pullCount = 0
         self._containers = {}
 
     def images(self):
@@ -54,6 +55,7 @@ class Client(object):
 
     def pull(self, image, *args, **kwargs):
         if image in self._pullable:
+            self._pullCount += 1
             self._images.append({'RepoTags': [image]})
 
     def containers(self, filters=None, *args, **kwargs):

--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -226,6 +226,30 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase):
         id, name = self.successResultOf(bs.start_instance(self.build))
         self.assertEqual(name, 'alpine:latest')
 
+    def test_start_instance_image_pull(self):
+        bs = self.setupWorker(
+            'bot', 'pass', 'tcp://1234:2375', 'tester:latest', autopull=True)
+        id, name = self.successResultOf(bs.start_instance(self.build))
+        self.assertEqual(name, 'tester:latest')
+        client = docker.Client.latest
+        self.assertEqual(client._pullCount, 0)
+
+    def test_start_instance_image_alwayspull(self):
+        bs = self.setupWorker(
+            'bot', 'pass', 'tcp://1234:2375', 'tester:latest', autopull=True, alwaysPull=True)
+        id, name = self.successResultOf(bs.start_instance(self.build))
+        self.assertEqual(name, 'tester:latest')
+        client = docker.Client.latest
+        self.assertEqual(client._pullCount, 1)
+
+    def test_start_instance_image_noauto_alwayspull(self):
+        bs = self.setupWorker(
+            'bot', 'pass', 'tcp://1234:2375', 'tester:latest', autopull=False, alwaysPull=True)
+        id, name = self.successResultOf(bs.start_instance(self.build))
+        self.assertEqual(name, 'tester:latest')
+        client = docker.Client.latest
+        self.assertEqual(client._pullCount, 0)
+
     def test_start_instance_noimage_renderabledockerfile(self):
         bs = self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'customworker',

--- a/master/docs/manual/cfg-workers-docker.rst
+++ b/master/docs/manual/cfg-workers-docker.rst
@@ -229,6 +229,10 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
     (optional, defaults to false)
     Automatically pulls image if requested image is not on docker host.
 
+``alwayPull``
+    (optional, defaults to false)
+    Always pulls image if autopull is set to true.
+
 Setting up Volumes
 ..................
 


### PR DESCRIPTION
This will allow a flag to be set to always pull the image. Useful for testing on docker images that follow a master branch or on latest. 
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
