### PR TITLE
pylint: Fix pylint trailing comma tuple warnings

### DIFF
--- a/common/pylintrc
+++ b/common/pylintrc
@@ -153,7 +153,6 @@ disable=
   assignment-from-none,
   self-cls-assignment,
   useless-import-alias,
-  trailing-comma-tuple,
   comparison-with-callable,
   comparison-with-itself,
   assignment-from-no-return,

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -143,8 +143,8 @@ class OldTriggeringMethods(unittest.TestCase):
 
     def test_addChange_args_new_and_old(self):
         func = self.do_test_addChange_args
-        kwargs = dict(who='author',
-                      author='author'),
+        kwargs = (dict(who='author',
+                       author='author'),)
         exp_data_kwargs = dict(author='author')
         self.assertRaises(TypeError, func, kwargs=kwargs,
                           exp_data_kwargs=exp_data_kwargs)

--- a/master/buildbot/test/unit/test_reporter_bitbucket.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucket.py
@@ -82,7 +82,7 @@ class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin
                 'state': 'INPROGRESS',
                 'key': u'Builder0',
                 'name': u'Builder0'},
-            code=201),
+            code=201)
         self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
                               content_json={'access_token': 'foo'})
         self._http.expect(
@@ -93,7 +93,7 @@ class TestBitbucketStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin
                 'state': 'SUCCESSFUL',
                 'key': u'Builder0',
                 'name': u'Builder0'},
-            code=201),
+            code=201)
         self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
                               content_json={'access_token': 'foo'})
         self._http.expect(

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -595,7 +595,7 @@ class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
         self.assertEqual(spec.limit, expected_limit)
 
     def test_decode_result_spec_order(self):
-        expected_order = 'info',
+        expected_order = ('info',)
         self.make_request(b'/test')
         self.request.args = {b'order': expected_order}
         spec = self.rsrc.decodeResultSpec(self.request, endpoint.Test)
@@ -625,7 +625,7 @@ class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
 
     def test_decode_result_spec_not_a_collection_order(self):
         def expectRaiseBadRequest():
-            order = 'info',
+            order = ('info',)
             self.make_request(b'/test')
             self.request.args = {b'order': order}
             self.rsrc.decodeResultSpec(self.request, endpoint.TestEndpoint)

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -451,7 +451,7 @@ class EC2LatentWorker(AbstractLatentWorker):
             goal = (SHUTTINGDOWN, TERMINATED)
             instance.reload()
         else:
-            goal = TERMINATED,
+            goal = (TERMINATED,)
         while instance.state['Name'] not in goal:
             time.sleep(interval)
             duration += interval


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
