### PR TITLE
master/buildbot/worker/docker.py: Fix test fail when docker is not in…

### DIFF
--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -41,6 +41,7 @@ try:
 except ImportError:
     docker = None
     client = None
+    docker_py_version = 0.0
 
 
 def _handle_stream_line(line):


### PR DESCRIPTION
…stalled

This fixes numerous tracebacks (note, only partial traceback):

  File "/usr/lib64/python3.6/site-packages/buildbot/worker/docker.py", line 259, in _thd_start_instance
    if docker_py_version >= 2.2:
builtins.NameError: name 'docker_py_version' is not defined

With this patch, the tests pass.
