### PR TITLE
Builder page should display worker-name or worker-id based on settings

### DIFF
--- a/master/buildbot/newsfragments/worker_name_instead_of_id.bugfix
+++ b/master/buildbot/newsfragments/worker_name_instead_of_id.bugfix
@@ -1,0 +1,1 @@
+Fixed Builder page should display worker name instead of id (:issue:`3901`).

--- a/www/base/src/app/builders/builders.route.coffee
+++ b/www/base/src/app/builders/builders.route.coffee
@@ -36,6 +36,11 @@ class State extends Config
                 caption:'Show old builders'
                 default_value: false
             ,
+                type:'bool'
+                name:'show_workers_name'
+                caption:'Show workers name'
+                default_value: false
+            ,
                 type:'integer'
                 name:'buildFetchLimit'
                 caption:'Maximum number of builds to fetch'

--- a/www/base/src/app/builders/builders.tpl.jade
+++ b/www/base/src/app/builders/builders.tpl.jade
@@ -54,9 +54,11 @@
           td(style="width:20%;")
             span(data-ng-repeat="worker in builder.workers")
                 a(ui-sref='worker({worker: worker.workerid})')
-                    span.badge-status(title="{{worker.name}}" ng-class="connected2class(worker, 'pulse')")
+                    span.badge-status(title="{{worker.name}}" ng-class="connected2class(worker, 'pulse')" ng-if="!settings.show_workers_name.value")
                         .badge-inactive {{worker.workerid}}
                         .badge-active {{worker.name}}
+                    span.badge-status(title="{{worker.name}}" ng-class="connected2class(worker, 'pulse')" ng-if="settings.show_workers_name.value")
+                      | {{ worker.name }}
   .row
       .form-group
           label.checkbox-inline


### PR DESCRIPTION
Fixed https://github.com/buildbot/buildbot/issues/3901