### PR TITLE
Add GitHub teams to groups by slug as well as name

### DIFF
--- a/master/buildbot/newsfragments/add_github_teams_by_slug.feature
+++ b/master/buildbot/newsfragments/add_github_teams_by_slug.feature
@@ -1,0 +1,5 @@
+GitHub teams added to a user's ``groups`` by
+:py:class:`~buildbot.www.oauth2.GitHubAuth`'s ``getTeamsMembership`` option are
+now added by slug as well as by name.
+This means a team named "Bot Builders" in the organization "buildbot" will be
+added as both ``buildbot/Bot Builders`` and ``buildbot/bot-builders``.

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -322,6 +322,12 @@ class OAuth2Auth(www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
                                         'slug': 'committers'
                                     }
                                 },
+                                {
+                                    'node': {
+                                        'name': 'Team with spaces and caps',
+                                        'slug': 'team-with-spaces-and-caps'
+                                    }
+                                },
                             ]
                         }
                     },
@@ -334,11 +340,15 @@ class OAuth2Auth(www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
                           'groups': [
                               'hello',
                               'grp',
+                              'grp/Team with spaces and caps',
                               'grp/committers',
                               'grp/contributors',
                               'grp/developers',
+                              'grp/develpers',
+                              'grp/team-with-spaces-and-caps',
                               'hello/contributors',
-                              'hello/developers'
+                              'hello/developers',
+                              'hello/develpers',
                           ],
                           'full_name': 'foo bar'}, res)
 

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -342,6 +342,7 @@ class GitHubAuth(OAuth2Auth):
                         # since different organizations might share a common
                         # team name
                         teams.add('%s/%s' % (orgs_name_slug_mapping[org], node['node']['name']))
+                        teams.add('%s/%s' % (orgs_name_slug_mapping[org], node['node']['slug']))
                 user_info['groups'].extend(sorted(teams))
         if self.debug:
             log.info('{klass} User Details: {user_info}',


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] ~~I have updated the appropriate documentation~~ Docs are sufficently ambiguous to go with what's already there.