### PR TITLE
Use @defer.inlineCallbacks where possible (part 5)

### DIFF
--- a/master/buildbot/test/unit/test_db_workers.py
+++ b/master/buildbot/test/unit/test_db_workers.py
@@ -674,17 +674,15 @@ class TestRealDB(unittest.TestCase,
                  connector_component.ConnectorComponentMixin,
                  RealTests, querylog.SqliteMaxVariableMixin):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        d = self.setUpConnectorComponent(
+        yield self.setUpConnectorComponent(
             table_names=['workers', 'masters', 'builders',
                          'builder_masters', 'connected_workers',
                          'configured_workers'])
 
-        @d.addCallback
-        def finish_setup(_):
-            self.db.workers = \
-                workers.WorkersConnectorComponent(self.db)
-        return d
+        self.db.workers = \
+            workers.WorkersConnectorComponent(self.db)
 
     @defer.inlineCallbacks
     def test_workerConfiguredMany(self):

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -191,38 +191,35 @@ class InitTests(unittest.SynchronousTestCase):
 
 class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpLogging()
         self.basedir = os.path.abspath('basedir')
-        d = self.setUpDirs(self.basedir)
+        yield self.setUpDirs(self.basedir)
 
-        @d.addCallback
-        def make_master(_):
-            # don't create child services
-            self.patch(master.BuildMaster, 'create_child_services',
-                       lambda self: None)
+        # don't create child services
+        self.patch(master.BuildMaster, 'create_child_services',
+                   lambda self: None)
 
-            # patch out a few other annoying things the master likes to do
-            self.patch(monkeypatches, 'patch_all', lambda: None)
-            self.patch(signal, 'signal', lambda sig, hdlr: None)
-            # XXX temporary
-            self.patch(master, 'Status', lambda master: mock.Mock())
+        # patch out a few other annoying things the master likes to do
+        self.patch(monkeypatches, 'patch_all', lambda: None)
+        self.patch(signal, 'signal', lambda sig, hdlr: None)
+        # XXX temporary
+        self.patch(master, 'Status', lambda master: mock.Mock())
 
-            master.BuildMaster.masterHeartbeatService = mock.Mock()
-            self.reactor = self.make_reactor()
-            self.master = master.BuildMaster(
-                self.basedir, reactor=self.reactor, config_loader=DefaultLoader())
-            self.master.sendBuildbotNetUsageData = mock.Mock()
-            self.master.botmaster = FakeBotMaster()
-            self.db = self.master.db = fakedb.FakeDBConnector(self)
-            self.db.setServiceParent(self.master)
-            self.mq = self.master.mq = fakemq.FakeMQConnector(self)
-            self.mq.setServiceParent(self.master)
-            self.data = self.master.data = fakedata.FakeDataConnector(
-                self.master, self)
-            self.data.setServiceParent(self.master)
-
-        return d
+        master.BuildMaster.masterHeartbeatService = mock.Mock()
+        self.reactor = self.make_reactor()
+        self.master = master.BuildMaster(
+            self.basedir, reactor=self.reactor, config_loader=DefaultLoader())
+        self.master.sendBuildbotNetUsageData = mock.Mock()
+        self.master.botmaster = FakeBotMaster()
+        self.db = self.master.db = fakedb.FakeDBConnector(self)
+        self.db.setServiceParent(self.master)
+        self.mq = self.master.mq = fakemq.FakeMQConnector(self)
+        self.mq.setServiceParent(self.master)
+        self.data = self.master.data = fakedata.FakeDataConnector(
+            self.master, self)
+        self.data.setServiceParent(self.master)
 
     def tearDown(self):
         return self.tearDownDirs()
@@ -235,46 +232,40 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
         return r
 
     # tests
+    @defer.inlineCallbacks
     def test_startup_bad_config(self):
         self.master.config_loader = FailingLoader()
 
-        d = self.master.startService()
+        yield self.master.startService()
 
-        @d.addCallback
-        def check(_):
-            self.reactor.stop.assert_called_with()
-            self.assertLogged("oh noes")
-            self.assertLogged("BuildMaster startup failed")
-        return d
+        self.reactor.stop.assert_called_with()
+        self.assertLogged("oh noes")
+        self.assertLogged("BuildMaster startup failed")
 
+    @defer.inlineCallbacks
     def test_startup_db_not_ready(self):
         def db_setup():
             log.msg("GOT HERE")
             raise exceptions.DatabaseNotReadyError()
         self.db.setup = db_setup
 
-        d = self.master.startService()
+        yield self.master.startService()
 
-        @d.addCallback
-        def check(_):
-            self.reactor.stop.assert_called_with()
-            self.assertLogged("GOT HERE")
-            self.assertLogged("BuildMaster startup failed")
-        return d
+        self.reactor.stop.assert_called_with()
+        self.assertLogged("GOT HERE")
+        self.assertLogged("BuildMaster startup failed")
 
+    @defer.inlineCallbacks
     def test_startup_error(self):
         def db_setup():
             raise RuntimeError("oh noes")
         self.db.setup = db_setup
 
-        d = self.master.startService()
+        yield self.master.startService()
 
-        @d.addCallback
-        def check(_):
-            self.reactor.stop.assert_called_with()
-            self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1)
-            self.assertLogged("BuildMaster startup failed")
-        return d
+        self.reactor.stop.assert_called_with()
+        self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1)
+        self.assertLogged("BuildMaster startup failed")
 
     @defer.inlineCallbacks
     def test_startup_ok(self):

--- a/master/buildbot/test/unit/test_scripts_create_master.py
+++ b/master/buildbot/test/unit/test_scripts_create_master.py
@@ -75,21 +75,17 @@ class TestCreateMaster(misc.StdoutAssertionsMixin, unittest.TestCase):
                 repl.assert_called_with(config)
         return d
 
+    @defer.inlineCallbacks
     def test_createMaster_quiet(self):
-        d = self.do_test_createMaster(mkconfig(quiet=True))
+        yield self.do_test_createMaster(mkconfig(quiet=True))
 
-        @d.addCallback
-        def check(_):
-            self.assertWasQuiet()
-        return d
+        self.assertWasQuiet()
 
+    @defer.inlineCallbacks
     def test_createMaster_loud(self):
-        d = self.do_test_createMaster(mkconfig(quiet=False))
+        yield self.do_test_createMaster(mkconfig(quiet=False))
 
-        @d.addCallback
-        def check(_):
-            self.assertInStdout('buildmaster configured in')
-        return d
+        self.assertInStdout('buildmaster configured in')
 
 
 class TestCreateMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,

--- a/master/buildbot/test/unit/test_steps_python_twisted.py
+++ b/master/buildbot/test/unit/test_steps_python_twisted.py
@@ -201,7 +201,7 @@ class Trial(steps.BuildStepMixin, unittest.TestCase):
                 buildbot.test.unit.test_steps_python_twisted.Trial.test_run_env_supplement ... [FAILURE]/home/dustin/code/buildbot/t/buildbot/master/buildbot/test/fake/logfile.py:92: UserWarning: step uses removed LogFile method `getText`
                 buildbot.test.unit.test_steps_python_twisted.Trial.test_run_jobs ... [FAILURE]/home/dustin/code/buildbot/t/buildbot/master/buildbot/test/fake/logfile.py:92: UserWarning: step uses removed LogFile method `getText`
                 buildbot.test.unit.test_steps_python_twisted.Trial.test_run_jobsProperties ... [FAILURE]
-                ''')) # noqa: max-line-length
+                '''))  # noqa: max-line-length
         return self.runStep()
 
     def testProperties(self):

--- a/master/buildbot/test/unit/test_util_lru.py
+++ b/master/buildbot/test/unit/test_util_lru.py
@@ -471,6 +471,7 @@ class AsyncLRUCacheTest(unittest.TestCase):
             res = yield self.lru.get(c)
             self.check_result(res, short(c))
 
+    @defer.inlineCallbacks
     def test_massively_parallel(self):
         chars = list(string.ascii_lowercase * 5)
 
@@ -486,17 +487,15 @@ class AsyncLRUCacheTest(unittest.TestCase):
         def check(c, d):
             d.addCallback(self.check_result, short(c))
             return d
-        d = defer.gatherResults([
+        yield defer.gatherResults([
             check(c, self.lru.get(c))
             for c in chars])
 
-        @d.addCallback
-        def post_check(_):
-            self.assertEqual(misses[0], 26)
-            self.assertEqual(self.lru.misses, 26)
-            self.assertEqual(self.lru.hits, 4 * 26)
-        return d
+        self.assertEqual(misses[0], 26)
+        self.assertEqual(self.lru.misses, 26)
+        self.assertEqual(self.lru.hits, 4 * 26)
 
+    @defer.inlineCallbacks
     def test_slow_fetch(self):
         def slower_miss_fn(k):
             d = defer.Deferred()
@@ -515,12 +514,9 @@ class AsyncLRUCacheTest(unittest.TestCase):
             reactor.callLater(0.02 * i, do_get, d, 'x')
             ds.append(d)
 
-        d = defer.gatherResults(ds)
+        yield defer.gatherResults(ds)
 
-        @d.addCallback
-        def check(_):
-            self.assertEqual((self.lru.hits, self.lru.misses), (7, 1))
-        return d
+        self.assertEqual((self.lru.hits, self.lru.misses), (7, 1))
 
     def test_slow_failure(self):
         def slow_fail_miss_fn(k):

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -22,7 +22,6 @@ import hashlib
 from twisted.application import service
 from twisted.internet import defer
 from twisted.internet import task
-from twisted.python import failure
 from twisted.python import log
 from twisted.python import reflect
 from twisted.python.reflect import accumulateClassList
@@ -124,31 +123,28 @@ class SharedService(AsyncMultiService):
     """a service that is created only once per parameter set in a parent service"""
 
     @classmethod
+    @defer.inlineCallbacks
     def getService(cls, parent, *args, **kwargs):
         name = cls.getName(*args, **kwargs)
         if name in parent.namedServices:
-            return defer.succeed(parent.namedServices[name])
-        try:
-            instance = cls(*args, **kwargs)
-        except Exception:
-            # we transform all exceptions into failure
-            return defer.fail(failure.Failure())
+            defer.returnValue(parent.namedServices[name])
+            return  # pragma: no cover
+
+        instance = cls(*args, **kwargs)
+
         # The class is not required to initialized its name
         # but we use the name to identify the instance in the parent service
         # so we force it with the name we used
         instance.name = name
-        d = instance.setServiceParent(parent)
+        yield instance.setServiceParent(parent)
 
-        @d.addCallback
-        def returnInstance(res):
-            # we put the service on top of the list, so that it is stopped the last
-            # This make sense as the shared service is used as a dependency
-            # for other service
-            parent.services.remove(instance)
-            parent.services.insert(0, instance)
-            # hook the return value to the instance object
-            return instance
-        return d
+        # we put the service on top of the list, so that it is stopped the last
+        # This make sense as the shared service is used as a dependency
+        # for other service
+        parent.services.remove(instance)
+        parent.services.insert(0, instance)
+        # hook the return value to the instance object
+        defer.returnValue(instance)
 
     @classmethod
     def getName(cls, *args, **kwargs):

--- a/worker/buildbot_worker/test/unit/test_commands_fs.py
+++ b/worker/buildbot_worker/test/unit/test_commands_fs.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import os
 import shutil
 
+from twisted.internet import defer
 from twisted.python import runtime
 from twisted.trial import unittest
 
@@ -41,21 +42,20 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.make_command(fs.RemoveDirectory, dict(
             dir='workdir',
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertFalse(
-                os.path.exists(os.path.abspath(os.path.join(self.basedir, 'workdir'))))
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertFalse(
+            os.path.exists(os.path.abspath(os.path.join(self.basedir, 'workdir'))))
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_simple_exception(self):
         if runtime.platformType == "posix":
             return  # we only use rmdirRecursive on windows
@@ -66,29 +66,24 @@ class TestRemoveDirectory(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.RemoveDirectory, dict(
             dir='workdir',
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertIn({'rc': -1}, self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertIn({'rc': -1}, self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_multiple_dirs(self):
         self.make_command(fs.RemoveDirectory, dict(
             dir=['workdir', 'sourcedir'],
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            for dirname in ['workdir', 'sourcedir']:
-                self.assertFalse(
-                    os.path.exists(os.path.abspath(os.path.join(self.basedir, dirname))))
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        for dirname in ['workdir', 'sourcedir']:
+            self.assertFalse(
+                os.path.exists(os.path.abspath(os.path.join(self.basedir, dirname))))
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
 
 class TestCopyDirectory(CommandTestMixin, unittest.TestCase):
@@ -99,22 +94,21 @@ class TestCopyDirectory(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.make_command(fs.CopyDirectory, dict(
             fromdir='workdir',
             todir='copy',
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertTrue(
-                os.path.exists(os.path.abspath(os.path.join(self.basedir, 'copy'))))
-            self.assertIn({'rc': 0},  # this may ignore a 'header' : '..', which is OK
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertTrue(
+            os.path.exists(os.path.abspath(os.path.join(self.basedir, 'copy'))))
+        self.assertIn({'rc': 0},  # this may ignore a 'header' : '..', which is OK
+                      self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_simple_exception(self):
         if runtime.platformType == "posix":
             return  # we only use rmdirRecursive on windows
@@ -126,14 +120,11 @@ class TestCopyDirectory(CommandTestMixin, unittest.TestCase):
             fromdir='workdir',
             todir='copy',
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertIn({'rc': -1},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertIn({'rc': -1},
+                      self.get_updates(),
+                      self.builder.show())
 
 
 class TestMakeDirectory(CommandTestMixin, unittest.TestCase):
@@ -144,48 +135,42 @@ class TestMakeDirectory(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.make_command(fs.MakeDirectory, dict(
             dir='test-dir',
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertTrue(
-                os.path.exists(os.path.abspath(os.path.join(self.basedir, 'test-dir'))))
-            self.assertUpdates(
-                [{'rc': 0}],
-                self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertTrue(
+            os.path.exists(os.path.abspath(os.path.join(self.basedir, 'test-dir'))))
+        self.assertUpdates(
+            [{'rc': 0}],
+        self.builder.show())
 
+    @defer.inlineCallbacks
     def test_already_exists(self):
         self.make_command(fs.MakeDirectory, dict(
             dir='workdir',
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertUpdates(
-                [{'rc': 0}],
-                self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertUpdates(
+            [{'rc': 0}],
+            self.builder.show())
 
+    @defer.inlineCallbacks
     def test_existing_file(self):
         self.make_command(fs.MakeDirectory, dict(
             dir='test-file',
         ), True)
         with open(os.path.join(self.basedir, 'test-file'), "w"):
             pass
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertIn({'rc': errno.EEXIST},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertIn({'rc': errno.EEXIST},
+                      self.get_updates(),
+                      self.builder.show())
 
 
 class TestStatFile(CommandTestMixin, unittest.TestCase):
@@ -196,35 +181,32 @@ class TestStatFile(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_non_existent(self):
         self.make_command(fs.StatFile, dict(
             file='no-such-file',
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertIn({'rc': errno.ENOENT},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertIn({'rc': errno.ENOENT},
+                      self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_directory(self):
         self.make_command(fs.StatFile, dict(
             file='workdir',
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            import stat
-            self.assertTrue(
-                stat.S_ISDIR(self.get_updates()[0]['stat'][stat.ST_MODE]))
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        import stat
+        self.assertTrue(
+            stat.S_ISDIR(self.get_updates()[0]['stat'][stat.ST_MODE]))
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_file(self):
         self.make_command(fs.StatFile, dict(
             file='test-file',
@@ -232,18 +214,16 @@ class TestStatFile(CommandTestMixin, unittest.TestCase):
         with open(os.path.join(self.basedir, 'test-file'), "w"):
             pass
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            import stat
-            self.assertTrue(
-                stat.S_ISREG(self.get_updates()[0]['stat'][stat.ST_MODE]))
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        import stat
+        self.assertTrue(
+            stat.S_ISREG(self.get_updates()[0]['stat'][stat.ST_MODE]))
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_file_workdir(self):
         self.make_command(fs.StatFile, dict(
             file='test-file',
@@ -253,17 +233,14 @@ class TestStatFile(CommandTestMixin, unittest.TestCase):
         with open(os.path.join(self.basedir, 'wd', 'test-file'), "w"):
             pass
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            import stat
-            self.assertTrue(
-                stat.S_ISREG(self.get_updates()[0]['stat'][stat.ST_MODE]))
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        import stat
+        self.assertTrue(
+            stat.S_ISREG(self.get_updates()[0]['stat'][stat.ST_MODE]))
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
 
 class TestGlobPath(CommandTestMixin, unittest.TestCase):
@@ -274,35 +251,32 @@ class TestGlobPath(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_non_existent(self):
         self.make_command(fs.GlobPath, dict(
             path='no-*-file',
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertEqual(self.get_updates()[0]['files'], [])
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.get_updates()[0]['files'], [])
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_directory(self):
         self.make_command(fs.GlobPath, dict(
             path='[wxyz]or?d*',
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertEqual(
-                self.get_updates()[0]['files'], [os.path.join(self.basedir, 'workdir')])
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertEqual(
+            self.get_updates()[0]['files'], [os.path.join(self.basedir, 'workdir')])
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_file(self):
         self.make_command(fs.GlobPath, dict(
             path='t*-file',
@@ -310,16 +284,13 @@ class TestGlobPath(CommandTestMixin, unittest.TestCase):
         with open(os.path.join(self.basedir, 'test-file'), "w"):
             pass
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertEqual(
-                self.get_updates()[0]['files'], [os.path.join(self.basedir, 'test-file')])
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertEqual(
+            self.get_updates()[0]['files'], [os.path.join(self.basedir, 'test-file')])
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
 
 
 class TestListDir(CommandTestMixin, unittest.TestCase):
@@ -330,19 +301,18 @@ class TestListDir(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_non_existent(self):
         self.make_command(fs.ListDir,
                           dict(dir='no-such-dir'),
                           True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertIn({'rc': errno.ENOENT},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertIn({'rc': errno.ENOENT},
+                      self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_dir(self):
         self.make_command(fs.ListDir, dict(
             dir='workdir',
@@ -353,23 +323,20 @@ class TestListDir(CommandTestMixin, unittest.TestCase):
         with open(os.path.join(workdir, 'file2'), "w"):
             pass
 
-        d = self.run_command()
+        yield self.run_command()
 
         def any(items):  # not a builtin on python-2.4
             for i in items:
                 if i:
                     return True
 
-        def check(_):
-            self.assertIn({'rc': 0},
-                          self.get_updates(),
-                          self.builder.show())
-            self.assertTrue(any([
-                'files' in upd and sorted(upd['files']) == ['file1', 'file2']
-                for upd in self.get_updates()]),
-                self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
+        self.assertTrue(any([
+            'files' in upd and sorted(upd['files']) == ['file1', 'file2']
+            for upd in self.get_updates()]),
+            self.builder.show())
 
 
 class TestRemoveFile(CommandTestMixin, unittest.TestCase):
@@ -380,6 +347,7 @@ class TestRemoveFile(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         workdir = os.path.join(self.basedir, 'workdir')
         self.file1_path = os.path.join(workdir, 'file1')
@@ -389,17 +357,15 @@ class TestRemoveFile(CommandTestMixin, unittest.TestCase):
 
         with open(os.path.join(workdir, 'file1'), "w"):
             pass
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertFalse(
-                os.path.exists(self.file1_path))
-            self.assertIn({'rc': 0},  # this may ignore a 'header' : '..', which is OK
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertFalse(
+            os.path.exists(self.file1_path))
+        self.assertIn({'rc': 0},  # this may ignore a 'header' : '..', which is OK
+                      self.get_updates(),
+                      self.builder.show())
 
+    @defer.inlineCallbacks
     def test_simple_exception(self):
         workdir = os.path.join(self.basedir, 'workdir')
         self.file2_path = os.path.join(workdir, 'file2')
@@ -409,11 +375,8 @@ class TestRemoveFile(CommandTestMixin, unittest.TestCase):
         self.make_command(fs.RemoveFile, dict(
             path=self.file2_path
         ), True)
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertIn({'rc': 2},
-                          self.get_updates(),
-                          self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertIn({'rc': 2},
+                      self.get_updates(),
+                      self.builder.show())

--- a/worker/buildbot_worker/test/unit/test_commands_shell.py
+++ b/worker/buildbot_worker/test/unit/test_commands_shell.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot_worker.commands import shell
@@ -31,6 +32,7 @@ class TestWorkerShellCommand(CommandTestMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownCommand()
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.make_command(shell.WorkerShellCommand, dict(
             command=['echo', 'hello'],
@@ -43,14 +45,11 @@ class TestWorkerShellCommand(CommandTestMixin, unittest.TestCase):
             + 0,
         )
 
-        d = self.run_command()
+        yield self.run_command()
 
         # note that WorkerShellCommand does not add any extra updates of it own
-        def check(_):
-            self.assertUpdates(
-                [{'hdr': 'headers'}, {'stdout': 'hello\n'}, {'rc': 0}],
-                self.builder.show())
-        d.addCallback(check)
-        return d
+        self.assertUpdates(
+            [{'hdr': 'headers'}, {'stdout': 'hello\n'}, {'rc': 0}],
+            self.builder.show())
 
     # TODO: test all functionality that WorkerShellCommand adds atop RunProcess


### PR DESCRIPTION
This PR continues work by @p12tic (https://github.com/buildbot/buildbot/pull/4174). The `d.addCallback()` or `@d.addCallback()` style is replaced by @defer.inlineCallbacks decorator. The work is coordinated with @p12tic so there's no duplication of effort. The changes have been split into several PRs for easier reviewing.