### PR TITLE
Fix buildrequest number badge in builder page

### DIFF
--- a/master/buildbot/newsfragments/fix-buildrequest-badge-on-builder-page.bugfix
+++ b/master/buildbot/newsfragments/fix-buildrequest-badge-on-builder-page.bugfix
@@ -1,0 +1,1 @@
+Fixed display of the buildrequest number badge text in the builder page when on hover.

--- a/www/base/src/app/builders/builder/builder.tpl.jade
+++ b/www/base/src/app/builders/builder/builder.tpl.jade
@@ -15,9 +15,7 @@
       tr(ng-repeat='br in buildrequests | orderBy:"-submitted_at"', ng-if="br.claimed==false" )
           td
             a(ui-sref="buildrequest({buildrequest:br.buildrequestid})")
-              span.badge-status(ng-class="results2class(br, 'pulse')")
-                  .badge-inactive {{br.buildrequestid}}
-                  .badge-active {{results2text(br)}}
+              span.badge-status {{br.buildrequestid}}
           td
             span(title="{{br.submitted_at | dateformat:'LLL'}}")
               | {{br.submitted_at | timeago }}


### PR DESCRIPTION
Trivial fix: previously the unclaimed buildrequests badge was being cleared on hover as results2text is not well defined for unclaimed buildrequests.. It seems that the code in the template has been copied from build template sometime in the past, causing this small usability error.