### PR TITLE
Correct typo in documentation

### DIFF
--- a/master/buildbot/newsfragments/typo_correction.doc
+++ b/master/buildbot/newsfragments/typo_correction.doc
@@ -1,0 +1,1 @@
+Corrected typo in description of libvirt

--- a/master/docs/manual/cfg-workers-libvirt.rst
+++ b/master/docs/manual/cfg-workers-libvirt.rst
@@ -15,7 +15,7 @@ Libvirt
 `libvirt <http://www.libvirt.org/>`_ is a virtualization API for interacting with the virtualization capabilities of recent versions of Linux and other OSes.
 It is LGPL and comes with a stable C API, and Python bindings.
 
-This means we know have an API which when tied to buildbot allows us to have workers that run under Xen, QEMU, KVM, LXC, OpenVZ, User Mode Linux, VirtualBox and VMWare.
+This means we now have an API which when tied to buildbot allows us to have workers that run under Xen, QEMU, KVM, LXC, OpenVZ, User Mode Linux, VirtualBox and VMWare.
 
 The libvirt code in Buildbot was developed against libvirt 0.7.5 on Ubuntu Lucid.
 It is used with KVM to test Python code on VMs, but obviously isn't limited to that.


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation