### PR TITLE
www: Use non-default port for e2e tests

### DIFF
--- a/smokes/e2e/pages/base.ts
+++ b/smokes/e2e/pages/base.ts
@@ -16,7 +16,7 @@ export class BasePage {
     }
 
     async loginUser(user, password) {
-        await browser.get(`http://${user}:${password}@localhost:8010/auth/login`);
+        await browser.get(`http://${user}:${password}@localhost:8011/auth/login`);
         const anonymousButton = element(By.css('.dropdown'));
         expect(await anonymousButton.getText()).not.toContain("Anonymous");
     }

--- a/smokes/master.cfg
+++ b/smokes/master.cfg
@@ -128,10 +128,12 @@ c['titleURL'] = "https://launchpad.net/pyflakes"
 # the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
 
-c['buildbotURL'] = "http://localhost:8010/"
+c['buildbotURL'] = "http://localhost:8011/"
 
 # minimalistic config to activate new web UI
-c['www'] = dict(port=8010,
+# we're not using the default port so that it would not accidentally conflict
+# with any development instances of buildbot on developer machines
+c['www'] = dict(port=8011,
                 change_hook_dialects={'base': True},
                 plugins=dict(waterfall_view={}, console_view={}, grid_view={}, badges={}),
                 ui_default_config={'Builders.buildFetchLimit': 201})

--- a/smokes/protractor-headless.conf.js
+++ b/smokes/protractor-headless.conf.js
@@ -16,7 +16,7 @@ exports.config = {
         }
     },
 
-    baseUrl: 'http://localhost:8010',
+    baseUrl: 'http://localhost:8011',
 
     framework: 'jasmine',
 

--- a/smokes/protractor.conf.js
+++ b/smokes/protractor.conf.js
@@ -18,7 +18,7 @@ exports.config = {
         }
     },
 
-    baseUrl: 'http://localhost:8010',
+    baseUrl: 'http://localhost:8011',
 
     framework: 'jasmine',
 


### PR DESCRIPTION
e2e tests currently use the default buildbot port. This does not allow running any test buildbot instances on a developer machine without additional configuration.

This PR changes e2e tests to use a non-default port which is a small usability improvement without any downsides.