### PR TITLE
fix yarn mutex to work on multiplatform

### DIFF
--- a/master/buildbot/newsfragments/windows_pkg.bugfix
+++ b/master/buildbot/newsfragments/windows_pkg.bugfix
@@ -1,0 +1,1 @@
+Fixed issue with ``buildbot_pkg``` not hanging on yarn step on windows (:issue:`3890`).

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -214,8 +214,7 @@ class BuildJsCommand(distutils.cmd.Command):
 
             # if we find yarn, then we use it as it is much faster
             if yarn_version != "":
-                # --mutex allows to build in parallel
-                commands.append(['yarn', 'install', '--pure-lockfile', '--mutex', 'file:/tmp/.yarn-mutex'])
+                commands.append(['yarn', 'install', '--pure-lockfile'])
             else:
                 commands.append(['npm', 'install'])
 


### PR DESCRIPTION
buildbot_pkg was reportedly broken on windows since the yarn mutex fix
