### PR TITLE
steps/source/repo.py: Use --force-sync for sync step

### DIFF
--- a/master/buildbot/newsfragments/repo_force_sync.feature
+++ b/master/buildbot/newsfragments/repo_force_sync.feature
@@ -1,0 +1,1 @@
+The repo source step now syncs with the ``--force-sync`` flag which allows the sync to proceed when a source repo in the manifest has changed.

--- a/master/buildbot/steps/source/repo.py
+++ b/master/buildbot/steps/source/repo.py
@@ -311,7 +311,7 @@ class Repo(Source):
         for command in self.manifestDownloads:
             yield self._Cmd(command, workdir=self.build.path_module.join(self.workdir, ".repo", "manifests"))
 
-        command = ['sync']
+        command = ['sync', '--force-sync']
         if self.jobs:
             command.append('-j' + str(self.jobs))
         if not self.syncAllBranches:

--- a/master/buildbot/test/unit/test_steps_source_repo.py
+++ b/master/buildbot/test/unit/test_steps_source_repo.py
@@ -132,7 +132,7 @@ class TestRepo(sourcesteps.SourceStepMixin, unittest.TestCase):
                 command=['repo', 'init', '-u', 'git://myrepo.com/manifest.git',
                          '-b', 'mb', '-m', 'mf', '--depth', str(depth)])
         ] + override_commands + [
-            self.ExpectShell(command=['repo', 'sync'] + syncoptions),
+            self.ExpectShell(command=['repo', 'sync', '--force-sync'] + syncoptions),
             self.ExpectShell(
                 command=['repo', 'manifest', '-r', '-o', 'manifest-original.xml'])
         ]
@@ -422,7 +422,7 @@ class TestRepo(sourcesteps.SourceStepMixin, unittest.TestCase):
                 workdir='wkdir/.repo/manifests',
                 command=['git', 'cherry-pick', 'FETCH_HEAD'])
             + 0,
-            self.ExpectShell(command=['repo', 'sync', '-c'])
+            self.ExpectShell(command=['repo', 'sync', '--force-sync', '-c'])
             + 0,
             self.ExpectShell(
                 command=['repo', 'manifest', '-r', '-o', 'manifest-original.xml'])


### PR DESCRIPTION
Pass the --force-sync option to repo sync. This ensures that if
we change a module location in the manifest then the sync will
still succeed.

This option is not the default behaviour as it can cause data loss
in the working directory but this is not a concern for buildbot
as no changes are ever made in the checked out copy.

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

http://trac.buildbot.net/wiki/Development
And especially:
http://trac.buildbot.net/wiki/SubmittingPatches

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
