### PR TITLE
Remove dead code and fix pylint warnings on Ubuntu 18.04

### DIFF
--- a/common/pylintrc
+++ b/common/pylintrc
@@ -143,6 +143,9 @@ disable=
   comparison-with-itself,
   assignment-from-no-return,
   stop-iteration-return,
+  old-style-class,
+  redefined-variable-type,
+  deprecated-lambda,
 
 
 [REPORTS]

--- a/master/buildbot/test/unit/test_data_types.py
+++ b/master/buildbot/test/unit/test_data_types.py
@@ -140,7 +140,7 @@ class Identifier(TypeMixin, unittest.TestCase):
         (b'abcd', u'abcd'),
     ]
     badStringValues = [
-        b'', '\N{SNOWMAN}', b'abcdef'
+        b'', r'\N{SNOWMAN}', b'abcdef'
     ]
     cmpResults = [
         (u'aaaa', b'bbbb', -1),

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -314,15 +314,6 @@ class EC2LatentWorker(AbstractLatentWorker):
                     new_dev_config['Ebs'])
             new_mapping_definitions.append(new_dev_config)
         return new_mapping_definitions
-        if not mapping_definitions:
-            return None
-
-        for mapping_definition in mapping_definitions:
-            ebs = mapping_definition.get('Ebs')
-            if ebs:
-                ebs.setdefault('DeleteOnTermination', True)
-
-        return mapping_definitions
 
     def get_image(self):
         # pylint: disable=too-many-nested-blocks


### PR DESCRIPTION
Fixes #3019. The currently dead code has been copied to `create_block_device_mapping` in the same file just above.

Also this PR disables some pylint warnings that started appearing on Ubuntu 18.04 in `make virtualenv` / `pip install -r requirements-ci.txt` environment. Looks like pylint enabled some Python 3 related warnings or something like that.