### PR TITLE
Fix pylint warnings by using 'in' keyword

### DIFF
--- a/common/pylintrc
+++ b/common/pylintrc
@@ -150,7 +150,6 @@ disable=
   no-else-return,
   consider-using-dict-comprehension,
   consider-using-set-comprehension,
-  consider-using-in,
   assignment-from-none,
   chained-comparision,
   self-cls-assignment,

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -351,9 +351,7 @@ class SVNCommitEmailMaildirSource(MaildirSource):
         # commit message is terminated by the file-listing section
         while lines:
             line = lines.pop(0)
-            if (line == "Modified:\n" or
-                line == "Added:\n" or
-                    line == "Removed:\n"):
+            if line in ("Modified:\n", "Added:\n", "Removed:\n"):
                 break
             comments += line
         comments = comments.rstrip() + "\n"

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -616,7 +616,7 @@ class UserOptions(base.SubcommandOptions):
         if not info and not ids:
             raise usage.UsageError("must specify either --ids or --info")
 
-        if op == 'add' or op == 'update':
+        if op in ('add', 'update'):
             if ids:
                 raise usage.UsageError("cannot use --ids with 'add' or "
                                        "'update'")
@@ -631,7 +631,7 @@ class UserOptions(base.SubcommandOptions):
                     if 'identifier' in user:
                         raise usage.UsageError("identifier found in add info, "
                                                "use: --info=type=value,type=value,..")
-        if op == 'remove' or op == 'get':
+        if op in ('remove', 'get'):
             if info:
                 raise usage.UsageError("cannot use --info with 'remove' "
                                        "or 'get'")

--- a/master/buildbot/www/sse.py
+++ b/master/buildbot/www/sse.py
@@ -92,7 +92,7 @@ class EventResource(resource.Resource):
             cid = unicode2bytes(str(uuid.uuid4()))
             consumer = Consumer(request)
 
-        elif command == b"add" or command == b"remove":
+        elif command in (b"add", b"remove"):
             if path:
                 cid = path[0]
                 path = path[1:]


### PR DESCRIPTION
Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
