### PR TITLE
Builder page should show worker column

### DIFF
--- a/newsfragments/show_workername_on_build_page.bugfix
+++ b/newsfragments/show_workername_on_build_page.bugfix
@@ -1,0 +1,1 @@
+Partially fix Builder page should show the worker information  (:issue:`3546`).

--- a/www/base/src/app/builders/builder/builder.controller.coffee
+++ b/www/base/src/app/builders/builder/builder.controller.coffee
@@ -99,7 +99,7 @@ class Builder extends Controller
             if $stateParams.numbuilds?
                 $scope.numbuilds = +$stateParams.numbuilds
             $scope.builds = builder.getBuilds
-                property: ["owner"]
+                property: ["owner", "workername"]
                 limit: $scope.numbuilds
                 order: '-number'
             $scope.buildrequests = builder.getBuildrequests(claimed:false)

--- a/www/base/src/app/common/directives/builds/buildstable.tpl.jade
+++ b/www/base/src/app/common/directives/builds/buildstable.tpl.jade
@@ -9,6 +9,7 @@
         td(width='150px') Started At
         td(width='150px') Duration
         td(width='200px') Owner
+        td(width='150px') Worker
         td Status
       tr(ng-repeat='build in builds | orderBy:"-started_at"')
           td(ng-show="builders") {{ builders.get(build.builderid).name }}
@@ -27,6 +28,9 @@
           td
             span(title="{{build.properties.owner[0]}}")
               | {{ build.properties.owner[0] }}
+          td
+            a(ui-sref='worker({worker: build.workerid})')
+              | {{build.properties.workername[0]}}
           td
             ul.list-inline
               li


### PR DESCRIPTION
Partially Fix https://github.com/buildbot/buildbot/issues/3546

Dividing https://github.com/buildbot/buildbot/pull/3905 into multiple smaller PRs.