### PR TITLE
Use @defer.inlineCallbacks where possible (part 2)

### DIFF
--- a/master/buildbot/test/unit/test_changes_base.py
+++ b/master/buildbot/test/unit/test_changes_base.py
@@ -83,18 +83,16 @@ class TestPollingChangeSource(changesource.ChangeSourceMixin, unittest.TestCase)
     class Subclass(base.PollingChangeSource):
         pass
 
+    @defer.inlineCallbacks
     def setUp(self):
         # patch in a Clock so we can manipulate the reactor's time
         self.clock = task.Clock()
         self.patch(reactor, 'callLater', self.clock.callLater)
         self.patch(reactor, 'seconds', self.clock.seconds)
 
-        d = self.setUpChangeSource()
+        yield self.setUpChangeSource()
 
-        @d.addCallback
-        def create_changesource(_):
-            self.attachChangeSource(self.Subclass(name="DummyCS"))
-        return d
+        self.attachChangeSource(self.Subclass(name="DummyCS"))
 
     def tearDown(self):
         return self.tearDownChangeSource()
@@ -192,18 +190,16 @@ class TestReconfigurablePollingChangeSource(changesource.ChangeSourceMixin, unit
     class Subclass(base.ReconfigurablePollingChangeSource):
         pass
 
+    @defer.inlineCallbacks
     def setUp(self):
         # patch in a Clock so we can manipulate the reactor's time
         self.clock = task.Clock()
         self.patch(reactor, 'callLater', self.clock.callLater)
         self.patch(reactor, 'seconds', self.clock.seconds)
 
-        d = self.setUpChangeSource()
+        yield self.setUpChangeSource()
 
-        @d.addCallback
-        def create_changesource(_):
-            self.attachChangeSource(self.Subclass(name="DummyCS"))
-        return d
+        self.attachChangeSource(self.Subclass(name="DummyCS"))
 
     def tearDown(self):
         return self.tearDownChangeSource()

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -312,17 +312,15 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
         self.expectTriggeredWith(a=(False, [], {}))
         return self.runStep()
 
+    @defer.inlineCallbacks
     def test_simple_exception(self):
         self.setupStep(trigger.Trigger(schedulerNames=['a']))
         self.scheduler_a.exception = True
         self.expectOutcome(result=SUCCESS, state_string='triggered a')
         self.expectTriggeredWith(a=(False, [], {}))
-        d = self.runStep()
+        yield self.runStep()
 
-        def flush(_):
-            self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1)
-        d.addCallback(flush)
-        return d
+        self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1)
 
     @defer.inlineCallbacks
     def test_bogus_scheduler(self):

--- a/master/buildbot/test/unit/test_util_eventual.py
+++ b/master/buildbot/test/unit/test_util_eventual.py
@@ -43,13 +43,11 @@ class Eventually(unittest.TestCase):
         self.results.append(r)
 
     # flush the queue and assert results
+    @defer.inlineCallbacks
     def assertResults(self, exp):
-        d = eventual.flushEventualQueue()
+        yield eventual.flushEventualQueue()
 
-        @d.addCallback
-        def cb(_):
-            self.assertEqual(self.results, exp)
-        return d
+        self.assertEqual(self.results, exp)
 
     # tests
 

--- a/master/buildbot/test/unit/test_util_lineboundaries.py
+++ b/master/buildbot/test/unit/test_util_lineboundaries.py
@@ -152,10 +152,8 @@ class LBF(unittest.TestCase):
         yield self.lbf.flush()
         self.assertCallbacks([('12' * 2048 + '\n') * 16])
 
+    @defer.inlineCallbacks
     def test_empty_flush(self):
-        d = self.lbf.flush()
+        yield self.lbf.flush()
 
-        @d.addCallback
-        def check(_):
-            self.assertEqual(self.callbacks, [])
-        return d
+        self.assertEqual(self.callbacks, [])

--- a/master/buildbot/test/unit/test_util_misc.py
+++ b/master/buildbot/test/unit/test_util_misc.py
@@ -29,6 +29,7 @@ class deferredLocked(unittest.TestCase):
     def test_name(self):
         self.assertEqual(util.deferredLocked, misc.deferredLocked)
 
+    @defer.inlineCallbacks
     def test_fn(self):
         lock = defer.DeferredLock()
 
@@ -36,12 +37,9 @@ class deferredLocked(unittest.TestCase):
         def check_locked(arg1, arg2):
             self.assertEqual([lock.locked, arg1, arg2], [True, 1, 2])
             return defer.succeed(None)
-        d = check_locked(1, 2)
+        yield check_locked(1, 2)
 
-        @d.addCallback
-        def check_unlocked(_):
-            self.assertFalse(lock.locked)
-        return d
+        self.assertFalse(lock.locked)
 
     def test_fn_fails(self):
         lock = defer.DeferredLock()
@@ -72,6 +70,7 @@ class deferredLocked(unittest.TestCase):
                        lambda _: self.assertFalse(lock.locked))
         return d
 
+    @defer.inlineCallbacks
     def test_method(self):
         testcase = self
 
@@ -84,12 +83,9 @@ class deferredLocked(unittest.TestCase):
                 return defer.succeed(None)
         obj = C()
         obj.aLock = defer.DeferredLock()
-        d = obj.check_locked(1, 2)
+        yield obj.check_locked(1, 2)
 
-        @d.addCallback
-        def check_unlocked(_):
-            self.assertFalse(obj.aLock.locked)
-        return d
+        self.assertFalse(obj.aLock.locked)
 
 
 class TestCancelAfter(unittest.TestCase):

--- a/master/buildbot/test/unit/test_util_state.py
+++ b/master/buildbot/test/unit/test_util_state.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.fake.fakemaster import make_master
@@ -37,23 +38,19 @@ class TestStateMixin(unittest.TestCase):
         self.master = make_master(wantDb=True, testcase=self)
         self.object = FakeObject(self.master)
 
+    @defer.inlineCallbacks
     def test_getState(self):
         self.master.db.state.fakeState('fake-name', 'FakeObject',
                                        fav_color=['red', 'purple'])
-        d = self.object.getState('fav_color')
+        res = yield self.object.getState('fav_color')
 
-        @d.addCallback
-        def check(res):
-            self.assertEqual(res, ['red', 'purple'])
-        return d
+        self.assertEqual(res, ['red', 'purple'])
 
+    @defer.inlineCallbacks
     def test_getState_default(self):
-        d = self.object.getState('fav_color', 'black')
+        res = yield self.object.getState('fav_color', 'black')
 
-        @d.addCallback
-        def check(res):
-            self.assertEqual(res, 'black')
-        return d
+        self.assertEqual(res, 'black')
 
     def test_getState_KeyError(self):
         self.master.db.state.fakeState('fake-name', 'FakeObject',
@@ -69,21 +66,17 @@ class TestStateMixin(unittest.TestCase):
         d.addCallbacks(cb, check_exc)
         return d
 
+    @defer.inlineCallbacks
     def test_setState(self):
-        d = self.object.setState('y', 14)
+        yield self.object.setState('y', 14)
 
-        @d.addCallback
-        def check(_):
-            self.master.db.state.assertStateByClass('fake-name', 'FakeObject',
-                                                    y=14)
-        return d
+        self.master.db.state.assertStateByClass('fake-name', 'FakeObject',
+                                                y=14)
 
+    @defer.inlineCallbacks
     def test_setState_existing(self):
         self.master.db.state.fakeState('fake-name', 'FakeObject', x=13)
-        d = self.object.setState('x', 14)
+        yield self.object.setState('x', 14)
 
-        @d.addCallback
-        def check(_):
-            self.master.db.state.assertStateByClass('fake-name', 'FakeObject',
-                                                    x=14)
-        return d
+        self.master.db.state.assertStateByClass('fake-name', 'FakeObject',
+                                                x=14)

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -483,6 +483,7 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
         d.addCallback(check)
         return d
 
+    @defer.inlineCallbacks
     def test_truncated(self):
         self.fakemaster.data = test_data = b'tenchars--' * 10
 
@@ -495,22 +496,19 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
             mode=0o777,
         ))
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertUpdates([
-                'read(s)', 'close',
-                {'rc': 1,
-                 'stderr': "Maximum filesize reached, truncating file '{0}'".format(
-                 os.path.join(self.basedir, '.', 'data'))}
-            ])
-            datafile = os.path.join(self.basedir, 'data')
-            self.assertTrue(os.path.exists(datafile))
-            with open(datafile, mode="rb") as f:
-                data = f.read()
-            self.assertEqual(data, test_data[:50])
-        d.addCallback(check)
-        return d
+        self.assertUpdates([
+            'read(s)', 'close',
+            {'rc': 1,
+             'stderr': "Maximum filesize reached, truncating file '{0}'".format(
+             os.path.join(self.basedir, '.', 'data'))}
+        ])
+        datafile = os.path.join(self.basedir, 'data')
+        self.assertTrue(os.path.exists(datafile))
+        with open(datafile, mode="rb") as f:
+            data = f.read()
+        self.assertEqual(data, test_data[:50])
 
     def test_interrupted(self):
         self.fakemaster.data = b'tenchars--' * 100  # 1k

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -105,70 +105,61 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         self.assertIsInstance(s.command[0], bytes)
         self.assertIsInstance(s.fake_command[0], bytes)
 
+    @defer.inlineCallbacks
     def testStart(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(b, stdoutCommand('hello'), self.basedir)
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.assertTrue({'stdout': nl('hello\n')} in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.assertTrue({'stdout': nl('hello\n')} in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
+    @defer.inlineCallbacks
     def testNoStdout(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(
             b, stdoutCommand('hello'), self.basedir, sendStdout=False)
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.failIf({'stdout': nl('hello\n')} in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.failIf({'stdout': nl('hello\n')} in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
+    @defer.inlineCallbacks
     def testKeepStdout(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(
             b, stdoutCommand('hello'), self.basedir, keepStdout=True)
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.assertTrue({'stdout': nl('hello\n')} in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-            self.assertEqual(s.stdout, nl('hello\n'))
-        d.addCallback(check)
-        return d
+        self.assertTrue({'stdout': nl('hello\n')} in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
+        self.assertEqual(s.stdout, nl('hello\n'))
 
+    @defer.inlineCallbacks
     def testStderr(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(b, stderrCommand("hello"), self.basedir)
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.failIf({'stderr': nl('hello\n')} not in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.failIf({'stderr': nl('hello\n')} not in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
+    @defer.inlineCallbacks
     def testNoStderr(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(
             b, stderrCommand("hello"), self.basedir, sendStderr=False)
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.failIf({'stderr': nl('hello\n')} in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.failIf({'stderr': nl('hello\n')} in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
+    @defer.inlineCallbacks
     def test_incrementalDecoder(self):
         b = FakeWorkerForBuilder(self.basedir)
         b.unicode_encoding = "utf-8"
@@ -180,41 +171,34 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         pp.outReceived(b"\x98\x83")
         pp.errReceived(b"\xe2")
         pp.errReceived(b"\x98\x83")
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.assertTrue({'stderr': u"\N{SNOWMAN}"} in b.updates)
-            self.assertTrue({'stdout': u"\N{SNOWMAN}"} in b.updates)
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.assertTrue({'stderr': u"\N{SNOWMAN}"} in b.updates)
+        self.assertTrue({'stdout': u"\N{SNOWMAN}"} in b.updates)
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
+    @defer.inlineCallbacks
     def testKeepStderr(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(
             b, stderrCommand("hello"), self.basedir, keepStderr=True)
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.assertTrue({'stderr': nl('hello\n')} in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-            self.assertEqual(s.stderr, nl('hello\n'))
-        d.addCallback(check)
-        return d
+        self.assertTrue({'stderr': nl('hello\n')} in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
+        self.assertEqual(s.stderr, nl('hello\n'))
 
+    @defer.inlineCallbacks
     def testStringCommand(self):
         b = FakeWorkerForBuilder(self.basedir)
         # careful!  This command must execute the same on windows and UNIX
         s = runprocess.RunProcess(b, 'echo hello', self.basedir)
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.assertTrue({'stdout': nl('hello\n')} in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.assertTrue({'stdout': nl('hello\n')} in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
     def testObfuscatedCommand(self):
         b = FakeWorkerForBuilder(self.basedir)
@@ -224,6 +208,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         self.assertEqual(s.command, [b'abcd'])
         self.assertEqual(s.fake_command, [b'ABCD'])
 
+    @defer.inlineCallbacks
     def testMultiWordStringCommand(self):
         b = FakeWorkerForBuilder(self.basedir)
         # careful!  This command must execute the same on windows and UNIX
@@ -232,27 +217,23 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         # no quoting occurs
         exp = nl('Happy Days and Jubilation\n')
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.assertTrue({'stdout': exp} in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.assertTrue({'stdout': exp} in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
+    @defer.inlineCallbacks
     def testInitialStdinUnicode(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(
             b, catCommand(), self.basedir, initialStdin=u'hello')
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.assertTrue({'stdout': nl('hello')} in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.assertTrue({'stdout': nl('hello')} in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
+    @defer.inlineCallbacks
     def testMultiWordStringCommandQuotes(self):
         b = FakeWorkerForBuilder(self.basedir)
         # careful!  This command must execute the same on windows and UNIX
@@ -265,14 +246,12 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
             exp = nl('"Happy Days and Jubilation"\n')
         else:
             exp = nl('Happy Days and Jubilation\n')
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.assertTrue({'stdout': exp} in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.assertTrue({'stdout': exp} in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
+    @defer.inlineCallbacks
     def testTrickyArguments(self):
         # make sure non-trivial arguments are passed verbatim
         b = FakeWorkerForBuilder(self.basedir)
@@ -287,14 +266,12 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         ]
 
         s = runprocess.RunProcess(b, printArgsCommand() + args, self.basedir)
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.assertTrue({'stdout': nl(repr(args))} in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.assertTrue({'stdout': nl(repr(args))} in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
+    @defer.inlineCallbacks
     @compat.skipUnlessPlatformIs("win32")
     def testPipeString(self):
         b = FakeWorkerForBuilder(self.basedir)
@@ -303,45 +280,43 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
             ' -c "import sys; sys.stdout.write(\'b\\na\\n\')" | sort'
         s = runprocess.RunProcess(b, cmd, self.basedir)
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.assertTrue({'stdout': nl('a\nb\n')} in b.updates, b.show())
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.assertTrue({'stdout': nl('a\nb\n')} in b.updates, b.show())
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
+    @defer.inlineCallbacks
     def testCommandTimeout(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(b, sleepCommand(10), self.basedir, timeout=5)
         clock = task.Clock()
         s._reactor = clock
+
         d = s.start()
-
-        def check(ign):
-            self.assertTrue(
-                {'stdout': nl('hello\n')} not in b.updates, b.show())
-            self.assertTrue({'rc': FATAL_RC} in b.updates, b.show())
-        d.addCallback(check)
         clock.advance(6)
-        return d
+        yield d
 
+        self.assertTrue(
+            {'stdout': nl('hello\n')} not in b.updates, b.show())
+        self.assertTrue({'rc': FATAL_RC} in b.updates, b.show())
+
+    @defer.inlineCallbacks
     def testCommandMaxTime(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(b, sleepCommand(10), self.basedir, maxTime=5)
         clock = task.Clock()
         s._reactor = clock
-        d = s.start()
 
-        def check(ign):
-            self.assertTrue(
-                {'stdout': nl('hello\n')} not in b.updates, b.show())
-            self.assertTrue({'rc': FATAL_RC} in b.updates, b.show())
-        d.addCallback(check)
+        d = s.start()
         clock.advance(6)  # should knock out maxTime
-        return d
+        yield d
+
+        self.assertTrue(
+            {'stdout': nl('hello\n')} not in b.updates, b.show())
+        self.assertTrue({'rc': FATAL_RC} in b.updates, b.show())
 
     @compat.skipUnlessPlatformIs("posix")
+    @defer.inlineCallbacks
     def test_stdin_closed(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(b,
@@ -350,12 +325,9 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
                                   # if usePTY=True, stdin is never closed
                                   usePTY=False,
                                   logEnviron=False)
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            self.assertTrue({'rc': 0} in b.updates, b.show())
-        d.addCallback(check)
-        return d
+        self.assertTrue({'rc': 0} in b.updates, b.show())
 
     @compat.usesFlushLoggedErrors
     def test_startCommand_exception(self):
@@ -383,34 +355,31 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         d.addBoth(lambda _: self.flushLoggedErrors())
         return d
 
+    @defer.inlineCallbacks
     def testLogEnviron(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(b, stdoutCommand('hello'), self.basedir,
                                   environ={"FOO": "BAR"})
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            headers = "".join([list(update.values())[0]
-                               for update in b.updates if list(update) == ["header"]])
-            self.assertTrue("FOO=BAR" in headers, "got:\n" + headers)
-        d.addCallback(check)
-        return d
+        headers = "".join([list(update.values())[0]
+                           for update in b.updates if list(update) == ["header"]])
+        self.assertTrue("FOO=BAR" in headers, "got:\n" + headers)
 
+    @defer.inlineCallbacks
     def testNoLogEnviron(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(b, stdoutCommand('hello'), self.basedir,
                                   environ={"FOO": "BAR"}, logEnviron=False)
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            headers = "".join([list(update.values())[0]
-                               for update in b.updates if list(update) == ["header"]])
-            self.assertTrue("FOO=BAR" not in headers, "got:\n" + headers)
-        d.addCallback(check)
-        return d
+        headers = "".join([list(update.values())[0]
+                           for update in b.updates if list(update) == ["header"]])
+        self.assertTrue("FOO=BAR" not in headers, "got:\n" + headers)
 
+    @defer.inlineCallbacks
     def testEnvironExpandVar(self):
         b = FakeWorkerForBuilder(self.basedir)
         environ = {"EXPND": "-${PATH}-",
@@ -419,62 +388,53 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
         s = runprocess.RunProcess(
             b, stdoutCommand('hello'), self.basedir, environ=environ)
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            headers = "".join([list(update.values())[0]
-                               for update in b.updates if list(update) == ["header"]])
-            self.assertTrue("EXPND=-$" not in headers, "got:\n" + headers)
-            self.assertTrue("DOESNT_FIND=--" in headers, "got:\n" + headers)
-            self.assertTrue(
-                "DOESNT_EXPAND=-${---}-" in headers, "got:\n" + headers)
-        d.addCallback(check)
-        return d
+        headers = "".join([list(update.values())[0]
+                           for update in b.updates if list(update) == ["header"]])
+        self.assertTrue("EXPND=-$" not in headers, "got:\n" + headers)
+        self.assertTrue("DOESNT_FIND=--" in headers, "got:\n" + headers)
+        self.assertTrue(
+            "DOESNT_EXPAND=-${---}-" in headers, "got:\n" + headers)
 
+    @defer.inlineCallbacks
     def testUnsetEnvironVar(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(b, stdoutCommand('hello'), self.basedir,
                                   environ={"PATH": None})
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            headers = "".join([list(update.values())[0]
-                               for update in b.updates if list(update) == ["header"]])
-            self.assertFalse(
-                re.match('\bPATH=', headers), "got:\n" + headers)
-        d.addCallback(check)
-        return d
+        headers = "".join([list(update.values())[0]
+                           for update in b.updates if list(update) == ["header"]])
+        self.assertFalse(
+            re.match('\bPATH=', headers), "got:\n" + headers)
 
+    @defer.inlineCallbacks
     def testEnvironPythonPath(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(b, stdoutCommand('hello'), self.basedir,
                                   environ={"PYTHONPATH": 'a'})
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            headers = "".join([list(update.values())[0]
-                               for update in b.updates if list(update) == ["header"]])
-            self.assertFalse(re.match('\bPYTHONPATH=a{0}'.format(os.pathsep), headers),
-                             "got:\n" + headers)
-        d.addCallback(check)
-        return d
+        headers = "".join([list(update.values())[0]
+                           for update in b.updates if list(update) == ["header"]])
+        self.assertFalse(re.match('\bPYTHONPATH=a{0}'.format(os.pathsep), headers),
+                         "got:\n" + headers)
 
+    @defer.inlineCallbacks
     def testEnvironArray(self):
         b = FakeWorkerForBuilder(self.basedir)
         s = runprocess.RunProcess(b, stdoutCommand('hello'), self.basedir,
                                   environ={"FOO": ['a', 'b']})
 
-        d = s.start()
+        yield s.start()
 
-        def check(ign):
-            headers = "".join([list(update.values())[0]
-                               for update in b.updates if list(update) == ["header"]])
-            self.assertFalse(re.match('\bFOO=a{0}b\b'.format(os.pathsep), headers),
-                             "got:\n" + headers)
-        d.addCallback(check)
-        return d
+        headers = "".join([list(update.values())[0]
+                           for update in b.updates if list(update) == ["header"]])
+        self.assertFalse(re.match('\bFOO=a{0}b\b'.format(os.pathsep), headers),
+                         "got:\n" + headers)
 
     def testEnvironInt(self):
         b = FakeWorkerForBuilder(self.basedir)


### PR DESCRIPTION
This PR continues work by @p12tic (https://github.com/buildbot/buildbot/pull/4174). The `d.addCallback()` or `@d.addCallback()` style is replaced by @defer.inlineCallbacks decorator. The work is coordinated with @p12tic so there's no duplication of effort. The changes have been split into several PRs for easier reviewing.
