### PR TITLE
fix umask is set to 0 when using localWorker

### DIFF
--- a/master/buildbot/newsfragments/localworker_umask.bugfix
+++ b/master/buildbot/newsfragments/localworker_umask.bugfix
@@ -1,0 +1,1 @@
+Fix umask set to 0 when using LocalWorker (:issue:`3878`)

--- a/master/buildbot/worker/local.py
+++ b/master/buildbot/worker/local.py
@@ -26,7 +26,7 @@ from buildbot.worker.base import Worker
 
 class LocalWorker(Worker):
 
-    def checkConfig(self, name, workdir=None, usePty=False, **kwargs):
+    def checkConfig(self, name, workdir=None, **kwargs):
         Worker.checkConfig(self, name, None, **kwargs)
         self.LocalWorkerFactory = None
         try:
@@ -39,7 +39,7 @@ class LocalWorker(Worker):
         self.remote_worker = None
 
     @defer.inlineCallbacks
-    def reconfigService(self, name, workdir=None, usePty=False, **kwargs):
+    def reconfigService(self, name, workdir=None, **kwargs):
         Worker.reconfigService(self, name, None, **kwargs)
         if workdir is None:
             workdir = name
@@ -52,9 +52,8 @@ class LocalWorker(Worker):
             # create the actual worker as a child service
             # we only create at reconfig, to avoid polluting memory in case of
             # reconfig
-            self.remote_worker = self.LocalWorkerFactory(name, workdir, usePty)
+            self.remote_worker = self.LocalWorkerFactory(name, workdir)
             yield self.remote_worker.setServiceParent(self)
         else:
             # The case of a reconfig, we forward the parameters
             self.remote_worker.bot.basedir = workdir
-            self.remote_worker.usePty = usePty


### PR DESCRIPTION
since 9f2d60d7c3e4fa7b862d96ce5c627b40397b234e usepty is no more an argument of
BaseWorker, so usepty set as a positional argument was actually setting the umask to 0

Fixes: #3878
