### PR TITLE
Remove version upper bounds for boto3/botocore and update

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -18,6 +18,10 @@ env:
   global:
   - BUILDBOT_TEST_DB_URL=sqlite://
   - HYPER_SIZE=m1
+  # Current moto (1.3.7) requires dummy credentials to work
+  # https://github.com/spulec/moto/issues/1924
+  - AWS_SECRET_ACCESS_KEY=foobar_secret
+  - AWS_ACCESS_KEY_ID=foobar_key
   matrix:
   - TWISTED=latest SQLALCHEMY=latest TESTS=coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,19 @@ python:
   - "2.7"
 
 env:
-  # we now use travis only for real database testing
-  # travis containers do have much more optimized db installations
+  global:
+    # Current moto (1.3.7) requires dummy credentials to work
+    # https://github.com/spulec/moto/issues/1924
+    - AWS_SECRET_ACCESS_KEY=foobar_secret
+    - AWS_ACCESS_KEY_ID=foobar_key
+  matrix:
+    # we now use travis only for real database testing
+    # travis containers do have much more optimized db installations
 
-  - TWISTED=latest SQLALCHEMY=latest TESTS=coverage BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest?storage_engine=InnoDB
-  # Configuration that runs tests with real PostgreSQL database with pg8000 and psycopg2 drivers
-  - TWISTED=latest SQLALCHEMY=latest TESTS=coverage BUILDBOT_TEST_DB_URL=postgresql+psycopg2:///bbtest?user=postgres
-  - TWISTED=latest SQLALCHEMY=latest TESTS=coverage BUILDBOT_TEST_DB_URL=postgresql+pg8000:///bbtest?user=postgres
+    - TWISTED=latest SQLALCHEMY=latest TESTS=coverage BUILDBOT_TEST_DB_URL=mysql+mysqldb://travis@127.0.0.1/bbtest?storage_engine=InnoDB
+    # Configuration that runs tests with real PostgreSQL database with pg8000 and psycopg2 drivers
+    - TWISTED=latest SQLALCHEMY=latest TESTS=coverage BUILDBOT_TEST_DB_URL=postgresql+psycopg2:///bbtest?user=postgres
+    - TWISTED=latest SQLALCHEMY=latest TESTS=coverage BUILDBOT_TEST_DB_URL=postgresql+pg8000:///bbtest?user=postgres
 
 # Dependencies installation commands
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,11 @@
 # https://www.appveyor.com/docs
 
 environment:
+  # Current moto (1.3.7) requires dummy credentials to work
+  # https://github.com/spulec/moto/issues/1924
+  AWS_SECRET_ACCESS_KEY: foobar_secret
+  AWS_ACCESS_KEY_ID: foobar_key
+
   matrix:
     # For Python versions available on AppVeyor, see
     # http://www.appveyor.com/docs/installed-software#python

--- a/master/setup.py
+++ b/master/setup.py
@@ -493,7 +493,6 @@ test_deps = [
     'pyjade',
     # boto3 and moto required for running EC2 tests
     'boto3',
-    'botocore<1.11', # botocore>=1.11.0 broke moto
     'moto',
     'mock>=2.0.0',
 ]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -9,8 +9,8 @@ Babel==2.6.0
 backports.functools-lru-cache==1.5
 blockdiag==1.5.4
 boto==2.49.0
-boto3==1.8.6
-botocore==1.10.65 # pyup: ignore
+boto3==1.9.41
+botocore==1.12.41
 cffi==1.11.5
 click==7.0
 configparser==3.5.0
@@ -40,7 +40,7 @@ markdown2==2.3.6
 MarkupSafe==1.0
 mccabe==0.6.1
 mock==2.0.0
-moto==1.3.5
+moto==1.3.7
 olefile==0.46
 packaging==18.0
 pathlib2==2.3.2


### PR DESCRIPTION
Version upper bounds are no longer necessary after the latest moto3
supports the latest boto3/botocore [1].

[1] https://github.com/spulec/moto/pull/1907

This pull request partially reverts https://github.com/buildbot/buildbot/pull/4359.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

(None of above is applicable for such changes, IMO)