### PR TITLE
Use @defer.inlineCallbacks where possible (part 4)

### DIFF
--- a/master/buildbot/test/unit/test_changes_mail.py
+++ b/master/buildbot/test/unit/test_changes_mail.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import os
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.changes import mail
@@ -28,12 +29,12 @@ from buildbot.test.util import dirs
 class TestMaildirSource(changesource.ChangeSourceMixin, dirs.DirsMixin,
                         unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.maildir = os.path.abspath("maildir")
 
-        d = self.setUpChangeSource()
-        d.addCallback(lambda _: self.setUpDirs(self.maildir))
-        return d
+        yield self.setUpChangeSource()
+        yield self.setUpDirs(self.maildir)
 
     def populateMaildir(self):
         "create a fake maildir with a fake new message ('newmsg') in it"
@@ -54,10 +55,10 @@ class TestMaildirSource(changesource.ChangeSourceMixin, dirs.DirsMixin,
         self.assertTrue(
             os.path.exists(os.path.join(self.maildir, "cur", "newmsg")))
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        d = self.tearDownDirs()
-        d.addCallback(lambda _: self.tearDownChangeSource())
-        return d
+        yield self.tearDownDirs()
+        yield self.tearDownChangeSource()
 
     # tests
 
@@ -65,6 +66,7 @@ class TestMaildirSource(changesource.ChangeSourceMixin, dirs.DirsMixin,
         mds = mail.MaildirSource(self.maildir)
         self.assertSubstring(self.maildir, mds.describe())
 
+    @defer.inlineCallbacks
     def test_messageReceived_svn(self):
         self.populateMaildir()
         mds = mail.MaildirSource(self.maildir)
@@ -76,28 +78,26 @@ class TestMaildirSource(changesource.ChangeSourceMixin, dirs.DirsMixin,
             return (u'svn', dict(author=u'jimmy'))
         mds.parse = parse
 
-        d = mds.messageReceived('newmsg')
+        yield mds.messageReceived('newmsg')
 
-        def check(_):
-            self.assertMailProcessed()
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': 'jimmy',
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': None,
-                'files': None,
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': 'svn',
-                'when_timestamp': None,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertMailProcessed()
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': 'jimmy',
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': None,
+            'files': None,
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': 'svn',
+            'when_timestamp': None,
+        }])
 
+    @defer.inlineCallbacks
     def test_messageReceived_bzr(self):
         self.populateMaildir()
         mds = mail.MaildirSource(self.maildir)
@@ -109,24 +109,21 @@ class TestMaildirSource(changesource.ChangeSourceMixin, dirs.DirsMixin,
             return (u'bzr', dict(author=u'jimmy'))
         mds.parse = parse
 
-        d = mds.messageReceived('newmsg')
+        yield mds.messageReceived('newmsg')
 
-        def check(_):
-            self.assertMailProcessed()
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': 'jimmy',
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': None,
-                'files': None,
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': 'bzr',
-                'when_timestamp': None,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertMailProcessed()
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': 'jimmy',
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': None,
+            'files': None,
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': 'bzr',
+            'when_timestamp': None,
+        }])

--- a/master/buildbot/test/unit/test_changes_pb.py
+++ b/master/buildbot/test/unit/test_changes_pb.py
@@ -41,15 +41,12 @@ class TestPBChangeSource(
 
     EXP_DEFAULT_REGISTRATION = ('9999', 'alice', 'sekrit')
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpPBChangeSource()
-        d = self.setUpChangeSource()
+        yield self.setUpChangeSource()
 
-        @d.addCallback
-        def setup(_):
-            self.master.pbmanager = self.pbmanager
-
-        return d
+        self.master.pbmanager = self.pbmanager
 
     def test_registration_no_workerport(self):
         return self._test_registration(None, exp_ConfigErrors=True,
@@ -222,270 +219,248 @@ class TestChangePerspective(unittest.TestCase):
         self.master = fakemaster.make_master(testcase=self,
                                              wantDb=True, wantData=True)
 
+    @defer.inlineCallbacks
     def test_addChange_noprefix(self):
         cp = pb.ChangePerspective(self.master, None)
-        d = cp.perspective_addChange(dict(who="bar", files=['a']))
+        yield cp.perspective_addChange(dict(who="bar", files=['a']))
 
-        def check(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': u'bar',
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': None,
-                'files': [u'a'],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': None,
-                'when_timestamp': None,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': u'bar',
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': None,
+            'files': [u'a'],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': None,
+            'when_timestamp': None,
+        }])
 
+    @defer.inlineCallbacks
     def test_addChange_codebase(self):
         cp = pb.ChangePerspective(self.master, None)
-        d = cp.perspective_addChange(dict(who="bar", files=[], codebase='cb'))
+        yield cp.perspective_addChange(dict(who="bar", files=[], codebase='cb'))
 
-        def check(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': u'bar',
-                'branch': None,
-                'category': None,
-                'codebase': u'cb',
-                'comments': None,
-                'files': [],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': None,
-                'when_timestamp': None,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': u'bar',
+            'branch': None,
+            'category': None,
+            'codebase': u'cb',
+            'comments': None,
+            'files': [],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': None,
+            'when_timestamp': None,
+        }])
 
+    @defer.inlineCallbacks
     def test_addChange_prefix(self):
         cp = pb.ChangePerspective(self.master, 'xx/')
-        d = cp.perspective_addChange(
+        yield cp.perspective_addChange(
             dict(who="bar", files=['xx/a', 'yy/b']))
 
-        def check(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': u'bar',
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': None,
-                'files': [u'a'],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': None,
-                'when_timestamp': None,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': u'bar',
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': None,
+            'files': [u'a'],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': None,
+            'when_timestamp': None,
+        }])
 
+    @defer.inlineCallbacks
     def test_addChange_sanitize_None(self):
         cp = pb.ChangePerspective(self.master, None)
-        d = cp.perspective_addChange(
+        yield cp.perspective_addChange(
             dict(project=None, revlink=None, repository=None)
         )
 
-        def check(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': None,
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': None,
-                'files': [],
-                'project': u'',
-                'properties': {},
-                'repository': u'',
-                'revision': None,
-                'revlink': u'',
-                'src': None,
-                'when_timestamp': None,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': None,
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': None,
+            'files': [],
+            'project': u'',
+            'properties': {},
+            'repository': u'',
+            'revision': None,
+            'revlink': u'',
+            'src': None,
+            'when_timestamp': None,
+        }])
 
+    @defer.inlineCallbacks
     def test_addChange_when_None(self):
         cp = pb.ChangePerspective(self.master, None)
-        d = cp.perspective_addChange(
+        yield cp.perspective_addChange(
             dict(when=None)
         )
 
-        def check(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': None,
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': None,
-                'files': [],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': None,
-                'when_timestamp': None,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': None,
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': None,
+            'files': [],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': None,
+            'when_timestamp': None,
+        }])
 
+    @defer.inlineCallbacks
     def test_addChange_files_tuple(self):
         cp = pb.ChangePerspective(self.master, None)
-        d = cp.perspective_addChange(
+        yield cp.perspective_addChange(
             dict(files=('a', 'b'))
         )
 
-        def check(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': None,
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': None,
-                'files': [u'a', u'b'],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': None,
-                'when_timestamp': None,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': None,
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': None,
+            'files': [u'a', u'b'],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': None,
+            'when_timestamp': None,
+        }])
 
+    @defer.inlineCallbacks
     def test_addChange_unicode(self):
         cp = pb.ChangePerspective(self.master, None)
-        d = cp.perspective_addChange(dict(author=u"\N{SNOWMAN}",
+        yield cp.perspective_addChange(dict(author=u"\N{SNOWMAN}",
                                           comments=u"\N{SNOWMAN}",
                                           files=[u'\N{VERY MUCH GREATER-THAN}']))
 
-        def check(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': u'\u2603',
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': u'\u2603',
-                'files': [u'\u22d9'],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': None,
-                'when_timestamp': None,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': u'\u2603',
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': u'\u2603',
+            'files': [u'\u22d9'],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': None,
+            'when_timestamp': None,
+        }])
 
+    @defer.inlineCallbacks
     def test_addChange_unicode_as_bytestring(self):
         cp = pb.ChangePerspective(self.master, None)
-        d = cp.perspective_addChange(dict(author=u"\N{SNOWMAN}".encode('utf8'),
+        yield cp.perspective_addChange(dict(author=u"\N{SNOWMAN}".encode('utf8'),
                                           comments=u"\N{SNOWMAN}".encode(
                                               'utf8'),
                                           files=[u'\N{VERY MUCH GREATER-THAN}'.encode('utf8')]))
 
-        def check(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': u'\u2603',
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': u'\u2603',
-                'files': [u'\u22d9'],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': None,
-                'when_timestamp': None,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': u'\u2603',
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': u'\u2603',
+            'files': [u'\u22d9'],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': None,
+            'when_timestamp': None,
+        }])
 
+    @defer.inlineCallbacks
     def test_addChange_non_utf8_bytestring(self):
         cp = pb.ChangePerspective(self.master, None)
         bogus_utf8 = b'\xff\xff\xff\xff'
         replacement = bogus_utf8.decode('utf8', 'replace')
-        d = cp.perspective_addChange(dict(author=bogus_utf8, files=['a']))
+        yield cp.perspective_addChange(dict(author=bogus_utf8, files=['a']))
 
-        def check(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': replacement,
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': None,
-                'files': [u'a'],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': None,
-                'when_timestamp': None,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': replacement,
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': None,
+            'files': [u'a'],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': None,
+            'when_timestamp': None,
+        }])
 
+    @defer.inlineCallbacks
     def test_addChange_old_param_names(self):
         cp = pb.ChangePerspective(self.master, None)
-        d = cp.perspective_addChange(dict(who='me', when=1234,
+        yield cp.perspective_addChange(dict(who='me', when=1234,
                                           files=[]))
 
-        def check(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': u'me',
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': None,
-                'files': [],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': None,
-                'when_timestamp': 1234,
-            }])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': u'me',
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': None,
+            'files': [],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': None,
+            'when_timestamp': 1234,
+        }])
 
+    @defer.inlineCallbacks
     def test_createUserObject_git_src(self):
         cp = pb.ChangePerspective(self.master, None)
-        d = cp.perspective_addChange(dict(who="c <h@c>", src='git'))
+        yield cp.perspective_addChange(dict(who="c <h@c>", src='git'))
 
-        def check_change(_):
-            self.assertEqual(self.master.data.updates.changesAdded, [{
-                'author': u'c <h@c>',
-                'branch': None,
-                'category': None,
-                'codebase': None,
-                'comments': None,
-                'files': [],
-                'project': '',
-                'properties': {},
-                'repository': '',
-                'revision': None,
-                'revlink': '',
-                'src': u'git',
-                'when_timestamp': None,
-            }])
-        d.addCallback(check_change)
-        return d
+        self.assertEqual(self.master.data.updates.changesAdded, [{
+            'author': u'c <h@c>',
+            'branch': None,
+            'category': None,
+            'codebase': None,
+            'comments': None,
+            'files': [],
+            'project': '',
+            'properties': {},
+            'repository': '',
+            'revision': None,
+            'revlink': '',
+            'src': u'git',
+            'when_timestamp': None,
+        }])

--- a/master/buildbot/test/unit/test_clients_sendchange.py
+++ b/master/buildbot/test/unit/test_clients_sendchange.py
@@ -75,77 +75,68 @@ class Sender(unittest.TestCase):
                           self.creds.username, self.creds.password,
                           self.added_changes])
 
+    @defer.inlineCallbacks
     def test_send_minimal(self):
         s = sendchange.Sender('localhost:1234')
-        d = s.send('branch', 'rev', 'comm', ['a'])
+        yield s.send('branch', 'rev', 'comm', ['a'])
 
-        def check(_):
-            self.assertProcess('localhost', 1234, 'change', 'changepw', [
-                dict(project='', repository='', who=None, files=['a'],
-                     comments='comm', branch='branch', revision='rev',
-                     category=None, when=None, properties={}, revlink='',
-                     src=None)])
-        d.addCallback(check)
-        return d
+        self.assertProcess('localhost', 1234, 'change', 'changepw', [
+            dict(project='', repository='', who=None, files=['a'],
+                 comments='comm', branch='branch', revision='rev',
+                 category=None, when=None, properties={}, revlink='',
+                 src=None)])
 
+    @defer.inlineCallbacks
     def test_send_auth(self):
         s = sendchange.Sender('localhost:1234', auth=('me', 'sekrit'))
-        d = s.send('branch', 'rev', 'comm', ['a'])
+        yield s.send('branch', 'rev', 'comm', ['a'])
 
-        def check(_):
-            self.assertProcess('localhost', 1234, 'me', 'sekrit', [
-                dict(project='', repository='', who=None, files=['a'],
-                     comments='comm', branch='branch', revision='rev',
-                     category=None, when=None, properties={}, revlink='',
-                     src=None)])
-        d.addCallback(check)
-        return d
+        self.assertProcess('localhost', 1234, 'me', 'sekrit', [
+            dict(project='', repository='', who=None, files=['a'],
+                 comments='comm', branch='branch', revision='rev',
+                 category=None, when=None, properties={}, revlink='',
+                 src=None)])
 
+    @defer.inlineCallbacks
     def test_send_full(self):
         s = sendchange.Sender('localhost:1234')
-        d = s.send('branch', 'rev', 'comm', ['a'], who='me', category='cats',
+        yield s.send('branch', 'rev', 'comm', ['a'], who='me', category='cats',
                    when=1234, properties={'a': 'b'}, repository='r', vc='git',
                    project='p', revlink='rl')
 
-        def check(_):
-            self.assertProcess('localhost', 1234, 'change', 'changepw', [
-                dict(project='p', repository='r', who='me', files=['a'],
-                     comments='comm', branch='branch', revision='rev',
-                     category='cats', when=1234, properties={'a': 'b'},
-                     revlink='rl', src='git')])
-        d.addCallback(check)
-        return d
+        self.assertProcess('localhost', 1234, 'change', 'changepw', [
+            dict(project='p', repository='r', who='me', files=['a'],
+                 comments='comm', branch='branch', revision='rev',
+                 category='cats', when=1234, properties={'a': 'b'},
+                 revlink='rl', src='git')])
 
+    @defer.inlineCallbacks
     def test_send_files_tuple(self):
         # 'buildbot sendchange' sends files as a tuple, rather than a list..
         s = sendchange.Sender('localhost:1234')
-        d = s.send('branch', 'rev', 'comm', ('a', 'b'))
+        yield s.send('branch', 'rev', 'comm', ('a', 'b'))
 
-        def check(_):
-            self.assertProcess('localhost', 1234, 'change', 'changepw', [
-                dict(project='', repository='', who=None, files=['a', 'b'],
-                     comments='comm', branch='branch', revision='rev',
-                     category=None, when=None, properties={}, revlink='',
-                     src=None)])
-        d.addCallback(check)
-        return d
+        self.assertProcess('localhost', 1234, 'change', 'changepw', [
+            dict(project='', repository='', who=None, files=['a', 'b'],
+                 comments='comm', branch='branch', revision='rev',
+                 category=None, when=None, properties={}, revlink='',
+                 src=None)])
 
+    @defer.inlineCallbacks
     def test_send_codebase(self):
         s = sendchange.Sender('localhost:1234')
-        d = s.send('branch', 'rev', 'comm', ['a'], codebase='mycb')
+        yield s.send('branch', 'rev', 'comm', ['a'], codebase='mycb')
 
-        def check(_):
-            self.assertProcess('localhost', 1234, 'change', 'changepw', [
-                dict(project='', repository='', who=None, files=['a'],
-                     comments='comm', branch='branch', revision='rev',
-                     category=None, when=None, properties={}, revlink='',
-                     src=None, codebase='mycb')])
-        d.addCallback(check)
-        return d
+        self.assertProcess('localhost', 1234, 'change', 'changepw', [
+            dict(project='', repository='', who=None, files=['a'],
+                 comments='comm', branch='branch', revision='rev',
+                 category=None, when=None, properties={}, revlink='',
+                 src=None, codebase='mycb')])
 
+    @defer.inlineCallbacks
     def test_send_unicode(self):
         s = sendchange.Sender('localhost:1234')
-        d = s.send(u'\N{DEGREE SIGN}',
+        yield s.send(u'\N{DEGREE SIGN}',
                    u'\U0001f49e',
                    u'\N{POSTAL MARK FACE}',
                    [u'\U0001F4C1'],
@@ -157,27 +148,25 @@ class Sender(unittest.TestCase):
                    properties={u'\N{LATIN SMALL LETTER A WITH MACRON}': 'b'},
                    revlink=u'\U0001F517')
 
-        def check(_):
-            self.assertProcess('localhost', 1234, 'change', 'changepw', [
-                dict(project=u'\N{SKULL AND CROSSBONES}',
-                     repository=u'\N{SNOWMAN}',
-                     who=u'\N{THAI CHARACTER KHOMUT}',
-                     files=[u'\U0001F4C1'],  # FILE FOLDER
-                     comments=u'\N{POSTAL MARK FACE}',
-                     branch=u'\N{DEGREE SIGN}',
-                     revision=u'\U0001f49e',  # REVOLVING HEARTS
-                     category=u'\U0001F640',  # WEARY CAT FACE
-                     when=1234,
-                     properties={u'\N{LATIN SMALL LETTER A WITH MACRON}': 'b'},
-                     revlink=u'\U0001F517',  # LINK SYMBOL
-                     src=None)])
-        d.addCallback(check)
-        return d
+        self.assertProcess('localhost', 1234, 'change', 'changepw', [
+            dict(project=u'\N{SKULL AND CROSSBONES}',
+                 repository=u'\N{SNOWMAN}',
+                 who=u'\N{THAI CHARACTER KHOMUT}',
+                 files=[u'\U0001F4C1'],  # FILE FOLDER
+                 comments=u'\N{POSTAL MARK FACE}',
+                 branch=u'\N{DEGREE SIGN}',
+                 revision=u'\U0001f49e',  # REVOLVING HEARTS
+                 category=u'\U0001F640',  # WEARY CAT FACE
+                 when=1234,
+                 properties={u'\N{LATIN SMALL LETTER A WITH MACRON}': 'b'},
+                 revlink=u'\U0001F517',  # LINK SYMBOL
+                 src=None)])
 
+    @defer.inlineCallbacks
     def test_send_unicode_utf8(self):
         s = sendchange.Sender('localhost:1234')
 
-        d = s.send(u'\N{DEGREE SIGN}'.encode('utf8'),
+        yield s.send(u'\N{DEGREE SIGN}'.encode('utf8'),
                    u'\U0001f49e'.encode('utf8'),
                    u'\N{POSTAL MARK FACE}'.encode('utf8'),
                    [u'\U0001F4C1'.encode('utf8')],
@@ -190,30 +179,28 @@ class Sender(unittest.TestCase):
                        u'\N{LATIN SMALL LETTER A WITH MACRON}'.encode('utf8'): 'b'},
                    revlink=u'\U0001F517'.encode('utf8'))
 
-        def check(_):
-            self.assertProcess('localhost', 1234, 'change', 'changepw', [
-                dict(project=u'\N{SKULL AND CROSSBONES}',
-                     repository=u'\N{SNOWMAN}',
-                     who=u'\N{THAI CHARACTER KHOMUT}',
-                     files=[u'\U0001F4C1'],  # FILE FOLDER
-                     comments=u'\N{POSTAL MARK FACE}',
-                     branch=u'\N{DEGREE SIGN}',
-                     revision=u'\U0001f49e',  # REVOLVING HEARTS
-                     category=u'\U0001F640',  # WEARY CAT FACE
-                     when=1234,
-                     # NOTE: not decoded!
-                     properties={b'\xc4\x81': 'b'},
-                     revlink=u'\U0001F517',  # LINK SYMBOL
-                     src=None)])
-        d.addCallback(check)
-        return d
+        self.assertProcess('localhost', 1234, 'change', 'changepw', [
+            dict(project=u'\N{SKULL AND CROSSBONES}',
+                 repository=u'\N{SNOWMAN}',
+                 who=u'\N{THAI CHARACTER KHOMUT}',
+                 files=[u'\U0001F4C1'],  # FILE FOLDER
+                 comments=u'\N{POSTAL MARK FACE}',
+                 branch=u'\N{DEGREE SIGN}',
+                 revision=u'\U0001f49e',  # REVOLVING HEARTS
+                 category=u'\U0001F640',  # WEARY CAT FACE
+                 when=1234,
+                 # NOTE: not decoded!
+                 properties={b'\xc4\x81': 'b'},
+                 revlink=u'\U0001F517',  # LINK SYMBOL
+                 src=None)])
 
+    @defer.inlineCallbacks
     def test_send_unicode_latin1(self):
         # hand send() a bunch of latin1 strings, and expect them recoded
         # to unicode
         s = sendchange.Sender('localhost:1234', encoding='latin1')
 
-        d = s.send(u'\N{YEN SIGN}'.encode('latin1'),
+        yield s.send(u'\N{YEN SIGN}'.encode('latin1'),
                    u'\N{POUND SIGN}'.encode('latin1'),
                    u'\N{BROKEN BAR}'.encode('latin1'),
                    [u'\N{NOT SIGN}'.encode('latin1')],
@@ -226,20 +213,17 @@ class Sender(unittest.TestCase):
                        u'\N{SUPERSCRIPT ONE}'.encode('latin1'): 'b'},
                    revlink=u'\N{INVERTED QUESTION MARK}'.encode('latin1'))
 
-        def check(_):
-            self.assertProcess('localhost', 1234, 'change', 'changepw', [
-                dict(project=u'\N{DEGREE SIGN}',
-                     repository=u'\N{SECTION SIGN}',
-                     who=u'\N{MACRON}',
-                     files=[u'\N{NOT SIGN}'],
-                     comments=u'\N{BROKEN BAR}',
-                     branch=u'\N{YEN SIGN}',
-                     revision=u'\N{POUND SIGN}',
-                     category=u'\N{PILCROW SIGN}',
-                     when=1234,
-                     # NOTE: not decoded!
-                     properties={b'\xb9': 'b'},
-                     revlink=u'\N{INVERTED QUESTION MARK}',
-                     src=None)])
-        d.addCallback(check)
-        return d
+        self.assertProcess('localhost', 1234, 'change', 'changepw', [
+            dict(project=u'\N{DEGREE SIGN}',
+                 repository=u'\N{SECTION SIGN}',
+                 who=u'\N{MACRON}',
+                 files=[u'\N{NOT SIGN}'],
+                 comments=u'\N{BROKEN BAR}',
+                 branch=u'\N{YEN SIGN}',
+                 revision=u'\N{POUND SIGN}',
+                 category=u'\N{PILCROW SIGN}',
+                 when=1234,
+                 # NOTE: not decoded!
+                 properties={b'\xb9': 'b'},
+                 revlink=u'\N{INVERTED QUESTION MARK}',
+                 src=None)])

--- a/master/buildbot/test/unit/test_clients_usersclient.py
+++ b/master/buildbot/test/unit/test_clients_usersclient.py
@@ -70,26 +70,22 @@ class TestUsersClient(unittest.TestCase):
         self.assertEqual([host, port, called_with],
                          [self.conn_host, self.conn_port, self.called_with])
 
+    @defer.inlineCallbacks
     def test_usersclient_info(self):
         uc = usersclient.UsersClient('localhost', "user", "userpw", 1234)
-        d = uc.send('update', 'bb_user', 'hashed_bb_pass', None,
+        yield uc.send('update', 'bb_user', 'hashed_bb_pass', None,
                     [{'identifier': 'x', 'svn': 'x'}])
 
-        def check(_):
-            self.assertProcess('localhost', 1234,
-                               dict(op='update', bb_username='bb_user',
-                                    bb_password='hashed_bb_pass', ids=None,
-                                    info=[dict(identifier='x', svn='x')]))
-        d.addCallback(check)
-        return d
+        self.assertProcess('localhost', 1234,
+                           dict(op='update', bb_username='bb_user',
+                                bb_password='hashed_bb_pass', ids=None,
+                                info=[dict(identifier='x', svn='x')]))
 
+    @defer.inlineCallbacks
     def test_usersclient_ids(self):
         uc = usersclient.UsersClient('localhost', "user", "userpw", 1234)
-        d = uc.send('remove', None, None, ['x'], None)
+        yield uc.send('remove', None, None, ['x'], None)
 
-        def check(_):
-            self.assertProcess('localhost', 1234,
-                               dict(op='remove', bb_username=None,
-                                    bb_password=None, ids=['x'], info=None))
-        d.addCallback(check)
-        return d
+        self.assertProcess('localhost', 1234,
+                           dict(op='remove', bb_username=None,
+                           bb_password=None, ids=['x'], info=None))

--- a/master/buildbot/test/unit/test_data_changes.py
+++ b/master/buildbot/test/unit/test_data_changes.py
@@ -217,6 +217,7 @@ class Change(interfaces.InterfaceTests, unittest.TestCase):
         return self.do_test_addChange(kwargs,
                                       expectedRoutingKey, expectedMessage, expectedRow)
 
+    @defer.inlineCallbacks
     def test_addChange_src_codebase(self):
         createUserObject = mock.Mock(spec=users.createUserObject)
         createUserObject.return_value = defer.succeed(123)
@@ -270,15 +271,11 @@ class Change(interfaces.InterfaceTests, unittest.TestCase):
             project='Buildbot',
             sourcestampid=100,
         )
-        d = self.do_test_addChange(kwargs,
+        yield self.do_test_addChange(kwargs,
                                    expectedRoutingKey, expectedMessage, expectedRow,
                                    expectedChangeUsers=[123])
 
-        @d.addCallback
-        def check(_):
-            createUserObject.assert_called_once_with(
-                self.master, 'warner', 'git')
-        return d
+        createUserObject.assert_called_once_with(self.master, 'warner', 'git')
 
     def test_addChange_src_codebaseGenerator(self):
         def preChangeGenerator(**kwargs):

--- a/master/buildbot/test/unit/test_db_buildrequests.py
+++ b/master/buildbot/test/unit/test_db_buildrequests.py
@@ -20,6 +20,7 @@ from future.utils import lrange
 
 import datetime
 
+from twisted.internet import defer
 from twisted.internet import task
 from twisted.trial import unittest
 
@@ -698,20 +699,18 @@ class TestRealDB(unittest.TestCase,
                  connector_component.ConnectorComponentMixin,
                  Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        d = self.setUpConnectorComponent(
+        yield self.setUpConnectorComponent(
             table_names=['patches', 'changes', 'builders',
                          'buildsets', 'buildset_properties', 'buildrequests',
                          'buildset_sourcestamps', 'masters', 'buildrequest_claims',
                          'sourcestamps', 'sourcestampsets', 'builds', 'workers',
                          ])
 
-        @d.addCallback
-        def finish_setup(_):
-            self.db.buildrequests = \
-                buildrequests.BuildRequestsConnectorComponent(self.db)
-        d.addCallback(lambda _: self.setUpTests())
-        return d
+        self.db.buildrequests = \
+            buildrequests.BuildRequestsConnectorComponent(self.db)
+        yield self.setUpTests()
 
     def tearDown(self):
         return self.tearDownConnectorComponent()

--- a/master/buildbot/test/unit/test_db_connector.py
+++ b/master/buildbot/test/unit/test_db_connector.py
@@ -80,16 +80,14 @@ class DBConnector(db.RealDatabaseMixin, unittest.TestCase):
         self.db._doCleanup()
         self.assertFalse(self.db.changes.pruneChanges.called)
 
+    @defer.inlineCallbacks
     def test_doCleanup_configured(self):
         self.db.changes.pruneChanges = mock.Mock(
             return_value=defer.succeed(None))
-        d = self.startService()
+        yield self.startService()
 
-        @d.addCallback
-        def check(_):
-            self.db._doCleanup()
-            self.assertTrue(self.db.changes.pruneChanges.called)
-        return d
+        self.db._doCleanup()
+        self.assertTrue(self.db.changes.pruneChanges.called)
 
     def test_setup_check_version_bad(self):
         if self.db_url == 'sqlite://':

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -97,20 +97,18 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
             fakedb.BuildsetSourceStamp(buildsetid=11, sourcestampid=21),
         ]
 
+    @defer.inlineCallbacks
     def makeBuilder(self, patch_random=False, startBuildsForSucceeds=True, **config_kwargs):
-        d = BuilderMixin.makeBuilder(
+        yield BuilderMixin.makeBuilder(
             self, patch_random=patch_random, **config_kwargs)
 
-        @d.addCallback
-        def patch_startBuildsFor(_):
-            # patch into the _startBuildsFor method
-            self.builds_started = []
+        # patch into the _startBuildsFor method
+        self.builds_started = []
 
-            def _startBuildFor(workerforbuilder, buildrequests):
-                self.builds_started.append((workerforbuilder, buildrequests))
-                return defer.succeed(startBuildsForSucceeds)
-            self.bldr._startBuildFor = _startBuildFor
-        return d
+        def _startBuildFor(workerforbuilder, buildrequests):
+            self.builds_started.append((workerforbuilder, buildrequests))
+            return defer.succeed(startBuildsForSucceeds)
+        self.bldr._startBuildFor = _startBuildFor
 
     def assertBuildsStarted(self, exp):
         # munge builds_started into a list of (worker, [brids])

--- a/master/buildbot/test/unit/test_process_cache.py
+++ b/master/buildbot/test/unit/test_process_cache.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import mock
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process import cache
@@ -40,17 +41,16 @@ class CacheManager(unittest.TestCase):
         self.assertIdentical(foo_cache, foo_cache2)
         self.assertNotIdentical(foo_cache, bar_cache)
 
+    @defer.inlineCallbacks
     def test_reconfigServiceWithBuildbotConfig(self):
         # load config with one cache loaded and the other not
         foo_cache = self.caches.get_cache("foo", None)
-        d = self.caches.reconfigServiceWithBuildbotConfig(
+        yield self.caches.reconfigServiceWithBuildbotConfig(
             self.make_config(foo=5, bar=6, bing=11))
 
-        @d.addCallback
-        def check(_):
-            bar_cache = self.caches.get_cache("bar", None)
-            self.assertEqual((foo_cache.max_size, bar_cache.max_size),
-                             (5, 6))
+        bar_cache = self.caches.get_cache("bar", None)
+        self.assertEqual((foo_cache.max_size, bar_cache.max_size),
+                         (5, 6))
 
     def test_get_metrics(self):
         self.caches.get_cache("foo", None)


### PR DESCRIPTION
This PR continues work by @p12tic (https://github.com/buildbot/buildbot/pull/4174). The `d.addCallback()` or `@d.addCallback()` style is replaced by @defer.inlineCallbacks decorator. The work is coordinated with @p12tic so there's no duplication of effort. The changes have been split into several PRs for easier reviewing.
