### PR TITLE
Check that returned GH team membership is not null.

### DIFF
--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -337,7 +337,8 @@ class GitHubAuth(OAuth2Auth):
                         # identical with the inclusion of the organization
                         # since different organizations might share a common
                         # team name
-                        teams.add('%s/%s' % (orgs_name_slug_mapping[org], node['node']['name']))
+                        if node['node'] is not None:
+                            teams.add('%s/%s' % (orgs_name_slug_mapping[org], node['node']['name']))
                 user_info['groups'].extend(sorted(teams))
         if self.debug:
             log.info('{klass} User Details: {user_info}',


### PR DESCRIPTION
This can happen when an organisation has enabled access restriction, forbidding third-parties from reading the data.

Closes #4077

