### PR TITLE
model change for worker state

### DIFF
--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -440,3 +440,9 @@ class ResultSpec(object):
             rv.offset, rv.total = offset, total
             rv.limit = limit
             return rv
+
+# a resultSpec which does not implement filtering in python (for tests)
+class OptimisedResultSpec(ResultSpec):
+
+    def apply(self, data):
+        return data

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -441,6 +441,7 @@ class ResultSpec(object):
             rv.limit = limit
             return rv
 
+
 # a resultSpec which does not implement filtering in python (for tests)
 class OptimisedResultSpec(ResultSpec):
 

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -94,9 +94,13 @@ class WorkersEndpoint(Db2DataMixin, base.Endpoint):
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
+        paused = resultSpec.popBooleanFilter('paused')
+        graceful = resultSpec.popBooleanFilter('graceful')
         workers_dicts = yield self.master.db.workers.getWorkers(
             builderid=kwargs.get('builderid'),
-            masterid=kwargs.get('masterid'))
+            masterid=kwargs.get('masterid'),
+            paused=paused,
+            graceful=graceful)
         defer.returnValue([self.db2data(w) for w in workers_dicts])
 
 
@@ -164,6 +168,16 @@ class Worker(base.ResourceType):
         bs['last_connection'] = last_connection
         bs['notify'] = notify
         self.produceEvent(bs, 'missing')
+
+    @base.updateMethod
+    @defer.inlineCallbacks
+    def setWorkerState(self, workerid, paused, graceful):
+        yield self.master.db.workers.setWorkerState(
+            workerid=workerid,
+            paused=paused,
+            graceful=graceful)
+        bs = yield self.master.data.get(('workers', workerid))
+        self.produceEvent(bs, 'state_updated')
 
     @base.updateMethod
     def deconfigureAllWorkersForMaster(self, masterid):

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -31,6 +31,8 @@ class Db2DataMixin(object):
             'workerid': dbdict['id'],
             'name': dbdict['name'],
             'workerinfo': dbdict['workerinfo'],
+            'paused': dbdict['paused'],
+            'graceful': dbdict['graceful'],
             'connected_to': [
                 {'masterid': id}
                 for id in dbdict['connected_to']],
@@ -117,6 +119,8 @@ class Worker(base.ResourceType):
             masterid=types.Integer(),
             builderid=types.Integer()))
         workerinfo = types.JsonObject()
+        paused = types.Boolean()
+        graceful = types.Boolean()
     entityType = EntityType(name)
 
     @base.updateMethod

--- a/master/buildbot/db/migrate/versions/051_add_worker_status.py
+++ b/master/buildbot/db/migrate/versions/051_add_worker_status.py
@@ -1,0 +1,33 @@
+# This file is part of Buildbot. Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import sqlalchemy as sa
+
+from buildbot.util import sautils
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+    workers_table = sautils.Table('workers', metadata, autoload=True)
+    paused = sa.Column('paused', sa.SmallInteger,
+                    nullable=False, server_default="0")
+    graceful = sa.Column('graceful', sa.SmallInteger,
+                         nullable=False, server_default="0")
+    paused.create(workers_table)
+    graceful.create(workers_table)

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -290,6 +290,8 @@ class Model(base.DBConnectorComponent):
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column("name", sa.String(50), nullable=False),
         sa.Column("info", JsonObject, nullable=False),
+        sa.Column("paused", sa.SmallInteger, nullable=False, server_default="0"),
+        sa.Column("graceful", sa.SmallInteger, nullable=False, server_default="0"),
     )
 
     # link workers to all builder/master pairs for which they are

--- a/master/buildbot/db/workers.py
+++ b/master/buildbot/db/workers.py
@@ -237,3 +237,10 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
                                        (tbl.c.masterid == masterid))
             conn.execute(q)
         return self.db.pool.do(thd)
+
+    def setWorkerState(self, workerid, paused, graceful):
+        def thd(conn):
+            tbl = self.db.model.workers
+            q = tbl.update(whereclause=(tbl.c.id == workerid))
+            conn.execute(q, paused=int(paused), graceful=int(graceful))
+        return self.db.pool.do(thd)

--- a/master/buildbot/newsfragments/worker_state.feature
+++ b/master/buildbot/newsfragments/worker_state.feature
@@ -1,0 +1,4 @@
+``paused`` and ``graceful`` :ref:`Worker-states` are now stored in the database.
+:ref:`Worker-states` are now displayed in the UI.
+Quarantine timers is now using the ``paused`` worker state.
+Quarantine timer is now enabled when a build finish on ``EXCEPTION`` state.

--- a/master/buildbot/spec/types/worker.raml
+++ b/master/buildbot/spec/types/worker.raml
@@ -23,6 +23,12 @@ properties:
     name:
         description: the name of the worker
         type: string
+    paused:
+        description: the worker is paused if it is connected but doesn't accept new builds.
+        type: bool
+    graceful:
+        description: the worker is graceful if it doesn't accept new builds, and will shutdown when builds are finished.
+        type: bool
     workerinfo:
         description: |
             information about the worker.

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -425,6 +425,12 @@ class FakeUpdates(service.AsyncService):
     def schedulerEnable(self, schedulerid, v):
         return self.master.db.schedulers.enable(schedulerid, v)
 
+    def setWorkerState(self, workerid, paused, graceful):
+        return self.master.db.workers.setWorkerState(
+            workerid=workerid,
+            paused=paused,
+            graceful=graceful)
+
 
 class FakeDataConnector(service.AsyncMultiService):
     # FakeDataConnector delegates to the real DataConnector so it can get all

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -429,6 +429,8 @@ class Worker(Row):
         id=None,
         name='some:worker',
         info={"a": "b"},
+        paused=0,
+        graceful=0,
     )
 
     id_column = 'id'
@@ -1448,6 +1450,8 @@ class FakeWorkersComponent(FakeDBComponent):
                 self.workers[row.id] = dict(
                     id=row.id,
                     name=row.name,
+                    paused=0,
+                    graceful=0,
                     info=row.info)
             elif isinstance(row, ConfiguredWorker):
                 row.id = row.buildermasterid * 10000 + row.workerid
@@ -1497,7 +1501,7 @@ class FakeWorkersComponent(FakeDBComponent):
         # by builderid and masterid
         return defer.succeed(self._mkdict(worker, builderid, masterid))
 
-    def getWorkers(self, masterid=None, builderid=None):
+    def getWorkers(self, masterid=None, builderid=None, paused=None, graceful=None):
         if masterid is not None or builderid is not None:
             builder_masters = self.db.builders.builder_masters
             workers = []
@@ -1597,6 +1601,8 @@ class FakeWorkersComponent(FakeDBComponent):
             'id': w['id'],
             'workerinfo': w['info'],
             'name': w['name'],
+            'paused': bool(w.get('paused')),
+            'graceful': bool(w.get('graceful')),
             'configured_on': self._configuredOn(w['id'], builderid, masterid),
             'connected_to': self._connectedTo(w['id'], masterid),
         }

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1573,6 +1573,12 @@ class FakeWorkersComponent(FakeDBComponent):
                 break
         return defer.succeed(None)
 
+    def setWorkerState(self, workerid, paused, graceful):
+        worker = self.workers.get(workerid)
+        if worker is not None:
+            worker['paused'] = int(paused)
+            worker['graceful'] = int(graceful)
+
     def _configuredOn(self, workerid, builderid=None, masterid=None):
         cfg = []
         for cs in itervalues(self.configured):

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1523,6 +1523,11 @@ class FakeWorkersComponent(FakeDBComponent):
         else:
             workers = list(itervalues(self.workers))
 
+        if paused is not None:
+            workers = [w for w in workers if w['paused'] == paused]
+        if graceful is not None:
+            workers = [w for w in workers if w['graceful'] == graceful]
+
         return defer.succeed([
             self._mkdict(worker, builderid, masterid)
             for worker in workers])

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -203,8 +203,10 @@ class RunSteps(unittest.TestCase):
         self.buildrequest = \
             yield buildrequest.BuildRequest.fromBrdict(self.master, self.brdict)
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        return self.builder.stopService()
+        yield self.worker.stopService()
+        yield self.builder.stopService()
 
     @defer.inlineCallbacks
     def do_test_step(self):

--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -31,13 +31,6 @@ from buildbot.test.util import interfaces
 from buildbot.util import epoch2datetime
 
 
-# override resultSpec implementation to be noop
-class MockedResultSpec(resultspec.ResultSpec):
-
-    def apply(self, data):
-        return data
-
-
 class BuildEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     endpointClass = builds.BuildEndpoint
@@ -102,7 +95,7 @@ class BuildEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_properties_injection(self):
-        resultSpec = MockedResultSpec(
+        resultSpec = resultspec.OptimisedResultSpec(
             filters=[resultspec.Filter('property', 'eq', [False])])
         build = yield self.callGet(('builders', 77, 'builds', 5), resultSpec=resultSpec)
         self.validateData(build)
@@ -197,7 +190,7 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_get_buildrequest_via_filter(self):
-        resultSpec = MockedResultSpec(
+        resultSpec = resultspec.OptimisedResultSpec(
             filters=[resultspec.Filter('buildrequestid', 'eq', [82])])
         builds = yield self.callGet(('builds',), resultSpec=resultSpec)
         [self.validateData(build) for build in builds]
@@ -205,7 +198,7 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_get_buildrequest_via_filter_with_string(self):
-        resultSpec = MockedResultSpec(
+        resultSpec = resultspec.OptimisedResultSpec(
             filters=[resultspec.Filter('buildrequestid', 'eq', ['82'])])
         builds = yield self.callGet(('builds',), resultSpec=resultSpec)
         [self.validateData(build) for build in builds]
@@ -219,7 +212,7 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_get_complete(self):
-        resultSpec = MockedResultSpec(
+        resultSpec = resultspec.OptimisedResultSpec(
             filters=[resultspec.Filter('complete', 'eq', [False])])
         builds = yield self.callGet(('builds',), resultSpec=resultSpec)
         [self.validateData(build) for build in builds]
@@ -227,7 +220,7 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_get_complete_at(self):
-        resultSpec = MockedResultSpec(
+        resultSpec = resultspec.OptimisedResultSpec(
             filters=[resultspec.Filter('complete_at', 'eq', [None])])
         builds = yield self.callGet(('builds',), resultSpec=resultSpec)
         [self.validateData(build) for build in builds]
@@ -235,7 +228,7 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_properties_injection(self):
-        resultSpec = MockedResultSpec(
+        resultSpec = resultspec.OptimisedResultSpec(
             filters=[resultspec.Filter('property', 'eq', [False])])
         builds = yield self.callGet(('builds',), resultSpec=resultSpec)
         for b in builds:
@@ -244,7 +237,7 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_get_filter_eq(self):
-        resultSpec = MockedResultSpec(
+        resultSpec = resultspec.OptimisedResultSpec(
             filters=[resultspec.Filter('builderid', 'eq', [78, 79])])
         builds = yield self.callGet(('builds',), resultSpec=resultSpec)
         [self.validateData(b) for b in builds]
@@ -252,7 +245,7 @@ class BuildsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_get_filter_ne(self):
-        resultSpec = MockedResultSpec(
+        resultSpec = resultspec.OptimisedResultSpec(
             filters=[resultspec.Filter('builderid', 'ne', [78, 79])])
         builds = yield self.callGet(('builds',), resultSpec=resultSpec)
         [self.validateData(b) for b in builds]

--- a/master/buildbot/test/unit/test_data_workers.py
+++ b/master/buildbot/test/unit/test_data_workers.py
@@ -76,6 +76,8 @@ def w1(builderid=None, masterid=None):
         'workerid': 1,
         'name': 'linux',
         'workerinfo': {},
+        'paused': False,
+        'graceful': False,
         'connected_to': [
             {'masterid': 13},
         ],
@@ -91,6 +93,8 @@ def w2(builderid=None, masterid=None):
         'workerid': 2,
         'name': 'windows',
         'workerinfo': {'a': 'b'},
+        'paused': False,
+        'graceful': False,
         'connected_to': [
             {'masterid': 14},
         ],

--- a/master/buildbot/test/unit/test_db_migrate_versions_051_add_workers_status.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_051_add_workers_status.py
@@ -1,0 +1,74 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import sqlalchemy as sa
+
+from twisted.trial import unittest
+
+from buildbot.db.types.json import JsonObject
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_thd(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        # workers
+        workers = sautils.Table(
+            "workers", metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.String(50), nullable=False),
+            sa.Column("info", JsonObject, nullable=False),
+        )
+        workers.create()
+
+        conn.execute(workers.insert(), [
+            dict(id=3, name='foo', info='{}')])
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            workers = sautils.Table('workers', metadata, autoload=True)
+            self.assertIsInstance(workers.c.paused.type, sa.SmallInteger)
+            self.assertIsInstance(workers.c.graceful.type, sa.SmallInteger)
+
+            q = sa.select(
+                [workers.c.name, workers.c.paused, workers.c.graceful])
+            num_rows = 0
+            for row in conn.execute(q):
+                # verify that the default value was set correctly
+                self.assertEqual(row.paused, False)
+                self.assertEqual(row.graceful, False)
+                num_rows += 1
+            self.assertEqual(num_rows, 1)
+
+        return self.do_test_migration(50, 51, setup_thd, verify_thd)

--- a/master/buildbot/test/unit/test_db_workers.py
+++ b/master/buildbot/test/unit/test_db_workers.py
@@ -105,7 +105,7 @@ class Tests(interfaces.InterfaceTests):
 
     def test_signature_getWorkers(self):
         @self.assertArgSpecMatches(self.db.workers.getWorkers)
-        def getWorkers(self, masterid=None, builderid=None):
+        def getWorkers(self, masterid=None, builderid=None, paused=None, graceful=None):
             pass
 
     def test_signature_workerConnected(self):
@@ -159,7 +159,7 @@ class Tests(interfaces.InterfaceTests):
         workerdict = yield self.db.workers.getWorker(workerid=30)
         validation.verifyDbDict(self, 'workerdict', workerdict)
         self.assertEqual(workerdict,
-                         dict(id=30, name='zero', workerinfo={'a': 'b'},
+                         dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                               connected_to=[], configured_on=[]))
 
     @defer.inlineCallbacks
@@ -173,7 +173,7 @@ class Tests(interfaces.InterfaceTests):
         workerdict = yield self.db.workers.getWorker(workerid=32)
         validation.verifyDbDict(self, 'workerdict', workerdict)
         self.assertEqual(workerdict,
-                         dict(id=32, name='two', workerinfo={'a': 'b'},
+                         dict(id=32, name='two', workerinfo={'a': 'b'}, paused=False, graceful=False,
                               connected_to=[11], configured_on=[]))
 
     @defer.inlineCallbacks
@@ -192,7 +192,7 @@ class Tests(interfaces.InterfaceTests):
         workerdict = yield self.db.workers.getWorker(workerid=32)
         validation.verifyDbDict(self, 'workerdict', workerdict)
         self.assertEqual(workerdict,
-                         dict(id=32, name='two', workerinfo={'a': 'b'},
+                         dict(id=32, name='two', workerinfo={'a': 'b'}, paused=False, graceful=False,
                               connected_to=[10, 11], configured_on=[
                                   {'builderid': 20, 'masterid': 10},
                                   {'builderid': 20, 'masterid': 11},
@@ -204,7 +204,7 @@ class Tests(interfaces.InterfaceTests):
         workerdict = yield self.db.workers.getWorker(name='zero')
         validation.verifyDbDict(self, 'workerdict', workerdict)
         self.assertEqual(workerdict,
-                         dict(id=30, name='zero', workerinfo={'a': 'b'},
+                         dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                               connected_to=[], configured_on=[]))
 
     @defer.inlineCallbacks
@@ -216,7 +216,7 @@ class Tests(interfaces.InterfaceTests):
         workerdict = yield self.db.workers.getWorker(workerid=30)
         validation.verifyDbDict(self, 'workerdict', workerdict)
         self.assertEqual(workerdict,
-                         dict(id=30, name='zero', workerinfo={'a': 'b'},
+                         dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                               configured_on=[
                                   {'masterid': 10, 'builderid': 20}],
                               connected_to=[]))
@@ -231,7 +231,7 @@ class Tests(interfaces.InterfaceTests):
         workerdict = yield self.db.workers.getWorker(workerid=30)
         validation.verifyDbDict(self, 'workerdict', workerdict)
         self.assertEqual(workerdict,
-                         dict(id=30, name='zero', workerinfo={'a': 'b'},
+                         dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                               configured_on=[
                                   {'masterid': 10, 'builderid': 20}],
                               connected_to=[10]))
@@ -244,7 +244,7 @@ class Tests(interfaces.InterfaceTests):
         workerdict['configured_on'] = sorted(
             workerdict['configured_on'], key=configuredOnKey)
         self.assertEqual(workerdict,
-                         dict(id=30, name='zero', workerinfo={'a': 'b'},
+                         dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                               configured_on=sorted([
                                   {'masterid': 10, 'builderid': 20},
                                   {'masterid': 10, 'builderid': 21},
@@ -259,7 +259,7 @@ class Tests(interfaces.InterfaceTests):
         workerdict['configured_on'] = sorted(
             workerdict['configured_on'], key=configuredOnKey)
         self.assertEqual(workerdict,
-                         dict(id=30, name='zero', workerinfo={'a': 'b'},
+                         dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                               configured_on=sorted([
                                   {'masterid': 10, 'builderid': 20},
                                   {'masterid': 11, 'builderid': 20},
@@ -271,7 +271,7 @@ class Tests(interfaces.InterfaceTests):
         workerdict = yield self.db.workers.getWorker(workerid=30, masterid=11)
         validation.verifyDbDict(self, 'workerdict', workerdict)
         self.assertEqual(workerdict,
-                         dict(id=30, name='zero', workerinfo={'a': 'b'},
+                         dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                               configured_on=[
                                   {'masterid': 11, 'builderid': 20},
                          ], connected_to=[]))
@@ -283,7 +283,7 @@ class Tests(interfaces.InterfaceTests):
                                                      builderid=20, masterid=11)
         validation.verifyDbDict(self, 'workerdict', workerdict)
         self.assertEqual(workerdict,
-                         dict(id=30, name='zero', workerinfo={'a': 'b'},
+                         dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                               configured_on=[
                                   {'masterid': 11, 'builderid': 20},
                          ], connected_to=[]))
@@ -295,7 +295,7 @@ class Tests(interfaces.InterfaceTests):
                                                      builderid=20, masterid=11)
         validation.verifyDbDict(self, 'workerdict', workerdict)
         self.assertEqual(workerdict,
-                         dict(id=30, name='zero', workerinfo={'a': 'b'},
+                         dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                               configured_on=[
                                   {'masterid': 11, 'builderid': 20},
                          ], connected_to=[]))
@@ -307,9 +307,9 @@ class Tests(interfaces.InterfaceTests):
         [validation.verifyDbDict(self, 'workerdict', workerdict)
          for workerdict in workerdicts]
         self.assertEqual(sorted(workerdicts, key=workerKey), sorted([
-            dict(id=30, name='zero', workerinfo={'a': 'b'},
+            dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                  configured_on=[], connected_to=[]),
-            dict(id=31, name='one', workerinfo={'a': 'b'},
+            dict(id=31, name='one', workerinfo={'a': 'b'}, paused=False, graceful=False,
                  configured_on=[], connected_to=[]),
         ], key=workerKey))
 
@@ -322,13 +322,13 @@ class Tests(interfaces.InterfaceTests):
             workerdict['configured_on'] = sorted(
                 workerdict['configured_on'], key=configuredOnKey)
         self.assertEqual(sorted(workerdicts, key=workerKey), sorted([
-            dict(id=30, name='zero', workerinfo={'a': 'b'},
+            dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                  configured_on=sorted([
                      {'masterid': 10, 'builderid': 20},
                      {'masterid': 10, 'builderid': 21},
                      {'masterid': 11, 'builderid': 20},
                  ], key=configuredOnKey), connected_to=[10]),
-            dict(id=31, name='one', workerinfo={'a': 'b'},
+            dict(id=31, name='one', workerinfo={'a': 'b'}, paused=False, graceful=False,
                  configured_on=sorted([
                      {'masterid': 11, 'builderid': 20},
                      {'masterid': 11, 'builderid': 22},
@@ -354,12 +354,12 @@ class Tests(interfaces.InterfaceTests):
             workerdict['configured_on'] = sorted(
                 workerdict['configured_on'], key=configuredOnKey)
         self.assertEqual(sorted(workerdicts, key=workerKey), sorted([
-            dict(id=30, name='zero', workerinfo={'a': 'b'},
+            dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                  configured_on=sorted([
                      {'masterid': 10, 'builderid': 20},
                      {'masterid': 11, 'builderid': 20},
                  ], key=configuredOnKey), connected_to=[10]),
-            dict(id=31, name='one', workerinfo={'a': 'b'},
+            dict(id=31, name='one', workerinfo={'a': 'b'}, paused=False, graceful=False,
                  configured_on=sorted([
                      {'masterid': 11, 'builderid': 20},
                  ], key=configuredOnKey), connected_to=[11]),
@@ -374,7 +374,7 @@ class Tests(interfaces.InterfaceTests):
             workerdict['configured_on'] = sorted(
                 workerdict['configured_on'], key=configuredOnKey)
         self.assertEqual(sorted(workerdicts, key=workerKey), sorted([
-            dict(id=30, name='zero', workerinfo={'a': 'b'},
+            dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                  configured_on=sorted([
                      {'masterid': 10, 'builderid': 20},
                      {'masterid': 10, 'builderid': 21},
@@ -390,11 +390,11 @@ class Tests(interfaces.InterfaceTests):
             workerdict['configured_on'] = sorted(
                 workerdict['configured_on'], key=configuredOnKey)
         self.assertEqual(sorted(workerdicts, key=workerKey), sorted([
-            dict(id=30, name='zero', workerinfo={'a': 'b'},
+            dict(id=30, name='zero', workerinfo={'a': 'b'}, paused=False, graceful=False,
                  configured_on=sorted([
                      {'masterid': 11, 'builderid': 20},
                  ], key=configuredOnKey), connected_to=[]),
-            dict(id=31, name='one', workerinfo={'a': 'b'},
+            dict(id=31, name='one', workerinfo={'a': 'b'}, paused=False, graceful=False,
                  configured_on=sorted([
                      {'masterid': 11, 'builderid': 20},
                      {'masterid': 11, 'builderid': 22},
@@ -411,7 +411,7 @@ class Tests(interfaces.InterfaceTests):
             workerdict['configured_on'] = sorted(
                 workerdict['configured_on'], key=configuredOnKey)
         self.assertEqual(sorted(workerdicts, key=workerKey), sorted([
-            dict(id=31, name='one', workerinfo={'a': 'b'},
+            dict(id=31, name='one', workerinfo={'a': 'b'}, paused=False, graceful=False,
                  configured_on=sorted([
                      {'masterid': 11, 'builderid': 22},
                  ], key=configuredOnKey), connected_to=[11]),
@@ -431,6 +431,8 @@ class Tests(interfaces.InterfaceTests):
             'id': self.W1_ID,
             'name': self.W1_NAME,
             'workerinfo': NEW_INFO,
+            'paused': False,
+            'graceful': False,
             'configured_on': [],
             'connected_to': [11]})
 

--- a/master/buildbot/test/unit/test_db_workers.py
+++ b/master/buildbot/test/unit/test_db_workers.py
@@ -423,6 +423,34 @@ class Tests(interfaces.InterfaceTests):
         ], key=workerKey))
 
     @defer.inlineCallbacks
+    def test_getWorkers_with_paused(self):
+        yield self.insertTestData(self.baseRows + self.multipleMasters)
+        yield self.db.workers.setWorkerState(31, paused=True, graceful=False)
+        workerdicts = yield self.db.workers.getWorkers(
+            paused=True)
+        for workerdict in workerdicts:
+            validation.verifyDbDict(self, 'workerdict', workerdict)
+            workerdict['configured_on'] = []
+        self.assertEqual(workerdicts, [
+            dict(id=31, name='one', workerinfo={'a': 'b'}, paused=True, graceful=False,
+                 configured_on=[], connected_to=[11]),
+        ])
+
+    @defer.inlineCallbacks
+    def test_getWorkers_with_graceful(self):
+        yield self.insertTestData(self.baseRows + self.multipleMasters)
+        yield self.db.workers.setWorkerState(31, paused=False, graceful=True)
+        workerdicts = yield self.db.workers.getWorkers(
+            graceful=True)
+        for workerdict in workerdicts:
+            validation.verifyDbDict(self, 'workerdict', workerdict)
+            workerdict['configured_on'] = []
+        self.assertEqual(workerdicts, [
+            dict(id=31, name='one', workerinfo={'a': 'b'}, paused=False, graceful=True,
+                 configured_on=[], connected_to=[11]),
+        ])
+
+    @defer.inlineCallbacks
     def test_workerConnected_existing(self):
         yield self.insertTestData(self.baseRows + self.worker1_rows)
 

--- a/master/buildbot/test/unit/test_db_workers.py
+++ b/master/buildbot/test/unit/test_db_workers.py
@@ -128,6 +128,11 @@ class Tests(interfaces.InterfaceTests):
         def deconfigureAllWorkersForMaster(self, masterid):
             pass
 
+    def test_signature_setWorkerState(self):
+        @self.assertArgSpecMatches(self.db.workers.setWorkerState)
+        def setWorkerState(self, workerid, paused, graceful):
+            pass
+
     @defer.inlineCallbacks
     def test_findWorkerId_insert(self):
         id = yield self.db.workers.findWorkerId(name=u"xyz")
@@ -470,6 +475,36 @@ class Tests(interfaces.InterfaceTests):
 
         w = yield self.db.workers.getWorker(self.W1_ID)
         self.assertEqual(w['connected_to'], [])
+
+    @defer.inlineCallbacks
+    def test_setWorkerState_existing(self):
+        yield self.insertTestData(self.baseRows + self.worker1_rows)
+
+        yield self.db.workers.setWorkerState(
+            workerid=self.W1_ID, paused=False, graceful=True)
+
+        w = yield self.db.workers.getWorker(self.W1_ID)
+        self.assertEqual(w, {
+            'id': self.W1_ID,
+            'name': self.W1_NAME,
+            'workerinfo': self.W1_INFO,
+            'paused': False,
+            'graceful': True,
+            'configured_on': [],
+            'connected_to': []})
+
+        yield self.db.workers.setWorkerState(
+            workerid=self.W1_ID, paused=True, graceful=False)
+
+        w = yield self.db.workers.getWorker(self.W1_ID)
+        self.assertEqual(w, {
+            'id': self.W1_ID,
+            'name': self.W1_NAME,
+            'workerinfo': self.W1_INFO,
+            'paused': True,
+            'graceful': False,
+            'configured_on': [],
+            'connected_to': []})
 
     @defer.inlineCallbacks
     def test_workerConfigured(self):

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -410,6 +410,8 @@ dbdict['workerdict'] = DictValidator(
             builderid=IntValidator(),
         )
     ),
+    paused=BooleanValidator(),
+    graceful=BooleanValidator(),
     connected_to=ListValidator(IntValidator()),
     workerinfo=JsonValidator(),
 )

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -665,6 +665,8 @@ workers
     * ``id``
     * ``name`` - the name of the worker
     * ``workerinfo`` - worker information as dictionary
+    * ``paused`` - boolean indicating worker is paused and shall not take new builds
+    * ``graceful`` - boolean indicating worker will be shutdown as soon as build finished
     * ``connected_to`` - a list of masters, by ID, to which this worker is currently connected.
       This list will typically contain only one master, but in unusual circumstances the same worker may appear to be connected to multiple masters simultaneously.
     * ``configured_on`` - a list of master-builder pairs, on which this worker is configured.

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -744,6 +744,15 @@ workers
         Unregister all the workers configured to a master for given builders.
         This shall happen when master disabled or before reconfiguration
 
+    .. py:method:: setWorkerState(workerid, paused, graceful)
+
+        :param integer workerid: the ID of the worker whose state is being changed
+        :param integer paused: the paused state
+        :param integer graceful: the graceful state
+        :returns: Deferred
+
+        Change the state of a worker (see definition of states above in worker dict description)
+
 changes
 ~~~~~~~
 

--- a/master/docs/manual/cfg-workers.rst
+++ b/master/docs/manual/cfg-workers.rst
@@ -126,6 +126,43 @@ Note that if you want to have a :class:`MailNotifier` for worker-missing emails 
                           notify_on_missing='bob@example.com')
     ]
 
+
+.. _Worker-states:
+
+Workers States
+++++++++++++++
+
+There are some times when a worker misbehaves because of issues with its configuration.
+In those cases, you may want to pause the worker, or maybe completely shut it down.
+
+There are three actions that you may take (in the worker's web page *Actions* dialog)
+
+- *Pause*: If a worker is paused, it won't accept new builds. The action of pausing a worker will not affect any build ongoing.
+
+- *Graceful Shutdown*: If a worker is in graceful shutdown mode, it won't accept new builds, but will finish the current builds.
+  When all of its build are finished, the :command:`buildbot-worker` process will terminate.
+
+- *Force Shutdown*: If a worker is in force shutdown mode, it will terminate immediately, and the build he was currently doing will be put to retry state.
+
+Those actions will put the worker in two states
+
+- *paused*: the worker is paused if it is connected but doesn't accept new builds.
+- *graceful*: the worker is graceful if it doesn't accept new builds, and will shutdown when builds are finished.
+
+
+A worker might be put to ``paused`` state automatically if buildbot detects a misbehavior.
+This is called the *quarantine timer*.
+
+Quarantine timer is an exponential back-off mechanism for workers.
+This avoids a misbehaving worker to eat the build queue by quickly finishing builds in ``EXCEPTION`` state.
+When misbehavior is detected, the timer will pause the worker for 10 second, and then that time will double at each misbehavior detection, until the worker finishes a build.
+
+The first case of misbehavior is for a latent worker to not start properly.
+The second case of misbehavior is for a build to end with an ``EXCEPTION`` status.
+
+Worker states are stored in the database, can be queried via :ref:`REST_API` and visible in the UI's workers page.
+
+
 .. index:: Workers; local
 
 .. _Local-Workers:

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -473,6 +473,7 @@ MiB
 minified
 minifies
 mis
+misbehaving
 mixin
 Mixins
 mkdir
@@ -621,6 +622,7 @@ Pywin
 qcow
 qmail
 queuedir
+queried
 queueing
 Queueing
 Raml

--- a/www/base/src/app/workers/workeraction.dialog.coffee
+++ b/www/base/src/app/workers/workeraction.dialog.coffee
@@ -12,7 +12,7 @@ class State extends Config
                 url: "/actions",
                 data: group: null
                 ### @ngInject ###
-                onEnter: ($stateParams, $state, $uibModal) ->
+                onEnter: ($stateParams, $state, $uibModal, dataService, $q) ->
                     modal = {}
                     modal.modal = $uibModal.open
                         templateUrl: "views/workeractions.html"
@@ -23,6 +23,12 @@ class State extends Config
                             schedulerid: -> $stateParams.scheduler
                             multiple: -> state.multiple
                             modal: -> modal
+                            workers: ->
+                                d = $q.defer()
+                                dataService.getWorkers(subscribe: false).onChange = (workers) ->
+                                    workers.then = undefined  # angular will try to call it if it exists
+                                    d.resolve(workers)
+                                return d.promise
 
                     goUp = (result) ->
                         $state.go "^",
@@ -30,19 +36,34 @@ class State extends Config
                     modal.modal.result.then(goUp, goUp)
 
 class workerActionsDialog extends Controller
-    constructor: ($scope, config, $state, modal, workerid, multiple, $rootScope, dataService) ->
+    constructor: ($scope, config, $state, modal, workerid, multiple, $rootScope, $q, workers) ->
         $scope.select_options = []
         $scope.worker_selection = []
-        dataService.getWorkers(subscribe: false).onChange = (workers) ->
-            if not multiple
-                worker = workers.get(workerid)
-                $scope.worker_selection.push(worker.name)
-            angular.extend $scope,
-                multiple: multiple
-                worker: worker
-                select_options: (worker.name for worker in workers)
-                action: (a)->
-                    worker.control(a, reason: $scope.reason).then (res) ->
-                        modal.modal.close(res.result)
-                cancel: ->
-                    modal.modal.dismiss()
+        if not multiple
+            worker = workers.get(workerid)
+            $scope.worker_selection.push(worker.name)
+            $scope.stop_disabled = worker.connected_to.length == 0
+            $scope.pause_disabled = worker.paused
+            $scope.unpause_disabled = not worker.paused
+        else
+            $scope.stop_disabled = false
+            $scope.pause_disabled = false
+            $scope.unpause_disabled = false
+        angular.extend $scope,
+            multiple: multiple
+            worker: worker
+            select_options: (w.name for w in workers)
+            action: (a)->
+                dl = []
+                workers.forEach (w) ->
+                    if w.name in $scope.worker_selection
+                        p = w.control(a, reason: $scope.reason)
+                        p.catch (err) ->
+                            msg = "unable to #{a} worker #{w.name}:"
+                            msg += err.error.message
+                            $scope.error = msg
+                        dl.push(p)
+                $q.all(dl).then (res) ->
+                    modal.modal.close(res.result)
+            cancel: ->
+                modal.modal.dismiss()

--- a/www/base/src/app/workers/workeractions.tpl.jade
+++ b/www/base/src/app/workers/workeractions.tpl.jade
@@ -1,7 +1,7 @@
 .modal-content
     .modal-header
         // put the header in the body in order to correctly display error popup
-        h4(ng-if="multiple") 
+        h4(ng-show="multiple")
             .col-sm-4 Worker actions for...
             .col-sm-8
                 multiselect(ng-model="worker_selection" options="select_options" show-select-all="true" show-unselect-all="true" show-search="true")
@@ -16,7 +16,7 @@
                 textarea.form-control(rows="15", ng-model="reason")
     .modal-footer
       button.btn.btn-default(ng-click="cancel()") Cancel
-      button.btn.btn-primary(ng-click="action('stop')") Graceful Shutdown
-      button.btn.btn-primary(ng-click="action('kill')") Force Shutdown
-      button.btn.btn-primary(ng-click="action('pause')") Pause
-      button.btn.btn-primary(ng-click="action('unpause')") Unpause
+      button.btn.btn-primary(ng-click="action('stop')",ng-class="{disabled: stop_disabled}") Graceful Shutdown
+      button.btn.btn-primary(ng-click="action('kill')",ng-class="{disabled: stop_disabled}") Force Shutdown
+      button.btn.btn-primary(ng-click="action('pause')",ng-class="{disabled: pause_disabled}") Pause
+      button.btn.btn-primary(ng-click="action('unpause')",ng-class="{disabled: unpause_disabled}") Unpause

--- a/www/base/src/app/workers/workers.tpl.jade
+++ b/www/base/src/app/workers/workers.tpl.jade
@@ -2,22 +2,28 @@
     .row
         table.table.table-hover.table-striped.table-condensed
             tr
+                th State
                 th Masters
                 th WorkerName
                 th Recent Builds
                 th(ng-if="settings.showWorkerBuilders.value") Builders
                 th(ng-repeat="info in worker_infos") {{ capitalize(info) }}
-                    
+
             tr(ng-repeat='worker in workers | orderBy: ["-num_connections", "name"]',
                ng-hide="maybeHideWorker(worker)")
-                td 
+                td
+                    a(ui-sref='worker.actions({worker: worker.workerid})')
+                        i.fa.fa-pause(ng-if="worker.paused", title="paused") &nbsp;
+                        i.fa.fa-stop(ng-if="worker.graceful", title="graceful shutdown")
+                        i.fa.fa-smile-o(ng-if="!worker.paused && !worker.graceful && worker.num_connections")
+                td
                     div(ng-hide="worker.num_connections")
                         i.fa.fa-times.text-danger(title="disconnected")
                     div(ng-repeat="masterid in worker.connected_to")
                         a(ui-sref="master({master:masterid.masterid})")
                             span.badge-status.results_SUCCESS(title="{{ masters.get(masterid.masterid).name }}")
                                 | {{ masterid.masterid }}
-                td 
+                td
                     a(ui-sref='worker({worker: worker.workerid})')
                         | {{worker.name}}
                 td

--- a/www/data_module/guanlecoja/config.coffee
+++ b/www/data_module/guanlecoja/config.coffee
@@ -13,7 +13,7 @@ gulp.task "publish", ['default'], ->
     exec "git clone git@github.com:buildbot/buildbot-data-js.git"
     bower_json =
         name: "buildbot-data"
-        version: "2.2.2"
+        version: "2.2.3"
         main: ["buildbot-data.js"]
         moduleType: [],
         license: "MIT",

--- a/www/data_module/src/classes/base.service.coffee
+++ b/www/data_module/src/classes/base.service.coffee
@@ -24,7 +24,7 @@ class Base extends Factory
                 @$accessor = a
 
             update: (o) ->
-                angular.merge(this, o)
+                angular.extend(this, o)
 
             get: (args...) ->
                 dataService.get(@_endpoint, @_id, args...)


### PR DESCRIPTION
Now the pause and graceful states are stored in DB, and thus available in the UI.

Fixes #3429
