### PR TITLE
Add new source step GitLab that handles merge requests better

### DIFF
--- a/master/buildbot/newsfragments/issue4107-gitlab-example.doc
+++ b/master/buildbot/newsfragments/issue4107-gitlab-example.doc
@@ -1,0 +1,1 @@
+Added ``examples/gitlab.cfg`` to demonstrate integrating Buildbot with GitLab.

--- a/master/buildbot/newsfragments/issue4107-handle-gitlab-mr-from-fork.bugfix
+++ b/master/buildbot/newsfragments/issue4107-handle-gitlab-mr-from-fork.bugfix
@@ -1,0 +1,1 @@
+Add GitLab source step; using it, we now handle GitLab merge requests from forks properly (:issue:`4107`)

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -142,13 +142,20 @@ class GitLabStatusPush(http.HttpStatusPushBase):
 
         sourcestamps = build['buildset']['sourcestamps']
 
+        # FIXME: probably only want to report status for the last commit in the changeset
         for sourcestamp in sourcestamps:
             sha = sourcestamp['revision']
-            proj_id = yield self.getProjectId(sourcestamp)
+            if 'source_project_id' in props:
+                proj_id = props['source_project_id']
+            else:
+                proj_id = yield self.getProjectId(sourcestamp)
             if proj_id is None:
                 continue
             try:
-                branch = unicode2NativeString(sourcestamp['branch'])
+                if 'source_branch' in props:
+                    branch = props['source_branch']
+                else:
+                    branch = unicode2NativeString(sourcestamp['branch'])
                 sha = unicode2NativeString(sha)
                 state = unicode2NativeString(state)
                 target_url = unicode2NativeString(build['url'])

--- a/master/buildbot/steps/source/gitlab.py
+++ b/master/buildbot/steps/source/gitlab.py
@@ -1,0 +1,50 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from twisted.python import log
+
+from buildbot.steps.source.git import Git
+
+
+class GitLab(Git):
+    """
+    Source step that knows how to handle merge requests from
+    the GitLab change source
+    """
+
+    def startVC(self, branch, revision, patch):
+        # If this is a merge request:
+        if self.build.hasProperty("target_branch"):
+            target_repourl = self.build.getProperty("target_git_ssh_url", None)
+            if self.repourl != target_repourl:
+                log.msg("GitLab.startVC: note: GitLab step for merge requests"
+                        " should probably have repourl='%s' instead of '%s'?" %
+                        (target_repourl, self.repourl))
+            # This step is (probably) configured to fetch the target
+            # branch of a merge (because it is impractical for users to
+            # configure one builder for each of the infinite number of
+            # possible source branches for merge requests).
+            # Point instead to the source being proposed for merge.
+            branch = self.build.getProperty("source_branch", None)
+            # FIXME: layering violation, should not be modifying self here?
+            self.repourl = self.build.getProperty("source_git_ssh_url", None)
+            # The revision is unlikely to exist in the repo already,
+            # so tell Git to not check.
+            revision = None
+
+        super(GitLab, self).startVC(branch, revision, patch)

--- a/master/buildbot/test/unit/test_reporter_gitlab.py
+++ b/master/buildbot/test/unit/test_reporter_gitlab.py
@@ -121,6 +121,23 @@ class TestGitLabStatusPush(unittest.TestCase, ReporterTestMixin, logging.Logging
         self.sp.buildStarted(("build", 20, "started"), build)
 
     @defer.inlineCallbacks
+    def test_merge_request_forked(self):
+        self.TEST_REPO = u'git@gitlab:buildbot/buildbot.git'
+        self.TEST_PROPS['source_project_id'] = 20922342342
+        build = yield self.setupBuildResults(SUCCESS)
+        self._http.expect(
+            'post',
+            '/api/v3/projects/20922342342/statuses/d34db33fd43db33f',
+            json={'state': 'running',
+                  'target_url': 'http://localhost:8080/#builders/79/builds/0',
+                  'ref': 'master',
+                  'description': 'Build started.', 'name': 'buildbot/Builder0'})
+        build['complete'] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        # Don't run these tests in parallel!
+        del self.TEST_PROPS['source_project_id']
+
+    @defer.inlineCallbacks
     def test_noproject(self):
         self.TEST_REPO = u'git@gitlab:buildbot/buildbot.git'
         self.setUpLogging()

--- a/master/buildbot/test/unit/test_steps_source_gitlab.py
+++ b/master/buildbot/test/unit/test_steps_source_gitlab.py
@@ -1,0 +1,92 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from twisted.trial import unittest
+
+from buildbot.process.results import SUCCESS
+from buildbot.steps.source import gitlab
+from buildbot.test.fake.remotecommand import Expect
+from buildbot.test.fake.remotecommand import ExpectShell
+from buildbot.test.util import config
+from buildbot.test.util import sourcesteps
+
+
+class TestGitLab(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.TestCase):
+    stepClass = gitlab.GitLab
+
+    def setUp(self):
+        self.sourceName = self.stepClass.__name__
+        return self.setUpSourceStep()
+
+    def setupStep(self, step, args, **kwargs):
+        step = sourcesteps.SourceStepMixin.setupStep(self, step, args, **kwargs)
+        step.build.properties.setProperty("source_branch", "ms-viewport", "gitlab source branch")
+        step.build.properties.setProperty("source_git_ssh_url", "git@gitlab.example.com:build/awesome_project.git", "gitlab source git ssh url")
+        step.build.properties.setProperty("source_project_id", 2337, "gitlab source project ID")
+        step.build.properties.setProperty("target_branch", "master", "gitlab target branch")
+        step.build.properties.setProperty("target_git_ssh_url", "git@gitlab.example.com:mmusterman/awesome_project.git", "gitlab target git ssh url")
+        step.build.properties.setProperty("target_project_id", 239, "gitlab target project ID")
+        return step
+
+    def tearDown(self):
+        return self.tearDownSourceStep()
+
+    def test_with_merge_branch(self):
+        self.setupStep(
+            self.stepClass(repourl='git@gitlab.example.com:mmusterman/awesome_project.git',
+                           mode='full', method='clean'),
+            dict(branch='master', revision='12345678'))
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            # here we always ignore revision, and fetch the merge branch
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'fetch', '-t',
+                                 'git@gitlab.example.com:build/awesome_project.git',
+                                 'ms-viewport'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'checkout', '-B', 'ms-viewport'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', 'GitLab')
+        return self.runStep()

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -725,7 +725,7 @@ gitJsonPayloadMR_open_forked = b"""
          "homepage" : "https://gitlab.example.com/build/awesome_project",
          "http_url" : "https://gitlab.example.com/build/awesome_project.git",
          "id" : 2337,
-         "name" : "hello",
+         "name" : "awesome_project",
          "namespace" : "build",
          "path_with_namespace" : "build/awesome_project",
          "ssh_url" : "git@gitlab.example.com:build/awesome_project.git",
@@ -746,7 +746,7 @@ gitJsonPayloadMR_open_forked = b"""
          "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
          "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
          "id" : 239,
-         "name" : "hello",
+         "name" : "awesome_project",
          "namespace" : "mmusterman",
          "path_with_namespace" : "mmusterman/awesome_project",
          "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
@@ -775,7 +775,7 @@ gitJsonPayloadMR_open_forked = b"""
       "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
       "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
       "id" : 239,
-      "name" : "hello",
+      "name" : "awesome_project",
       "namespace" : "mmusterman",
       "path_with_namespace" : "mmusterman/awesome_project",
       "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
@@ -786,7 +786,7 @@ gitJsonPayloadMR_open_forked = b"""
    "repository" : {
       "description" : "Trivial project for testing build machinery quickly",
       "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
-      "name" : "hello",
+      "name" : "awesome_project",
       "url" : "git@gitlab.example.com:mmusterman/awesome_project.git"
    },
    "user" : {
@@ -824,7 +824,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         )
         self.assertEqual(change["branch"], "v1.0.0")
 
-    def check_changes_mr_event(self, r, project='', codebase=None, timestamp=1526309644, source_repo=None):
+    def check_changes_mr_event(self, r, project='awesome_project', codebase=None, timestamp=1526309644, source_repo=None):
         self.assertEqual(len(self.changeHook.master.addedChanges), 1)
         change = self.changeHook.master.addedChanges[0]
 
@@ -844,8 +844,9 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(change['properties']["source_branch"], 'ms-viewport')
         self.assertEqual(change['properties']["target_branch"], 'master')
         self.assertEqual(change["category"], "merge_request")
+        self.assertEqual(change.get("project"), project)
 
-    def check_changes_push_event(self, r, project='', codebase=None):
+    def check_changes_push_event(self, r, project='diaspora', codebase=None):
         self.assertEqual(len(self.changeHook.master.addedChanges), 2)
         change = self.changeHook.master.addedChanges[0]
 
@@ -880,7 +881,9 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(change[
             "revlink"], "http://localhost/diaspora/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7")
 
-        self.assertEqual(change.get("project"), project)
+        # FIXME: should we convert project name to canonical case?
+        # Or should change filter be case insensitive?
+        self.assertEqual(change.get("project").lower(), project.lower())
         self.assertEqual(change.get("codebase"), codebase)
 
     # Test 'base' hook with attributes. We should get a json string representing
@@ -898,11 +901,11 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def testGitWithChange_WithProjectToo(self):
         self.request = FakeRequest(content=gitJsonPayload)
         self.request.uri = b"/change_hook/gitlab"
-        self.request.args = {b'project': [b'MyProject']}
+        self.request.args = {b'project': [b'Diaspora']}
         self.request.received_headers[_HEADER_EVENT] = b"Push Hook"
         self.request.method = b"POST"
         res = yield self.request.test_render(self.changeHook)
-        self.check_changes_push_event(res, project="MyProject")
+        self.check_changes_push_event(res, project="Diaspora")
 
     @defer.inlineCallbacks
     def testGitWithChange_WithCodebaseToo(self):

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -113,6 +113,7 @@ gitJsonPayloadTag = b"""
 }
 """
 
+# == Merge requests from a different branch of the same project
 # GITLAB commit payload from an actual version 10.7.1-ee gitlab instance
 # chronicling the lives and times of a trivial MR through the operations
 # open, edit description, add commit, close, and reopen, in that order.
@@ -670,6 +671,132 @@ gitJsonPayloadMR_reopen = b"""
 }
 """
 
+# == Merge requests from a fork of the project
+# (Captured more accurately than above test data)
+gitJsonPayloadMR_open_forked = b"""
+{
+   "changes" : {
+      "total_time_spent" : {
+         "current" : 0,
+         "previous" : null
+      }
+   },
+   "event_type" : "merge_request",
+   "labels" : [],
+   "object_attributes" : {
+      "action" : "open",
+      "assignee_id" : null,
+      "author_id" : 15,
+      "created_at" : "2018-05-19 06:57:12 -0700",
+      "description" : "This is a merge request from a fork of the project.",
+      "head_pipeline_id" : null,
+      "human_time_estimate" : null,
+      "human_total_time_spent" : null,
+      "id" : 10914,
+      "iid" : 7,
+      "last_commit" : {
+         "author" : {
+            "email" : "mmusterman@example.com",
+            "name" : "Max Mustermann"
+         },
+         "id" : "e46ee239f3d6d41ade4d1e610669dd71ed86ec80",
+         "message" : "Add note to README",
+         "timestamp" : "2018-05-19T06:35:26-07:00",
+         "url" : "https://gitlab.example.com/mmusterman/awesome_project/commit/e46ee239f3d6d41ade4d1e610669dd71ed86ec80"
+      },
+      "last_edited_at" : null,
+      "last_edited_by_id" : null,
+      "merge_commit_sha" : null,
+      "merge_error" : null,
+      "merge_params" : {
+         "force_remove_source_branch" : "0"
+      },
+      "merge_status" : "unchecked",
+      "merge_user_id" : null,
+      "merge_when_pipeline_succeeds" : false,
+      "milestone_id" : null,
+      "source" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/build/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:build/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/build/awesome_project",
+         "http_url" : "https://gitlab.example.com/build/awesome_project.git",
+         "id" : 2337,
+         "name" : "hello",
+         "namespace" : "build",
+         "path_with_namespace" : "build/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:build/awesome_project.git",
+         "url" : "git@gitlab.example.com:build/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/build/awesome_project"
+      },
+      "source_branch" : "ms-viewport",
+      "source_project_id" : 2337,
+      "state" : "opened",
+      "target" : {
+         "avatar_url" : null,
+         "ci_config_path" : null,
+         "default_branch" : "master",
+         "description" : "Trivial project for testing build machinery quickly",
+         "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+         "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+         "id" : 239,
+         "name" : "hello",
+         "namespace" : "mmusterman",
+         "path_with_namespace" : "mmusterman/awesome_project",
+         "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+         "visibility_level" : 0,
+         "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+      },
+      "target_branch" : "master",
+      "target_project_id" : 239,
+      "time_estimate" : 0,
+      "title" : "Add note to README",
+      "total_time_spent" : 0,
+      "updated_at" : "2018-05-19 06:57:12 -0700",
+      "updated_by_id" : null,
+      "url" : "https://gitlab.example.com/mmusterman/awesome_project/merge_requests/7",
+      "work_in_progress" : false
+   },
+   "object_kind" : "merge_request",
+   "project" : {
+      "avatar_url" : null,
+      "ci_config_path" : null,
+      "default_branch" : "master",
+      "description" : "Trivial project for testing build machinery quickly",
+      "git_http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "git_ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+      "http_url" : "https://gitlab.example.com/mmusterman/awesome_project.git",
+      "id" : 239,
+      "name" : "hello",
+      "namespace" : "mmusterman",
+      "path_with_namespace" : "mmusterman/awesome_project",
+      "ssh_url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "url" : "git@gitlab.example.com:mmusterman/awesome_project.git",
+      "visibility_level" : 0,
+      "web_url" : "https://gitlab.example.com/mmusterman/awesome_project"
+   },
+   "repository" : {
+      "description" : "Trivial project for testing build machinery quickly",
+      "homepage" : "https://gitlab.example.com/mmusterman/awesome_project",
+      "name" : "hello",
+      "url" : "git@gitlab.example.com:mmusterman/awesome_project.git"
+   },
+   "user" : {
+      "avatar_url" : "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40&d=identicon",
+      "name" : "Max Mustermann",
+      "username" : "mmusterman"
+   }
+}
+"""
+
 
 def FakeRequestMR(content):
     request = FakeRequest(content=content)
@@ -697,19 +824,24 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         )
         self.assertEqual(change["branch"], "v1.0.0")
 
-    def check_changes_mr_event(self, r, project='', codebase=None, timestamp=1526309644):
+    def check_changes_mr_event(self, r, project='', codebase=None, timestamp=1526309644, source_repo=None):
         self.assertEqual(len(self.changeHook.master.addedChanges), 1)
         change = self.changeHook.master.addedChanges[0]
 
         self.assertEqual(change["repository"],
                          "https://gitlab.example.com/mmusterman/awesome_project.git")
+        if source_repo is None:
+            source_repo = "https://gitlab.example.com/mmusterman/awesome_project.git"
+        self.assertEqual(change['properties']["source_repository"],
+                         source_repo)
         self.assertEqual(change['properties']["target_repository"],
                          "https://gitlab.example.com/mmusterman/awesome_project.git")
         self.assertEqual(
             calendar.timegm(change["when_timestamp"].utctimetuple()),
             timestamp
         )
-        self.assertEqual(change["branch"], "ms-viewport")
+        self.assertEqual(change["branch"], "master")
+        self.assertEqual(change['properties']["source_branch"], 'ms-viewport')
         self.assertEqual(change['properties']["target_branch"], 'master')
         self.assertEqual(change["category"], "merge_request")
 
@@ -852,6 +984,16 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = FakeRequestMR(content=gitJsonPayloadMR_reopen)
         res = yield self.request.test_render(self.changeHook)
         self.check_changes_mr_event(res, codebase="MyCodebase", timestamp=1526395871)
+        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(change["category"], "merge_request")
+
+    @defer.inlineCallbacks
+    def testGitWithChange_WithMR_open_forked(self):
+        self.request = FakeRequestMR(content=gitJsonPayloadMR_open_forked)
+        res = yield self.request.test_render(self.changeHook)
+        self.check_changes_mr_event(
+                res, codebase="MyCodebase", timestamp=1526736926,
+                source_repo="https://gitlab.example.com/build/awesome_project.git")
         change = self.changeHook.master.addedChanges[0]
         self.assertEqual(change["category"], "merge_request")
 

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -32,7 +32,7 @@ _HEADER_GITLAB_TOKEN = b'X-Gitlab-Token'
 
 class GitLabHandler(BaseHookHandler):
 
-    def _process_change(self, payload, user, repo, repo_url, project, event,
+    def _process_change(self, payload, user, repo, repo_url, event,
                         codebase=None):
         """
         Consumes the JSON as a python object and actually starts the build.
@@ -44,6 +44,8 @@ class GitLabHandler(BaseHookHandler):
         """
         changes = []
         refname = payload['ref']
+        # project name from http headers is empty for me, so get it from repository/name
+        project = payload['repository']['name']
 
         # We only care about regular heads or tags
         match = re.match(r"^refs/(heads|tags)/(.+)$", refname)
@@ -94,7 +96,7 @@ class GitLabHandler(BaseHookHandler):
 
         return changes
 
-    def _process_merge_request_change(self, payload, project, event, codebase=None):
+    def _process_merge_request_change(self, payload, event, codebase=None):
         """
         Consumes the merge_request JSON as a python object and turn it into a buildbot change.
 
@@ -108,6 +110,8 @@ class GitLabHandler(BaseHookHandler):
         when_timestamp = dateparse(commit['timestamp'])
         # @todo provide and document a way to choose between http and ssh url
         repo_url = attrs['target']['git_http_url']
+        # project name from http headers is empty for me, so get it from object_attributes/target/name
+        project = attrs['target']['name']
 
         # Filter out uninteresting events
         state = attrs['state']
@@ -171,8 +175,6 @@ class GitLabHandler(BaseHookHandler):
         # newer version of gitlab have a object_kind parameter,
         # which allows not to use the http header
         event_type = payload.get('object_kind', event_type)
-        project = request.args.get(b'project', [''])[0]
-        project = bytes2unicode(project)
         codebase = request.args.get(b'codebase', [None])[0]
         codebase = bytes2unicode(codebase)
         if event_type in ("push", "tag_push", "Push Hook"):
@@ -180,10 +182,10 @@ class GitLabHandler(BaseHookHandler):
             repo = payload['repository']['name']
             repo_url = payload['repository']['url']
             changes = self._process_change(
-                payload, user, repo, repo_url, project, event_type, codebase=codebase)
+                payload, user, repo, repo_url, event_type, codebase=codebase)
         elif event_type == 'merge_request':
             changes = self._process_merge_request_change(
-                payload, project, event_type, codebase=codebase)
+                payload, event_type, codebase=codebase)
         else:
             changes = []
         if changes:

--- a/master/buildbot/www/hooks/gitlab.py
+++ b/master/buildbot/www/hooks/gitlab.py
@@ -107,7 +107,7 @@ class GitLabHandler(BaseHookHandler):
         commit = attrs['last_commit']
         when_timestamp = dateparse(commit['timestamp'])
         # @todo provide and document a way to choose between http and ssh url
-        repo_url = attrs['source']['git_http_url']
+        repo_url = attrs['target']['git_http_url']
 
         # Filter out uninteresting events
         state = attrs['state']
@@ -126,14 +126,20 @@ class GitLabHandler(BaseHookHandler):
             'comments': "MR#{}: {}\n\n{}".format(attrs['iid'], attrs['title'], attrs['description']),
             'revision': commit['id'],
             'when_timestamp': when_timestamp,
-            'branch': attrs['source_branch'],
+            'branch': attrs['target_branch'],
             'repository': repo_url,
             'project': project,
             'category': event,
             'revlink': attrs['url'],
             'properties': {
+                'source_branch': attrs['source_branch'],
+                'source_project_id': attrs['source_project_id'],
+                'source_repository': attrs['source']['git_http_url'],
+                'source_git_ssh_url': attrs['source']['git_ssh_url'],
                 'target_branch': attrs['target_branch'],
+                'target_project_id': attrs['target_project_id'],
                 'target_repository': attrs['target']['git_http_url'],
+                'target_git_ssh_url': attrs['target']['git_ssh_url'],
                 'event': event,
             },
         }]

--- a/master/docs/examples/gitlab.cfg
+++ b/master/docs/examples/gitlab.cfg
@@ -1,0 +1,223 @@
+# -*- python -*-
+# ex: set filetype=python:
+
+# This is a sample buildmaster config file. It must be installed as
+# 'master.cfg' in your buildmaster's base directory.
+
+from buildbot.plugins import *
+import re
+
+
+# Are all your projects built the same way?
+# Do you yearn for a way to do simple static configuration?
+# If so, try writing a function.
+# Here's an example that
+# - uses GitLab
+# - provides one regular builder and one smoke test builder per project
+# - assumes the projects use Gnu automake etc.
+#
+# To use this example with your own local instance of gitlab:
+#
+# 0. Edit this file to replace example.com with your own domain.
+#
+# 1. Set up local mirrors of the gnu projects, e.g.
+#   for proj in hello time
+#   do 
+#     git clone --mirror git@gitlab.com:GNU/$proj.git
+#     cd $proj
+#     git push --mirror git@gitlab.example.com:build/gnu-$proj.git
+#     cd ..
+#   done
+#
+# 2. Follow instructions below marked "CONFIGME: GitLab" to
+# configure GitLab to know about this buildbot.
+#
+# Your buildbot should then do automated builds of merge requests
+# that target forks of those local projects.
+
+def addGitLabProject(repourl, workernames, branch=None):
+    '''
+    Add a builder and a merge request builder for the given branch
+    of the given project, running on the given workers.
+    Give each a Force button.
+    Gets project name from the repourl, ignoring namespace.
+    '''
+
+    if branch is None:
+        branch = "master"
+    # Strip off everything before project name
+    # FIXME: parse this more artfully to allow projects in folders
+    name = re.sub(r'^.*/', '', repourl)
+    # Strip off .git suffix, if present
+    name = re.sub(r'\.git$', '', name)
+
+    # Regular builder
+    # Adjust this factory to match your site's build steps.
+    # This example uses the canonical gnu configure/make steps.
+    factory = util.BuildFactory()
+    factory.addStep(steps.GitLab(repourl=repourl, mode='incremental'))
+    factory.addStep(steps.ShellCommand(haltOnFailure=True, command=["sh", "-c", "if test -x ./bootstrap; then ./bootstrap; fi"]))
+    factory.addStep(steps.ShellCommand(haltOnFailure=True, command=["./configure"]))
+    factory.addStep(steps.ShellCommand(haltOnFailure=True, command=["make"]))
+    factory.addStep(steps.ShellCommand(haltOnFailure=True, command=["make", "check"]))
+    factory.addStep(steps.ShellCommand(haltOnFailure=True, command=["echo", "would package and upload here if this were a real project"]))
+
+    id = name + "-" + branch
+    c['schedulers'].append(schedulers.SingleBranchScheduler(
+        name=id,
+        change_filter=util.ChangeFilter(
+            project=name, branch=branch, category="push"),
+        treeStableTimer=None,
+        builderNames=[id]))
+    c['schedulers'].append(schedulers.ForceScheduler(
+        name=id + '-force',
+        builderNames=[id]))
+    c['builders'].append(
+        util.BuilderConfig(name=id,
+                           workernames=workernames,
+                           factory=factory))
+
+    # Merge request builder (e.g. smoke test, don't fully publish artifacts;
+    # for quick feedback of works-in-progress)
+    # Adjust this factory to match your site's build steps.
+    tryfactory = util.BuildFactory()
+    tryfactory.addStep(steps.GitLab(repourl=repourl, mode='incremental'))
+    tryfactory.addStep(steps.ShellCommand(haltOnFailure=True, command=["sh", "-c", "if test -x ./bootstrap; then ./bootstrap; fi"]))
+    tryfactory.addStep(steps.ShellCommand(haltOnFailure=True, command=["./configure"]))
+    tryfactory.addStep(steps.ShellCommand(haltOnFailure=True, command=["make"]))
+    tryfactory.addStep(steps.ShellCommand(haltOnFailure=True, command=["make", "check"]))
+    tryid = name + "-" + branch + "-try"
+    c['schedulers'].append(schedulers.SingleBranchScheduler(
+        name=tryid,
+        change_filter=util.ChangeFilter(
+            project=name, branch=branch, category="merge_request"),
+        treeStableTimer=None,
+        builderNames=[tryid]))
+    c['schedulers'].append(schedulers.ForceScheduler(
+        name=tryid + '-force',
+        builderNames=[tryid]))
+    c['builders'].append(
+        util.BuilderConfig(name=tryid,
+                           workernames=workernames,
+                           factory=tryfactory))
+
+
+# This is the dictionary that the buildmaster pays attention to. We also use
+# a shorter alias to save typing.
+c = BuildmasterConfig = {}
+
+####### WORKERS
+
+# The 'workers' list defines the set of recognized workers. Each element is
+# a Worker object, specifying a unique worker name and password.  The same
+# worker name and password must be configured on the worker.
+c['workers'] = [worker.Worker("buildbot-worker", "buildbot-pass")]
+workernames = ["buildbot-worker"]
+
+# 'protocols' contains information about protocols which master will use for
+# communicating with workers. You must define at least 'port' option that workers
+# could connect to your master with this protocol.
+# 'port' must match the value configured into the workers (with their
+# --master option)
+c['protocols'] = {'pb': {'port': 9989}}
+
+####### CHANGESOURCES
+
+# the 'change_source' setting tells the buildmaster how it should find out
+# about source code changes.
+
+c['change_source'] = []
+
+####### SCHEDULERS AND BUILDERS
+
+# The Schedulers decide how to react to incoming changes.  
+c['schedulers'] = []
+# The 'builders' list defines the Builders, which tell Buildbot how to
+# perform a build: what steps, and which workers can execute them.
+# Note that any particular build will only take place on one worker.
+c['builders'] = []
+
+# Call addGitLabProject once for each similar project you want to build.
+# It adds factories, schedulers, and builders for the project
+# in one fell swoop, making it easier to have a large number
+# of similar projects.
+addGitLabProject('git@gitlab.example.com:build/gnu-hello', workernames)
+addGitLabProject('git@gitlab.example.com:build/gnu-time', workernames)
+
+####### BUILDBOT SERVICES
+
+# 'services' is a list of BuildbotService items like reporter targets. The
+# status of each build will be pushed to these targets. buildbot/reporters/*.py
+# has a variety to choose from, like IRC bots.
+
+c['services'] = []
+
+####### PROJECT IDENTITY
+
+# the 'title' string will appear at the top of this buildbot installation's
+# home pages (linked to the 'titleURL').
+
+c['title'] = "Gnu Hello GitLab"
+c['titleURL'] = "https://gitlab.example.com/build/"
+
+# the 'buildbotURL' string should point to the location where the buildbot's
+# internal web server is visible. This typically uses the port number set in
+# the 'www' entry below, but with an externally-visible host name which the
+# buildbot cannot figure out without some help.
+
+c['buildbotURL'] = "http://buildbot.example.com:8010/"
+
+# CONFIGME: buildbot authentication
+# This example tries to show nothing to anonymous users.
+# authz = util.Authz(
+#   allowRules=[
+#     util.AnyEndpointMatcher(role="platform"),
+#     util.AnyEndpointMatcher(role="snorglepuss-does-not-exist", defaultDeny=True),
+#   ],
+#   roleMatchers=[
+#     util.RolesFromGroups()
+#   ]
+# )
+
+# minimalistic config to activate new web UI
+c['www'] = dict(
+    port=8010,
+    # CONFIGME: GitLab application
+    # Enter the URL of your buildbot gitlab hook into the GitLab UI at
+    #  "User Settings / Applications / Add New Application"
+    # to obtain the 2nd and 3rd parameters for GitLabAuth.
+    auth=util.GitLabAuth("https://gitlab.example.com",
+                         "036777777777777777777777777777777777777777777777777777777cea803a",
+                         "bae69888888888888888888888888888888888888888888888888888888888ec"),
+    # CONFIGME: buildbot authentication
+    #authz=authz,
+    change_hook_dialects=dict(
+       gitlab={
+           # CONFIGME: GitLab webhook
+           # Create a webhook in the GitLab UI at
+           #  project / Settings / Integrations / Add Webhook 
+           # with a URL of e.g.
+           #   http://buildbot.example.com:8010/change_hook/gitlab
+           # with push and merge request triggers checked, 
+           # and with a secret that matches the one here (please change):
+           'secret': 'changeme',
+       },
+    ),
+    plugins=dict(waterfall_view={}, console_view={}, grid_view={}))
+
+# CONFIGME: GitLab access token
+# Create an access token in the GitLab UI at
+#   "User Settings / Access Tokens / Add a personal access token"
+# to obtain 1st and 2nd parameters for GitLabStatusPush.
+gl = reporters.GitLabStatusPush('Sas23r293232ddzfHAvd', context='youchoose/this', baseURL='https://gitlab.example.com', verbose=True)
+c['services'].append(gl)
+
+c['buildbotNetUsageData'] = None
+
+####### DB URL
+
+c['db'] = {
+    # This specifies what database buildbot uses to store its state.  You can leave
+    # this at its default for all but the largest installations.
+    'db_url' : "sqlite:///state.sqlite",
+}

--- a/master/docs/examples/gitlab.cfg
+++ b/master/docs/examples/gitlab.cfg
@@ -90,71 +90,96 @@ from buildbot.plugins import *
 import os
 import re
 
-def addGitLabProject(repourl, workernames, branch=None):
+
+def makeFactoryNormal(repourl, branch):
     '''
-    Add a builder and a merge request builder for the given branch
-    of the given project, running on the given workers.
-    Give each a Force button.
+    A Factory that builds, tests, and uploads incoming changesets.
+    The branch argument is a default in case the changeset lacks one.
+    '''
+    # Adjust this factory to match your site's build steps.
+    # This example uses the canonical gnu configure/make steps.
+    # Adjust to match your site's build system.
+    f = util.BuildFactory()
+    f.addStep(steps.GitLab(repourl=repourl, branch=branch))
+    f.addStep(steps.ShellCommand(haltOnFailure=True,
+              command=["if test -x ./bootstrap; then ./bootstrap; fi"]))
+    f.addStep(steps.ShellCommand(haltOnFailure=True, command=["./configure"]))
+    f.addStep(steps.ShellCommand(haltOnFailure=True, command=["make"]))
+    f.addStep(steps.ShellCommand(haltOnFailure=True, command=["make check"]))
+    f.addStep(steps.ShellCommand(haltOnFailure=True, command=[": insert upload step here"]))
+    return f
+
+
+def makeFactorySmoke(repourl, branch):
+    '''
+    A Factory that just builds and tests incoming changesets.
+    The branch argument is a default in case the changeset lacks one.
+    '''
+    f = util.BuildFactory()
+    f.addStep(steps.GitLab(repourl=repourl, branch=branch))
+    f.addStep(steps.ShellCommand(haltOnFailure=True,
+              command=["if test -x ./bootstrap; then ./bootstrap; fi"]))
+    f.addStep(steps.ShellCommand(haltOnFailure=True, command=["./configure"]))
+    f.addStep(steps.ShellCommand(haltOnFailure=True, command=["make"]))
+    f.addStep(steps.ShellCommand(haltOnFailure=True, command=["make check"]))
+    return f
+
+
+def repoUrlToName(repourl):
+    '''
     Gets project name from the repourl, ignoring namespace.
     '''
-
-    if branch is None:
-        branch = "master"
     # Strip off everything before project name
     # FIXME: parse this more artfully to allow projects in folders
     name = re.sub(r'^.*/', '', repourl)
     # Strip off .git suffix, if present
-    name = re.sub(r'\.git$', '', name)
+    return re.sub(r'\.git$', '', name)
 
-    # Regular builder
-    # Adjust this factory to match your site's build steps.
-    # This example uses the canonical gnu configure/make steps.
-    factory = util.BuildFactory()
-    factory.addStep(steps.GitLab(repourl=repourl, mode='incremental'))
-    factory.addStep(steps.ShellCommand(haltOnFailure=True, command=["sh", "-c", "if test -x ./bootstrap; then ./bootstrap; fi"]))
-    factory.addStep(steps.ShellCommand(haltOnFailure=True, command=["./configure"]))
-    factory.addStep(steps.ShellCommand(haltOnFailure=True, command=["make"]))
-    factory.addStep(steps.ShellCommand(haltOnFailure=True, command=["make", "check"]))
-    factory.addStep(steps.ShellCommand(haltOnFailure=True, command=["echo", "would package and upload here if this were a real project"]))
 
-    id = name + "-" + branch
+def addBuilder(repourl, branch, flavor, workernames):
+    '''
+    Add a builder for the given project and branch on the given workers.
+    Give each a Force button.
+    flavor must be 'smoke' or 'normal'.
+    '''
+
+    factory = None
+    changehook_category = None
+    if flavor is "normal":
+        # Respond to push events with a normal build
+        changehook_category = "push"
+        factory = makeFactoryNormal(repourl, branch)
+    elif flavor is "smoke":
+        # Respond to merge request events with a smoke build
+        changehook_category = "merge_request"
+        factory = makeFactorySmoke(repourl, branch)
+    else:
+        raise ValueError("wanted 'normal' or 'smoke', got '%s'" % flavor)
+
+    name = repoUrlToName(repourl)
+    id = name + "-" + branch + "-" + flavor
+    builder = util.BuilderConfig(name=id,
+                                 workernames=workernames,
+                                 factory=factory)
+    c['builders'].append(builder)
+
     c['schedulers'].append(schedulers.SingleBranchScheduler(
         name=id,
         change_filter=util.ChangeFilter(
-            project=name, branch=branch, category="push"),
+            project=name, branch=branch, category=changehook_category),
         treeStableTimer=None,
-        builderNames=[id]))
+        builderNames=[builder.name]))
     c['schedulers'].append(schedulers.ForceScheduler(
         name=id + '-force',
-        builderNames=[id]))
-    c['builders'].append(
-        util.BuilderConfig(name=id,
-                           workernames=workernames,
-                           factory=factory))
+        builderNames=[builder.name]))
 
-    # Merge request builder (e.g. smoke test, don't fully publish artifacts;
-    # for quick feedback of works-in-progress)
-    # Adjust this factory to match your site's build steps.
-    tryfactory = util.BuildFactory()
-    tryfactory.addStep(steps.GitLab(repourl=repourl, mode='incremental'))
-    tryfactory.addStep(steps.ShellCommand(haltOnFailure=True, command=["sh", "-c", "if test -x ./bootstrap; then ./bootstrap; fi"]))
-    tryfactory.addStep(steps.ShellCommand(haltOnFailure=True, command=["./configure"]))
-    tryfactory.addStep(steps.ShellCommand(haltOnFailure=True, command=["make"]))
-    tryfactory.addStep(steps.ShellCommand(haltOnFailure=True, command=["make", "check"]))
-    tryid = name + "-" + branch + "-try"
-    c['schedulers'].append(schedulers.SingleBranchScheduler(
-        name=tryid,
-        change_filter=util.ChangeFilter(
-            project=name, branch=branch, category="merge_request"),
-        treeStableTimer=None,
-        builderNames=[tryid]))
-    c['schedulers'].append(schedulers.ForceScheduler(
-        name=tryid + '-force',
-        builderNames=[tryid]))
-    c['builders'].append(
-        util.BuilderConfig(name=tryid,
-                           workernames=workernames,
-                           factory=tryfactory))
+
+# For parts of buildbot that don't support Secret interpolation yet.
+# Once https://github.com/buildbot/buildbot/issues/4118 is fixed,
+# use util.Secret(s) instead.
+def dumbSecret(s):
+    with open(os.path.join(secrets_dir, s), 'r') as myfile:
+        return myfile.read().replace('\n', '')
 
 
 # This is the dictionary that the buildmaster pays attention to. We also use
@@ -166,28 +191,24 @@ c = BuildmasterConfig = {}
 # best practice is to keep them elsewhere else.
 
 # Place the secrets directory next to master.cfg:
-secrets_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'secrets.dir')
+this_dir = os.path.dirname(os.path.abspath(__file__))
+secrets_dir = os.path.join(this_dir, 'secrets.dir')
 c['secretsProviders'] = [secrets.SecretInAFile(dirname=secrets_dir)]
-
-# For parts of buildbot that don't support Secret interpolation yet
-# Once https://github.com/buildbot/buildbot/issues/4118 is fixed,
-# use util.Secret(s) instead.
-def dumbSecret(s):
-    with open(os.path.join(secrets_dir, s), 'r') as myfile:
-        return myfile.read().replace('\n', '')
 
 ####### WORKERS
 
-# The 'workers' list defines the set of recognized workers. Each element is
-# a Worker object, specifying a unique worker name and password.  The same
-# worker name and password must be configured on the worker.
+# The 'workers' list defines the set of recognized workers.
+# Each element is a Worker object, with a unique worker name and password.
+# The same worker name and password must be configured on the worker.
 # CONFIGME
-c['workers'] = [worker.Worker("buildbot-worker", "buildbot-pass")]
-workernames = ["buildbot-worker"]
+c['workers'] = [
+  worker.Worker("buildbot-worker",  "buildbot-pass"),
+]
+workernames = [x.name for x in c['workers']]
 
 # 'protocols' contains information about protocols which master will use for
-# communicating with workers. You must define at least 'port' option that workers
-# could connect to your master with this protocol.
+# communicating with workers. You must define at least a 'port' option;
+# the master will listen on that port for connections from workers.
 # 'port' must match the value configured into the workers (with their
 # --master option)
 c['protocols'] = {'pb': {'port': 9989}}
@@ -208,12 +229,17 @@ c['schedulers'] = []
 # Note that any particular build will only take place on one worker.
 c['builders'] = []
 
-# Call addGitLabProject once for each similar project you want to build.
-# It adds factories, schedulers, and builders for the project
-# in one fell swoop, making it easier to have a large number
-# of similar projects.
-addGitLabProject('git@gitlab.example.com:build/gnu-hello', workernames)
-addGitLabProject('git@gitlab.example.com:build/gnu-time', workernames)
+# Call addBuilder for each similar project you want to build.
+# It adds a builder with both normal and force schedulers.
+# Note: urls must start with git@ and end with .git
+addBuilder('git@gitlab.example.com:build/gnu-hello.git',
+           branch='master', flavor='normal', workernames=workernames)
+addBuilder('git@gitlab.example.com:build/gnu-hello.git',
+           branch='master', flavor='smoke',  workernames=workernames)
+addBuilder('git@gitlab.example.com:build/gnu-time.git',
+           branch='master', flavor='normal', workernames=workernames)
+addBuilder('git@gitlab.example.com:build/gnu-time.git',
+           branch='master', flavor='smoke',  workernames=workernames)
 
 ####### BUILDBOT SERVICES
 
@@ -223,7 +249,7 @@ addGitLabProject('git@gitlab.example.com:build/gnu-time', workernames)
 
 c['services'] = []
 
-# CONFIGME: uncomment for gitlab status reporting
+## CONFIGME: uncomment for gitlab status reporting
 ## Report build status back to GitLab UI
 #c['services'].append(reporters.GitLabStatusPush(
 #    token=util.Secret('my-gitlab-token'),
@@ -250,9 +276,8 @@ c['buildbotURL'] = "http://buildbot.example.com:8010/"
 ## This example tries to show nothing to anonymous users.
 #authz = util.Authz(
 #  allowRules=[
-#    # CONFIGME: replace "<mygroup>" here with a valid gitlab group
-#    util.AnyEndpointMatcher(role="<mygroup>"),
-#    util.AnyEndpointMatcher(role="snorglepuss-does-not-exist", defaultDeny=True),
+#    util.AnyEndpointMatcher(role="platform"),
+#    util.AnyEndpointMatcher(role="xxend-of-listxx", defaultDeny=True),
 #  ],
 #  roleMatchers=[
 #    util.RolesFromGroups()
@@ -262,7 +287,7 @@ c['buildbotURL'] = "http://buildbot.example.com:8010/"
 # minimalistic config to activate new web UI
 c['www'] = dict(
     port=8010,
-    # CONFIGME: uncomment for buildbot authentication
+    ## CONFIGME: uncomment for buildbot authentication
     #auth=util.GitLabAuth("https://gitlab.example.com",
     #                     dumbSecret('my-gitlab-appid'),
     #                     dumbSecret('my-gitlab-appsecret')),
@@ -281,7 +306,7 @@ c['buildbotNetUsageData'] = 'basic'
 ####### DB URL
 
 c['db'] = {
-    # This specifies what database buildbot uses to store its state.  You can leave
-    # this at its default for all but the largest installations.
-    'db_url' : "sqlite:///state.sqlite",
+    # This specifies what database buildbot uses to store its state.
+    # You can leave this at its default for all but the largest installations.
+    'db_url': "sqlite:///state.sqlite",
 }

--- a/master/docs/examples/gitlab.cfg
+++ b/master/docs/examples/gitlab.cfg
@@ -3,37 +3,92 @@
 
 # This is a sample buildmaster config file. It must be installed as
 # 'master.cfg' in your buildmaster's base directory.
-
-from buildbot.plugins import *
-import re
-
-
+#
 # Are all your projects built the same way?
 # Do you yearn for a way to do simple static configuration?
-# If so, try writing a function.
+# If so, try writing a function!
+#
 # Here's an example that
-# - uses GitLab
-# - provides one regular builder and one smoke test builder per project
-# - assumes the projects use Gnu automake etc.
+# - uses a function to make adding new projects easy
+# - provides a regular builder and a smoke test builder per project
+# - stores secrets in separate files
+# - integrates with GitLab, and does smoke builds on merge requests
+# - demonstrates access control using GitLab authentication
 #
-# To use this example with your own local instance of gitlab:
+# To use this example with your own local instance of GitLab:
 #
-# 0. Edit this file to replace example.com with your own domain.
+# 0. Set up local mirrors of the gnu hello and time projects, e.g.
+#  for proj in hello time
+#  do
+#    git clone --mirror git@gitlab.com:GNU/$proj.git
+#    cd $proj
+#    git push --mirror git@gitlab.example.com:build/gnu-$proj.git
+#    cd ..
+#  done
 #
-# 1. Set up local mirrors of the gnu projects, e.g.
-#   for proj in hello time
-#   do 
-#     git clone --mirror git@gitlab.com:GNU/$proj.git
-#     cd $proj
-#     git push --mirror git@gitlab.example.com:build/gnu-$proj.git
-#     cd ..
-#   done
+# 1. Edit this file to replace example.com with your own domain,
+#  and adjust worker name and password in c['workers'].
 #
-# 2. Follow instructions below marked "CONFIGME: GitLab" to
-# configure GitLab to know about this buildbot.
+# 2. Create secrets.dir next to master.cfg:
+#  mkdir secrets.dir
 #
-# Your buildbot should then do automated builds of merge requests
-# that target forks of those local projects.
+# 3. Tell GitLab to use webhooks to request builds.
+#  Pick a random password for our webhook and save it as a secret, e.g.
+#    echo "<string-webhook-token>" > secrets.dir/my-webhook-token
+#    chmod 600 secrets.dir/*
+#  (where <value> is just a placeholder for a value).
+#  For each project to build, create a webhook in the GitLab UI at
+#    project / Settings / Integrations / Add Webhook
+#  with a URL of e.g.
+#    http://buildbot.example.com:8010/change_hook/gitlab
+#  the secret chosen above,
+#  and with push and merge request triggers checked.
+#
+#  Then start the build master and worker.
+#  Test the webhook by visiting
+#    project / Settings / Integrations / Webhooks
+#  and clicking 'test' on your webhook.
+#  If something goes wrong, GitLab will show a red banner with the reason.
+#  GitLab merge requests should now trigger buildbot builds.
+#
+# 4. Tell buildbot to report build status to GitLab.
+#  Uncomment sections below marked
+#    "CONFIGME: uncomment for gitlab status reporting"
+#  Create a GitLab access token (so buildbot can send status to GitLab).
+#  Pick a display name for your buildbot and save it as a secret, e.g.
+#    echo "<string-buildbot-name>" > secrets.dir/my-buildbot-name
+#    chmod 600 secrets.dir/*
+#  Create an access token in the GitLab UI at
+#    "User Settings / Access Tokens / Add a personal access token"
+#  using that display name as the context, and save it as a secret, e.g.
+#    echo "<string-gitlab-token>" > secrets.dir/my-gitlab-token
+#    chmod 600 secrets.dir/*
+#
+#  Then restart the master.
+#  GitLab merge requests should now show status of buildbot's builds.
+#
+# 5. Tell GitLab to accept authentication requests from buildbot.
+#  Enter the URL of your buildbot gitlab hook, e.g.
+#    http://buildbot.example.com:8010/change_hook/gitlab
+#  into the GitLab UI at
+#    "User Settings / Applications / Add New Application",
+#  with scopes 'api' and 'openid' ticked,
+#  and save the appid and secret it produces:
+#    echo "<longhexstring-appid>" > secrets.dir/my-gitlab-appid
+#    echo "<longhexstring-appsecret>" > secrets.dir/my-gitlab-appsecret
+#    chmod 600 secrets.dir/*
+# 6. Restrict buildbot web UI access to logged in GitLab users.
+#  Uncomment sections below marked
+#    "CONFIGME: uncomment for buildbot authentication"
+#  and replace <mygroup> with a valid GitLab group.
+#
+#  Then restart the master.
+#  Buildbot's web ui should now require you to be logged in to
+#  that GitLab group before it shows you much or lets you force builds.
+
+from buildbot.plugins import *
+import os
+import re
 
 def addGitLabProject(repourl, workernames, branch=None):
     '''
@@ -106,11 +161,27 @@ def addGitLabProject(repourl, workernames, branch=None):
 # a shorter alias to save typing.
 c = BuildmasterConfig = {}
 
+####### SECRETS
+# Checking secrets into your master.cfg is insecure;
+# best practice is to keep them elsewhere else.
+
+# Place the secrets directory next to master.cfg:
+secrets_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'secrets.dir')
+c['secretsProviders'] = [secrets.SecretInAFile(dirname=secrets_dir)]
+
+# For parts of buildbot that don't support Secret interpolation yet
+# Once https://github.com/buildbot/buildbot/issues/4118 is fixed,
+# use util.Secret(s) instead.
+def dumbSecret(s):
+    with open(os.path.join(secrets_dir, s), 'r') as myfile:
+        return myfile.read().replace('\n', '')
+
 ####### WORKERS
 
 # The 'workers' list defines the set of recognized workers. Each element is
 # a Worker object, specifying a unique worker name and password.  The same
 # worker name and password must be configured on the worker.
+# CONFIGME
 c['workers'] = [worker.Worker("buildbot-worker", "buildbot-pass")]
 workernames = ["buildbot-worker"]
 
@@ -130,7 +201,7 @@ c['change_source'] = []
 
 ####### SCHEDULERS AND BUILDERS
 
-# The Schedulers decide how to react to incoming changes.  
+# The Schedulers decide how to react to incoming changes.
 c['schedulers'] = []
 # The 'builders' list defines the Builders, which tell Buildbot how to
 # perform a build: what steps, and which workers can execute them.
@@ -152,6 +223,14 @@ addGitLabProject('git@gitlab.example.com:build/gnu-time', workernames)
 
 c['services'] = []
 
+# CONFIGME: uncomment for gitlab status reporting
+## Report build status back to GitLab UI
+#c['services'].append(reporters.GitLabStatusPush(
+#    token=util.Secret('my-gitlab-token'),
+#    context=util.Secret('my-buildbot-name'),
+#    baseURL='https://gitlab.example.com',
+#    verbose=True))
+
 ####### PROJECT IDENTITY
 
 # the 'title' string will appear at the top of this buildbot installation's
@@ -167,52 +246,37 @@ c['titleURL'] = "https://gitlab.example.com/build/"
 
 c['buildbotURL'] = "http://buildbot.example.com:8010/"
 
-# CONFIGME: buildbot authentication
-# This example tries to show nothing to anonymous users.
-# authz = util.Authz(
-#   allowRules=[
-#     util.AnyEndpointMatcher(role="platform"),
-#     util.AnyEndpointMatcher(role="snorglepuss-does-not-exist", defaultDeny=True),
-#   ],
-#   roleMatchers=[
-#     util.RolesFromGroups()
-#   ]
-# )
+# CONFIGME: uncomment for buildbot authentication
+## This example tries to show nothing to anonymous users.
+#authz = util.Authz(
+#  allowRules=[
+#    # CONFIGME: replace "<mygroup>" here with a valid gitlab group
+#    util.AnyEndpointMatcher(role="<mygroup>"),
+#    util.AnyEndpointMatcher(role="snorglepuss-does-not-exist", defaultDeny=True),
+#  ],
+#  roleMatchers=[
+#    util.RolesFromGroups()
+#  ]
+#)
 
 # minimalistic config to activate new web UI
 c['www'] = dict(
     port=8010,
-    # CONFIGME: GitLab application
-    # Enter the URL of your buildbot gitlab hook into the GitLab UI at
-    #  "User Settings / Applications / Add New Application"
-    # to obtain the 2nd and 3rd parameters for GitLabAuth.
-    auth=util.GitLabAuth("https://gitlab.example.com",
-                         "036777777777777777777777777777777777777777777777777777777cea803a",
-                         "bae69888888888888888888888888888888888888888888888888888888888ec"),
-    # CONFIGME: buildbot authentication
+    # CONFIGME: uncomment for buildbot authentication
+    #auth=util.GitLabAuth("https://gitlab.example.com",
+    #                     dumbSecret('my-gitlab-appid'),
+    #                     dumbSecret('my-gitlab-appsecret')),
     #authz=authz,
     change_hook_dialects=dict(
        gitlab={
-           # CONFIGME: GitLab webhook
-           # Create a webhook in the GitLab UI at
-           #  project / Settings / Integrations / Add Webhook 
-           # with a URL of e.g.
-           #   http://buildbot.example.com:8010/change_hook/gitlab
-           # with push and merge request triggers checked, 
-           # and with a secret that matches the one here (please change):
-           'secret': 'changeme',
+           'secret': dumbSecret('my-webhook-token')
        },
     ),
     plugins=dict(waterfall_view={}, console_view={}, grid_view={}))
 
-# CONFIGME: GitLab access token
-# Create an access token in the GitLab UI at
-#   "User Settings / Access Tokens / Add a personal access token"
-# to obtain 1st and 2nd parameters for GitLabStatusPush.
-gl = reporters.GitLabStatusPush('Sas23r293232ddzfHAvd', context='youchoose/this', baseURL='https://gitlab.example.com', verbose=True)
-c['services'].append(gl)
 
-c['buildbotNetUsageData'] = None
+# Let buildbot developers know you're using gitlab support :-)
+c['buildbotNetUsageData'] = 'basic'
 
 ####### DB URL
 

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -928,6 +928,9 @@ GitLab
 When configuring builders, you can use a ChangeFilter with ``category = "push"``
 to select normal commits, and ``category = "merge_request"`` to select merge requests.
 
+See :file:`master/docs/examples/gitlab.cfg` in the Buildbot distribution
+for a tutorial example of integrating Buildbot with GitLab.
+
 .. note::
 
     Your build worker will need access to the source project of the

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -925,8 +925,19 @@ GitLab
 
 :bb:step:`GitLab` step is exactly like the :bb:step:`Git` step, except that it uses the source repo and branch sent by the :bb:chsrc:`GitLab` change hook when processing merge requests.
 
-When configuring builders, use a ChangeFilter with ``category = "push"``
+When configuring builders, you can use a ChangeFilter with ``category = "push"``
 to select normal commits, and ``category = "merge_request"`` to select merge requests.
+
+.. note::
+
+    Your build worker will need access to the source project of the
+    changeset, or it won't be able to check out the source.  This means
+    authenticating the build worker via ssh credentials in the usual
+    way, then granting it access [via a GitLab deploy key
+    or GitLab project membership](https://docs.gitlab.com/ee/ssh/).
+    This needs to be done not only for the main git repo, but also for
+    each fork that wants to be able to submit merge requests against
+    the main repo.
 
 .. bb:step:: Darcs
 

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -914,6 +914,20 @@ The revision in the GitHub event points to ``/head`` is important for the GitHub
 
 If you want to use  :bb:step:`Trigger` to create sub tests and want to have the GitHub reporter still update the original revision, make sure you set ``updateSourceStamp=False`` in the :bb:step:`Trigger` configuration.
 
+.. bb:step:: GitLab
+
+.. _Step-GitLab:
+
+GitLab
+++++++
+
+.. py:class:: buildbot.steps.source.gitlab.GitLab
+
+:bb:step:`GitLab` step is exactly like the :bb:step:`Git` step, except that it uses the source repo and branch sent by the :bb:chsrc:`GitLab` change hook when processing merge requests.
+
+When configuring builders, use a ChangeFilter with ``category = "push"``
+to select normal commits, and ``category = "merge_request"`` to select merge requests.
+
 .. bb:step:: Darcs
 
 .. _Step-Darcs:

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -344,6 +344,10 @@ These parameters will be passed along to the scheduler.
 
     Your Git step must be configured with a git@ repourl, not a https: one, else the change from the webhook will not trigger a build.
 
+.. note::
+
+    To handle merge requests from forks properly, use a GitLab source step rather than a Git source step.
+
 .. warning::
 
     As in the previous case, the incoming HTTP requests for this hook are not authenticated by default.

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -342,11 +342,11 @@ These parameters will be passed along to the scheduler.
 
 .. note::
 
-    Your Git step must be configured with a git@ repourl, not a https: one, else the change from the webhook will not trigger a build.
+    To handle merge requests from forks properly, it's easiest to use a GitLab source step rather than a Git source step.
 
 .. note::
 
-    To handle merge requests from forks properly, use a GitLab source step rather than a Git source step.
+    Your Git or GitLab step must be configured with a git@ repourl, not a https: one, else the change from the webhook will not trigger a build.
 
 .. warning::
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -304,6 +304,7 @@ setup_args = {
             ('buildbot.steps.source.gerrit', ['Gerrit']),
             ('buildbot.steps.source.git', ['Git']),
             ('buildbot.steps.source.github', ['GitHub']),
+            ('buildbot.steps.source.gitlab', ['GitLab']),
             ('buildbot.steps.source.mercurial', ['Mercurial']),
             ('buildbot.steps.source.mtn', ['Monotone']),
             ('buildbot.steps.source.p4', ['P4']),


### PR DESCRIPTION
Previously, only merge requests from the same gitlab project were supported (without using Interpolate, anyway).

Now:
- GitLab www hook uses repourl for the target project,
  but preserves source project id and repo url as properties
- GitLab source step and reporter operate on the
  source project so we build the right code and report
  status to the merge request.

Modelled after GitHub source step.

Fixes https://github.com/buildbot/buildbot/issues/4107