### PR TITLE
Fix incorrect encoding for #3796

### DIFF
--- a/master/buildbot/scripts/windows_service.py
+++ b/master/buildbot/scripts/windows_service.py
@@ -205,7 +205,7 @@ class BBService(win32serviceutil.ServiceFramework):
                        "Stopping the service.")
             return False
         if save_dirs:
-            dir_string = os.pathsep.join(self.dirs).encode("mbcs")
+            dir_string = os.pathsep.join(self.dirs)
             win32serviceutil.SetServiceCustomOption(self, "directories",
                                                     dir_string)
         return True


### PR DESCRIPTION
Values supplied to win32api.RegSetValueEx must be unicode not bytes.