### PR TITLE
Git step documentation update

### DIFF
--- a/master/buildbot/newsfragments/git-source-step-update.doc
+++ b/master/buildbot/newsfragments/git-source-step-update.doc
@@ -1,0 +1,9 @@
+Update Git source checkout build step documentation:
+
+* remove redundant empty lines
+* make the indentation consistent
+* make the code example explicitly Python snippet
+* make the SSH related parameter documentation compliant with one-sentence-per-line policy
+* re-format require/optional status and default values for the Git source checkout step
+* fix the Git spelling
+* align the docs with the code in `buildbot/steps/source/git.py` (tags are also supported)

--- a/master/buildbot/newsfragments/git-source-step-update.doc
+++ b/master/buildbot/newsfragments/git-source-step-update.doc
@@ -1,9 +1,1 @@
-Update Git source checkout build step documentation:
-
-* remove redundant empty lines
-* make the indentation consistent
-* make the code example explicitly Python snippet
-* make the SSH related parameter documentation compliant with one-sentence-per-line policy
-* re-format require/optional status and default values for the Git source checkout step
-* fix the Git spelling
-* align the docs with the code in `buildbot/steps/source/git.py` (tags are also supported)
+Misc improvement in Git source build step documentation.

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -362,7 +362,7 @@ The Git step takes the following arguments:
    The URL of the upstream Git repository.
 
 ``branch`` (optional)
-   This specifies the name of the branch to use when a Build does not provide one of its own.
+   This specifies the name of the branch or the tag to use when a Build does not provide one of its own.
    If this parameter is not specified, and the Build does not provide a branch, the default branch of the remote repository will be used.
    If ``alwaysUseLatest`` is ``True`` then the branch and revision information that comes with the Build is ignored and branch specified in this parameter is used.
 

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -387,7 +387,7 @@ The Git step takes the following arguments:
    This solves issues of long fetches being killed due to lack of output, but requires Git 1.7.2 or later.
 
 ``retryFetch`` (optional, default: ``False``)
-   If true, if the ``git fetch`` fails then buildbot retries to fetch again instead of failing the entire source checkout.
+   If true, if the ``git fetch`` fails then Buildbot retries to fetch again instead of failing the entire source checkout.
 
 ``clobberOnFailure`` (optional, default: ``False``)
    If a fetch or full clone fails we can checkout source removing everything.

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -345,17 +345,16 @@ Git
 
 The :bb:step:`Git` build step clones or updates a `Git <http://git.or.cz/>`_ repository and checks out the specified branch or revision.
 
-
 .. note::
 
-    The Buildbot supports Git version 1.2.0 and later: earlier versions (such as the one shipped in Ubuntu 'Dapper') do not support the :command:`git init` command that the Buildbot uses.
+   The Buildbot supports Git version 1.2.0 and later: earlier versions (such as the one shipped in Ubuntu 'Dapper') do not support the :command:`git init` command that the Buildbot uses.
 
 ::
 
-    from buildbot.plugins import steps
+   from buildbot.plugins import steps
 
-    factory.addStep(steps.Git(repourl='git://path/to/repo', mode='full',
-                              method='clobber', submodules=True))
+   factory.addStep(steps.Git(repourl='git://path/to/repo', mode='full',
+                             method='clobber', submodules=True))
 
 The Git step takes the following arguments:
 
@@ -399,24 +398,20 @@ The Git step takes the following arguments:
    If retry fails it fails the source checkout step.
 
 ``mode``
+   (optional): defaults to ``'incremental'``.
+   Specifies whether to clean the build tree or not.
 
-  (optional): defaults to ``'incremental'``.
-  Specifies whether to clean the build tree or not.
-
-    ``incremental``
+   ``incremental``
       The source is update, but any built files are left untouched.
 
-    ``full``
+   ``full``
       The build tree is clean of any built files.
       The exact method for doing this is controlled by the ``method`` argument.
 
-
 ``method``
-
    (optional): defaults to ``fresh`` when mode is ``full``.
    Git's incremental mode does not require a method.
    The full mode has four methods defined:
-
 
    ``clobber``
       It removes the build directory entirely then makes full clone from repo.
@@ -442,7 +437,6 @@ The Git step takes the following arguments:
       It performs all the incremental checkout behavior in ``source`` directory.
 
 ``getDescription``
-
    (optional) After checkout, invoke a `git describe` on the revision and save the result in a property; the property's name is either ``commit-description`` or ``commit-description-foo``, depending on whether the ``codebase`` argument was also provided.
    The argument should either be a ``bool`` or ``dict``, and will change how `git describe` is called:
 
@@ -471,11 +465,9 @@ The Git step takes the following arguments:
       * ``dirty=foo``: `--dirty=foo`
 
 ``config``
-
    (optional) A dict of git configuration settings to pass to the remote git commands.
 
 ``sshPrivateKey``
-
    (optional) The private key to use when running git for fetch operations. The
    ssh utility must be in the system path in order to use this option. On
    Windows only git distribution that embeds MINGW has been tested (as of July
@@ -484,12 +476,11 @@ The Git step takes the following arguments:
    `sshHostKey` option.
 
 ``sshHostKey``
-
-    (optional) Specifies public host key to match when authenticating with SSH
-    public key authentication. This may be either a :ref:`Secret` or just a
-    string. `sshPrivateKey` must be specified in order to use this option.
-    The host key must be in the form of `<key type> <base64-encoded string>`,
-    e.g. `ssh-rsa AAAAB3N<...>FAaQ==`.
+   (optional) Specifies public host key to match when authenticating with SSH
+   public key authentication. This may be either a :ref:`Secret` or just a
+   string. `sshPrivateKey` must be specified in order to use this option.
+   The host key must be in the form of `<key type> <base64-encoded string>`,
+   e.g. `ssh-rsa AAAAB3N<...>FAaQ==`.
 
 .. bb:step:: SVN
 

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -358,47 +358,43 @@ The :bb:step:`Git` build step clones or updates a `Git <http://git.or.cz/>`_ rep
 
 The Git step takes the following arguments:
 
-``repourl``
-   (required): the URL of the upstream Git repository.
+``repourl`` (required)
+   The URL of the upstream Git repository.
 
-``branch``
-   (optional): this specifies the name of the branch to use when a Build does not provide one of its own.
+``branch`` (optional)
+   This specifies the name of the branch to use when a Build does not provide one of its own.
    If this parameter is not specified, and the Build does not provide a branch, the default branch of the remote repository will be used.
    If ``alwaysUseLatest`` is ``True`` then the branch and revision information that comes with the Build is ignored and branch specified in this parameter is used.
 
-``submodules``
-   (optional): when initializing/updating a Git repository, this tells Buildbot whether to handle Git submodules.
-   Default: ``False``.
+``submodules`` (optional, default: ``False``)
+   When initializing/updating a Git repository, this tells Buildbot whether to handle Git submodules.
 
-``shallow``
-   (optional): instructs git to attempt shallow clones (``--depth 1``).
+``shallow`` (optional)
+   Instructs git to attempt shallow clones (``--depth 1``).
    The depth defaults to 1 and can be changed by passing an integer instead of ``True``.
    This option can be used only in full builds with clobber method.
 
-``reference``
-   (optional): use the specified string as a path to a reference repository on the local machine.
+``reference`` (optional)
+   Use the specified string as a path to a reference repository on the local machine.
    Git will try to grab objects from this path first instead of the main repository, if they exist.
 
-``origin``
-   (optional): By default, any clone will use the name "origin" as the remote repository (eg, "origin/master").
+``origin`` (optional)
+   By default, any clone will use the name "origin" as the remote repository (eg, "origin/master").
    This renderable option allows that to be configured to an alternate name.
 
-``progress``
-   (optional): passes the (``--progress``) flag to (:command:`git fetch`).
+``progress`` (optional)
+   Passes the (``--progress``) flag to (:command:`git fetch`).
    This solves issues of long fetches being killed due to lack of output, but requires Git 1.7.2 or later.
 
-``retryFetch``
-   (optional): defaults to ``False``.
+``retryFetch`` (optional, default: ``False``)
    If true, if the ``git fetch`` fails then buildbot retries to fetch again instead of failing the entire source checkout.
 
-``clobberOnFailure``
-   (optional): defaults to ``False``.
+``clobberOnFailure`` (optional, default: ``False``)
    If a fetch or full clone fails we can checkout source removing everything.
    This way new repository will be cloned.
    If retry fails it fails the source checkout step.
 
-``mode``
-   (optional): defaults to ``'incremental'``.
+``mode`` (optional, default: ``'incremental'``)
    Specifies whether to clean the build tree or not.
 
    ``incremental``
@@ -408,8 +404,7 @@ The Git step takes the following arguments:
       The build tree is clean of any built files.
       The exact method for doing this is controlled by the ``method`` argument.
 
-``method``
-   (optional): defaults to ``fresh`` when mode is ``full``.
+``method`` (optional, default: ``fresh`` when mode is ``full``)
    Git's incremental mode does not require a method.
    The full mode has four methods defined:
 
@@ -436,8 +431,8 @@ The Git step takes the following arguments:
       The behavior of source checkout follows exactly same as incremental.
       It performs all the incremental checkout behavior in ``source`` directory.
 
-``getDescription``
-   (optional) After checkout, invoke a `git describe` on the revision and save the result in a property; the property's name is either ``commit-description`` or ``commit-description-foo``, depending on whether the ``codebase`` argument was also provided.
+``getDescription`` (optional)
+   After checkout, invoke a `git describe` on the revision and save the result in a property; the property's name is either ``commit-description`` or ``commit-description-foo``, depending on whether the ``codebase`` argument was also provided.
    The argument should either be a ``bool`` or ``dict``, and will change how `git describe` is called:
 
    * ``getDescription=False``: disables this feature explicitly
@@ -464,17 +459,17 @@ The Git step takes the following arguments:
       * ``candidates=7``: `--candidates=7`
       * ``dirty=foo``: `--dirty=foo`
 
-``config``
-   (optional) A dict of git configuration settings to pass to the remote git commands.
+``config`` (optional)
+   A dict of git configuration settings to pass to the remote git commands.
 
-``sshPrivateKey``
-   (optional) The private key to use when running git for fetch operations.
+``sshPrivateKey`` (optional)
+   The private key to use when running git for fetch operations.
    The ssh utility must be in the system path in order to use this option.
    On Windows only git distribution that embeds MINGW has been tested (as of July 2017 the official distribution is MINGW-based).
    The worker must either have the host in the known hosts file or the host key must be specified via the `sshHostKey` option.
 
-``sshHostKey``
-   (optional) Specifies public host key to match when authenticating with SSH public key authentication.
+``sshHostKey`` (optional)
+   Specifies public host key to match when authenticating with SSH public key authentication.
    This may be either a :ref:`Secret` or just a string.
    `sshPrivateKey` must be specified in order to use this option.
    The host key must be in the form of `<key type> <base64-encoded string>`, e.g. `ssh-rsa AAAAB3N<...>FAaQ==`.

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -349,7 +349,7 @@ The :bb:step:`Git` build step clones or updates a `Git <http://git.or.cz/>`_ rep
 
    The Buildbot supports Git version 1.2.0 and later: earlier versions (such as the one shipped in Ubuntu 'Dapper') do not support the :command:`git init` command that the Buildbot uses.
 
-::
+.. code-block:: python
 
    from buildbot.plugins import steps
 

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -468,19 +468,16 @@ The Git step takes the following arguments:
    (optional) A dict of git configuration settings to pass to the remote git commands.
 
 ``sshPrivateKey``
-   (optional) The private key to use when running git for fetch operations. The
-   ssh utility must be in the system path in order to use this option. On
-   Windows only git distribution that embeds MINGW has been tested (as of July
-   2017 the official distribution is MINGW-based). The worker must either have
-   the host in the known hosts file or the host key must be specified via the
-   `sshHostKey` option.
+   (optional) The private key to use when running git for fetch operations.
+   The ssh utility must be in the system path in order to use this option.
+   On Windows only git distribution that embeds MINGW has been tested (as of July 2017 the official distribution is MINGW-based).
+   The worker must either have the host in the known hosts file or the host key must be specified via the `sshHostKey` option.
 
 ``sshHostKey``
-   (optional) Specifies public host key to match when authenticating with SSH
-   public key authentication. This may be either a :ref:`Secret` or just a
-   string. `sshPrivateKey` must be specified in order to use this option.
-   The host key must be in the form of `<key type> <base64-encoded string>`,
-   e.g. `ssh-rsa AAAAB3N<...>FAaQ==`.
+   (optional) Specifies public host key to match when authenticating with SSH public key authentication.
+   This may be either a :ref:`Secret` or just a string.
+   `sshPrivateKey` must be specified in order to use this option.
+   The host key must be in the form of `<key type> <base64-encoded string>`, e.g. `ssh-rsa AAAAB3N<...>FAaQ==`.
 
 .. bb:step:: SVN
 

--- a/master/docs/manual/cfg-buildsteps.rst
+++ b/master/docs/manual/cfg-buildsteps.rst
@@ -370,7 +370,7 @@ The Git step takes the following arguments:
    When initializing/updating a Git repository, this tells Buildbot whether to handle Git submodules.
 
 ``shallow`` (optional)
-   Instructs git to attempt shallow clones (``--depth 1``).
+   Instructs Git to attempt shallow clones (``--depth 1``).
    The depth defaults to 1 and can be changed by passing an integer instead of ``True``.
    This option can be used only in full builds with clobber method.
 
@@ -460,12 +460,12 @@ The Git step takes the following arguments:
       * ``dirty=foo``: `--dirty=foo`
 
 ``config`` (optional)
-   A dict of git configuration settings to pass to the remote git commands.
+   A dict of Git configuration settings to pass to the remote Git commands.
 
 ``sshPrivateKey`` (optional)
-   The private key to use when running git for fetch operations.
+   The private key to use when running Git for fetch operations.
    The ssh utility must be in the system path in order to use this option.
-   On Windows only git distribution that embeds MINGW has been tested (as of July 2017 the official distribution is MINGW-based).
+   On Windows only Git distribution that embeds MINGW has been tested (as of July 2017 the official distribution is MINGW-based).
    The worker must either have the host in the known hosts file or the host key must be specified via the `sshHostKey` option.
 
 ``sshHostKey`` (optional)


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

----

I finally found an internal project to use the latest Buildbot and while the only important change is about being able to use tags, I decided to polish the step's documentation.

Requests for more documentation updates are more than welcome :smile: