### PR TITLE
Change container name by moving the hash to the end

### DIFF
--- a/master/buildbot/newsfragments/docker-container-name.bugfix
+++ b/master/buildbot/newsfragments/docker-container-name.bugfix
@@ -1,0 +1,1 @@
+Fixes issue with Buildbot DockerLatentWorker, where Buildbot can kill running workers by mistake based on the form the worker name (:issue:`3800`)

--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -27,7 +27,8 @@ class Client(object):
         self.call_args_create_container = []
         self.call_args_create_host_config = []
         self.called_class_name = None
-        self._images = [{'RepoTags': ['busybox:latest', 'worker:latest', 'tester:latest']}]
+        self._images = [
+            {'RepoTags': ['busybox:latest', 'worker:latest', 'tester:latest']}]
         self._pullable = ['alpine:latest', 'tester:latest']
         self._pullCount = 0
         self._containers = {}
@@ -60,9 +61,19 @@ class Client(object):
 
     def containers(self, filters=None, *args, **kwargs):
         if filters is not None:
+            if 'existing' in filters.get('name', ''):
+                self.create_container(
+                    image='busybox:latest',
+                    name="buildbot-existing-87de7e"
+                )
+                self.create_container(
+                    image='busybox:latest',
+                    name="buildbot-existing-87de7ef"
+                )
+
             return [
                 c for c in self._containers.values()
-                if c['name'] == filters['name']
+                if c['name'].startswith(filters['name'])
             ]
         return self._containers.values()
 
@@ -87,7 +98,8 @@ class Client(object):
             'started': False,
             'image': image,
             'Id': ret['Id'],
-            'name': name
+            'name': name,  # docker does not return this
+            'Names': [name]  # this what docker returns
         }
         return ret
 

--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -258,6 +258,12 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase):
         id, name = self.successResultOf(bs.start_instance(self.build))
         self.assertEqual(name, 'customworker')
 
+    def test_start_worker_but_already_created_with_same_name(self):
+        bs = self.setupWorker(
+            'existing', 'pass', 'tcp://1234:2375', 'busybox:latest', ['bin/bash'])
+        id, name = self.successResultOf(bs.start_instance(self.build))
+        self.assertEqual(name, 'busybox:latest')
+
 
 class testDockerPyStreamLogs(unittest.TestCase):
 

--- a/master/buildbot/test/unit/test_worker_marathon.py
+++ b/master/buildbot/test/unit/test_worker_marathon.py
@@ -96,7 +96,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
         worker.masterFQDN = "master"
         self._http.expect(
             method='delete',
-            ep='/v2/apps/buildbot-worker/buildbotmasterhash-bot')
+            ep='/v2/apps/buildbot-worker/buildbot-bot-masterhash')
         self._http.expect(
             method='post',
             ep='/v2/apps',
@@ -109,7 +109,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
                     },
                     'type': 'DOCKER'
                 },
-                'id': u'buildbot-worker/buildbotmasterhash-bot',
+                'id': u'buildbot-worker/buildbot-bot-masterhash',
                 'env': {
                     'BUILDMASTER': "master",
                     'BUILDMASTER_PORT': '1234',
@@ -133,7 +133,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
         worker.masterFQDN = "master"
         self._http.expect(
             method='delete',
-            ep='/v2/apps/buildbot-worker/buildbotmasterhash-bot')
+            ep='/v2/apps/buildbot-worker/buildbot-bot-masterhash')
         self._http.expect(
             method='post',
             ep='/v2/apps',
@@ -146,7 +146,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
                     },
                     'type': 'DOCKER'
                 },
-                'id': u'buildbot-worker/buildbotmasterhash-bot',
+                'id': u'buildbot-worker/buildbot-bot-masterhash',
                 'env': {
                     'BUILDMASTER': "master",
                     'BUILDMASTER_PORT': '1234',
@@ -165,7 +165,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
         worker = self.makeWorker()
         self._http.expect(
             method='delete',
-            ep='/v2/apps/buildbot-worker/buildbotmasterhash-bot')
+            ep='/v2/apps/buildbot-worker/buildbot-bot-masterhash')
         self._http.expect(
             method='post',
             ep='/v2/apps',
@@ -178,7 +178,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
                     },
                     'type': 'DOCKER'
                 },
-                'id': u'buildbot-worker/buildbotmasterhash-bot',
+                'id': u'buildbot-worker/buildbot-bot-masterhash',
                 'env': {
                     'BUILDMASTER': "master",
                     'BUILDMASTER_PORT': '1234',
@@ -190,7 +190,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
             content_json={'message': 'image not found'})
         self._http.expect(
             method='delete',
-            ep='/v2/apps/buildbot-worker/buildbotmasterhash-bot')
+            ep='/v2/apps/buildbot-worker/buildbot-bot-masterhash')
         d = worker.substantiate(None, FakeBuild())
         self.reactor.advance(.1)
         self.failureResultOf(d)
@@ -213,7 +213,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
         worker.masterFQDN = "master"
         self._http.expect(
             method='delete',
-            ep='/v2/apps/buildbot-worker/buildbotmasterhash-bot')
+            ep='/v2/apps/buildbot-worker/buildbot-bot-masterhash')
         self._http.expect(
             method='post',
             ep='/v2/apps',
@@ -226,7 +226,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
                     },
                     'type': 'DOCKER'
                 },
-                'id': u'buildbot-worker/buildbotmasterhash-bot',
+                'id': u'buildbot-worker/buildbot-bot-masterhash',
                 'env': {
                     'BUILDMASTER': "master",
                     'BUILDMASTER_PORT': '1234',

--- a/www/badges/setup.py
+++ b/www/badges/setup.py
@@ -41,7 +41,8 @@ setup_www_plugin(
     ],
     package_data={
         '': [
-            'VERSION', 'templates/*.svg.j2', 'static/.placeholder' # dist is required by buildbot_pkg
+            # dist is required by buildbot_pkg
+            'VERSION', 'templates/*.svg.j2', 'static/.placeholder'
         ],
     },
     entry_points="""


### PR DESCRIPTION
Avoids issue when the filter to find container is matching on the start of the string. This causes cases in which we find more than one worker container and it force removes running instances.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
