### PR TITLE
Allow SVNPoller to work with paths which contain non-ASCII characters

### DIFF
--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -30,7 +30,6 @@ from twisted.python import log
 
 from buildbot import util
 from buildbot.changes import base
-from buildbot.util import bytes2NativeString
 from buildbot.util import bytes2unicode
 
 # these split_file_* functions are available for use as values to the
@@ -355,11 +354,7 @@ class SVNPoller(base.PollingChangeSource, util.ComparableMixin):
             for p in pathlist.getElementsByTagName("path"):
                 kind = p.getAttribute("kind")
                 action = p.getAttribute("action")
-                path = "".join([t.data for t in p.childNodes])
-                # Convert the path from unicode to bytes
-                path = path.encode("ascii")
-                # Convert path from bytes to native string.  Needed for Python 3.
-                path = bytes2NativeString(path, "ascii")
+                path = u"".join([t.data for t in p.childNodes])
                 if path.startswith("/"):
                     path = path[1:]
                 if kind == "dir" and not path.endswith("/"):

--- a/master/buildbot/newsfragments/svn-utf8.bugfix
+++ b/master/buildbot/newsfragments/svn-utf8.bugfix
@@ -1,0 +1,1 @@
+Fix (:issue:`3865`) so that now :py:class:`~buildbot.changes.svnpoller.SVNPoller` works with paths that contain valid UTF-8 characters which are not ASCII.

--- a/master/buildbot/test/unit/test_changes_svnpoller.py
+++ b/master/buildbot/test/unit/test_changes_svnpoller.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 # This file is part of Buildbot.  Buildbot is free software: you can
 # redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation, version 2.
@@ -156,7 +157,7 @@ sample_logentries[2] = b"""\
 <date>2006-10-01T19:35:10.215692Z</date>
 <paths>
 <path
-   action="M">/sample/branch/main.c</path>
+   action="M">/sample/branch/c\xcc\xa7main.c</path>
 </paths>
 <msg>commit_on_branch</msg>
 </logentry>
@@ -379,7 +380,7 @@ class TestSVNPoller(gpo.GetProcessOutputMixin,
         self.assertEqual(changes[0]['project'], '')
         self.assertEqual(changes[0]['repository'], base)
         self.assertEqual(changes[1]['branch'], "branch")
-        self.assertEqual(changes[1]['files'], ["main.c"])
+        self.assertEqual(changes[1]['files'], [u"çmain.c"])
         self.assertEqual(changes[1]['revision'], '3')
         self.assertEqual(changes[1]['project'], '')
         self.assertEqual(changes[1]['repository'], base)
@@ -388,7 +389,7 @@ class TestSVNPoller(gpo.GetProcessOutputMixin,
         self.assertEqual(len(changes), 1)
         self.assertEqual(changes[0]['branch'], None)
         self.assertEqual(changes[0]['revision'], '4')
-        self.assertEqual(changes[0]['files'], ["version.c"])
+        self.assertEqual(changes[0]['files'], [u"version.c"])
 
         # r5 should *not* create a change as it's a branch deletion
         changes = s.create_changes([logentries[5]])
@@ -399,7 +400,7 @@ class TestSVNPoller(gpo.GetProcessOutputMixin,
         self.assertEqual(len(changes), 1)
         self.assertEqual(changes[0]['branch'], 'branch')
         self.assertEqual(changes[0]['revision'], '6')
-        self.assertEqual(changes[0]['files'], ["version.c"])
+        self.assertEqual(changes[0]['files'], [u"version.c"])
 
     def makeInfoExpect(self, password='bbrocks'):
         args = ['svn', 'info', '--xml', '--non-interactive', sample_base,
@@ -443,7 +444,7 @@ class TestSVNPoller(gpo.GetProcessOutputMixin,
         self.assertEqual(changes[0]['codebase'], "overridden-codebase")
 
         self.assertEqual(changes[1]['branch'], "branch")
-        self.assertEqual(changes[1]['files'], ["main.c"])
+        self.assertEqual(changes[1]['files'], [u'çmain.c'])
         self.assertEqual(changes[1]['revision'], '3')
         self.assertEqual(changes[1]['project'], "overridden-project")
         self.assertEqual(changes[1]['repository'], "overridden-repository")
@@ -489,7 +490,7 @@ class TestSVNPoller(gpo.GetProcessOutputMixin,
                 'category': None,
                 'codebase': None,
                 'comments': u'make_branch',
-                'files': [''],
+                'files': [u''],
                 'project': '',
                 'properties': {},
                 'repository': 'file:///usr/home/warner/stuff/Projects/Buildbot/trees/misc/_trial_temp/test_vc/repositories/SVN-Repository/sample',
@@ -514,7 +515,7 @@ class TestSVNPoller(gpo.GetProcessOutputMixin,
                 'category': None,
                 'codebase': None,
                 'comments': u'commit_on_branch',
-                'files': ['main.c'],
+                'files': [u'çmain.c'],
                 'project': '',
                 'properties': {},
                 'repository': 'file:///usr/home/warner/stuff/Projects/Buildbot/trees/misc/_trial_temp/test_vc/repositories/SVN-Repository/sample',
@@ -528,7 +529,7 @@ class TestSVNPoller(gpo.GetProcessOutputMixin,
                 'category': None,
                 'codebase': None,
                 'comments': u'revised_to_2',
-                'files': ['version.c'],
+                'files': [u'version.c'],
                 'project': '',
                 'properties': {},
                 'repository': 'file:///usr/home/warner/stuff/Projects/Buildbot/trees/misc/_trial_temp/test_vc/repositories/SVN-Repository/sample',


### PR DESCRIPTION
Fixes #3865 