### PR TITLE
Passed headers overwrite base headers

### DIFF
--- a/master/buildbot/newsfragments/httpclient-headers.feature
+++ b/master/buildbot/newsfragments/httpclient-headers.feature
@@ -1,0 +1,1 @@
+Any header that is defined at service instantiation should be overridden by any header of the same explicitly passed when making a request.

--- a/master/buildbot/test/unit/test_util_httpclientservice.py
+++ b/master/buildbot/test/unit/test_util_httpclientservice.py
@@ -121,6 +121,18 @@ class HTTPClientServiceTestTxRequest(HTTPClientServiceTestBase):
                                                                 'Content-Type': 'application/json'
                                                             })
 
+    def test_passed_headers_overwrite_base_headers(self):
+        self.base_headers.update({'X-TOKEN': 'XXXYYY'})
+        self._http.post('/bar', json={'foo': 'bar'}, headers={'X-TOKEN': 'AABBCC'})
+        jsonStr = json.dumps(dict(foo='bar'))
+        jsonBytes = unicode2bytes(jsonStr)
+        self._http._session.request.assert_called_once_with('post', 'http://foo/bar',
+                                                            background_callback=mock.ANY,
+                                                            data=jsonBytes,
+                                                            headers={
+                                                                'X-TOKEN': 'AABBCC',
+                                                                'Content-Type': 'application/json'})
+
 
 class HTTPClientServiceTestTReq(HTTPClientServiceTestBase):
 

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -143,9 +143,13 @@ class HTTPClientService(service.SharedService):
         url = self._base_url + ep
         if self._auth is not None and 'auth' not in kwargs:
             kwargs['auth'] = self._auth
-        headers = kwargs.get('headers', {})
-        if self._headers is not None:
-            headers.update(self._headers)
+
+        # First grab a copy of instantiation passed headers
+        headers = self._headers.copy() if self._headers else {}
+        # Now update/overwrite those headers with any headers passed
+        # explicitly in this request
+        headers.update(kwargs.get('headers', {}))
+        # Reassign headers to kwargs
         kwargs['headers'] = headers
 
         # we manually do the json encoding in order to automatically convert timestamps


### PR DESCRIPTION
Any header that is defined at service instantiation should be overridden by any header of the same explicitly passed when making a request.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
