### PR TITLE
Add support for specifying private SSH keys for Git older than v2.3

### DIFF
--- a/master/buildbot/newsfragments/git-support-private-ssh-key.feature
+++ b/master/buildbot/newsfragments/git-support-private-ssh-key.feature
@@ -1,2 +1,2 @@
 -:bb:step:`Git` now supports `sshPrivateKey` parameter to specify private ssh
-key for fetch operations. This feature is supported on git 2.3 and newer.
+key for fetch operations.

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -125,8 +125,8 @@ class Git(Source):
 
         @type  sshPrivateKey: Secret or string
         @param sshPrivateKey: The private key to use when running git for fetch
-                              operations. git must be 2.3 or newer in order to
-                              use this parameter.
+                              operations. The ssh utility must be in the system
+                              path in order to use this option.
 
         @type  config: dict
         @param config: Git configuration options to enable when running git
@@ -151,7 +151,7 @@ class Git(Source):
         self.supportsBranch = True
         self.supportsSubmoduleForce = True
         self.supportsSubmoduleCheckout = True
-        self.supportsSshPrivateKey = True
+        self.supportsSshPrivateKeyAsEnvOption = True
         self.supportsSshPrivateKeyAsConfigOption = True
         self.srcdir = 'source'
         self.origin = origin
@@ -171,11 +171,6 @@ class Git(Source):
         if not isinstance(self.getDescription, (bool, dict)):
             bbconfig.error("Git: getDescription must be a boolean or a dict.")
 
-    def _checkRequiredGitFeatures(self):
-        if self.sshPrivateKey is not None and not self.supportsSshPrivateKey:
-            raise WorkerTooOldError('ssh private key support requires '
-                                    'git 2.3.0')
-
     @defer.inlineCallbacks
     def startVC(self, branch, revision, patch):
         self.branch = branch or 'HEAD'
@@ -189,7 +184,6 @@ class Git(Source):
 
             if not gitInstalled:
                 raise WorkerTooOldError("git is not installed on worker")
-            self._checkRequiredGitFeatures()
 
             patched = yield self.sourcedirIsPatched()
 
@@ -396,16 +390,30 @@ class Git(Source):
     def _getSshPrivateKeyPath(self):
         return self.build.path_module.join(self._getSshDataPath(), 'ssh-key')
 
+    def _getSshWrapperScriptPath(self):
+        return self.build.path_module.join(self._getSshDataPath(), 'ssh-wrapper.sh')
+
+    def _getSshWrapperScript(self):
+        rel_key_path = self.build.path_module.relpath(
+                self._getSshPrivateKeyPath(), self._getSshDataWorkDir())
+
+        # note that this works on windows if using git with MINGW embedded.
+        return '#!/bin/sh\nssh -i "{0}" "$@"\n'.format(rel_key_path)
+
     def _adjustCommandParamsForSshPrivateKey(self, full_command, full_env):
 
         rel_key_path = self.build.path_module.relpath(
                 self._getSshPrivateKeyPath(), self.workdir)
+        rel_ssh_wrapper_path = self.build.path_module.relpath(
+                self._getSshWrapperScriptPath(), self.workdir)
 
         if self.supportsSshPrivateKeyAsConfigOption:
             full_command.append('-c')
             full_command.append('core.sshCommand=ssh -i "{0}"'.format(rel_key_path))
-        else:
+        elif self.supportsSshPrivateKeyAsEnvOption:
             full_env['GIT_SSH_COMMAND'] = 'ssh -i "{0}"'.format(rel_key_path)
+        else:
+            full_env['GIT_SSH'] = rel_ssh_wrapper_path
 
     @defer.inlineCallbacks
     def _dovccmd(self, command, abandonOnFailure=True, collectStdout=False, initialStdin=None):
@@ -675,7 +683,7 @@ class Git(Source):
         if LooseVersion(version) < LooseVersion("1.7.8"):
             self.supportsSubmoduleCheckout = False
         if LooseVersion(version) < LooseVersion("2.3.0"):
-            self.supportsSshPrivateKey = False
+            self.supportsSshPrivateKeyAsEnvOption = False
             self.supportsSshPrivateKeyAsConfigOption = False
         if LooseVersion(version) < LooseVersion("2.10.0"):
             self.supportsSshPrivateKeyAsConfigOption = False
@@ -733,8 +741,16 @@ class Git(Source):
 
         rel_key_path = self.build.path_module.relpath(
                 self._getSshPrivateKeyPath(), workdir)
+        rel_wrapper_script_path = self.build.path_module.relpath(
+                self._getSshWrapperScriptPath(), workdir)
 
         yield self.runMkdir(self._getSshDataPath())
+
+        if not self.supportsSshPrivateKeyAsEnvOption:
+            yield self.downloadFileContentToWorker(rel_wrapper_script_path,
+                                                   self._getSshWrapperScript(),
+                                                   workdir=workdir, mode=0o700)
+
         yield self.downloadFileContentToWorker(rel_key_path, private_key,
                                                workdir=workdir, mode=0o400)
 

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -727,13 +727,16 @@ class Git(Source):
         p.master = self.master
         private_key = yield p.render(self.sshPrivateKey)
 
+        # not using self.workdir because it may be changed depending on step
+        # options
+        workdir = self._getSshDataWorkDir()
+
         rel_key_path = self.build.path_module.relpath(
-                self._getSshPrivateKeyPath(), self._getSshDataWorkDir())
+                self._getSshPrivateKeyPath(), workdir)
 
         yield self.runMkdir(self._getSshDataPath())
         yield self.downloadFileContentToWorker(rel_key_path, private_key,
-                                               workdir=self._getSshDataWorkDir(),
-                                               mode=0o400)
+                                               workdir=workdir, mode=0o400)
 
         self.didDownloadSshPrivateKey = True
         defer.returnValue(RC_SUCCESS)

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -194,6 +194,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean'))
         self.build.path_module = namedModule('ntpath')
+        self.worker.worker_system = 'win32'
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -234,6 +235,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.build.path_module = namedModule('ntpath')
+        self.worker.worker_system = 'win32'
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -288,6 +290,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.build.path_module = namedModule('ntpath')
+        self.worker.worker_system = 'win32'
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -189,6 +189,66 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
         return self.runStep()
 
+    def test_mode_full_clean_ssh_key_1_7(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='clean', sshPrivateKey='sshkey'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.0')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('mkdir', dict(dir='.wkdir.buildbot',
+                                 logEnviron=True))
+            + 0,
+            Expect('downloadFile', dict(blocksize=32768, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='../.wkdir.buildbot/ssh-wrapper.sh',
+                                        workdir='wkdir',
+                                        mode=0o700))
+            + 0,
+            Expect('downloadFile', dict(blocksize=32768, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workdir='wkdir',
+                                        mode=0o400))
+            + 0,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD'],
+                        env={'GIT_SSH': '../.wkdir.buildbot/ssh-wrapper.sh'})
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+            Expect('rmdir', dict(dir='.wkdir.buildbot',
+                                 logEnviron=True))
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.runStep()
+
     def test_mode_full_clean_win32path(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
@@ -322,6 +382,68 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
                         env={'GIT_SSH_COMMAND': 'ssh -i "..\\.wkdir.buildbot\\ssh-key"'})
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+            Expect('rmdir', dict(dir='.wkdir.buildbot',
+                                 logEnviron=True))
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.runStep()
+
+    def test_mode_full_clean_win32path_ssh_key_1_7(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='clean', sshPrivateKey='sshkey'))
+        self.build.path_module = namedModule('ntpath')
+        self.worker.worker_system = 'win32'
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.0')
+            + 0,
+            Expect('stat', dict(file='wkdir\\.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('mkdir', dict(dir='.wkdir.buildbot',
+                                 logEnviron=True))
+            + 0,
+            Expect('downloadFile', dict(blocksize=32768, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='..\\.wkdir.buildbot\\ssh-wrapper.sh',
+                                        workdir='wkdir',
+                                        mode=0o700))
+            + 0,
+            Expect('downloadFile', dict(blocksize=32768, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='..\\.wkdir.buildbot\\ssh-key',
+                                        workdir='wkdir',
+                                        mode=0o400))
+            + 0,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD'],
+                        env={'GIT_SSH': '..\\.wkdir.buildbot\\ssh-wrapper.sh'})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -2837,18 +2959,4 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         step = self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                               mode='full', method='clean')
         msg = 'git is not installed on worker'
-        return self._test_WorkerTooOldError(_dovccmd, step, msg)
-
-    def test_gitVersionTooOldForSshPrivateKeySupport(self):
-        @defer.inlineCallbacks
-        def _dovccmd(command, abandonOnFailure=True, collectStdout=False,
-                     initialStdin=None):
-            # ssh private keys supported since 2.10.0
-            yield
-            defer.returnValue("git version 2.2.9")
-
-        step = self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
-                              mode='full', method='clean',
-                              sshPrivateKey='sshkey')
-        msg = 'ssh private key support requires git 2.3.0'
         return self._test_WorkerTooOldError(_dovccmd, step, msg)


### PR DESCRIPTION
This PR adds support for specifying private SSH keys for Git older than v2.3. The outcome of the discussions in https://github.com/buildbot/buildbot/pull/4160 and https://github.com/buildbot/buildbot/pull/4154 was that the official buildbot doesn't necessarily need support for Git older than v2.3. However, I need this feature anyway, so the code was written regardless. The implementation is simple and I personally think that the benefits outweigh the minimal increase of maintenance burden for the buildbot project. But feel free to reject the PR, at least it's public so someone who badly needs this feature might cherry pick the commits :-)

Major distributions that are still supported and ship git older than 2.3:
 - Debian Jessie, [git 2.1.4](https://packages.debian.org/jessie/git), [supported till 2020-06-30](https://wiki.debian.org/LTS)
 - Ubuntu Trusty, [git 1.9.1](https://packages.ubuntu.com/trusty-updates/git), [supported till 2019-04](https://wiki.ubuntu.com/Releases)
 - Centos 6, [git 1.7.1](http://mirror.centos.org/centos/6/os/x86_64/Packages/), [supported till 2020-11-30](https://wiki.centos.org/About/Product)
 - Centos 7, [git 1.8.3](http://mirror.centos.org/centos/7/os/x86_64/Packages/), [supported till 2024-06-30](https://wiki.centos.org/About/Product)

The changes have been tested on Windows and Linux.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
