### PR TITLE
hooks: allow remote ref to be specified for GitHub hook closes #3998

### DIFF
--- a/master/buildbot/newsfragments/issue3998-github-changehook-ref-option.feature
+++ b/master/buildbot/newsfragments/issue3998-github-changehook-ref-option.feature
@@ -1,0 +1,1 @@
+Allow the remote ref to be specified in the GitHub hook configuration (:issue:`3998`)

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -48,6 +48,7 @@ class GitHubEventHandler(PullRequestMixin):
                  master=None,
                  skips=None,
                  github_api_endpoint=None,
+                 pullrequest_ref=None,
                  token=None,
                  debug=False,
                  verify=False):
@@ -55,6 +56,7 @@ class GitHubEventHandler(PullRequestMixin):
         self._strict = strict
         self._token = token
         self._codebase = codebase
+        self.pullrequest_ref = pullrequest_ref
         self.github_property_whitelist = github_property_whitelist
         self.skips = skips
         self.github_api_endpoint = github_api_endpoint
@@ -156,7 +158,7 @@ class GitHubEventHandler(PullRequestMixin):
     def handle_pull_request(self, payload, event):
         changes = []
         number = payload['number']
-        refname = 'refs/pull/{}/merge'.format(number)
+        refname = 'refs/pull/{}/{}'.format(number, self.pullrequest_ref)
         commits = payload['pull_request']['commits']
         title = payload['pull_request']['title']
         comments = payload['pull_request']['body']
@@ -327,6 +329,7 @@ class GitHubHandler(BaseHookHandler):
             'github_property_whitelist': options.get('github_property_whitelist', None),
             'skips': options.get('skips', None),
             'github_api_endpoint': options.get('github_api_endpoint', None) or 'https://api.github.com',
+            'pullrequest_ref': options.get('pullrequest_ref', None) or 'merge',
             'token': options.get('token', None),
             'debug': options.get('debug', None) or False,
             'verify': options.get('verify', None) or False,

--- a/master/docs/manual/cfg-wwwhooks.rst
+++ b/master/docs/manual/cfg-wwwhooks.rst
@@ -131,6 +131,11 @@ The GitHub hook has the following parameters:
 ``token``
     If your GitHub or GitHub Enterprise instance does not allow anonymous communication, you need to provide an access token.  Instructions can be found here <https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/>
 
+``pullrequest_ref`` (default ``merge``)
+    Remote ref to test if a pull request is sent to the endpoint. See the GitHub developer manual
+    for possible values for pull requests. (e.g. ``head``)
+
+
 The simplest way to use GitHub hook is as follows:
 
 .. code-block:: python


### PR DESCRIPTION
* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

This will allow bigger repositories with a lot of merge conflicts to avoid
spurious build failures due to not/late available `/merge` ref