### PR TITLE
Fix optional IRC notices

### DIFF
--- a/master/buildbot/newsfragments/notice_on_channel.feature
+++ b/master/buildbot/newsfragments/notice_on_channel.feature
@@ -1,0 +1,5 @@
+Added ``noticeOnChannel`` option to :bb:reporter:`IRC` to send notices instead
+of messages to channels.
+This was an option in v0.8.x and removed in v0.9.0, which defaulted to sending
+notices.
+The v0.8.x default of sending messages is now restored.

--- a/master/buildbot/test/unit/test_reporters_irc.py
+++ b/master/buildbot/test/unit/test_reporters_irc.py
@@ -50,7 +50,7 @@ class TestIrcStatusBot(unittest.TestCase):
 
     def makeBot(self, *args, **kwargs):
         if not args:
-            args = ('nick', 'pass', ['#ch'], [], [], {})
+            args = ('nick', 'pass', ['#ch'], [], False, [], {})
         return irc.IrcStatusBot(*args, **kwargs)
 
     def test_groupDescribe(self):
@@ -63,6 +63,14 @@ class TestIrcStatusBot(unittest.TestCase):
 
     def test_groupChat(self):
         b = self.makeBot()
+        b.msg = lambda d, m: evts.append(('n', d, m))
+
+        evts = []
+        b.groupChat('#chan', 'hi')
+        self.assertEqual(evts, [('n', '#chan', 'hi')])
+
+    def test_groupChat_notice(self):
+        b = self.makeBot('nick', 'pass', ['#ch'], [], True, [], {})
         b.notice = lambda d, m: evts.append(('n', d, m))
 
         evts = []
@@ -104,7 +112,7 @@ class TestIrcStatusBot(unittest.TestCase):
         self.assertEqual(c.messages, ['hello'])
 
     def test_privmsg_user_uppercase(self):
-        b = self.makeBot('NICK', 'pass', ['#ch'], [], [], {})
+        b = self.makeBot('NICK', 'pass', ['#ch'], [], False, [], {})
         b.contactClass = FakeContact
         b.privmsg('jimmy!~foo@bar', 'NICK', 'hello')
 
@@ -155,7 +163,7 @@ class TestIrcStatusBot(unittest.TestCase):
     def test_signedOn(self):
         b = self.makeBot('nick', 'pass',
                          ['#ch1', dict(channel='#ch2', password='sekrits')],
-                         ['jimmy', 'bobby'], [], {})
+                         ['jimmy', 'bobby'], False, [], {})
         evts = []
 
         def msg(d, m):
@@ -247,6 +255,7 @@ class TestIRC(config.ConfigErrorsMixin, unittest.TestCase):
             nick='nick',
             channels=['channels'],
             pm_to_nicks=['pm', 'to', 'nicks'],
+            noticeOnChannel=True,
             port=1234,
             allowForce=True,
             tags=['tags'],
@@ -269,7 +278,7 @@ class TestIRC(config.ConfigErrorsMixin, unittest.TestCase):
         p = factory.buildProtocol('address')
         self.assertIdentical(p, proto_obj)
         factory.protocol.assert_called_with(
-            'nick', 'pass', ['channels'], ['pm', 'to', 'nicks'],
+            'nick', 'pass', ['channels'], ['pm', 'to', 'nicks'], True,
             ['tags'], {'successToFailure': 1},
             useColors=False,
             useRevisions=True,

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -587,6 +587,10 @@ The following parameters are accepted by this class:
     At the moment, irc bot can listen to build 'start' and 'finish' events.
     This parameter can be changed during run-time by sending the ``notify`` command to the bot.
 
+``noticeOnChannel``
+   (optional)
+   Whether to send notices rather than messages when communicating with a channel.
+
 ``showBlameList``
     (optional, disabled by default)
     Whether or not to display the blame list for failed builds.

--- a/master/docs/manual/cfg-reporters.rst
+++ b/master/docs/manual/cfg-reporters.rst
@@ -588,7 +588,7 @@ The following parameters are accepted by this class:
     This parameter can be changed during run-time by sending the ``notify`` command to the bot.
 
 ``noticeOnChannel``
-   (optional)
+   (optional, disabled by default)
    Whether to send notices rather than messages when communicating with a channel.
 
 ``showBlameList``


### PR DESCRIPTION
This restores the `noticeOnChannel` option from v0.8.x, which was (I believe) mistakenly removed.  Support was broken in https://github.com/buildbot/buildbot/commit/c3126d5e87a519ac2cf03917750658e427f6eab5 when `msgOrNotice()` was removed, then it was incorrectly documented in https://github.com/buildbot/buildbot/commit/eacb13a7fdf5840da5f6a54f04a01fc34a9c08a2, and finally removed in https://github.com/buildbot/buildbot/commit/b67ad22f68c5c458f9a30d7d15ca0a7cb5f1fa37 based on the incorrect documentation of its intention.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
