### PR TITLE
pylint: Work around OOM on CI by reducing concurrent jobs

### DIFF
--- a/common/pylintrc
+++ b/common/pylintrc
@@ -146,6 +146,7 @@ disable=
   old-style-class,
   redefined-variable-type,
   deprecated-lambda,
+  cyclic-import,  # only happens when pylint is ran in non-parallel mode
 
 
 [REPORTS]

--- a/master/Makefile
+++ b/master/Makefile
@@ -1,6 +1,6 @@
 # developer utilities
 pylint:
-	pylint -j2 --rcfile=../common/pylintrc buildbot
+	pylint --rcfile=../common/pylintrc buildbot
 	@test ! -f fail
 
 tutorial:


### PR DESCRIPTION
https://github.com/buildbot/buildbot/issues/4413 shows that we sometimes run pylint jobs on workers with only 1GB of RAM. Reducing concurrent jobs to 1 core will increase the amount of memory available to pylint twice. Hopefully this will be enough to fix the instabilities on the CI until #4413 is fixed.