### PR TITLE
Update Dockerfile to include ssh in the container

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -80,7 +80,8 @@ RUN \
         dumb-init \
         tar \
         tzdata \
-        curl && \
+        curl \
+        openssh && \
 # install pip dependencies
     pip install --upgrade pip setuptools && \
     pip install /wheels/*.whl && \


### PR DESCRIPTION
Pooling with GitPooler for resources available over ssh do not work.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

Checklist is not relevant I believe.