### PR TITLE
docs:manual: show the exact interpolated string

### DIFF
--- a/master/docs/manual/cfg-properties.rst
+++ b/master/docs/manual/cfg-properties.rst
@@ -188,7 +188,11 @@ A common mistake is to omit the trailing "s", leading to a rather obscure error 
                 util.Interpolate('REVISION=%(prop:got_revision)s'),
                 'dist']))
 
-This example will result in a ``make`` command with an argument like ``REVISION=12098``.
+This example will result in the command: ``make REVISION=12098 dist``,
+while being careful with quoting the property to protect from the shell.
+So if a property contains ``12098; rm -rf /;``, no harm will come to
+the server.
+
 
 .. _Interpolate-DictStyle:
 


### PR DESCRIPTION
in the example.  I spent too long trying to figure out how dist was an
arg for the %(prop:got_revision)s specifier.

Unfortunately I cannot make the docs ... I only hope I did not introduce
a syntax error.

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

http://trac.buildbot.net/wiki/Development
And especially:
http://trac.buildbot.net/wiki/SubmittingPatches

## Contributor Checklist:

* [ N/A, I think?] I have updated the unit tests
* [ N/A, I think? ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ This _is_ a documentation update] I have updated the appropriate documentation

Why yes, I am a rank newbie with buildbot.  I hesitate to report the documentation-building as broken since I haven't yet read all of it ...

And I think this contribution is too small for a license, but anyway you can do what you want with it (I expect you will set the license to your normal license).