### PR TITLE
Fixed Builders page doesn't list workers in multi-master configuration

### DIFF
--- a/master/buildbot/newsfragments/multimaster_datagrouper.bugfix
+++ b/master/buildbot/newsfragments/multimaster_datagrouper.bugfix
@@ -1,0 +1,1 @@
+Fixed builders page doesn't list workers in multi-master configuration (:issue:`4326`)

--- a/www/base/src/app/common/services/datagrouper/datagrouper.service.coffee
+++ b/www/base/src/app/common/services/datagrouper/datagrouper.service.coffee
@@ -25,7 +25,8 @@ class dataGrouperService extends Factory('common')
                                 group = collection1.get(item2[joinid])[attribute] ?= []
                             else
                                 group = temp_dict[item2[joinid]] ?= []
-                            group.push(item)
+                            if item not in group
+                                group.push(item)
                 else
                     collection2.onNew = (item) ->
                         # the collection1 might not be yet loaded, so we need to store the worker list


### PR DESCRIPTION
Fixed  https://github.com/buildbot/buildbot/issues/4326: 'Builders page doesn't list workers in multi-master configuration'.