### PR TITLE
Delete batch file accidentally added with pull request #3997

### DIFF
--- a/www/base/startProxy.bat
+++ b/www/base/startProxy.bat
@@ -1,1 +1,0 @@
-gulp dev proxy --host plumbuild


### PR DESCRIPTION
Apologies, this was a batch file I had added to make it convenient to start "gulp dev proxy" but has hardcoded server name.  I have moved this outside my repo directory so it doesn't accidentally get added anymore.