### PR TITLE
Support proxying to buildbot instance server over HTTPS for developing www base; fix typos

### DIFF
--- a/master/buildbot/newsfragments/proxy_www_base_ssl.feature
+++ b/master/buildbot/newsfragments/proxy_www_base_ssl.feature
@@ -1,0 +1,2 @@
+Added SSL proxy capability to base web application's developer test setup
+(``gulp dev proxy --host the-buildbot-host --secure``).

--- a/master/docs/developer/www-base-app.rst
+++ b/master/docs/developer/www-base-app.rst
@@ -257,7 +257,7 @@ You can then just point your browser to localhost:8010, and you will access `<ht
 Guanlecoja
 ----------
 
-Buildbot's build environment has been factorized for reuse in other projects and plugins, and is callsed Guanlecoja.
+Buildbot's build environment has been factorized for reuse in other projects and plugins, and is called Guanlecoja.
 
 The documentation and meaning of this name is maintained in Guanlecoja's own site. https://github.com/buildbot/guanlecoja/
 

--- a/master/docs/developer/www-base-app.rst
+++ b/master/docs/developer/www-base-app.rst
@@ -251,7 +251,7 @@ Provided you run it in a buildbot master virtualenv, the following command will 
 
     gulp dev proxy --host nine.buildbot.net
 
-You can then just point your browser to localhost:8010, and you will access `<http://nine.buildbot.net>`__, with your own version of the UI.
+You can then just point your browser to localhost:8080, and you will access `<http://nine.buildbot.net>`__, with your own version of the UI.
 
 
 Guanlecoja

--- a/master/docs/developer/www-base-app.rst
+++ b/master/docs/developer/www-base-app.rst
@@ -253,6 +253,13 @@ Provided you run it in a buildbot master virtualenv, the following command will 
 
 You can then just point your browser to localhost:8080, and you will access `<http://nine.buildbot.net>`__, with your own version of the UI.
 
+If your buildbot instance is served over HTTPS, use the ``--secure`` argument to access the host via ``https://`` and ``wss://``, respectively. The argument ``--ignoresslerrors`` may be helpful if the server uses a self-signed certificate. Note that the ``--host`` parameter can specify port and URL path, in case buildbot is served on a non-standard port or not from the root path ``/``.
+
+.. code-block:: none
+
+    gulp dev proxy --host ssl-protected.ci.example.com --secure
+    gulp dev proxy --host self-signed-ssl.ci.example.com/buildbot --secure --ignoresslerrors
+
 
 Guanlecoja
 ----------

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -118,8 +118,8 @@ bzrignore
 CaaS
 callables
 Callables
+called
 callee
-callsed
 camelCase
 cancelled
 cancelling


### PR DESCRIPTION
* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory) **– yes, but the directory is called plural `newsfragments`**
* [x] I have updated the appropriate documentation
