### PR TITLE
db: always return the most recent change from ssid

### DIFF
--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -221,6 +221,9 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
             changes_tbl = self.db.model.changes
             q = changes_tbl.select(
                 whereclause=(changes_tbl.c.sourcestampid == sourcestampid))
+            # if there are multiple changes for this ssid, get the most recent one
+            q = q.order_by(changes_tbl.c.changeid.desc())
+            q = q.limit(1)
             rp = conn.execute(q)
             row = rp.fetchone()
             if not row:

--- a/master/buildbot/newsfragments/rebuild-change-properties.bugfix
+++ b/master/buildbot/newsfragments/rebuild-change-properties.bugfix
@@ -1,0 +1,1 @@
+Rebuilding with the same revision now takes new change properties into account instead of re-using the original build change properties (:issue:`3701`).


### PR DESCRIPTION
When submitting multiple times the same revision via change hooks, a new change is created each time but linked to the same sourcestampid.

These changes may carry different properties but when schedulers are notified of a new change, they access to the change(s) via sourcestampid via `self.master.data.get(('sourcestamp', ssid, 'changes'))` which only returns the first one.

Change this and return the most recent one instead. This will not affect nominal cases where there only is one change by ssid.

Fixes issue #3701.