### PR TITLE
Display revision and worker column on Builder page

### DIFF
--- a/master/buildbot/newsfragments/revision_workers_column.bugfix
+++ b/master/buildbot/newsfragments/revision_workers_column.bugfix
@@ -1,0 +1,3 @@
+Fixed Builder page should show revisions (:issue:`3903`).
+Fixed Owner column is always empty on Builder page (:issue:`3904`).
+Partially fix Builder page should show the worker information  (:issue:`3546`).

--- a/www/base/src/app/builders/builder/builder.controller.coffee
+++ b/www/base/src/app/builders/builder/builder.controller.coffee
@@ -98,7 +98,10 @@ class Builder extends Controller
             $scope.numbuilds = 200
             if $stateParams.numbuilds?
                 $scope.numbuilds = +$stateParams.numbuilds
-            $scope.builds = builder.getBuilds(limit:$scope.numbuilds, order:'-number')
+            $scope.builds = builder.getBuilds
+                property: ["got_revision", "workername"]
+                limit: $scope.numbuilds
+                order: '-number'
             $scope.buildrequests = builder.getBuildrequests(claimed:false)
             $scope.builds.onChange=refreshContextMenu
             $scope.buildrequests.onChange=refreshContextMenu

--- a/www/base/src/app/common/directives/builds/buildstable.tpl.jade
+++ b/www/base/src/app/common/directives/builds/buildstable.tpl.jade
@@ -8,7 +8,8 @@
         td(width='100px') #
         td(width='150px') Started At
         td(width='150px') Duration
-        td(width='200px') Owner
+        td(width='150px') Revision
+        td(width='150px') Worker
         td Status
       tr(ng-repeat='build in builds | orderBy:"-started_at"')
           td(ng-show="builders") {{ builders.get(build.builderid).name }}
@@ -25,6 +26,12 @@
             span(ng-show="build.complete", title="{{(build.complete_at - build.started_at)| durationformat:'LLL' }}")
               | {{(build.complete_at - build.started_at)| duration }}
           td
+            span(title="Revision")
+              p(ng-repeat='(codebase, revision) in build.properties.got_revision[0]')
+                | {{codebase}}: {{revision | limitTo: '8'}}
+          td
+            a(ui-sref='worker({worker: build.workerid})')
+              | {{build.properties.workername[0]}}
           td
             ul.list-inline
               li


### PR DESCRIPTION
Fixed https://github.com/buildbot/buildbot/issues/3903
Fixed https://github.com/buildbot/buildbot/issues/3904
Partially fix https://github.com/buildbot/buildbot/issues/3546