### PR TITLE
Fix bug in worker disconnected notice

### DIFF
--- a/master/buildbot/newsfragments/issue4131-fix-worker-disconnection-notice.bugfix
+++ b/master/buildbot/newsfragments/issue4131-fix-worker-disconnection-notice.bugfix
@@ -1,0 +1,3 @@
+Fixed a bug in :py:class:`~buildbot.reporters.mail.MailNotifier`'s
+``createEmail`` method when called with the default *builds* value which
+resulted in mail not being sent.

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -236,7 +236,7 @@ class MailNotifier(NotifierBase):
         # interpolation if only one build was given
         if self.extraHeaders:
             extraHeaders = self.extraHeaders
-            if len(builds) == 1:
+            if builds is not None and len(builds) == 1:
                 props = Properties.fromDict(builds[0]['properties'])
                 props.master = self.master
                 extraHeaders = yield props.render(extraHeaders)


### PR DESCRIPTION
This bug causes worker disconnection notices to not be sent to our CPython buildbot worker owners. The fix is straightforward and apparently not covered by existing tests; I haven't attempted to add one.


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] ~~I have updated the appropriate documentation~~
