### PR TITLE
Fix for Builds column on builders page doesn't display recent builds for many builders

### DIFF
--- a/master/buildbot/newsfragments/increase_num_bubbles.bugfix
+++ b/master/buildbot/newsfragments/increase_num_bubbles.bugfix
@@ -1,0 +1,1 @@
+Fixed Builds column on builders page doesn't display recent builds for many builders (:issue:`3545`).

--- a/www/base/src/app/builders/builders.route.coffee
+++ b/www/base/src/app/builders/builders.route.coffee
@@ -39,5 +39,5 @@ class State extends Config
                 type:'integer'
                 name:'buildFetchLimit'
                 caption:'Maximum number of builds to fetch'
-                default_value: 200
+                default_value: 500
             ]


### PR DESCRIPTION
Fixed https://github.com/buildbot/buildbot/issues/3545

200 builds was an extremely small number of builds to fetch. Even https://nine.buildbot.net/#/builders doesn't have bubbles for many builders. Large instances with large number of builders see this issue prominently.

Given that data output from Buildbot 0.9 API is very compact, fetching 1000 builds should be fine.