### PR TITLE
Fix CI docs failures by reverting towncrier to 18.5.0

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -77,7 +77,7 @@ sqlparse==0.2.4
 Tempita==0.5.2
 termcolor==1.1.0
 toml==0.9.4
-towncrier==18.6.0
+towncrier==18.5.0
 treq==18.6.0
 Twisted==18.7.0
 txaio==18.7.1

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -4,4 +4,4 @@ sphinxcontrib-blockdiag==1.5.5
 sphinxcontrib-spelling==4.2.0
 sphinxcontrib-websupport==1.1.0
 Pygments==2.2.0
-towncrier==18.6.0
+towncrier==18.5.0


### PR DESCRIPTION
The towncrier dependency dropped the python 2.7 support in 18.6.0 (see https://github.com/hawkowl/towncrier/commit/d0068ccec159ccbe8a38d4c1adc2ae486db4c65f). This got noticed in https://github.com/hawkowl/towncrier/issues/121 and fixed for a future version of towncrier which is not yet released. Until it's released and we can upgrade we should probably revert to an older version of towncrier.

This PR reverts to towncrier 18.5.0.

## Contributor Checklist:

* [not applicable] I have updated the unit tests
* [not applicable] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [not applicable] I have updated the appropriate documentation
