### PR TITLE
pylint: reenable self-cls-assignment warning

### DIFF
--- a/common/pylintrc
+++ b/common/pylintrc
@@ -151,7 +151,6 @@ disable=
   consider-using-dict-comprehension,
   consider-using-set-comprehension,
   assignment-from-none,
-  self-cls-assignment,
   useless-import-alias,
   trailing-comma-tuple,
   comparison-with-callable,

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -433,10 +433,6 @@ class IStatus(Interface):
                            of builds that will be examined within any given
                            Builder.
         """
-        if builders is None:
-            builders = []
-        if branches is None:
-            branches = []
 
     def subscribe(receiver):
         """Register an IStatusReceiver to receive new status events. The
@@ -663,8 +659,6 @@ class IBuilderStatus(Interface):
                            This argument imposes a hard limit on the number
                            of builds that will be examined.
         """
-        if branches is None:
-            branches = []
 
     def subscribe(receiver):
         """Register an IStatusReceiver to receive new status events. The
@@ -702,14 +696,6 @@ class IEventSource(Interface):
         @param minTime: a timestamp. Do not generate events occurring prior to
         this timestamp.
         """
-        if branches is None:
-            branches = []
-        if categories is None:
-            categories = []
-        if committers is None:
-            committers = []
-        if projects is None:
-            projects = []
 
 
 class IBuildStatus(Interface):


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
