### PR TITLE
break callback stack

### DIFF
--- a/master/buildbot/pbmanager.py
+++ b/master/buildbot/pbmanager.py
@@ -30,6 +30,7 @@ from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
 from buildbot.util import service
 from buildbot.util import unicode2bytes
+from buildbot.util.eventual import eventually
 
 debug = False
 
@@ -214,4 +215,4 @@ class Dispatcher(service.AsyncService):
             log.msg("invalid login from unknown user '%s'" % creds.username)
             raise error.UnauthorizedLogin()
         finally:
-            yield self.master.initLock.release()
+            eventually(self.master.initLock.release)


### PR DESCRIPTION
When lots of worker are connecting at the same time, we can get lots of waiters
waiting for the worker configuration lock.
This patch release the lock eventually, un rolling the stack before calling the next worker.

Fixes #4042 
