### PR TITLE
Add support for specifying private SSH keys for GitPoller

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1086,6 +1086,7 @@ requestsubmitted
 requeue
 requiredargs
 reschedulenextbuild
+resetmocks
 resourceneedsreconfigs
 resourcetype
 restrmatcher

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -140,7 +140,6 @@ class GitPoller(base.PollingChangeSource, StateMixin):
             log.msg("gitpoller: using workdir '{}'".format(self.workdir))
 
         try:
-            yield self._checkGitFeatures()
             self.lastRev = yield self.getState('lastRev', {})
 
             base.PollingChangeSource.activate(self)
@@ -193,6 +192,8 @@ class GitPoller(base.PollingChangeSource, StateMixin):
 
     @defer.inlineCallbacks
     def poll(self):
+        yield self._checkGitFeatures()
+
         try:
             yield self._dovccmd('init', ['--bare', self.workdir])
         except GitError as e:

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -20,6 +20,8 @@ from future.utils import itervalues
 
 import os
 import re
+import stat
+from distutils.version import LooseVersion
 
 from twisted.internet import defer
 from twisted.internet import utils
@@ -28,6 +30,7 @@ from twisted.python import log
 from buildbot import config
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
+from buildbot.util import private_tempdir
 from buildbot.util.state import StateMixin
 
 
@@ -44,7 +47,9 @@ class GitPoller(base.PollingChangeSource, StateMixin):
     compare_attrs = ("repourl", "branches", "workdir",
                      "pollInterval", "gitbin", "usetimestamps",
                      "category", "project", "pollAtLaunch",
-                     "buildPushesWithNoCommits")
+                     "buildPushesWithNoCommits", "sshPrivateKey")
+
+    secrets = ("sshPrivateKey", )
 
     def __init__(self, repourl, branches=None, branch=None,
                  workdir=None, pollInterval=10 * 60,
@@ -52,7 +57,8 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                  category=None, project=None,
                  pollinterval=-2, fetch_refspec=None,
                  encoding='utf-8', name=None, pollAtLaunch=False,
-                 buildPushesWithNoCommits=False, only_tags=False):
+                 buildPushesWithNoCommits=False, only_tags=False,
+                 sshPrivateKey=None):
 
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
@@ -63,7 +69,8 @@ class GitPoller(base.PollingChangeSource, StateMixin):
 
         base.PollingChangeSource.__init__(self, name=name,
                                           pollInterval=pollInterval,
-                                          pollAtLaunch=pollAtLaunch)
+                                          pollAtLaunch=pollAtLaunch,
+                                          sshPrivateKey=sshPrivateKey)
 
         if project is None:
             project = ''
@@ -92,6 +99,9 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         self.project = bytes2unicode(project, encoding=self.encoding)
         self.changeCount = 0
         self.lastRev = {}
+        self.sshPrivateKey = sshPrivateKey
+        self.supportsSshPrivateKey = True
+        self.supportsSshPrivateKeyAsConfigOption = True
 
         if fetch_refspec is not None:
             config.error("GitPoller: fetch_refspec is no longer supported. "
@@ -110,6 +120,17 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                 version = stdout.strip().split(' ')[2]
             except IndexError:
                 raise EnvironmentError('Git is not installed')
+        else:
+            raise EnvironmentError('Git is not installed')
+
+        if LooseVersion(version) < LooseVersion("2.3.0"):
+            self.supportsSshPrivateKey = False
+            self.supportsSshPrivateKeyAsConfigOption = False
+        if LooseVersion(version) < LooseVersion("2.10.0"):
+            self.supportsSshPrivateKeyAsConfigOption = False
+
+        if self.sshPrivateKey is not None and not self.supportsSshPrivateKey:
+            raise EnvironmentError('SSH private keys require Git 2.3.0 or newer')
 
     @defer.inlineCallbacks
     def activate(self):
@@ -348,17 +369,69 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                 repository=bytes2unicode(self.repourl, encoding=self.encoding),
                 category=self.category, src=u'git')
 
+    def _isSshPrivateKeyNeededForCommand(self, command):
+        commandsThatNeedKey = [
+            'fetch',
+            'ls-remote',
+        ]
+        if self.sshPrivateKey is not None and command in commandsThatNeedKey:
+            return True
+        return False
+
+    def _downloadSshPrivateKey(self, keyPath):
+        with open(keyPath, 'w') as keyFile:
+            # change the permissions of the key file to be user-readable only
+            # so that ssh does not complain. This is not used for security
+            # because the parent directory will have proper permissions.
+            os.chmod(keyPath, stat.S_IRUSR)
+            keyFile.write(self.sshPrivateKey)
+
+    def _adjustCommandParamsForSshPrivateKey(self, full_command, full_env,
+                                             key_path):
+        if self.supportsSshPrivateKeyAsConfigOption:
+            full_command.append('-c')
+            full_command.append('core.sshCommand=ssh -i "{0}"'.format(key_path))
+        else:
+            full_env['GIT_SSH_COMMAND'] = 'ssh -i "{0}"'.format(key_path)
+
+    def _getSshDataPath(self):
+        return os.path.join(self.workdir, '.buildbot-ssh')
+
+    def _getSshPrivateKeyPath(self):
+        return os.path.join(self._getSshDataPath(), 'ssh-key')
+
     @defer.inlineCallbacks
     def _dovccmd(self, command, args, path=None):
+        if self._isSshPrivateKeyNeededForCommand(command):
+            key_dir = self._getSshDataPath()
+            with private_tempdir.PrivateTemporaryDirectory(name=key_dir):
+                stdout = yield self._dovccmdImpl(command, args, path)
+        else:
+            stdout = yield self._dovccmdImpl(command, args, path)
+        defer.returnValue(stdout)
+
+    @defer.inlineCallbacks
+    def _dovccmdImpl(self, command, args, path):
+        full_args = []
+        full_env = os.environ.copy()
+
+        if self._isSshPrivateKeyNeededForCommand(command):
+            key_path = self._getSshPrivateKeyPath()
+            self._downloadSshPrivateKey(key_path)
+            self._adjustCommandParamsForSshPrivateKey(full_args, full_env,
+                                                      key_path)
+
+        full_args += [command] + args
+
         res = yield utils.getProcessOutputAndValue(self.gitbin,
-            [command] + args, path=path, env=os.environ)
+            full_args, path=path, env=full_env)
         (stdout, stderr, code) = res
         stdout = bytes2unicode(stdout, self.encoding)
         stderr = bytes2unicode(stderr, self.encoding)
         if code != 0:
             if code == 128:
-                raise GitError('command {} {} in {} on repourl {} failed with exit code {}: {}'.format(
-                               command, args, path, self.repourl, code, stderr))
-            raise EnvironmentError('command {} {} in {} on repourl {} failed with exit code {}: {}'.format(
-                                   command, args, path, self.repourl, code, stderr))
+                raise GitError('command {} in {} on repourl {} failed with exit code {}: {}'.format(
+                               full_args, path, self.repourl, code, stderr))
+            raise EnvironmentError('command {} in {} on repourl {} failed with exit code {}: {}'.format(
+                                   full_args, path, self.repourl, code, stderr))
         defer.returnValue(stdout.strip())

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -101,6 +101,17 @@ class GitPoller(base.PollingChangeSource, StateMixin):
             self.workdir = 'gitpoller-work'
 
     @defer.inlineCallbacks
+    def _checkGitFeatures(self):
+        stdout = yield self._dovccmd('--version', [])
+
+        version = "0.0.0"
+        if 'git' in stdout:
+            try:
+                version = stdout.strip().split(' ')[2]
+            except IndexError:
+                raise EnvironmentError('Git is not installed')
+
+    @defer.inlineCallbacks
     def activate(self):
         # make our workdir absolute, relative to the master's basedir
         if not os.path.isabs(self.workdir):
@@ -108,6 +119,7 @@ class GitPoller(base.PollingChangeSource, StateMixin):
             log.msg("gitpoller: using workdir '{}'".format(self.workdir))
 
         try:
+            yield self._checkGitFeatures()
             self.lastRev = yield self.getState('lastRev', {})
 
             base.PollingChangeSource.activate(self)

--- a/master/buildbot/newsfragments/gitpoller-support-private-ssh-key.feature
+++ b/master/buildbot/newsfragments/gitpoller-support-private-ssh-key.feature
@@ -1,0 +1,2 @@
+-:bb:chsrc:`GitPoller` now supports `sshPrivateKey` parameter to specify private ssh
+key for fetch operations. This feature is supported on git 2.3 and newer.

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -172,13 +172,17 @@ class GitOutputParsing(gpo.GetProcessOutputMixin, unittest.TestCase):
     # _get_changes is tested in TestGitPoller, below
 
 
-class TestGitPoller(gpo.GetProcessOutputMixin,
-                    changesource.ChangeSourceMixin,
-                    logging.LoggingMixin,
-                    unittest.TestCase):
+class TestGitPollerBase(gpo.GetProcessOutputMixin,
+                        changesource.ChangeSourceMixin,
+                        logging.LoggingMixin,
+                        unittest.TestCase):
 
     REPOURL = 'git@example.com:foo/baz.git'
     REPOURL_QUOTED = 'git%40example.com%3Afoo%2Fbaz.git'
+
+    def createPoller(self):
+        # this is overridden in TestGitPollerWithSshPrivateKey
+        return gitpoller.GitPoller(self.REPOURL)
 
     def setUp(self):
         self.setUpGetProcessOutput()
@@ -186,12 +190,15 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
 
         @d.addCallback
         def create_poller(_):
-            self.poller = gitpoller.GitPoller(self.REPOURL)
+            self.poller = self.createPoller()
             self.poller.setServiceParent(self.master)
         return d
 
     def tearDown(self):
         return self.tearDownChangeSource()
+
+
+class TestGitPoller(TestGitPollerBase):
 
     def test_describe(self):
         self.assertSubstring("GitPoller", self.poller.describe())
@@ -203,6 +210,31 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
         # and one with explicit name...
         other = gitpoller.GitPoller(self.REPOURL, name="MyName")
         self.assertEqual("MyName", other.name)
+
+    @defer.inlineCallbacks
+    def test_checkGitFeatures_git_not_installed(self):
+        self.setUpLogging()
+        self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'Command not found'),
+        )
+
+        yield self.assertFailure(self.poller._checkGitFeatures(),
+                                 EnvironmentError)
+        self.assertAllCommandsRan()
+
+    @defer.inlineCallbacks
+    def test_checkGitFeatures_git_bad_version(self):
+        self.setUpLogging()
+        self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git ')
+        )
+
+        yield self.assertFailure(self.poller._checkGitFeatures(),
+                                 EnvironmentError)
+
+        self.assertAllCommandsRan()
 
     def test_poll_initial(self):
         self.expectCommands(
@@ -1303,6 +1335,143 @@ class TestGitPoller(gpo.GetProcessOutputMixin,
             })
             startService.assert_called_once_with(self.poller)
         return d
+
+
+class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
+
+    def createPoller(self):
+        return gitpoller.GitPoller(self.REPOURL, sshPrivateKey='ssh-key')
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory._create_dir')
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory.cleanup')
+    @mock.patch('buildbot.changes.gitpoller.GitPoller._downloadSshPrivateKey')
+    @defer.inlineCallbacks
+    def test_check_git_features_ssh_1_7(self, download_mock, cleanup_dir_mock,
+                                        create_dir_mock):
+        self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
+        )
+
+        yield self.assertFailure(self.poller._checkGitFeatures(), EnvironmentError)
+
+        self.assertAllCommandsRan()
+
+        create_dir_mock.assert_not_called()
+        cleanup_dir_mock.assert_not_called()
+        download_mock.assert_not_called()
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory._create_dir')
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory.cleanup')
+    @mock.patch('buildbot.changes.gitpoller.GitPoller._downloadSshPrivateKey')
+    @defer.inlineCallbacks
+    def test_poll_initial_2_10(self, download_mock, cleanup_dir_mock,
+                               create_dir_mock):
+        self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 2.10.0\n'),
+            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
+            gpo.Expect('git',
+                       '-c', 'core.sshCommand=ssh -i "{0}"'.format(
+                            os.path.join('gitpoller-work', '.buildbot-ssh', 'ssh-key')),
+                       'fetch', self.REPOURL,
+                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
+            .path('gitpoller-work'),
+            gpo.Expect('git', 'rev-parse',
+                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
+            .path('gitpoller-work')
+            .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
+        )
+
+        yield self.poller._checkGitFeatures()
+        yield self.poller.poll()
+
+        self.assertAllCommandsRan()
+        self.assertEqual(self.poller.lastRev, {
+            'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
+        })
+        self.master.db.state.assertStateByClass(
+            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
+            lastRev={
+                'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
+            })
+
+        create_dir_mock.assert_called_with(
+                os.path.join('gitpoller-work', '.buildbot-ssh'), 0o700)
+        cleanup_dir_mock.assert_called()
+        download_mock.assert_called_with(
+                os.path.join('gitpoller-work', '.buildbot-ssh', 'ssh-key'))
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory._create_dir')
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory.cleanup')
+    @mock.patch('buildbot.changes.gitpoller.GitPoller._downloadSshPrivateKey')
+    @defer.inlineCallbacks
+    def test_poll_initial_2_3(self, download_mock, cleanup_dir_mock,
+                              create_dir_mock):
+        self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 2.3.0\n'),
+            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
+            gpo.Expect('git', 'fetch', self.REPOURL,
+                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
+            .path('gitpoller-work')
+            .env({'GIT_SSH_COMMAND': 'ssh -i "{0}"'.format(
+                 os.path.join('gitpoller-work', '.buildbot-ssh', 'ssh-key'))}),
+            gpo.Expect('git', 'rev-parse',
+                       'refs/buildbot/' + self.REPOURL_QUOTED + '/master')
+            .path('gitpoller-work')
+            .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
+        )
+
+        yield self.poller._checkGitFeatures()
+        yield self.poller.poll()
+
+        self.assertAllCommandsRan()
+        self.assertEqual(self.poller.lastRev, {
+            'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
+        })
+        self.master.db.state.assertStateByClass(
+            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
+            lastRev={
+                'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
+            })
+
+        create_dir_mock.assert_called_with(
+                os.path.join('gitpoller-work', '.buildbot-ssh'), 0o700)
+        cleanup_dir_mock.assert_called()
+        download_mock.assert_called_with(
+                os.path.join('gitpoller-work', '.buildbot-ssh', 'ssh-key'))
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory._create_dir')
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory.cleanup')
+    @mock.patch('buildbot.changes.gitpoller.GitPoller._downloadSshPrivateKey')
+    @defer.inlineCallbacks
+    def test_poll_failFetch_git_2_10(self, download_mock, cleanup_dir_mock,
+                                     create_dir_mock):
+        # make sure we cleanup the private key when fetch fails
+        self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 2.10.0\n'),
+            gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
+            gpo.Expect('git',
+                       '-c', 'core.sshCommand=ssh -i "{0}"'.format(
+                            os.path.join('gitpoller-work', '.buildbot-ssh', 'ssh-key')),
+                       'fetch', self.REPOURL,
+                       '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
+            .path('gitpoller-work')
+            .exit(1),
+        )
+
+        yield self.poller._checkGitFeatures()
+        yield self.assertFailure(self.poller.poll(), EnvironmentError)
+
+        self.assertAllCommandsRan()
+
+        create_dir_mock.assert_called_with(
+                os.path.join('gitpoller-work', '.buildbot-ssh'), 0o700)
+        cleanup_dir_mock.assert_called()
+        download_mock.assert_called_with(
+                os.path.join('gitpoller-work', '.buildbot-ssh', 'ssh-key'))
 
 
 class TestGitPollerConstructor(unittest.TestCase, config.ConfigErrorsMixin):

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -238,6 +238,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_initial(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
@@ -265,6 +267,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_failInit(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work')
             .exit(1),
         )
@@ -276,6 +280,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_failFetch(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
@@ -289,6 +295,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_failRevParse(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
@@ -309,6 +317,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_failLog(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
@@ -356,6 +366,8 @@ class TestGitPoller(TestGitPollerBase):
     def test_poll_GitError_log(self):
         self.setUpLogging()
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work')
             .exit(128),
         )
@@ -372,6 +384,8 @@ class TestGitPoller(TestGitPollerBase):
         self.addGetProcessOutputExpectEnv({'ENVVAR': 'TRUE'})
 
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
@@ -407,6 +421,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_multipleBranches_initial(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
@@ -438,6 +454,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_multipleBranches(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master',
@@ -560,6 +578,8 @@ class TestGitPoller(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_poll_multipleBranches_buildPushesWithNoCommits_default(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release')
@@ -597,6 +617,8 @@ class TestGitPoller(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_poll_multipleBranches_buildPushesWithNoCommits_true(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release')
@@ -667,6 +689,8 @@ class TestGitPoller(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_poll_multipleBranches_buildPushesWithNoCommits_true_fast_forward(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+release:refs/buildbot/' + self.REPOURL_QUOTED + '/release')
@@ -738,6 +762,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_allBranches_single(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
@@ -818,6 +844,8 @@ class TestGitPoller(TestGitPollerBase):
         self.addGetProcessOutputExpectEnv({'ENVVAR': 'TRUE'})
 
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
@@ -851,6 +879,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_allBranches_multiple(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
             .stdout(b'\n'.join([
@@ -952,6 +982,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_callableFilteredBranches(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
             .stdout(b'\n'.join([
@@ -1042,6 +1074,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_branchFilter(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
             .stdout(b'\n'.join([
@@ -1130,6 +1164,8 @@ class TestGitPoller(TestGitPollerBase):
         # patch out getProcessOutput and getProcessOutputAndValue for the
         # benefit of the _get_changes method
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'fetch', self.REPOURL,
                        '+master:refs/buildbot/' + self.REPOURL_QUOTED + '/master')
@@ -1222,6 +1258,8 @@ class TestGitPoller(TestGitPollerBase):
 
     def test_poll_callableCategory(self):
         self.expectCommands(
+            gpo.Expect('git', '--version')
+            .stdout(b'git version 1.7.5\n'),
             gpo.Expect('git', 'init', '--bare', 'gitpoller-work'),
             gpo.Expect('git', 'ls-remote', '--refs', self.REPOURL)
             .stdout(b'4423cdbcbb89c14e50dd5f4152415afd686c5241\t'
@@ -1383,7 +1421,6 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
-        yield self.poller._checkGitFeatures()
         yield self.poller.poll()
 
         self.assertAllCommandsRan()
@@ -1423,7 +1460,6 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
             .stdout(b'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5\n'),
         )
 
-        yield self.poller._checkGitFeatures()
         yield self.poller.poll()
 
         self.assertAllCommandsRan()
@@ -1462,7 +1498,6 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
             .exit(1),
         )
 
-        yield self.poller._checkGitFeatures()
         yield self.assertFailure(self.poller.poll(), EnvironmentError)
 
         self.assertAllCommandsRan()

--- a/master/buildbot/test/unit/test_util_private_tempdir.py
+++ b/master/buildbot/test/unit/test_util_private_tempdir.py
@@ -1,0 +1,70 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import shutil
+import tempfile
+
+from twisted.trial import unittest
+
+from buildbot.test.util.decorators import skipUnlessPlatformIs
+from buildbot.util.private_tempdir import PrivateTemporaryDirectory
+
+
+class TestTemporaryDirectory(unittest.TestCase):
+    # In this test we want to also check potential platform differences, so
+    # we don't mock the filesystem access
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_simple(self):
+        dir = os.path.join(self.tempdir, 'simple')
+
+        with PrivateTemporaryDirectory(dir):
+            self.assertTrue(os.path.isdir(dir))
+        self.assertFalse(os.path.isdir(dir))
+
+    @skipUnlessPlatformIs('posix')
+    def test_mode(self):
+        dir = os.path.join(self.tempdir, 'mode')
+
+        with PrivateTemporaryDirectory(dir, mode=0o700):
+            self.assertEqual(0o40700, os.stat(dir).st_mode)
+
+    def test_already_exists(self):
+        dir = os.path.join(self.tempdir, 'already_exists')
+
+        os.makedirs(dir)
+        with self.assertRaises(Exception):
+            with PrivateTemporaryDirectory(dir):
+                pass
+        shutil.rmtree(dir)
+
+    def test_cleanup(self):
+        dir = os.path.join(self.tempdir, 'cleanup')
+
+        with PrivateTemporaryDirectory(dir) as ctx:
+            self.assertTrue(os.path.isdir(dir))
+            ctx.cleanup()
+            self.assertFalse(os.path.isdir(dir))
+            ctx.cleanup()  # also check whether multiple calls don't throw
+            ctx.cleanup()

--- a/master/buildbot/util/private_tempdir.py
+++ b/master/buildbot/util/private_tempdir.py
@@ -1,0 +1,50 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import shutil
+
+
+class PrivateTemporaryDirectory(object):
+    """ Works similarly to python 3.2+ TemporaryDirectory except the
+        permissions and the exact path are given to the class.
+
+        TODO: Use TemporaryDirectory when python 2.x is dropped
+
+        Note, that Windows ignores the permissions.
+    """
+
+    def __init__(self, name, mode=0o700):
+        self.name = name
+        self.mode = mode
+        self._cleanup_needed = True
+
+    def _create_dir(self, name, mode):
+        os.makedirs(name, mode=mode)
+
+    def __enter__(self):
+        self._create_dir(self.name, self.mode)
+        return self
+
+    def __exit__(self, exc, value, tb):
+        self.cleanup()
+
+    def cleanup(self):
+        if self._cleanup_needed:
+            shutil.rmtree(self.name)
+            self._cleanup_needed = False

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -806,6 +806,10 @@ It accepts the following arguments:
 ``only_tags``
     Determines if the GitPoller should poll for new tags in the git repository.
 
+``sshPrivateKey``
+    Specifies private SSH key for git to use. This may be either a :ref:`Secret`
+    or just a string. This option requires Git-2.3 or later.
+
 A configuration for the Git poller might look like this:
 
 .. code-block:: python


### PR DESCRIPTION
Currently there's no way to poll ssh:// git repositories if public key authentication is needed. E.g. Gitlab (at least the self-hosted instances) don't allow cloning via user+password combo. The workaround is to put the private key into the worker along with appropriate ssh config, which is inconvenient when many workers are involved and keys need to be changed or introduced.

Git allows specification of the private SSH key via the following approaches:
 - Git 2.10 and newer support specifying private SSH key via the `-c core.sshCommand=ssh -i "{path_to_key}"` command line option
 - Git 2.3 and newer support specifying private SSH key via the `GIT_SSH_COMMAND=ssh -i "{path_to_key}"`environment variable
 - Git 1.0 supports pointing `GIT_SSH` to a wrapper script and specifying SSH options there.

This PR implements the first two approaches and supports git 2.3 and newer. The GitPoller source step will upload the private SSH key when needed, use appropriate `core.sshCommand` config or environment option to specify the key, and delete the key file when done. This way keys can be updated by just changing the secret in the secret provider without changing anything on the master.

A similar approach has been implemented for Git step. See https://github.com/buildbot/buildbot/pull/4160 and https://github.com/buildbot/buildbot/pull/4173.

The private keys are exposed as sshPrivateKey parameter to GitPoller step. The value may be either secret or just a string.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
