### PR TITLE
Install psycopg2 and dependent library in buildbot master Dockerfile

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -74,6 +74,7 @@ RUN \
     apk add --no-cache \
         git \
         python \
+        postgresql-libs \
         py-pip \
         gosu@testing \
         dumb-init \

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -28,7 +28,8 @@ RUN \
         git \
         python-dev \
         libffi-dev \
-        openssl-dev \
+        libressl-dev \
+        postgresql-dev \
         py-pip \
         alpine-sdk \
         tar \

--- a/master/requirements-docker-extras.txt
+++ b/master/requirements-docker-extras.txt
@@ -1,1 +1,2 @@
 requests==2.18.4
+psycopg2==2.7.4


### PR DESCRIPTION
Fixes #4057 