### PR TITLE
WIP: Add pywin32 to requirements-ci.txt on Windows

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -62,6 +62,7 @@ pyOpenSSL==18.0.0
 pyparsing==2.2.0
 python-dateutil==2.7.3
 pytz==2018.5
+pywin32; sys_platform == 'win32'
 PyYAML==3.13
 requests==2.19.1
 s3transfer==0.1.13


### PR DESCRIPTION
This may fix python3.6 test failures on Appveyor.

See https://ci.appveyor.com/project/djmitche/buildbot/build/1.0.6934.