### PR TITLE
Fix #3799. Use bytes2NativeString when calling NamedTemporaryFile.write() and add related unittest.

### DIFF
--- a/master/buildbot/newsfragments/namedtemporaryfile_encoding_issue.bugfix
+++ b/master/buildbot/newsfragments/namedtemporaryfile_encoding_issue.bugfix
@@ -1,1 +1,1 @@
-Fix encoding problem of :py:class:`~NamedTemporaryFile` and add related unittest (:issue:`3799`).
+Fix encoding issues of commands with Windows workers (:issue:`3799`).

--- a/master/buildbot/newsfragments/namedtemporaryfile_encoding_issue.bugfix
+++ b/master/buildbot/newsfragments/namedtemporaryfile_encoding_issue.bugfix
@@ -1,0 +1,1 @@
+Fix encoding problem of :py:class:`~NamedTemporaryFile` and add related unittest (:issue:`3799`).

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -47,6 +47,7 @@ from twisted.python import runtime
 from twisted.python.win32 import quoteArguments
 
 from buildbot_worker import util
+from buildbot_worker.compat import bytes2NativeString
 from buildbot_worker.compat import bytes2unicode
 from buildbot_worker.compat import unicode2bytes
 from buildbot_worker.exceptions import AbandonChain
@@ -60,7 +61,7 @@ def win32_batch_quote(cmd_list, unicode_encoding='utf-8'):
     # Windows batch file. This is not quite the same as quoting it for the
     # shell, as cmd.exe doesn't support the %% escape in interactive mode.
     def escape_arg(arg):
-        arg = bytes2unicode(arg, unicode_encoding)
+        arg = bytes2NativeString(arg, unicode_encoding)
         arg = quoteArguments([arg])
         # escape shell special characters
         arg = re.sub(r'[@()^"<>&|]', r'^\g<0>', arg)
@@ -614,9 +615,9 @@ class RunProcess(object):
         # echo off hides this cheat from the log files.
         tf.write(u"@echo off\n")
         if isinstance(self.command, (string_types, bytes)):
-            tf.write(bytes2unicode(self.command, self.builder.unicode_encoding))
+            tf.write(bytes2NativeString(self.command, self.builder.unicode_encoding))
         else:
-            tf.write(win32_batch_quote(self.command))
+            tf.write(win32_batch_quote(self.command, self.builder.unicode_encoding))
         tf.close()
 
         argv = os.environ['COMSPEC'].split()  # allow %COMSPEC% to have args

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -611,9 +611,9 @@ class RunProcess(object):
         """A cheat that routes around the impedance mismatch between
         twisted and cmd.exe with respect to escaping quotes"""
 
-        # NamedTemporaryFile(NTF) differs in PY2 and PY3.
-        # In PY2, NTF needs encoded str and its encoding cannot be specified.
-        # In PY3, NTF needs str which is unicode and its encoding can be specified.
+        # NamedTemporaryFile differs in PY2 and PY3.
+        # In PY2, it needs encoded str and its encoding cannot be specified.
+        # In PY3, it needs str which is unicode and its encoding can be specified.
         if PY3:
             tf = NamedTemporaryFile(mode='w+', dir='.', suffix=".bat",
                                     delete=False, encoding=self.builder.unicode_encoding)

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -23,6 +23,7 @@ from future.builtins import range
 from future.utils import iteritems
 from future.utils import string_types
 from future.utils import text_type
+from future.utils import PY3
 
 import os
 import pprint
@@ -610,8 +611,16 @@ class RunProcess(object):
         """A cheat that routes around the impedance mismatch between
         twisted and cmd.exe with respect to escaping quotes"""
 
-        tf = NamedTemporaryFile(mode='w+', dir='.', suffix=".bat",
-                                delete=False, encoding=self.builder.unicode_encoding)
+        # NamedTemporaryFile(NTF) differs in PY2 and PY3.
+        # In PY2, NTF needs encoded str and its encoding cannot be specified.
+        # In PY3, NTF needs str which is unicode and its encoding can be specified.
+        if PY3:
+            tf = NamedTemporaryFile(mode='w+', dir='.', suffix=".bat",
+                                    delete=False, encoding=self.builder.unicode_encoding)
+        else:
+            tf = NamedTemporaryFile(mode='w+', dir='.', suffix=".bat",
+                                    delete=False)
+
         # echo off hides this cheat from the log files.
         tf.write(u"@echo off\n")
         if isinstance(self.command, (string_types, bytes)):

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -20,10 +20,10 @@ Support for running 'shell commands'
 from __future__ import absolute_import
 from __future__ import print_function
 from future.builtins import range
+from future.utils import PY3
 from future.utils import iteritems
 from future.utils import string_types
 from future.utils import text_type
-from future.utils import PY3
 
 import os
 import pprint

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -611,7 +611,7 @@ class RunProcess(object):
         twisted and cmd.exe with respect to escaping quotes"""
 
         tf = NamedTemporaryFile(mode='w+', dir='.', suffix=".bat",
-                                delete=False)
+                                delete=False, encoding=self.builder.unicode_encoding)
         # echo off hides this cheat from the log files.
         tf.write(u"@echo off\n")
         if isinstance(self.command, (string_types, bytes)):

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -509,10 +509,10 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         return self._test_spawnAsBatch(stdoutCommand('hello'), "cmd.exe /c")
 
     def test_spawnAsBatchCommandWithNonAscii(self):
-        return self._test_spawnAsBatch(b"echo \xe6\x88\x91", "cmd.exe")
+        return self._test_spawnAsBatch(u"echo \u6211", "cmd.exe")
 
     def test_spawnAsBatchCommandListWithNonAscii(self):
-        return self._test_spawnAsBatch([b'echo', b'\xe6\x88\x91'], "cmd.exe /c")
+        return self._test_spawnAsBatch(['echo', u"\u6211"], "cmd.exe /c")
 
 
 class TestPOSIXKilling(BasedirMixin, unittest.TestCase):

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -508,6 +508,12 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
     def test_spawnAsBatchCommandList(self):
         return self._test_spawnAsBatch(stdoutCommand('hello'), "cmd.exe /c")
 
+    def test_spawnAsBatchCommandWithNonAscii(self):
+        return self._test_spawnAsBatch(b"echo \xe6\x88\x91", "cmd.exe")
+
+    def test_spawnAsBatchCommandListWithNonAscii(self):
+        return self._test_spawnAsBatch([b'echo', b'\xe6\x88\x91'], "cmd.exe /c")
+
 
 class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
 


### PR DESCRIPTION
Fix #3799. Use bytes2NativeString when calling NamedTemporaryFile.write() and add related unittest.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
