### PR TITLE
Badge rendering overrides, and fixes

### DIFF
--- a/master/docs/manual/cfg-www.rst
+++ b/master/docs/manual/cfg-www.rst
@@ -268,6 +268,8 @@ The default templates are very much configurable via the following options.
     {
         "left_text": "Build Status",  # text on the left part of the image
         "left_color": "#555",  # color of the left part of the image
+        "left_size": "40", # override autodetected font width, omit if not required
+        "right_size": "50", # override autodetected font width, omit if not required
         "style": "flat",  # style of the template availables are "flat", "flat-square", "plastic"
         "template_name": "{style}.svg.j2",  # name of the template
         "font_face": "DejaVu Sans",

--- a/www/badges/buildbot_badges/__init__.py
+++ b/www/badges/buildbot_badges/__init__.py
@@ -128,12 +128,12 @@ class Api(object):
         left = {
             "color": left_color,
             "text": left_text,
-            "width": self.textwidth(left_text, config)
+            "width": int(config['left_width']) or self.textwidth(left_text, config)
         }
         right = {
             "color": right_color,
             "text": right_text,
-            "width": self.textwidth(right_text, config)
+            "width": int(config['right_width']) or self.textwidth(right_text, config)
         }
 
         template = self.env.get_template(config['template_name'].format(**config))

--- a/www/badges/buildbot_badges/templates/flat-square.svg.j2
+++ b/www/badges/buildbot_badges/templates/flat-square.svg.j2
@@ -5,6 +5,6 @@
   <rect width="{{ left.width + right.width }}" height="20" fill-opacity=".1"/>
   <g fill="#fff" text-anchor="middle" font-family="{{config.font_face}},Verdana,Geneva,sans-serif" font-size="{{config.font_size}}">
     <text x="{{ left.width/2+1 }}" y="14">{{ left.text }}</text>
-    <text x="{{ left.width+right.width/2-1 }}" y="14">{{ right.text }}</text>
+    <text x="{{ right.width/2+left.width-1 }}" y="14">{{ right.text }}</text>
   </g>
 </svg>

--- a/www/badges/buildbot_badges/templates/flat.svg.j2
+++ b/www/badges/buildbot_badges/templates/flat.svg.j2
@@ -10,7 +10,7 @@
   <g fill="#fff" text-anchor="middle" font-family="{{config.font_face}},Verdana,Geneva,sans-serif" font-size="{{config.font_size}}">
     <text x="{{ left.width/2+1 }}" y="15" fill="#010101" fill-opacity=".3">{{ left.text }}</text>
     <text x="{{ left.width/2+1 }}" y="14">{{ left.text }}</text>
-    <text x="{{ left.width+right.width/2-1 }}" y="15" fill="#010101" fill-opacity=".3">{{ right.text }}</text>
-    <text x="{{ left.width+right.width/2-1 }}" y="14">{{ right.text }}</text>
+    <text x="{{ right.width/2+left.width-1 }}" y="15" fill="#010101" fill-opacity=".3">{{ right.text }}</text>
+    <text x="{{ right.width/2+left.width-1 }}" y="14">{{ right.text }}</text>
   </g>
 </svg>

--- a/www/badges/buildbot_badges/templates/plastic.svg.j2
+++ b/www/badges/buildbot_badges/templates/plastic.svg.j2
@@ -12,7 +12,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="{{ left.width/2+1 }}" y="14" fill="#010101" fill-opacity=".3">{{ left.text }}</text>
     <text x="{{ left.width/2+1 }}" y="13">{{ left.text }}</text>
-    <text x="{{ left.width+right.width/2-1 }}" y="14" fill="#010101" fill-opacity=".3">{{ right.text }}</text>
-    <text x="{{ left.width+right.width/2-1 }}" y="13">{{ right.text }}</text>
+    <text x="{{ right.width/2+left.width-1 }}" y="14" fill="#010101" fill-opacity=".3">{{ right.text }}</text>
+    <text x="{{ right.width/2+left.width-1 }}" y="13">{{ right.text }}</text>
   </g>
 </svg>


### PR DESCRIPTION
## Contributor Checklist:

* [X] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation

## Description

We were experiencing issues where rendered badges looked like ![15](https://user-images.githubusercontent.com/5639561/42598259-da8095fa-8518-11e8-9fb9-bf2fb427e54d.png) rather than the expected common formats.  We are using the Buildbot Docker image for the master, so I'm guessing this is somehow related to the Cairo implementation within that image.  This patch implements:

- An optional override to Cairo's autodetection.  
- A modification to the badges to render text in the right place

## Known TODOs:
- Is this a feature, or a bugfix?  I have not created the newsfragment item.
- Unclear how I might test this.  `trail buildbot.test` passes, but I'm guessing there's more to do?