### PR TITLE
Relax builder name length restriction

### DIFF
--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -87,7 +87,7 @@ class Builder(base.ResourceType):
 
     class EntityType(types.Entity):
         builderid = types.Integer()
-        name = types.Identifier(50)
+        name = types.Identifier(70)
         masterids = types.List(of=types.Integer())
         description = types.NoneOk(types.String())
         tags = types.List(of=types.String())

--- a/master/buildbot/newsfragments/relax_buildername_length_restriction.bugfix
+++ b/master/buildbot/newsfragments/relax_buildername_length_restriction.bugfix
@@ -1,0 +1,1 @@
+Fixed Relax builder name length restriction (:issue:`3413`).

--- a/master/docs/manual/installation/nine-upgrade.rst
+++ b/master/docs/manual/installation/nine-upgrade.rst
@@ -162,7 +162,7 @@ Unfortunately, many existing names do not fit this pattern.
 The following fields are identifiers:
 
 * worker name (50-character)
-* builder name (50-character)
+* builder name (70-character)
 * step name (50-character)
 
 Serving static files


### PR DESCRIPTION
Fix https://github.com/buildbot/buildbot/issues/3413

There are clearly some open-source instances which uses builder names longer than 50 character. There would be many more private instances which would be hit by this issue.

The only concern with longer builder names is that some UI like console view might not look so good. I believe this decision should be left with the admin of Buildbot instead of forcing them to shorten the names, some Buildbot instances do not even enable console/waterfall view, even in those cases we are enforcing this strict limit.