### PR TITLE
Simplify buildrequestdistributor tests

### DIFF
--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -360,7 +360,7 @@ class BuildRequestDistributor(service.AsyncMultiService):
 
         try:
             yield d
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             log.err(e, "while starting builds on {0}".format(new_builders))
         finally:
             self._pendingMSBOCalls.remove(d)
@@ -392,7 +392,7 @@ class BuildRequestDistributor(service.AsyncMultiService):
                 # working on that.
                 if not self.active:
                     self._activity_loop_deferred = self._activityLoop()
-            except Exception:
+            except Exception:  # pragma: no cover
                 log.err(Failure(),
                         "while attempting to start builds on %s" % self.name)
 

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -549,6 +549,5 @@ class BuildRequestDistributor(service.AsyncMultiService):
 
     @defer.inlineCallbacks
     def _waitForFinish(self):
-        # shim for tests
         if self._activity_loop_deferred is not None:
             yield self._activity_loop_deferred

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -65,7 +65,7 @@ class BuildChooserBase(object):
         worker, breq = yield self.popNextBuild()
         if not worker or not breq:
             defer.returnValue((None, None))
-            return
+            return  # pragma: no cover
 
         defer.returnValue((worker, [breq]))
 
@@ -229,7 +229,7 @@ class BasicBuildChooser(BuildChooserBase):
         yield self._fetchUnclaimedBrdicts()
         if not self.unclaimedBrdicts:
             defer.returnValue(None)
-            return
+            return  # pragma: no cover
 
         if self.nextBuild:
             # nextBuild expects BuildRequest objects
@@ -255,7 +255,7 @@ class BasicBuildChooser(BuildChooserBase):
         if self.preferredWorkers:
             worker = self.preferredWorkers.pop(0)
             defer.returnValue(worker)
-            return
+            return  # pragma: no cover
 
         while self.workerpool:
             try:
@@ -274,7 +274,7 @@ class BasicBuildChooser(BuildChooserBase):
             canStart = yield self.bldr.canStartWithWorkerForBuilder(worker, [buildrequest])
             if canStart:
                 defer.returnValue(worker)
-                return
+                return  # pragma: no cover
 
             # save as a last resort, just in case we need them later
             if self.rejectedWorkers is not None:
@@ -284,7 +284,7 @@ class BasicBuildChooser(BuildChooserBase):
         if self.rejectedWorkers:
             worker = self.rejectedWorkers.pop(0)
             defer.returnValue(worker)
-            return
+            return  # pragma: no cover
 
         defer.returnValue(None)
 
@@ -373,7 +373,7 @@ class BuildRequestDistributor(service.AsyncMultiService):
         # if we won't add any builders, there's nothing to do
         if new_builders < existing_pending:
             defer.returnValue(None)
-            return
+            return  # pragma: no cover
 
         # reset the list of pending builders
         @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -189,7 +189,7 @@ class Test(TestBRDBase):
     def test_maybeStartBuildsOn_simple(self):
         self.useMock_maybeStartBuildsOnBuilder()
         self.addBuilders(['bldr1'])
-        self.brd.maybeStartBuildsOn(['bldr1'])
+        yield self.brd.maybeStartBuildsOn(['bldr1'])
 
         yield self.brd._waitForFinish()
         self.assertEqual(self.maybeStartBuildsOnBuilder_calls, ['bldr1'])
@@ -216,7 +216,7 @@ class Test(TestBRDBase):
         self.useMock_maybeStartBuildsOnBuilder()
         self.addBuilders(builders)
         for bldr in builders:
-            self.brd.maybeStartBuildsOn([bldr])
+            yield self.brd.maybeStartBuildsOn([bldr])
 
         yield self.brd._waitForFinish()
         self.assertEqual(self.maybeStartBuildsOnBuilder_calls, builders)
@@ -234,7 +234,7 @@ class Test(TestBRDBase):
             return d
         self.brd._maybeStartBuildsOnBuilder = _maybeStartBuildsOnBuilder
 
-        self.brd.maybeStartBuildsOn(['bldr1'])
+        yield self.brd.maybeStartBuildsOn(['bldr1'])
 
         yield self.brd._waitForFinish()
         self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1)
@@ -244,11 +244,11 @@ class Test(TestBRDBase):
     def test_maybeStartBuildsOn_collapsing(self):
         self.useMock_maybeStartBuildsOnBuilder()
         self.addBuilders(['bldr1', 'bldr2', 'bldr3'])
-        self.brd.maybeStartBuildsOn(['bldr3'])
-        self.brd.maybeStartBuildsOn(['bldr2', 'bldr1'])
-        self.brd.maybeStartBuildsOn(['bldr4'])  # should be ignored
-        self.brd.maybeStartBuildsOn(['bldr2'])  # already queued - ignored
-        self.brd.maybeStartBuildsOn(['bldr3', 'bldr2'])
+        yield self.brd.maybeStartBuildsOn(['bldr3'])
+        yield self.brd.maybeStartBuildsOn(['bldr2', 'bldr1'])
+        yield self.brd.maybeStartBuildsOn(['bldr4'])  # should be ignored
+        yield self.brd.maybeStartBuildsOn(['bldr2'])  # already queued - ignored
+        yield self.brd.maybeStartBuildsOn(['bldr3', 'bldr2'])
 
         yield self.brd._waitForFinish()
         # bldr3 gets invoked twice, since it's considered to have started
@@ -261,7 +261,7 @@ class Test(TestBRDBase):
     def test_maybeStartBuildsOn_builders_missing(self):
         self.useMock_maybeStartBuildsOnBuilder()
         self.addBuilders(['bldr1', 'bldr2', 'bldr3'])
-        self.brd.maybeStartBuildsOn(['bldr1', 'bldr2', 'bldr3'])
+        yield self.brd.maybeStartBuildsOn(['bldr1', 'bldr2', 'bldr3'])
         # bldr1 is already run, so surreptitiously remove the other
         # two - nothing should crash, but the builders should not run
         self.removeBuilder('bldr2')


### PR DESCRIPTION
This PR removes the `_quiet()` function that is called when build request distributor's activity loop finishes and instead just stores deferred to the activity loop itself. A separate function to wait on that deferred is added `_waitForFinish()` and tests can use that instead of the `_quiet` hack. This is IMO a cleaner approach.

Also, this PR add more uses of `inlineCallbacks` and adds waits for deferreds returned from functions that were not waited for before.