### PR TITLE
Add support for explicit SSH host key checking to Git and Gitpoller

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -376,17 +376,20 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
             return True
         return False
 
+    def _writeLocalFile(self, path, contents, mode=None):  # pragma: no cover
+        with open(path, 'w') as file:
+            if mode is not None:
+                os.chmod(path, mode)
+            file.write(contents)
+
     def _downloadSshPrivateKey(self, keyPath):
-        with open(keyPath, 'w') as keyFile:
-            # change the permissions of the key file to be user-readable only
-            # so that ssh does not complain. This is not used for security
-            # because the parent directory will have proper permissions.
-            os.chmod(keyPath, stat.S_IRUSR)
-            keyFile.write(self.sshPrivateKey)
+        # We change the permissions of the key file to be user-readable only so
+        # that ssh does not complain. This is not used for security because the
+        # parent directory will have proper permissions.
+        self._writeLocalFile(keyPath, self.sshPrivateKey, mode=stat.S_IRUSR)
 
     def _downloadSshKnownHosts(self, path):
-        with open(path, 'w') as hostsFile:
-            hostsFile.write(getSshKnownHostsContents(self.sshHostKey))
+        self._writeLocalFile(path, getSshKnownHostsContents(self.sshHostKey))
 
     def _getSshDataPath(self):
         return os.path.join(self.workdir, '.buildbot-ssh')

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -31,6 +31,7 @@ from buildbot.changes import base
 from buildbot.util import bytes2unicode
 from buildbot.util import private_tempdir
 from buildbot.util.git import GitMixin
+from buildbot.util.git import getSshKnownHostsContents
 from buildbot.util.state import StateMixin
 
 
@@ -47,9 +48,9 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
     compare_attrs = ("repourl", "branches", "workdir",
                      "pollInterval", "gitbin", "usetimestamps",
                      "category", "project", "pollAtLaunch",
-                     "buildPushesWithNoCommits", "sshPrivateKey")
+                     "buildPushesWithNoCommits", "sshPrivateKey", "sshHostKey")
 
-    secrets = ("sshPrivateKey", )
+    secrets = ("sshPrivateKey", "sshHostKey")
 
     def __init__(self, repourl, branches=None, branch=None,
                  workdir=None, pollInterval=10 * 60,
@@ -58,7 +59,7 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
                  pollinterval=-2, fetch_refspec=None,
                  encoding='utf-8', name=None, pollAtLaunch=False,
                  buildPushesWithNoCommits=False, only_tags=False,
-                 sshPrivateKey=None):
+                 sshPrivateKey=None, sshHostKey=None):
 
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
@@ -67,10 +68,16 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
         if name is None:
             name = repourl
 
+        if sshHostKey is not None and sshPrivateKey is None:
+            config.error('GitPoller: sshPrivateKey must be provided in order '
+                         'use sshHostKey')
+            sshPrivateKey = None
+
         base.PollingChangeSource.__init__(self, name=name,
                                           pollInterval=pollInterval,
                                           pollAtLaunch=pollAtLaunch,
-                                          sshPrivateKey=sshPrivateKey)
+                                          sshPrivateKey=sshPrivateKey,
+                                          sshHostKey=sshHostKey)
 
         if project is None:
             project = ''
@@ -100,6 +107,7 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
         self.changeCount = 0
         self.lastRev = {}
         self.sshPrivateKey = sshPrivateKey
+        self.sshHostKey = sshHostKey
         self.setupGit()
 
         if fetch_refspec is not None:
@@ -376,11 +384,18 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
             os.chmod(keyPath, stat.S_IRUSR)
             keyFile.write(self.sshPrivateKey)
 
+    def _downloadSshKnownHosts(self, path):
+        with open(path, 'w') as hostsFile:
+            hostsFile.write(getSshKnownHostsContents(self.sshHostKey))
+
     def _getSshDataPath(self):
         return os.path.join(self.workdir, '.buildbot-ssh')
 
     def _getSshPrivateKeyPath(self):
         return os.path.join(self._getSshDataPath(), 'ssh-key')
+
+    def _getSshKnownHostsPath(self):
+        return os.path.join(self._getSshDataPath(), 'ssh-known-hosts')
 
     @defer.inlineCallbacks
     def _dovccmd(self, command, args, path=None):
@@ -400,8 +415,15 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
         if self._isSshPrivateKeyNeededForCommand(command):
             key_path = self._getSshPrivateKeyPath()
             self._downloadSshPrivateKey(key_path)
+
+            known_hosts_path = None
+            if self.sshHostKey is not None:
+                known_hosts_path = self._getSshKnownHostsPath()
+                self._downloadSshKnownHosts(known_hosts_path)
+
             self.adjustCommandParamsForSshPrivateKey(full_args, full_env,
-                                                     key_path)
+                                                     key_path, None,
+                                                     known_hosts_path)
 
         full_args += [command] + args
 

--- a/master/buildbot/newsfragments/git-support-host-ssh-key.feature
+++ b/master/buildbot/newsfragments/git-support-host-ssh-key.feature
@@ -1,0 +1,2 @@
+-:bb:step:`Git` now supports `sshHostKey` parameter to specify ssh public host
+key for fetch operations.

--- a/master/buildbot/newsfragments/gitpoller-support-host-ssh-key.feature
+++ b/master/buildbot/newsfragments/gitpoller-support-host-ssh-key.feature
@@ -1,0 +1,3 @@
+-:bb:chsrc:`GitPoller` now supports `sshHostKey` parameter to specify ssh
+public host key for fetch operations. This feature is supported on
+git 2.3 and newer.

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -249,6 +249,204 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
         return self.runStep()
 
+    def test_mode_full_clean_ssh_host_key_2_10(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='clean', sshPrivateKey='sshkey',
+                           sshHostKey='sshhostkey'))
+
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "../.wkdir.buildbot/ssh-key" ' \
+            '-o "UserKnownHostsFile=../.wkdir.buildbot/ssh-known-hosts"'
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 2.10.0')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('mkdir', dict(dir='.wkdir.buildbot',
+                                 logEnviron=True))
+            + 0,
+            Expect('downloadFile', dict(blocksize=32768, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workdir='wkdir',
+                                        mode=0o400))
+            + 0,
+            Expect('downloadFile',
+                   dict(blocksize=32768, maxsize=None,
+                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
+                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workdir='wkdir',
+                        mode=0o400))
+            + 0,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', '-c', ssh_command_config,
+                                 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+            Expect('rmdir', dict(dir='.wkdir.buildbot',
+                                 logEnviron=True))
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.runStep()
+
+    def test_mode_full_clean_ssh_host_key_2_3(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='clean', sshPrivateKey='sshkey',
+                           sshHostKey='sshhostkey'))
+
+        ssh_command = \
+            'ssh -i "../.wkdir.buildbot/ssh-key" ' \
+            '-o "UserKnownHostsFile=../.wkdir.buildbot/ssh-known-hosts"'
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 2.3.0')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('mkdir', dict(dir='.wkdir.buildbot',
+                                 logEnviron=True))
+            + 0,
+            Expect('downloadFile', dict(blocksize=32768, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workdir='wkdir',
+                                        mode=0o400))
+            + 0,
+            Expect('downloadFile',
+                   dict(blocksize=32768, maxsize=None,
+                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
+                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workdir='wkdir',
+                        mode=0o400))
+            + 0,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD'],
+                        env={'GIT_SSH_COMMAND': ssh_command})
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+            Expect('rmdir', dict(dir='.wkdir.buildbot',
+                                 logEnviron=True))
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.runStep()
+
+    def test_mode_full_clean_ssh_host_key_1_7(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='clean', sshPrivateKey='sshkey',
+                           sshHostKey='sshhostkey'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.0')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('mkdir', dict(dir='.wkdir.buildbot',
+                                 logEnviron=True))
+            + 0,
+            Expect('downloadFile', dict(blocksize=32768, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='../.wkdir.buildbot/ssh-wrapper.sh',
+                                        workdir='wkdir',
+                                        mode=0o700))
+            + 0,
+            Expect('downloadFile', dict(blocksize=32768, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workdir='wkdir',
+                                        mode=0o400))
+            + 0,
+            Expect('downloadFile',
+                   dict(blocksize=32768, maxsize=None,
+                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
+                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workdir='wkdir',
+                        mode=0o400))
+            + 0,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD'],
+                        env={'GIT_SSH': '../.wkdir.buildbot/ssh-wrapper.sh'})
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+            Expect('rmdir', dict(dir='.wkdir.buildbot',
+                                 logEnviron=True))
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.runStep()
+
     def test_mode_full_clean_win32path(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',

--- a/master/buildbot/test/unit/test_util_git.py
+++ b/master/buildbot/test/unit/test_util_git.py
@@ -65,6 +65,17 @@ class TestParseGitFeatures(GitMixin, unittest.TestCase):
         self.assertTrue(self.supportsSshPrivateKeyAsConfigOption)
 
 
+class TestAdjustCommandParamsForSshPrivateKey(GitMixin, unittest.TestCase):
+    def test_throws_when_wrapper_not_given(self):
+        self.gitInstalled = True
+
+        command = []
+        env = {}
+        with self.assertRaises(Exception):
+            self.adjustCommandParamsForSshPrivateKey(command, env,
+                                                     'path/to/key')
+
+
 class TestGetSshKnownHostsContents(unittest.TestCase):
     def test(self):
         key = 'ssh-rsa AAAA<...>WsHQ=='

--- a/master/buildbot/test/unit/test_util_git.py
+++ b/master/buildbot/test/unit/test_util_git.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 from twisted.trial import unittest
 
 from buildbot.util.git import GitMixin
+from buildbot.util.git import getSshKnownHostsContents
 
 
 class TestParseGitFeatures(GitMixin, unittest.TestCase):
@@ -62,3 +63,11 @@ class TestParseGitFeatures(GitMixin, unittest.TestCase):
         self.assertTrue(self.supportsSubmoduleCheckout)
         self.assertTrue(self.supportsSshPrivateKeyAsEnvOption)
         self.assertTrue(self.supportsSshPrivateKeyAsConfigOption)
+
+
+class TestGetSshKnownHostsContents(unittest.TestCase):
+    def test(self):
+        key = 'ssh-rsa AAAA<...>WsHQ=='
+
+        expected = '* ssh-rsa AAAA<...>WsHQ=='
+        self.assertEqual(expected, getSshKnownHostsContents(key))

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -476,7 +476,17 @@ The Git step takes the following arguments:
    (optional) The private key to use when running git for fetch operations. The
    ssh utility must be in the system path in order to use this option. On
    Windows only git distribution that embeds MINGW has been tested (as of July
-   2017 the official distribution is MINGW-based).
+   2017 the official distribution is MINGW-based). The worker must either have
+   the host in the known hosts file or the host key must be specified via the
+   `sshHostKey` option.
+
+``sshHostKey``
+
+    (optional) Specifies public host key to match when authenticating with SSH
+    public key authentication. This may be either a :ref:`Secret` or just a
+    string. `sshPrivateKey` must be specified in order to use this option.
+    The host key must be in the form of `<key type> <base64-encoded string>`,
+    e.g. `ssh-rsa AAAAB3N<...>FAaQ==`.
 
 .. bb:step:: SVN
 

--- a/master/docs/manual/cfg-changesources.rst
+++ b/master/docs/manual/cfg-changesources.rst
@@ -808,7 +808,16 @@ It accepts the following arguments:
 
 ``sshPrivateKey``
     Specifies private SSH key for git to use. This may be either a :ref:`Secret`
-    or just a string. This option requires Git-2.3 or later.
+    or just a string. This option requires Git-2.3 or later. The master must
+    either have the host in the known hosts file or the host key must be
+    specified via the `sshHostKey` option.
+
+``sshHostKey``
+    Specifies public host key to match when authenticating with SSH
+    public key authentication. This may be either a :ref:`Secret` or just a
+    string. `sshPrivateKey` must be specified in order to use this option.
+    The host key must be in the form of `<key type> <base64-encoded string>`,
+    e.g. `ssh-rsa AAAAB3N<...>FAaQ==`.
 
 A configuration for the Git poller might look like this:
 


### PR DESCRIPTION
The PR adds support for checking SSH host keys explicitly when SSH private key is specified. This avoids any need to maintain `known_hosts` files in any way or change the SSH configuration. If SSH config is modified to accept new host keys by default, this increase the risk of MITM in containerized test environments where depending on container setup the saved host key may be lost each time container state is purged.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
