### PR TITLE
mail: fix error when addresses have real name parts

### DIFF
--- a/common/pylintrc
+++ b/common/pylintrc
@@ -142,6 +142,7 @@ disable=
   interface-not-implemented,
   bad-continuation,
   keyword-arg-before-vararg,
+  unsubscriptable-object,
   inconsistent-return-statements  # (implicit return None)
 
 [REPORTS]

--- a/master/buildbot/newsfragments/email-real-names.bugfix
+++ b/master/buildbot/newsfragments/email-real-names.bugfix
@@ -1,0 +1,1 @@
+The :bb:reporter:`MailNotifier` no longer crashes when sending from/to email addresses with "Real Name" parts (e.g., ``John Doe <john.doe@domain.tld``).

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -24,6 +24,7 @@ from email.message import Message
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formatdate
+from email.utils import parseaddr
 from io import BytesIO
 
 from twisted.internet import defer
@@ -329,9 +330,10 @@ class MailNotifier(NotifierBase):
         useAuth = self.smtpUser and self.smtpPassword
 
         s = unicode2bytes(s)
+        recipients = [parseaddr(r)[1] for r in recipients]
         sender_factory = ESMTPSenderFactory(
             unicode2bytes(self.smtpUser), unicode2bytes(self.smtpPassword),
-            self.fromaddr, recipients, BytesIO(s),
+            parseaddr(self.fromaddr)[1], recipients, BytesIO(s),
             result, requireTransportSecurity=self.useTls,
             requireAuthentication=useAuth)
 


### PR DESCRIPTION
When trying to send email with addresses (from and/or recipients) that contain real name parts, e.g.:

`John Doe <john.doe@buildbot.net>`

There is an error:

```
 raise AddressError("Parse error at %r of %r" % (atl[0], (addr, atl)))
   twisted.mail._except.AddressError: Parse error at ' ' of (
   'John Doe <john.doe@buildbot.net>', [' ', '<', 'john', '.',
   'doe', '@', 'buildbot', '.', 'net', '>'])
```

The addresses provided to `ESMTPSenderFactory` must not contain any real name part, they must be [RFC 2821](https://www.ietf.org/rfc/rfc2821.txt) compliant. Strip the real name parts from the addresses before sending.

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
