### PR TITLE
data_module: Fix properties event generation

### DIFF
--- a/www/data_module/src/services/dataUtils/dataUtils.service.coffee
+++ b/www/data_module/src/services/dataUtils/dataUtils.service.coffee
@@ -32,9 +32,11 @@ class DataUtils extends Service
             socketPath: (arg) ->
                 a = @copyOrSplit(arg)
                 # if the argument count is even, the last argument is an id
+                # Format of properties endpoint is an exception
+                # and needs to be properties/*, not properties/*/*
                 stars = ['*']
                 # is it odd?
-                if a.length % 2 is 1 then stars.push('*')
+                if a.length % 2 is 1 and not arg.endsWith("/properties") then stars.push('*')
                 a.concat(stars).join('/')
 
             socketPathRE: (socketPath) ->


### PR DESCRIPTION
Currently the socketPath used for watching for properties events is
incorrect. properties events have the form:

builds/123/properties/update

socketPath currently translates a restPath of builds/123/properties
into builds/123/properties/*/* which won't match the above events.

Add in a special case handling for properties events to ensure the
correct socketPath is generated and data_module users then receive
the expected properties change notifications.

Fixes #4321