### PR TITLE
Fix test_linux_distro on Arch Linux (closes #4279)

### DIFF
--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -153,6 +153,6 @@ class Tests(unittest.TestCase):
         distro = linux_distribution()
         self.assertEqual(len(distro), 2)
         self.assertNotIn("unknown", distro[0])
-        # Rolling distros like Arch Linux (arch) does not have VERSION_ID
+        # Rolling distributions like Arch Linux (arch) does not have VERSION_ID
         if distro[0] != "arch":
             self.assertNotIn("unknown", distro[1])

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -153,4 +153,6 @@ class Tests(unittest.TestCase):
         distro = linux_distribution()
         self.assertEqual(len(distro), 2)
         self.assertNotIn("unknown", distro[0])
-        self.assertNotIn("unknown", distro[1])
+        # Rolling distros like Arch Linux (arch) does not have VERSION_ID
+        if distro[0] != "arch":
+            self.assertNotIn("unknown", distro[1])


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory) - this change looks too trivial for a news item
* [ ] I have updated the appropriate documentation - same as above