### PR TITLE
integration test for secret in services

### DIFF
--- a/common/flake8rc
+++ b/common/flake8rc
@@ -20,5 +20,8 @@ max-line-length = 100
 # E721 do not compare types, use 'isinstance()'
 # W503 line break before binary operator
 # E731 do not assign a lambda expression, use a def
+# H302 only import modules (we also import classes)
+# H301 one import per line (we rely on isort for that)
+# H306 sorted import (we rely on isort for that)
 
-ignore = E122,E123,E126,E128,E211,E501,E711,E712,E721,E731,W503
+ignore = E122,E123,E126,E128,E211,E501,E711,E712,E721,E731,W503,H302,H306,H301

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -193,6 +193,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
 
         self.secrets_manager = SecretManager()
         self.secrets_manager.setServiceParent(self)
+        self.secrets_manager.reconfig_priority = 2000
 
         self.service_manager = service.BuildbotServiceManager()
         self.service_manager.setServiceParent(self)

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -487,13 +487,13 @@ class _SecretRenderer(object):
 
     @defer.inlineCallbacks
     def getRenderingFor(self, properties):
-        secretsSrv = properties.getBuild().master.namedServices.get("secrets")
+        secretsSrv = properties.master.namedServices.get("secrets")
         if not secretsSrv:
             error_message = "secrets service not started, need to configure" \
                             " SecretManager in c['services'] to use 'secrets'" \
                             "in Interpolate"
             raise KeyError(error_message)
-        credsservice = properties.getBuild().master.namedServices['secrets']
+        credsservice = properties.master.namedServices['secrets']
         secret_detail = yield credsservice.get(self.secret_name)
         if secret_detail is None:
             raise KeyError("secret key %s is not found in any provider" % self.secret_name)

--- a/master/buildbot/test/integration/interop/test_integration_secrets.py
+++ b/master/buildbot/test/integration/interop/test_integration_secrets.py
@@ -20,9 +20,9 @@ import os
 from twisted.internet import defer
 
 from buildbot.process.properties import Interpolate
+from buildbot.reporters.http import HttpStatusPush
 from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.test.util.integration import RunMasterBase
-from buildbot.reporters.http import HttpStatusPush
 
 
 class FakeSecretReporter(HttpStatusPush):

--- a/master/buildbot/test/integration/interop/test_integration_secrets.py
+++ b/master/buildbot/test/integration/interop/test_integration_secrets.py
@@ -22,13 +22,21 @@ from twisted.internet import defer
 from buildbot.process.properties import Interpolate
 from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.test.util.integration import RunMasterBase
+from buildbot.reporters.http import HttpStatusPush
+
+
+class FakeSecretReporter(HttpStatusPush):
+    def send(self, build):
+        assert self.auth == ('user', 'myhttppasswd')
+        self.reported = True
 
 
 class SecretsConfig(RunMasterBase):
 
     @defer.inlineCallbacks
     def test_secret(self):
-        yield self.setupConfig(masterConfig())
+        c = masterConfig()
+        yield self.setupConfig(c)
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         res = yield self.checkBuildStepLogExist(build, "echo <foo>")
@@ -38,6 +46,7 @@ class SecretsConfig(RunMasterBase):
         # at this point, build contains all the log and steps info that is in the db
         # we check that our secret is not in there!
         self.assertNotIn("bar", repr(build))
+        self.assertTrue(c['services'][0].reported)
 
     @defer.inlineCallbacks
     def test_secretReconfig(self):
@@ -66,13 +75,15 @@ def masterConfig():
     from buildbot.process.factory import BuildFactory
     from buildbot.plugins import schedulers, steps
 
+    c['services'] = [FakeSecretReporter('http://example.com/hook',
+                                        auth=('user', Interpolate('%(secret:httppasswd)s')))]
     c['schedulers'] = [
         schedulers.ForceScheduler(
             name="force",
             builderNames=["testy"])]
 
     c['secretsProviders'] = [FakeSecretStorage(
-        secretdict={"foo": "bar", "something": "more"})]
+        secretdict={"foo": "bar", "something": "more", 'httppasswd': 'myhttppasswd'})]
     f = BuildFactory()
     if os.name == "posix":
         f.addStep(steps.ShellCommand(command=Interpolate(

--- a/newsfragments/secret_in_services.bugfix
+++ b/newsfragments/secret_in_services.bugfix
@@ -1,0 +1,1 @@
+Fix the configuration order so that services can actually use secrets in their configuraion (:issue:`3985`)


### PR DESCRIPTION
we need to have the secret service configured before all the other

Fixes #3985

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
