### PR TITLE
Fix IRC output for Python3 master

### DIFF
--- a/master/buildbot/reporters/irc.py
+++ b/master/buildbot/reporters/irc.py
@@ -60,13 +60,13 @@ class IrcStatusBot(StatusBot, irc.IRCClient):
 
     # The following methods are called when we write something.
     def groupChat(self, channel, message):
-        self.notice(channel, message.encode('utf-8', 'replace'))
+        self.notice(channel, message)
 
     def chat(self, user, message):
-        self.msg(user, message.encode('utf-8', 'replace'))
+        self.msg(user, message)
 
     def groupDescribe(self, channel, action):
-        self.describe(channel, action.encode('utf-8', 'replace'))
+        self.describe(channel, action)
 
     def getContact(self, user=None, channel=None):
         # nicknames and channel names are case insensitive


### PR DESCRIPTION
A Python3 master outputs `bytes` reprs to IRC:

```
[py-bb] b'Build x86 Windows7 3.6 #209 is complete: Warnings [\x038warnings test (warnings)\x0f] - http://buildbot.python.org/all/#builders/90/builds/209'
```

Stripping explicit encodes from `master/buildbot/reporters/irc.py` and just letting Twisted handle the encoding seems to fix it complete with color:

```
[py-bb] Build AMD64 Windows8 3.x #659 is complete: Success [build successful] - http://buildbot.python.org/all/#builders/32/builds/659
```

I don't understand the buildbot codebase or Twisted framework well enough to say whether this fix is actually *correct*, and can't get the tests to work properly on my machine anyway, so please feel free to fix up this PR as necessary or close it outright in favor of the correct fix.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
