### PR TITLE
fix FOSSA badges in reStructuredText

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,3 @@
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fbuildbot%2Fbuildbot.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fbuildbot%2Fbuildbot?ref=badge_shield)
-
 ==========
  Buildbot
 ==========
@@ -14,7 +12,7 @@ lothar . com>`_, and currently maintained by `the Botherders
 
 Visit us on http://buildbot.net !
 
-|travis-badge|_ |codecov-badge|_ |readthedocs-badge|_
+|travis-badge|_ |codecov-badge|_ |readthedocs-badge|_ |fossa-badge|_
 
 Buildbot consists of several components:
 
@@ -39,7 +37,5 @@ Related repositories:
 .. _codecov-badge: http://codecov.io/github/buildbot/buildbot?branch=master
 .. |readthedocs-badge| image:: https://readthedocs.org/projects/buildbot/badge/?version=latest
 .. _readthedocs-badge: https://readthedocs.org/projects/buildbot/builds/
-
-
-## License
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fbuildbot%2Fbuildbot.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fbuildbot%2Fbuildbot?ref=badge_large)
+.. |fossa-badge| image:: https://app.fossa.io/api/projects/git%2Bgithub.com%2Fbuildbot%2Fbuildbot.svg?type=shield
+.. _fossa-badge: https://app.fossa.io/projects/git%2Bgithub.com%2Fbuildbot%2Fbuildbot?ref=badge_shield


### PR DESCRIPTION
The formatting for the FOSSA badges was for markdown