### PR TITLE
disable forceHouseKeeping every 24h.

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -206,10 +206,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
             if self.masterid is not None:
                 yield self.data.updates.masterActive(name=self.name,
                                                      masterid=self.masterid)
-            # force housekeeping once a day
-            self.masterHouskeepingTimer += 1
-            yield self.data.updates.expireMasters(
-                forceHouseKeeping=(self.masterHouskeepingTimer % (24 * 60)) == 0)
+            yield self.data.updates.expireMasters()
         self.masterHeartbeatService = internet.TimerService(60, heartbeat)
         # we do setServiceParent only when the master is configured
         # master should advertise itself only at that time

--- a/master/buildbot/newsfragments/housekeeping.bugfix
+++ b/master/buildbot/newsfragments/housekeeping.bugfix
@@ -1,0 +1,1 @@
+Fix issue which marked all workers dis-configured in the database every 24h (:issue:`3981` :issue:`3956` :issue:`3970`)

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -135,3 +135,6 @@ warnings.filterwarnings('ignore',
 # moto warning v1.0.0
 warnings.filterwarnings('ignore', "Flags not at the start of the expression")
 warnings.filterwarnings('ignore', r"object\(\) takes no parameters")
+
+# this warning happens sometimes on python3.4
+warnings.filterwarnings('ignore', r"The value of convert_charrefs will become True in 3.5")


### PR DESCRIPTION
Force housekeeping will act as if the master was reset, which will deconfigure all worker in the db (among other things)

Fixes: #3981
