### PR TITLE
repo.py: Allow syncing quietly

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1308,6 +1308,7 @@ swartz
 symlink
 syncallbranches
 syncmail
+syncQuietly
 syntaxerror
 sys
 tac

--- a/master/buildbot/steps/source/repo.py
+++ b/master/buildbot/steps/source/repo.py
@@ -123,6 +123,7 @@ class Repo(Source):
                  manifestOverrideUrl=None,
                  repoDownloads=None,
                  depth=0,
+                 syncQuietly=False,
                  **kwargs):
         """
         @type  manifestURL: string
@@ -153,6 +154,9 @@ class Repo(Source):
         @type depth: integer
         @param depth: optional depth parameter to repo init.
                           If specified, create a shallow clone with given depth.
+
+        @type syncQuietly: bool.
+        @param syncQuietly: true, then suppress verbose output from repo sync.
         """
         self.manifestURL = manifestURL
         self.manifestBranch = manifestBranch
@@ -166,6 +170,7 @@ class Repo(Source):
             repoDownloads = []
         self.repoDownloads = repoDownloads
         self.depth = depth
+        self.syncQuietly = syncQuietly
         Source.__init__(self, **kwargs)
 
         assert self.manifestURL is not None
@@ -311,6 +316,8 @@ class Repo(Source):
             command.append('-j' + str(self.jobs))
         if not self.syncAllBranches:
             command.append('-c')
+        if self.syncQuietly:
+            command.append('-q')
         self.step_status.setText(["repo sync"])
         self.stdio_log.addHeader("synching manifest %s from branch %s from %s\n"
                                  % (self.manifestFile, self.manifestBranch, self.manifestURL))


### PR DESCRIPTION
Syncing large trees can result in many hundreds of lines of log
output which is mostly not very useful. Optionally allow
repo sync to be run quietly.

Signed-off-by: Will Newton <will.newton@andromedadigital.com>
