### PR TITLE
db: add primary keys in tables lacking them

### DIFF
--- a/master/buildbot/db/migrate/versions/051_add_missing_primary_keys.py
+++ b/master/buildbot/db/migrate/versions/051_add_missing_primary_keys.py
@@ -1,0 +1,48 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+from future.utils import iteritems
+
+import sqlalchemy as sa
+from migrate.changeset.constraint import PrimaryKeyConstraint
+
+from buildbot.util import sautils
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+
+    for t, cols in iteritems(TABLES_PKEYS):
+        table = sautils.Table(t, metadata, autoload=True)
+        pk = PrimaryKeyConstraint(*cols)
+        table.append_constraint(pk)
+        pk.create()
+
+
+TABLES_PKEYS = {
+    'buildrequest_claims': ['brid'],
+    'build_properties': ['buildid', 'name'],
+    'logchunks': ['logid', 'first_line', 'last_line'],
+    'buildset_properties': ['buildsetid', 'property_name'],
+    'change_files': ['changeid', 'filename'],
+    'change_properties': ['changeid', 'property_name'],
+    'change_users': ['changeid', 'uid'],
+    'scheduler_changes': ['schedulerid', 'changeid'],
+    'object_state': ['objectid', 'name'],
+    'users_info': ['uid', 'attr_type'],
+}

--- a/master/buildbot/db/migrate_utils.py
+++ b/master/buildbot/db/migrate_utils.py
@@ -31,6 +31,7 @@ def test_unicode(migrate_engine):
 
     test_unicode = sautils.Table(
         'test_unicode', submeta,
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
         sa.Column('u', sa.Unicode(length=100)),
         sa.Column('b', sa.LargeBinary),
     )

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -108,7 +108,7 @@ class Model(base.DBConnectorComponent):
         'buildrequest_claims', metadata,
         sa.Column('brid', sa.Integer,
                   sa.ForeignKey('buildrequests.id', ondelete='CASCADE'),
-                  nullable=False),
+                  primary_key=True),
         sa.Column('masterid', sa.Integer,
                   sa.ForeignKey('masters.id', ondelete='CASCADE'),
                   index=True, nullable=True),
@@ -122,8 +122,8 @@ class Model(base.DBConnectorComponent):
         'build_properties', metadata,
         sa.Column('buildid', sa.Integer,
                   sa.ForeignKey('builds.id', ondelete='CASCADE'),
-                  nullable=False),
-        sa.Column('name', sa.String(256), nullable=False),
+                  primary_key=True),
+        sa.Column('name', sa.String(256), primary_key=True),
         # JSON encoded value
         sa.Column('value', sa.Text, nullable=False),
         sa.Column('source', sa.String(256), nullable=False),
@@ -197,11 +197,12 @@ class Model(base.DBConnectorComponent):
     logchunks = sautils.Table(
         'logchunks', metadata,
         sa.Column('logid', sa.Integer,
-                  sa.ForeignKey('logs.id', ondelete='CASCADE')),
+                  sa.ForeignKey('logs.id', ondelete='CASCADE'),
+                  primary_key=True),
         # 0-based line number range in this chunk (inclusive); note that for
         # HTML logs, this counts lines of HTML, not lines of rendered output
-        sa.Column('first_line', sa.Integer, nullable=False),
-        sa.Column('last_line', sa.Integer, nullable=False),
+        sa.Column('first_line', sa.Integer, primary_key=True),
+        sa.Column('last_line', sa.Integer, primary_key=True),
         # log contents, including a terminating newline, encoded in utf-8 or,
         # if 'compressed' is not 0, compressed with gzip, bzip2 or lz4
         sa.Column('content', sa.LargeBinary(65536)),
@@ -215,8 +216,8 @@ class Model(base.DBConnectorComponent):
         'buildset_properties', metadata,
         sa.Column('buildsetid', sa.Integer,
                   sa.ForeignKey('buildsets.id', ondelete='CASCADE'),
-                  nullable=False),
-        sa.Column('property_name', sa.String(256), nullable=False),
+                  primary_key=True),
+        sa.Column('property_name', sa.String(256), primary_key=True),
         # JSON-encoded tuple of (value, source)
         sa.Column('property_value', sa.Text, nullable=False),
     )
@@ -324,8 +325,8 @@ class Model(base.DBConnectorComponent):
         'change_files', metadata,
         sa.Column('changeid', sa.Integer,
                   sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
-                  nullable=False),
-        sa.Column('filename', sa.String(1024), nullable=False),
+                  primary_key=True),
+        sa.Column('filename', sa.String(1024), primary_key=True),
     )
 
     # Properties for changes
@@ -333,8 +334,8 @@ class Model(base.DBConnectorComponent):
         'change_properties', metadata,
         sa.Column('changeid', sa.Integer,
                   sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
-                  nullable=False),
-        sa.Column('property_name', sa.String(256), nullable=False),
+                  primary_key=True),
+        sa.Column('property_name', sa.String(256), primary_key=True),
         # JSON-encoded tuple of (value, source)
         sa.Column('property_value', sa.Text, nullable=False),
     )
@@ -346,11 +347,11 @@ class Model(base.DBConnectorComponent):
         "change_users", metadata,
         sa.Column('changeid', sa.Integer,
                   sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
-                  nullable=False),
+                  primary_key=True),
         # uid for the author of the change with the given changeid
         sa.Column('uid', sa.Integer,
                   sa.ForeignKey('users.uid', ondelete='CASCADE'),
-                  nullable=False),
+                  primary_key=True),
     )
 
     # Changes to the source code, produced by ChangeSources
@@ -525,9 +526,11 @@ class Model(base.DBConnectorComponent):
     scheduler_changes = sautils.Table(
         'scheduler_changes', metadata,
         sa.Column('schedulerid', sa.Integer,
-                  sa.ForeignKey('schedulers.id', ondelete='CASCADE')),
+                  sa.ForeignKey('schedulers.id', ondelete='CASCADE'),
+                  primary_key=True),
         sa.Column('changeid', sa.Integer,
-                  sa.ForeignKey('changes.changeid', ondelete='CASCADE')),
+                  sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                  primary_key=True),
         # true (nonzero) if this change is important to this scheduler
         sa.Column('important', sa.Integer),
     )
@@ -602,9 +605,9 @@ class Model(base.DBConnectorComponent):
         # object for which this value is set
         sa.Column('objectid', sa.Integer,
                   sa.ForeignKey('objects.id', ondelete='CASCADE'),
-                  nullable=False),
+                  primary_key=True),
         # name for this value (local to the object)
-        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("name", sa.String(length=255), primary_key=True),
         # value, as a JSON string
         sa.Column("value_json", sa.Text, nullable=False),
     )
@@ -635,10 +638,10 @@ class Model(base.DBConnectorComponent):
         # unique user id number
         sa.Column('uid', sa.Integer,
                   sa.ForeignKey('users.uid', ondelete='CASCADE'),
-                  nullable=False),
+                  primary_key=True),
 
         # type of user attribute, such as 'git'
-        sa.Column("attr_type", sa.String(128), nullable=False),
+        sa.Column("attr_type", sa.String(128), primary_key=True),
 
         # data for given user attribute, such as a commit string or password
         sa.Column("attr_data", sa.String(128), nullable=False),

--- a/master/buildbot/newsfragments/primary-keys.bugfix
+++ b/master/buildbot/newsfragments/primary-keys.bugfix
@@ -1,0 +1,1 @@
+All database tables now have a primary key (:issue:`3841`).

--- a/master/buildbot/test/unit/test_db_migrate_versions_051_add_missing_pkeys.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_051_add_missing_pkeys.py
@@ -1,0 +1,276 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        # create tables (prior to schema migration)
+        masters = sautils.Table(
+            "masters", metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        masters.create()
+
+        users = sautils.Table(
+            "users", metadata,
+            sa.Column("uid", sa.Integer, primary_key=True),
+        )
+        users.create()
+
+        workers = sautils.Table(
+            "workers", metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        workers.create()
+
+        sourcestamps = sautils.Table(
+            'sourcestamps', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        sourcestamps.create()
+
+        schedulers = sautils.Table(
+            'schedulers', metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        schedulers.create()
+
+        buildsets = sautils.Table(
+            'buildsets', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        buildsets.create()
+
+        builders = sautils.Table(
+            'builders', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        builders.create()
+
+        buildrequests = sautils.Table(
+            'buildrequests', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('buildsetid', sa.Integer,
+                      sa.ForeignKey('buildsets.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('builderid', sa.Integer,
+                      sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                      nullable=False),
+        )
+        buildrequests.create()
+
+        builds = sautils.Table(
+            'builds', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('builderid', sa.Integer,
+                      sa.ForeignKey('builders.id', ondelete='CASCADE')),
+            sa.Column('buildrequestid', sa.Integer,
+                      sa.ForeignKey(
+                          'buildrequests.id', use_alter=True,
+                          name='buildrequestid', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('workerid', sa.Integer,
+                      sa.ForeignKey('workers.id', ondelete='CASCADE')),
+            sa.Column('masterid', sa.Integer,
+                      sa.ForeignKey('masters.id', ondelete='CASCADE'),
+                      nullable=False),
+        )
+        builds.create()
+
+        buildrequest_claims = sautils.Table(
+            'buildrequest_claims', metadata,
+            sa.Column('brid', sa.Integer,
+                      sa.ForeignKey('buildrequests.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('masterid', sa.Integer,
+                      sa.ForeignKey('masters.id', ondelete='CASCADE'),
+                      index=True, nullable=True),
+        )
+        buildrequest_claims.create()
+
+        build_properties = sautils.Table(
+            'build_properties', metadata,
+            sa.Column('buildid', sa.Integer,
+                      sa.ForeignKey('builds.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('name', sa.String(256), nullable=False),
+        )
+        build_properties.create()
+
+        steps = sautils.Table(
+            'steps', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('buildid', sa.Integer,
+                      sa.ForeignKey('builds.id', ondelete='CASCADE')),
+        )
+        steps.create()
+
+        logs = sautils.Table(
+            'logs', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('stepid', sa.Integer,
+                      sa.ForeignKey('steps.id', ondelete='CASCADE')),
+        )
+        logs.create()
+
+        logchunks = sautils.Table(
+            'logchunks', metadata,
+            sa.Column('logid', sa.Integer,
+                      sa.ForeignKey('logs.id', ondelete='CASCADE')),
+            sa.Column('first_line', sa.Integer, nullable=False),
+            sa.Column('last_line', sa.Integer, nullable=False),
+        )
+        logchunks.create()
+
+        buildset_properties = sautils.Table(
+            'buildset_properties', metadata,
+            sa.Column('buildsetid', sa.Integer,
+                      sa.ForeignKey('buildsets.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('property_name', sa.String(256), nullable=False),
+        )
+        buildset_properties.create()
+
+        changes = sautils.Table(
+            'changes', metadata,
+            sa.Column('changeid', sa.Integer, primary_key=True),
+            sa.Column('sourcestampid', sa.Integer,
+                      sa.ForeignKey('sourcestamps.id', ondelete='CASCADE')),
+            sa.Column('parent_changeids', sa.Integer,
+                      sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                      nullable=True),
+        )
+        changes.create()
+
+        change_files = sautils.Table(
+            'change_files', metadata,
+            sa.Column('changeid', sa.Integer,
+                      sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('filename', sa.String(1024), nullable=False),
+        )
+        change_files.create()
+
+        change_properties = sautils.Table(
+            'change_properties', metadata,
+            sa.Column('changeid', sa.Integer,
+                      sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('property_name', sa.String(256), nullable=False),
+        )
+        change_properties.create()
+
+        change_users = sautils.Table(
+            "change_users", metadata,
+            sa.Column('changeid', sa.Integer,
+                      sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('uid', sa.Integer,
+                      sa.ForeignKey('users.uid', ondelete='CASCADE'),
+                      nullable=False),
+        )
+        change_users.create()
+
+        patches = sautils.Table(
+            'patches', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        patches.create()
+
+        scheduler_changes = sautils.Table(
+            'scheduler_changes', metadata,
+            sa.Column('schedulerid', sa.Integer,
+                      sa.ForeignKey('schedulers.id', ondelete='CASCADE')),
+            sa.Column('changeid', sa.Integer,
+                      sa.ForeignKey('changes.changeid', ondelete='CASCADE')),
+        )
+        scheduler_changes.create()
+
+        objects = sautils.Table(
+            "objects", metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        objects.create()
+
+        object_state = sautils.Table(
+            "object_state", metadata,
+            sa.Column('objectid', sa.Integer,
+                      sa.ForeignKey('objects.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=False),
+        )
+        object_state.create()
+
+        users_info = sautils.Table(
+            "users_info", metadata,
+            sa.Column('uid', sa.Integer,
+                      sa.ForeignKey('users.uid', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column("attr_type", sa.String(128), nullable=False),
+        )
+        users_info.create()
+
+    TABLE_NAMES = (
+        'buildrequest_claims',
+        'build_properties',
+        'logchunks',
+        'buildset_properties',
+        'change_files',
+        'change_properties',
+        'change_users',
+        'scheduler_changes',
+        'object_state',
+        'users_info',
+    )
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables(conn)
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+            for t in self.TABLE_NAMES:
+                table = sautils.Table(t, metadata, autoload=True)
+                found_pkey = False
+                for cons in table.constraints:
+                    if isinstance(cons, sa.PrimaryKeyConstraint):
+                        found_pkey = True
+                        break
+                self.assertTrue(found_pkey,
+                                'missing primary key in table %s' % table)
+
+        return self.do_test_migration(50, 51, setup_thd, verify_thd)


### PR DESCRIPTION
This is based on work done by @vincent-olivert-riera in #3432. I added unit tests and reworked the migration script.

Fixes #3841 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)