### PR TITLE
Fix MultipleFileUpload to correctly compute path name when worker and…

### DIFF
--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -405,16 +405,11 @@ class MultipleFileUpload(_TransferBuildStep, WorkerAPICompatMixin,
 
         @defer.inlineCallbacks
         def globSources(sources):
-            dl = defer.DeferredList([
+            results = yield defer.gatherResults([
                 self.runGlob(
                     os.path.join(self.workdir, source), abandonOnFailure=False) for source in sources
             ])
-            results = yield dl
-            results = [
-                result[1]
-                for result in filter(lambda result: result[0], results)
-            ]
-            results = flatten(results)
+            results = [self.workerPathToMasterPath(p) for p in flatten(results)]
             defer.returnValue(results)
 
         @defer.inlineCallbacks

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -233,6 +233,9 @@ class MakeDirectory(WorkerBuildStep):
 
 class CompositeStepMixin():
 
+    def workerPathToMasterPath(self, path):
+        return os.path.join(*self.worker.path_module.split(path))
+
     def addLogForRemoteCommands(self, logname):
         """This method must be called by user classes
         composite steps could create several logs, this mixin functions will write

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -211,6 +211,7 @@ class BuildStepMixin(object):
         # step.worker
 
         self.worker = step.worker = worker.FakeWorker(self.master)
+        self.worker.attached(None)
 
         # step overrides
 

--- a/newsfragments/crossostransfer.bugfix
+++ b/newsfragments/crossostransfer.bugfix
@@ -1,0 +1,1 @@
+Fix :bb:step:`MultipleFileUpload` to correctly compute path name when worker and master are on different OS (:issue:`4019`)


### PR DESCRIPTION
… master are on different OS

Fixes #4019

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
