### PR TITLE
git: Use absolute paths for ssh data so that git submodules work

### DIFF
--- a/master/buildbot/newsfragments/git_ssh_key_fix_submodules.bugfix
+++ b/master/buildbot/newsfragments/git_ssh_key_fix_submodules.bugfix
@@ -1,0 +1,1 @@
+Fix git submodule support when using `sshPrivateKey` and `sshHostKey` settings by passing ssh data as absolute, not relative paths.

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -88,6 +88,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -97,13 +103,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -115,7 +121,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', '-c', 'core.sshCommand=ssh -i "../.wkdir.buildbot/ssh-key"',
+                        command=['git', '-c', ssh_command_config,
                                  'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'])
@@ -128,7 +134,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -141,6 +147,11 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -150,13 +161,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -171,7 +182,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
-                        env={'GIT_SSH_COMMAND': 'ssh -i "../.wkdir.buildbot/ssh-key"'})
+                        env={'GIT_SSH_COMMAND': ssh_command})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -181,7 +192,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -194,6 +205,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_wrapper_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -203,20 +220,20 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-wrapper.sh',
+                                        workerdest=ssh_wrapper_path,
                                         workdir='wkdir',
                                         mode=0o700))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -231,7 +248,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
-                        env={'GIT_SSH': '../.wkdir.buildbot/ssh-wrapper.sh'})
+                        env={'GIT_SSH': ssh_wrapper_path})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -241,7 +258,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -256,9 +273,15 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
         ssh_command_config = \
-            'core.sshCommand=ssh -i "../.wkdir.buildbot/ssh-key" ' \
-            '-o "UserKnownHostsFile=../.wkdir.buildbot/ssh-known-hosts"'
+            'core.sshCommand=ssh -i "{0}" ' \
+            '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
+                                                 ssh_known_hosts_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -268,20 +291,20 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -306,7 +329,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -321,9 +344,15 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
         ssh_command = \
-            'ssh -i "../.wkdir.buildbot/ssh-key" ' \
-            '-o "UserKnownHostsFile=../.wkdir.buildbot/ssh-known-hosts"'
+            'ssh -i "{0}" ' \
+            '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
+                                                 ssh_known_hosts_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -333,20 +362,20 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -371,7 +400,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -385,6 +414,14 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_wrapper_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -394,27 +431,27 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-wrapper.sh',
+                                        workerdest=ssh_wrapper_path,
                                         workdir='wkdir',
                                         mode=0o700))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -429,7 +466,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
-                        env={'GIT_SSH': '../.wkdir.buildbot/ssh-wrapper.sh'})
+                        env={'GIT_SSH': ssh_wrapper_path})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -439,7 +476,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -495,6 +532,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.build.path_module = namedModule('ntpath')
         self.worker.worker_system = 'win32'
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -504,13 +547,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir\\.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='..\\.wkdir.buildbot\\ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -522,7 +565,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', '-c', 'core.sshCommand=ssh -i "..\\.wkdir.buildbot\\ssh-key"',
+                        command=['git', '-c', ssh_command_config,
                                  'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'])
@@ -535,7 +578,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -550,6 +593,11 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.build.path_module = namedModule('ntpath')
         self.worker.worker_system = 'win32'
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')
+        ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -559,13 +607,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir\\.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='..\\.wkdir.buildbot\\ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -580,7 +628,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
-                        env={'GIT_SSH_COMMAND': 'ssh -i "..\\.wkdir.buildbot\\ssh-key"'})
+                        env={'GIT_SSH_COMMAND': ssh_command})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -590,7 +638,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -605,6 +653,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.build.path_module = namedModule('ntpath')
         self.worker.worker_system = 'win32'
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')
+        ssh_wrapper_path = \
+            self.build.path_module.abspath('.wkdir.buildbot\\ssh-wrapper.sh')
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -614,20 +668,20 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir\\.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='..\\.wkdir.buildbot\\ssh-wrapper.sh',
+                                        workerdest=ssh_wrapper_path,
                                         workdir='wkdir',
                                         mode=0o700))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='..\\.wkdir.buildbot\\ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -642,7 +696,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
-                        env={'GIT_SSH': '..\\.wkdir.buildbot\\ssh-wrapper.sh'})
+                        env={'GIT_SSH': ssh_wrapper_path})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -652,7 +706,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -1456,6 +1510,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='incremental', branch='test-branch',
                            sshPrivateKey='ssh-key'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -1465,13 +1525,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -1480,7 +1540,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', '-c', 'core.sshCommand=ssh -i "../.wkdir.buildbot/ssh-key"',
+                        command=['git', '-c', ssh_command_config,
                                  'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'test-branch'])
@@ -1496,7 +1556,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -2146,6 +2206,11 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='copy', sshPrivateKey='sshkey'))
 
+        ssh_workdir = self.build.path_module.abspath('.source.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.source.buildbot/ssh-key')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -2155,13 +2220,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.source.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.source.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='source',
                                         mode=0o400))
             + 0,
@@ -2173,7 +2238,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='source',
-                        command=['git', '-c', 'core.sshCommand=ssh -i "../.source.buildbot/ssh-key"',
+                        command=['git', '-c', ssh_command_config,
                                  'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'])
@@ -2189,7 +2254,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.source.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3232,26 +3297,30 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     def test_push_ssh_key_2_10(self):
         url = 'ssh://github.com/test/test.git'
-        ssh_command_config = \
-            'core.sshCommand=ssh -i "../.wkdir.buildbot/ssh-key"'
 
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 2.10.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -3259,7 +3328,7 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '-c', ssh_command_config,
                                  'push', url, 'testbranch'])
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3268,25 +3337,29 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     def test_push_ssh_key_2_3(self):
         url = 'ssh://github.com/test/test.git'
-        ssh_command = 'ssh -i "../.wkdir.buildbot/ssh-key"'
 
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 2.3.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -3294,7 +3367,7 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'push', url, 'testbranch'],
                         env={'GIT_SSH_COMMAND': ssh_command})
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3307,20 +3380,26 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_wrapper_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 1.7.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-wrapper.sh',
+                        workerdest=ssh_wrapper_path,
                         workdir='wkdir',
                         mode=0o700))
             + 0,
@@ -3328,15 +3407,15 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'push', url, 'testbranch'],
-                        env={'GIT_SSH': '../.wkdir.buildbot/ssh-wrapper.sh'})
+                        env={'GIT_SSH': ssh_wrapper_path})
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3345,35 +3424,41 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     def test_push_ssh_host_key_2_10(self):
         url = 'ssh://github.com/test/test.git'
-        ssh_command_config = \
-            'core.sshCommand=ssh -i "../.wkdir.buildbot/ssh-key" ' \
-            '-o "UserKnownHostsFile=../.wkdir.buildbot/ssh-known-hosts"'
-
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}" ' \
+            '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
+                                                 ssh_known_hosts_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 2.10.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -3381,7 +3466,7 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '-c', ssh_command_config,
                                  'push', url, 'testbranch'])
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3390,35 +3475,41 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     def test_push_ssh_host_key_2_3(self):
         url = 'ssh://github.com/test/test.git'
-        ssh_command = \
-            'ssh -i "../.wkdir.buildbot/ssh-key" ' \
-            '-o "UserKnownHostsFile=../.wkdir.buildbot/ssh-known-hosts"'
-
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+        ssh_command = \
+            'ssh -i "{0}" ' \
+            '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
+                                                 ssh_known_hosts_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 2.3.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -3426,7 +3517,7 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'push', url, 'testbranch'],
                         env={'GIT_SSH_COMMAND': ssh_command})
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3435,25 +3526,32 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     def test_push_ssh_host_key_1_7(self):
         url = 'ssh://github.com/test/test.git'
-
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_wrapper_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 1.7.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-wrapper.sh',
+                        workerdest=ssh_wrapper_path,
                         workdir='wkdir',
                         mode=0o700))
             + 0,
@@ -3461,22 +3559,22 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'push', url, 'testbranch'],
-                        env={'GIT_SSH': '../.wkdir.buildbot/ssh-wrapper.sh'})
+                        env={'GIT_SSH': ssh_wrapper_path})
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )


### PR DESCRIPTION
Turns out git submodule commands are executed from different directories than the git repository root and thus relative paths to any data given to original git command no longer work. This PR fixes that by using absolute paths.

Tested with both Git and GitPush step.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [not necessary] I have updated the appropriate documentation
