### PR TITLE
gitlab web hook: don't schedule build on non-interesting changes; fixes #3635

### DIFF
--- a/master/buildbot/newsfragments/issue3635-filter-gitlab-mr-better.bugfix
+++ b/master/buildbot/newsfragments/issue3635-filter-gitlab-mr-better.bugfix
@@ -1,0 +1,1 @@
+Don't schedule a build when a GitLab merge request is deleted or edited (:issue:3635)

--- a/master/buildbot/newsfragments/issue3635-filter-gitlab-mr-better.bugfix
+++ b/master/buildbot/newsfragments/issue3635-filter-gitlab-mr-better.bugfix
@@ -1,1 +1,1 @@
-Don't schedule a build when a GitLab merge request is deleted or edited (:issue:3635)
+Don't schedule a build when a GitLab merge request is deleted or edited (:issue:`3635`)

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -112,85 +112,572 @@ gitJsonPayloadTag = b"""
    "total_commits_count": 2
 }
 """
-gitJsonPayloadMR = b"""
+
+# GITLAB commit payload from an actual version 10.7.1-ee gitlab instance
+# chronicling the lives and times of a trivial MR through the operations
+# open, edit description, add commit, close, and reopen, in that order.
+# (Tidied with json_pp --json_opt=canonical,pretty and an editor.)
+# FIXME: only show diffs here to keep file smaller and increase clarity
+gitJsonPayloadMR_open = b"""
 {
-  "object_kind": "merge_request",
-  "user": {
-    "name": "Administrator",
-    "username": "root",
-    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40&d=identicon"
-  },
-  "object_attributes": {
-    "id": 99,
-    "target_branch": "master",
-    "source_branch": "ms-viewport",
-    "source_project_id": 14,
-    "author_id": 51,
-    "assignee_id": 6,
-    "title": "MS-Viewport",
-    "created_at": "2013-12-03T17:23:34Z",
-    "updated_at": "2013-12-03T17:23:34Z",
-    "st_commits": null,
-    "st_diffs": null,
-    "milestone_id": null,
-    "state": "opened",
-    "merge_status": "unchecked",
-    "target_project_id": 14,
-    "iid": 1,
-    "description": "",
-    "source":{
-      "name":"Awesome Project",
-      "description":"Aut reprehenderit ut est.",
-      "web_url":"http://example.com/awesome_user/awesome_project",
-      "avatar_url":null,
-      "git_ssh_url":"git@example.com:awesome_user/awesome_project.git",
-      "git_http_url":"http://example.com/awesome_user/awesome_project.git",
-      "namespace":"Awesome Space",
-      "visibility_level":20,
-      "path_with_namespace":"awesome_user/awesome_project",
-      "default_branch":"master",
-      "homepage":"http://example.com/awesome_user/awesome_project",
-      "url":"http://example.com/awesome_user/awesome_project.git",
-      "ssh_url":"git@example.com:awesome_user/awesome_project.git",
-      "http_url":"http://example.com/awesome_user/awesome_project.git"
-    },
-    "target": {
-      "name":"Awesome Project",
-      "description":"Aut reprehenderit ut est.",
-      "web_url":"http://example.com/awesome_space/awesome_project",
-      "avatar_url":null,
-      "git_ssh_url":"git@example.com:awesome_space/awesome_project.git",
-      "git_http_url":"http://example.com/awesome_space/awesome_project.git",
-      "namespace":"Awesome Space",
-      "visibility_level":20,
-      "path_with_namespace":"awesome_space/awesome_project",
-      "default_branch":"master",
-      "homepage":"http://example.com/awesome_space/awesome_project",
-      "url":"http://example.com/awesome_space/awesome_project.git",
-      "ssh_url":"git@example.com:awesome_space/awesome_project.git",
-      "http_url":"http://example.com/awesome_space/awesome_project.git"
-    },
-    "last_commit": {
-      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
-      "message": "fixed readme",
-      "timestamp": "2012-01-03T23:36:29+02:00",
-      "url": "http://example.com/awesome_space/awesome_project/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
-      "author": {
-        "name": "GitLab dev user",
-        "email": "gitlabdev@dv6700.(none)"
-      }
-    },
-    "work_in_progress": false,
-    "url": "http://example.com/diaspora/merge_requests/1",
-    "action": "open",
-    "assignee": {
-      "name": "User1",
-      "username": "user1",
-      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40&d=identicon"
-    }
-  }
+   "event_type" : "merge_request",
+   "object_attributes" : {
+      "action" : "open",
+      "assignee_id" : null,
+      "author_id" : 15,
+      "created_at" : "2018-05-15 07:45:37 -0700",
+      "description" : "This to both gitlab gateways!",
+      "head_pipeline_id" : 29931,
+      "human_time_estimate" : null,
+      "human_total_time_spent" : null,
+      "id" : 10850,
+      "iid" : 6,
+      "last_commit" : {
+         "author" : {
+            "email" : "mmusterman@example.com",
+            "name" : "Max Mustermann"
+         },
+         "id" : "92268bc781b24f0a61b907da062950e9e5252a69",
+         "message" : "Remove the dummy line again",
+         "timestamp" : "2018-05-14T07:54:04-07:00",
+         "url" : "https://gitlab.example.com/mmusterman/awesome_project/commit/92268bc781b24f0a61b907da062950e9e5252a69"
+      },
+      "last_edited_at" : null,
+      "last_edited_by_id" : null,
+      "merge_commit_sha" : null,
+      "merge_error" : null,
+      "merge_params" : {
+         "force_remove_source_branch" : 0
+      },
+      "merge_status" : "unchecked",
+      "merge_user_id" : null,
+      "merge_when_pipeline_succeeds" : false,
+      "milestone_id" : null,
+      "source" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+         "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "id" : 239,
+         "name" : "awesome_project",
+         "namespace" : "mmusterman",
+         "path_with_namespace" : "mmusterman/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+      },
+      "source_branch" : "ms-viewport",
+      "source_project_id" : 239,
+      "state" : "opened",
+      "target" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+         "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "id" : 239,
+         "name" : "awesome_project",
+         "namespace" : "mmusterman",
+         "path_with_namespace" : "mmusterman/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+      },
+      "target_branch" : "master",
+      "target_project_id" : 239,
+      "time_estimate" : 0,
+      "title" : "Remove the dummy line again",
+      "total_time_spent" : 0,
+      "updated_at" : "2018-05-15 07:45:37 -0700",
+      "updated_by_id" : null,
+      "url" : "https://gitlab.example.com/mmusterman/awesome_project/merge_requests/6",
+      "work_in_progress" : false
+   },
+   "object_kind" : "merge_request",
+   "project" : {
+      "avatar_url" : null,
+      "ci_config_path" : null,
+      "default_branch" : "master",
+      "description" : "Trivial project for testing build machinery quickly",
+      "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+      "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "id" : 239,
+      "name" : "awesome_project",
+      "namespace" : "mmusterman",
+      "path_with_namespace" : "mmusterman/awesome_project",
+      "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "visibility_level" : 0,
+      "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+   },
+   "user" : {
+      "avatar_url" : "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40&d=identicon",
+      "name" : "Max Mustermann",
+      "username" : "mmusterman"
+   }
 }
 """
+gitJsonPayloadMR_editdesc = b"""
+{
+   "event_type" : "merge_request",
+   "object_attributes" : {
+      "action" : "update",
+      "assignee_id" : null,
+      "author_id" : 15,
+      "created_at" : "2018-05-15 07:45:37 -0700",
+      "description" : "Edited description.",
+      "head_pipeline_id" : 29931,
+      "human_time_estimate" : null,
+      "human_total_time_spent" : null,
+      "id" : 10850,
+      "iid" : 6,
+      "last_commit" : {
+         "author" : {
+            "email" : "mmusterman@example.com",
+            "name" : "Max Mustermann"
+         },
+         "id" : "92268bc781b24f0a61b907da062950e9e5252a69",
+         "message" : "Remove the dummy line again",
+         "timestamp" : "2018-05-14T07:54:04-07:00",
+         "url" : "https://gitlab.example.com/mmusterman/awesome_project/commit/92268bc781b24f0a61b907da062950e9e5252a69"
+      },
+      "last_edited_at" : "2018-05-15 07:49:55 -0700",
+      "last_edited_by_id" : 15,
+      "merge_commit_sha" : null,
+      "merge_error" : null,
+      "merge_params" : {
+         "force_remove_source_branch" : 0
+      },
+      "merge_status" : "can_be_merged",
+      "merge_user_id" : null,
+      "merge_when_pipeline_succeeds" : false,
+      "milestone_id" : null,
+      "source" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+         "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "id" : 239,
+         "name" : "awesome_project",
+         "namespace" : "mmusterman",
+         "path_with_namespace" : "mmusterman/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+      },
+      "source_branch" : "ms-viewport",
+      "source_project_id" : 239,
+      "state" : "opened",
+      "target" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+         "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "id" : 239,
+         "name" : "awesome_project",
+         "namespace" : "mmusterman",
+         "path_with_namespace" : "mmusterman/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+      },
+      "target_branch" : "master",
+      "target_project_id" : 239,
+      "time_estimate" : 0,
+      "title" : "Remove the dummy line again",
+      "total_time_spent" : 0,
+      "updated_at" : "2018-05-15 07:49:55 -0700",
+      "updated_by_id" : 15,
+      "url" : "https://gitlab.example.com/mmusterman/awesome_project/merge_requests/6",
+      "work_in_progress" : false
+   },
+   "object_kind" : "merge_request",
+   "project" : {
+      "avatar_url" : null,
+      "ci_config_path" : null,
+      "default_branch" : "master",
+      "description" : "Trivial project for testing build machinery quickly",
+      "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+      "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "id" : 239,
+      "name" : "awesome_project",
+      "namespace" : "mmusterman",
+      "path_with_namespace" : "mmusterman/awesome_project",
+      "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "visibility_level" : 0,
+      "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+   },
+   "user" : {
+      "avatar_url" : "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40&d=identicon",
+      "name" : "Max Mustermann",
+      "username" : "mmusterman"
+   }
+}
+"""
+gitJsonPayloadMR_addcommit = b"""
+{
+   "event_type" : "merge_request",
+   "object_attributes" : {
+      "action" : "update",
+      "assignee_id" : null,
+      "author_id" : 15,
+      "created_at" : "2018-05-15 07:45:37 -0700",
+      "description" : "Edited description.",
+      "head_pipeline_id" : 29931,
+      "human_time_estimate" : null,
+      "human_total_time_spent" : null,
+      "id" : 10850,
+      "iid" : 6,
+      "last_commit" : {
+         "author" : {
+            "email" : "mmusterman@example.com",
+            "name" : "Max Mustermann"
+         },
+         "id" : "cee8b01dcbaeed89563c2822f7c59a93c813eb6b",
+         "message" : "debian/compat: update to 9",
+         "timestamp" : "2018-05-15T07:51:11-07:00",
+         "url" : "https://gitlab.example.com/mmusterman/awesome_project/commit/cee8b01dcbaeed89563c2822f7c59a93c813eb6b"
+      },
+      "last_edited_at" : "2018-05-15 14:49:55 UTC",
+      "last_edited_by_id" : 15,
+      "merge_commit_sha" : null,
+      "merge_error" : null,
+      "merge_params" : {
+         "force_remove_source_branch" : 0
+      },
+      "merge_status" : "unchecked",
+      "merge_user_id" : null,
+      "merge_when_pipeline_succeeds" : false,
+      "milestone_id" : null,
+      "oldrev" : "92268bc781b24f0a61b907da062950e9e5252a69",
+      "source" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+         "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "id" : 239,
+         "name" : "awesome_project",
+         "namespace" : "mmusterman",
+         "path_with_namespace" : "mmusterman/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+      },
+      "source_branch" : "ms-viewport",
+      "source_project_id" : 239,
+      "state" : "opened",
+      "target" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+         "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "id" : 239,
+         "name" : "awesome_project",
+         "namespace" : "mmusterman",
+         "path_with_namespace" : "mmusterman/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+      },
+      "target_branch" : "master",
+      "target_project_id" : 239,
+      "time_estimate" : 0,
+      "title" : "Remove the dummy line again",
+      "total_time_spent" : 0,
+      "updated_at" : "2018-05-15 14:51:27 UTC",
+      "updated_by_id" : 15,
+      "url" : "https://gitlab.example.com/mmusterman/awesome_project/merge_requests/6",
+      "work_in_progress" : false
+   },
+   "object_kind" : "merge_request",
+   "project" : {
+      "avatar_url" : null,
+      "ci_config_path" : null,
+      "default_branch" : "master",
+      "description" : "Trivial project for testing build machinery quickly",
+      "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+      "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "id" : 239,
+      "name" : "awesome_project",
+      "namespace" : "mmusterman",
+      "path_with_namespace" : "mmusterman/awesome_project",
+      "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "visibility_level" : 0,
+      "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+   },
+   "user" : {
+      "avatar_url" : "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40&d=identicon",
+      "name" : "Max Mustermann",
+      "username" : "mmusterman"
+   }
+}
+"""
+gitJsonPayloadMR_close = b"""
+{
+   "event_type" : "merge_request",
+   "object_attributes" : {
+      "action" : "close",
+      "assignee_id" : null,
+      "author_id" : 15,
+      "created_at" : "2018-05-15 07:45:37 -0700",
+      "description" : "Edited description.",
+      "head_pipeline_id" : 29958,
+      "human_time_estimate" : null,
+      "human_total_time_spent" : null,
+      "id" : 10850,
+      "iid" : 6,
+      "last_commit" : {
+         "author" : {
+            "email" : "mmusterman@example.com",
+            "name" : "Max Mustermann"
+         },
+         "id" : "cee8b01dcbaeed89563c2822f7c59a93c813eb6b",
+         "message" : "debian/compat: update to 9",
+         "timestamp" : "2018-05-15T07:51:11-07:00",
+         "url" : "https://gitlab.example.com/mmusterman/awesome_project/commit/cee8b01dcbaeed89563c2822f7c59a93c813eb6b"
+      },
+      "last_edited_at" : "2018-05-15 07:49:55 -0700",
+      "last_edited_by_id" : 15,
+      "merge_commit_sha" : null,
+      "merge_error" : null,
+      "merge_params" : {
+         "force_remove_source_branch" : 0
+      },
+      "merge_status" : "can_be_merged",
+      "merge_user_id" : null,
+      "merge_when_pipeline_succeeds" : false,
+      "milestone_id" : null,
+      "source" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+         "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "id" : 239,
+         "name" : "awesome_project",
+         "namespace" : "mmusterman",
+         "path_with_namespace" : "mmusterman/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+      },
+      "source_branch" : "ms-viewport",
+      "source_project_id" : 239,
+      "state" : "closed",
+      "target" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+         "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "id" : 239,
+         "name" : "awesome_project",
+         "namespace" : "mmusterman",
+         "path_with_namespace" : "mmusterman/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+      },
+      "target_branch" : "master",
+      "target_project_id" : 239,
+      "time_estimate" : 0,
+      "title" : "Remove the dummy line again",
+      "total_time_spent" : 0,
+      "updated_at" : "2018-05-15 07:52:01 -0700",
+      "updated_by_id" : 15,
+      "url" : "https://gitlab.example.com/mmusterman/awesome_project/merge_requests/6",
+      "work_in_progress" : false
+   },
+   "object_kind" : "merge_request",
+   "project" : {
+      "avatar_url" : null,
+      "ci_config_path" : null,
+      "default_branch" : "master",
+      "description" : "Trivial project for testing build machinery quickly",
+      "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+      "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "id" : 239,
+      "name" : "awesome_project",
+      "namespace" : "mmusterman",
+      "path_with_namespace" : "mmusterman/awesome_project",
+      "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "visibility_level" : 0,
+      "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+   },
+   "user" : {
+      "avatar_url" : "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40&d=identicon",
+      "name" : "Max Mustermann",
+      "username" : "mmusterman"
+   }
+}
+"""
+gitJsonPayloadMR_reopen = b"""
+{
+   "event_type" : "merge_request",
+   "object_attributes" : {
+      "action" : "reopen",
+      "assignee_id" : null,
+      "author_id" : 15,
+      "created_at" : "2018-05-15 07:45:37 -0700",
+      "description" : "Edited description.",
+      "head_pipeline_id" : 29958,
+      "human_time_estimate" : null,
+      "human_total_time_spent" : null,
+      "id" : 10850,
+      "iid" : 6,
+      "last_commit" : {
+         "author" : {
+            "email" : "mmusterman@example.com",
+            "name" : "Max Mustermann"
+         },
+         "id" : "cee8b01dcbaeed89563c2822f7c59a93c813eb6b",
+         "message" : "debian/compat: update to 9",
+         "timestamp" : "2018-05-15T07:51:11-07:00",
+         "url" : "https://gitlab.example.com/mmusterman/awesome_project/commit/cee8b01dcbaeed89563c2822f7c59a93c813eb6b"
+      },
+      "last_edited_at" : "2018-05-15 07:49:55 -0700",
+      "last_edited_by_id" : 15,
+      "merge_commit_sha" : null,
+      "merge_error" : null,
+      "merge_params" : {
+         "force_remove_source_branch" : 0
+      },
+      "merge_status" : "can_be_merged",
+      "merge_user_id" : null,
+      "merge_when_pipeline_succeeds" : false,
+      "milestone_id" : null,
+      "source" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+         "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "id" : 239,
+         "name" : "awesome_project",
+         "namespace" : "mmusterman",
+         "path_with_namespace" : "mmusterman/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+      },
+      "source_branch" : "ms-viewport",
+      "source_project_id" : 239,
+      "state" : "opened",
+      "target" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+         "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "id" : 239,
+         "name" : "awesome_project",
+         "namespace" : "mmusterman",
+         "path_with_namespace" : "mmusterman/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+      },
+      "target_branch" : "master",
+      "target_project_id" : 239,
+      "time_estimate" : 0,
+      "title" : "Remove the dummy line again",
+      "total_time_spent" : 0,
+      "updated_at" : "2018-05-15 07:53:27 -0700",
+      "updated_by_id" : 15,
+      "url" : "https://gitlab.example.com/mmusterman/awesome_project/merge_requests/6",
+      "work_in_progress" : false
+   },
+   "object_kind" : "merge_request",
+   "project" : {
+      "avatar_url" : null,
+      "ci_config_path" : null,
+      "default_branch" : "master",
+      "description" : "Trivial project for testing build machinery quickly",
+      "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+      "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "id" : 239,
+      "name" : "awesome_project",
+      "namespace" : "mmusterman",
+      "path_with_namespace" : "mmusterman/awesome_project",
+      "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "visibility_level" : 0,
+      "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+   },
+   "user" : {
+      "avatar_url" : "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40&d=identicon",
+      "name" : "Max Mustermann",
+      "username" : "mmusterman"
+   }
+}
+"""
+
+
+def FakeRequestMR(content):
+    request = FakeRequest(content=content)
+    request.uri = b"/change_hook/gitlab"
+    request.args = {b'codebase': [b'MyCodebase']}
+    request.received_headers[_HEADER_EVENT] = b"Merge Request Hook"
+    request.method = b"POST"
+    return request
 
 
 class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
@@ -210,17 +697,17 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         )
         self.assertEqual(change["branch"], "v1.0.0")
 
-    def check_changes_mr_event(self, r, project='', codebase=None):
+    def check_changes_mr_event(self, r, project='', codebase=None, timestamp=1526309644):
         self.assertEqual(len(self.changeHook.master.addedChanges), 1)
         change = self.changeHook.master.addedChanges[0]
 
         self.assertEqual(change["repository"],
-                         "http://example.com/awesome_user/awesome_project.git")
+                         "https://gitlab.example.com/mmusterman/awesome_project.git")
         self.assertEqual(change['properties']["target_repository"],
-                         "http://example.com/awesome_space/awesome_project.git")
+                         "https://gitlab.example.com/mmusterman/awesome_project.git")
         self.assertEqual(
             calendar.timegm(change["when_timestamp"].utctimetuple()),
-            1325626589
+            timestamp
         )
         self.assertEqual(change["branch"], "ms-viewport")
         self.assertEqual(change['properties']["target_branch"], 'master')
@@ -333,14 +820,38 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(change["category"], "Push Hook")
 
     @defer.inlineCallbacks
-    def testGitWithChange_WithMR(self):
-        self.request = FakeRequest(content=gitJsonPayloadMR)
-        self.request.uri = b"/change_hook/gitlab"
-        self.request.args = {b'codebase': [b'MyCodebase']}
-        self.request.received_headers[_HEADER_EVENT] = b"Merge Request Hook"
-        self.request.method = b"POST"
+    def testGitWithChange_WithMR_open(self):
+        self.request = FakeRequestMR(content=gitJsonPayloadMR_open)
         res = yield self.request.test_render(self.changeHook)
         self.check_changes_mr_event(res, codebase="MyCodebase")
+        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(change["category"], "merge_request")
+
+    @defer.inlineCallbacks
+    def testGitWithChange_WithMR_editdesc(self):
+        self.request = FakeRequestMR(content=gitJsonPayloadMR_editdesc)
+        yield self.request.test_render(self.changeHook)
+        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+
+    @defer.inlineCallbacks
+    def testGitWithChange_WithMR_addcommit(self):
+        self.request = FakeRequestMR(content=gitJsonPayloadMR_addcommit)
+        res = yield self.request.test_render(self.changeHook)
+        self.check_changes_mr_event(res, codebase="MyCodebase", timestamp=1526395871)
+        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(change["category"], "merge_request")
+
+    @defer.inlineCallbacks
+    def testGitWithChange_WithMR_close(self):
+        self.request = FakeRequestMR(content=gitJsonPayloadMR_close)
+        yield self.request.test_render(self.changeHook)
+        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+
+    @defer.inlineCallbacks
+    def testGitWithChange_WithMR_reopen(self):
+        self.request = FakeRequestMR(content=gitJsonPayloadMR_reopen)
+        res = yield self.request.test_render(self.changeHook)
+        self.check_changes_mr_event(res, codebase="MyCodebase", timestamp=1526395871)
         change = self.changeHook.master.addedChanges[0]
         self.assertEqual(change["category"], "merge_request")
 


### PR DESCRIPTION
Idea is simple: don't rebuild when somebody e.g. closes the MR or assigns it to somebody else;
save rebuilding for when we know there's something worth rebuilding.

This MR causes builds to happen only when a MR is originally opened, when it is reopened, or when new code is pushed.