### PR TITLE
Move docs and isort builds to Python 3.6

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -19,7 +19,6 @@ env:
   - BUILDBOT_TEST_DB_URL=sqlite://
   - HYPER_SIZE=m1
   matrix:
-  - TWISTED=latest SQLALCHEMY=latest TESTS=isort 
   - TWISTED=latest SQLALCHEMY=latest TESTS=coverage
 
   # add js tests in separate job. Start it early because it is quite long
@@ -61,9 +60,11 @@ matrix:
   fast_finish: true
   include:
     # python 3 tests
-    # flake8, pylint, docs first as they're more likely to find issues
+    # flake8, isort, pylint, docs first as they're more likely to find issues
     - python: "3.6"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=flake8
+    - python: "3.6"
+      env: TWISTED=latest SQLALCHEMY=latest TESTS=isort
     - python: "3.6"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=pylint HYPER_SIZE=m3
     - python: "3.6"

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -19,9 +19,7 @@ env:
   - BUILDBOT_TEST_DB_URL=sqlite://
   - HYPER_SIZE=m1
   matrix:
-  # flake8, docs and coverage first as they're more likely to find issues
   - TWISTED=latest SQLALCHEMY=latest TESTS=isort 
-  - TWISTED=latest SQLALCHEMY=latest TESTS=docs
   - TWISTED=latest SQLALCHEMY=latest TESTS=coverage
 
   # add js tests in separate job. Start it early because it is quite long
@@ -62,12 +60,14 @@ env:
 matrix:
   fast_finish: true
   include:
-
+    # python 3 tests
+    # flake8, pylint, docs first as they're more likely to find issues
+    - python: "3.6"
+      env: TWISTED=latest SQLALCHEMY=latest TESTS=flake8
     - python: "3.6"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=pylint HYPER_SIZE=m3
     - python: "3.6"
-      env: TWISTED=latest SQLALCHEMY=latest TESTS=flake8
-    # python 3 tests
+      env: TWISTED=latest SQLALCHEMY=latest TESTS=docs
     - python: "3.4"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=trial
 


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
