### PR TITLE
Use @defer.inlineCallbacks where possible (part 3)

### DIFF
--- a/master/buildbot/test/unit/test_changes_p4poller.py
+++ b/master/buildbot/test/unit/test_changes_p4poller.py
@@ -20,6 +20,7 @@ import datetime
 
 import dateutil.tz
 
+from twisted.internet import defer
 from twisted.internet import error
 from twisted.internet import reactor
 from twisted.python import failure
@@ -140,6 +141,7 @@ class TestP4Poller(changesource.ChangeSourceMixin,
                        split_file=lambda x: x.split('/', 1))
         self.assertEqual("MyName", cs2.name)
 
+    @defer.inlineCallbacks
     def do_test_poll_successful(self, **kwargs):
         encoding = kwargs.get('encoding', 'utf8')
         self.attachChangeSource(
@@ -160,78 +162,72 @@ class TestP4Poller(changesource.ChangeSourceMixin,
 
         # The first time, it just learns the change to start at.
         self.assertTrue(self.changesource.last_change is None)
-        d = self.changesource.poll()
+        yield self.changesource.poll()
 
-        def check_first_check(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [])
-            self.assertEqual(self.changesource.last_change, 1)
-        d.addCallback(check_first_check)
+        self.assertEqual(self.master.data.updates.changesAdded, [])
+        self.assertEqual(self.changesource.last_change, 1)
 
         # Subsequent times, it returns Change objects for new changes.
-        d.addCallback(lambda _: self.changesource.poll())
+        yield self.changesource.poll()
 
-        def check_second_check(res):
+        # when_timestamp is converted from a local time spec, so just
+        # replicate that here
+        when1 = self.makeTime("2006/04/13 21:46:23")
+        when2 = self.makeTime("2006/04/13 21:51:39")
 
-            # when_timestamp is converted from a local time spec, so just
-            # replicate that here
-            when1 = self.makeTime("2006/04/13 21:46:23")
-            when2 = self.makeTime("2006/04/13 21:51:39")
-
-            # these two can happen in either order, since they're from the same
-            # perforce change.
-            changesAdded = self.master.data.updates.changesAdded
-            if changesAdded[1]['branch'] == 'branch_c':
-                changesAdded[1:] = reversed(changesAdded[1:])
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': u'slamb',
-                'branch': u'trunk',
-                'category': None,
-                'codebase': None,
-                'comments': u'creation',
-                'files': [u'whatbranch'],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': '2',
-                'revlink': '',
-                'src': None,
-                'when_timestamp': datetime2epoch(when1),
-            }, {
-                'author': u'bob',
-                'branch': u'branch_b',
-                'category': None,
-                'codebase': None,
-                'comments':
-                    u'short desc truncated because this is a long description.\n'
-                    u'ASDF-GUI-P3-\u2018Upgrade Icon\u2019 disappears sometimes.',
-                'files': [u'branch_b_file', u'whatbranch'],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': '3',
-                'revlink': '',
-                'src': None,
-                'when_timestamp': datetime2epoch(when2),
-            }, {
-                'author': u'bob',
-                'branch': u'branch_c',
-                'category': None,
-                'codebase': None,
-                'comments':
-                    u'short desc truncated because this is a long description.\n'
-                    u'ASDF-GUI-P3-\u2018Upgrade Icon\u2019 disappears sometimes.',
-                'files': [u'whatbranch'],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': '3',
-                'revlink': '',
-                'src': None,
-                'when_timestamp': datetime2epoch(when2),
-            }])
-            self.assertAllCommandsRan()
-        d.addCallback(check_second_check)
-        return d
+        # these two can happen in either order, since they're from the same
+        # perforce change.
+        changesAdded = self.master.data.updates.changesAdded
+        if changesAdded[1]['branch'] == 'branch_c':
+            changesAdded[1:] = reversed(changesAdded[1:])
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': u'slamb',
+            'branch': u'trunk',
+            'category': None,
+            'codebase': None,
+            'comments': u'creation',
+            'files': [u'whatbranch'],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': '2',
+            'revlink': '',
+            'src': None,
+            'when_timestamp': datetime2epoch(when1),
+        }, {
+            'author': u'bob',
+            'branch': u'branch_b',
+            'category': None,
+            'codebase': None,
+            'comments':
+                u'short desc truncated because this is a long description.\n'
+                u'ASDF-GUI-P3-\u2018Upgrade Icon\u2019 disappears sometimes.',
+            'files': [u'branch_b_file', u'whatbranch'],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': '3',
+            'revlink': '',
+            'src': None,
+            'when_timestamp': datetime2epoch(when2),
+        }, {
+            'author': u'bob',
+            'branch': u'branch_c',
+            'category': None,
+            'codebase': None,
+            'comments':
+                u'short desc truncated because this is a long description.\n'
+                u'ASDF-GUI-P3-\u2018Upgrade Icon\u2019 disappears sometimes.',
+            'files': [u'whatbranch'],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': '3',
+            'revlink': '',
+            'src': None,
+            'when_timestamp': datetime2epoch(when2),
+        }])
+        self.assertAllCommandsRan()
 
     def test_poll_successful_default_encoding(self):
         return self.do_test_poll_successful()
@@ -251,6 +247,7 @@ class TestP4Poller(changesource.ChangeSourceMixin,
         d = self.changesource._poll()
         return self.assertFailure(d, P4PollerError)
 
+    @defer.inlineCallbacks
     def test_poll_failed_describe(self):
         self.attachChangeSource(
             P4Source(p4port=None, p4user=None,
@@ -267,15 +264,12 @@ class TestP4Poller(changesource.ChangeSourceMixin,
         self.changesource.last_change = 2
 
         # call _poll, so we can catch the failure
-        d = self.changesource._poll()
-        self.assertFailure(d, P4PollerError)
+        with self.assertRaises(P4PollerError):
+            yield self.changesource._poll()
 
-        @d.addCallback
-        def check(_):
-            # check that 2 was processed OK
-            self.assertEqual(self.changesource.last_change, 2)
-            self.assertAllCommandsRan()
-        return d
+        # check that 2 was processed OK
+        self.assertEqual(self.changesource.last_change, 2)
+        self.assertAllCommandsRan()
 
     def test_poll_unicode_error(self):
         self.attachChangeSource(
@@ -312,6 +306,7 @@ class TestP4Poller(changesource.ChangeSourceMixin,
         d = self.changesource._poll()
         return d
 
+    @defer.inlineCallbacks
     def test_acquire_ticket_auth(self):
         self.attachChangeSource(
             P4Source(p4port=None, p4user=None, p4passwd='pass',
@@ -347,14 +342,12 @@ class TestP4Poller(changesource.ChangeSourceMixin,
             pp.processEnded(failure.Failure(so))
         self.patch(reactor, 'spawnProcess', spawnProcess)
 
-        d = self.changesource.poll()
+        yield self.changesource.poll()
 
-        def check_ticket_passwd(_):
-            self.assertEqual(
-                self.changesource._ticket_passwd, 'TICKET_ID_GOES_HERE')
-        d.addCallback(check_ticket_passwd)
-        return d
+        self.assertEqual(
+            self.changesource._ticket_passwd, 'TICKET_ID_GOES_HERE')
 
+    @defer.inlineCallbacks
     def test_poll_split_file(self):
         """Make sure split file works on branch only changes"""
         self.attachChangeSource(
@@ -368,55 +361,53 @@ class TestP4Poller(changesource.ChangeSourceMixin,
         self.add_p4_describe_result(5, p4change[5])
 
         self.changesource.last_change = 50
-        d = self.changesource.poll()
+        yield self.changesource.poll()
 
-        def check(res):
-            # when_timestamp is converted from a local time spec, so just
-            # replicate that here
-            when = self.makeTime("2006/04/13 21:55:39")
+        # when_timestamp is converted from a local time spec, so just
+        # replicate that here
+        when = self.makeTime("2006/04/13 21:55:39")
 
-            def changeKey(change):
-                """ Let's sort the array of changes by branch,
-                    because in P4Source._poll(), changeAdded()
-                    is called by iterating over a dictionary of
-                    branches"""
-                return change['branch']
+        def changeKey(change):
+            """ Let's sort the array of changes by branch,
+                because in P4Source._poll(), changeAdded()
+                is called by iterating over a dictionary of
+                branches"""
+            return change['branch']
 
-            self.assertEqual(sorted(self.master.data.updates.changesAdded, key=changeKey),
-                sorted([{
-                'author': u'mpatel',
-                'branch': u'branch_c',
-                'category': None,
-                'codebase': None,
-                'comments': u'This is a multiline comment with tabs and spaces\n\nA list:\n  Item 1\n\tItem 2',
-                'files': [u'branch_c_file'],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': '5',
-                'revlink': '',
-                'src': None,
-                'when_timestamp': datetime2epoch(when),
-            }, {
-                'author': u'mpatel',
-                'branch': u'branch_b',
-                'category': None,
-                'codebase': None,
-                'comments': u'This is a multiline comment with tabs and spaces\n\nA list:\n  Item 1\n\tItem 2',
-                'files': [u'branch_b_file'],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': '5',
-                'revlink': '',
-                'src': None,
-                'when_timestamp': datetime2epoch(when),
-            }], key=changeKey))
-            self.assertEqual(self.changesource.last_change, 5)
-            self.assertAllCommandsRan()
-        d.addCallback(check)
-        return d
+        self.assertEqual(sorted(self.master.data.updates.changesAdded, key=changeKey),
+            sorted([{
+            'author': u'mpatel',
+            'branch': u'branch_c',
+            'category': None,
+            'codebase': None,
+            'comments': u'This is a multiline comment with tabs and spaces\n\nA list:\n  Item 1\n\tItem 2',
+            'files': [u'branch_c_file'],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': '5',
+            'revlink': '',
+            'src': None,
+            'when_timestamp': datetime2epoch(when),
+        }, {
+            'author': u'mpatel',
+            'branch': u'branch_b',
+            'category': None,
+            'codebase': None,
+            'comments': u'This is a multiline comment with tabs and spaces\n\nA list:\n  Item 1\n\tItem 2',
+            'files': [u'branch_b_file'],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': '5',
+            'revlink': '',
+            'src': None,
+            'when_timestamp': datetime2epoch(when),
+        }], key=changeKey))
+        self.assertEqual(self.changesource.last_change, 5)
+        self.assertAllCommandsRan()
 
+    @defer.inlineCallbacks
     def test_server_tz(self):
         """Verify that the server_tz parameter is handled correctly"""
         self.attachChangeSource(
@@ -431,21 +422,18 @@ class TestP4Poller(changesource.ChangeSourceMixin,
         self.add_p4_describe_result(5, p4change[5])
 
         self.changesource.last_change = 50
-        d = self.changesource.poll()
+        yield self.changesource.poll()
 
-        def check(res):
-            # when_timestamp is converted from 21:55:39 Berlin time to UTC
-            when_berlin = self.makeTime("2006/04/13 21:55:39")
-            when_berlin = when_berlin.replace(
-                tzinfo=dateutil.tz.gettz('Europe/Berlin'))
-            when = datetime2epoch(when_berlin)
+        # when_timestamp is converted from 21:55:39 Berlin time to UTC
+        when_berlin = self.makeTime("2006/04/13 21:55:39")
+        when_berlin = when_berlin.replace(
+            tzinfo=dateutil.tz.gettz('Europe/Berlin'))
+        when = datetime2epoch(when_berlin)
 
-            self.assertEqual([ch['when_timestamp']
-                              for ch in self.master.data.updates.changesAdded],
-                             [when, when])
-            self.assertAllCommandsRan()
-        d.addCallback(check)
-        return d
+        self.assertEqual([ch['when_timestamp']
+                          for ch in self.master.data.updates.changesAdded],
+                         [when, when])
+        self.assertAllCommandsRan()
 
     def test_resolveWho_callable(self):
         self.assertRaisesConfigError("You need to provide a valid callable for resolvewho",

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1645,16 +1645,14 @@ class FakeService(service.ReconfigurableServiceMixin,
     succeed = True
     call_index = 1
 
+    @defer.inlineCallbacks
     def reconfigServiceWithBuildbotConfig(self, new_config):
         self.called = FakeService.call_index
         FakeService.call_index += 1
-        d = service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(
+        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(
             self, new_config)
         if not self.succeed:
-            @d.addCallback
-            def fail(_):
-                raise ValueError("oh noes")
-        return d
+            raise ValueError("oh noes")
 
 
 class FakeMultiService(service.ReconfigurableServiceMixin,
@@ -1669,14 +1667,12 @@ class FakeMultiService(service.ReconfigurableServiceMixin,
 
 class ReconfigurableServiceMixin(unittest.TestCase):
 
+    @defer.inlineCallbacks
     def test_service(self):
         svc = FakeService()
-        d = svc.reconfigServiceWithBuildbotConfig(mock.Mock())
+        yield svc.reconfigServiceWithBuildbotConfig(mock.Mock())
 
-        @d.addCallback
-        def check(_):
-            self.assertTrue(svc.called)
-        return d
+        self.assertTrue(svc.called)
 
     @defer.inlineCallbacks
     def test_service_failure(self):
@@ -1689,6 +1685,7 @@ class ReconfigurableServiceMixin(unittest.TestCase):
         else:
             self.fail("should have raised ValueError")
 
+    @defer.inlineCallbacks
     def test_multiservice(self):
         svc = FakeMultiService()
         ch1 = FakeService()
@@ -1697,16 +1694,14 @@ class ReconfigurableServiceMixin(unittest.TestCase):
         ch2.setServiceParent(svc)
         ch3 = FakeService()
         ch3.setServiceParent(ch2)
-        d = svc.reconfigServiceWithBuildbotConfig(mock.Mock())
+        yield svc.reconfigServiceWithBuildbotConfig(mock.Mock())
 
-        @d.addCallback
-        def check(_):
-            self.assertTrue(svc.called)
-            self.assertTrue(ch1.called)
-            self.assertTrue(ch2.called)
-            self.assertTrue(ch3.called)
-        return d
+        self.assertTrue(svc.called)
+        self.assertTrue(ch1.called)
+        self.assertTrue(ch2.called)
+        self.assertTrue(ch3.called)
 
+    @defer.inlineCallbacks
     def test_multiservice_priority(self):
         parent = FakeMultiService()
         svc128 = FakeService()
@@ -1719,14 +1714,11 @@ class ReconfigurableServiceMixin(unittest.TestCase):
             svc.setServiceParent(parent)
             services.append(svc)
 
-        d = parent.reconfigServiceWithBuildbotConfig(mock.Mock())
+        yield parent.reconfigServiceWithBuildbotConfig(mock.Mock())
 
-        @d.addCallback
-        def check(_):
-            prio_order = [svc.called for svc in services]
-            called_order = sorted(prio_order)
-            self.assertEqual(prio_order, called_order)
-        return d
+        prio_order = [s.called for s in services]
+        called_order = sorted(prio_order)
+        self.assertEqual(prio_order, called_order)
 
     @defer.inlineCallbacks
     def test_multiservice_nested_failure(self):

--- a/master/buildbot/test/unit/test_db_base.py
+++ b/master/buildbot/test/unit/test_db_base.py
@@ -95,15 +95,13 @@ class TestBase(unittest.TestCase):
 class TestBaseAsConnectorComponent(unittest.TestCase,
                                    connector_component.ConnectorComponentMixin):
 
+    @defer.inlineCallbacks
     def setUp(self):
         # this co-opts the masters table to test findSomethingId
-        d = self.setUpConnectorComponent(
+        yield self.setUpConnectorComponent(
             table_names=['masters'])
 
-        @d.addCallback
-        def finish_setup(_):
-            self.db.base = base.DBConnectorComponent(self.db)
-        return d
+        self.db.base = base.DBConnectorComponent(self.db)
 
     @defer.inlineCallbacks
     def test_findSomethingId_race(self):

--- a/master/buildbot/test/unit/test_db_builders.py
+++ b/master/buildbot/test/unit/test_db_builders.py
@@ -263,19 +263,16 @@ class TestRealDB(unittest.TestCase,
                  connector_component.ConnectorComponentMixin,
                  RealTests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        d = self.setUpConnectorComponent(
+        yield self.setUpConnectorComponent(
             table_names=['builders', 'masters', 'builder_masters',
                          'builders_tags', 'tags'])
 
-        @d.addCallback
-        def finish_setup(_):
-            self.db.builders = builders.BuildersConnectorComponent(self.db)
-            self.db.tags = tags.TagsConnectorComponent(self.db)
-            self.master = self.db.master
-            self.master.db = self.db
-
-        return d
+        self.db.builders = builders.BuildersConnectorComponent(self.db)
+        self.db.tags = tags.TagsConnectorComponent(self.db)
+        self.master = self.db.master
+        self.master.db = self.db
 
     def tearDown(self):
         return self.tearDownConnectorComponent()

--- a/master/buildbot/test/unit/test_db_builds.py
+++ b/master/buildbot/test/unit/test_db_builds.py
@@ -443,15 +443,13 @@ class TestRealDB(unittest.TestCase,
                  connector_component.ConnectorComponentMixin,
                  RealTests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        d = self.setUpConnectorComponent(
+        yield self.setUpConnectorComponent(
             table_names=['builds', 'builders', 'masters', 'buildrequests',
                          'buildsets', 'workers', 'build_properties'])
 
-        @d.addCallback
-        def finish_setup(_):
-            self.db.builds = builds.BuildsConnectorComponent(self.db)
-        return d
+        self.db.builds = builds.BuildsConnectorComponent(self.db)
 
     def tearDown(self):
         return self.tearDownConnectorComponent()

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -587,16 +587,14 @@ class TestRealDB(unittest.TestCase,
                  connector_component.ConnectorComponentMixin,
                  RealTests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        d = self.setUpConnectorComponent(
+        yield self.setUpConnectorComponent(
             table_names=['logs', 'logchunks', 'steps', 'builds', 'builders',
                          'masters', 'buildrequests', 'buildsets',
                          'workers'])
 
-        @d.addCallback
-        def finish_setup(_):
-            self.db.logs = logs.LogsConnectorComponent(self.db)
-        return d
+        self.db.logs = logs.LogsConnectorComponent(self.db)
 
     def tearDown(self):
         return self.tearDownConnectorComponent()

--- a/master/buildbot/test/unit/test_db_masters.py
+++ b/master/buildbot/test/unit/test_db_masters.py
@@ -222,17 +222,15 @@ class TestRealDB(unittest.TestCase,
                  connector_component.ConnectorComponentMixin,
                  RealTests):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.clock = task.Clock()
         self.clock.advance(SOMETIME)
 
-        d = self.setUpConnectorComponent(
+        yield self.setUpConnectorComponent(
             table_names=['masters', 'schedulers', 'scheduler_masters'])
 
-        @d.addCallback
-        def finish_setup(_):
-            self.db.masters = masters.MastersConnectorComponent(self.db)
-        return d
+        self.db.masters = masters.MastersConnectorComponent(self.db)
 
     def tearDown(self):
         return self.tearDownConnectorComponent()

--- a/master/buildbot/test/unit/test_db_steps.py
+++ b/master/buildbot/test/unit/test_db_steps.py
@@ -359,15 +359,13 @@ class TestRealDB(unittest.TestCase,
                  connector_component.ConnectorComponentMixin,
                  RealTests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        d = self.setUpConnectorComponent(
+        yield self.setUpConnectorComponent(
             table_names=['steps', 'builds', 'builders', 'masters',
                          'buildrequests', 'buildsets', 'workers'])
 
-        @d.addCallback
-        def finish_setup(_):
-            self.db.steps = steps.StepsConnectorComponent(self.db)
-        return d
+        self.db.steps = steps.StepsConnectorComponent(self.db)
 
     def tearDown(self):
         return self.tearDownConnectorComponent()

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -70,18 +70,16 @@ class MQConnector(unittest.TestCase):
         self.assertEqual(self.conn.impl.startConsuming,
                          self.conn.startConsuming)
 
+    @defer.inlineCallbacks
     def test_reconfigServiceWithBuildbotConfig(self):
         self.patchFakeMQ()
         self.mqconfig['type'] = 'fake'
         self.conn.setup()
         new_config = mock.Mock()
         new_config.mq = dict(type='fake')
-        d = self.conn.reconfigServiceWithBuildbotConfig(new_config)
+        yield self.conn.reconfigServiceWithBuildbotConfig(new_config)
 
-        @d.addCallback
-        def check(_):
-            self.assertIdentical(self.conn.impl.new_config, new_config)
-        return d
+        self.assertIdentical(self.conn.impl.new_config, new_config)
 
     @defer.inlineCallbacks
     def test_reconfigService_change_type(self):

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -163,6 +163,7 @@ class TestBotMaster(unittest.TestCase):
     def tearDown(self):
         return self.botmaster.stopService()
 
+    @defer.inlineCallbacks
     def test_reconfigServiceWithBuildbotConfig(self):
         # check that reconfigServiceBuilders is called.
         self.patch(self.botmaster, 'reconfigServiceBuilders',
@@ -171,15 +172,12 @@ class TestBotMaster(unittest.TestCase):
                    mock.Mock())
 
         new_config = mock.Mock()
-        d = self.botmaster.reconfigServiceWithBuildbotConfig(new_config)
+        yield self.botmaster.reconfigServiceWithBuildbotConfig(new_config)
 
-        @d.addCallback
-        def check(_):
-            self.botmaster.reconfigServiceBuilders.assert_called_with(
-                new_config)
-            self.assertTrue(
-                self.botmaster.maybeStartBuildsForAllBuilders.called)
-        return d
+        self.botmaster.reconfigServiceBuilders.assert_called_with(
+            new_config)
+        self.assertTrue(
+            self.botmaster.maybeStartBuildsForAllBuilders.called)
 
     @defer.inlineCallbacks
     def test_reconfigServiceBuilders_add_remove(self):


### PR DESCRIPTION
This PR continues work by @p12tic (https://github.com/buildbot/buildbot/pull/4174). The `d.addCallback()` or `@d.addCallback()` style is replaced by @defer.inlineCallbacks decorator. The work is coordinated with @p12tic so there's no duplication of effort. The changes have been split into several PRs for easier reviewing.
