### PR TITLE
WIP: Add support for specifying private SSH keys for Git and GitPoller

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1086,6 +1086,7 @@ requestsubmitted
 requeue
 requiredargs
 reschedulenextbuild
+resetmocks
 resourceneedsreconfigs
 resourcetype
 restrmatcher

--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -94,6 +94,7 @@ backoff
 backporting
 backslashing
 basedir
+basename
 basepath
 baserev
 basetgz

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -220,13 +220,16 @@ class Source(LoggingBuildStep, CompositeStepMixin):
             return cmd.rc
         return d
 
-    def _downloadFile(self, buf, filename, mode=None):
+    def _downloadFile(self, buf, filename, workdir=None, mode=None):
+        if workdir is None:
+            workdir = self.workdir
+
         filereader = remotetransfer.StringFileReader(buf)
         args = {
             'maxsize': None,
             'reader': filereader,
             'blocksize': 16 * 1024,
-            'workdir': self.workdir,
+            'workdir': workdir,
             'mode': mode
         }
 

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -83,6 +83,56 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
         return self.runStep()
 
+    def test_mode_full_clean_ssh_key(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='clean', sshPrivateKey='sshkey'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 2.10.0')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('downloadFile', dict(blocksize=16384, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='../.wkdir.buildbot-ssh-key',
+                                        workdir='wkdir',
+                                        mode=0o400))
+            + 0,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', '-c', 'core.sshCommand=ssh -i "../.wkdir.buildbot-ssh-key"',
+                                 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+            Expect('rmdir', dict(dir='wkdir/../.wkdir.buildbot-ssh-key',
+                                 logEnviron=True))
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.runStep()
+
     def test_mode_full_clean_win32path(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
@@ -116,6 +166,57 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'rev-parse', 'HEAD'])
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.runStep()
+
+    def test_mode_full_clean_win32path_ssh_key(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='clean', sshPrivateKey='sshkey'))
+        self.build.path_module = namedModule('ntpath')
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 2.10.0')
+            + 0,
+            Expect('stat', dict(file='wkdir\\.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('downloadFile', dict(blocksize=16384, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='..\\.wkdir.buildbot-ssh-key',
+                                        workdir='wkdir',
+                                        mode=0o400))
+            + 0,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', '-c', 'core.sshCommand=ssh -i "..\\.wkdir.buildbot-ssh-key"',
+                                 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+            Expect('rmdir', dict(dir='wkdir\\..\\.wkdir.buildbot-ssh-key',
+                                 logEnviron=True))
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
@@ -913,6 +1014,57 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
         return self.runStep()
 
+    def test_mode_incremental_branch_ssh_key(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='incremental', branch='test-branch',
+                           sshPrivateKey='ssh-key'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 2.10.0')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('downloadFile', dict(blocksize=16384, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='../.wkdir.buildbot-ssh-key',
+                                        workdir='wkdir',
+                                        mode=0o400))
+            + 0,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', '-c', 'core.sshCommand=ssh -i "../.wkdir.buildbot-ssh-key"',
+                                 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'test-branch'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'checkout', '-B', 'test-branch'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+            Expect('rmdir', dict(dir='wkdir/../.wkdir.buildbot-ssh-key',
+                                 logEnviron=True))
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.runStep()
+
     def test_mode_full_fresh(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
@@ -1542,6 +1694,60 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'rev-parse', 'HEAD'])
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.runStep()
+
+    def test_mode_full_copy_ssh_key(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='copy', sshPrivateKey='sshkey'))
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 2.10.0')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('downloadFile', dict(blocksize=16384, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='../.source.buildbot-ssh-key',
+                                        workdir='source',
+                                        mode=0o400))
+            + 0,
+            Expect('rmdir', dict(dir='wkdir',
+                                 logEnviron=True,
+                                 timeout=1200)),
+            Expect('listdir', {'dir': 'source', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='source',
+                        command=['git', '-c', 'core.sshCommand=ssh -i "../.source.buildbot-ssh-key"',
+                                 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD'])
+            + 0,
+            ExpectShell(workdir='source',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            Expect('cpdir', {'fromdir': 'source', 'todir': 'wkdir',
+                             'logEnviron': True, 'timeout': 1200})
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+            Expect('rmdir', dict(dir='source/../.source.buildbot-ssh-key',
+                                 logEnviron=True))
             + 0,
         )
         self.expectOutcome(result=SUCCESS)
@@ -2506,4 +2712,21 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             yield
             defer.returnValue("git ")
 
-        return self._test_invalidGit(_dovccmd)
+        step = self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                              mode='full', method='clean')
+        msg = 'git is not installed on worker'
+        return self._test_WorkerTooOldError(_dovccmd, step, msg)
+
+    def test_gitVersionTooOldForSshPrivateKeySupport(self):
+        @defer.inlineCallbacks
+        def _dovccmd(command, abandonOnFailure=True, collectStdout=False,
+                     initialStdin=None):
+            # ssh private keys supported since 2.10.0
+            yield
+            defer.returnValue("git version 2.9.9")
+
+        step = self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                              mode='full', method='clean',
+                              sshPrivateKey='sshkey')
+        msg = 'ssh private key support requires git 2.10.0'
+        return self._test_WorkerTooOldError(_dovccmd, step, msg)

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -2466,15 +2466,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.expectOutcome(result=RETRY, state_string="update (retry)")
         return self.runStep()
 
-    def _test_invalidGit(self, _dovccmd):
+    def _test_WorkerTooOldError(self, _dovccmd, step, msg):
         def check(failure):
             self.assertIsInstance(failure.value, WorkerTooOldError)
-            self.assertEqual(str(failure.value), "git is not installed on worker")
+            self.assertEqual(str(failure.value), msg)
 
         self.patch(self.stepClass, "_dovccmd", _dovccmd)
-        gitStep = self.setupStep(
-            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
-                           mode='full', method='clean'))
+        gitStep = self.setupStep(step)
 
         gitStep._start_deferred = defer.Deferred()
         gitStep.startVC("branch", "revision", "patch")
@@ -2491,7 +2489,10 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             yield
             defer.returnValue("command not found:")
 
-        return self._test_invalidGit(_dovccmd)
+        step = self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                              mode='full', method='clean')
+        msg = 'git is not installed on worker'
+        return self._test_WorkerTooOldError(_dovccmd, step, msg)
 
     def test_gitCommandOutputShowsNoVersion(self):
         @defer.inlineCallbacks


### PR DESCRIPTION
Currently there's no way to clone ssh:// git repositories if public key authentication is needed. E.g. Gitlab (at least the self-hosted instances) don't allow cloning via user+password combo. The workaround is to put the private key into the worker along with appropriate ssh config, which is inconvenient when many workers are involved and keys need to be changed or introduced.

Git allows specification of the private SSH key via the following approaches:
 - Git 2.10 and newer support specifying private SSH key via the `-c core.sshCommand=ssh -i "{path_to_key}"` command line option
 - Git 2.3 and newer support specifying private SSH key via the `GIT_SSH_COMMAND=ssh -i "{path_to_key}"`environment variable
 - Git 1.0 supports pointing `GIT_SSH` to a wrapper script and specifying SSH options there.

I've hacked a proof of concept code for the first approach. The Git source step will upload the private SSH key when needed, use appropriate `core.sshCommand` config option to specify the key, and delete the key file when done. This way keys can be updated by just changing the secret on the master without any changes on the workers.

Similar approach has been adopted for GitPoller. This allows the keys to be specified as a secret and avoids the need to modify the buildbot master when changing SSH keys.

The private keys are exposed as sshPrivateKey parameter to both Git and GitPoller. The value may be either secret or just a string.

I'd like to add support for old git versions too by creating a temporary wrapper SSH script on the worker just like this PR does with the private SSH key. Do you think it's worthwhile to add this to the official buildbot project? I need this for myself anyway, so I'll likely maintain my own patches if this is deemed too hacky :-)

Please tell me what do you think about this and I will finish the PR according to the feedback.

## Contributor Checklist:

* [partially] I have updated the unit tests
* [not yet] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [not yet] I have updated the appropriate documentation
