### PR TITLE
bitbucketcloud.py: Add BitbucketCloud change hook

### DIFF
--- a/master/buildbot/newsfragments/bitbucketcloud_change_hook.feature
+++ b/master/buildbot/newsfragments/bitbucketcloud_change_hook.feature
@@ -1,0 +1,1 @@
+Implement support for Bitbucket Cloud webhook plugin in :py:class:`~buildbot.www.hooks.bitbucketcloud.BitbucketCloudEventHandler`

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketcloud.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketcloud.py
@@ -1,0 +1,852 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+# Copyright Mamba Team
+
+from __future__ import absolute_import
+from __future__ import print_function
+from future.utils import text_type
+
+from io import BytesIO
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+import buildbot.www.change_hook as change_hook
+from buildbot.test.fake.web import FakeRequest
+from buildbot.test.fake.web import fakeMasterForHooks
+from buildbot.util import unicode2bytes
+from buildbot.www.hooks.bitbucketcloud import _HEADER_EVENT
+
+_CT_JSON = b'application/json'
+
+pushJsonPayload = u"""
+{
+    "actor": {
+        "username": "John",
+        "display_name": "John Smith"
+    },
+    "repository": {
+        "scm": "git",
+        "project": {
+            "key": "CI",
+            "name": "Continuous Integration"
+        },
+        "slug": "py-repo",
+        "links": {
+            "self": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            },
+            "html": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            }
+        },
+        "public": false,
+        "ownerName": "CI",
+        "owner": {
+            "username": "CI",
+            "display_name": "CI"
+        },
+        "fullName": "CI/py-repo"
+    },
+    "push": {
+        "changes": [
+            {
+                "created": false,
+                "closed": false,
+                "new": {
+                    "type": "branch",
+                    "name": "branch_1496411680",
+                    "target": {
+                        "type": "commit",
+                        "hash": "793d4754230023d85532f9a38dba3290f959beb4"
+                    }
+                },
+                "old": {
+                    "type": "branch",
+                    "name": "branch_1496411680",
+                    "target": {
+                        "type": "commit",
+                        "hash": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba"
+                    }
+                }
+            }
+        ]
+    }
+}
+"""
+
+pullRequestCreatedJsonPayload = u"""
+{
+    "actor": {
+        "username": "John",
+        "display_name": "John Smith"
+    },
+    "pullrequest": {
+        "id": "21",
+        "title": "dot 1496311906",
+        "link": "http://localhost:7990/projects/CI/repos/py-repo/pull-requests/21",
+        "authorLogin": "John Smith",
+        "fromRef": {
+            "repository": {
+                "scm": "git",
+                "project": {
+                    "key": "CI",
+                    "name": "Continuous Integration"
+                },
+                "slug": "py-repo",
+                "links": {
+                    "self": {
+                        "href": "http://localhost:7990/projects/CI/repos/py-repo"
+                    }
+                },
+                "public": false,
+                "ownerName": "CI",
+                "owner": {
+                    "username": "CI",
+                    "display_name": "CI"
+                },
+                "fullName": "CI/py-repo"
+            },
+            "commit": {
+                "message": null,
+                "date": null,
+                "hash": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba",
+                "authorTimestamp": 0
+            },
+            "branch": {
+                "rawNode": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba",
+                "name": "branch_1496411680"
+            }
+        },
+        "toRef": {
+            "repository": {
+                "scm": "git",
+                "project": {
+                    "key": "CI",
+                    "name": "Continuous Integration"
+                },
+                "slug": "py-repo",
+                "links": {
+                    "self": {
+                        "href": "http://localhost:7990/projects/CI/repos/py-repo"
+                    }
+                },
+                "public": false,
+                "ownerName": "CI",
+                "owner": {
+                    "username": "CI",
+                    "display_name": "CI"
+                },
+                "fullName": "CI/py-repo"
+            },
+            "commit": {
+                "message": null,
+                "date": null,
+                "hash": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+                "authorTimestamp": 0
+            },
+            "branch": {
+                "rawNode": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+                "name": "master"
+            }
+        }
+    },
+    "repository": {
+        "scm": "git",
+        "project": {
+            "key": "CI",
+            "name": "Continuous Integration"
+        },
+        "slug": "py-repo",
+        "links": {
+            "self": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            }
+        },
+        "public": false,
+        "ownerName": "CI",
+        "owner": {
+            "username": "CI",
+            "display_name": "CI"
+        },
+        "fullName": "CI/py-repo"
+    }
+}
+"""
+
+pullRequestUpdatedJsonPayload = u"""
+{
+    "actor": {
+        "username": "John",
+        "display_name": "John Smith"
+    },
+    "pullrequest": {
+        "id": "21",
+        "title": "dot 1496311906",
+        "link": "http://localhost:7990/projects/CI/repos/py-repo/pull-requests/21",
+        "authorLogin": "Buildbot",
+        "fromRef": {
+            "repository": {
+                "scm": "git",
+                "project": {
+                    "key": "CI",
+                    "name": "Continuous Integration"
+                },
+                "slug": "py-repo",
+                "links": {
+                    "self": {
+                        "href": "http://localhost:7990/projects/CI/repos/py-repo"
+                    }
+                },
+                "public": false,
+                "ownerName": "CI",
+                "owner": {
+                    "username": "CI",
+                    "display_name": "CI"
+                },
+                "fullName": "CI/py-repo"
+            },
+            "commit": {
+                "message": null,
+                "date": null,
+                "hash": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba",
+                "authorTimestamp": 0
+            },
+            "branch": {
+                "rawNode": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba",
+                "name": "branch_1496411680"
+            }
+        },
+        "toRef": {
+            "repository": {
+                "scm": "git",
+                "project": {
+                    "key": "CI",
+                    "name": "Continuous Integration"
+                },
+                "slug": "py-repo",
+                "links": {
+                    "self": {
+                        "href": "http://localhost:7990/projects/CI/repos/py-repo"
+                    }
+                },
+                "public": false,
+                "ownerName": "CI",
+                "owner": {
+                    "username": "CI",
+                    "display_name": "CI"
+                },
+                "fullName": "CI/py-repo"
+            },
+            "commit": {
+                "message": null,
+                "date": null,
+                "hash": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+                "authorTimestamp": 0
+            },
+            "branch": {
+                "rawNode": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+                "name": "master"
+            }
+        }
+    },
+    "repository": {
+        "scm": "git",
+        "project": {
+            "key": "CI",
+            "name": "Continuous Integration"
+        },
+        "slug": "py-repo",
+        "links": {
+            "self": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            }
+        },
+        "public": false,
+        "ownerName": "CI",
+        "owner": {
+            "username": "CI",
+            "display_name": "CI"
+        },
+        "fullName": "CI/py-repo"
+    }
+}
+"""
+
+pullRequestRejectedJsonPayload = u"""
+{
+    "actor": {
+        "username": "John",
+        "display_name": "John Smith"
+    },
+    "pullrequest": {
+        "id": "21",
+        "title": "dot 1496311906",
+        "link": "http://localhost:7990/projects/CI/repos/py-repo/pull-requests/21",
+        "authorLogin": "Buildbot",
+        "fromRef": {
+            "repository": {
+                "scm": "git",
+                "project": {
+                    "key": "CI",
+                    "name": "Continuous Integration"
+                },
+                "slug": "py-repo",
+                "links": {
+                    "self": {
+                        "href": "http://localhost:7990/projects/CI/repos/py-repo"
+                    }
+                },
+                "public": false,
+                "ownerName": "CI",
+                "owner": {
+                    "username": "CI",
+                    "display_name": "CI"
+                },
+                "fullName": "CI/py-repo"
+            },
+            "commit": {
+                "message": null,
+                "date": null,
+                "hash": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba",
+                "authorTimestamp": 0
+            },
+            "branch": {
+                "rawNode": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba",
+                "name": "branch_1496411680"
+            }
+        },
+        "toRef": {
+            "repository": {
+                "scm": "git",
+                "project": {
+                    "key": "CI",
+                    "name": "Continuous Integration"
+                },
+                "slug": "py-repo",
+                "links": {
+                    "self": {
+                        "href": "http://localhost:7990/projects/CI/repos/py-repo"
+                    }
+                },
+                "public": false,
+                "ownerName": "CI",
+                "owner": {
+                    "username": "CI",
+                    "display_name": "CI"
+                },
+                "fullName": "CI/py-repo"
+            },
+            "commit": {
+                "message": null,
+                "date": null,
+                "hash": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+                "authorTimestamp": 0
+            },
+            "branch": {
+                "rawNode": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+                "name": "master"
+            }
+        }
+    },
+    "repository": {
+        "scm": "git",
+        "project": {
+            "key": "CI",
+            "name": "Continuous Integration"
+        },
+        "slug": "py-repo",
+        "links": {
+            "self": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            }
+        },
+        "public": false,
+        "ownerName": "CI",
+        "owner": {
+            "username": "CI",
+            "display_name": "CI"
+        },
+        "fullName": "CI/py-repo"
+    }
+}
+"""
+
+pullRequestFulfilledJsonPayload = u"""
+{
+    "actor": {
+        "username": "John",
+        "display_name": "John Smith"
+    },
+    "pullrequest": {
+        "id": "21",
+        "title": "Branch 1496411680",
+        "link": "http://localhost:7990/projects/CI/repos/py-repo/pull-requests/21",
+        "authorLogin": "Buildbot",
+        "fromRef": {
+            "repository": {
+                "scm": "git",
+                "project": {
+                    "key": "CI",
+                    "name": "Continuous Integration"
+                },
+                "slug": "py-repo",
+                "links": {
+                    "self": {
+                        "href": "http://localhost:7990/projects/CI/repos/py-repo"
+                    }
+                },
+                "public": false,
+                "ownerName": "CI",
+                "owner": {
+                    "username": "CI",
+                    "display_name": "CI"
+                },
+                "fullName": "CI/py-repo"
+            },
+            "commit": {
+                "message": null,
+                "date": null,
+                "hash": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba",
+                "authorTimestamp": 0
+            },
+            "branch": {
+                "rawNode": "a87e21f7433d8c16ac7be7413483fbb76c72a8ba",
+                "name": "branch_1496411680"
+            }
+        },
+        "toRef": {
+            "repository": {
+                "scm": "git",
+                "project": {
+                    "key": "CI",
+                    "name": "Continuous Integration"
+                },
+                "slug": "py-repo",
+                "links": {
+                    "self": {
+                        "href": "http://localhost:7990/projects/CI/repos/py-repo"
+                    }
+                },
+                "public": false,
+                "ownerName": "CI",
+                "owner": {
+                    "username": "CI",
+                    "display_name": "CI"
+                },
+                "fullName": "CI/py-repo"
+            },
+            "commit": {
+                "message": null,
+                "date": null,
+                "hash": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+                "authorTimestamp": 0
+            },
+            "branch": {
+                "rawNode": "7aebbb0089c40fce138a6d0b36d2281ea34f37f5",
+                "name": "master"
+            }
+        }
+    },
+    "repository": {
+        "scm": "git",
+        "project": {
+            "key": "CI",
+            "name": "Continuous Integration"
+        },
+        "slug": "py-repo",
+        "links": {
+            "self": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            }
+        },
+        "public": false,
+        "ownerName": "CI",
+        "owner": {
+            "username": "CI",
+            "display_name": "CI"
+        },
+        "fullName": "CI/py-repo"
+    }
+}
+"""
+
+deleteTagJsonPayload = u"""
+{
+    "actor": {
+        "username": "John",
+        "display_name": "John Smith"
+    },
+    "repository": {
+        "scm": "git",
+        "project": {
+            "key": "CI",
+            "name": "Continuous Integration"
+        },
+        "slug": "py-repo",
+        "links": {
+            "self": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            },
+            "html": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            }
+        },
+        "ownerName": "BUIL",
+        "public": false,
+        "owner": {
+            "username": "CI",
+            "display_name": "CI"
+        },
+        "fullName": "CI/py-repo"
+    },
+    "push": {
+        "changes": [
+            {
+                "created": false,
+                "closed": true,
+                "old": {
+                    "type": "tag",
+                    "name": "1.0.0",
+                    "target": {
+                        "type": "commit",
+                        "hash": "793d4754230023d85532f9a38dba3290f959beb4"
+                    }
+                },
+                "new": null
+            }
+        ]
+    }
+}
+"""
+
+deleteBranchJsonPayload = u"""
+{
+    "actor": {
+        "username": "John",
+        "display_name": "John Smith"
+    },
+    "repository": {
+        "scm": "git",
+        "project": {
+            "key": "CI",
+            "name": "Continuous Integration"
+        },
+        "slug": "py-repo",
+        "links": {
+            "self": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            },
+            "html": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            }
+        },
+        "ownerName": "CI",
+        "public": false,
+        "owner": {
+            "username": "CI",
+            "display_name": "CI"
+        },
+        "fullName": "CI/py-repo"
+    },
+    "push": {
+        "changes": [
+            {
+                "created": false,
+                "closed": true,
+                "old": {
+                    "type": "branch",
+                    "name": "branch_1496758965",
+                    "target": {
+                        "type": "commit",
+                        "hash": "793d4754230023d85532f9a38dba3290f959beb4"
+                    }
+                },
+                "new": null
+            }
+        ]
+    }
+}
+"""
+
+newTagJsonPayload = u"""
+{
+    "actor": {
+        "username": "John",
+        "display_name": "John Smith"
+    },
+    "repository": {
+        "scm": "git",
+        "project": {
+            "key": "CI",
+            "name": "Continuous Integration"
+        },
+        "slug": "py-repo",
+        "links": {
+            "self": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            },
+            "html": {
+                "href": "http://localhost:7990/projects/CI/repos/py-repo"
+            }
+        },
+        "public": false,
+        "ownerName": "CI",
+        "owner": {
+            "username": "CI",
+            "display_name": "CI"
+        },
+        "fullName": "CI/py-repo"
+    },
+    "push": {
+        "changes": [
+            {
+                "created": true,
+                "closed": false,
+                "old": null,
+                "new": {
+                    "type": "tag",
+                    "name": "1.0.0",
+                    "target": {
+                        "type": "commit",
+                        "hash": "793d4754230023d85532f9a38dba3290f959beb4"
+                    }
+                }
+            }
+        ]
+    }
+}
+"""
+
+
+def _prepare_request(payload, headers=None, change_dict=None):
+    headers = headers or {}
+    request = FakeRequest(change_dict)
+    request.uri = b"/change_hook/bitbucketcloud"
+    request.method = b"POST"
+    if isinstance(payload, text_type):
+        payload = unicode2bytes(payload)
+    request.content = BytesIO(payload)
+    request.received_headers[b'Content-Type'] = _CT_JSON
+    request.received_headers.update(headers)
+    return request
+
+
+class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
+
+    def setUp(self):
+        self.change_hook = change_hook.ChangeHookResource(
+            dialects={'bitbucketcloud': {}}, master=fakeMasterForHooks())
+
+    def _checkPush(self, change):
+        self.assertEqual(
+            change['repository'],
+            'http://localhost:7990/projects/CI/repos/py-repo')
+        self.assertEqual(change['author'], 'John Smith <John>')
+        self.assertEqual(change['project'], 'Continuous Integration')
+        self.assertEqual(change['revision'],
+                         '793d4754230023d85532f9a38dba3290f959beb4')
+        self.assertEqual(
+            change['comments'], 'Bitbucket Cloud commit '
+                                '793d4754230023d85532f9a38dba3290f959beb4')
+        self.assertEqual(
+            change['revlink'],
+            'http://localhost:7990/projects/CI/repos/py-repo/commits/'
+            '793d4754230023d85532f9a38dba3290f959beb4')
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnPushEvent(self):
+
+        request = _prepare_request(
+            pushJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
+
+        yield request.test_render(self.change_hook)
+
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPush(change)
+        self.assertEqual(change['branch'], 'refs/heads/branch_1496411680')
+        self.assertEqual(change['category'], 'push')
+
+    @defer.inlineCallbacks
+    def testHookWithNonDictOption(self):
+        self.change_hook.dialects = {'bitbucketcloud': True}
+        yield self.testHookWithChangeOnPushEvent()
+
+    def _checkPullRequest(self, change):
+        self.assertEqual(
+            change['repository'],
+            'http://localhost:7990/projects/CI/repos/py-repo')
+        self.assertEqual(change['author'], 'John Smith <John>')
+        self.assertEqual(change['project'], 'Continuous Integration')
+        self.assertEqual(change['comments'],
+                         'Bitbucket Cloud Pull Request #21')
+        self.assertEqual(change['revlink'],
+                         'http://localhost:7990/projects/'
+                         'CI/repos/py-repo/pull-requests/21')
+        self.assertEqual(change['revision'],
+                         'a87e21f7433d8c16ac7be7413483fbb76c72a8ba')
+        pr_url = change['properties'].get('pullrequesturl')
+        self.assertNotEqual(pr_url, None)
+        self.assertEqual(
+            pr_url,
+            "http://localhost:7990/projects/CI/repos/py-repo/pull-requests/21")
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnPullRequestCreated(self):
+        request = _prepare_request(
+            pullRequestCreatedJsonPayload,
+            headers={_HEADER_EVENT: 'pullrequest:created'})
+
+        yield request.test_render(self.change_hook)
+
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPullRequest(change)
+        self.assertEqual(change['branch'], 'refs/pull-requests/21/merge')
+        self.assertEqual(change['category'], 'pull-created')
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnPullRequestUpdated(self):
+        request = _prepare_request(
+            pullRequestUpdatedJsonPayload,
+            headers={_HEADER_EVENT: 'pullrequest:updated'})
+
+        yield request.test_render(self.change_hook)
+
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPullRequest(change)
+        self.assertEqual(change['branch'], 'refs/pull-requests/21/merge')
+        self.assertEqual(change['category'], 'pull-updated')
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnPullRequestRejected(self):
+        request = _prepare_request(
+            pullRequestRejectedJsonPayload,
+            headers={_HEADER_EVENT: 'pullrequest:rejected'})
+
+        yield request.test_render(self.change_hook)
+
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPullRequest(change)
+        self.assertEqual(change['branch'], 'refs/heads/branch_1496411680')
+        self.assertEqual(change['category'], 'pull-rejected')
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnPullRequestFulfilled(self):
+        request = _prepare_request(
+            pullRequestFulfilledJsonPayload,
+            headers={_HEADER_EVENT: 'pullrequest:fulfilled'})
+
+        yield request.test_render(self.change_hook)
+
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPullRequest(change)
+        self.assertEqual(change['branch'], 'refs/heads/master')
+        self.assertEqual(change['category'], 'pull-fulfilled')
+
+    @defer.inlineCallbacks
+    def _checkCodebase(self, event_type, expected_codebase):
+        payloads = {
+            'repo:push': pushJsonPayload,
+            'pullrequest:updated': pullRequestUpdatedJsonPayload}
+        request = _prepare_request(
+            payloads[event_type], headers={_HEADER_EVENT: event_type})
+        yield request.test_render(self.change_hook)
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(change['codebase'], expected_codebase)
+
+    @defer.inlineCallbacks
+    def testHookWithCodebaseValueOnPushEvent(self):
+        self.change_hook.dialects = {
+            'bitbucketcloud': {'codebase': 'super-codebase'}}
+        yield self._checkCodebase('repo:push', 'super-codebase')
+
+    @defer.inlineCallbacks
+    def testHookWithCodebaseFunctionOnPushEvent(self):
+        self.change_hook.dialects = {
+            'bitbucketcloud': {
+                'codebase':
+                    lambda payload: payload['repository']['project']['key']}}
+        yield self._checkCodebase('repo:push', 'CI')
+
+    @defer.inlineCallbacks
+    def testHookWithCodebaseValueOnPullEvent(self):
+        self.change_hook.dialects = {
+            'bitbucketcloud': {'codebase': 'super-codebase'}}
+        yield self._checkCodebase('pullrequest:updated', 'super-codebase')
+
+    @defer.inlineCallbacks
+    def testHookWithCodebaseFunctionOnPullEvent(self):
+        self.change_hook.dialects = {
+            'bitbucketcloud': {
+                'codebase':
+                    lambda payload: payload['repository']['project']['key']}}
+        yield self._checkCodebase('pullrequest:updated', 'CI')
+
+    @defer.inlineCallbacks
+    def testHookWithUnhandledEvent(self):
+        request = _prepare_request(
+            pushJsonPayload, headers={_HEADER_EVENT: 'invented:event'})
+        yield request.test_render(self.change_hook)
+        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+        self.assertEqual(request.written, b"Unknown event: invented_event")
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnCreateTag(self):
+        request = _prepare_request(
+            newTagJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
+        yield request.test_render(self.change_hook)
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPush(change)
+        self.assertEqual(change['branch'], 'refs/tags/1.0.0')
+        self.assertEqual(change['category'], 'push')
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnDeleteTag(self):
+        request = _prepare_request(
+            deleteTagJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
+        yield request.test_render(self.change_hook)
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPush(change)
+        self.assertEqual(change['branch'], 'refs/tags/1.0.0')
+        self.assertEqual(change['category'], 'ref-deleted')
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnDeleteBranch(self):
+        request = _prepare_request(
+            deleteBranchJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
+        yield request.test_render(self.change_hook)
+        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
+        change = self.change_hook.master.addedChanges[0]
+        self._checkPush(change)
+        self.assertEqual(change['branch'], 'refs/heads/branch_1496758965')
+        self.assertEqual(change['category'], 'ref-deleted')
+
+    @defer.inlineCallbacks
+    def testHookWithInvalidContentType(self):
+        request = _prepare_request(
+            pushJsonPayload, headers={_HEADER_EVENT: b'repo:push'})
+        request.received_headers[b'Content-Type'] = b'invalid/content'
+        yield request.test_render(self.change_hook)
+        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+        self.assertEqual(request.written,
+                         b"Unknown content type: invalid/content")

--- a/master/buildbot/www/hooks/bitbucketcloud.py
+++ b/master/buildbot/www/hooks/bitbucketcloud.py
@@ -1,0 +1,168 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+# Copyright Mamba Team
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import json
+
+from twisted.python import log
+
+from buildbot.util import bytes2NativeString
+
+GIT_BRANCH_REF = "refs/heads/{}"
+GIT_MERGE_REF = "refs/pull-requests/{}/merge"
+GIT_TAG_REF = "refs/tags/{}"
+
+_HEADER_EVENT = b'X-Event-Key'
+
+
+class BitbucketCloudEventHandler(object):
+
+    def __init__(self, master, options=None):
+        if options is None:
+            options = {}
+        self.master = master
+        if not isinstance(options, dict):
+            options = {}
+        self.options = options
+        self._codebase = self.options.get('codebase', None)
+
+    def process(self, request):
+        payload = self._get_payload(request)
+        event_type = request.getHeader(_HEADER_EVENT)
+        event_type = bytes2NativeString(event_type)
+        log.msg("Processing event {header}: {event}"
+                .format(header=_HEADER_EVENT, event=event_type))
+        event_type = event_type.replace(":", "_")
+        handler = getattr(self, 'handle_{}'.format(event_type), None)
+
+        if handler is None:
+            raise ValueError('Unknown event: {}'.format(event_type))
+
+        return handler(payload)
+
+    def _get_payload(self, request):
+        content = request.content.read()
+        content = bytes2NativeString(content)
+        content_type = request.getHeader(b'Content-Type')
+        content_type = bytes2NativeString(content_type)
+        if content_type.startswith('application/json'):
+            payload = json.loads(content)
+        else:
+            raise ValueError('Unknown content type: {}'
+                             .format(content_type))
+
+        log.msg("Payload: {}".format(payload))
+
+        return payload
+
+    def handle_repo_push(self, payload):
+        changes = []
+        project = payload['repository']['project']['name']
+        repo_url = payload['repository']['links']['self']['href']
+        web_url = payload['repository']['links']['html']['href']
+
+        for payload_change in payload['push']['changes']:
+            if payload_change['new']:
+                age = 'new'
+                category = 'push'
+            else:  # when new is null the ref is deleted
+                age = 'old'
+                category = 'ref-deleted'
+
+            commit_hash = payload_change[age]['target']['hash']
+
+            if payload_change[age]['type'] == 'branch':
+                branch = GIT_BRANCH_REF.format(payload_change[age]['name'])
+            elif payload_change[age]['type'] == 'tag':
+                branch = GIT_TAG_REF.format(payload_change[age]['name'])
+
+            change = {
+                'revision': commit_hash,
+                'revlink': '{}/commits/{}'.format(web_url, commit_hash),
+                'repository': repo_url,
+                'author': '{} <{}>'.format(payload['actor']['display_name'],
+                                           payload['actor']['username']),
+                'comments': 'Bitbucket Cloud commit {}'.format(commit_hash),
+                'branch': branch,
+                'project': project,
+                'category': category
+            }
+
+            if callable(self._codebase):
+                change['codebase'] = self._codebase(payload)
+            elif self._codebase is not None:
+                change['codebase'] = self._codebase
+
+            changes.append(change)
+
+        return (changes, payload['repository']['scm'])
+
+    def handle_pullrequest_created(self, payload):
+        return self.handle_pullrequest(
+            payload,
+            GIT_MERGE_REF.format(int(payload['pullrequest']['id'])),
+            "pull-created")
+
+    def handle_pullrequest_updated(self, payload):
+        return self.handle_pullrequest(
+            payload,
+            GIT_MERGE_REF.format(int(payload['pullrequest']['id'])),
+            "pull-updated")
+
+    def handle_pullrequest_fulfilled(self, payload):
+        return self.handle_pullrequest(
+            payload,
+            GIT_BRANCH_REF.format(
+                payload['pullrequest']['toRef']['branch']['name']),
+            "pull-fulfilled")
+
+    def handle_pullrequest_rejected(self, payload):
+        return self.handle_pullrequest(
+            payload,
+            GIT_BRANCH_REF.format(
+                payload['pullrequest']['fromRef']['branch']['name']),
+            "pull-rejected")
+
+    def handle_pullrequest(self, payload, refname, category):
+        pr_number = int(payload['pullrequest']['id'])
+        repo_url = payload['repository']['links']['self']['href']
+        change = {
+            'revision': payload['pullrequest']['fromRef']['commit']['hash'],
+            'revlink': payload['pullrequest']['link'],
+            'repository': repo_url,
+            'author': '{} <{}>'.format(payload['actor']['display_name'],
+                                       payload['actor']['username']),
+            'comments': 'Bitbucket Cloud Pull Request #{}'.format(pr_number),
+            'branch': refname,
+            'project': payload['repository']['project']['name'],
+            'category': category,
+            'properties': {'pullrequesturl': payload['pullrequest']['link']}
+        }
+
+        if callable(self._codebase):
+            change['codebase'] = self._codebase(payload)
+        elif self._codebase is not None:
+            change['codebase'] = self._codebase
+
+        return [change], payload['repository']['scm']
+
+    def getChanges(self, request):
+        return self.process(request)
+
+
+bitbucketcloud = BitbucketCloudEventHandler

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -214,6 +214,30 @@ Then, create a BitBucket service hook (see https://confluence.atlassian.com/disp
 
 Note that as before, not using ``change_hook_auth`` can expose you to security risks.
 
+Bitbucket Cloud hook
++++++++++++++++++++++
+
+.. code-block:: python
+
+    c['www'] = dict(
+        ...,
+        change_hook_dialects={'bitbucketcloud': {}},
+    )
+
+When this is setup you should add a webhook pointing to ``/change_hook/bitbucketcloud`` relative to the root of the web status.
+
+According to the type of the event, the change category is set to ``push``, ``pull-created``, ``pull-rejected``, ``pull-updated``, ``pull-fulfilled`` or ``ref-deleted``.
+
+The Bitbucket Cloud hook may have the following optional parameters:
+
+``codebase`` (default `None`)
+    The codebase value to include with changes or a callable object that will be passed the payload in order to get it.
+
+.. Warning::
+    The incoming HTTP requests for this hook are not authenticated by default.
+    Anyone who can access the web server can "fake" a request from Bitbucket Cloud, potentially causing the buildmaster to run arbitrary code
+
+
 Bitbucket Server hook
 +++++++++++++++++++++
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -414,6 +414,7 @@ setup_args = {
             ('buildbot.www.hooks.gitlab', ['gitlab']),
             ('buildbot.www.hooks.gitorious', ['gitorious']),
             ('buildbot.www.hooks.poller', ['poller']),
+            ('buildbot.www.hooks.bitbucketcloud', ['bitbucketcloud']),
             ('buildbot.www.hooks.bitbucketserver', ['bitbucketserver'])
         ])
     ]), {


### PR DESCRIPTION
This is closely based on bitbucketserver.py but has a number of small
differences in how it parses the payload in order to match what the
current Bitbucket Cloud product delivers.

Signed-off-by: Will Newton <will.newton@gmail.com>

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

http://trac.buildbot.net/wiki/Development
And especially:
http://trac.buildbot.net/wiki/SubmittingPatches

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
