### PR TITLE
Update fiveminutes.rst

### DIFF
--- a/master/docs/tutorial/fiveminutes.rst
+++ b/master/docs/tutorial/fiveminutes.rst
@@ -193,7 +193,7 @@ First we create two builders, one for each branch (see the builders paragraph ab
     c['schedulers'] = [trunkchanged, branch72changed]
 
 The syntax of the change filter is VCS-dependent (above is for SVN), but again once the idea is clear, the documentation has all the details.
-Another feature of the scheduler is that is can be told which changes, within those it's paying attention to, are important and which are not.
+Another feature of the scheduler is that it can be told which changes, within those it's paying attention to, are important and which are not.
 For example, there may be a documentation directory in the branch the scheduler is watching, but changes under that directory should not trigger a build of the binary.
 This finer filtering is implemented by means of the ``fileIsImportant`` argument to the scheduler (full details in the docs and - alas - in the sources).
 


### PR DESCRIPTION
Correcting a grammatical error

Since this is a very minor change to documentation, the items in the checklist do not apply

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
