### PR TITLE
Change docker-py module to modern version

### DIFF
--- a/master/buildbot/newsfragments/docker-pr-requirement.bugfix
+++ b/master/buildbot/newsfragments/docker-pr-requirement.bugfix
@@ -1,0 +1,1 @@
+Update requirement text to use the modern "docker" module from the older "docker-py" module name

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -123,7 +123,7 @@ class DockerLatentWorker(DockerBaseWorker):
         DockerBaseWorker.checkConfig(self, name, password, image, masterFQDN, **kwargs)
 
         if not client:
-            config.error("The python module 'docker-py>=1.4' is needed to use a"
+            config.error("The python module 'docker>=2.0' is needed to use a"
                          " DockerLatentWorker")
         if not image and not dockerfile:
             config.error("DockerLatentWorker: You need to specify at least"

--- a/master/buildbot/worker/hyper.py
+++ b/master/buildbot/worker/hyper.py
@@ -97,7 +97,7 @@ class HyperLatentWorker(DockerBaseWorker):
         DockerBaseWorker.checkConfig(self, name, password, image=image, masterFQDN=masterFQDN, **kwargs)
 
         if not Hyper:
-            config.error("The python modules 'docker-py>=1.4' and 'hyper_sh' are needed to use a"
+            config.error("The python modules 'docker>=2.0' and 'hyper_sh' are needed to use a"
                          " HyperLatentWorker")
 
         if not IRenderable.providedBy(hyper_size) and hyper_size not in self.ALLOWED_SIZES:


### PR DESCRIPTION
Update message to reflex the current docker package name of "docker" from the older named "dcoker-py"

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
