### PR TITLE
Allow urlText in DirectoryUpload

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -371,6 +371,7 @@ diff
 diffs
 dir
 directoryenterpattern
+directoryupload
 dirname
 dirs
 dirwatcher
@@ -1440,6 +1441,7 @@ urllib
 urlopen
 urlparse
 urls
+urltext
 usa
 usageerror
 usechange

--- a/master/buildbot/newsfragments/urlText-in-DirectoryUpload.feature
+++ b/master/buildbot/newsfragments/urlText-in-DirectoryUpload.feature
@@ -1,1 +1,1 @@
-Allow urlText to be set on a url linked to a DirectoryUpload (:issue:`3983`)
+Allow ``urlText`` to be set on a url linked to a ``DirectoryUpload`` step (:issue:`3983`)

--- a/master/buildbot/newsfragments/urlText-in-DirectoryUpload.feature
+++ b/master/buildbot/newsfragments/urlText-in-DirectoryUpload.feature
@@ -1,0 +1,1 @@
+Allow urlText to be set on a url linked to a DirectoryUpload (:issue:`3983`)

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -197,7 +197,7 @@ class DirectoryUpload(_TransferBuildStep, WorkerAPICompatMixin):
 
     def __init__(self, workersrc=None, masterdest=None,
                  workdir=None, maxsize=None, blocksize=16 * 1024,
-                 compress=None, url=None,
+                 compress=None, url=None, urlText=None,
                  slavesrc=None,  # deprecated, use `workersrc` instead
                  **buildstep_kwargs
                  ):
@@ -225,6 +225,7 @@ class DirectoryUpload(_TransferBuildStep, WorkerAPICompatMixin):
                 "'compress' must be one of None, 'gz', or 'bz2'")
         self.compress = compress
         self.url = url
+        self.urlText = urlText
 
     def start(self):
         self.checkWorkerHasCommand("uploadDirectory")
@@ -241,8 +242,12 @@ class DirectoryUpload(_TransferBuildStep, WorkerAPICompatMixin):
 
         self.descriptionDone = "uploading %s" % os.path.basename(source)
         if self.url is not None:
-            self.addURL(
-                os.path.basename(os.path.normpath(masterdest)), self.url)
+            urlText = self.urlText
+
+            if urlText is None:
+                urlText = os.path.basename(os.path.normpath(masterdest))
+
+            self.addURL(urlText, self.url)
 
         # we use maxsize to limit the amount of data on both sides
         dirWriter = remotetransfer.DirectoryWriter(


### PR DESCRIPTION
Allow `urlText` to be set on a `DirectoryUpload`.

Adresses #3983 

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
