### PR TITLE
Correct pluralization in HTML template

### DIFF
--- a/master/buildbot/newsfragments/landing_page_pluralization.bugfix
+++ b/master/buildbot/newsfragments/landing_page_pluralization.bugfix
@@ -1,0 +1,1 @@
+Corrected pluralization of text on landing page of the web UI

--- a/smokes/e2e/pages/home.coffee
+++ b/smokes/e2e/pages/home.coffee
@@ -37,7 +37,7 @@ class HomePage extends BasePage
         noRunningBuilds = () ->
             element.all(By.css("h4")).getText().then (text) ->
                 text = text.join(" ")
-                return text.toLowerCase().indexOf("0 build running") >= 0
+                return text.toLowerCase().indexOf("0 builds running") >= 0
         browser.wait(noRunningBuilds, 20000)
 
 module.exports = HomePage

--- a/www/base/src/app/home/home.tpl.jade
+++ b/www/base/src/app/home/home.tpl.jade
@@ -9,7 +9,7 @@
     .col-sm-12
       .well
         h2 Welcome to buildbot
-        h4 {{ buildsRunning.length }} build{{ buildsRunning.length > 1 ? 's' : '' }} running currently
+        h4 {{ buildsRunning.length }} build{{ buildsRunning.length == 1 ? '' : 's' }} running currently
         ul
           li.unstyled(ng-repeat="build in buildsRunning | filter:complete:false")
             buildsticker(build="build")


### PR DESCRIPTION
Correct pluralization of the word "build" when there are zero builds
running.
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
