### PR TITLE
config: check for duplicate service names

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -848,6 +848,10 @@ class MasterConfig(util.ComparableMixin, WorkerAPICompatMixin):
 
                 continue
 
+            if _service.name in self.services:
+                error('Duplicate service name %r' % _service.name)
+                continue
+
             self.services[_service.name] = _service
 
     def check_single_master(self):

--- a/master/buildbot/newsfragments/duplicate-service-name.bugfix
+++ b/master/buildbot/newsfragments/duplicate-service-name.bugfix
@@ -1,0 +1,1 @@
+When multiple :bb:cfg:`reporter` or :bb:cfg:`services` are configured with the same name, an error is now displayed instead of silently discarding all but the last one :issue:`3813`.

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1052,6 +1052,20 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         errMsg += "object should be an instance of buildbot.util.service.BuildbotService"
         self.assertConfigError(self.errors, errMsg)
 
+    def test_load_services_duplicate(self):
+
+        class MyService(service.BuildbotService):
+            name = 'myservice'
+
+            def reconfigService(self, x=None):
+                self.x = x
+
+        self.cfg.load_services(self.filename, dict(
+            services=[MyService(x='a'), MyService(x='b')]))
+
+        self.assertConfigError(
+            self.errors, 'Duplicate service name %r' % MyService.name)
+
     def test_load_configurators_norminal(self):
 
         class MyConfigurator(configurators.ConfiguratorBase):


### PR DESCRIPTION
Most services have a default `name` attribute. When instantiating the same service class multiple times (e.g. multiple email notifiers), if the user does not override the name, only the last service is actually
configured.

Make sure that all services have a unique name.

Fixes #3813 

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)