### PR TITLE
Show all workers combo fix

### DIFF
--- a/master/buildbot/newsfragments/show_old_workers.bugfix
+++ b/master/buildbot/newsfragments/show_old_workers.bugfix
@@ -1,0 +1,1 @@
+Fix 'Show old workers' combo behavior.

--- a/www/base/src/app/workers/workers.controller.coffee
+++ b/www/base/src/app/workers/workers.controller.coffee
@@ -19,8 +19,8 @@ class Workers extends Controller
             if $stateParams.worker?
                 return worker.workerid != +$stateParams.worker
             if $scope.settings.show_old_workers.value
-                return worker.configured_on.length == 0
-            return 0
+                return 0
+            return worker.configured_on.length == 0
 
         data = dataService.open().closeOnDestroy($scope)
 


### PR DESCRIPTION
'Show old workers' combo in www workers view works opposite to its desired behavior (unchecking it shows all workers and checking it hides them). This small patch fixes this.