### PR TITLE
Support URLs without repo owners in util.giturlparse

### DIFF
--- a/master/buildbot/test/unit/test_util_giturlparse.py
+++ b/master/buildbot/test/unit/test_util_giturlparse.py
@@ -34,6 +34,7 @@ class Tests(unittest.TestCase):
             self.assertEqual(u.domain, "github.com")
             self.assertEqual(u.owner, "buildbot")
             self.assertEqual(u.repo, "buildbot")
+            self.assertIsNone(u.port)
 
     def test_gitlab(self):
         for u in [
@@ -42,6 +43,7 @@ class Tests(unittest.TestCase):
                 "git@mygitlab.com:group/subgrouptest/testproject.git",
                 "git://mygitlab.com/group/subgrouptest/testproject.git"]:
             u = giturlparse(u)
+            self.assertIsNone(u.port)
             self.assertIn(u.user, (None, "git"))
             self.assertEqual(u.domain, "mygitlab.com")
             self.assertEqual(u.owner, "group/subgrouptest")
@@ -54,6 +56,7 @@ class Tests(unittest.TestCase):
                 "git://mygitlab.com/group/subgrouptest/subsubgroup/testproject.git"]:
             u = giturlparse(u)
             self.assertIn(u.user, (None, "git"))
+            self.assertIsNone(u.port)
             self.assertEqual(u.domain, "mygitlab.com")
             self.assertEqual(u.owner, "group/subgrouptest/subsubgroup")
             self.assertEqual(u.repo, "testproject")
@@ -64,6 +67,7 @@ class Tests(unittest.TestCase):
                 "https://buildbot@mygitlab.com/group/subgrouptest/testproject.git"]:
             u = giturlparse(u)
             self.assertEqual(u.domain, "mygitlab.com")
+            self.assertIsNone(u.port)
             self.assertEqual(u.user, "buildbot")
             self.assertEqual(u.owner, "group/subgrouptest")
             self.assertEqual(u.repo, "testproject")
@@ -88,6 +92,19 @@ class Tests(unittest.TestCase):
             self.assertIn(u.user, (None, "git"))
             self.assertEqual(u.domain, "bitbucket.org")
             self.assertEqual(u.owner, "org")
+            self.assertEqual(u.repo, "repo")
+
+    def test_no_owner(self):
+        for u in [
+                "https://example.org/repo.git",
+                "ssh://example.org:repo.git",
+                "ssh://git@example.org:repo.git",
+                "git@example.org:repo.git",
+                ]:
+            u = giturlparse(u)
+            self.assertIn(u.user, (None, "git"))
+            self.assertEqual(u.domain, "example.org")
+            self.assertIsNone(u.owner)
             self.assertEqual(u.repo, "repo")
 
     def test_protos(self):

--- a/master/buildbot/util/giturlparse.py
+++ b/master/buildbot/util/giturlparse.py
@@ -34,16 +34,16 @@ GitUrl = namedtuple('GitUrl', ['proto', 'user', 'domain', 'port', 'owner', 'repo
 
 def giturlparse(url):
     res = _giturlmatcher.match(url)
-    if res is not None:
-        port = res.group("port")
-        if port is not None:
-            port = int(port)
-        proto = res.group("proto")
-        if proto:
-            proto = proto[:-3]
-        else:
-            proto = 'ssh'  # implicit proto is ssh
-        return GitUrl(
-            proto, res.group('user'),
-            res.group("domain"), port, res.group("owner"),
-            res.group("repo"))
+    if res is None:
+        return None
+
+    port = res.group("port")
+    if port is not None:
+        port = int(port)
+    proto = res.group("proto")
+    if proto:
+        proto = proto[:-3]
+    else:
+        proto = 'ssh'  # implicit proto is ssh
+    return GitUrl(proto, res.group('user'), res.group("domain"),
+                  port, res.group('owner'), res.group('repo'))

--- a/master/buildbot/util/giturlparse.py
+++ b/master/buildbot/util/giturlparse.py
@@ -27,7 +27,7 @@ _giturlmatcher = re.compile(
     r'(?P<proto>(https?://|ssh://|git://|))'
     r'((?P<user>.*)@)?'
     r'(?P<domain>[^\/:]+)(:((?P<port>[0-9]+)/)?|/)'
-    r'(?P<owner>.+)/(?P<repo>[^/]+?)(\.git)?$')
+    r'((?P<owner>.+)/)?(?P<repo>[^/]+?)(\.git)?$')
 
 GitUrl = namedtuple('GitUrl', ['proto', 'user', 'domain', 'port', 'owner', 'repo'])
 


### PR DESCRIPTION
Looks like util.giturlparse does not support URLs like `https://example.org/repo.git`. This PR fixes that.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not applicable] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [not applicable] I have updated the appropriate documentation
