### PR TITLE
Fix usage of master paths in worker on git operations when ssh key is used (fixes #4316)

### DIFF
--- a/master/buildbot/newsfragments/use-worker-paths-for-git.bugfix
+++ b/master/buildbot/newsfragments/use-worker-paths-for-git.bugfix
@@ -1,0 +1,1 @@
+Fix usage of master paths when doing Git operations on worker (:issue:`4268`)

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -88,8 +88,8 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
 
@@ -147,8 +147,8 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
         ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
 
         self.expectCommands(
@@ -205,10 +205,9 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
-        ssh_wrapper_path = \
-            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_wrapper_path = '/wrk/.wkdir.buildbot/ssh-wrapper.sh'
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',
@@ -272,10 +271,9 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
-        ssh_known_hosts_path = \
-            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}" ' \
             '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
@@ -343,10 +341,9 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
-        ssh_known_hosts_path = \
-            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
         ssh_command = \
             'ssh -i "{0}" ' \
             '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
@@ -414,12 +411,10 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
-        ssh_wrapper_path = \
-            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
-        ssh_known_hosts_path = \
-            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_wrapper_path = '/wrk/.wkdir.buildbot/ssh-wrapper.sh'
+        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',
@@ -484,6 +479,79 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
         return self.runStep()
 
+    def test_mode_full_clean_ssh_host_key_2_10_abs_workdir(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='clean', sshPrivateKey='sshkey',
+                           sshHostKey='sshhostkey'),
+            wantDefaultWorkdir=False)
+        workdir = '/myworkdir/workdir'
+        self.build.workdir = workdir
+
+        ssh_workdir = '/myworkdir/.workdir.buildbot'
+        ssh_key_path = '/myworkdir/.workdir.buildbot/ssh-key'
+        ssh_known_hosts_path = '/myworkdir/.workdir.buildbot/ssh-known-hosts'
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}" ' \
+            '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
+                                                 ssh_known_hosts_path)
+
+        self.expectCommands(
+            ExpectShell(workdir=workdir,
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 2.10.0')
+            + 0,
+            Expect('stat', dict(file='/myworkdir/workdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('mkdir', dict(dir=ssh_workdir,
+                                 logEnviron=True))
+            + 0,
+            Expect('downloadFile', dict(blocksize=32768, maxsize=None,
+                                        reader=ExpectRemoteRef(
+                                            remotetransfer.StringFileReader),
+                                        workerdest=ssh_key_path,
+                                        workdir=workdir,
+                                        mode=0o400))
+            + 0,
+            Expect('downloadFile',
+                   dict(blocksize=32768, maxsize=None,
+                        reader=ExpectRemoteRef(remotetransfer.StringFileReader),
+                        workerdest=ssh_known_hosts_path,
+                        workdir=workdir,
+                        mode=0o400))
+            + 0,
+            Expect('listdir', {'dir': workdir, 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir=workdir,
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir=workdir,
+                        command=['git', '-c', ssh_command_config,
+                                 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD'])
+            + 0,
+            ExpectShell(workdir=workdir,
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir=workdir,
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+            Expect('rmdir', dict(dir=ssh_workdir,
+                                 logEnviron=True))
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.runStep()
+
     def test_mode_full_clean_win32path(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
@@ -530,10 +598,9 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.changeWorkerSystem('win32')
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')
-        ssh_command_config = \
-            'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
+        ssh_workdir = '\\wrk\\.wkdir.buildbot'
+        ssh_key_path = '\\wrk\\.wkdir.buildbot\\ssh-key'
+        ssh_command_config = 'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',
@@ -590,8 +657,8 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.changeWorkerSystem('win32')
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')
+        ssh_workdir = '\\wrk\\.wkdir.buildbot'
+        ssh_key_path = '\\wrk\\.wkdir.buildbot\\ssh-key'
         ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
 
         self.expectCommands(
@@ -649,10 +716,9 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.changeWorkerSystem('win32')
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')
-        ssh_wrapper_path = \
-            self.build.path_module.abspath('.wkdir.buildbot\\ssh-wrapper.sh')
+        ssh_workdir = '\\wrk\\.wkdir.buildbot'
+        ssh_key_path = '\\wrk\\.wkdir.buildbot\\ssh-key'
+        ssh_wrapper_path = '\\wrk\\.wkdir.buildbot\\ssh-wrapper.sh'
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',
@@ -1506,8 +1572,8 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='incremental', branch='test-branch',
                            sshPrivateKey='ssh-key'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
 
@@ -2201,8 +2267,8 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='copy', sshPrivateKey='sshkey'))
 
-        ssh_workdir = self.build.path_module.abspath('.source.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.source.buildbot/ssh-key')
+        ssh_workdir = '/wrk/.source.buildbot'
+        ssh_key_path = '/wrk/.source.buildbot/ssh-key'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
 
@@ -3297,8 +3363,8 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
 
@@ -3337,8 +3403,8 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
         ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
 
         self.expectCommands(
@@ -3376,10 +3442,9 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
-        ssh_wrapper_path = \
-            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_wrapper_path = '/wrk/.wkdir.buildbot/ssh-wrapper.sh'
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',
@@ -3424,10 +3489,9 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
-        ssh_known_hosts_path = \
-            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}" ' \
             '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
@@ -3475,10 +3539,9 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
-        ssh_known_hosts_path = \
-            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
         ssh_command = \
             'ssh -i "{0}" ' \
             '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
@@ -3526,12 +3589,10 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
-        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
-        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
-        ssh_wrapper_path = \
-            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
-        ssh_known_hosts_path = \
-            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+        ssh_workdir = '/wrk/.wkdir.buildbot'
+        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_wrapper_path = '/wrk/.wkdir.buildbot/ssh-wrapper.sh'
+        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -88,6 +88,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -97,13 +103,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -115,7 +121,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', '-c', 'core.sshCommand=ssh -i "../.wkdir.buildbot/ssh-key"',
+                        command=['git', '-c', ssh_command_config,
                                  'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'])
@@ -128,7 +134,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -141,6 +147,11 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -150,13 +161,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -171,7 +182,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
-                        env={'GIT_SSH_COMMAND': 'ssh -i "../.wkdir.buildbot/ssh-key"'})
+                        env={'GIT_SSH_COMMAND': ssh_command})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -181,7 +192,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -194,6 +205,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_wrapper_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -203,20 +220,20 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-wrapper.sh',
+                                        workerdest=ssh_wrapper_path,
                                         workdir='wkdir',
                                         mode=0o700))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -231,7 +248,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
-                        env={'GIT_SSH': '../.wkdir.buildbot/ssh-wrapper.sh'})
+                        env={'GIT_SSH': ssh_wrapper_path})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -241,7 +258,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -256,9 +273,15 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
         ssh_command_config = \
-            'core.sshCommand=ssh -i "../.wkdir.buildbot/ssh-key" ' \
-            '-o "UserKnownHostsFile=../.wkdir.buildbot/ssh-known-hosts"'
+            'core.sshCommand=ssh -i "{0}" ' \
+            '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
+                                                 ssh_known_hosts_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -268,20 +291,20 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -306,7 +329,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -321,9 +344,15 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
         ssh_command = \
-            'ssh -i "../.wkdir.buildbot/ssh-key" ' \
-            '-o "UserKnownHostsFile=../.wkdir.buildbot/ssh-known-hosts"'
+            'ssh -i "{0}" ' \
+            '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
+                                                 ssh_known_hosts_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -333,20 +362,20 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -371,7 +400,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -385,6 +414,14 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_wrapper_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -394,27 +431,27 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-wrapper.sh',
+                                        workerdest=ssh_wrapper_path,
                                         workdir='wkdir',
                                         mode=0o700))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -429,7 +466,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
-                        env={'GIT_SSH': '../.wkdir.buildbot/ssh-wrapper.sh'})
+                        env={'GIT_SSH': ssh_wrapper_path})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -439,7 +476,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -495,6 +532,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.build.path_module = namedModule('ntpath')
         self.worker.worker_system = 'win32'
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -504,13 +547,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir\\.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='..\\.wkdir.buildbot\\ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -522,7 +565,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', '-c', 'core.sshCommand=ssh -i "..\\.wkdir.buildbot\\ssh-key"',
+                        command=['git', '-c', ssh_command_config,
                                  'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'])
@@ -535,7 +578,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -550,6 +593,11 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.build.path_module = namedModule('ntpath')
         self.worker.worker_system = 'win32'
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')
+        ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -559,13 +607,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir\\.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='..\\.wkdir.buildbot\\ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -580,7 +628,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
-                        env={'GIT_SSH_COMMAND': 'ssh -i "..\\.wkdir.buildbot\\ssh-key"'})
+                        env={'GIT_SSH_COMMAND': ssh_command})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -590,7 +638,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -605,6 +653,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.build.path_module = namedModule('ntpath')
         self.worker.worker_system = 'win32'
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')
+        ssh_wrapper_path = \
+            self.build.path_module.abspath('.wkdir.buildbot\\ssh-wrapper.sh')
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -614,20 +668,20 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir\\.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='..\\.wkdir.buildbot\\ssh-wrapper.sh',
+                                        workerdest=ssh_wrapper_path,
                                         workdir='wkdir',
                                         mode=0o700))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='..\\.wkdir.buildbot\\ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -642,7 +696,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
-                        env={'GIT_SSH': '..\\.wkdir.buildbot\\ssh-wrapper.sh'})
+                        env={'GIT_SSH': ssh_wrapper_path})
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -652,7 +706,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -1456,6 +1510,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='incremental', branch='test-branch',
                            sshPrivateKey='ssh-key'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -1465,13 +1525,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.wkdir.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='wkdir',
                                         mode=0o400))
             + 0,
@@ -1480,7 +1540,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', '-c', 'core.sshCommand=ssh -i "../.wkdir.buildbot/ssh-key"',
+                        command=['git', '-c', ssh_command_config,
                                  'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'test-branch'])
@@ -1496,7 +1556,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -2146,6 +2206,11 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='copy', sshPrivateKey='sshkey'))
 
+        ssh_workdir = self.build.path_module.abspath('.source.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.source.buildbot/ssh-key')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -2155,13 +2220,13 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             Expect('stat', dict(file='wkdir/.buildbot-patched',
                                 logEnviron=True))
             + 1,
-            Expect('mkdir', dict(dir='.source.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile', dict(blocksize=32768, maxsize=None,
                                         reader=ExpectRemoteRef(
                                             remotetransfer.StringFileReader),
-                                        workerdest='../.source.buildbot/ssh-key',
+                                        workerdest=ssh_key_path,
                                         workdir='source',
                                         mode=0o400))
             + 0,
@@ -2173,7 +2238,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='source',
-                        command=['git', '-c', 'core.sshCommand=ssh -i "../.source.buildbot/ssh-key"',
+                        command=['git', '-c', ssh_command_config,
                                  'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'])
@@ -2189,7 +2254,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
             + 0,
-            Expect('rmdir', dict(dir='.source.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3232,26 +3297,30 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     def test_push_ssh_key_2_10(self):
         url = 'ssh://github.com/test/test.git'
-        ssh_command_config = \
-            'core.sshCommand=ssh -i "../.wkdir.buildbot/ssh-key"'
 
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 2.10.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -3259,7 +3328,7 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '-c', ssh_command_config,
                                  'push', url, 'testbranch'])
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3268,25 +3337,29 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     def test_push_ssh_key_2_3(self):
         url = 'ssh://github.com/test/test.git'
-        ssh_command = 'ssh -i "../.wkdir.buildbot/ssh-key"'
 
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 2.3.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -3294,7 +3367,7 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'push', url, 'testbranch'],
                         env={'GIT_SSH_COMMAND': ssh_command})
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3307,20 +3380,26 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_wrapper_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 1.7.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-wrapper.sh',
+                        workerdest=ssh_wrapper_path,
                         workdir='wkdir',
                         mode=0o700))
             + 0,
@@ -3328,15 +3407,15 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'push', url, 'testbranch'],
-                        env={'GIT_SSH': '../.wkdir.buildbot/ssh-wrapper.sh'})
+                        env={'GIT_SSH': ssh_wrapper_path})
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3345,35 +3424,41 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     def test_push_ssh_host_key_2_10(self):
         url = 'ssh://github.com/test/test.git'
-        ssh_command_config = \
-            'core.sshCommand=ssh -i "../.wkdir.buildbot/ssh-key" ' \
-            '-o "UserKnownHostsFile=../.wkdir.buildbot/ssh-known-hosts"'
-
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+        ssh_command_config = \
+            'core.sshCommand=ssh -i "{0}" ' \
+            '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
+                                                 ssh_known_hosts_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 2.10.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -3381,7 +3466,7 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', '-c', ssh_command_config,
                                  'push', url, 'testbranch'])
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3390,35 +3475,41 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     def test_push_ssh_host_key_2_3(self):
         url = 'ssh://github.com/test/test.git'
-        ssh_command = \
-            'ssh -i "../.wkdir.buildbot/ssh-key" ' \
-            '-o "UserKnownHostsFile=../.wkdir.buildbot/ssh-known-hosts"'
-
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+        ssh_command = \
+            'ssh -i "{0}" ' \
+            '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
+                                                 ssh_known_hosts_path)
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 2.3.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
@@ -3426,7 +3517,7 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'push', url, 'testbranch'],
                         env={'GIT_SSH_COMMAND': ssh_command})
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )
@@ -3435,25 +3526,32 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     def test_push_ssh_host_key_1_7(self):
         url = 'ssh://github.com/test/test.git'
-
         self.setupStep(
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
+
+        ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
+        ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot/ssh-key')
+        ssh_wrapper_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-wrapper.sh')
+        ssh_known_hosts_path = \
+            self.build.path_module.abspath('.wkdir.buildbot/ssh-known-hosts')
+
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 1.7.0')
             + 0,
-            Expect('mkdir', dict(dir='.wkdir.buildbot',
+            Expect('mkdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-wrapper.sh',
+                        workerdest=ssh_wrapper_path,
                         workdir='wkdir',
                         mode=0o700))
             + 0,
@@ -3461,22 +3559,22 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(
                             remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-key',
+                        workerdest=ssh_key_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
             Expect('downloadFile',
                    dict(blocksize=32768, maxsize=None,
                         reader=ExpectRemoteRef(remotetransfer.StringFileReader),
-                        workerdest='../.wkdir.buildbot/ssh-known-hosts',
+                        workerdest=ssh_known_hosts_path,
                         workdir='wkdir',
                         mode=0o400))
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'push', url, 'testbranch'],
-                        env={'GIT_SSH': '../.wkdir.buildbot/ssh-wrapper.sh'})
+                        env={'GIT_SSH': ssh_wrapper_path})
             + 0,
-            Expect('rmdir', dict(dir='.wkdir.buildbot',
+            Expect('rmdir', dict(dir=ssh_workdir,
                                  logEnviron=True))
             + 0,
         )

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -18,7 +18,6 @@ from __future__ import print_function
 
 from twisted.internet import defer
 from twisted.internet import error
-from twisted.python.reflect import namedModule
 from twisted.trial import unittest
 
 from buildbot.interfaces import WorkerTooOldError
@@ -489,8 +488,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean'))
-        self.build.path_module = namedModule('ntpath')
-        self.worker.worker_system = 'win32'
+        self.changeWorkerSystem('win32')
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -530,8 +528,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
-        self.build.path_module = namedModule('ntpath')
-        self.worker.worker_system = 'win32'
+        self.changeWorkerSystem('win32')
 
         ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
         ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')
@@ -591,8 +588,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
-        self.build.path_module = namedModule('ntpath')
-        self.worker.worker_system = 'win32'
+        self.changeWorkerSystem('win32')
 
         ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
         ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')
@@ -651,8 +647,7 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
-        self.build.path_module = namedModule('ntpath')
-        self.worker.worker_system = 'win32'
+        self.changeWorkerSystem('win32')
 
         ssh_workdir = self.build.path_module.abspath('.wkdir.buildbot')
         ssh_key_path = self.build.path_module.abspath('.wkdir.buildbot\\ssh-key')

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -24,6 +24,7 @@ import mock
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.python import log
+from twisted.python.reflect import namedModule
 
 from buildbot import interfaces
 from buildbot.process import buildstep
@@ -438,3 +439,11 @@ class BuildStepMixin(object):
             if not exp.shouldKeepMatchingAfter(command):
                 self.expected_remote_commands.pop(0)
         defer.returnValue(command)
+
+    def changeWorkerSystem(self, system):
+        self.worker.worker_system = system
+        if system in ['nt', 'win32']:
+            self.build.path_module = namedModule('ntpath')
+        else:
+            self.build.path_module = namedModule('posixpath')
+

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -444,6 +444,7 @@ class BuildStepMixin(object):
         self.worker.worker_system = system
         if system in ['nt', 'win32']:
             self.build.path_module = namedModule('ntpath')
+            self.worker.worker_basedir = '\\wrk'
         else:
             self.build.path_module = namedModule('posixpath')
-
+            self.worker.worker_basedir = '/wrk'

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -139,7 +139,11 @@ class GitStepMixin(GitMixin):
         path_module = self.build.path_module
 
         workdir = self._getSshDataWorkDir().rstrip('/\\')
-        parent_path = path_module.abspath(path_module.dirname(workdir))
+        if path_module.isabs(workdir):
+            parent_path = path_module.dirname(workdir)
+        else:
+            parent_path = path_module.join(self.worker.worker_basedir,
+                                           path_module.dirname(workdir))
 
         basename = '.{0}.buildbot'.format(path_module.basename(workdir))
         return path_module.join(parent_path, basename)

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -139,7 +139,7 @@ class GitStepMixin(GitMixin):
         path_module = self.build.path_module
 
         workdir = self._getSshDataWorkDir().rstrip('/\\')
-        parent_path = path_module.dirname(workdir)
+        parent_path = path_module.abspath(path_module.dirname(workdir))
 
         basename = '.{0}.buildbot'.format(path_module.basename(workdir))
         return path_module.join(parent_path, basename)
@@ -154,26 +154,19 @@ class GitStepMixin(GitMixin):
         return self.build.path_module.join(self._getSshDataPath(), 'ssh-wrapper.sh')
 
     def _getSshWrapperScript(self):
-        rel_key_path = self.build.path_module.relpath(
-                self._getSshPrivateKeyPath(), self._getSshDataWorkDir())
-
-        return getSshWrapperScriptContents(rel_key_path)
+        return getSshWrapperScriptContents(self._getSshPrivateKeyPath)
 
     def _adjustCommandParamsForSshPrivateKey(self, full_command, full_env):
 
-        rel_key_path = self.build.path_module.relpath(
-                self._getSshPrivateKeyPath(), self.workdir)
-        rel_ssh_wrapper_path = self.build.path_module.relpath(
-                self._getSshWrapperScriptPath(), self.workdir)
-        rel_host_key_path = None
+        key_path = self._getSshPrivateKeyPath()
+        ssh_wrapper_path = self._getSshWrapperScriptPath()
+        host_key_path = None
         if self.sshHostKey is not None:
-            rel_host_key_path = self.build.path_module.relpath(
-                    self._getSshHostKeyPath(), self.workdir)
+            host_key_path = self._getSshHostKeyPath()
 
         self.adjustCommandParamsForSshPrivateKey(full_command, full_env,
-                                                 rel_key_path,
-                                                 rel_ssh_wrapper_path,
-                                                 rel_host_key_path)
+                                                 key_path, ssh_wrapper_path,
+                                                 host_key_path)
 
     @defer.inlineCallbacks
     def _dovccmd(self, command, abandonOnFailure=True, collectStdout=False, initialStdin=None):
@@ -256,26 +249,20 @@ class GitStepMixin(GitMixin):
         # options
         workdir = self._getSshDataWorkDir()
 
-        rel_key_path = self.build.path_module.relpath(
-                self._getSshPrivateKeyPath(), workdir)
-        rel_host_key_path = self.build.path_module.relpath(
-                self._getSshHostKeyPath(), workdir)
-        rel_wrapper_script_path = self.build.path_module.relpath(
-                self._getSshWrapperScriptPath(), workdir)
-
         yield self.runMkdir(self._getSshDataPath())
 
         if not self.supportsSshPrivateKeyAsEnvOption:
-            yield self.downloadFileContentToWorker(rel_wrapper_script_path,
+            yield self.downloadFileContentToWorker(self._getSshWrapperScriptPath(),
                                                    self._getSshWrapperScript(),
                                                    workdir=workdir, mode=0o700)
 
-        yield self.downloadFileContentToWorker(rel_key_path, private_key,
+        yield self.downloadFileContentToWorker(self._getSshPrivateKeyPath(),
+                                               private_key,
                                                workdir=workdir, mode=0o400)
 
         if self.sshHostKey is not None:
             known_hosts_contents = getSshKnownHostsContents(host_key)
-            yield self.downloadFileContentToWorker(rel_host_key_path,
+            yield self.downloadFileContentToWorker(self._getSshHostKeyPath(),
                                                    known_hosts_contents,
                                                    workdir=workdir, mode=0o400)
 


### PR DESCRIPTION
The recent ssh key code used master paths to store temporary data and thus broke users with different filesystem layouts (#4316). This PR reverts the reversion of #4268 and fixes the issue. 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [not applicable] I have updated the appropriate documentation
