### PR TITLE
Update Gitlab api endpoint to v4.

### DIFF
--- a/master/buildbot/newsfragments/issue4143-gitlab-v3-api-deprecated.bugfix
+++ b/master/buildbot/newsfragments/issue4143-gitlab-v3-api-deprecated.bugfix
@@ -1,1 +1,1 @@
-GitLab v3 API is deprecated and has been removed from gitlab.com, so we now use v4. (:issue:`4143`)
+GitLab v3 API is deprecated and has been removed from http://gitlab.com, so we now use v4. (:issue:`4143`)

--- a/master/buildbot/newsfragments/issue4143-gitlab-v3-api-deprecated.bugfix
+++ b/master/buildbot/newsfragments/issue4143-gitlab-v3-api-deprecated.bugfix
@@ -1,0 +1,1 @@
+GitLab v3 API is deprecated and has been removed from gitlab.com, so we now use v4. (:issue:`4143`)

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -89,7 +89,7 @@ class GitLabStatusPush(http.HttpStatusPushBase):
         if context is not None:
             payload['name'] = context
 
-        return self._http.post('/api/v3/projects/%d/statuses/%s' % (
+        return self._http.post('/api/v4/projects/%d/statuses/%s' % (
             project_id, sha),
             json=payload)
 
@@ -106,7 +106,7 @@ class GitLabStatusPush(http.HttpStatusPushBase):
         project_full_name = urlquote_plus(project_full_name)
 
         if project_full_name not in self.project_ids:
-            response = yield self._http.get('/api/v3/projects/%s' % (project_full_name))
+            response = yield self._http.get('/api/v4/projects/%s' % (project_full_name))
             proj = yield response.json()
             if response.code not in (200, ):
                 log.msg(

--- a/master/buildbot/test/unit/test_reporter_gitlab.py
+++ b/master/buildbot/test/unit/test_reporter_gitlab.py
@@ -68,26 +68,26 @@ class TestGitLabStatusPush(unittest.TestCase, ReporterTestMixin, logging.Logging
         # we make sure proper calls to txrequests have been made
         self._http.expect(
             'get',
-            '/api/v3/projects/buildbot%2Fbuildbot', content_json={
+            '/api/v4/projects/buildbot%2Fbuildbot', content_json={
                 "id": 1
             })
         self._http.expect(
             'post',
-            '/api/v3/projects/1/statuses/d34db33fd43db33f',
+            '/api/v4/projects/1/statuses/d34db33fd43db33f',
             json={'state': 'running',
                   'target_url': 'http://localhost:8080/#builders/79/builds/0',
                   'ref': 'master',
                   'description': 'Build started.', 'name': 'buildbot/Builder0'})
         self._http.expect(
             'post',
-            '/api/v3/projects/1/statuses/d34db33fd43db33f',
+            '/api/v4/projects/1/statuses/d34db33fd43db33f',
             json={'state': 'success',
                   'target_url': 'http://localhost:8080/#builders/79/builds/0',
                   'ref': 'master',
                   'description': 'Build done.', 'name': 'buildbot/Builder0'})
         self._http.expect(
             'post',
-            '/api/v3/projects/1/statuses/d34db33fd43db33f',
+            '/api/v4/projects/1/statuses/d34db33fd43db33f',
             json={'state': 'failed',
                   'target_url': 'http://localhost:8080/#builders/79/builds/0',
                   'ref': 'master',
@@ -107,12 +107,12 @@ class TestGitLabStatusPush(unittest.TestCase, ReporterTestMixin, logging.Logging
         # we make sure proper calls to txrequests have been made
         self._http.expect(
             'get',
-            '/api/v3/projects/buildbot%2Fbuildbot', content_json={
+            '/api/v4/projects/buildbot%2Fbuildbot', content_json={
                 "id": 1
             })
         self._http.expect(
             'post',
-            '/api/v3/projects/1/statuses/d34db33fd43db33f',
+            '/api/v4/projects/1/statuses/d34db33fd43db33f',
             json={'state': 'running',
                   'target_url': 'http://localhost:8080/#builders/79/builds/0',
                   'ref': 'master',
@@ -127,7 +127,7 @@ class TestGitLabStatusPush(unittest.TestCase, ReporterTestMixin, logging.Logging
         build = yield self.setupBuildResults(SUCCESS)
         self._http.expect(
             'post',
-            '/api/v3/projects/20922342342/statuses/d34db33fd43db33f',
+            '/api/v4/projects/20922342342/statuses/d34db33fd43db33f',
             json={'state': 'running',
                   'target_url': 'http://localhost:8080/#builders/79/builds/0',
                   'ref': 'master',
@@ -145,7 +145,7 @@ class TestGitLabStatusPush(unittest.TestCase, ReporterTestMixin, logging.Logging
         # we make sure proper calls to txrequests have been made
         self._http.expect(
             'get',
-            '/api/v3/projects/buildbot%2Fbuildbot', content_json={
+            '/api/v4/projects/buildbot%2Fbuildbot', content_json={
                 "message": 'project not found'
             }, code=404)
         build['complete'] = False
@@ -169,12 +169,12 @@ class TestGitLabStatusPush(unittest.TestCase, ReporterTestMixin, logging.Logging
         # we make sure proper calls to txrequests have been made
         self._http.expect(
             'get',
-            '/api/v3/projects/buildbot%2Fbuildbot', content_json={
+            '/api/v4/projects/buildbot%2Fbuildbot', content_json={
                 "id": 1
             })
         self._http.expect(
             'post',
-            '/api/v3/projects/1/statuses/d34db33fd43db33f',
+            '/api/v4/projects/1/statuses/d34db33fd43db33f',
             json={'state': 'running',
                   'target_url': 'http://localhost:8080/#builders/79/builds/0',
                   'ref': 'master',
@@ -194,7 +194,7 @@ class TestGitLabStatusPush(unittest.TestCase, ReporterTestMixin, logging.Logging
         # we make sure proper calls to txrequests have been made
         self._http.expect(
             'get',
-            '/api/v3/projects/buildbot%2Fbuildbot', content_json={
+            '/api/v4/projects/buildbot%2Fbuildbot', content_json={
                 "id": 1
             })
         build['complete'] = False

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -358,7 +358,7 @@ class GitLabAuth(OAuth2Auth):
         uri = instanceUri.rstrip("/")
         self.authUri = "%s/oauth/authorize" % uri
         self.tokenUri = "%s/oauth/token" % uri
-        self.resourceEndpoint = "%s/api/v3" % uri
+        self.resourceEndpoint = "%s/api/v4" % uri
         super(GitLabAuth, self).__init__(clientId, clientSecret, **kwargs)
 
     def getUserInfoFromOAuthClient(self, c):


### PR DESCRIPTION
Update Gitlab API endpoint from v3 to v4.

Fixes #4143 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation