### PR TITLE
Fix adding groups from GitHub teams

### DIFF
--- a/master/buildbot/newsfragments/restrict_teams_to_membership.bugfix
+++ b/master/buildbot/newsfragments/restrict_teams_to_membership.bugfix
@@ -1,0 +1,4 @@
+Restricted groups added by :py:class:`~buildbot.www.oauth2.GitHubAuth`'s
+``getTeamsMembership`` option to only those teams to which the user belongs.
+Previously, groups were added for all teams for all organizations to which the
+user belongs.

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -209,7 +209,7 @@ class GitHubAuth(OAuth2Auth):
         query getOrgTeamMembership {
           {%- for org_slug, org_name in organizations.items() %}
           {{ org_slug }}: organization(login: "{{ org_name }}") {
-            teams(first: 100) {
+            teams(first: 100 userLogins: ["{{ user_info.username }}"]) {
               edges {
                 node {
                   name,


### PR DESCRIPTION
* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] ~~I have updated the appropriate documentation~~ Docs seem correct.