### PR TITLE
Fix `Build.getUrl()` to not ignore virtual builders.

### DIFF
--- a/master/buildbot/newsfragments/4273.bugfix
+++ b/master/buildbot/newsfragments/4273.bugfix
@@ -1,0 +1,1 @@
+Fix `Build.getUrl()` to not ignore virtual builders.

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -704,7 +704,7 @@ class Build(properties.PropertiesMixin, WorkerAPICompatMixin):
 
     @defer.inlineCallbacks
     def getUrl(self):
-        builder_id = yield self.builder.getBuilderId()
+        builder_id = yield self.getBuilderId()
         defer.returnValue(getURLForBuild(self.master, builder_id, self.number))
 
     def waitUntilFinished(self):

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -116,9 +116,11 @@ class FakeBuilder:
         self.name = 'fred'
         self.master = master
         self.botmaster = master.botmaster
+        self.builderid = 83
+        self._builders = {}
 
     def getBuilderId(self):
-        return defer.succeed(83)
+        return defer.succeed(self.builderid)
 
     def setupProperties(self, props):
         pass
@@ -127,7 +129,7 @@ class FakeBuilder:
         pass
 
     def getBuilderIdForName(self, name):
-        return defer.succeed(83)
+        return defer.succeed(self._builders.get(name, None) or self.builderid)
 
 
 @implementer(interfaces.IBuildStepFactory)
@@ -821,6 +823,15 @@ class TestBuild(unittest.TestCase):
         self.build.number = 3
         url = yield self.build.getUrl()
         self.assertEqual(url, 'http://localhost:8080/#builders/83/builds/3')
+
+    @defer.inlineCallbacks
+    def testGetUrlForVirtualBuilder(self):
+        # Let's fake a virtual builder
+        self.builder._builders['wilma'] = 108
+        self.build.setProperty('virtual_builder_name', 'wilma', 'Build')
+        self.build.number = 33
+        url = yield self.build.getUrl()
+        self.assertEqual(url, 'http://localhost:8080/#builders/108/builds/33')
 
     def test_active_builds_metric(self):
         """


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] ~I have updated the appropriate documentation~
