### PR TITLE
www: Print webdriver stdio to console in e2e tests

### DIFF
--- a/smokes/protractor-headless.conf.js
+++ b/smokes/protractor-headless.conf.js
@@ -9,6 +9,12 @@ exports.config = {
 
     SELENIUM_PROMISE_MANAGER: false,
 
+    localSeleniumStandaloneOpts: {
+        // undocumented option to pass the stdio output of selenium webdriver to
+        // console
+        stdio: "inherit",
+    },
+
     capabilities: {
         'browserName': 'chrome',
         'chromeOptions': {

--- a/smokes/protractor.conf.js
+++ b/smokes/protractor.conf.js
@@ -9,6 +9,12 @@ exports.config = {
 
     SELENIUM_PROMISE_MANAGER: false,
 
+    localSeleniumStandaloneOpts: {
+        // undocumented option to pass the stdio output of selenium webdriver to
+        // console
+        stdio: "inherit",
+    },
+
     capabilities: {
         'browserName': 'chrome',
         chromeOptions: {


### PR DESCRIPTION
This PR turns on redirection of webdriver stdio to console. This way we can debug intermittent webdriver startup failures like https://nine.buildbot.net/#/builders/10/builds/3108. The option is not documented and comes from webdriver js bindings. See https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/remote/index.js where `opt_options` to `SeleniumServer` constructor is `localSeleniumStandaloneOpts` from protractor config.