### PR TITLE
Fix encoding in windows worker service

### DIFF
--- a/worker/buildbot_worker/scripts/windows_service.py
+++ b/worker/buildbot_worker/scripts/windows_service.py
@@ -204,7 +204,7 @@ class BBService(win32serviceutil.ServiceFramework):
                        "Stopping the service.")
             return False
         if save_dirs:
-            dir_string = os.pathsep.join(self.dirs).encode("mbcs")
+            dir_string = os.pathsep.join(self.dirs)
             win32serviceutil.SetServiceCustomOption(self, "directories",
                                                     dir_string)
         return True


### PR DESCRIPTION
Same fix as in https://github.com/buildbot/buildbot/pull/3797 but this time for the worker service.