### PR TITLE
Set tags for spot instances in EC2LatentWorker

### DIFF
--- a/master/buildbot/newsfragments/spot_instance_tags.bugfix
+++ b/master/buildbot/newsfragments/spot_instance_tags.bugfix
@@ -1,0 +1,1 @@
+EC2LatentBuilder now correctly sets tags on spot instances. Fixes (:issue:`3739`).

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -413,9 +413,6 @@ class EC2LatentWorker(AbstractLatentWorker):
         self.instance = reservations[0]
         instance_id, start_time = self._wait_for_instance()
         if None not in [instance_id, image.id, start_time]:
-            if self.tags:
-                self.instance.create_tags(Tags=[{"Key": k, "Value": v}
-                                                for k, v in self.tags.items()])
             return [instance_id, image.id, start_time]
         else:
             self.failed_to_start(self.instance.id, self.instance.state['Name'])
@@ -558,6 +555,9 @@ class EC2LatentWorker(AbstractLatentWorker):
                 minutes // 60, minutes % 60, seconds)
             if self.volumes:
                 self._attach_volumes()
+            if self.tags:
+                self.instance.create_tags(Tags=[{"Key": k, "Value": v}
+                                                for k, v in self.tags.items()])
             return self.instance.id, start_time
         else:
             self.failed_to_start(self.instance.id, self.instance.state['Name'])


### PR DESCRIPTION
EC2LatentWorker ignores its "tags" parameter when spot_instance is
True.  We move the call to create_tags() from _start_instance(),
which only applies to non-spot instances, to _wait_for_instance(),
which is part of both the normal and spot instance call paths.
