### PR TITLE
remove ramlfications from dependencies

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1021,7 +1021,6 @@ radez
 raiseexpectationfailure
 ralph
 raml
-ramlfications
 rc
 reactorname
 readlines

--- a/master/setup.py
+++ b/master/setup.py
@@ -494,7 +494,6 @@ test_deps = [
     'moto',
     # txgithub required to run buildbot.status.github module tests
     'txgithub',
-    'ramlfications',
     'mock>=2.0.0',
 ]
 if sys.platform != 'win32':
@@ -539,7 +538,6 @@ setup_args['extras_require'] = {
         'sphinxcontrib-spelling',
         'pyenchant',
         'docutils>=0.8',
-        'ramlfications',
         'sphinx-jinja',
         'towncrier'
     ],

--- a/newsfragments/ramlfication.removal
+++ b/newsfragments/ramlfication.removal
@@ -1,0 +1,1 @@
+Removed ramlfication as a dependency to build the docs and run the tests.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -63,7 +63,6 @@ pyparsing==2.2.0
 python-dateutil==2.6.1
 pytz==2017.3
 PyYAML==3.12
-ramlfications==0.1.9
 requests==2.18.4
 s3transfer==0.1.12
 scandir==1.6


### PR DESCRIPTION
Raml being too much flexible, it turns out very difficult to make generic tooling.
So ramlfication struggles to reach raml 1.0 support.

The Buildbot raml spec as it is now still is useful, we just include the basic parser able to generate the doc.

This will help @rjarry work of pushing buildbot to debian
