### PR TITLE
Use .winerror accessor instead of indexing

### DIFF
--- a/worker/buildbot_worker/scripts/windows_service.py
+++ b/worker/buildbot_worker/scripts/windows_service.py
@@ -408,7 +408,7 @@ class BBService(win32serviceutil.ServiceFramework):
             except pywintypes.error as err:
                 # ERROR_BROKEN_PIPE means the child process closed the
                 # handle - ie, it terminated.
-                if err[0] != winerror.ERROR_BROKEN_PIPE:
+                if err.winerror != winerror.ERROR_BROKEN_PIPE:
                     self.warning("Error reading output from process: {0}".format(err))
                 break
             captured_blocks.append(data)


### PR DESCRIPTION
Seems at some point pywin32 silently dropped the support for indexing.
This fixes the error brought up by @rodrigc here:

  https://github.com/buildbot/buildbot/issues/3796#issuecomment-349159727