### PR TITLE
Use @defer.inlineCallbacks where possible (part 1) 

### DIFF
--- a/master/buildbot/test/unit/test_reporters_words.py
+++ b/master/buildbot/test/unit/test_reporters_words.py
@@ -634,70 +634,58 @@ class TestContactChannel(unittest.TestCase):
             ('#buildbot', u'unmuted, unicode \u2603'),
         ])
 
+    @defer.inlineCallbacks
     def test_handleMessage_silly(self):
         silly_prompt = list(self.contact.silly)[0]
         self.contact.doSilly = mock.Mock()
-        d = self.contact.handleMessage(silly_prompt)
+        yield self.contact.handleMessage(silly_prompt)
 
-        @d.addCallback
-        def cb(_):
-            self.contact.doSilly.assert_called_with(silly_prompt)
-        return d
+        self.contact.doSilly.assert_called_with(silly_prompt)
 
+    @defer.inlineCallbacks
     def test_handleMessage_short_command(self):
         self.contact.command_TESTY = mock.Mock()
-        d = self.contact.handleMessage('testy')
+        yield self.contact.handleMessage('testy')
 
-        @d.addCallback
-        def cb(_):
-            self.contact.command_TESTY.assert_called_with('')
-        return d
+        self.contact.command_TESTY.assert_called_with('')
 
+    @defer.inlineCallbacks
     def test_handleMessage_long_command(self):
         self.contact.command_TESTY = mock.Mock()
-        d = self.contact.handleMessage('testy   westy boo')
+        yield self.contact.handleMessage('testy   westy boo')
 
-        @d.addCallback
-        def cb(_):
-            self.contact.command_TESTY.assert_called_with('westy boo')
-        return d
+        self.contact.command_TESTY.assert_called_with('westy boo')
 
+    @defer.inlineCallbacks
     def test_handleMessage_excited(self):
         self.patch_send()
-        d = self.contact.handleMessage('hi!')
+        yield self.contact.handleMessage('hi!')
 
-        @d.addCallback
-        def cb(_):
-            self.assertEqual(len(self.sent), 1)  # who cares what it says..
-        return d
+        self.assertEqual(len(self.sent), 1)  # who cares what it says..
 
+    @defer.inlineCallbacks
     def test_handleMessage_exception(self):
         self.patch_send()
 
         def command_TESTY(msg):
             raise RuntimeError("FAIL")
         self.contact.command_TESTY = command_TESTY
-        d = self.contact.handleMessage('testy boom')
+        yield self.contact.handleMessage('testy boom')
 
-        @d.addCallback
-        def cb(_):
-            self.assertEqual(self.sent,
-                             ["Something bad happened (see logs)"])
-            self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1)
-        return d
+        self.assertEqual(self.sent,
+                         ["Something bad happened (see logs)"])
+        self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1)
 
+    @defer.inlineCallbacks
     def test_handleMessage_UsageError(self):
         self.patch_send()
 
         def command_TESTY(msg):
             raise words.UsageError("oh noes")
         self.contact.command_TESTY = command_TESTY
-        d = self.contact.handleMessage('testy boom')
+        yield self.contact.handleMessage('testy boom')
 
-        @d.addCallback
-        def cb(_):
-            self.assertEqual(self.sent, ["oh noes"])
-        return d
+        self.assertEqual(self.sent, ["oh noes"])
 
     def test_handleAction_ignored(self):
         self.patch_act()

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -927,20 +927,17 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         res = yield self.request.test_render(self.changeHook)
         self.check_changes_tag_event(res, codebase="MyCodebase")
 
+    @defer.inlineCallbacks
     def testGitWithNoJson(self):
         self.request = FakeRequest()
         self.request.uri = b"/change_hook/gitlab"
         self.request.method = b"POST"
         self.request.received_headers[_HEADER_EVENT] = b"Push Hook"
-        d = self.request.test_render(self.changeHook)
+        yield self.request.test_render(self.changeHook)
 
-        def check_changes(r):
-            self.assertEqual(len(self.changeHook.master.addedChanges), 0)
-            self.assertIn(b"Error loading JSON:", self.request.written)
-            self.request.setResponseCode.assert_called_with(400, mock.ANY)
-
-        d.addCallback(check_changes)
-        return d
+        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertIn(b"Error loading JSON:", self.request.written)
+        self.request.setResponseCode.assert_called_with(400, mock.ANY)
 
     @defer.inlineCallbacks
     def test_event_property(self):

--- a/master/buildbot/test/unit/test_www_hooks_gitorious.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitorious.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import calendar
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 import buildbot.www.change_hook as change_hook
@@ -72,50 +73,44 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
     # Test 'base' hook with attributes. We should get a json string
     # representing a Change object as a dictionary. All values show be set.
+    @defer.inlineCallbacks
     def testGitWithChange(self):
         changeDict = {b"payload": [gitJsonPayload]}
         self.request = FakeRequest(changeDict)
         self.request.uri = b"/change_hook/gitorious"
         self.request.method = b"POST"
-        d = self.request.test_render(self.changeHook)
+        yield self.request.test_render(self.changeHook)
 
-        def check_changes(r):
-            self.assertEqual(len(self.changeHook.master.addedChanges), 1)
-            change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
+        change = self.changeHook.master.addedChanges[0]
 
-            # Gitorious doesn't send changed files
-            self.assertEqual(change['files'], [])
-            self.assertEqual(change["repository"],
-                             "http://gitorious.org/q/mainline")
-            self.assertEqual(
-                calendar.timegm(change["when_timestamp"].utctimetuple()),
-                1326218547
-            )
-            self.assertEqual(change["author"], "jason <jason@nospam.org>")
-            self.assertEqual(change["revision"],
-                             'df5744f7bc8663b39717f87742dc94f52ccbf4dd')
-            self.assertEqual(change["comments"],
-                             "added a place to put the docstring for Book")
-            self.assertEqual(change["branch"], "new_look")
-            revlink = ("http://gitorious.org/q/mainline/commit/"
-                       "df5744f7bc8663b39717f87742dc94f52ccbf4dd")
-            self.assertEqual(change["revlink"], revlink)
+        # Gitorious doesn't send changed files
+        self.assertEqual(change['files'], [])
+        self.assertEqual(change["repository"],
+                         "http://gitorious.org/q/mainline")
+        self.assertEqual(
+            calendar.timegm(change["when_timestamp"].utctimetuple()),
+            1326218547
+        )
+        self.assertEqual(change["author"], "jason <jason@nospam.org>")
+        self.assertEqual(change["revision"],
+                         'df5744f7bc8663b39717f87742dc94f52ccbf4dd')
+        self.assertEqual(change["comments"],
+                         "added a place to put the docstring for Book")
+        self.assertEqual(change["branch"], "new_look")
+        revlink = ("http://gitorious.org/q/mainline/commit/"
+                   "df5744f7bc8663b39717f87742dc94f52ccbf4dd")
+        self.assertEqual(change["revlink"], revlink)
 
-        d.addCallback(check_changes)
-        return d
-
+    @defer.inlineCallbacks
     def testGitWithNoJson(self):
         self.request = FakeRequest()
         self.request.uri = b"/change_hook/gitorious"
         self.request.method = b"GET"
-        d = self.request.test_render(self.changeHook)
+        yield self.request.test_render(self.changeHook)
 
-        def check_changes(r):
-            expected = b"Error processing changes."
-            self.assertEqual(len(self.changeHook.master.addedChanges), 0)
-            self.assertEqual(self.request.written, expected)
-            self.request.setResponseCode.assert_called_with(500, expected)
-            self.assertEqual(len(self.flushLoggedErrors()), 1)
-
-        d.addCallback(check_changes)
-        return d
+        expected = b"Error processing changes."
+        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(self.request.written, expected)
+        self.request.setResponseCode.assert_called_with(500, expected)
+        self.assertEqual(len(self.flushLoggedErrors()), 1)

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -43,16 +43,14 @@ class RestRootResource(www.WwwTestMixin, unittest.TestCase):
 
     maxVersion = 2
 
+    @defer.inlineCallbacks
     def test_render(self):
         master = self.make_master(url='h:/a/b/')
         rsrc = rest.RestRootResource(master)
 
-        d = self.render_resource(rsrc, b'/')
+        rv = yield self.render_resource(rsrc, b'/')
 
-        @d.addCallback
-        def check(rv):
-            self.assertIn(b'api_versions', rv)
-        return d
+        self.assertIn(b'api_versions', rv)
 
     def test_versions(self):
         master = self.make_master(url='h:/a/b/')

--- a/master/buildbot/test/unit/test_www_service.py
+++ b/master/buildbot/test/unit/test_www_service.py
@@ -64,14 +64,12 @@ class Test(www.WwwTestMixin, unittest.TestCase):
         self.master.config = new_config
         return new_config
 
+    @defer.inlineCallbacks
     def test_reconfigService_no_port(self):
         new_config = self.makeConfig()
-        d = self.svc.reconfigServiceWithBuildbotConfig(new_config)
+        yield self.svc.reconfigServiceWithBuildbotConfig(new_config)
 
-        @d.addCallback
-        def check(_):
-            self.assertEqual(self.svc.site, None)
-        return d
+        self.assertEqual(self.svc.site, None)
 
     @defer.inlineCallbacks
     def test_reconfigService_reconfigResources(self):
@@ -87,59 +85,47 @@ class Test(www.WwwTestMixin, unittest.TestCase):
         yield self.svc.reconfigServiceWithBuildbotConfig(new_config)
         self.assertEqual(NeedsReconfigResource.reconfigs, 2)
 
+    @defer.inlineCallbacks
     def test_reconfigService_port(self):
         new_config = self.makeConfig(port=20)
-        d = self.svc.reconfigServiceWithBuildbotConfig(new_config)
+        yield self.svc.reconfigServiceWithBuildbotConfig(new_config)
 
-        @d.addCallback
-        def check(_):
-            self.assertNotEqual(self.svc.site, None)
-            self.assertNotEqual(self.svc.port_service, None)
-            self.assertEqual(self.svc.port, 20)
-        return d
+        self.assertNotEqual(self.svc.site, None)
+        self.assertNotEqual(self.svc.port_service, None)
+        self.assertEqual(self.svc.port, 20)
 
+    @defer.inlineCallbacks
     def test_reconfigService_expiration_time(self):
         new_config = self.makeConfig(port=80, cookie_expiration_time=datetime.timedelta(minutes=1))
-        d = self.svc.reconfigServiceWithBuildbotConfig(new_config)
+        yield self.svc.reconfigServiceWithBuildbotConfig(new_config)
 
-        @d.addCallback
-        def check(_):
-            self.assertNotEqual(self.svc.site, None)
-            self.assertNotEqual(self.svc.port_service, None)
-            self.assertEqual(service.BuildbotSession.expDelay, datetime.timedelta(minutes=1))
-        return d
+        self.assertNotEqual(self.svc.site, None)
+        self.assertNotEqual(self.svc.port_service, None)
+        self.assertEqual(service.BuildbotSession.expDelay, datetime.timedelta(minutes=1))
 
+    @defer.inlineCallbacks
     def test_reconfigService_port_changes(self):
         new_config = self.makeConfig(port=20)
-        d = self.svc.reconfigServiceWithBuildbotConfig(new_config)
+        yield self.svc.reconfigServiceWithBuildbotConfig(new_config)
 
-        @d.addCallback
-        def reconfig(_):
-            newer_config = self.makeConfig(port=999)
-            return self.svc.reconfigServiceWithBuildbotConfig(newer_config)
+        newer_config = self.makeConfig(port=999)
+        yield self.svc.reconfigServiceWithBuildbotConfig(newer_config)
 
-        @d.addCallback
-        def check(_):
-            self.assertNotEqual(self.svc.site, None)
-            self.assertNotEqual(self.svc.port_service, None)
-            self.assertEqual(self.svc.port, 999)
-        return d
+        self.assertNotEqual(self.svc.site, None)
+        self.assertNotEqual(self.svc.port_service, None)
+        self.assertEqual(self.svc.port, 999)
 
+    @defer.inlineCallbacks
     def test_reconfigService_port_changes_to_none(self):
         new_config = self.makeConfig(port=20)
-        d = self.svc.reconfigServiceWithBuildbotConfig(new_config)
+        yield self.svc.reconfigServiceWithBuildbotConfig(new_config)
 
-        @d.addCallback
-        def reconfig(_):
-            newer_config = self.makeConfig()
-            return self.svc.reconfigServiceWithBuildbotConfig(newer_config)
+        newer_config = self.makeConfig()
+        yield self.svc.reconfigServiceWithBuildbotConfig(newer_config)
 
-        @d.addCallback
-        def check(_):
-            # (note the site sticks around)
-            self.assertEqual(self.svc.port_service, None)
-            self.assertEqual(self.svc.port, None)
-        return d
+        # (note the site sticks around)
+        self.assertEqual(self.svc.port_service, None)
+        self.assertEqual(self.svc.port, None)
 
     def test_setupSite(self):
         self.svc.setupSite(self.makeConfig())

--- a/master/buildbot/test/util/changesource.py
+++ b/master/buildbot/test/util/changesource.py
@@ -77,14 +77,12 @@ class ChangeSourceMixin(object):
         self.started = True
         return self.changesource.startService()
 
+    @defer.inlineCallbacks
     def stopChangeSource(self):
         "stop the change source again; returns a deferred"
-        d = self.changesource.stopService()
+        yield self.changesource.stopService()
 
-        @d.addCallback
-        def mark_stopped(_):
-            self.started = False
-        return d
+        self.started = False
 
     def setChangeSourceToMaster(self, otherMaster):
         # some tests build the CS late, so for those tests we will require that

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -74,23 +74,20 @@ class EndpointMixin(interfaces.InterfaceTests):
 
     # call methods, with extra checks
 
+    @defer.inlineCallbacks
     def callGet(self, path, resultSpec=None):
         self.assertIsInstance(path, tuple)
         if resultSpec is None:
             resultSpec = resultspec.ResultSpec()
         endpoint, kwargs = self.matcher[path]
         self.assertIdentical(endpoint, self.ep)
-        d = endpoint.get(resultSpec, kwargs)
-        self.assertIsInstance(d, defer.Deferred)
+        rv = yield endpoint.get(resultSpec, kwargs)
 
-        @d.addCallback
-        def checkNumber(rv):
-            if self.ep.isCollection:
-                self.assertIsInstance(rv, (list, base.ListResult))
-            else:
-                self.assertIsInstance(rv, (dict, type(None)))
-            return rv
-        return d
+        if self.ep.isCollection:
+            self.assertIsInstance(rv, (list, base.ListResult))
+        else:
+            self.assertIsInstance(rv, (dict, type(None)))
+        defer.returnValue(rv)
 
     def callControl(self, action, args, path):
         self.assertIsInstance(path, tuple)

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -123,16 +123,15 @@ class SchedulerMixin(interfaces.InterfaceTests):
         def patch(meth):
             oldMethod = getattr(scheduler, meth)
 
+            @defer.inlineCallbacks
             def newMethod():
                 self._parentMethodCalled = False
-                d = defer.maybeDeferred(oldMethod)
+                rv = yield defer.maybeDeferred(oldMethod)
 
-                @d.addCallback
-                def check(rv):
-                    self.assertTrue(self._parentMethodCalled,
-                                    "'%s' did not call its parent" % meth)
-                    return rv
-                return d
+                self.assertTrue(self._parentMethodCalled,
+                    "'%s' did not call its parent" % meth)
+                defer.returnValue(rv)
+
             setattr(scheduler, meth, newMethod)
 
             oldParent = getattr(base.BaseScheduler, meth)


### PR DESCRIPTION
This PR continues work by @p12tic (https://github.com/buildbot/buildbot/pull/4174). The `d.addCallback()` or `@d.addCallback()` style is replaced by @defer.inlineCallbacks decorator. The work is coordinated with @p12tic so there's no duplication of effort. The changes have been split into several PRs for easier reviewing.