### PR TITLE
Allow Perforce change sources to resolve the 'who' field into a more verbose format using a callable

### DIFF
--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -125,7 +125,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
                  pollInterval=60 * 10, histmax=None, pollinterval=-2,
                  encoding='utf8', project=None, name=None,
                  use_tickets=False, ticket_login_interval=60 * 60 * 24,
-                 server_tz=None, pollAtLaunch=False, revlink=lambda branch, revision: (u''), resolvewho=lambda who: who):
+                 server_tz=None, pollAtLaunch=False, revlink=lambda branch, revision: (u''), resolvewho=lambda who: (who)):
 
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
@@ -148,6 +148,10 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
         if not callable(revlink):
             config.error(
                 "You need to provide a valid callable for revlink")
+
+        if not callable(resolvewho):
+            config.error(
+                "You need to provide a valid callable for resolvewho")
 
         self.p4port = p4port
         self.p4user = p4user

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -125,7 +125,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
                  pollInterval=60 * 10, histmax=None, pollinterval=-2,
                  encoding='utf8', project=None, name=None,
                  use_tickets=False, ticket_login_interval=60 * 60 * 24,
-                 server_tz=None, pollAtLaunch=False, revlink=lambda branch, revision: (u'')):
+                 server_tz=None, pollAtLaunch=False, revlink=lambda branch, revision: (u''), resolvewho=lambda who: who):
 
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
@@ -160,6 +160,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
         self.use_tickets = use_tickets
         self.ticket_login_interval = ticket_login_interval
         self.revlink_callable = revlink
+        self.resolvewho_callable = resolvewho
         self.server_tz = dateutil.tz.gettz(server_tz) if server_tz else None
         if server_tz is not None and self.server_tz is None:
             raise P4PollerError("Failed to get timezone from server_tz string '{}'".format(server_tz))
@@ -301,7 +302,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
             if not m:
                 raise P4PollerError(
                     "Unexpected 'p4 describe -s' result: %r" % result)
-            who = m.group('who')
+            who = self.resolvewho_callable(m.group('who'))
             when = datetime.datetime.strptime(m.group('when'), self.datefmt)
             if self.server_tz:
                 # Convert from the server's timezone to the local timezone.

--- a/master/buildbot/newsfragments/p4resolvewho.feature
+++ b/master/buildbot/newsfragments/p4resolvewho.feature
@@ -1,0 +1,3 @@
+Added callable to p4 source that allows client code to resolve the p4 user and workspace into a more complete author. 
+Default behaviour is a lambda that simply returns the original supplied who. 
+This callable happens after the existing regex is performed.

--- a/master/buildbot/test/unit/test_changes_p4poller.py
+++ b/master/buildbot/test/unit/test_changes_p4poller.py
@@ -29,6 +29,7 @@ from buildbot.changes.p4poller import P4PollerError
 from buildbot.changes.p4poller import P4Source
 from buildbot.changes.p4poller import get_simple_split
 from buildbot.test.util import changesource
+from buildbot.test.util import config
 from buildbot.test.util import gpo
 from buildbot.util import datetime2epoch
 
@@ -98,6 +99,7 @@ p4change = {
 
 class TestP4Poller(changesource.ChangeSourceMixin,
                    gpo.GetProcessOutputMixin,
+                   config.ConfigErrorsMixin,
                    unittest.TestCase):
 
     def setUp(self):
@@ -440,6 +442,10 @@ class TestP4Poller(changesource.ChangeSourceMixin,
             self.assertAllCommandsRan()
         d.addCallback(check)
         return d
+
+    def test_resolveWho_callable(self):
+        self.assertRaisesConfigError("You need to provide a valid callable for resolvewho",
+                                     lambda: P4Source(resolvewho=None))
 
 
 class TestSplit(unittest.TestCase):

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -537,6 +537,11 @@ It accepts the following arguments:
     This function must be a callable which takes two arguments, the branch and the revision.
     Defaults to lambda branch, revision: (u'')
 
+``resolvewho``
+    A function that resolves the Perforce 'user@workspace' into a more verbose form, stored as the author of the change. Useful when usernames do not match email addresses and external, client-side lookup is required.
+    This function must be a callable which takes one argument.
+    Defaults to lambda who: (who)
+
 Example #1
 ++++++++++
 


### PR DESCRIPTION
* [X] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
