### PR TITLE
Create a "Pending Buildrequests" page that lists all unclaimed buildrequests (fixes #4239)

### DIFF
--- a/master/buildbot/newsfragments/add-pending-buildrequests-page.feature
+++ b/master/buildbot/newsfragments/add-pending-buildrequests-page.feature
@@ -1,0 +1,1 @@
+Added a page that lists all pending buildrequests (:issue:`4239`)

--- a/www/base/src/app/buildrequests/pendingbuildrequests.controller.coffee
+++ b/www/base/src/app/buildrequests/pendingbuildrequests.controller.coffee
@@ -1,0 +1,16 @@
+class Pendingbuildrequests extends Controller
+    constructor: ($log, $scope, dataService, bbSettingsService) ->
+        $scope.settings = bbSettingsService.getSettingsGroup("BuildRequests")
+        $scope.$watch('settings', ->
+            bbSettingsService.save()
+        , true)
+        buildrequestFetchLimit = $scope.settings.buildrequestFetchLimit.value
+
+        data = dataService.open().closeOnDestroy($scope)
+        $scope.buildrequests = data.getBuildrequests(limit: buildrequestFetchLimit, order:'-submitted_at', claimed:false)
+        $scope.buildrequests.onNew = (buildrequest) ->
+            data.getBuildsets(buildrequest.buildsetid).onNew = (buildset) ->
+                buildset.getProperties().onNew = (properties) ->
+                    buildrequest.properties = properties
+            data.getBuilders(buildrequest.builderid).onNew = (builder) ->
+                buildrequest.builder = builder

--- a/www/base/src/app/buildrequests/pendingbuildrequests.route.coffee
+++ b/www/base/src/app/buildrequests/pendingbuildrequests.route.coffee
@@ -1,0 +1,30 @@
+class State extends Config
+    constructor: ($stateProvider, bbSettingsServiceProvider) ->
+
+        # Name of the state
+        name = 'pendingbuildrequests'
+
+        # Configuration
+        cfg =
+            group: "builds"
+            caption: 'Pending Buildrequests'
+
+        # Register new state
+        state =
+            controller: "#{name}Controller"
+            templateUrl: "views/#{name}.html"
+            name: name
+            url: '/pendingbuildrequests'
+            data: cfg
+
+        $stateProvider.state(state)
+
+        bbSettingsServiceProvider.addSettingsGroup
+            name:'BuildRequests'
+            caption: 'Buildreqests page related settings'
+            items:[
+                type:'integer'
+                name:'buildrequestFetchLimit'
+                caption:'Maximum number of pending buildrequests to fetch'
+                default_value: 50
+            ]

--- a/www/base/src/app/buildrequests/pendingbuildrequests.tpl.jade
+++ b/www/base/src/app/buildrequests/pendingbuildrequests.tpl.jade
@@ -1,0 +1,23 @@
+.container
+  .row
+    h4 Pending Buildrequests:
+    span(ng-hide='buildrequests.length>0')
+      | None
+    table.table.table-hover.table-striped.table-condensed(ng-show='buildrequests.length>0')
+      tr
+        td(width='100px') #
+        td(width='150px') Builder
+        td(width='150px') Submitted At
+        td(width='150px') Owner
+      tr(ng-repeat='br in buildrequests | orderBy:"-submitted_at"' )
+          td
+            a(ui-sref="buildrequest({buildrequest:br.buildrequestid})")
+              span.badge-status {{br.buildrequestid}}
+          td
+            a(ui-sref="builder({builder:br.builderid})")
+              span {{br.builder.name}}
+          td
+            span(title="{{br.submitted_at | dateformat:'LLL'}}")
+              | {{br.submitted_at | timeago }}
+          td
+            span {{br.properties.owner[0]}}


### PR DESCRIPTION
Relatively simple addition done by the approach suggested in #4239. This change is not tested by a e2e test, should I create one?

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
