### PR TITLE
move `chown buildbot` after all COPY instructions

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -39,12 +39,13 @@ RUN         apt-get update && \
     # Install required python packages, and twisted
     pip --no-cache-dir install 'twisted[tls]' && \
     mkdir /buildbot &&\
-    useradd -ms /bin/bash buildbot && chown -R buildbot /buildbot
+    useradd -ms /bin/bash buildbot
 
 COPY . /usr/src/buildbot-worker
 COPY docker/buildbot.tac /buildbot/buildbot.tac
 
-RUN pip install /usr/src/buildbot-worker
+RUN pip install /usr/src/buildbot-worker && \
+    chown -R buildbot /buildbot
 
 USER buildbot
 WORKDIR /buildbot


### PR DESCRIPTION
`/buildbot/buildbot.tac` was owned as root because of the COPY call after the `chown`

This probably isn't _needed_ since the worker probably isn't touching this file, but it seems like a loose end with `/buildbot` being owned by `buildbot` and the `chown` call happening right before the copy.

I'm not updating any of the below as this isn't really "newsworthy"

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
