### PR TITLE
Support extra state in buildbot.process.properties.renderer

### DIFF
--- a/master/buildbot/newsfragments/renderer-support-extra-args.feature
+++ b/master/buildbot/newsfragments/renderer-support-extra-args.feature
@@ -1,0 +1,1 @@
+Objects returned by :ref:`renderer` now are able to pass extra arguments to the rendered function via `withArgs` method.

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -909,8 +909,11 @@ class _Renderer(util.ComparableMixin, object):
 
     @defer.inlineCallbacks
     def getRenderingFor(self, props):
+        args = yield props.render(self.args)
+        kwargs = yield props.render(self.kwargs)
+
         # We allow the renderer fn to return a renderable for convenience
-        result = yield self.fn(props, *self.args, **self.kwargs)
+        result = yield self.fn(props, *args, **kwargs)
         result = yield props.render(result)
         defer.returnValue(result)
 

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -907,11 +907,12 @@ class _Renderer(util.ComparableMixin, object):
         new_renderer.kwargs.update(kwargs)
         return new_renderer
 
+    @defer.inlineCallbacks
     def getRenderingFor(self, props):
         # We allow the renderer fn to return a renderable for convenience
-        d = defer.maybeDeferred(self.fn, props, *self.args, **self.kwargs)
-        d.addCallback(props.render)
-        return d
+        result = yield self.fn(props, *self.args, **self.kwargs)
+        result = yield props.render(result)
+        defer.returnValue(result)
 
     def __repr__(self):
         if self.args or self.kwargs:

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -897,14 +897,26 @@ class _Renderer(util.ComparableMixin, object):
 
     def __init__(self, fn):
         self.fn = fn
+        self.args = []
+        self.kwargs = {}
+
+    def withArgs(self, *args, **kwargs):
+        new_renderer = _Renderer(self.fn)
+        new_renderer.args = self.args + list(args)
+        new_renderer.kwargs = dict(self.kwargs)
+        new_renderer.kwargs.update(kwargs)
+        return new_renderer
 
     def getRenderingFor(self, props):
         # We allow the renderer fn to return a renderable for convenience
-        d = defer.maybeDeferred(self.fn, props)
+        d = defer.maybeDeferred(self.fn, props, *self.args, **self.kwargs)
         d.addCallback(props.render)
         return d
 
     def __repr__(self):
+        if self.args or self.kwargs:
+            return 'renderer(%r, args=%r, kwargs=%r)' % (self.fn, self.args,
+                                                         self.kwargs)
         return 'renderer(%r)' % (self.fn,)
 
 

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -1460,6 +1460,19 @@ class Renderer(unittest.TestCase):
             yield self.build.render(rend_with_args('y'))
 
     @defer.inlineCallbacks
+    def test_renderer_with_state_renders_args(self):
+        self.props.setProperty("x", "X", "test")
+        self.props.setProperty('arg', 'ARG', 'test2')
+        self.props.setProperty('kw', 'KW', 'test3')
+
+        def rend(p, arg, kwarg='y'):
+            return 'x-%s-%s-%s' % (p.getProperty('x'), arg, kwarg)
+
+        res = yield self.build.render(
+            renderer(rend).withArgs(Property('arg'), kwarg=Property('kw')))
+        self.assertEqual('x-X-ARG-KW', res)
+
+    @defer.inlineCallbacks
     def test_renderer_decorator_with_state(self):
         self.props.setProperty("x", "X", "test")
 

--- a/master/docs/manual/cfg-properties.rst
+++ b/master/docs/manual/cfg-properties.rst
@@ -308,6 +308,32 @@ You can think of ``renderer`` as saying "call this function when the step starts
 
     Since 0.9.3, renderer can itself return :class:`~buildbot.interfaces.IRenderable` objects or containers containing :class:`~buildbot.interfaces.IRenderable`.
 
+Optionally, extra arguments may be passed to the rendered function at any time by calling ``withArgs`` on the renderable object.
+The ``withArgs`` method accepts ``*args`` and ``**kwargs`` arguments which are stored in a new renderable object which is returned.
+The original renderable object is not modified.
+Multiple ``withArgs`` calls may be chained.
+The passed ``*args`` and ``**kwargs`` parameters are rendered and the results are passed to the rendered function at the time it is itself rendered.
+For example::
+
+    from buildbot.plugins import steps, util
+
+    @util.renderer
+    def makeCommand(props, target):
+        command = ['make']
+        cpus = props.getProperty('CPUs')
+        if cpus:
+            command.extend(['-j', str(cpus+1)])
+        else:
+            command.extend(['-j', '2'])
+        command.extend([target])
+        return command
+
+    f.addStep(steps.ShellCommand(command=makeCommand.withArgs('mytarget')))
+
+.. note::
+
+    The rendering of the renderable object may happen at unexpected times, so it is best to ensure that the passed extra arguments are not changed.
+
 .. note::
 
     Config errors with Renderables may not always be caught via checkconfig


### PR DESCRIPTION
Currently `buildbot.process.properties.renderer` supports only simple renderings that are dependent only on the properties passed to it. In more complex buildbot configurations where large part of it is generated it's sometimes needed to have a renderer that has access to full properties set of the build and also depends on some other data which could vary. Unfortunately, `Transform` does not satisfy this use case because it only allows predefined properties to be combined and does not give both properties and extra arguments to the same function. Thus the only solution is to implement custom renderer that satisfies the `IRenderable` interface and stores that extra data as part of state.

I propose that we allow supplying extra arguments to the object returned by `buildbot.process.properties.renderer` decorator that are later passed to the renderer function. For example:

```
@util.renderer
def my_test_renderer(props, extra_arg, extra_kwarg='default'):
    return '%s-%s-%s' % (props.getProperty('myprop'), extra_arg, extra_kwarg)

...

SomeStep(some_renderable_arg=my_test_renderer.withArgs('arg', extra_kwarg='kw'), ...)
```

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
