### PR TITLE
Increase protractor wait timeouts from 5s to 10s

### DIFF
--- a/smokes/e2e/pages/about.ts
+++ b/smokes/e2e/pages/about.ts
@@ -17,7 +17,7 @@ export class AboutPage extends BasePage {
     async goAbout() {
         await browser.get('#/about');
         await browser.wait(EC.urlContains('#/about'),
-                           5000,
+                           10000,
                            "URL does not contain #/about");
     }
 

--- a/smokes/e2e/pages/builder.ts
+++ b/smokes/e2e/pages/builder.ts
@@ -22,7 +22,7 @@ export class BuilderPage extends BasePage {
     async go() {
         await browser.get('#/builders');
         await browser.wait(EC.urlContains('#/builders'),
-                           5000,
+                           10000,
                            "URL does not contain #/builders");
         const localBuilder = element.all(By.linkText(this.builder));
         await localBuilder.click();

--- a/smokes/e2e/pages/console.ts
+++ b/smokes/e2e/pages/console.ts
@@ -16,7 +16,7 @@ export class ConsolePage extends BasePage {
     async go() {
         await browser.get('#/console');
         await browser.wait(EC.urlContains('#/console'),
-                           5000,
+                           10000,
                            "URL does not contain #/console");
     }
 

--- a/smokes/e2e/pages/dashboard.ts
+++ b/smokes/e2e/pages/dashboard.ts
@@ -16,7 +16,7 @@ export class DashboardPage extends BasePage {
     async go() {
         await browser.get('#/mydashboard');
         await browser.wait(EC.urlContains('#/mydashboard'),
-                           5000,
+                           10000,
                            "URL does not contain #/mydashboard");
     }
 }

--- a/smokes/e2e/pages/home.ts
+++ b/smokes/e2e/pages/home.ts
@@ -17,7 +17,7 @@ export class HomePage extends BasePage {
     async go() {
         await browser.get('#/');
         await browser.wait(EC.urlContains('#/'),
-                           5000,
+                           10000,
                            "URL does not contain #/");
     }
 

--- a/smokes/e2e/pages/settings.ts
+++ b/smokes/e2e/pages/settings.ts
@@ -17,7 +17,7 @@ export class SettingsPage extends BasePage {
     async goSettings() {
         await browser.get('#/settings');
         await browser.wait(EC.urlContains('#/settings'),
-                           5000,
+                           10000,
                            "URL does not contain #/settings");
     }
 

--- a/smokes/e2e/pages/waterfall.ts
+++ b/smokes/e2e/pages/waterfall.ts
@@ -17,7 +17,7 @@ export class WaterfallPage extends BasePage {
     async go() {
         await browser.get('#/waterfall');
         await browser.wait(EC.urlContains('#/waterfall'),
-                           5000,
+                           10000,
                            "URL does not contain #/waterfall");
     }
 

--- a/smokes/e2e/pages/worker.ts
+++ b/smokes/e2e/pages/worker.ts
@@ -19,7 +19,7 @@ export class WorkerPage extends BasePage {
     async goWorker() {
         await browser.get('#/workers');
         await browser.wait(EC.urlContains('#/workers'),
-                           5000,
+                           10000,
                            "URL does not contain #/workers");
     }
 


### PR DESCRIPTION
I've tried to figure out why protractor tests fail due to timeout failures sometimes. My hypothesis was that maybe the travis environment has much less CPU power than our local machines thus may fail intermittently. To emulate this, I created cgroups to limit CPU quota to 30% of single core on my local machine:
  
    sudo cgset -r cpu.cfs_period_us=10000 cpulimited
    sudo cgset -r cpu.cfs_quota_us=3000 cpulimited

Then the test command was ran by calling:

    sudo cgexec -g cpu:cpulimited sudo -u $user -g $group -- $test_command

Turns out, that some browser.wait calls fail always in this environment with reduced CPU quota.

This PR increases the explicit timeouts in `browser.wait` calls from 5s to 10s. Unfortunately, I could not reproduce the failure in `✓ should navigate to the worker page, check the one builder inside` that I was seeing in some of the travis test runs so it's likely not fixed in this PR.