### PR TITLE
Configurable Start Timeout Delay

### DIFF
--- a/master/buildbot/newsfragments/4275.feature
+++ b/master/buildbot/newsfragments/4275.feature
@@ -1,0 +1,6 @@
+Allow the buildbot master initial start timeout to be configurable.
+
+On big setups, with a lot of workers or a lot of builders, buildbot will take way more than 10 seconds to start.
+The result is that buildbot stop's itself in the middle of the start process.
+
+This change allows for the initial start timeout to be configurable so that these big setups can adjust.

--- a/master/buildbot/scripts/logwatcher.py
+++ b/master/buildbot/scripts/logwatcher.py
@@ -60,13 +60,14 @@ class LogWatcher(LineOnlyReceiver):
     TIMEOUT_DELAY = 10.0
     delimiter = unicode2bytes(os.linesep)
 
-    def __init__(self, logfile):
+    def __init__(self, logfile, timeout_delay=None):
         self.logfile = logfile
         self.in_reconfig = False
         self.transport = FakeTransport()
         self.pp = TailProcess()
         self.pp.lw = self
         self.timer = None
+        self.timeout_delay = timeout_delay or self.TIMEOUT_DELAY
 
     def start(self):
         # If the log file doesn't exist, create it now.
@@ -96,7 +97,7 @@ class LogWatcher(LineOnlyReceiver):
         return self.d
 
     def startTimer(self):
-        self.timer = reactor.callLater(self.TIMEOUT_DELAY, self.timeout)
+        self.timer = reactor.callLater(self.timeout_delay, self.timeout)
 
     def timeout(self):
         # was the timeout set to be ignored? if so, restart it

--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -34,10 +34,10 @@ from buildbot.util import rewrap
 
 class Follower:
 
-    def follow(self, basedir):
+    def follow(self, basedir, timeout_delay=None):
         self.rc = 0
         print("Following twistd.log until startup finished..")
-        lw = LogWatcher(os.path.join(basedir, "twistd.log"))
+        lw = LogWatcher(os.path.join(basedir, "twistd.log"), timeout_delay=timeout_delay)
         d = lw.start()
         d.addCallbacks(self._success, self._failure)
         reactor.run()
@@ -142,5 +142,6 @@ def start(config):
         return 0
 
     # this is the parent
-    rc = Follower().follow(config['basedir'])
+    rc = Follower().follow(config['basedir'],
+                           timeout_delay=config.get('start_timeout_delay', None))
     return rc


### PR DESCRIPTION
On big setups, with a lot of workers or a lot of builders, Buildbot will take way more than 10 seconds to start.
The result is that Buildbot stop's itself in the middle of the start process.
    
This change allows for the initial start timeout to be configurable so that these big setups can adjust.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
