### PR TITLE
builders: Reduce number of db queries

### DIFF
--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -131,7 +131,7 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
             # build up a intermediate builder id -> tag names map (fixes performance issue #3396)
             bldr_id_to_tags = defaultdict(list)
             bldr_q = sa.select([builders_tags_tbl.c.builderid, tags_tbl.c.name])
-                       .select_from(tags_tbl.join(builders_tags_tbl))
+            bldr_q = bldr_q.select_from(tags_tbl.join(builders_tags_tbl))
 
             for bldr_id, tag in conn.execute(bldr_q).fetchall():
                 bldr_id_to_tags[bldr_id].append(tag)

--- a/master/buildbot/newsfragments/optimize-db-queries.bugfix
+++ b/master/buildbot/newsfragments/optimize-db-queries.bugfix
@@ -1,0 +1,1 @@
+Speed up generation of api/v2/builders by an order of magnitude. Fixes (:issue:`3396`).


### PR DESCRIPTION
When calling api/v2/builders:
Instead of running one query per builder id to get related tag names, just run one.

This makes generation of api/v2/builders faster by one order of magnitude.

On our production system, api/v2/builders returns around 1000 builderids (400 of them are stale/inactive, but anyway).

Poor man's benchmark (checked loading times with Chromium inspector):
* Time to load *before* patch: ~2000ms
* Time to load *after* patch: ~200ms

Fixes #3396

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
