### PR TITLE
changes: Make changesFetchLimit configurable

### DIFF
--- a/www/base/src/app/changes/changes.controller.coffee
+++ b/www/base/src/app/changes/changes.controller.coffee
@@ -1,5 +1,11 @@
 class Changes extends Controller
-    constructor: ($log, $scope, dataService) ->
+    constructor: ($log, $scope, dataService, bbSettingsService) ->
+        $scope.settings = bbSettingsService.getSettingsGroup("Changes")
+        $scope.$watch('settings', ->
+            bbSettingsService.save()
+        , true)
+        changesFetchLimit = $scope.settings.changesFetchLimit.value
+
         data = dataService.open().closeOnDestroy($scope)
         #  unlike other order, this particular order by changeid is optimised by the backend
-        $scope.changes = data.getChanges(limit:50, order:'-changeid')
+        $scope.changes = data.getChanges(limit: changesFetchLimit, order:'-changeid')

--- a/www/base/src/app/changes/changes.route.coffee
+++ b/www/base/src/app/changes/changes.route.coffee
@@ -1,5 +1,5 @@
 class State extends Config
-    constructor: ($stateProvider) ->
+    constructor: ($stateProvider, bbSettingsServiceProvider) ->
 
         # Name of the state
         name = 'changes'
@@ -18,3 +18,13 @@ class State extends Config
             data: cfg
 
         $stateProvider.state(state)
+
+        bbSettingsServiceProvider.addSettingsGroup
+            name:'Changes'
+            caption: 'Changes page related settings'
+            items:[
+                type:'integer'
+                name:'changesFetchLimit'
+                caption:'Maximum number of changes to fetch'
+                default_value: 50
+            ]


### PR DESCRIPTION
Fix #4027: Configurable changes fetch limit in UI.

To check it you could insert following line in master.cfg: `c['www']['ui_default_config'] = { 'Changes.changesFetchLimit': 2 }`