### PR TITLE
Rename logfile to logname in ShellArg

### DIFF
--- a/master/buildbot/newsfragments/shellarg-rename-logfile-logname.bugfix
+++ b/master/buildbot/newsfragments/shellarg-rename-logfile-logname.bugfix
@@ -1,0 +1,1 @@
+Rename ShellArg's logfile to logname to reflect the actual meaning. (:issue:`3771`)

--- a/master/buildbot/newsfragments/shellarg-rename-logfile-logname.bugfix
+++ b/master/buildbot/newsfragments/shellarg-rename-logfile-logname.bugfix
@@ -1,1 +1,1 @@
-Rename ShellArg's logfile to logname to reflect the actual meaning. (:issue:`3771`)
+Deprecated ShellArg's ``logfile`` argument over ``logname`` to reflect the actual meaning. (:issue:`3771`)

--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -42,6 +42,7 @@ class ShellArg(results.ResultComputingConfigMixin):
 
         self.logname = logname
         if logfile is not None:
+            config.warnDeprecated('1.0.1', "logfile is deprecated, use logname")
             if self.logname is not None:
                 config.error("the 'logfile' parameter of %s "
                              "must not be specified when 'logname' is set" % (name,))

--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -31,7 +31,7 @@ from buildbot.process import results
 class ShellArg(results.ResultComputingConfigMixin):
     publicAttributes = (
         results.ResultComputingConfigMixin.resultConfig +
-        ["command", "logname", "logfile"])
+        ["command", "logname"])
 
     def __init__(self, command=None, logname=None, logfile=None, **kwargs):
         name = self.__class__.__name__

--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -31,15 +31,22 @@ from buildbot.process import results
 class ShellArg(results.ResultComputingConfigMixin):
     publicAttributes = (
         results.ResultComputingConfigMixin.resultConfig +
-        ["command", "logfile"])
+        ["command", "logname", "logfile"])
 
-    def __init__(self, command=None, logfile=None, **kwargs):
+    def __init__(self, command=None, logname=None, logfile=None, **kwargs):
         name = self.__class__.__name__
         if command is None:
             config.error("the 'command' parameter of %s "
                          "must not be None" % (name,))
         self.command = command
-        self.logfile = logfile
+
+        self.logname = logname
+        if logfile is not None:
+            if self.logname is not None:
+                config.error("the 'logfile' parameter of %s "
+                             "must not be specified when 'logname' is set" % (name,))
+            self.logname = logfile
+
         for k, v in iteritems(kwargs):
             if k not in self.resultConfig:
                 config.error("the parameter '%s' is not "
@@ -115,7 +122,7 @@ class ShellSequence(buildstep.ShellMixin, buildstep.BuildStep):
             self.last_command = command
 
             cmd = yield self.makeRemoteShellCommand(command=command,
-                                                    stdioLogName=arg.logfile)
+                                                    stdioLogName=arg.logname)
             yield self.runCommand(cmd)
             overall_result, terminate = results.computeResultAndTermination(
                 arg, cmd.results(), overall_result)

--- a/master/buildbot/test/unit/test_steps_shellsequence.py
+++ b/master/buildbot/test/unit/test_steps_shellsequence.py
@@ -153,7 +153,7 @@ class TestOneShellCommand(steps.BuildStepMixin, unittest.TestCase, configmixin.C
         each new build.
         """
         arg = shellsequence.ShellArg(command=WithProperties('make %s', 'project'),
-                                     logfile=WithProperties('make %s', 'project'))
+                                     lognamee=WithProperties('make %s', 'project'))
         step = shellsequence.ShellSequence(commands=[arg], workdir='build')
 
         # First "build"

--- a/master/buildbot/test/unit/test_steps_shellsequence.py
+++ b/master/buildbot/test/unit/test_steps_shellsequence.py
@@ -63,7 +63,7 @@ class TestOneShellCommand(steps.BuildStepMixin, unittest.TestCase, configmixin.C
 
     def testShellArgsAreRendered(self):
         arg1 = shellsequence.ShellArg(command=WithProperties('make %s', 'project'),
-                                      logfile=WithProperties('make %s', 'project'))
+                                      logname=WithProperties('make %s', 'project'))
         self.setupStep(
             shellsequence.ShellSequence(commands=[arg1],
                                         workdir='build'))
@@ -100,7 +100,7 @@ class TestOneShellCommand(steps.BuildStepMixin, unittest.TestCase, configmixin.C
 
     def testMultipleCommandsAreRun(self):
         arg1 = shellsequence.ShellArg(command='make p1')
-        arg2 = shellsequence.ShellArg(command='deploy p1', logfile='deploy')
+        arg2 = shellsequence.ShellArg(command='deploy p1', logname='deploy')
         self.setupStep(
             shellsequence.ShellSequence(commands=[arg1, arg2],
                                         workdir='build'))

--- a/master/buildbot/test/unit/test_steps_shellsequence.py
+++ b/master/buildbot/test/unit/test_steps_shellsequence.py
@@ -153,7 +153,7 @@ class TestOneShellCommand(steps.BuildStepMixin, unittest.TestCase, configmixin.C
         each new build.
         """
         arg = shellsequence.ShellArg(command=WithProperties('make %s', 'project'),
-                                     lognamee=WithProperties('make %s', 'project'))
+                                     logname=WithProperties('make %s', 'project'))
         step = shellsequence.ShellSequence(commands=[arg], workdir='build')
 
         # First "build"

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -1249,24 +1249,24 @@ A list of :class:`~buildbot.steps.shellsequence.ShellArg` objects or a renderabl
     f.addStep(steps.ShellSequence(
         commands=[
             util.ShellArg(command=['configure']),
-            util.ShellArg(command=['make'], logfile='make'),
-            util.ShellArg(command=['make', 'check_warning'], logfile='warning', warnOnFailure=True),
-            util.ShellArg(command=['make', 'install'], logfile='make install')
+            util.ShellArg(command=['make'], logname='make'),
+            util.ShellArg(command=['make', 'check_warning'], logname='warning', warnOnFailure=True),
+            util.ShellArg(command=['make', 'install'], logname='make install')
         ]))
 
 All these commands share the same configuration of ``environment``, ``workdir`` and ``pty`` usage that can be setup the same way as in :bb:step:`ShellCommand`.
 
-.. py:class:: buildbot.steps.shellsequence.ShellArg(self, command=None, logfile=None, haltOnFailure=False, flunkOnWarnings=False, flunkOnFailure=False, warnOnWarnings=False, warnOnFailure=False)
+.. py:class:: buildbot.steps.shellsequence.ShellArg(self, command=None, logname=None, haltOnFailure=False, flunkOnWarnings=False, flunkOnFailure=False, warnOnWarnings=False, warnOnFailure=False)
 
     :param command: (see the :bb:step:`ShellCommand` ``command`` argument),
-    :param logfile: optional log file name, used as the stdio log of the command
+    :param logname: optional log name, used as the stdio log of the command
 
     The ``haltOnFailure``, ``flunkOnWarnings``, ``flunkOnFailure``, ``warnOnWarnings``, ``warnOnFailure`` parameters drive the execution of the sequence, the same way steps are scheduled in the build.
     They have the same default values as for buildsteps - see :ref:`Buildstep-Common-Parameters`.
 
     Any of the arguments to this class can be renderable.
 
-    Note that if ``logfile`` name does not start with the prefix ``stdio``, that prefix will be set like ``stdio <logfile>``.
+    Note that if ``logname`` name does not start with the prefix ``stdio``, that prefix will be set like ``stdio <logname>``. If no ``logname`` is supplied, the output of the command will not be collected.
 
 
 The two :bb:step:`ShellSequence` methods below tune the behavior of how the list of shell commands are executed, and can be overridden in subclasses.


### PR DESCRIPTION
The name logfile suggests that a file should be specified, while it is just the log name to use for the stdio output of the command beeing run. This commit renames logfile to logname while keeping the old logfile parameter around for compatibility.

This addresses the problem mentioned in #3771.

I'm not sure about the following part in the doc:

> Note that if ``logname`` name does not start with the prefix ``stdio``, that prefix will be set like ``stdio <logname>``

I don't see this on my buildbot. When I specify ``logfile='test'`` the log is just displayed as ``test`` in the web ui.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation