### PR TITLE
Badges: Fix url arguments for python3

### DIFF
--- a/master/buildbot/newsfragments/badges-python3.bugfix
+++ b/master/buildbot/newsfragments/badges-python3.bugfix
@@ -1,0 +1,1 @@
+Fix url arguments in Buildbot Badges for python3.

--- a/www/badges/buildbot_badges/__init__.py
+++ b/www/badges/buildbot_badges/__init__.py
@@ -27,6 +27,7 @@ from buildbot.data import resultspec
 from buildbot.process.results import Results
 from buildbot.www.plugin import Application
 from xml.sax.saxutils import escape
+from buildbot.util import bytes2NativeString
 
 
 class Api(object):
@@ -68,7 +69,8 @@ class Api(object):
                 config[k] = v
 
         for k, v in request.args.items():
-            config[k] = escape(v[0])
+            k = bytes2NativeString(k)
+            config[k] = escape(bytes2NativeString(v[0]))
         return config
 
     @app.route("/<string:builder>.png", methods=['GET'])


### PR DESCRIPTION
Fixes error when overwriting the badge style with URL arguments
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
