### PR TITLE
Python 3 string fixes in REMOTE_USER + LDAP auth

### DIFF
--- a/master/buildbot/newsfragments/python3-ldap-encoding.bugfix
+++ b/master/buildbot/newsfragments/python3-ldap-encoding.bugfix
@@ -1,0 +1,1 @@
+LDAP bytes/unicode handling has been fixed to work with Python 3.  This means that LDAP authentication, REMOTE_USER authentication, and LDAP avatars now work on Python 3.  In addition, an of bounds access when trying to load the value of an empty LDAP attribute has been fixed.

--- a/master/buildbot/pbmanager.py
+++ b/master/buildbot/pbmanager.py
@@ -208,10 +208,10 @@ class Dispatcher(service.AsyncService):
                 matched = yield defer.maybeDeferred(
                     creds.checkPassword, unicode2bytes(password))
                 if not matched:
-                    log.msg("invalid login from user '%s'" % creds.username)
+                    log.msg("invalid login from user '{}'".format(username))
                     raise error.UnauthorizedLogin()
                 defer.returnValue(creds.username)
-            log.msg("invalid login from unknown user '%s'" % creds.username)
+            log.msg("invalid login from unknown user '{}'".format(username))
             raise error.UnauthorizedLogin()
         finally:
             yield self.master.initLock.release()

--- a/master/buildbot/test/unit/test_www_ldapuserinfo.py
+++ b/master/buildbot/test/unit/test_www_ldapuserinfo.py
@@ -26,8 +26,16 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
+
+def get_config_parameter(p):
+    params = {'DEFAULT_SERVER_ENCODING': 'utf-8'}
+    return params[p]
+
+
 fake_ldap = types.ModuleType('ldap3')
 fake_ldap.SEARCH_SCOPE_WHOLE_SUBTREE = 2
+fake_ldap.get_config_parameter = get_config_parameter
+
 with mock.patch.dict(sys.modules, {'ldap3': fake_ldap}):
     from buildbot.www import ldapuserinfo
 
@@ -62,7 +70,7 @@ class CommonTestCase(unittest.TestCase):
         raise NotImplementedError
 
     def makeSearchSideEffect(self, ret):
-        ret = [[{'dn': i[0], 'raw_attributes': i[1]} for i in r]
+        ret = [[{'dn': i[0], 'attributes': i[1]} for i in r]
              for r in ret]
         self.userInfoProvider.search.side_effect = ret
 

--- a/master/buildbot/test/unit/test_www_ldapuserinfo.py
+++ b/master/buildbot/test/unit/test_www_ldapuserinfo.py
@@ -142,25 +142,12 @@ class LdapUserInfo(CommonTestCase):
     @defer.inlineCallbacks
     def test_updateUserInfoGroupsUnicodeDn(self):
         # In case of non Ascii DN, ldap3 lib returns an UTF-8 str
-        dn = "cn=Sébastien,dc=example,dc=org"
+        dn = u"cn=Sébastien,dc=example,dc=org"
         # If groupMemberPattern is an str, and dn is not decoded,
         # the resulting filter will be an str, leading to UnicodeDecodeError
         # in ldap3.protocol.convert.validate_assertion_value()
         # So we use an unicode pattern:
         self.userInfoProvider.groupMemberPattern = u'(member=%(dn)s)'
-        self.makeSearchSideEffect([[(dn, {"accountFullName": "me too",
-                                          "accountEmail": "mee@too"})],
-                                   [("cn", {"groupName": ["group"]}),
-                                    ("cn", {"groupName": ["group2"]})
-                                    ], []])
-        res = yield self.userInfoProvider.getUserInfo("me")
-        self.assertEqual(res, {'email': 'mee@too', 'full_name': 'me too',
-                               'groups': ["group", "group2"], 'username': 'me'})
-
-        # and if dn is decoded, it also works with an str groupMemberPattern,
-        # provided it's ASCII (can be decoded implicitly in any case)
-        # promotion occurs because of the % operator
-        self.userInfoProvider.groupMemberPattern = '(member=%(dn)s)'
         self.makeSearchSideEffect([[(dn, {"accountFullName": "me too",
                                           "accountEmail": "mee@too"})],
                                    [("cn", {"groupName": ["group"]}),

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -113,7 +113,7 @@ class RemoteUserAuth(AuthBase):
         if header is not None:
             self.header = header
         if headerRegex is not None:
-            self.headerRegex = re.compile(headerRegex)
+            self.headerRegex = re.compile(unicode2bytes(headerRegex))
 
     @defer.inlineCallbacks
     def maybeAutoLogin(self, request):

--- a/master/buildbot/www/change_hook.py
+++ b/master/buildbot/www/change_hook.py
@@ -109,7 +109,7 @@ class ChangeHookResource(resource.Resource):
             request.write(b"no change found")
         else:
             yield self.submitChanges(changes, request, src)
-            request.write("{} change found".format(len(changes)).encode())
+            request.write(unicode2bytes("{} change found".format(len(changes))))
 
     def makeHandler(self, dialect):
         """create and cache the handler object for this dialect"""

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -27,6 +27,7 @@ from twisted.python import log
 from twisted.web.error import Error
 
 from buildbot.interfaces import IConfigured
+from buildbot.util import unicode2bytes
 from buildbot.www import resource
 
 
@@ -158,4 +159,4 @@ class IndexResource(resource.Resource):
         tpl = tpl.render(configjson=json.dumps(config, default=toJson),
                          custom_templates=self.custom_templates,
                          config=self.config)
-        defer.returnValue(tpl.encode("ascii"))
+        defer.returnValue(unicode2bytes(tpl, encoding='ascii'))

--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -23,6 +23,8 @@ from __future__ import print_function
 
 import json
 
+from buildbot.util import bytes2unicode
+
 
 class BaseHookHandler(object):
     def __init__(self, master, options):
@@ -68,9 +70,7 @@ class BaseHookHandler(object):
         author = firstOrNothing(args.get(b'author'))
         if not author:
             author = firstOrNothing(args.get(b'who'))
-        comments = firstOrNothing(args.get(b'comments'))
-        if isinstance(comments, bytes):
-            comments = comments.decode('utf-8')
+        comments = bytes2unicode(firstOrNothing(args.get(b'comments')))
         branch = firstOrNothing(args.get(b'branch'))
         category = firstOrNothing(args.get(b'category'))
         revlink = firstOrNothing(args.get(b'revlink'))

--- a/master/buildbot/www/ldapuserinfo.py
+++ b/master/buildbot/www/ldapuserinfo.py
@@ -104,7 +104,9 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
 
             def getLdapInfo(x):
                 if isinstance(x, list):
-                    return x[0]
+                    x = x[0]
+                if isinstance(x, bytes):
+                    x = x.decode('utf-8')
                 return x
             infos['full_name'] = getLdapInfo(ldap_infos[self.accountFullName])
             infos['email'] = getLdapInfo(ldap_infos[self.accountEmail])
@@ -120,8 +122,10 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
             pattern = self.groupMemberPattern % dict(dn=dn)
             res = self.search(c, self.groupBase, pattern,
                               attributes=[self.groupName])
-            infos['groups'] = flatten(
+            _groups = flatten(
                 [group_infos['raw_attributes'][self.groupName] for group_infos in res])
+            infos['groups'] = [g if not isinstance(g, bytes) else g.decode('utf-8')
+                for g in _groups]
             return infos
         return threads.deferToThread(thd)
 

--- a/master/buildbot/www/ldapuserinfo.py
+++ b/master/buildbot/www/ldapuserinfo.py
@@ -13,6 +13,17 @@
 #
 # Copyright Buildbot Team Members
 
+
+# NOTE regarding LDAP encodings:
+#
+# By default the encoding used in ldap3 is utf-8. The encoding is user-configurable, though.
+# For more information check ldap3's documentation on this topic:
+# http://ldap3.readthedocs.io/encoding.html
+#
+# It is recommended to use ldap3's auto-decoded `attributes` values for
+# `unicode` and `raw_*` attributes for `bytes`.
+
+
 from __future__ import absolute_import
 from __future__ import print_function
 from future.moves.urllib.parse import urlparse
@@ -21,6 +32,7 @@ import ldap3
 
 from twisted.internet import threads
 
+from buildbot.util import bytes2unicode
 from buildbot.util import flatten
 from buildbot.www import auth
 from buildbot.www import avatar
@@ -65,6 +77,7 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
         if accountExtraFields is None:
             accountExtraFields = []
         self.accountExtraFields = accountExtraFields
+        self.ldap_encoding = ldap3.get_config_parameter('DEFAULT_SERVER_ENCODING')
 
     def connectLdap(self):
         server = urlparse(self.uri)
@@ -87,6 +100,8 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
         return c.response
 
     def getUserInfo(self, username):
+        username = bytes2unicode(username)
+
         def thd():
             c = self.connectLdap()
             infos = {'username': username}
@@ -98,21 +113,18 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
             if len(res) != 1:
                 raise KeyError(
                     "ldap search \"%s\" returned %d results" % (pattern, len(res)))
-            dn, ldap_infos = res[0]['dn'], res[0]['raw_attributes']
-            if isinstance(dn, bytes):
-                dn = dn.decode('utf-8')
+            dn, ldap_infos = res[0]['dn'], res[0]['attributes']
 
-            def getLdapInfo(x):
+            def getFirstLdapInfo(x):
                 if isinstance(x, list):
-                    x = x[0]
-                if isinstance(x, bytes):
-                    x = x.decode('utf-8')
+                    x = x[0] if x else None
                 return x
-            infos['full_name'] = getLdapInfo(ldap_infos[self.accountFullName])
-            infos['email'] = getLdapInfo(ldap_infos[self.accountEmail])
+
+            infos['full_name'] = getFirstLdapInfo(ldap_infos[self.accountFullName])
+            infos['email'] = getFirstLdapInfo(ldap_infos[self.accountEmail])
             for f in self.accountExtraFields:
                 if f in ldap_infos:
-                    infos[f] = getLdapInfo(ldap_infos[f])
+                    infos[f] = getFirstLdapInfo(ldap_infos[f])
 
             if self.groupMemberPattern is None:
                 infos['groups'] = []
@@ -122,25 +134,26 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
             pattern = self.groupMemberPattern % dict(dn=dn)
             res = self.search(c, self.groupBase, pattern,
                               attributes=[self.groupName])
-            _groups = flatten(
-                [group_infos['raw_attributes'][self.groupName] for group_infos in res])
-            infos['groups'] = [g if not isinstance(g, bytes) else g.decode('utf-8')
-                for g in _groups]
+            infos['groups'] = flatten([group_infos['attributes'][self.groupName]
+                                      for group_infos in res])
+
             return infos
         return threads.deferToThread(thd)
 
     def findAvatarMime(self, data):
         # http://en.wikipedia.org/wiki/List_of_file_signatures
-        if data.startswith("\xff\xd8\xff"):
+        if data.startswith(b"\xff\xd8\xff"):
             return ("image/jpeg", data)
-        if data.startswith("\x89PNG"):
+        if data.startswith(b"\x89PNG"):
             return ("image/png", data)
-        if data.startswith("GIF8"):
+        if data.startswith(b"GIF8"):
             return ("image/gif", data)
         # ignore unknown image format
         return None
 
     def getUserAvatar(self, user_email, size, defaultAvatarUrl):
+        user_email = bytes2unicode(user_email)
+
         def thd():
             c = self.connectLdap()
             pattern = self.avatarPattern % dict(email=user_email)

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -356,9 +356,9 @@ class V2RootResource(resource.Resource):
 
     def encodeRaw(self, data, request):
         request.setHeader(b"content-type",
-                          unicode2bytes(data['mime-type'] + '; charset=utf-8')
+                          unicode2bytes(data['mime-type']) + b'; charset=utf-8')
         request.setHeader(b"content-disposition",
-                          unicode2bytes('attachment; filename=' + data['filename']))
+                          b'attachment; filename=' + unicode2bytes(data['filename']))
         request.write(unicode2bytes(data['raw']))
         return
 

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -356,10 +356,10 @@ class V2RootResource(resource.Resource):
 
     def encodeRaw(self, data, request):
         request.setHeader(b"content-type",
-                          data['mime-type'].encode() + b'; charset=utf-8')
+                          unicode2bytes(data['mime-type'] + '; charset=utf-8')
         request.setHeader(b"content-disposition",
-                          b'attachment; filename=' + data['filename'].encode())
-        request.write(data['raw'].encode('utf-8'))
+                          unicode2bytes('attachment; filename=' + data['filename']))
+        request.write(unicode2bytes(data['raw']))
         return
 
     @defer.inlineCallbacks

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -28,6 +28,7 @@ from twisted.python import log
 
 from buildbot.util import bytes2NativeString
 from buildbot.util import toJson
+from buildbot.util import unicode2bytes
 
 
 class WsProtocol(WebSocketServerProtocol):
@@ -39,7 +40,7 @@ class WsProtocol(WebSocketServerProtocol):
         self.debug = self.master.config.www.get('debug', False)
 
     def sendJsonMessage(self, **msg):
-        return self.sendMessage(json.dumps(msg, default=toJson, separators=(',', ':')).encode('utf8'))
+        return self.sendMessage(unicode2bytes(json.dumps(msg, default=toJson, separators=(',', ':'))))
 
     def onMessage(self, frame, isBinary):
         if self.debug:


### PR DESCRIPTION
When running Buildbot 1.1 on Python 3 with `REMOTE_USER` auth and LDAP user info backend the web interface fails to load because the dictionaries containing byte strings can't be serialized.
These changes fixed the web interface for me.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
