### PR TITLE
builder: add defaultProperties support

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -960,7 +960,7 @@ class BuilderConfig(util_config.ConfiguredMixin, WorkerAPICompatMixin):
                  tags=None, category=None,
                  nextWorker=None, nextBuild=None, locks=None, env=None,
                  properties=None, collapseRequests=None, description=None,
-                 canStartBuild=None,
+                 canStartBuild=None, defaultProperties=None,
 
                  slavename=None,  # deprecated, use `workername` instead
                  slavenames=None,  # deprecated, use `workernames` instead
@@ -1106,6 +1106,7 @@ class BuilderConfig(util_config.ConfiguredMixin, WorkerAPICompatMixin):
         if not isinstance(self.env, dict):
             error("builder's env must be a dictionary")
         self.properties = properties or {}
+        self.defaultProperties = defaultProperties or {}
         self.collapseRequests = collapseRequests
 
         self.description = description
@@ -1132,6 +1133,8 @@ class BuilderConfig(util_config.ConfiguredMixin, WorkerAPICompatMixin):
             rv['env'] = self.env
         if self.properties:
             rv['properties'] = self.properties
+        if self.defaultProperties:
+            rv['defaultProperties'] = self.defaultProperties
         if self.collapseRequests is not None:
             rv['collapseRequests'] = self.collapseRequests
         if self.description:

--- a/master/buildbot/newsfragments/builder-defaultProperties.feature
+++ b/master/buildbot/newsfragments/builder-defaultProperties.feature
@@ -1,0 +1,1 @@
+Added the ``defaultProperties`` parameter to :bb:cfg:`builders`.

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -375,6 +375,12 @@ class Builder(util_service.ReconfigurableServiceMixin,
                 props.setProperty(propertyname,
                                   self.config.properties[propertyname],
                                   "Builder")
+        if self.config.defaultProperties:
+            for propertyname in self.config.defaultProperties:
+                if propertyname not in props:
+                    props.setProperty(propertyname,
+                                      self.config.defaultProperties[propertyname],
+                                      "Builder")
 
     def buildFinished(self, build, wfb):
         """This is called when the Build has finished (either success or

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -31,6 +31,7 @@ from buildbot import interfaces
 from buildbot import locks
 from buildbot.process import builder
 from buildbot.process import factory
+from buildbot.process.properties import Properties
 from buildbot.process.properties import renderer
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
@@ -477,6 +478,19 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
             deprecated = self.bldr.expectations
 
         self.assertIdentical(deprecated, None)
+
+    @defer.inlineCallbacks
+    def test_defaultProperties(self):
+        props = Properties()
+        props.setProperty('foo', 1, 'Scheduler')
+        props.setProperty('bar', 'bleh', 'Change')
+
+        yield self.makeBuilder(defaultProperties={'bar': 'onoes', 'cuckoo': 42})
+
+        self.bldr.setupProperties(props)
+
+        self.assertEquals(props.getProperty('bar'), 'bleh')
+        self.assertEquals(props.getProperty('cuckoo'), 42)
 
 
 class TestGetBuilderId(BuilderMixin, unittest.TestCase):

--- a/master/docs/manual/cfg-builders.rst
+++ b/master/docs/manual/cfg-builders.rst
@@ -127,6 +127,10 @@ Other optional keys may be set on each ``BuilderConfig``:
     Those values can be used later on like other properties.
     :ref:`Interpolate`.
 
+``defaultProperties``
+    Similar to the ``properties`` parameter.
+    But ``defaultProperties`` will only be added to :ref:`Build-Properties` if they are not already set by :ref:`another source <Properties>`.
+
 ``description``
     A builder may be given an arbitrary description, which will show up in the web status on the builder's page.
 


### PR DESCRIPTION
Add a new `defaultProperties` field for `BuilderConfig`. Properties set here will only be exported to builds if they are not already set by changes or schedulers.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
