### PR TITLE
github: use payload "head_commit" when "commits" is empty

### DIFF
--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -263,12 +263,16 @@ class GitHubEventHandler(PullRequestMixin):
             log.msg("Branch `{}' deleted, ignoring".format(branch))
             return changes
 
+        if not payload['head_commit'] and not payload['commits']:
+            log.msg("No commits specified for branch `{}', ignoring".format(branch))
+            return changes
+
         # check skip pattern in commit message. e.g.: [ci skip] and [skip ci]
         head_msg = payload['head_commit'].get('message', '')
         if self._has_skip(head_msg):
             return changes
         commits = payload['commits']
-        if payload.get('created'):
+        if not commits:
             commits = [payload['head_commit']]
         for commit in commits:
             files = []


### PR DESCRIPTION
I received the following payload from GitHub and it was ignored because it was neither a "created" event nor did it have any "commits". I don't think using "head_commit" if "commits" is empty should be a problem, but alternatively the change could be to check "forced" or "created".

```json
{
  "ref": "refs/heads/branch",
  "before": "5a1c519a859da198bfb20265e2e23a53655e6bc5",
  "after": "9edc7d39d46aedbe39e417d630a122144d7e2295",
  "created": false,
  "deleted": false,
  "forced": true,
  "base_ref": null,
  "compare": "https://github.com/org/repo/compare/5a1c519a859da198bfb20265e2e23a53655e6bc5...9edc7d39d46aedbe39e417d630a122144d7e2295",
  "commits": [ ],
  "head_commit": {
    "id": "9edc7d39d46aedbe39e417d630a122144d7e2295",
    "tree_id": "782c3d6c4b3cd122738af78203052c2bf7d64033",
    "distinct": true,
    "message": "commit message",
    "timestamp": "2018-09-19T12:40:21-07:00",
    "url": "https://github.com/org/repo/commit/9edc7d39d46aedbe39e417d630a122144d7e2295",
    "author": {
      ...
    },
    "committer": {
      ...
    },
    "added": [
      "filename",
    ],
    "removed": [ ],
    "modified": [ ]
  }
}
                                                                            
```

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
