### PR TITLE
Github hook: handle creation of new tag and new branch

### DIFF
--- a/master/buildbot/newsfragments/github_new_tag.bugfix
+++ b/master/buildbot/newsfragments/github_new_tag.bugfix
@@ -1,0 +1,2 @@
+:bb:chsrc:`GitHub` hook now properly creates a change in case of new tag or new branch.
+:bb:chsrc:`GitHub` changes will have the ``category`` set to ``tag`` when a tag was pushed to easily distinguish from a branch push.

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -450,7 +450,75 @@ gitJsonPayloadEmpty = b"""
   "ref": "refs/heads/master"
 }
 """
+gitJsonPayloadCreateTag = b"""
+{
+  "ref": "refs/tags/v0.9.15.post1",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "ffe1e9affb2b5399369443194c02068032f9295e",
+  "created": true,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/buildbot/buildbot/compare/v0.9.15.post1",
+  "commits": [
 
+  ],
+  "head_commit": {
+    "id": "57df618a4a450410c1dee440c7827ee105f5a226",
+    "tree_id": "f9768673dc968b5c8fcbb15f119ce237b50b3252",
+    "distinct": true,
+    "message": "...",
+    "timestamp": "2018-01-07T16:30:52+01:00",
+    "url": "https://github.com/buildbot/buildbot/commit/...",
+    "author": {
+      "name": "User",
+      "email": "userid@example.com",
+      "username": "userid"
+    },
+    "committer": {
+      "name": "GitHub",
+      "email": "noreply@github.com",
+      "username": "web-flow"
+    },
+    "added": [
+
+    ],
+    "removed": [
+      "master/buildbot/newsfragments/bit_length.bugfix",
+      "master/buildbot/newsfragments/localworker_umask.bugfix",
+      "master/buildbot/newsfragments/svn-utf8.bugfix"
+    ],
+    "modified": [
+      ".bbtravis.yml",
+      "circle.yml",
+      "master/docs/relnotes/index.rst"
+    ]
+  },
+  "repository": {
+    "html_url": "https://github.com/buildbot/buildbot",
+    "name": "buildbot",
+    "full_name": "buildbot"
+  },
+  "pusher": {
+    "name": "userid",
+    "email": "userid@example.com"
+  },
+  "organization": {
+    "login": "buildbot",
+    "url": "https://api.github.com/orgs/buildbot",
+    "description": "Continous integration and delivery framework"
+  },
+  "sender": {
+    "login": "userid",
+    "gravatar_id": "",
+    "type": "User",
+    "site_admin": false
+  },
+  "ref_name": "v0.9.15.post1",
+  "distinct_commits": [
+
+  ]
+}"""
 _HEADER_CT = b'Content-Type'
 _CT_ENCODED = b'application/x-www-form-urlencoded'
 _CT_JSON = b'application/json'
@@ -564,6 +632,19 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(change["author"],
                          "Fred Flinstone <fred@flinstone.org>")
         self.assertEqual(change["branch"], "v1.0.0")
+        self.assertEqual(change["category"], "tag")
+
+    @defer.inlineCallbacks
+    def test_git_with_push_newtag(self):
+        self.request = _prepare_request(b'push', gitJsonPayloadCreateTag)
+        yield self.request.test_render(self.changeHook)
+
+        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
+        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(change["author"],
+                         "User <userid@example.com>")
+        self.assertEqual(change["branch"], "v0.9.15.post1")
+        self.assertEqual(change["category"], "tag")
 
     # Test 'base' hook with attributes. We should get a json string
     # representing a Change object as a dictionary. All values show be set.

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -171,18 +171,20 @@ The parameters are:
 And then press the ``Add Webhook`` button.
 
 
-Github hook create 3 kinds of changes, distinguishable by their ``category`` field:
+Github hook creates 3 kinds of changes, distinguishable by their ``category`` field:
 
 - ``None``: This change is a push to a branch.
     Use ``util.ChangeFilter(category=None, repository="http://github.com/<org>/<project>")``
+
 - ``'tag'``: This change is a push to a tag.
     Use ``util.ChangeFilter(category='tag', repository="http://github.com/<org>/<project>")``
+
 - ``'pull'``: This change is from a pull-request creation or update.
     Use ``util.ChangeFilter(category='pull', repository="http://github.com/<org>/<project>")``
-   In this case, the :bb:step:`GitHub` step must be used instead of the standard :bb:step:`Git` in order to be able to pull GitHub's magic refs.
-   With this method, the :bb:step:`GitHub` step will always checkout the branch merged with latest master.
-   This allows to test the result of the merge instead of the just the source branch.
-   Note that you can use the :bb:step:`GitHub` for all categories of event.
+    In this case, the :bb:step:`GitHub` step must be used instead of the standard :bb:step:`Git` in order to be able to pull GitHub's magic refs.
+    With this method, the :bb:step:`GitHub` step will always checkout the branch merged with latest master.
+    This allows to test the result of the merge instead of just the source branch.
+    Note that you can use the :bb:step:`GitHub` for all categories of event.
 
 .. warning::
 

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -55,7 +55,7 @@ create a file ``changehook.passwd`` with content:
 
     user:password
 
-``change_hook_auth`` should be a list of :py:class:`ICredentialsChecker`. 
+``change_hook_auth`` should be a list of :py:class:`ICredentialsChecker`.
 See the details of available options in `Twisted documentation <https://twistedmatrix.com/documents/current/core/howto/cred.html>`_.
 
 .. bb:chsrc:: Mercurial
@@ -89,7 +89,7 @@ GitHub hook
 .. note::
 
    There is a standalone HTTP server available for receiving GitHub notifications as well: :contrib-src:`master/contrib/github_buildbot.py`.
-   This script may be useful in cases where you cannot expose the WebStatus for public consumption. Alternatively, you can setup a reverse proxy :ref:`Reverse_Proxy_Config` 
+   This script may be useful in cases where you cannot expose the WebStatus for public consumption. Alternatively, you can setup a reverse proxy :ref:`Reverse_Proxy_Config`
 
 The GitHub hook has the following parameters:
 
@@ -135,7 +135,7 @@ The simplest way to use GitHub hook is as follows:
 
 .. code-block:: python
 
-    c['www'] = dict(    
+    c['www'] = dict(
         change_hook_dialects={'github': {}},
     )
 
@@ -166,9 +166,23 @@ The parameters are:
             )
 
 :guilabel:`Which events would you like to trigger this webhook?`
-    Leave the default -- ``Just the push [tag]  events`` -- other kind of events are not currently supported.
+    Click -- ``Let me select individual events``, then select ``Push`` and ``Pull request`` -- other kind of events are not currently supported.
 
 And then press the ``Add Webhook`` button.
+
+
+Github hook create 3 kinds of changes, distinguishable by their ``category`` field:
+
+- ``None``: This change is a push to a branch.
+    Use ``util.ChangeFilter(category=None, repository="http://github.com/<org>/<project>")``
+- ``'tag'``: This change is a push to a tag.
+    Use ``util.ChangeFilter(category='tag', repository="http://github.com/<org>/<project>")``
+- ``'pull'``: This change is from a pull-request creation or update.
+    Use ``util.ChangeFilter(category='pull', repository="http://github.com/<org>/<project>")``
+   In this case, the :bb:step:`GitHub` step must be used instead of the standard :bb:step:`Git` in order to be able to pull GitHub's magic refs.
+   With this method, the :bb:step:`GitHub` step will always checkout the branch merged with latest master.
+   This allows to test the result of the merge instead of the just the source branch.
+   Note that you can use the :bb:step:`GitHub` for all categories of event.
 
 .. warning::
 
@@ -180,9 +194,6 @@ Then change the the ``Payload URL`` of your GitHub webhook to ``https://user:pas
 
 Patches are welcome to implement: https://developer.github.com/webhooks/securing/
 
-.. note::
-
-   When using a :ref:`ChangeFilter<Change-Filters>` with a GitHub webhook ensure that your filter matches all desired requests as fields such as ``repository`` and ``project`` may differ in different events.
 
 .. bb:chsrc:: BitBucket
 


### PR DESCRIPTION
When a new tag or new branch is created, a push event with no commit is sent.
We must build the head_commit in that case, and then create an event with that.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
