### PR TITLE
Fix no commit msg crash for Github Pull Requests

### DIFF
--- a/master/buildbot/newsfragments/no-commit-msg-crash.bugfix
+++ b/master/buildbot/newsfragments/no-commit-msg-crash.bugfix
@@ -1,0 +1,3 @@
+Fixed a Github crash that happened on Pull Requests, triggered by Github Web-hooks.
+The json sent by the API does not contain a commit message. In github.py this causes a crash,
+resulting into response 500 sent back to Github and building failure.

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -223,7 +223,7 @@ class GitHubEventHandler(PullRequestMixin):
             debug=self.debug, verify=self.verify)
         res = yield http.get(url)
         data = yield res.json()
-        msg = data['commit']['message']
+        msg = data.get('commit', {'message': 'No message field'})['message']
         defer.returnValue(msg)
 
     def _process_change(self, payload, user, repo, repo_url, project, event,


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
