### PR TITLE
Add virtualenv to Dockerfile worker

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -38,6 +38,7 @@ RUN         apt-get update && \
     easy_install pip && \
     # Install required python packages, and twisted
     pip --no-cache-dir install 'twisted[tls]' && \
+    pip install virtualenv && \
     mkdir /buildbot &&\
     useradd -ms /bin/bash buildbot
 


### PR DESCRIPTION
This PR will fix this issue:

```
bash -c 'PYTHON='"'"'python2.7'"'"'
VE='"'"'sandbox'"'"'
VEPYTHON='"'"'sandbox/bin/python'"'"'
# first, set up the virtualenv if it hasn'"'"'t already been done, or if it'"'"'s
# broken (as sometimes happens when a slave'"'"'s Python is updated)
if ! test -f "$VE/bin/pip" || ! test -d "$VE/lib/$PYTHON" || ! "$VE/bin/python" -c '"'"'import math'"'"'; then
    echo "Setting up virtualenv $VE";
    rm -rf "$VE";
    test -d "$VE" && { echo "$VE couldn'"'"'t be removed"; exit 1; };
    virtualenv -p $PYTHON "$VE" || exit 1;
else
    echo "Virtualenv already exists"
fi
echo "Upgrading pip";
$VE/bin/pip install -U pip
'
 in dir /buildbot/demo-ci-job/build (timeout 1200 secs)
 watching logfiles {}
 argv: [b'bash', b'-c', b'PYTHON=\'python2.7\'\nVE=\'sandbox\'\nVEPYTHON=\'sandbox/bin/python\'\n\n# first, set up the virtualenv if it hasn\'t already been done, or if it\'s\n# broken (as sometimes happens when a slave\'s Python is updated)\nif ! test -f "$VE/bin/pip" || ! test -d "$VE/lib/$PYTHON" || ! "$VE/bin/python" -c \'import math\'; then\n    echo "Setting up virtualenv $VE";\n    rm -rf "$VE";\n    test -d "$VE" && { echo "$VE couldn\'t be removed"; exit 1; };\n    virtualenv -p $PYTHON "$VE" || exit 1;\nelse\n    echo "Virtualenv already exists"\nfi\n\necho "Upgrading pip";\n$VE/bin/pip install -U pip\n\n']
 environment:
  BUILDMASTER=master
  BUILDMASTER_PORT=9989
  HOME=/home/buildbot
  HOSTNAME=bcb50fd69a14
  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
  PWD=/buildbot/demo-ci-job/build
  WORKERNAME=worker1
  security_updates_as_of=2018-06-15
 using PTY: False
Setting up virtualenv sandbox
bash: line 10: virtualenv: command not found
program finished with exit code 1
elapsedTime=0.019420
```

Issue: **virtualenv: command not found**