### PR TITLE
Disable flaky windows tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,6 @@ _build
 master/setuptools_trial*
 master/buildbot/www/static/js/default/
 sandbox
+sandbox.*
 .idea/
 /.venv/

--- a/master/buildbot/test/integration/interop/test_interruptcommand.py
+++ b/master/buildbot/test/integration/interop/test_interruptcommand.py
@@ -19,12 +19,15 @@ from __future__ import print_function
 from twisted.internet import defer
 
 from buildbot.process.results import CANCELLED
+from buildbot.test.util.decorators import flaky
 from buildbot.test.util.integration import RunMasterBase
 from buildbot.util import asyncSleep
 
 
 class InterruptCommand(RunMasterBase):
     """Make sure we can interrupt a command"""
+
+    @flaky(bugNumber=4404, onPlatform='win32')
     @defer.inlineCallbacks
     def test_setProp(self):
         yield self.setupConfig(masterConfig())

--- a/master/buildbot/test/integration/interop/test_transfer.py
+++ b/master/buildbot/test/integration/interop/test_transfer.py
@@ -22,6 +22,7 @@ import shutil
 from twisted.internet import defer
 
 from buildbot.process.results import SUCCESS
+from buildbot.test.util.decorators import flaky
 from buildbot.test.util.integration import RunMasterBase
 
 # This integration test creates a master and worker environment
@@ -43,6 +44,7 @@ class TransferStepsMasterPb(RunMasterBase):
                     contents[fn] = f.read()
         return contents
 
+    @flaky(bugNumber=4407, onPlatform='win32')
     @defer.inlineCallbacks
     def test_transfer(self):
         yield self.setupConfig(masterConfig(bigfilename=self.mktemp()))

--- a/master/buildbot/test/unit/test_scripts_cleanupdb.py
+++ b/master/buildbot/test/unit/test_scripts_cleanupdb.py
@@ -30,6 +30,7 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.util import db
 from buildbot.test.util import dirs
 from buildbot.test.util import misc
+from buildbot.test.util.decorators import flaky
 
 from . import test_db_logs
 
@@ -123,6 +124,7 @@ class TestCleanupDb(misc.StdoutAssertionsMixin, dirs.DirsMixin,
         # complain
         self.flushLoggedErrors()
 
+    @flaky(bugNumber=4406, onPlatform='win32')
     @defer.inlineCallbacks
     def test_cleanup(self):
 

--- a/master/buildbot/test/util/decorators.py
+++ b/master/buildbot/test/util/decorators.py
@@ -42,13 +42,15 @@ def todo(message):
 
 def flaky(bugNumber=None, issueNumber=None):
     def wrap(fn):
-        if not os.environ.get(_FLAKY_ENV_VAR):
-            if bugNumber is not None:
-                fn.skip = ("Flaky test (http://trac.buildbot.net/ticket/%d) "
-                        "- set $%s to run anyway" % (bugNumber, _FLAKY_ENV_VAR))
-            if issueNumber is not None:
-                fn.skip = ("Flaky test (https://github.com/buildbot/buildbot/issues/%d) "
-                        "- set $%s to run anyway" % (issueNumber, _FLAKY_ENV_VAR))
+        if os.environ.get(_FLAKY_ENV_VAR):
+            return fn
+
+        if bugNumber is not None:
+            fn.skip = ("Flaky test (http://trac.buildbot.net/ticket/%d) "
+                    "- set $%s to run anyway" % (bugNumber, _FLAKY_ENV_VAR))
+        if issueNumber is not None:
+            fn.skip = ("Flaky test (https://github.com/buildbot/buildbot/issues/%d) "
+                    "- set $%s to run anyway" % (issueNumber, _FLAKY_ENV_VAR))
         return fn
     return wrap
 

--- a/master/buildbot/test/util/decorators.py
+++ b/master/buildbot/test/util/decorators.py
@@ -40,8 +40,11 @@ def todo(message):
     return wrap
 
 
-def flaky(bugNumber=None, issueNumber=None):
+def flaky(bugNumber=None, issueNumber=None, onPlatform=None):
     def wrap(fn):
+        if onPlatform is not None and sys.platform != onPlatform:
+            return fn
+
         if os.environ.get(_FLAKY_ENV_VAR):
             return fn
 


### PR DESCRIPTION
Adds a onPlatform attribute to `@flaky` decorator and uses it to disable buildbot.test.integration.interop.test_interruptcommand.InterruptCommand.test_setProp on Windows.

Also, add files created during smoke tests to .gitignore.