### PR TITLE
db: update schema to allow easier cleanup

### DIFF
--- a/master/buildbot/db/migrate/versions/050_cascading_deletes_all.py
+++ b/master/buildbot/db/migrate/versions/050_cascading_deletes_all.py
@@ -1,0 +1,90 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+from future.utils import iteritems
+
+import sqlalchemy as sa
+from migrate.changeset.constraint import ForeignKeyConstraint
+from migrate.exceptions import NotSupportedError
+
+from buildbot.util import sautils
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+
+    tables = {}
+    for t in TABLES_FKEYS:
+        tables[t] = sautils.Table(t, metadata, autoload=True)
+
+    fks_to_change = []
+    # We need to parse the reflected model in order to find the automatic
+    # fk name that was put.
+    # Mysql and postgres have different naming convention so this is not very
+    # easy to have generic code working.
+    for t, keys in iteritems(TABLES_FKEYS):
+        table = tables[t]
+        for fk in table.constraints:
+            if not isinstance(fk, sa.ForeignKeyConstraint):
+                continue
+            for c in fk.elements:
+                if str(c.column) in keys:
+                    # migrate.xx.ForeignKeyConstraint is changing the model
+                    # so initializing here would break the iteration
+                    # (Set changed size during iteration)
+                    fks_to_change.append((
+                        table, (fk.columns, [c.column]),
+                        dict(name=fk.name, ondelete='CASCADE')))
+
+    for table, args, kwargs in fks_to_change:
+        fk = ForeignKeyConstraint(*args, **kwargs)
+        table.append_constraint(fk)
+        try:
+            fk.drop()
+        except NotSupportedError:
+            # some versions of sqlite do not support drop,
+            # but will still update the fk
+            pass
+        fk.create()
+
+
+TABLES_FKEYS = {
+    'buildrequests': ['buildsets.id', 'builders.id'],
+    'buildrequest_claims': ['buildrequests.id', 'masters.id'],
+    'build_properties': ['builds.id'],
+    'builds': ['builders.id', 'buildrequests.id', 'workers.id', 'masters.id'],
+    'steps': ['builds.id'],
+    'logs': ['steps.id'],
+    'logchunks': ['logs.id'],
+    'buildset_properties': ['buildsets.id'],
+    'buildsets': ['builds.id'],
+    'changesource_masters': ['changesources.id', 'masters.id'],
+    # 'configured_workers': ['builder_masters.id', 'workers.id'],
+    'connected_workers': ['masters.id', 'workers.id'],
+    'changes': ['sourcestamps.id', 'changes.changeid'],
+    'change_files': ['changes.changeid'],
+    'change_properties': ['changes.changeid'],
+    'change_users': ['changes.changeid', 'users.uid'],
+    'buildset_sourcestamps': ['buildsets.id', 'sourcestamps.id'],
+    'scheduler_masters': ['schedulers.id', 'masters.id'],
+    'scheduler_changes': ['schedulers.id', 'changes.changeid'],
+    # 'builder_masters': ['builders.id', 'masters.id'],
+    'builders_tags': ['builders.id', 'tags.id'],
+    'object_state': ['objects.id'],
+    'users_info': ['users.uid'],
+}

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -73,9 +73,11 @@ class Model(base.DBConnectorComponent):
     buildrequests = sautils.Table(
         'buildrequests', metadata,
         sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('buildsetid', sa.Integer, sa.ForeignKey("buildsets.id"),
+        sa.Column('buildsetid', sa.Integer,
+                  sa.ForeignKey('buildsets.id', ondelete='CASCADE'),
                   nullable=False),
-        sa.Column('builderid', sa.Integer, sa.ForeignKey('builders.id'),
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
                   nullable=False),
         sa.Column('priority', sa.Integer, nullable=False,
                   server_default=sa.DefaultClause("0")),
@@ -104,9 +106,11 @@ class Model(base.DBConnectorComponent):
     # claim is made by the master referenced by masterid.
     buildrequest_claims = sautils.Table(
         'buildrequest_claims', metadata,
-        sa.Column('brid', sa.Integer, sa.ForeignKey('buildrequests.id'),
+        sa.Column('brid', sa.Integer,
+                  sa.ForeignKey('buildrequests.id', ondelete='CASCADE'),
                   nullable=False),
-        sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
+        sa.Column('masterid', sa.Integer,
+                  sa.ForeignKey('masters.id', ondelete='CASCADE'),
                   index=True, nullable=True),
         sa.Column('claimed_at', sa.Integer, nullable=False),
     )
@@ -116,7 +120,8 @@ class Model(base.DBConnectorComponent):
     # This table contains the build properties
     build_properties = sautils.Table(
         'build_properties', metadata,
-        sa.Column('buildid', sa.Integer, sa.ForeignKey('builds.id'),
+        sa.Column('buildid', sa.Integer,
+                  sa.ForeignKey('builds.id', ondelete='CASCADE'),
                   nullable=False),
         sa.Column('name', sa.String(256), nullable=False),
         # JSON encoded value
@@ -129,7 +134,8 @@ class Model(base.DBConnectorComponent):
         'builds', metadata,
         sa.Column('id', sa.Integer, primary_key=True),
         sa.Column('number', sa.Integer, nullable=False),
-        sa.Column('builderid', sa.Integer, sa.ForeignKey('builders.id')),
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE')),
         # note that there is 1:N relationship here.
         # In case of worker loss, build has results RETRY
         # and buildrequest is unclaimed.
@@ -137,13 +143,16 @@ class Model(base.DBConnectorComponent):
         # (buildrequests -> buildsets -> builds).
         sa.Column('buildrequestid', sa.Integer,
                   sa.ForeignKey(
-                      'buildrequests.id', use_alter=True, name='buildrequestid'),
+                      'buildrequests.id', use_alter=True,
+                      name='buildrequestid', ondelete='CASCADE'),
                   nullable=False),
         # worker which performed this build
         # keep nullable to support worker-free builds
-        sa.Column('workerid', sa.Integer, sa.ForeignKey('workers.id')),
+        sa.Column('workerid', sa.Integer,
+                  sa.ForeignKey('workers.id', ondelete='CASCADE')),
         # master which controlled this build
-        sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
+        sa.Column('masterid', sa.Integer,
+                  sa.ForeignKey('masters.id', ondelete='CASCADE'),
                   nullable=False),
         # start/complete times
         sa.Column('started_at', sa.Integer, nullable=False),
@@ -159,7 +168,8 @@ class Model(base.DBConnectorComponent):
         sa.Column('id', sa.Integer, primary_key=True),
         sa.Column('number', sa.Integer, nullable=False),
         sa.Column('name', sa.String(50), nullable=False),
-        sa.Column('buildid', sa.Integer, sa.ForeignKey('builds.id')),
+        sa.Column('buildid', sa.Integer,
+                  sa.ForeignKey('builds.id', ondelete='CASCADE')),
         sa.Column('started_at', sa.Integer),
         sa.Column('complete_at', sa.Integer),
         sa.Column('state_string', sa.Text, nullable=False),
@@ -176,7 +186,8 @@ class Model(base.DBConnectorComponent):
         sa.Column('id', sa.Integer, primary_key=True),
         sa.Column('name', sa.Text, nullable=False),
         sa.Column('slug', sa.String(50), nullable=False),
-        sa.Column('stepid', sa.Integer, sa.ForeignKey('steps.id')),
+        sa.Column('stepid', sa.Integer,
+                  sa.ForeignKey('steps.id', ondelete='CASCADE')),
         sa.Column('complete', sa.SmallInteger, nullable=False),
         sa.Column('num_lines', sa.Integer, nullable=False),
         # 's' = stdio, 't' = text, 'h' = html, 'd' = deleted
@@ -185,7 +196,8 @@ class Model(base.DBConnectorComponent):
 
     logchunks = sautils.Table(
         'logchunks', metadata,
-        sa.Column('logid', sa.Integer, sa.ForeignKey('logs.id')),
+        sa.Column('logid', sa.Integer,
+                  sa.ForeignKey('logs.id', ondelete='CASCADE')),
         # 0-based line number range in this chunk (inclusive); note that for
         # HTML logs, this counts lines of HTML, not lines of rendered output
         sa.Column('first_line', sa.Integer, nullable=False),
@@ -201,7 +213,8 @@ class Model(base.DBConnectorComponent):
     # This table contains input properties for buildsets
     buildset_properties = sautils.Table(
         'buildset_properties', metadata,
-        sa.Column('buildsetid', sa.Integer, sa.ForeignKey('buildsets.id'),
+        sa.Column('buildsetid', sa.Integer,
+                  sa.ForeignKey('buildsets.id', ondelete='CASCADE'),
                   nullable=False),
         sa.Column('property_name', sa.String(256), nullable=False),
         # JSON-encoded tuple of (value, source)
@@ -234,7 +247,8 @@ class Model(base.DBConnectorComponent):
         # optional parent build, we use use_alter to prevent circular reference
         # http://docs.sqlalchemy.org/en/latest/orm/relationships.html#rows-that-point-to-themselves-mutually-dependent-rows
         sa.Column('parent_buildid', sa.Integer,
-                  sa.ForeignKey('builds.id', use_alter=True, name='parent_buildid')),
+                  sa.ForeignKey('builds.id', use_alter=True,
+                                name='parent_buildid', ondelete='CASCADE')),
         # text describing what is the relationship with the build
         # could be 'triggered from', 'rebuilt from', 'inherited from'
         sa.Column('parent_relationship', sa.Text),
@@ -262,9 +276,11 @@ class Model(base.DBConnectorComponent):
     # exactly one claim succeeds.
     changesource_masters = sautils.Table(
         'changesource_masters', metadata,
-        sa.Column('changesourceid', sa.Integer, sa.ForeignKey('changesources.id'),
+        sa.Column('changesourceid', sa.Integer,
+                  sa.ForeignKey('changesources.id', ondelete='CASCADE'),
                   nullable=False, primary_key=True),
-        sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
+        sa.Column('masterid', sa.Integer,
+                  sa.ForeignKey('masters.id', ondelete='CASCADE'),
                   nullable=False),
     )
 
@@ -294,8 +310,10 @@ class Model(base.DBConnectorComponent):
         'connected_workers', metadata,
         sa.Column('id', sa.Integer, primary_key=True, nullable=False),
         sa.Column('masterid', sa.Integer,
-                  sa.ForeignKey('masters.id'), nullable=False),
-        sa.Column('workerid', sa.Integer, sa.ForeignKey('workers.id'),
+                  sa.ForeignKey('masters.id', ondelete='CASCADE'),
+                  nullable=False),
+        sa.Column('workerid', sa.Integer,
+                  sa.ForeignKey('workers.id', ondelete='CASCADE'),
                   nullable=False),
     )
 
@@ -304,7 +322,8 @@ class Model(base.DBConnectorComponent):
     # Files touched in changes
     change_files = sautils.Table(
         'change_files', metadata,
-        sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
+        sa.Column('changeid', sa.Integer,
+                  sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
                   nullable=False),
         sa.Column('filename', sa.String(1024), nullable=False),
     )
@@ -312,7 +331,8 @@ class Model(base.DBConnectorComponent):
     # Properties for changes
     change_properties = sautils.Table(
         'change_properties', metadata,
-        sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
+        sa.Column('changeid', sa.Integer,
+                  sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
                   nullable=False),
         sa.Column('property_name', sa.String(256), nullable=False),
         # JSON-encoded tuple of (value, source)
@@ -324,10 +344,12 @@ class Model(base.DBConnectorComponent):
     # and committer, for example.
     change_users = sautils.Table(
         "change_users", metadata,
-        sa.Column("changeid", sa.Integer, sa.ForeignKey('changes.changeid'),
+        sa.Column('changeid', sa.Integer,
+                  sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
                   nullable=False),
         # uid for the author of the change with the given changeid
-        sa.Column("uid", sa.Integer, sa.ForeignKey('users.uid'),
+        sa.Column('uid', sa.Integer,
+                  sa.ForeignKey('users.uid', ondelete='CASCADE'),
                   nullable=False),
     )
 
@@ -376,14 +398,15 @@ class Model(base.DBConnectorComponent):
 
         # the sourcestamp this change brought the codebase to
         sa.Column('sourcestampid', sa.Integer,
-                  sa.ForeignKey('sourcestamps.id')),
+                  sa.ForeignKey('sourcestamps.id', ondelete='CASCADE')),
 
         # The parent of the change
         # Even if for the moment there's only 1 parent for a change, we use plural here because
         # somedays a change will have multiple parent. This way we don't need
         # to change the API
-        sa.Column('parent_changeids', sa.Integer, sa.ForeignKey(
-            'changes.changeid'), nullable=True),
+        sa.Column('parent_changeids', sa.Integer,
+                  sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                  nullable=True),
     )
 
     # sourcestamps
@@ -429,7 +452,8 @@ class Model(base.DBConnectorComponent):
         sa.Column('revision', sa.String(256)),
 
         # the patch to apply to generate this source code
-        sa.Column('patchid', sa.Integer, sa.ForeignKey('patches.id')),
+        sa.Column('patchid', sa.Integer,
+                  sa.ForeignKey('patches.id', ondelete='CASCADE')),
 
         # the repository from which this source should be checked out
         sa.Column('repository', sa.String(length=512), nullable=False,
@@ -452,10 +476,10 @@ class Model(base.DBConnectorComponent):
         'buildset_sourcestamps', metadata,
         sa.Column('id', sa.Integer, primary_key=True),
         sa.Column('buildsetid', sa.Integer,
-                  sa.ForeignKey('buildsets.id'),
+                  sa.ForeignKey('buildsets.id', ondelete='CASCADE'),
                   nullable=False),
         sa.Column('sourcestampid', sa.Integer,
-                  sa.ForeignKey('sourcestamps.id'),
+                  sa.ForeignKey('sourcestamps.id', ondelete='CASCADE'),
                   nullable=False),
     )
 
@@ -485,9 +509,11 @@ class Model(base.DBConnectorComponent):
     # see bug #1053.
     scheduler_masters = sautils.Table(
         'scheduler_masters', metadata,
-        sa.Column('schedulerid', sa.Integer, sa.ForeignKey('schedulers.id'),
+        sa.Column('schedulerid', sa.Integer,
+                  sa.ForeignKey('schedulers.id', ondelete='CASCADE'),
                   nullable=False, primary_key=True),
-        sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
+        sa.Column('masterid', sa.Integer,
+                  sa.ForeignKey('masters.id', ondelete='CASCADE'),
                   nullable=False),
     )
 
@@ -498,8 +524,10 @@ class Model(base.DBConnectorComponent):
     # the change.
     scheduler_changes = sautils.Table(
         'scheduler_changes', metadata,
-        sa.Column('schedulerid', sa.Integer, sa.ForeignKey('schedulers.id')),
-        sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid')),
+        sa.Column('schedulerid', sa.Integer,
+                  sa.ForeignKey('schedulers.id', ondelete='CASCADE')),
+        sa.Column('changeid', sa.Integer,
+                  sa.ForeignKey('changes.changeid', ondelete='CASCADE')),
         # true (nonzero) if this change is important to this scheduler
         sa.Column('important', sa.Integer),
     )
@@ -545,9 +573,11 @@ class Model(base.DBConnectorComponent):
     builders_tags = sautils.Table(
         'builders_tags', metadata,
         sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('builderid', sa.Integer, sa.ForeignKey('builders.id'),
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
                   nullable=False),
-        sa.Column('tagid', sa.Integer, sa.ForeignKey('tags.id'),
+        sa.Column('tagid', sa.Integer,
+                  sa.ForeignKey('tags.id', ondelete='CASCADE'),
                   nullable=False),
     )
 
@@ -570,7 +600,8 @@ class Model(base.DBConnectorComponent):
     object_state = sautils.Table(
         "object_state", metadata,
         # object for which this value is set
-        sa.Column("objectid", sa.Integer, sa.ForeignKey('objects.id'),
+        sa.Column('objectid', sa.Integer,
+                  sa.ForeignKey('objects.id', ondelete='CASCADE'),
                   nullable=False),
         # name for this value (local to the object)
         sa.Column("name", sa.String(length=255), nullable=False),
@@ -602,7 +633,8 @@ class Model(base.DBConnectorComponent):
     users_info = sautils.Table(
         "users_info", metadata,
         # unique user id number
-        sa.Column("uid", sa.Integer, sa.ForeignKey('users.uid'),
+        sa.Column('uid', sa.Integer,
+                  sa.ForeignKey('users.uid', ondelete='CASCADE'),
                   nullable=False),
 
         # type of user attribute, such as 'git'

--- a/master/buildbot/newsfragments/delete-cascade.feature
+++ b/master/buildbot/newsfragments/delete-cascade.feature
@@ -1,0 +1,1 @@
+The database schema now supports cascade deletes for all objects instead of raising an error when deleting a record which has other records pointing to it via foreign keys.

--- a/master/buildbot/test/unit/test_db_migrate_versions_050_cascading_deletes_all.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_050_cascading_deletes_all.py
@@ -1,0 +1,448 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_and_insert_data(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        # create tables (prior to schema migration)
+        masters = sautils.Table(
+            "masters", metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        masters.create()
+
+        users = sautils.Table(
+            "users", metadata,
+            sa.Column("uid", sa.Integer, primary_key=True),
+        )
+        users.create()
+
+        workers = sautils.Table(
+            "workers", metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        workers.create()
+
+        sourcestamps = sautils.Table(
+            'sourcestamps', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        sourcestamps.create()
+
+        schedulers = sautils.Table(
+            'schedulers', metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        schedulers.create()
+
+        buildsets = sautils.Table(
+            'buildsets', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        buildsets.create()
+
+        builders = sautils.Table(
+            'builders', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        builders.create()
+
+        tags = sautils.Table(
+            'tags', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        tags.create()
+
+        changesources = sautils.Table(
+            'changesources', metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        changesources.create()
+
+        buildrequests = sautils.Table(
+            'buildrequests', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('buildsetid', sa.Integer, sa.ForeignKey("buildsets.id"),
+                      nullable=False),
+            sa.Column('builderid', sa.Integer, sa.ForeignKey('builders.id'),
+                      nullable=False),
+        )
+        buildrequests.create()
+
+        builds = sautils.Table(
+            'builds', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('builderid', sa.Integer, sa.ForeignKey('builders.id')),
+            sa.Column('buildrequestid', sa.Integer,
+                      sa.ForeignKey(
+                          'buildrequests.id', use_alter=True, name='buildrequestid'),
+                      nullable=False),
+            sa.Column('workerid', sa.Integer, sa.ForeignKey('workers.id')),
+            sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
+                      nullable=False),
+        )
+        builds.create()
+
+        buildrequest_claims = sautils.Table(
+            'buildrequest_claims', metadata,
+            sa.Column('brid', sa.Integer, sa.ForeignKey('buildrequests.id'),
+                      nullable=False),
+            sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
+                      index=True, nullable=True),
+        )
+        buildrequest_claims.create()
+
+        build_properties = sautils.Table(
+            'build_properties', metadata,
+            sa.Column('buildid', sa.Integer, sa.ForeignKey('builds.id'),
+                      nullable=False),
+            sa.Column('name', sa.String(256), nullable=False),
+        )
+        build_properties.create()
+
+        steps = sautils.Table(
+            'steps', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('buildid', sa.Integer, sa.ForeignKey('builds.id')),
+        )
+        steps.create()
+
+        logs = sautils.Table(
+            'logs', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('stepid', sa.Integer, sa.ForeignKey('steps.id')),
+        )
+        logs.create()
+
+        logchunks = sautils.Table(
+            'logchunks', metadata,
+            sa.Column('logid', sa.Integer, sa.ForeignKey('logs.id')),
+            sa.Column('first_line', sa.Integer, nullable=False),
+            sa.Column('last_line', sa.Integer, nullable=False),
+        )
+        logchunks.create()
+
+        buildset_properties = sautils.Table(
+            'buildset_properties', metadata,
+            sa.Column('buildsetid', sa.Integer, sa.ForeignKey('buildsets.id'),
+                      nullable=False),
+            sa.Column('property_name', sa.String(256), nullable=False),
+        )
+        buildset_properties.create()
+
+        changesource_masters = sautils.Table(
+            'changesource_masters', metadata,
+            sa.Column('changesourceid', sa.Integer, sa.ForeignKey('changesources.id'),
+                      nullable=False, primary_key=True),
+            sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
+                      nullable=False),
+        )
+        changesource_masters.create()
+
+        buildset_sourcestamps = sautils.Table(
+            'buildset_sourcestamps', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('buildsetid', sa.Integer,
+                      sa.ForeignKey('buildsets.id'),
+                      nullable=False),
+            sa.Column('sourcestampid', sa.Integer,
+                      sa.ForeignKey('sourcestamps.id'),
+                      nullable=False),
+        )
+        buildset_sourcestamps.create()
+
+        connected_workers = sautils.Table(
+            'connected_workers', metadata,
+            sa.Column('id', sa.Integer, primary_key=True, nullable=False),
+            sa.Column('masterid', sa.Integer,
+                      sa.ForeignKey('masters.id'), nullable=False),
+            sa.Column('workerid', sa.Integer, sa.ForeignKey('workers.id'),
+                      nullable=False),
+        )
+        connected_workers.create()
+
+        changes = sautils.Table(
+            'changes', metadata,
+            sa.Column('changeid', sa.Integer, primary_key=True),
+            sa.Column('sourcestampid', sa.Integer,
+                      sa.ForeignKey('sourcestamps.id')),
+            sa.Column('parent_changeids', sa.Integer, sa.ForeignKey(
+                'changes.changeid'), nullable=True),
+        )
+        changes.create()
+
+        change_files = sautils.Table(
+            'change_files', metadata,
+            sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
+                      nullable=False),
+            sa.Column('filename', sa.String(1024), nullable=False),
+        )
+        change_files.create()
+
+        change_properties = sautils.Table(
+            'change_properties', metadata,
+            sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid'),
+                      nullable=False),
+            sa.Column('property_name', sa.String(256), nullable=False),
+        )
+        change_properties.create()
+
+        change_users = sautils.Table(
+            "change_users", metadata,
+            sa.Column("changeid", sa.Integer, sa.ForeignKey('changes.changeid'),
+                      nullable=False),
+            sa.Column("uid", sa.Integer, sa.ForeignKey('users.uid'),
+                      nullable=False),
+        )
+        change_users.create()
+
+        scheduler_masters = sautils.Table(
+            'scheduler_masters', metadata,
+            sa.Column('schedulerid', sa.Integer, sa.ForeignKey('schedulers.id'),
+                      nullable=False, primary_key=True),
+            sa.Column('masterid', sa.Integer, sa.ForeignKey('masters.id'),
+                      nullable=False),
+        )
+        scheduler_masters.create()
+
+        scheduler_changes = sautils.Table(
+            'scheduler_changes', metadata,
+            sa.Column('schedulerid', sa.Integer, sa.ForeignKey('schedulers.id')),
+            sa.Column('changeid', sa.Integer, sa.ForeignKey('changes.changeid')),
+        )
+        scheduler_changes.create()
+
+        builders_tags = sautils.Table(
+            'builders_tags', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('builderid', sa.Integer, sa.ForeignKey('builders.id'),
+                      nullable=False),
+            sa.Column('tagid', sa.Integer, sa.ForeignKey('tags.id'),
+                      nullable=False),
+        )
+        builders_tags.create()
+
+        objects = sautils.Table(
+            "objects", metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        objects.create()
+
+        object_state = sautils.Table(
+            "object_state", metadata,
+            sa.Column("objectid", sa.Integer, sa.ForeignKey('objects.id'),
+                      nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=False),
+        )
+        object_state.create()
+
+        users_info = sautils.Table(
+            "users_info", metadata,
+            sa.Column("uid", sa.Integer, sa.ForeignKey('users.uid'),
+                      nullable=False),
+            sa.Column("attr_type", sa.String(128), nullable=False),
+        )
+        users_info.create()
+
+        # insert data
+        conn.execute(masters.insert(), [
+            dict(id=1),
+        ])
+        conn.execute(objects.insert(), [
+            dict(id=1),
+        ])
+        conn.execute(object_state.insert(), [
+            dict(objectid=1, name='size'),
+        ])
+        conn.execute(users.insert(), [
+            dict(uid=1),
+            dict(uid=2),
+        ])
+        conn.execute(users_info.insert(), [
+            dict(uid=1, attr_type='first_name'),
+            dict(uid=1, attr_type='last_name'),
+            dict(uid=2, attr_type='first_name'),
+            dict(uid=2, attr_type='last_name'),
+        ])
+        conn.execute(builders.insert(), [
+            dict(id=1),
+            dict(id=2),
+        ])
+        conn.execute(tags.insert(), [
+            dict(id=1),
+            dict(id=2),
+        ])
+        conn.execute(builders_tags.insert(), [
+            dict(id=1, builderid=1, tagid=1),
+            dict(id=2, builderid=2, tagid=1),
+            dict(id=3, builderid=2, tagid=2),
+        ])
+        conn.execute(workers.insert(), [
+            dict(id=1),
+            dict(id=2),
+        ])
+        conn.execute(connected_workers.insert(), [
+            dict(id=1, masterid=1, workerid=1),
+            dict(id=2, masterid=1, workerid=2),
+        ])
+        conn.execute(changesources.insert(), [
+            dict(id=1),
+        ])
+        conn.execute(changesource_masters.insert(), [
+            dict(changesourceid=1, masterid=1),
+        ])
+        conn.execute(sourcestamps.insert(), [
+            dict(id=1),
+            dict(id=2),
+        ])
+        conn.execute(changes.insert(), [
+            dict(changeid=1, sourcestampid=1),
+            dict(changeid=2, sourcestampid=2),
+        ])
+        conn.execute(change_users.insert(), [
+            dict(changeid=1, uid=1),
+            dict(changeid=2, uid=2),
+        ])
+        conn.execute(change_properties.insert(), [
+            dict(changeid=1, property_name='release_lvl'),
+            dict(changeid=2, property_name='release_lvl'),
+        ])
+        conn.execute(change_files.insert(), [
+            dict(changeid=1, filename='README'),
+            dict(changeid=2, filename='setup.py'),
+        ])
+        conn.execute(schedulers.insert(), [
+            dict(changeid=1),
+        ])
+        conn.execute(scheduler_masters.insert(), [
+            dict(schedulerid=1, masterid=1),
+        ])
+        conn.execute(scheduler_changes.insert(), [
+            dict(schedulerid=1, changeid=1),
+            dict(schedulerid=1, changeid=2),
+        ])
+        conn.execute(buildsets.insert(), [
+            dict(id=1),
+            dict(id=2),
+        ])
+        conn.execute(buildset_properties.insert(), [
+            dict(buildsetid=1, property_name='color'),
+            dict(buildsetid=2, property_name='smell'),
+        ])
+        conn.execute(buildset_sourcestamps.insert(), [
+            dict(id=1, buildsetid=1, sourcestampid=1),
+            dict(id=2, buildsetid=2, sourcestampid=2),
+        ])
+        conn.execute(buildrequests.insert(), [
+            dict(id=1, buildsetid=1, builderid=1),
+            dict(id=2, buildsetid=1, builderid=2),
+            dict(id=3, buildsetid=2, builderid=1),
+            dict(id=4, buildsetid=2, builderid=2),
+        ])
+        conn.execute(buildrequest_claims.insert(), [
+            dict(brid=1, masterid=1),
+            dict(brid=2, masterid=1),
+            dict(brid=3, masterid=1),
+            dict(brid=4, masterid=1),
+        ])
+        conn.execute(builds.insert(), [
+            dict(id=1, builderid=1, buildrequestid=1, workerid=2, masterid=1),
+            dict(id=2, builderid=2, buildrequestid=2, workerid=1, masterid=1),
+            dict(id=3, builderid=1, buildrequestid=3, workerid=1, masterid=1),
+            dict(id=4, builderid=2, buildrequestid=4, workerid=2, masterid=1),
+        ])
+        conn.execute(build_properties.insert(), [
+            dict(buildid=1, name='buildername'),
+            dict(buildid=2, name='buildername'),
+            dict(buildid=3, name='buildername'),
+            dict(buildid=4, name='buildername'),
+        ])
+        conn.execute(steps.insert(), [
+            dict(id=1, buildid=1),
+            dict(id=2, buildid=1),
+            dict(id=3, buildid=2),
+            dict(id=4, buildid=2),
+            dict(id=5, buildid=1),
+            dict(id=6, buildid=1),
+            dict(id=7, buildid=2),
+            dict(id=8, buildid=2),
+        ])
+        conn.execute(logs.insert(), [
+            dict(id=1, stepid=1),
+            dict(id=2, stepid=2),
+            dict(id=3, stepid=3),
+            dict(id=4, stepid=4),
+            dict(id=5, stepid=5),
+            dict(id=6, stepid=6),
+            dict(id=7, stepid=7),
+            dict(id=8, stepid=8),
+        ])
+        conn.execute(logchunks.insert(), [
+            dict(logid=1, first_line=0, last_line=100),
+            dict(logid=2, first_line=0, last_line=100),
+            dict(logid=3, first_line=0, last_line=100),
+            dict(logid=4, first_line=0, last_line=100),
+            dict(logid=5, first_line=0, last_line=100),
+            dict(logid=6, first_line=0, last_line=100),
+            dict(logid=7, first_line=0, last_line=100),
+            dict(logid=8, first_line=0, last_line=100),
+        ])
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_and_insert_data(conn)
+
+        def verify_thd(conn):
+            """Can't verify much under SQLite
+
+            Even with PRAGMA foreign_keys=ON, the cascading deletes are
+            actually ignored with SQLite, so we can't really test the behaviour
+            in that environment.
+
+            On the other hand, SQLite's FKs apparently don't prevent removals.
+            The cascading behaviour is really needed for other DBs right now,
+            and only in reconfigs.
+            """
+            metadata = sa.MetaData()
+            metadata.bind = conn
+            sourcestamps = sautils.Table('sourcestamps', metadata,
+                                         autoload=True)
+            conn.execute(sourcestamps.delete().where(sourcestamps.c.id == 1))
+
+            q = sa.select([sourcestamps.c.id])
+            self.assertEqual(conn.execute(q).fetchall(), [(2,)])
+
+        return self.do_test_migration(49, 50, setup_thd, verify_thd)

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -103,5 +103,9 @@ class MigrateTestMixin(db.RealDatabaseMixin, dirs.DirsMixin):
                               "table %s does not have the utf8 charset" % tbl)
         d.addCallback(lambda _: self.db.pool.do(check_table_charsets_thd))
 
-        d.addCallback(lambda _: self.db.pool.do(verify_thd_cb))
+        def verify_thd(engine):
+            with sautils.withoutSqliteForeignKeys(engine):
+                verify_thd_cb(engine)
+
+        d.addCallback(lambda _: self.db.pool.do(verify_thd))
         return d


### PR DESCRIPTION
Some buildbot installs handle a lot of builders (more than 500) and therefore a lot of builds. This can cause the database to grow over time and take too much disk space (also, this can increase complex SQL queries response time).

`logchunks` cleanup is already available via the `JanitorConfigurator`. But there is no easy way to cleanup old `sourcestamps`, `changes`, `buildsets`, `buildrequests`, `builds`, `buildsteps` and `logs` since the database constraints will require that the cleanup procedure starts from the leafs. This can be very complex and time consuming.

In order to allow deleting any database record along with any other records that may link to it, modify the foreign key constraints to "cascade" delete records when linked records are deleted.