### PR TITLE
Fix version when installing from git archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+master/buildbot/__init__.py             export-subst
+pkg/buildbot_pkg.py                     export-subst
+worker/buildbot_worker/__init__.py      export-subst

--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -557,6 +557,7 @@ getworkerinfo
 gf
 gib
 giger
+gitattributes
 github
 gitlab
 gitorious

--- a/master/buildbot/__init__.py
+++ b/master/buildbot/__init__.py
@@ -61,6 +61,34 @@ def mTimeVersion(init_file):
     return d.strftime("%Y.%m.%d")
 
 
+def getVersionFromArchiveId(git_archive_id='$Format:%ct %d$'):
+    """ Extract the tag if a source is from git archive.
+
+        When source is exported via `git archive`, the git_archive_id init value is modified
+        and placeholders are expanded to the "archived" revision:
+
+            %ct: committer date, UNIX timestamp
+            %d: ref names, like the --decorate option of git-log
+
+        See man gitattributes(5) and git-log(1) (PRETTY FORMATS) for more details.
+    """
+    # mangle the magic string to make sure it is not replaced by git archive
+    if not git_archive_id.startswith('$For''mat:'):
+        # source was modified by git archive, try to parse the version from
+        # the value of git_archive_id
+
+        match = re.search(r'tag:\s*v([^,)]+)', git_archive_id)
+        if match:
+            # archived revision is tagged, use the tag
+            return gitDescribeToPep440(match.group(1))
+
+        # archived revision is not tagged, use the commit date
+        tstamp = git_archive_id.strip().split()[0]
+        d = datetime.datetime.fromtimestamp(int(tstamp))
+        return d.strftime('%Y.%m.%d')
+    return None
+
+
 def getVersion(init_file):
     """
     Return BUILDBOT_VERSION environment variable, content of VERSION file, git
@@ -80,28 +108,9 @@ def getVersion(init_file):
     except IOError:
         pass
 
-    # When source is exported via `git archive`, the following line is modified
-    # and placeholders are expanded to the "archived" revision:
-    #
-    #     %ct: committer date, UNIX timestamp
-    #     %d: ref names, like the --decorate option of git-log
-    #
-    # See man gitattributes(5) and git-log(1) (PRETTY FORMATS) for more details.
-    git_archive_id = '$Format:%ct %d$'
-
-    if not git_archive_id.startswith('$Format:'):
-        # source was modified by git archive, try to parse the version from
-        # the value of git_archive_id
-
-        match = re.search(r'tag:\s*v([^,)]+)', git_archive_id)
-        if match:
-            # archived revision is tagged, use the tag
-            return match.group(1)
-
-        # archived revision is not tagged, use the commit date
-        tstamp = git_archive_id.strip().split()[0]
-        d = datetime.datetime.fromtimestamp(int(tstamp))
-        return d.strftime('%Y.%m.%d')
+    version = getVersionFromArchiveId()
+    if version is not None:
+        return version
 
     try:
         p = Popen(['git', 'describe', '--tags', '--always'], stdout=PIPE, stderr=STDOUT, cwd=cwd)

--- a/master/buildbot/test/unit/test_version.py
+++ b/master/buildbot/test/unit/test_version.py
@@ -18,19 +18,38 @@ from __future__ import print_function
 
 from twisted.trial import unittest
 
-from buildbot import gitDescribeToPep440
+
+class VersioningUtilsTests(unittest.SynchronousTestCase):
+    # Version utils are copied in three packages.
+    # this unit test is made to be able to test the three versions
+    # with the same test
+    module_under_test = "buildbot"
+
+    def setUp(self):
+        self.m = __import__(self.module_under_test)
+
+    def test_gitDescribeToPep440devVersion(self):
+        self.assertEqual(self.m.gitDescribeToPep440("v0.9.8-20-gf0f45ca"), "0.9.9-dev20")
+
+    def test_gitDescribeToPep440tag(self):
+        self.assertEqual(self.m.gitDescribeToPep440("v0.9.8"), "0.9.8")
+
+    def test_gitDescribeToPep440p1tag(self):
+        self.assertEqual(self.m.gitDescribeToPep440("v0.9.9.post1"), "0.9.9.post1")
+
+    def test_gitDescribeToPep440p1dev(self):
+        self.assertEqual(self.m.gitDescribeToPep440("v0.9.9.post1-20-gf0f45ca"), "0.9.10-dev20")
+
+    def test_getVersionFromArchiveIdNoTag(self):
+        self.assertEqual(self.m.getVersionFromArchiveId("1514651968  (git-archive-version)"), "2017.12.30")
+
+    def test_getVersionFromArchiveIdtag(self):
+        self.assertEqual(self.m.getVersionFromArchiveId('1514808197  (HEAD -> master, tag: v1.0.0)'), "1.0.0")
 
 
-class GitDescribeToPep440(unittest.SynchronousTestCase):
+class VersioningUtilsTests_PKG(VersioningUtilsTests):
+    module_under_test = "buildbot_pkg"
 
-    def test_devVersion(self):
-        self.assertEqual(gitDescribeToPep440("v0.9.8-20-gf0f45ca"), "0.9.9-dev20")
 
-    def test_tag(self):
-        self.assertEqual(gitDescribeToPep440("v0.9.8"), "0.9.8")
-
-    def test_p1tag(self):
-        self.assertEqual(gitDescribeToPep440("v0.9.9.post1"), "0.9.9.post1")
-
-    def test_p1dev(self):
-        self.assertEqual(gitDescribeToPep440("v0.9.9.post1-20-gf0f45ca"), "0.9.10-dev20")
+class VersioningUtilsTests_WORKER(VersioningUtilsTests):
+    module_under_test = "buildbot_worker"

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -86,6 +86,34 @@ def mTimeVersion(init_file):
     return d.strftime("%Y.%m.%d")
 
 
+def getVersionFromArchiveId(git_archive_id='$Format:%ct %d$'):
+    """ Extract the tag if a source is from git archive.
+
+        When source is exported via `git archive`, the git_archive_id init value is modified
+        and placeholders are expanded to the "archived" revision:
+
+            %ct: committer date, UNIX timestamp
+            %d: ref names, like the --decorate option of git-log
+
+        See man gitattributes(5) and git-log(1) (PRETTY FORMATS) for more details.
+    """
+    # mangle the magic string to make sure it is not replaced by git archive
+    if not git_archive_id.startswith('$For''mat:'):
+        # source was modified by git archive, try to parse the version from
+        # the value of git_archive_id
+
+        match = re.search(r'tag:\s*v([^,)]+)', git_archive_id)
+        if match:
+            # archived revision is tagged, use the tag
+            return gitDescribeToPep440(match.group(1))
+
+        # archived revision is not tagged, use the commit date
+        tstamp = git_archive_id.strip().split()[0]
+        d = datetime.datetime.fromtimestamp(int(tstamp))
+        return d.strftime('%Y.%m.%d')
+    return None
+
+
 def getVersion(init_file):
     """
     Return BUILDBOT_VERSION environment variable, content of VERSION file, git
@@ -105,28 +133,9 @@ def getVersion(init_file):
     except IOError:
         pass
 
-    # When source is exported via `git archive`, the following line is modified
-    # and placeholders are expanded to the "archived" revision:
-    #
-    #     %ct: committer date, UNIX timestamp
-    #     %d: ref names, like the --decorate option of git-log
-    #
-    # See man gitattributes(5) and git-log(1) (PRETTY FORMATS) for more details.
-    git_archive_id = '$Format:%ct %d$'
-
-    if not git_archive_id.startswith('$Format:'):
-        # source was modified by git archive, try to parse the version from
-        # the value of git_archive_id
-
-        match = re.search(r'tag:\s*v([^,)]+)', git_archive_id)
-        if match:
-            # archived revision is tagged, use the tag
-            return match.group(1)
-
-        # archived revision is not tagged, use the commit date
-        tstamp = git_archive_id.strip().split()[0]
-        d = datetime.datetime.fromtimestamp(int(tstamp))
-        return d.strftime('%Y.%m.%d')
+    version = getVersionFromArchiveId()
+    if version is not None:
+        return version
 
     try:
         p = Popen(['git', 'describe', '--tags', '--always'], stdout=PIPE, stderr=STDOUT, cwd=cwd)

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -105,6 +105,29 @@ def getVersion(init_file):
     except IOError:
         pass
 
+    # When source is exported via `git archive`, the following line is modified
+    # and placeholders are expanded to the "archived" revision:
+    #
+    #     %ct: committer date, UNIX timestamp
+    #     %d: ref names, like the --decorate option of git-log
+    #
+    # See man gitattributes(5) and git-log(1) (PRETTY FORMATS) for more details.
+    git_archive_id = '$Format:%ct %d$'
+
+    if not git_archive_id.startswith('$Format:'):
+        # source was modified by git archive, try to parse the version from
+        # the value of git_archive_id
+
+        match = re.search(r'tag:\s*v([^,)]+)', git_archive_id)
+        if match:
+            # archived revision is tagged, use the tag
+            return match.group(1)
+
+        # archived revision is not tagged, use the commit date
+        tstamp = git_archive_id.strip().split()[0]
+        d = datetime.datetime.fromtimestamp(int(tstamp))
+        return d.strftime('%Y.%m.%d')
+
     try:
         p = Popen(['git', 'describe', '--tags', '--always'], stdout=PIPE, stderr=STDOUT, cwd=cwd)
         out = p.communicate()[0]

--- a/worker/buildbot_worker/__init__.py
+++ b/worker/buildbot_worker/__init__.py
@@ -63,6 +63,34 @@ def mTimeVersion(init_file):
     return d.strftime("%Y.%m.%d")
 
 
+def getVersionFromArchiveId(git_archive_id='$Format:%ct %d$'):
+    """ Extract the tag if a source is from git archive.
+
+        When source is exported via `git archive`, the git_archive_id init value is modified
+        and placeholders are expanded to the "archived" revision:
+
+            %ct: committer date, UNIX timestamp
+            %d: ref names, like the --decorate option of git-log
+
+        See man gitattributes(5) and git-log(1) (PRETTY FORMATS) for more details.
+    """
+    # mangle the magic string to make sure it is not replaced by git archive
+    if not git_archive_id.startswith('$For''mat:'):
+        # source was modified by git archive, try to parse the version from
+        # the value of git_archive_id
+
+        match = re.search(r'tag:\s*v([^,)]+)', git_archive_id)
+        if match:
+            # archived revision is tagged, use the tag
+            return gitDescribeToPep440(match.group(1))
+
+        # archived revision is not tagged, use the commit date
+        tstamp = git_archive_id.strip().split()[0]
+        d = datetime.datetime.fromtimestamp(int(tstamp))
+        return d.strftime('%Y.%m.%d')
+    return None
+
+
 def getVersion(init_file):
     """
     Return BUILDBOT_VERSION environment variable, content of VERSION file, git
@@ -82,28 +110,9 @@ def getVersion(init_file):
     except IOError:
         pass
 
-    # When source is exported via `git archive`, the following line is modified
-    # and placeholders are expanded to the "archived" revision:
-    #
-    #     %ct: committer date, UNIX timestamp
-    #     %d: ref names, like the --decorate option of git-log
-    #
-    # See man gitattributes(5) and git-log(1) (PRETTY FORMATS) for more details.
-    git_archive_id = '$Format:%ct %d$'
-
-    if not git_archive_id.startswith('$Format:'):
-        # source was modified by git archive, try to parse the version from
-        # the value of git_archive_id
-
-        match = re.search(r'tag:\s*v([^,)]+)', git_archive_id)
-        if match:
-            # archived revision is tagged, use the tag
-            return match.group(1)
-
-        # archived revision is not tagged, use the commit date
-        tstamp = git_archive_id.strip().split()[0]
-        d = datetime.datetime.fromtimestamp(int(tstamp))
-        return d.strftime('%Y.%m.%d')
+    version = getVersionFromArchiveId()
+    if version is not None:
+        return version
 
     try:
         p = Popen(['git', 'describe', '--tags', '--always'], stdout=PIPE, stderr=STDOUT, cwd=cwd)

--- a/worker/buildbot_worker/__init__.py
+++ b/worker/buildbot_worker/__init__.py
@@ -82,6 +82,29 @@ def getVersion(init_file):
     except IOError:
         pass
 
+    # When source is exported via `git archive`, the following line is modified
+    # and placeholders are expanded to the "archived" revision:
+    #
+    #     %ct: committer date, UNIX timestamp
+    #     %d: ref names, like the --decorate option of git-log
+    #
+    # See man gitattributes(5) and git-log(1) (PRETTY FORMATS) for more details.
+    git_archive_id = '$Format:%ct %d$'
+
+    if not git_archive_id.startswith('$Format:'):
+        # source was modified by git archive, try to parse the version from
+        # the value of git_archive_id
+
+        match = re.search(r'tag:\s*v([^,)]+)', git_archive_id)
+        if match:
+            # archived revision is tagged, use the tag
+            return match.group(1)
+
+        # archived revision is not tagged, use the commit date
+        tstamp = git_archive_id.strip().split()[0]
+        d = datetime.datetime.fromtimestamp(int(tstamp))
+        return d.strftime('%Y.%m.%d')
+
     try:
         p = Popen(['git', 'describe', '--tags', '--always'], stdout=PIPE, stderr=STDOUT, cwd=cwd)
         out = p.communicate()[0]


### PR DESCRIPTION
When installing from a git archive downloaded from github, the file `master/buildbot/VERSION` is not present since it is generated when building source archive with:

```
./setup.py sdist
```

We also do not have access to git.

To work around the problem, use the export-subst git attribute to make git archive write the current revison information in various files and parse this to try and detect a version.

> From: https://git-scm.com/docs/gitattributes
> 
> `export-subst`
> 
> If the attribute `export-subst` is set for a file then Git will expand several placeholders when adding this file to an archive. The expansion depends on the availability of a commit ID, i.e., if [git-archive[1]](https://git-scm.com/docs/git-archive) has been given a tree instead of a commit or a tag then no replacement will be done. The placeholders are the same as those for the option `--pretty=format:` of [git-log[1]](https://git-scm.com/docs/git-log), except that they need to be wrapped like this: `$Format:PLACEHOLDERS$` in the file. E.g. the string `$Format:%H$` will be replaced by the commit hash.

If the archived revision is tagged, the tag will be used as version otherwise `99.dev.$commitid` will be used. If the code is not issued from a `git archive`, the version will be extracted from git describe as it was already done before.