### PR TITLE
buildbot.reporters.hipchat: Include as reporter

### DIFF
--- a/master/buildbot/newsfragments/include_hipchat.bugfix
+++ b/master/buildbot/newsfragments/include_hipchat.bugfix
@@ -1,0 +1,1 @@
+Include `hipchat` as reporter.

--- a/master/setup.py
+++ b/master/setup.py
@@ -331,6 +331,7 @@ setup_args = {
             ('buildbot.reporters.gerrit', ['GerritStatusPush']),
             ('buildbot.reporters.gerrit_verify_status',
              ['GerritVerifyStatusPush']),
+            ('buildbot.reporters.hipchat', ['HipChatStatusPush']),
             ('buildbot.reporters.http', ['HttpStatusPush']),
             ('buildbot.reporters.github', ['GitHubStatusPush', 'GitHubCommentPush']),
             ('buildbot.reporters.gitlab', ['GitLabStatusPush']),


### PR DESCRIPTION
The documentation had old example that no longer worked

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
