### PR TITLE
Move code duplicated across git source step and gitpoller to util.git

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -376,14 +376,6 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
             os.chmod(keyPath, stat.S_IRUSR)
             keyFile.write(self.sshPrivateKey)
 
-    def _adjustCommandParamsForSshPrivateKey(self, full_command, full_env,
-                                             key_path):
-        if self.supportsSshPrivateKeyAsConfigOption:
-            full_command.append('-c')
-            full_command.append('core.sshCommand=ssh -i "{0}"'.format(key_path))
-        else:
-            full_env['GIT_SSH_COMMAND'] = 'ssh -i "{0}"'.format(key_path)
-
     def _getSshDataPath(self):
         return os.path.join(self.workdir, '.buildbot-ssh')
 
@@ -408,8 +400,8 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
         if self._isSshPrivateKeyNeededForCommand(command):
             key_path = self._getSshPrivateKeyPath()
             self._downloadSshPrivateKey(key_path)
-            self._adjustCommandParamsForSshPrivateKey(full_args, full_env,
-                                                      key_path)
+            self.adjustCommandParamsForSshPrivateKey(full_args, full_env,
+                                                     key_path)
 
         full_args += [command] + args
 

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -406,13 +406,9 @@ class Git(Source, GitMixin):
         rel_ssh_wrapper_path = self.build.path_module.relpath(
                 self._getSshWrapperScriptPath(), self.workdir)
 
-        if self.supportsSshPrivateKeyAsConfigOption:
-            full_command.append('-c')
-            full_command.append('core.sshCommand=ssh -i "{0}"'.format(rel_key_path))
-        elif self.supportsSshPrivateKeyAsEnvOption:
-            full_env['GIT_SSH_COMMAND'] = 'ssh -i "{0}"'.format(rel_key_path)
-        else:
-            full_env['GIT_SSH'] = rel_ssh_wrapper_path
+        self.adjustCommandParamsForSshPrivateKey(full_command, full_env,
+                                                 rel_key_path,
+                                                 rel_ssh_wrapper_path)
 
     @defer.inlineCallbacks
     def _dovccmd(self, command, abandonOnFailure=True, collectStdout=False, initialStdin=None):

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -29,6 +29,7 @@ from buildbot.process import remotecommand
 from buildbot.process.properties import Properties
 from buildbot.steps.source.base import Source
 from buildbot.util.git import GitMixin
+from buildbot.util.git import getSshWrapperScriptContents
 
 RC_SUCCESS = 0
 GIT_HASH_LENGTH = 40
@@ -396,8 +397,7 @@ class Git(Source, GitMixin):
         rel_key_path = self.build.path_module.relpath(
                 self._getSshPrivateKeyPath(), self._getSshDataWorkDir())
 
-        # note that this works on windows if using git with MINGW embedded.
-        return '#!/bin/sh\nssh -i "{0}" "$@"\n'.format(rel_key_path)
+        return getSshWrapperScriptContents(rel_key_path)
 
     def _adjustCommandParamsForSshPrivateKey(self, full_command, full_env):
 

--- a/master/buildbot/test/unit/test_util_git.py
+++ b/master/buildbot/test/unit/test_util_git.py
@@ -1,0 +1,64 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from twisted.trial import unittest
+
+from buildbot.util.git import GitMixin
+
+
+class TestParseGitFeatures(GitMixin, unittest.TestCase):
+
+    def test_no_output(self):
+        self.setupGit()
+        self.parseGitFeatures('')
+        self.assertFalse(self.gitInstalled)
+        self.assertFalse(self.supportsBranch)
+        self.assertFalse(self.supportsSubmoduleForce)
+        self.assertFalse(self.supportsSubmoduleCheckout)
+        self.assertFalse(self.supportsSshPrivateKeyAsEnvOption)
+        self.assertFalse(self.supportsSshPrivateKeyAsConfigOption)
+
+    def test_git_noversion(self):
+        self.setupGit()
+        self.parseGitFeatures('git')
+        self.assertFalse(self.gitInstalled)
+        self.assertFalse(self.supportsBranch)
+        self.assertFalse(self.supportsSubmoduleForce)
+        self.assertFalse(self.supportsSubmoduleCheckout)
+        self.assertFalse(self.supportsSshPrivateKeyAsEnvOption)
+        self.assertFalse(self.supportsSshPrivateKeyAsConfigOption)
+
+    def test_git_zero_version(self):
+        self.setupGit()
+        self.parseGitFeatures('git version 0.0.0')
+        self.assertTrue(self.gitInstalled)
+        self.assertFalse(self.supportsBranch)
+        self.assertFalse(self.supportsSubmoduleForce)
+        self.assertFalse(self.supportsSubmoduleCheckout)
+        self.assertFalse(self.supportsSshPrivateKeyAsEnvOption)
+        self.assertFalse(self.supportsSshPrivateKeyAsConfigOption)
+
+    def test_git_2_10_0(self):
+        self.setupGit()
+        self.parseGitFeatures('git version 2.10.0')
+        self.assertTrue(self.gitInstalled)
+        self.assertTrue(self.supportsBranch)
+        self.assertTrue(self.supportsSubmoduleForce)
+        self.assertTrue(self.supportsSubmoduleCheckout)
+        self.assertTrue(self.supportsSshPrivateKeyAsEnvOption)
+        self.assertTrue(self.supportsSshPrivateKeyAsConfigOption)

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -1,0 +1,52 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from distutils.version import LooseVersion
+
+
+class GitMixin(object):
+
+    def setupGit(self):
+        self.gitInstalled = False
+        self.supportsBranch = False
+        self.supportsSubmoduleForce = False
+        self.supportsSubmoduleCheckout = False
+        self.supportsSshPrivateKeyAsEnvOption = False
+        self.supportsSshPrivateKeyAsConfigOption = False
+
+    def parseGitFeatures(self, version_stdout):
+
+        if 'git' not in version_stdout:
+            return
+
+        try:
+            version = version_stdout.strip().split(' ')[2]
+        except IndexError:
+            return
+
+        self.gitInstalled = True
+        if LooseVersion(version) >= LooseVersion("1.6.5"):
+            self.supportsBranch = True
+        if LooseVersion(version) >= LooseVersion("1.7.6"):
+            self.supportsSubmoduleForce = True
+        if LooseVersion(version) >= LooseVersion("1.7.8"):
+            self.supportsSubmoduleCheckout = True
+        if LooseVersion(version) >= LooseVersion("2.3.0"):
+            self.supportsSshPrivateKeyAsEnvOption = True
+        if LooseVersion(version) >= LooseVersion("2.10.0"):
+            self.supportsSshPrivateKeyAsConfigOption = True

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -50,3 +50,16 @@ class GitMixin(object):
             self.supportsSshPrivateKeyAsEnvOption = True
         if LooseVersion(version) >= LooseVersion("2.10.0"):
             self.supportsSshPrivateKeyAsConfigOption = True
+
+    def adjustCommandParamsForSshPrivateKey(self, command, env,
+                                            keyPath, sshWrapperPath=None):
+        if self.supportsSshPrivateKeyAsConfigOption:
+            command.append('-c')
+            command.append('core.sshCommand=ssh -i "{0}"'.format(keyPath))
+        elif self.supportsSshPrivateKeyAsEnvOption:
+            env['GIT_SSH_COMMAND'] = 'ssh -i "{0}"'.format(keyPath)
+        else:
+            if sshWrapperPath is None:
+                raise Exception('Only SSH wrapper script is supported but path '
+                                'not given')
+            env['GIT_SSH'] = sshWrapperPath

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -63,3 +63,8 @@ class GitMixin(object):
                 raise Exception('Only SSH wrapper script is supported but path '
                                 'not given')
             env['GIT_SSH'] = sshWrapperPath
+
+
+def getSshWrapperScriptContents(keyPath):
+    # note that this works on windows if using git with MINGW embedded.
+    return '#!/bin/sh\nssh -i "{0}" "$@"\n'.format(keyPath)


### PR DESCRIPTION
This prepares for ssh host key support.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not applicable] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [not applicable] I have updated the appropriate documentation
