### PR TITLE
WIP: make urlText renderable for the FileUpload build step

### DIFF
--- a/master/buildbot/newsfragments/file-upload-urltext.feature
+++ b/master/buildbot/newsfragments/file-upload-urltext.feature
@@ -1,0 +1,1 @@
+Make urlText renderable for the :py:class:`~buildbot.steps.transfer.FileUpload` build step.

--- a/master/buildbot/newsfragments/file-upload-urltext.feature
+++ b/master/buildbot/newsfragments/file-upload-urltext.feature
@@ -1,1 +1,1 @@
-Make urlText renderable for the :py:class:`~buildbot.steps.transfer.FileUpload` build step.
+Make ``urlText`` renderable for the :py:class:`~buildbot.steps.transfer.FileUpload` build step.

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -92,7 +92,11 @@ class FileUpload(_TransferBuildStep, WorkerAPICompatMixin):
 
     name = 'upload'
 
-    renderables = ['workersrc', 'masterdest', 'url']
+    renderables = [
+        'masterdest',
+        'url',
+        'workersrc',
+    ]
 
     def __init__(self, workersrc=None, masterdest=None,
                  workdir=None, maxsize=None, blocksize=16 * 1024, mode=None,

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -95,6 +95,7 @@ class FileUpload(_TransferBuildStep, WorkerAPICompatMixin):
     renderables = [
         'masterdest',
         'url',
+        'urlText',
         'workersrc',
     ]
 


### PR DESCRIPTION
## Contributor Checklist:

* [?] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [?] I have updated the appropriate documentation
-----
@tardyp do you think we'd need a test case for this change and/or documentation: the former would rely on the renderables test suite and the latter would stand out from the other parameter documentation for this build step.