### PR TITLE
MailNotifier: Example of shortcutmodes as string

### DIFF
--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -175,6 +175,13 @@ MailNotifier arguments
     ``warnings``
         Equivalent to (``warnings``, ``failing``).
 
+    Set these shortcuts as actual strings in the configuration::
+
+        from buildbot.plugins import reporters
+        mn = reporters.MailNotifier(fromaddr="buildbot@example.org",
+                                    mode="warnings")
+        c['services'].append(mn)
+
     (list of strings).
     A combination of:
 


### PR DESCRIPTION
I mis-read the docs multiple times (along with the examples), as `'warnings'` and `('warnings',)` are different things.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
