### PR TITLE
steps/source/repo.py: Add support for parallel gzip

### DIFF
--- a/master/buildbot/newsfragments/repo_tarball_pigz.feature
+++ b/master/buildbot/newsfragments/repo_tarball_pigz.feature
@@ -1,1 +1,1 @@
-Add support for compressing the repo source step cache tarball with pigz, a parallel gzip compressor.
+Add support for compressing the repo source step cache tarball with ``pigz``, a parallel gzip compressor.

--- a/master/buildbot/newsfragments/repo_tarball_pigz.feature
+++ b/master/buildbot/newsfragments/repo_tarball_pigz.feature
@@ -1,0 +1,1 @@
+Add support for compressing the repo source step cache tarball with pigz, a parallel gzip compressor.

--- a/master/buildbot/steps/source/repo.py
+++ b/master/buildbot/steps/source/repo.py
@@ -393,13 +393,16 @@ class Repo(Source):
         # Keep in mind that the compression part of tarball generation
         # can be non negligible
         tar = ['tar']
-        if self.tarball.endswith("gz"):
+        if self.tarball.endswith("pigz"):
+            tar.append('-I')
+            tar.append('pigz')
+        elif self.tarball.endswith("gz"):
             tar.append('-z')
-        if self.tarball.endswith("bz2") or self.tarball.endswith("bz"):
+        elif self.tarball.endswith("bz2") or self.tarball.endswith("bz"):
             tar.append('-j')
-        if self.tarball.endswith("lzma"):
+        elif self.tarball.endswith("lzma"):
             tar.append('--lzma')
-        if self.tarball.endswith("lzop"):
+        elif self.tarball.endswith("lzop"):
             tar.append('--lzop')
         return tar
 

--- a/master/buildbot/test/unit/test_steps_source_repo.py
+++ b/master/buildbot/test/unit/test_steps_source_repo.py
@@ -289,6 +289,9 @@ class TestRepo(sourcesteps.SourceStepMixin, unittest.TestCase):
     def test_update_tarball_tgz(self):
         self.do_test_update_tarball("tgz", ["-z"])
 
+    def test_update_tarball_pigz(self):
+        self.do_test_update_tarball("pigz", ["-I", "pigz"])
+
     def test_update_tarball_bzip(self):
         self.do_test_update_tarball("tar.bz2", ["-j"])
 

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -819,6 +819,9 @@ The Repo step takes the following arguments:
     It is a copy of the ``.repo`` directory which contains all the Git objects.
     This feature helps to minimize network usage on very big projects with lots of workers.
 
+    The suffix of the tarball determines if the tarball is compressed and which compressor is chosen.
+    Supported suffixes are ``bz2``, ``gz``, ``lzma``, ``lzop``, and ``pigz``.
+
 ``jobs``
     (optional, defaults to ``None``): Number of projects to fetch simultaneously while syncing.
     Passed to repo sync subcommand with "-j".


### PR DESCRIPTION
If we find pigz (parallel gzip) in the path then use it as a
compressor in preference to gzip. On multicore machines pigz is
much faster than gzip.

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

http://trac.buildbot.net/wiki/Development
And especially:
http://trac.buildbot.net/wiki/SubmittingPatches

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
