### PR TITLE
Sort "Summary" log to top and auto-expand it.

### DIFF
--- a/newsfragments/summaryLog.feature
+++ b/newsfragments/summaryLog.feature
@@ -1,0 +1,1 @@
+When a build step has a log called "summary" (case-insensitive), the Build Summary page will sort that log first in the list of logs, and automatically expand it.

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
@@ -68,6 +68,16 @@ class _buildsummary extends Controller('common')
             hasProperty = self.properties && self.properties.hasOwnProperty(property)
             return  if hasProperty then self.properties[property][0] else null
 
+        @isSummaryLog = (log) -> 
+            return log.name.toLowerCase() == "summary"
+
+        # Returns the logs, sorted with the "Summary" log first, if it exists in the step's list of logs
+        @getLogs = (step) -> 
+            summaryLogs = step.logs.filter (log) => @isSummaryLog(log)
+            logs = summaryLogs.concat( step.logs.filter (log) => not @isSummaryLog(log) )
+            return logs
+
+
         @toggleFullDisplay = ->
             @fulldisplay = !@fulldisplay
             if @fullDisplay

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -49,7 +49,7 @@
           li(ng-if='buildsummary.isBuildRequestURL(url.url)', ng-repeat="url in step.urls")
             buildrequestsummary(style="margin-left:30px;margin-top:8px",buildrequestid='buildsummary.getBuildRequestIDFromURL(url.url)')
         div.anim-stepdetails(ng-if="step.fulldisplay")
-          logpreview(ng-repeat="log in step.logs", log="log",
-                     fulldisplay="step.logs.length == 1",
+          logpreview(ng-repeat="log in buildsummary.getLogs(step)", log="log",
+                     fulldisplay="step.logs.length == 1 || buildsummary.isSummaryLog(log)",
                      builderid="buildsummary.build.builderid", buildnumber="buildsummary.build.number",
                      step="step")


### PR DESCRIPTION
As discussed in Issue #3923.

When a build step has a log called "summary" (case-insensitive), the Build Summary page will sort that log first in the list of logs, and automatically expand it.