### PR TITLE
Improved FileUpload efficiency

### DIFF
--- a/master/buildbot/newsfragments/improve_fileupload.bugfix
+++ b/master/buildbot/newsfragments/improve_fileupload.bugfix
@@ -1,0 +1,1 @@
+Improved FileUpload efficiency (:issue:`3709`)

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -100,7 +100,7 @@ class FileUpload(_TransferBuildStep, WorkerAPICompatMixin):
     ]
 
     def __init__(self, workersrc=None, masterdest=None,
-                 workdir=None, maxsize=None, blocksize=16 * 1024, mode=None,
+                 workdir=None, maxsize=None, blocksize=256 * 1024, mode=None,
                  keepstamp=False, url=None, urlText=None,
                  slavesrc=None,  # deprecated, use `workersrc` instead
                  **buildstep_kwargs):

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -122,7 +122,7 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -140,7 +140,7 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 slavesrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -161,7 +161,7 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc=__file__, workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=True,
+                blocksize=262144, maxsize=None, keepstamp=True,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString('test', timestamp=timestamp))
             + 0)
@@ -191,7 +191,7 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc=__file__, workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -213,7 +213,7 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc=__file__, workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -237,7 +237,7 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc=__file__, workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -258,7 +258,7 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + 1)
 
@@ -278,7 +278,7 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(behavior))
 


### PR DESCRIPTION
Fixed: https://github.com/buildbot/buildbot/issues/3709  "Upload from worker to master sometimes takes few hours instead of seconds"