### PR TITLE
This PR fixes a bug where BitbucketPullrequestPoller was setting the wrong branch

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -150,7 +150,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
                         comments=u'pull-request #%d: %s\n%s' % (
                             nr, title, prlink),
                         when_timestamp=datetime2epoch(updated),
-                        branch=self.branch,
+                        branch=ascii2unicode(branch),
                         category=self.category,
                         project=self.project,
                         repository=ascii2unicode(repo),

--- a/master/buildbot/test/unit/test_changes_bitbucket.py
+++ b/master/buildbot/test/unit/test_changes_bitbucket.py
@@ -369,7 +369,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
 
         self.assertEqual(self.master.data.updates.changesAdded, [{
             'author': u'contributor',
-            'branch': None,
+            'branch': u'default',
             'category': None,
             'codebase': None,
             'comments': u'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
@@ -394,7 +394,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
 
         self.assertEqual(self.master.data.updates.changesAdded, [{
             'author': u'contributor',
-            'branch': None,
+            'branch': u'default',
             'category': None,
             'codebase': None,
             'comments': u'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
@@ -422,7 +422,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
 
         self.assertEqual(self.master.data.updates.changesAdded, [{
             'author': u'contributor',
-            'branch': None,
+            'branch': u'default',
             'category': None,
             'codebase': None,
             'comments': u'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
@@ -442,7 +442,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
         self.assertEqual(self.master.data.updates.changesAdded, [
             {
                 'author': u'contributor',
-                'branch': None,
+                'branch': u'default',
                 'category': None,
                 'codebase': None,
                 'comments': u'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
@@ -457,7 +457,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
             },
             {
                 'author': u'contributor',
-                'branch': None,
+                'branch': u'default',
                 'category': None,
                 'codebase': None,
                 'comments': u'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
@@ -502,7 +502,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
 
         self.assertEqual(self.master.data.updates.changesAdded, [{
             'author': u'contributor',
-            'branch': None,
+            'branch': u'default',
             'category': None,
             'codebase': None,
             'comments': u'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',
@@ -531,7 +531,7 @@ class TestBitbucketPullrequestPoller(changesource.ChangeSourceMixin, unittest.Te
         yield self.changesource.poll()
         self.assertEqual(self.master.data.updates.changesAdded, [{
             'author': u'contributor',
-            'branch': None,
+            'branch': u'default',
             'category': None,
             'codebase': None,
             'comments': u'pull-request #1: title\nhttps://bitbucket.org/owner/slug/pull-request/1',


### PR DESCRIPTION
BitbucketPullrequestPoller: use branch name from json response instead of the branch from self


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
