### PR TITLE
Upgrade to Guanlecoja-ui 1.8.0; Waterfall body height fix

### DIFF
--- a/master/buildbot/newsfragments/dialog-jump.bugfix
+++ b/master/buildbot/newsfragments/dialog-jump.bugfix
@@ -1,0 +1,1 @@
+Upgrading to `guanlecoja-ui` version 1.8.0, fixing two issues.  Fixed issue where the console view would jump to the top of page when opening the build summary dialog (#3657).  Also improved sidebar behaviour by remembering previous pinned vs. collapsed state.

--- a/www/base/guanlecoja/config.coffee
+++ b/www/base/guanlecoja/config.coffee
@@ -30,7 +30,7 @@ config =
         # JavaScript libraries (order matters)
         deps:
             "guanlecoja-ui":
-                version: '~1.7.1'
+                version: '~1.8.0'
                 files: ['vendors.js', 'scripts.js']
             moment:
                 version: "~2.6.0"

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -8,6 +8,19 @@
   display: none !important;
 }
 
+// Dashboards which use SVG to draw contents such as waterfall may require
+//  setting  body height to 100vh. (100% of viewport height)
+//  e.g. Waterfall uses this, otherwise the contents do not appear. 
+// The controller dynamically adds and removes this class to body
+//   when entering and leaving Waterfall.
+//
+//  (note: adding height:100vh to a div also would solve this problem 
+//   except that causes the dialogs to make the SVG disappear due to 
+//   the dialog setting the body to overflow:hidden via modal-open rule.)
+body.hundredpercent {
+  height: 100vh;
+}
+
 /* modal dialog customizations */
 @media screen {
   .modal-xlg {

--- a/www/waterfall_view/src/module/main.module.coffee
+++ b/www/waterfall_view/src/module/main.module.coffee
@@ -31,9 +31,9 @@ class Waterfall extends Controller
         #  class needs to removed upon exiting the waterfall via the $destroy
         #  event below.)
         body = @$rootElement.find("body")
-        body.addClass("waterfall")
+        body.addClass("hundredpercent")
         @$scope.$on("$destroy", ()=>
-            body.removeClass("waterfall")
+            body.removeClass("hundredpercent")
         );
 
         glTopbarContextualActionsService.setContextualActions(actions)

--- a/www/waterfall_view/src/module/main.module.coffee
+++ b/www/waterfall_view/src/module/main.module.coffee
@@ -10,7 +10,7 @@ class WaterfallView extends App
 
 class Waterfall extends Controller
     self = null
-    constructor: (@$scope, $q, $timeout, @$window, @$log,
+    constructor: (@$rootElement, @$scope, $q, $timeout, @$window, @$log,
                   @$uibModal, dataService, d3Service, @dataProcessorService,
                   scaleService, @bbSettingsService, glTopbarContextualActionsService) ->
         self = this
@@ -23,6 +23,19 @@ class Waterfall extends Controller
             icon: "search-minus"
             action: @zoomMinus
         ]
+
+        # 'waterfall' class needs to be dynamically added to the body in order 
+        #  to support waterfall-specific styling of the body.  (this is a bit
+        #  awkward since the body is provided by guanlecoja-ui and is the same
+        #  element as you switch between different plugin pages, therefore the
+        #  class needs to removed upon exiting the waterfall via the $destroy
+        #  event below.)
+        body = @$rootElement.find("body")
+        body.addClass("waterfall")
+        @$scope.$on("$destroy", ()=>
+            body.removeClass("waterfall")
+        );
+
         glTopbarContextualActionsService.setContextualActions(actions)
 
         # Show the loading spinner

--- a/www/waterfall_view/src/styles/styles.less
+++ b/www/waterfall_view/src/styles/styles.less
@@ -10,6 +10,7 @@
   width: auto;
   overflow-x: auto;
   overflow-y: hidden;
+  height: 100vh;
 
   .load-indicator {
     position: fixed;

--- a/www/waterfall_view/src/styles/styles.less
+++ b/www/waterfall_view/src/styles/styles.less
@@ -1,17 +1,6 @@
 @navbar-height: 52px;
 @main-color: #3498db;
 
-// Waterfall requires height:100%, otherwise nothing appears.
-// The controller dynamically adds and removes this class to body
-//   when entering and leaving Waterfall.
-//
-//  (note: adding height:100vh to .waterfall div also would solve this problem 
-//   except that causes the dialogs to make the SVG disappear due to 
-//   the dialog setting the body to overflow:hidden via modal-open rule.)
-body.waterfall {
-  height: 100%;
-}
-
 .waterfall {
   position: absolute;
   top: @navbar-height;

--- a/www/waterfall_view/src/styles/styles.less
+++ b/www/waterfall_view/src/styles/styles.less
@@ -1,6 +1,17 @@
 @navbar-height: 52px;
 @main-color: #3498db;
 
+// Waterfall requires height:100%, otherwise nothing appears.
+// The controller dynamically adds and removes this class to body
+//   when entering and leaving Waterfall.
+//
+//  (note: adding height:100vh to .waterfall div also would solve this problem 
+//   except that causes the dialogs to make the SVG disappear due to 
+//   the dialog setting the body to overflow:hidden via modal-open rule.)
+body.waterfall {
+  height: 100%;
+}
+
 .waterfall {
   position: absolute;
   top: @navbar-height;
@@ -10,7 +21,6 @@
   width: auto;
   overflow-x: auto;
   overflow-y: hidden;
-  height: 100vh;
 
   .load-indicator {
     position: fixed;


### PR DESCRIPTION
@tardyp, here are the changes which upgrade to `guanlecoja-ui` version 1.8.0 on buildbot, and also keep those changes from causing the waterfall view to be broken.

With regards to the waterfall view, I took a different approach then previously discussed.  The `.waterfall { height : 100vh }` trick did not work perfectly.   When testing the waterfall view with this 100vh rule in place, I noticed that when you clicked a build and brought up the dialog, everything in the background would disappear.   I think what was happening is that the angular-bootstrap modal has some javascript which dynamically adds the class `modal-open` onto the `body`, and this class sets `overflow:hidden`.   I suppose setting the `100vh` on the waterfall div was not causing the body to grow, and therefore most of the contents of the div were considered "overflow".

So instead of using `.waterfall{height:100vh}` I went back to the idea of setting waterfall-specific rules on the body.   Originally I was thinking that was a dirty thing to do, but upon discovering the way that angular-bootstrap dynamically adds/removes the`modal-open` class to `body`, I loosened my judgement of the morality of doing the same thing myself.

I accomplished this by having the waterfall controller's constructor add the class `waterfall` to the body.  It also needs to remove this when you leave the waterfall page so I did this on the waterfall's scope`s $destroy event.  The `body.waterfall` rule sets the `height:100%` which makes the waterfall work correctly but was causing the scroll-jump problem in Console.    Interestingly, even with `height:100%`, the waterfall does not exhibit the problem.


