### PR TITLE
gitattributes: do not export .git* files in archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 master/buildbot/__init__.py             export-subst
 pkg/buildbot_pkg.py                     export-subst
 worker/buildbot_worker/__init__.py      export-subst
+.gitattributes                          export-ignore
+.gitignore                              export-ignore


### PR DESCRIPTION
These files only make sense when in a git repository. Make sure they are not exported via git archive.