### PR TITLE
Include 'context' in the log message for 'GitHubStatusPush'

### DIFF
--- a/master/buildbot/newsfragments/context-in-githubstatuspush.feature
+++ b/master/buildbot/newsfragments/context-in-githubstatuspush.feature
@@ -1,0 +1,1 @@
+Include `context` in the log message for `GitHubStatusPush`

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -172,15 +172,17 @@ class GitHubStatusPush(http.HttpStatusPushBase):
                 )
                 if self.verbose:
                     log.msg(
-                        'Updated status with "{state}" for '
-                        '{repoOwner}/{repoName} at {sha}, issue {issue}.'.format(
-                            state=state, repoOwner=repoOwner, repoName=repoName, sha=sha, issue=issue))
+                        'Updated status with "{state}" for {repoOwner}/{repoName} '
+                        'at {sha}, context "{context}", issue {issue}.'.format(
+                            state=state, repoOwner=repoOwner, repoName=repoName,
+                            sha=sha, issue=issue, context=context))
             except Exception as e:
                 log.err(
                     e,
-                    'Failed to update "{state}" for '
-                    '{repoOwner}/{repoName} at {sha}, issue {issue}'.format(
-                        state=state, repoOwner=repoOwner, repoName=repoName, sha=sha, issue=issue))
+                    'Failed to update "{state}" for {repoOwner}/{repoName} '
+                    'at {sha}, context "{context}", issue {issue}.'.format(
+                        state=state, repoOwner=repoOwner, repoName=repoName,
+                        sha=sha, issue=issue, context=context))
 
 
 class GitHubCommentPush(GitHubStatusPush):


### PR DESCRIPTION
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
