### PR TITLE
Fix build-change association for multi-codebase builds.

### DIFF
--- a/master/buildbot/newsfragments/multi_codebase_build_change_association.bugfix
+++ b/master/buildbot/newsfragments/multi_codebase_build_change_association.bugfix
@@ -1,0 +1,2 @@
+Fix build-change association for multi-codebase builds in the console view..
+

--- a/www/console_view/src/module/main.module.coffee
+++ b/www/console_view/src/module/main.module.coffee
@@ -268,6 +268,8 @@ class Console extends Controller
         if  buildset? and buildset.sourcestamps?
             for sourcestamp in buildset.sourcestamps
                 change = @changesBySSID[sourcestamp.ssid]
+                if change?
+                    break
 
         if not change? and build.properties?.got_revision?
             rev = build.properties.got_revision[0]
@@ -278,9 +280,13 @@ class Console extends Controller
                     change = @makeFakeChange("", rev, build.started_at)
             else
                 for codebase, revision of rev
-                    change = @changesByRevision[rev]
-                    if not change?
-                        change = @makeFakeChange(codebase, revision, build.started_at)
+                    change = @changesByRevision[revision]
+                    if change?
+                        break;
+
+                if not change?
+                    revision = if rev is {} then "" else rev[rev.keys()[0]]
+                    change = @makeFakeChange(codebase, revision, build.started_at)
 
         if not change?
             revision = "unknown revision #{build.builderid}-#{build.buildid}"


### PR DESCRIPTION
Otherwise depending on iteration order, the codebase with the change
may not be the last one and the change gets overwritten again.

## Contributor Checklist:

* [ ] I have updated the unit tests
   I couldn't find any javascript/coffeescript tests to update?
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
