### PR TITLE
Fixes #4299 `headerRegex` should be a string pattern, as the `header` is

### DIFF
--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -111,7 +111,7 @@ class RemoteUserAuth(AuthBase):
         if self.userInfoProvider is None:
             self.userInfoProvider = UserInfoProviderBase()
         if header is not None:
-            self.header = header
+            self.header = unicode2bytes(header)
         if headerRegex is not None:
             self.headerRegex = re.compile(unicode2bytes(headerRegex))
 


### PR DESCRIPTION
I did not manage to pass all tests in `./common/validate.sh`. It does not seem related to the changes in the PR though.

## Contributor Checklist:

* [x] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
I don't think there is a documentation about this.
