### PR TITLE
Upgrade twisted

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -513,6 +513,7 @@ gatherresults
 gayton
 gcc
 gc'd
+gc
 gerrit
 getaddress
 getargspec

--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -118,17 +118,19 @@ def patch_unittest_testcase():
     if not getattr(TestCase, "assertRegex", None):
         TestCase.assertRegex = TestCase.assertRegexpMatches
 
+
 @onlyOnce
 def patch_testcase_flushLoggedErrors():
     from twisted.trial.unittest import SynchronousTestCase
     import gc
 
     # DebugInfo use of __del__ leads to hard to find gc timing issues
-    # https://twistedmatrix.com/trac/ticket/9506#ticket
+    # https://twistedmatrix.com/trac/ticket/9505
     def flushLoggedErrors(self, *errorTypes):
         gc.collect()
         return self._observer.flushErrors(*errorTypes)
     SynchronousTestCase.flushLoggedErrors = flushLoggedErrors
+
 
 def patch_all(for_tests=False):
     if for_tests:

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -79,7 +79,7 @@ termcolor==1.1.0
 toml==0.9.4
 towncrier==18.6.0
 treq==18.6.0
-Twisted==18.4.0
+Twisted==18.7.0
 txaio==18.7.1
 txrequests==0.9.6
 typing==3.6.4


### PR DESCRIPTION
context: when upgrading buildbot to twisted 18.7.0, the testsuite sudenly broke, with an Error coming from a previous test.

The culprit test is:

     def test_secret(self):
        command = Interpolate("echo %(secret:fuo)s")
        self.assertFailure(self.build.render(command), defer.FirstError)
        self.flushLoggedErrors(defer.FirstError)
        self.flushLoggedErrors(KeyError)
This test is depending on whether the DebugInfo has been garbage collected. If the DebugInfo has not been collected yet, the error will appear at the time of the next test.

```
@_oldStyle
class DebugInfo:
    """
    Deferred debug helper.
    """
    [...]


    def __del__(self):
        """
        Print tracebacks and die.

        If the *last* (and I do mean *last*) callback leaves me in an error
        state, print a traceback (if said errback is a L{Failure}).
        """
        if self.failResult is not None:
            [...]
            # this logs the failure at an undeterministic time
            log.failure(format,
                        self.failResult,
                        debugInfo=debugInfo)
```

This rootcause was pretty hard to find. Doing git bisect pointed to a completly unrelated commit, and it turned out that just modifying the import sequence would change gc timing, this is why we see the problem with this version of twisted.

We use this flushLoggedErrors pattern largely in Buildbot codebase (96 times)

So this is likely that this will bite us again.

My proposal for fixing it is to following patch to make sure gc happens before flushing the errors.
