### PR TITLE
Update sample config to use preferred API

### DIFF
--- a/master/buildbot/newsfragments/update_sample_config.doc
+++ b/master/buildbot/newsfragments/update_sample_config.doc
@@ -1,0 +1,1 @@
+Update sample config to use preferred API

--- a/master/buildbot/scripts/sample.cfg
+++ b/master/buildbot/scripts/sample.cfg
@@ -33,7 +33,7 @@ c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
         'git://github.com/buildbot/hello-world.git',
         workdir='gitpoller-workdir', branch='master',
-        pollinterval=300))
+        pollInterval=300))
 
 ####### SCHEDULERS
 


### PR DESCRIPTION
The change log for version 0.8.8 of Buildbot [1] includes the following
entry:

> - Several polling ChangeSources are now documented to take a
>   pollInterval argument, instead of pollinterval. The old name is
>   still supported.

Update the sample configuration file to use the preferred API.

[1] http://docs.buildbot.net/current/full.html#release-notes-for-buildbot-v0-8-8

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
