### PR TITLE
Fix example hook script for remote latent workers

### DIFF
--- a/master/docs/manual/cfg-workers-libvirt.rst
+++ b/master/docs/manual/cfg-workers-libvirt.rst
@@ -149,13 +149,13 @@ Configure remote libvirt server:
    }
 
    def delete_image_clone(vir_domain):
-       domain = domains[vir_domain]
-       if domain is not None:
+       if vir_domain in domains:
+	        domain = domains[vir_domain]
 	        os.remove(images_path + domain[1])
 
    def create_image_clone(vir_domain):
-       domain = domains[vir_domain]
-       if domain is not None:
+       if vir_domain in domains:
+	        domain = domains[vir_domain]
 	        cmd = ['/usr/bin/qemu-img', 'create', '-b', images_path + domain[0], '-f', 'qcow2', images_path + domain[1]]
 	        subprocess.call(cmd)
 


### PR DESCRIPTION
Accessing a dictionary with a non-existing key will produce a KeyError.
Check first whether the domain name is in the dictionary before getting
the corresponding entry.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
