### PR TITLE
Fix IRC output for Python 3 master

### DIFF
--- a/master/buildbot/newsfragments/python3-irc-bytes.bugfix
+++ b/master/buildbot/newsfragments/python3-irc-bytes.bugfix
@@ -1,0 +1,3 @@
+:py:class:`buildbot.reporters.irc.IrcStatusBot` no longer encodes messages
+before passing them on to methods of its Twisted base class to avoid posting
+the ``repr()`` of a bytes object when running on Python 3.

--- a/master/buildbot/reporters/irc.py
+++ b/master/buildbot/reporters/irc.py
@@ -60,13 +60,13 @@ class IrcStatusBot(StatusBot, irc.IRCClient):
 
     # The following methods are called when we write something.
     def groupChat(self, channel, message):
-        self.notice(channel, message.encode('utf-8', 'replace'))
+        self.notice(channel, message)
 
     def chat(self, user, message):
-        self.msg(user, message.encode('utf-8', 'replace'))
+        self.msg(user, message)
 
     def groupDescribe(self, channel, action):
-        self.describe(channel, action.encode('utf-8', 'replace'))
+        self.describe(channel, action)
 
     def getContact(self, user=None, channel=None):
         # nicknames and channel names are case insensitive

--- a/master/buildbot/test/unit/test_reporters_irc.py
+++ b/master/buildbot/test/unit/test_reporters_irc.py
@@ -53,6 +53,14 @@ class TestIrcStatusBot(unittest.TestCase):
             args = ('nick', 'pass', ['#ch'], [], [], {})
         return irc.IrcStatusBot(*args, **kwargs)
 
+    def test_groupDescribe(self):
+        b = self.makeBot()
+        b.describe = lambda d, m: evts.append(('n', d, m))
+
+        evts = []
+        b.groupDescribe('#chan', 'hi')
+        self.assertEqual(evts, [('n', '#chan', 'hi')])
+
     def test_groupChat(self):
         b = self.makeBot()
         b.notice = lambda d, m: evts.append(('n', d, m))

--- a/master/buildbot/test/unit/test_reporters_irc.py
+++ b/master/buildbot/test/unit/test_reporters_irc.py
@@ -59,7 +59,7 @@ class TestIrcStatusBot(unittest.TestCase):
 
         evts = []
         b.groupChat('#chan', 'hi')
-        self.assertEqual(evts, [('n', '#chan', b'hi')])
+        self.assertEqual(evts, [('n', '#chan', 'hi')])
 
     def test_chat(self):
         b = self.makeBot()
@@ -67,7 +67,7 @@ class TestIrcStatusBot(unittest.TestCase):
 
         evts = []
         b.chat('nick', 'hi')
-        self.assertEqual(evts, [('m', 'nick', b'hi')])
+        self.assertEqual(evts, [('m', 'nick', 'hi')])
 
     def test_getContact(self):
         b = self.makeBot()


### PR DESCRIPTION
Twisted takes care of any necessary encoding; doing the encoding in
buildbot when running on Python 3 causes the message to show up at the
server as a bytes object repr.

This is another shot at #3961, this time with tests fixed and newsfragment added.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] ~~I have updated the appropriate documentation~~
