### PR TITLE
fix decodeRC ignored for Compile step

### DIFF
--- a/master/buildbot/newsfragments/decodeRC.bugfix
+++ b/master/buildbot/newsfragments/decodeRC.bugfix
@@ -1,0 +1,1 @@
+Compile step now properly takes the decodeRC parameter in account (:issue:`3774`)

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -38,6 +38,7 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.process.results import Results
+from buildbot.process.results import worst_status
 from buildbot.steps.worker import CompositeStepMixin
 from buildbot.util import command_to_string
 from buildbot.util import flatten
@@ -611,12 +612,12 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
             "warnings-count", old_count + self.warnCount, "WarningCountingShellCommand")
 
     def evaluateCommand(self, cmd):
-        if (cmd.didFail() or
-                (self.maxWarnCount is not None and self.warnCount > self.maxWarnCount)):
-            return FAILURE
-        if self.warnCount:
-            return WARNINGS
-        return SUCCESS
+        result = cmd.results()
+        if (self.maxWarnCount is not None and self.warnCount > self.maxWarnCount):
+            result = worst_status(result, FAILURE)
+        elif self.warnCount:
+            result = worst_status(result, WARNINGS)
+        return result
 
 
 class Compile(WarningCountingShellCommand):

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -742,7 +742,7 @@ class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase,
         return self.runStep()
 
     def test_warn_with_decoderc(self):
-        self.setupStep(shell.WarningCountingShellCommand(command=['make'], decodeRC={3:WARNINGS}))
+        self.setupStep(shell.WarningCountingShellCommand(command=['make'], decodeRC={3: WARNINGS}))
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=["make"],

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -741,6 +741,19 @@ class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase,
         self.expectLogfile("warnings (1)", "warning: I might fail\n")
         return self.runStep()
 
+    def test_warn_with_decoderc(self):
+        self.setupStep(shell.WarningCountingShellCommand(command=['make'], decodeRC={3:WARNINGS}))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=["make"],
+                        )
+            + ExpectShell.log('stdio', stdout='I might fail with rc')
+            + 3
+        )
+        self.expectOutcome(result=WARNINGS)
+        self.expectProperty("warnings-count", 0)
+        return self.runStep()
+
     def do_test_suppressions(self, step, supps_file='', stdout='',
                              exp_warning_count=0, exp_warning_log='',
                              exp_exception=False, props=None):


### PR DESCRIPTION
Fixes: #3774


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
