### PR TITLE
GitPush step

### DIFF
--- a/master/buildbot/newsfragments/git-push-source-step.feature
+++ b/master/buildbot/newsfragments/git-push-source-step.feature
@@ -1,0 +1,1 @@
+Added new `GitPush` step to perform git push operations.

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -15,8 +15,19 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from future.utils import iteritems
 
 from distutils.version import LooseVersion
+
+from twisted.internet import defer
+from twisted.python import log
+
+from buildbot import config as bbconfig
+from buildbot.process import buildstep
+from buildbot.process import remotecommand
+from buildbot.process.properties import Properties
+
+RC_SUCCESS = 0
 
 
 def getSshCommand(keyPath, knownHostsPath):
@@ -87,3 +98,192 @@ def getSshWrapperScriptContents(keyPath, knownHostsPath=None):
 def getSshKnownHostsContents(hostKey):
     host_name = '*'
     return '{0} {1}'.format(host_name, hostKey)
+
+
+class GitStepMixin(GitMixin):
+
+    def setupGitStep(self):
+        self.didDownloadSshPrivateKey = False
+        self.setupGit()
+
+        if self.sshHostKey is not None and self.sshPrivateKey is None:
+            bbconfig.error('Git: sshPrivateKey must be provided in order '
+                           'use sshHostKey')
+            self.sshPrivateKey = None
+
+        if not self.repourl:
+            bbconfig.error("Git: must provide repourl.")
+
+    def _isSshPrivateKeyNeededForGitCommand(self, command):
+        if not command or self.sshPrivateKey is None:
+            return False
+
+        gitCommandsThatNeedSshKey = [
+            'clone', 'submodule', 'fetch'
+        ]
+        if command[0] in gitCommandsThatNeedSshKey:
+            return True
+        return False
+
+    def _getSshDataPath(self):
+        # we can't use the workdir for temporary ssh-related files, because
+        # it's needed when cloning repositories and git does not like the
+        # destination directory being non-empty. We have to use separate
+        # temporary directory for that data to ensure the confidentiality of it.
+        # So instead of
+        # '{path}/{to}/{workdir}/.buildbot-ssh-key' we put the key at
+        # '{path}/{to}/.{workdir}.buildbot/ssh-key'.
+
+        # basename and dirname interpret the last element being empty for paths
+        # ending with a slash
+        path_module = self.build.path_module
+
+        workdir = self._getSshDataWorkDir().rstrip('/\\')
+        parent_path = path_module.dirname(workdir)
+
+        basename = '.{0}.buildbot'.format(path_module.basename(workdir))
+        return path_module.join(parent_path, basename)
+
+    def _getSshPrivateKeyPath(self):
+        return self.build.path_module.join(self._getSshDataPath(), 'ssh-key')
+
+    def _getSshHostKeyPath(self):
+        return self.build.path_module.join(self._getSshDataPath(), 'ssh-known-hosts')
+
+    def _getSshWrapperScriptPath(self):
+        return self.build.path_module.join(self._getSshDataPath(), 'ssh-wrapper.sh')
+
+    def _getSshWrapperScript(self):
+        rel_key_path = self.build.path_module.relpath(
+                self._getSshPrivateKeyPath(), self._getSshDataWorkDir())
+
+        return getSshWrapperScriptContents(rel_key_path)
+
+    def _adjustCommandParamsForSshPrivateKey(self, full_command, full_env):
+
+        rel_key_path = self.build.path_module.relpath(
+                self._getSshPrivateKeyPath(), self.workdir)
+        rel_ssh_wrapper_path = self.build.path_module.relpath(
+                self._getSshWrapperScriptPath(), self.workdir)
+        rel_host_key_path = None
+        if self.sshHostKey is not None:
+            rel_host_key_path = self.build.path_module.relpath(
+                    self._getSshHostKeyPath(), self.workdir)
+
+        self.adjustCommandParamsForSshPrivateKey(full_command, full_env,
+                                                 rel_key_path,
+                                                 rel_ssh_wrapper_path,
+                                                 rel_host_key_path)
+
+    @defer.inlineCallbacks
+    def _dovccmd(self, command, abandonOnFailure=True, collectStdout=False, initialStdin=None):
+        full_command = ['git']
+        full_env = self.env.copy() if self.env else {}
+
+        if self.config is not None:
+            for name, value in iteritems(self.config):
+                full_command.append('-c')
+                full_command.append('%s=%s' % (name, value))
+
+        if self._isSshPrivateKeyNeededForGitCommand(command):
+            self._adjustCommandParamsForSshPrivateKey(full_command, full_env)
+
+        full_command.extend(command)
+
+        # check for the interruptSignal flag
+        sigtermTime = None
+        interruptSignal = None
+
+        # If possible prefer to send a SIGTERM to git before we send a SIGKILL.
+        # If we send a SIGKILL, git is prone to leaving around stale lockfiles.
+        # By priming it with a SIGTERM first we can ensure that it has a chance to shut-down gracefully
+        # before getting terminated
+        if not self.workerVersionIsOlderThan("shell", "2.16"):
+            # git should shut-down quickly on SIGTERM.  If it doesn't don't let it
+            # stick around for too long because this is on top of any timeout
+            # we have hit.
+            sigtermTime = 1
+        else:
+            # Since sigtermTime is unavailable try to just use SIGTERM by itself instead of
+            # killing.  This should be safe.
+            if self.workerVersionIsOlderThan("shell", "2.15"):
+                log.msg(
+                    "NOTE: worker does not allow master to specify interruptSignal. This may leave a stale lockfile around if the command is interrupted/times out\n")
+            else:
+                interruptSignal = 'TERM'
+
+        cmd = remotecommand.RemoteShellCommand(self.workdir,
+                                               full_command,
+                                               env=full_env,
+                                               logEnviron=self.logEnviron,
+                                               timeout=self.timeout,
+                                               sigtermTime=sigtermTime,
+                                               interruptSignal=interruptSignal,
+                                               collectStdout=collectStdout,
+                                               initialStdin=initialStdin)
+        cmd.useLog(self.stdio_log, False)
+        yield self.runCommand(cmd)
+
+        if abandonOnFailure and cmd.didFail():
+            log.msg("Source step failed while running command %s" % cmd)
+            raise buildstep.BuildStepFailed()
+        if collectStdout:
+            defer.returnValue(cmd.stdout)
+            return
+        defer.returnValue(cmd.rc)
+
+    @defer.inlineCallbacks
+    def checkBranchSupport(self):
+        stdout = yield self._dovccmd(['--version'], collectStdout=True)
+
+        self.parseGitFeatures(stdout)
+
+        defer.returnValue(self.gitInstalled)
+
+    @defer.inlineCallbacks
+    def _downloadSshPrivateKeyIfNeeded(self):
+        if self.sshPrivateKey is None:
+            defer.returnValue(RC_SUCCESS)
+
+        p = Properties()
+        p.master = self.master
+        private_key = yield p.render(self.sshPrivateKey)
+        host_key = yield p.render(self.sshHostKey)
+
+        # not using self.workdir because it may be changed depending on step
+        # options
+        workdir = self._getSshDataWorkDir()
+
+        rel_key_path = self.build.path_module.relpath(
+                self._getSshPrivateKeyPath(), workdir)
+        rel_host_key_path = self.build.path_module.relpath(
+                self._getSshHostKeyPath(), workdir)
+        rel_wrapper_script_path = self.build.path_module.relpath(
+                self._getSshWrapperScriptPath(), workdir)
+
+        yield self.runMkdir(self._getSshDataPath())
+
+        if not self.supportsSshPrivateKeyAsEnvOption:
+            yield self.downloadFileContentToWorker(rel_wrapper_script_path,
+                                                   self._getSshWrapperScript(),
+                                                   workdir=workdir, mode=0o700)
+
+        yield self.downloadFileContentToWorker(rel_key_path, private_key,
+                                               workdir=workdir, mode=0o400)
+
+        if self.sshHostKey is not None:
+            known_hosts_contents = getSshKnownHostsContents(host_key)
+            yield self.downloadFileContentToWorker(rel_host_key_path,
+                                                   known_hosts_contents,
+                                                   workdir=workdir, mode=0o400)
+
+        self.didDownloadSshPrivateKey = True
+        defer.returnValue(RC_SUCCESS)
+
+    @defer.inlineCallbacks
+    def _removeSshPrivateKeyIfNeeded(self):
+        if not self.didDownloadSshPrivateKey:
+            defer.returnValue(RC_SUCCESS)
+
+        yield self.runRmdir(self._getSshDataPath())
+        defer.returnValue(RC_SUCCESS)

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -119,7 +119,7 @@ class GitStepMixin(GitMixin):
             return False
 
         gitCommandsThatNeedSshKey = [
-            'clone', 'submodule', 'fetch'
+            'clone', 'submodule', 'fetch', 'push'
         ]
         if command[0] in gitCommandsThatNeedSshKey:
             return True

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -202,8 +202,8 @@ Source Checkout
 
         ... steps.Git ...
 
-Common Parameters
-+++++++++++++++++
+Common Parameters of source checkout operations
++++++++++++++++++++++++++++++++++++++++++++++++
 
 All source checkout steps accept some common parameters to control how they get the sources and where they should be placed.
 The remaining per-VC-system parameters are mostly to specify where exactly the sources are coming from.
@@ -1088,6 +1088,66 @@ Monotone step takes the following arguments:
       This way we make fresh builds with very less bandwidth to download source.
       The behavior of source checkout follows exactly same as incremental.
       It performs all the incremental checkout behavior in ``source`` directory.
+
+Other Source operations
+-----------------------
+
+Currently the only non-checkout step that is related to version control is ``GitPush``.
+
+.. bb:step:: GitPush
+
+GitPush
++++++++
+
+.. py:class:: buildbot.steps.source.git.GitPush
+
+The :bb:step:`GitPush` build step pushes new commits to a `Git <http://git.or.cz/>`_ repository.
+
+The GitPush step takes the following arguments:
+
+``workdir``
+    (required) The path to the local repository to push commits from.
+
+``repourl``
+    (required) The URL of the upstream Git repository.
+
+``branch``
+    (required) The branch to push.
+    The branch should already exist on the local repository.
+
+``force``
+    (optional) If ``True``, forces overwrite of refs on the remote repository.
+    Corresponds to the ``--force`` flag of the ``git push`` command.
+
+``logEnviron``
+    (optional) If this option is true (the default), then the step's logfile will describe the environment variables on the worker.
+    In situations where the environment is not relevant and is long, it may be easier to set ``logEnviron=False``.
+
+``env``
+    (optional) A dictionary of environment strings which will be added to the child command's environment.
+    The usual property interpolations can be used in environment variable names and values - see :ref:`Properties`.
+
+``timeout``
+    (optional) Specifies the timeout for worker-side operations, in seconds.
+    If your repositories are particularly large, then you may need to increase this  value from its default of 1200 (20 minutes).
+
+``config``
+
+    (optional) A dict of git configuration settings to pass to the remote git commands.
+
+``sshPrivateKey``
+
+    (optional) The private key to use when running git for fetch operations.
+    The ssh utility must be in the system path in order to use this option.
+    On Windows only git distribution that embeds MINGW has been tested (as of July 2017 the official distribution is MINGW-based).
+    The worker must either have the host in the known hosts file or the host key must be specified via the ``sshHostKey`` option.
+
+``sshHostKey``
+
+    (optional) Specifies public host key to match when authenticating with SSH public key authentication.
+    This may be either a :ref:`Secret` or just a string.
+    ``sshPrivateKey`` must be specified in order to use this option.
+    The host key must be in the form of ``<key type> <base64-encoded string>``, e.g. ``ssh-rsa AAAAB3N<...>FAaQ==``.
 
 .. bb:step:: ShellCommand
 


### PR DESCRIPTION
This is an initial PR for GitPush step for pushing git commits to remote repository. The PR is WIP, this specific implementation has not yet been tested, only the unit tests pass. I've created the PR to gather early feedback.

The PR consists of two parts: first, the guts of Git step that are reusable have been extracted to util.git.GitWorkerCommonMixin (please advise of better name and/or location if possible); then the GitPush step has been implemented on top. The GitPush step is relatively simple for now, for example, it does not support the codebase parameter.

I've put the GitPush to steps.source.git module, but I think it's a little bit confusing because until now everything in steps.source is related to source checkout, not other operations. It probably makes sense to use the opportunity think about other non-checkout related steps, e.g. pushes on other VCs or commit operation.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
