### PR TITLE
In the buildbot worker only, force string literals on Python 2 to be unicode, like on Python 3

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -687,7 +687,7 @@ class Try(pb.Referenceable):
         ss = self.sourcestamp
         output("Delivering job; comment=", self.comment)
 
-        d = remote.callRemote("try",
+        d = remote.callRemote(b"try",
                               ss.branch,
                               ss.revision,
                               ss.patch,
@@ -722,7 +722,7 @@ class Try(pb.Referenceable):
         if res:
             self.buildsetStatus = res
         # gather the set of BuildRequests
-        d = self.buildsetStatus.callRemote("getBuildRequests")
+        d = self.buildsetStatus.callRemote(b"getBuildRequests")
         d.addCallback(self._getStatus_2)
 
     def _getStatus_2(self, brs):
@@ -758,7 +758,7 @@ class Try(pb.Referenceable):
             self.ETA[n] = None
             # get new Builds for this buildrequest. We follow each one until
             # it finishes or is interrupted.
-            br.callRemote("subscribe", self)
+            br.callRemote(b"subscribe", self)
 
         # now that those queries are in transit, we can start the
         # display-status-every-30-seconds loop
@@ -770,10 +770,10 @@ class Try(pb.Referenceable):
 
     def remote_newbuild(self, bs, builderName):
         if self.builds[builderName]:
-            self.builds[builderName].callRemote("unsubscribe", self)
+            self.builds[builderName].callRemote(b"unsubscribe", self)
         self.builds[builderName] = bs
-        bs.callRemote("subscribe", self, 20)
-        d = bs.callRemote("waitUntilFinished")
+        bs.callRemote(b"subscribe", self, 20)
+        d = bs.callRemote(b"waitUntilFinished")
         d.addCallback(self._build_finished, builderName)
 
     def remote_stepStarted(self, buildername, build, stepname, step):
@@ -792,13 +792,13 @@ class Try(pb.Referenceable):
         self.builds[builderName] = None
         self.ETA[builderName] = None
         self.currentStep[builderName] = "finished"
-        d = bs.callRemote("getResults")
+        d = bs.callRemote(b"getResults")
         d.addCallback(self._build_finished_2, bs, builderName)
         return d
 
     def _build_finished_2(self, results, bs, builderName):
         self.results[builderName][0] = results
-        d = bs.callRemote("getText")
+        d = bs.callRemote(b"getText")
         d.addCallback(self._build_finished_3, builderName)
         return d
 
@@ -876,7 +876,7 @@ class Try(pb.Referenceable):
             "unknown connecttype '%s', should be 'pb'" % self.connect)
 
     def _getBuilderNames(self, remote):
-        d = remote.callRemote("getAvailableBuilderNames")
+        d = remote.callRemote(b"getAvailableBuilderNames")
         d.addCallback(self._getBuilderNames2)
         d.addCallback(lambda _: remote.broker.transport.loseConnection())
         return d

--- a/master/buildbot/clients/usersclient.py
+++ b/master/buildbot/clients/usersclient.py
@@ -45,7 +45,7 @@ class UsersClient(object):
 
         @d.addCallback
         def call_commandline(remote):
-            d = remote.callRemote("commandline", op, bb_username,
+            d = remote.callRemote(b"commandline", op, bb_username,
                                   bb_password, ids, info)
 
             @d.addCallback

--- a/master/buildbot/newsfragments/unicode_literals.feature
+++ b/master/buildbot/newsfragments/unicode_literals.feature
@@ -1,0 +1,1 @@
+String literals in the buildbot worker code are now forced to be unicode on Python 2 by importing :py:class:`__future__.unicode_literals`.  This will facilitate writing code in the buildbot worker which is compatible on Python 2 and 3.

--- a/worker/buildbot_worker/__init__.py
+++ b/worker/buildbot_worker/__init__.py
@@ -20,6 +20,7 @@
 
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 
 import os

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -198,7 +198,7 @@ class WorkerForBuilderBase(service.Service):
         if self.remoteStep:
             update = [data, 0]
             updates = [update]
-            d = self.remoteStep.callRemote("update", updates)
+            d = self.remoteStep.callRemote(b"update", updates)
             d.addCallback(self.ackUpdate)
             d.addErrback(self._ackFailed, "WorkerForBuilder.sendUpdate")
 
@@ -230,7 +230,7 @@ class WorkerForBuilderBase(service.Service):
             return
         if self.remoteStep:
             self.remoteStep.dontNotifyOnDisconnect(self.lostRemoteStep)
-            d = self.remoteStep.callRemote("complete", failure)
+            d = self.remoteStep.callRemote(b"complete", failure)
             d.addCallback(self.ackComplete)
             d.addErrback(self._ackFailed, "sendComplete")
             self.remoteStep = None

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import multiprocessing
 import os.path

--- a/worker/buildbot_worker/bot.py
+++ b/worker/buildbot_worker/bot.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from buildbot_worker.null import LocalWorker
 from buildbot_worker.pb import Worker

--- a/worker/buildbot_worker/commands/base.py
+++ b/worker/buildbot_worker/commands/base.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from twisted.internet import defer
 from twisted.internet import reactor

--- a/worker/buildbot_worker/commands/fs.py
+++ b/worker/buildbot_worker/commands/fs.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import glob
 import os

--- a/worker/buildbot_worker/commands/registry.py
+++ b/worker/buildbot_worker/commands/registry.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import buildbot_worker.commands.fs
 import buildbot_worker.commands.shell

--- a/worker/buildbot_worker/commands/shell.py
+++ b/worker/buildbot_worker/commands/shell.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -112,10 +112,10 @@ class WorkerFileUploadCommand(TransferCommand):
             if self.fp:
                 self.fp.close()
             self.fp = None
-            d1 = self.writer.callRemote("close")
+            d1 = self.writer.callRemote(b"close")
 
             def _utime_ok(res):
-                return self.writer.callRemote("utime", accessed_modified)
+                return self.writer.callRemote(b"utime", accessed_modified)
             if self.keepstamp:
                 d1.addCallback(_utime_ok)
             return d1
@@ -126,7 +126,7 @@ class WorkerFileUploadCommand(TransferCommand):
                 self.fp.close()
             self.fp = None
             # call remote's close(), but keep the existing failure
-            d1 = self.writer.callRemote("close")
+            d1 = self.writer.callRemote(b"close")
 
             def eb(f2):
                 log.msg("ignoring error from remote close():")
@@ -184,7 +184,7 @@ class WorkerFileUploadCommand(TransferCommand):
         if self.remaining is not None:
             self.remaining = self.remaining - len(data)
             assert self.remaining >= 0
-        d = self.writer.callRemote('write', data)
+        d = self.writer.callRemote(b'write', data)
         d.addCallback(lambda res: False)
         return d
 
@@ -239,7 +239,7 @@ class WorkerDirectoryUploadCommand(WorkerFileUploadCommand):
         self._reactor.callLater(0, self._loop, d)
 
         def unpack(res):
-            d1 = self.writer.callRemote("unpack")
+            d1 = self.writer.callRemote(b"unpack")
 
             def unpack_err(f):
                 self.rc = 1
@@ -326,7 +326,7 @@ class WorkerFileDownloadCommand(TransferCommand):
 
         def _close(res):
             # close the file, but pass through any errors from _loop
-            d1 = self.reader.callRemote('close')
+            d1 = self.reader.callRemote(b'close')
             d1.addErrback(log.err, 'while trying to close reader')
             d1.addCallback(lambda ignored: res)
             return d1
@@ -367,7 +367,7 @@ class WorkerFileDownloadCommand(TransferCommand):
                 self.rc = 1
             return True
         else:
-            d = self.reader.callRemote('read', length)
+            d = self.reader.callRemote(b'read', length)
             d.addCallback(self._writeData)
             return d
 

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import tarfile

--- a/worker/buildbot_worker/commands/utils.py
+++ b/worker/buildbot_worker/commands/utils.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 from future.utils import text_type
 
 import os

--- a/worker/buildbot_worker/compat.py
+++ b/worker/buildbot_worker/compat.py
@@ -21,6 +21,7 @@ between Python 2 and Python 3.
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 from future.utils import text_type
 
 if str != bytes:

--- a/worker/buildbot_worker/exceptions.py
+++ b/worker/buildbot_worker/exceptions.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 
 class AbandonChain(Exception):

--- a/worker/buildbot_worker/interfaces.py
+++ b/worker/buildbot_worker/interfaces.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from zope.interface import Interface
 

--- a/worker/buildbot_worker/monkeypatches/testcase_assert.py
+++ b/worker/buildbot_worker/monkeypatches/testcase_assert.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 from future.utils import string_types
 
 import re

--- a/worker/buildbot_worker/null.py
+++ b/worker/buildbot_worker/null.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from twisted.internet import defer
 

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os.path
 import signal

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -139,7 +139,7 @@ class BotFactory(ReconnectingPBClientFactory):
             # Send the keepalive request.  If an error occurs
             # was already dropped, so just log and ignore.
             log.msg("sending app-level keepalive")
-            d = self.perspective.callRemote("keepalive")
+            d = self.perspective.callRemote(b"keepalive")
             d.addErrback(log.err, "error sending keepalive")
         self.keepaliveTimer = self._reactor.callLater(self.keepaliveInterval,
                                                       doKeepalive)
@@ -255,7 +255,7 @@ class Worker(WorkerBase, service.MultiService):
 
         log.msg(
             "Telling the master we want to shutdown after any running builds are finished")
-        d = self.bf.perspective.callRemote("shutdown")
+        d = self.bf.perspective.callRemote(b"shutdown")
 
         def _shutdownfailed(err):
             if err.check(AttributeError):

--- a/worker/buildbot_worker/pbutil.py
+++ b/worker/buildbot_worker/pbutil.py
@@ -19,6 +19,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 from future.utils import iteritems
 
 from twisted.cred import error

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -19,6 +19,7 @@ Support for running 'shell commands'
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 from future.builtins import range
 from future.utils import iteritems
 from future.utils import string_types

--- a/worker/buildbot_worker/scripts/base.py
+++ b/worker/buildbot_worker/scripts/base.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 

--- a/worker/buildbot_worker/scripts/create_worker.py
+++ b/worker/buildbot_worker/scripts/create_worker.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 

--- a/worker/buildbot_worker/scripts/create_worker.py
+++ b/worker/buildbot_worker/scripts/create_worker.py
@@ -205,7 +205,7 @@ def createWorker(config):
 
     asd = config['allow-shutdown']
     if asd:
-        config['allow-shutdown'] = repr(asd)
+        config['allow-shutdown'] = repr(str(asd))
 
     if config['no-logrotate']:
         workerTAC = "".join([workerTACTemplate[0]] + workerTACTemplate[2:])

--- a/worker/buildbot_worker/scripts/logwatcher.py
+++ b/worker/buildbot_worker/scripts/logwatcher.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import platform

--- a/worker/buildbot_worker/scripts/restart.py
+++ b/worker/buildbot_worker/scripts/restart.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from buildbot_worker.scripts import base
 from buildbot_worker.scripts import start

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -222,7 +222,7 @@ class Options(usage.Options):
 
     def opt_version(self):
         import buildbot_worker
-        print("worker version: {}".format(buildbot_worker.version))
+        print(str("worker version: {}".format(buildbot_worker.version)))
         usage.Options.opt_version(self)
 
     def opt_verbose(self):

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import re

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -239,9 +239,9 @@ def run():
         config.parseOptions()
     except usage.error as e:
         print("{}:  {}".format(sys.argv[0], e))
-        print()
+        print("")
         c = getattr(config, 'subOptions', config)
-        print(str(c))
+        print("{}".format(c))
         sys.exit(1)
 
     subconfig = config.subOptions

--- a/worker/buildbot_worker/scripts/start.py
+++ b/worker/buildbot_worker/scripts/start.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/worker/buildbot_worker/scripts/stop.py
+++ b/worker/buildbot_worker/scripts/stop.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import time

--- a/worker/buildbot_worker/scripts/windows_service.py
+++ b/worker/buildbot_worker/scripts/windows_service.py
@@ -66,6 +66,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 from future.builtins import range
 
 import os

--- a/worker/buildbot_worker/test/fake/remote.py
+++ b/worker/buildbot_worker/test/fake/remote.py
@@ -19,6 +19,8 @@ from __future__ import unicode_literals
 
 from twisted.internet import defer
 
+from buildbot_worker.compat import bytes2unicode
+
 
 class FakeRemote(object):
 
@@ -31,7 +33,7 @@ class FakeRemote(object):
         self.method_prefix = method_prefix
 
     def callRemote(self, meth, *args, **kwargs):
-        fn = getattr(self.original, self.method_prefix + meth)
+        fn = getattr(self.original, self.method_prefix + bytes2unicode(meth))
         return defer.maybeDeferred(fn, *args, **kwargs)
 
     def notifyOnDisconnect(self, what):

--- a/worker/buildbot_worker/test/fake/remote.py
+++ b/worker/buildbot_worker/test/fake/remote.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from twisted.internet import defer
 

--- a/worker/buildbot_worker/test/fake/runprocess.py
+++ b/worker/buildbot_worker/test/fake/runprocess.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from twisted.internet import defer
 from twisted.python import failure

--- a/worker/buildbot_worker/test/fake/workerforbuilder.py
+++ b/worker/buildbot_worker/test/fake/workerforbuilder.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import pprint
 

--- a/worker/buildbot_worker/test/test_extra_coverage.py
+++ b/worker/buildbot_worker/test/test_extra_coverage.py
@@ -19,6 +19,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from buildbot_worker.scripts import logwatcher
 

--- a/worker/buildbot_worker/test/test_util_hangcheck.py
+++ b/worker/buildbot_worker/test/test_util_hangcheck.py
@@ -4,6 +4,7 @@ Tests for `buildbot_worker.util._hangcheck`.
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from twisted.internet import reactor
 from twisted.internet.defer import CancelledError

--- a/worker/buildbot_worker/test/unit/runprocess-scripts.py
+++ b/worker/buildbot_worker/test/unit/runprocess-scripts.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import select

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -63,7 +63,7 @@ class TestBot(unittest.TestCase):
         return d
 
     def test_getCommands(self):
-        d = self.bot.callRemote("getCommands")
+        d = self.bot.callRemote(b"getCommands")
 
         def check(cmds):
             # just check that 'shell' is present..
@@ -72,7 +72,7 @@ class TestBot(unittest.TestCase):
         return d
 
     def test_getVersion(self):
-        d = self.bot.callRemote("getVersion")
+        d = self.bot.callRemote(b"getVersion")
 
         def check(vers):
             self.assertEqual(vers, buildbot_worker.version)
@@ -89,7 +89,7 @@ class TestBot(unittest.TestCase):
         with open(os.path.join(infodir, "environ"), "w") as f:
             f.write("something else")
 
-        d = self.bot.callRemote("getWorkerInfo")
+        d = self.bot.callRemote(b"getWorkerInfo")
 
         def check(info):
             self.assertEqual(info, dict(
@@ -102,7 +102,7 @@ class TestBot(unittest.TestCase):
         return d
 
     def test_getWorkerInfo_nodir(self):
-        d = self.bot.callRemote("getWorkerInfo")
+        d = self.bot.callRemote(b"getWorkerInfo")
 
         def check(info):
             self.assertEqual(set(info.keys()), set(
@@ -111,7 +111,7 @@ class TestBot(unittest.TestCase):
         return d
 
     def test_setBuilderList_empty(self):
-        d = self.bot.callRemote("setBuilderList", [])
+        d = self.bot.callRemote(b"setBuilderList", [])
 
         def check(builders):
             self.assertEqual(builders, {})
@@ -119,7 +119,7 @@ class TestBot(unittest.TestCase):
         return d
 
     def test_setBuilderList_single(self):
-        d = self.bot.callRemote("setBuilderList", [('mybld', 'myblddir')])
+        d = self.bot.callRemote(b"setBuilderList", [('mybld', 'myblddir')])
 
         def check(builders):
             self.assertEqual(list(builders), ['mybld'])
@@ -135,7 +135,7 @@ class TestBot(unittest.TestCase):
         workerforbuilders = {}
 
         def add_my(_):
-            d = self.bot.callRemote("setBuilderList", [
+            d = self.bot.callRemote(b"setBuilderList", [
                 ('mybld', 'myblddir')])
 
             def check(builders):
@@ -148,7 +148,7 @@ class TestBot(unittest.TestCase):
         d.addCallback(add_my)
 
         def add_your(_):
-            d = self.bot.callRemote("setBuilderList", [
+            d = self.bot.callRemote(b"setBuilderList", [
                 ('mybld', 'myblddir'), ('yourbld', 'yourblddir')])
 
             def check(builders):
@@ -169,7 +169,7 @@ class TestBot(unittest.TestCase):
         d.addCallback(add_your)
 
         def remove_my(_):
-            d = self.bot.callRemote("setBuilderList", [
+            d = self.bot.callRemote(b"setBuilderList", [
                 ('yourbld', 'yourblddir2')])  # note new builddir
 
             def check(builders):
@@ -189,7 +189,8 @@ class TestBot(unittest.TestCase):
         d.addCallback(remove_my)
 
         def add_and_remove(_):
-            d = self.bot.callRemote("setBuilderList", [
+            d = self.bot.callRemote(b"setBuilderList", [
+
                 ('theirbld', 'theirblddir')])
 
             def check(builders):
@@ -209,7 +210,7 @@ class TestBot(unittest.TestCase):
     def test_shutdown(self):
         d1 = defer.Deferred()
         self.patch(reactor, "stop", lambda: d1.callback(None))
-        d2 = self.bot.callRemote("shutdown")
+        d2 = self.bot.callRemote(b"shutdown")
         # don't return until both the shutdown method has returned, and
         # reactor.stop has been called
         return defer.gatherResults([d1, d2])
@@ -267,20 +268,20 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         return d
 
     def test_print(self):
-        return self.wfb.callRemote("print", "Hello, WorkerForBuilder.")
+        return self.wfb.callRemote(b"print", "Hello, WorkerForBuilder.")
 
     def test_printWithCommand(self):
         self.wfb.original.command = Command("builder", "1", ["arg1", "arg2"])
-        return self.wfb.callRemote("print", "Hello again, WorkerForBuilder.")
+        return self.wfb.callRemote(b"print", "Hello again, WorkerForBuilder.")
 
     def test_setMaster(self):
         # not much to check here - what the WorkerForBuilder does with the
         # master is not part of the interface (and, in fact, it does very
         # little)
-        return self.wfb.callRemote("setMaster", mock.Mock())
+        return self.wfb.callRemote(b"setMaster", mock.Mock())
 
     def test_startBuild(self):
-        return self.wfb.callRemote("startBuild")
+        return self.wfb.callRemote(b"startBuild")
 
     def test_startCommand(self):
         # set up a fake step to receive updates
@@ -299,7 +300,7 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         d = defer.succeed(None)
 
         def do_start(_):
-            return self.wfb.callRemote("startCommand", FakeRemote(st),
+            return self.wfb.callRemote(b"startCommand", FakeRemote(st),
                                        "13", "shell", dict(
                 command=['echo', 'hello'],
                 workdir='workdir'))
@@ -333,7 +334,7 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         d = defer.succeed(None)
 
         def do_start(_):
-            return self.wfb.callRemote("startCommand", FakeRemote(st),
+            return self.wfb.callRemote(b"startCommand", FakeRemote(st),
                                        "13", "shell", dict(
                 command=['sleep', '10'],
                 workdir='workdir'))
@@ -348,7 +349,7 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
 
         # and then interrupt the step
         def do_interrupt(_):
-            return self.wfb.callRemote("interruptCommand", "13", "tl/dr")
+            return self.wfb.callRemote(b"interruptCommand", "13", "tl/dr")
         d.addCallback(do_interrupt)
 
         d.addCallback(lambda _: st.wait_for_finish())
@@ -380,7 +381,7 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         d = defer.succeed(None)
 
         def do_start(_):
-            return self.wfb.callRemote("startCommand", FakeRemote(st),
+            return self.wfb.callRemote(b"startCommand", FakeRemote(st),
                                        "13", "shell", dict(
                 command=['sleep', '10'],
                 workdir='workdir'))
@@ -399,7 +400,7 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         st = FakeStep()
 
         def do_start():
-            return self.wfb.callRemote("startCommand", FakeRemote(st),
+            return self.wfb.callRemote(b"startCommand", FakeRemote(st),
                                        "13", "shell", dict())
 
         yield self.assertFailure(do_start(), ValueError)
@@ -410,7 +411,7 @@ class TestWorkerForBuilder(command.CommandTestMixin, unittest.TestCase):
         st = FakeStep()
 
         def do_start():
-            return self.wfb.callRemote("startCommand", FakeRemote(st),
+            return self.wfb.callRemote(b"startCommand", FakeRemote(st),
                                        "13", "invalid command", dict())
 
         unknownCommand = yield self.assertFailure(do_start(), base.UnknownCommand)

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 from future.builtins import range
 
 import multiprocessing

--- a/worker/buildbot_worker/test/unit/test_bot_Worker.py
+++ b/worker/buildbot_worker/test/unit/test_bot_Worker.py
@@ -130,7 +130,7 @@ class TestWorker(misc.PatcherMixin, unittest.TestCase):
         # set up to call print when we are attached, and chain the results onto
         # the deferred for the whole test
         def call_print(mind):
-            print_d = mind.callRemote("print", "Hi, worker.")
+            print_d = mind.callRemote(b"print", "Hi, worker.")
             print_d.addCallbacks(d.callback, d.errback)
 
         # start up the master and worker

--- a/worker/buildbot_worker/test/unit/test_bot_Worker.py
+++ b/worker/buildbot_worker/test/unit/test_bot_Worker.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import shutil

--- a/worker/buildbot_worker/test/unit/test_commands_base.py
+++ b/worker/buildbot_worker/test/unit/test_commands_base.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from twisted.internet import defer
 from twisted.trial import unittest

--- a/worker/buildbot_worker/test/unit/test_commands_fs.py
+++ b/worker/buildbot_worker/test/unit/test_commands_fs.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import shutil

--- a/worker/buildbot_worker/test/unit/test_commands_registry.py
+++ b/worker/buildbot_worker/test/unit/test_commands_registry.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from twisted.trial import unittest
 

--- a/worker/buildbot_worker/test/unit/test_commands_shell.py
+++ b/worker/buildbot_worker/test/unit/test_commands_shell.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from twisted.trial import unittest
 

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import io
 import os

--- a/worker/buildbot_worker/test/unit/test_commands_utils.py
+++ b/worker/buildbot_worker/test/unit/test_commands_utils.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import shutil

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -291,7 +291,8 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         d = s.start()
 
         def check(ign):
-            self.assertTrue({'stdout': nl(repr(args))} in b.updates, b.show())
+            self.assertTrue({'stdout':
+                nl(repr([str(arg) for arg in args]))} in b.updates, b.show())
             self.assertTrue({'rc': 0} in b.updates, b.show())
         d.addCallback(check)
         return d

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import re

--- a/worker/buildbot_worker/test/unit/test_scripts_base.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_base.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/worker/buildbot_worker/test/unit/test_scripts_base.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_base.py
@@ -19,10 +19,10 @@ from __future__ import unicode_literals
 
 import os
 import sys
+from io import StringIO
 
 from twisted.trial import unittest
 
-from buildbot_worker.compat import NativeStringIO
 from buildbot_worker.scripts import base
 from buildbot_worker.test.util import misc
 
@@ -34,7 +34,7 @@ class TestIsWorkerDir(misc.FileIOMixin, misc.StdoutAssertionsMixin,
 
     def setUp(self):
         # capture output to stdout
-        self.mocked_stdout = NativeStringIO()
+        self.mocked_stdout = StringIO()
         self.patch(sys, "stdout", self.mocked_stdout)
 
         # generate OS specific relative path to buildbot.tac inside basedir
@@ -43,7 +43,7 @@ class TestIsWorkerDir(misc.FileIOMixin, misc.StdoutAssertionsMixin,
     def assertReadErrorMessage(self, strerror):
         expected_message = ("error reading '{0}': {1}\n"
                             "invalid worker directory 'testdir'\n".format(
-            self.tac_file_path, strerror))
+                                self.tac_file_path, strerror))
         self.assertEqual(self.mocked_stdout.getvalue(),
                          expected_message,
                          "unexpected error message on stdout")

--- a/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 

--- a/worker/buildbot_worker/test/unit/test_scripts_restart.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_restart.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import mock
 

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -291,15 +291,11 @@ class TestCreateWorkerOptions(OptionsMixin, unittest.TestCase):
                          "incorrect master host and/or port")
 
 
-class TestOptions(misc.StdoutAssertionsMixin, unittest.TestCase):
+class TestOptions(unittest.TestCase):
 
     """
     Test buildbot_worker.scripts.runner.Options class.
     """
-
-    def setUp(self):
-        self.setUpStdoutAssertions()
-
     def parse(self, *args):
         opts = runner.Options()
         opts.parseOptions(args)
@@ -311,9 +307,12 @@ class TestOptions(misc.StdoutAssertionsMixin, unittest.TestCase):
                                self.parse)
 
     def test_version(self):
+        from buildbot_worker.compat import NativeStringIO
+        stdout = NativeStringIO()
+        self.patch(sys, 'stdout', stdout)
         exception = self.assertRaises(SystemExit, self.parse, '--version')
         self.assertEqual(exception.code, 0, "unexpected exit code")
-        self.assertInStdout('worker version:')
+        self.assertIn(str('worker version:'), stdout.getvalue())
 
     def test_verbose(self):
         self.patch(log, 'startLogging', mock.Mock())

--- a/worker/buildbot_worker/test/unit/test_scripts_start.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_start.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import mock
 

--- a/worker/buildbot_worker/test/unit/test_scripts_stop.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_stop.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import errno
 import os

--- a/worker/buildbot_worker/test/unit/test_util.py
+++ b/worker/buildbot_worker/test/unit/test_util.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from twisted.trial import unittest
 

--- a/worker/buildbot_worker/test/unit/test_util.py
+++ b/worker/buildbot_worker/test/unit/test_util.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
+from future.utils import PY3
 
 from twisted.trial import unittest
 
@@ -66,7 +67,10 @@ class TestObfuscated(unittest.TestCase):
     def testSimple(self):
         c = util.Obfuscated('real', '****')
         self.assertEqual(str(c), '****')
-        self.assertEqual(repr(c), "'****'")
+        if PY3:
+            self.assertEqual(repr(c), "'****'")
+        else:
+            self.assertEqual(repr(c), "u'****'")
 
     def testObfuscatedCommand(self):
         cmd = ['echo', util.Obfuscated('password', '*******')]

--- a/worker/buildbot_worker/test/util/command.py
+++ b/worker/buildbot_worker/test/util/command.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import shutil

--- a/worker/buildbot_worker/test/util/compat.py
+++ b/worker/buildbot_worker/test/util/compat.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import sys
 

--- a/worker/buildbot_worker/test/util/misc.py
+++ b/worker/buildbot_worker/test/util/misc.py
@@ -21,7 +21,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
-from future.utils import PY3
 from future.utils import string_types
 
 import errno
@@ -29,7 +28,6 @@ import os
 import re
 import shutil
 import sys
-from io import BytesIO
 from io import StringIO
 
 import mock
@@ -225,16 +223,7 @@ class StdoutAssertionsMixin(object):
     """
 
     def setUpStdoutAssertions(self):
-        #
-        # sys.stdout is implemented differently
-        # in Python 2 and Python 3, so we need to
-        # override it differently.
-        # In Python 2, sys.stdout is a byte stream.
-        # In Python 3, sys.stdout is a text stream.
-        if PY3:
-            self.stdout = StringIO()
-        else:
-            self.stdout = BytesIO()
+        self.stdout = StringIO()
         self.patch(sys, 'stdout', self.stdout)
 
     def assertWasQuiet(self):

--- a/worker/buildbot_worker/test/util/misc.py
+++ b/worker/buildbot_worker/test/util/misc.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 from future.utils import PY3
 from future.utils import string_types
 

--- a/worker/buildbot_worker/test/util/sourcecommand.py
+++ b/worker/buildbot_worker/test/util/sourcecommand.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from buildbot_worker import runprocess
 from buildbot_worker.test.util import command

--- a/worker/buildbot_worker/util/_hangcheck.py
+++ b/worker/buildbot_worker/util/_hangcheck.py
@@ -9,6 +9,7 @@ wrapper will disconnect in that case, and inform the caller.
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from twisted.internet.interfaces import IProtocol
 from twisted.internet.interfaces import IProtocolFactory

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -21,6 +21,7 @@ Standard setup script.
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import sys


### PR DESCRIPTION
This helps with writing code which is Python 2 and Python 3 compatible,
without having to force people to remember to prefix strings with *u""*.

If we really need bytes, we can use *b""*.

We do this only in the worker for now.  The master has too much going on.