### PR TITLE
Show buildrequest owners in the builder page (fixes #4207, #3904)

### DIFF
--- a/master/buildbot/newsfragments/add-buildrequest-owner-on-builder-page.bugfix
+++ b/master/buildbot/newsfragments/add-buildrequest-owner-on-builder-page.bugfix
@@ -1,0 +1,1 @@
+Fixed missing buildrequest owners in the builder page (:issue:`4207`, :issue:`3904`)

--- a/www/base/src/app/builders/builder/builder.controller.coffee
+++ b/www/base/src/app/builders/builder/builder.controller.coffee
@@ -100,5 +100,9 @@ class Builder extends Controller
                 limit: $scope.numbuilds
                 order: '-number'
             $scope.buildrequests = builder.getBuildrequests(claimed:false)
+            $scope.buildrequests.onNew = (buildrequest) ->
+                data.getBuildsets(buildrequest.buildsetid).onNew = (buildset) ->
+                    buildset.getProperties().onNew = (properties) ->
+                        buildrequest.properties = properties
             $scope.builds.onChange=refreshContextMenu
             $scope.buildrequests.onChange=refreshContextMenu

--- a/www/base/src/app/builders/builder/builder.tpl.jade
+++ b/www/base/src/app/builders/builder/builder.tpl.jade
@@ -22,6 +22,7 @@
             span(title="{{br.submitted_at | dateformat:'LLL'}}")
               | {{br.submitted_at | timeago }}
           td
+            span {{br.properties.owner[0]}}
           td
   builds-table(builder="builder", builds="builds")
   a.btn.btn-default(ui-sref='builder({builder: builder.builderid, numbuilds: numbuilds + 100})', ng-if="builds.length>=numbuilds")


### PR DESCRIPTION
Fixes #4207, #3904.

This change is not tested by a e2e test, should I create one?

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
