### PR TITLE
Use assertRaisesConfigError as context manager

### DIFF
--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -1532,9 +1532,9 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
 class TestGitPollerConstructor(unittest.TestCase, config.ConfigErrorsMixin):
 
     def test_deprecatedFetchRefspec(self):
-        self.assertRaisesConfigError("fetch_refspec is no longer supported",
-                                     lambda: gitpoller.GitPoller("/tmp/git.git",
-                                                                 fetch_refspec='not-supported'))
+        with self.assertRaisesConfigError(
+                "fetch_refspec is no longer supported"):
+            gitpoller.GitPoller("/tmp/git.git", fetch_refspec='not-supported')
 
     def test_oldPollInterval(self):
         poller = gitpoller.GitPoller("/tmp/git.git", pollinterval=10)
@@ -1562,19 +1562,21 @@ class TestGitPollerConstructor(unittest.TestCase, config.ConfigErrorsMixin):
         self.assertIsNotNone(poller.branches)
 
     def test_branches_andBranch(self):
-        self.assertRaisesConfigError("can't specify both branch and branches",
-                                     lambda: gitpoller.GitPoller("/tmp/git.git",
-                                                                 branch='bad', branches=['listy']))
+        with self.assertRaisesConfigError(
+                "can't specify both branch and branches"):
+            gitpoller.GitPoller("/tmp/git.git", branch='bad',
+                                branches=['listy'])
 
     def test_branches_and_only_tags(self):
-        self.assertRaisesConfigError("can't specify only_tags and branch/branches",
-                                     lambda: gitpoller.GitPoller("/tmp/git.git",
-                                                                 only_tags=True, branches=['listy']))
+        with self.assertRaisesConfigError(
+                "can't specify only_tags and branch/branches"):
+            gitpoller.GitPoller("/tmp/git.git", only_tags=True,
+                                branches=['listy'])
 
     def test_branch_and_only_tags(self):
-        self.assertRaisesConfigError("can't specify only_tags and branch/branches",
-                                     lambda: gitpoller.GitPoller("/tmp/git.git",
-                                                                 only_tags=True, branch='bad'))
+        with self.assertRaisesConfigError(
+                "can't specify only_tags and branch/branches"):
+            gitpoller.GitPoller("/tmp/git.git", only_tags=True, branch='bad')
 
     def test_gitbin_default(self):
         poller = gitpoller.GitPoller("/tmp/git.git")

--- a/master/buildbot/test/unit/test_changes_p4poller.py
+++ b/master/buildbot/test/unit/test_changes_p4poller.py
@@ -436,8 +436,9 @@ class TestP4Poller(changesource.ChangeSourceMixin,
         self.assertAllCommandsRan()
 
     def test_resolveWho_callable(self):
-        self.assertRaisesConfigError("You need to provide a valid callable for resolvewho",
-                                     lambda: P4Source(resolvewho=None))
+        with self.assertRaisesConfigError(
+                "You need to provide a valid callable for resolvewho"):
+            P4Source(resolvewho=None)
 
 
 class TestSplit(unittest.TestCase):

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -101,17 +101,17 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
         When BuildStep is passed a name that isn't a string, it reports
         a config error.
         """
-        self.assertRaisesConfigError("BuildStep name must be a string",
-                                     lambda: buildstep.BuildStep(name=5))
+        with self.assertRaisesConfigError("BuildStep name must be a string"):
+            buildstep.BuildStep(name=5)
 
     def test_unexpectedKeywordArgument(self):
         """
         When BuildStep is passed an unknown keyword argument, it reports
         a config error.
         """
-        self.assertRaisesConfigError(
-            "__init__ got unexpected keyword argument(s) ['oogaBooga']",
-            lambda: buildstep.BuildStep(oogaBooga=5))
+        with self.assertRaisesConfigError(
+                "__init__ got unexpected keyword argument(s) ['oogaBooga']"):
+            buildstep.BuildStep(oogaBooga=5)
 
     def test_updateBuildSummaryPolicyDefaults(self):
         """
@@ -140,9 +140,9 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
         """
         updateBuildSummaryPolicy raise ConfigError in case of bad type
         """
-        self.assertRaisesConfigError(
-            "BuildStep updateBuildSummaryPolicy must be a list of result ids or boolean but it is 2",
-            lambda: buildstep.BuildStep(updateBuildSummaryPolicy=FAILURE))
+        with self.assertRaisesConfigError(
+                "BuildStep updateBuildSummaryPolicy must be a list of result ids or boolean but it is 2"):
+            buildstep.BuildStep(updateBuildSummaryPolicy=FAILURE)
 
     def test_getProperty(self):
         bs = buildstep.BuildStep()
@@ -986,16 +986,16 @@ class TestShellMixin(steps.BuildStepMixin,
 
     def test_setupShellMixin_bad_arg(self):
         mixin = ShellMixinExample()
-        self.assertRaisesConfigError(
-            "invalid ShellMixinExample argument invarg",
-            lambda: mixin.setupShellMixin({'invarg': 13}))
+        with self.assertRaisesConfigError(
+                "invalid ShellMixinExample argument invarg"):
+            mixin.setupShellMixin({'invarg': 13})
 
     def test_setupShellMixin_prohibited_arg(self):
         mixin = ShellMixinExample()
-        self.assertRaisesConfigError(
-            "invalid ShellMixinExample argument logfiles",
-            lambda: mixin.setupShellMixin({'logfiles': None},
-                                          prohibitArgs=['logfiles']))
+        with self.assertRaisesConfigError(
+                "invalid ShellMixinExample argument logfiles"):
+            mixin.setupShellMixin({'logfiles': None},
+                                  prohibitArgs=['logfiles'])
 
     def test_setupShellMixin_not_new_style(self):
         self.patch(ShellMixinExample, 'isNewStyle', lambda self: False)

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -292,56 +292,68 @@ class TestInterpolateConfigure(unittest.TestCase, ConfigErrorsMixin):
     """
 
     def test_invalid_args_and_kwargs(self):
-        self.assertRaisesConfigError("Interpolate takes either positional",
-                                     lambda: Interpolate("%s %(foo)s", 1, foo=2))
+        with self.assertRaisesConfigError("Interpolate takes either positional"):
+            Interpolate("%s %(foo)s", 1, foo=2)
 
     def test_invalid_selector(self):
-        self.assertRaisesConfigError("invalid Interpolate selector 'garbage'",
-                                     lambda: Interpolate("%(garbage:test)s"))
+        with self.assertRaisesConfigError(
+                "invalid Interpolate selector 'garbage'"):
+            Interpolate("%(garbage:test)s")
 
     def test_no_selector(self):
-        self.assertRaisesConfigError("invalid Interpolate substitution without selector 'garbage'",
-                                     lambda: Interpolate("%(garbage)s"))
+        with self.assertRaisesConfigError(
+                "invalid Interpolate substitution without selector 'garbage'"):
+            Interpolate("%(garbage)s")
 
     def test_invalid_default_type(self):
-        self.assertRaisesConfigError("invalid Interpolate default type '@'",
-                                     lambda: Interpolate("%(prop:some_prop:@wacky)s"))
+        with self.assertRaisesConfigError(
+                "invalid Interpolate default type '@'"):
+            Interpolate("%(prop:some_prop:@wacky)s")
 
     def test_nested_invalid_selector(self):
-        self.assertRaisesConfigError("invalid Interpolate selector 'garbage'",
-                                     lambda: Interpolate("%(prop:some_prop:~%(garbage:test)s)s"))
+        with self.assertRaisesConfigError(
+                "invalid Interpolate selector 'garbage'"):
+            Interpolate("%(prop:some_prop:~%(garbage:test)s)s")
 
     def test_colon_ternary_missing_delimeter(self):
-        self.assertRaisesConfigError("invalid Interpolate ternary expression 'one' with delimiter ':'",
-                                     lambda: Interpolate("echo '%(prop:P:?:one)s'"))
+        with self.assertRaisesConfigError(
+                "invalid Interpolate ternary expression 'one' with delimiter ':'"):
+            Interpolate("echo '%(prop:P:?:one)s'")
 
     def test_colon_ternary_paren_delimiter(self):
-        self.assertRaisesConfigError("invalid Interpolate ternary expression 'one(:)' with delimiter ':'",
-                                     lambda: Interpolate("echo '%(prop:P:?:one(:))s'"))
+        with self.assertRaisesConfigError(
+                "invalid Interpolate ternary expression 'one(:)' with delimiter ':'"):
+            Interpolate("echo '%(prop:P:?:one(:))s'")
 
     def test_colon_ternary_hash_bad_delimeter(self):
-        self.assertRaisesConfigError("invalid Interpolate ternary expression 'one' with delimiter '|'",
-                                     lambda: Interpolate("echo '%(prop:P:#?|one)s'"))
+        with self.assertRaisesConfigError(
+                "invalid Interpolate ternary expression 'one' with delimiter '|'"):
+            Interpolate("echo '%(prop:P:#?|one)s'")
 
     def test_prop_invalid_character(self):
-        self.assertRaisesConfigError("Property name must be alphanumeric for prop Interpolation 'a+a'",
-                                     lambda: Interpolate("echo '%(prop:a+a)s'"))
+        with self.assertRaisesConfigError(
+                "Property name must be alphanumeric for prop Interpolation 'a+a'"):
+            Interpolate("echo '%(prop:a+a)s'")
 
     def test_kw_invalid_character(self):
-        self.assertRaisesConfigError("Keyword must be alphanumeric for kw Interpolation 'a+a'",
-                                     lambda: Interpolate("echo '%(kw:a+a)s'"))
+        with self.assertRaisesConfigError(
+                "Keyword must be alphanumeric for kw Interpolation 'a+a'"):
+            Interpolate("echo '%(kw:a+a)s'")
 
     def test_src_codebase_invalid_character(self):
-        self.assertRaisesConfigError("Codebase must be alphanumeric for src Interpolation 'a+a:a'",
-                                     lambda: Interpolate("echo '%(src:a+a:a)s'"))
+        with self.assertRaisesConfigError(
+                "Codebase must be alphanumeric for src Interpolation 'a+a:a'"):
+            Interpolate("echo '%(src:a+a:a)s'")
 
     def test_src_attr_invalid_character(self):
-        self.assertRaisesConfigError("Attribute must be alphanumeric for src Interpolation 'a:a+a'",
-                                     lambda: Interpolate("echo '%(src:a:a+a)s'"))
+        with self.assertRaisesConfigError(
+                "Attribute must be alphanumeric for src Interpolation 'a:a+a'"):
+            Interpolate("echo '%(src:a:a+a)s'")
 
     def test_src_missing_attr(self):
-        self.assertRaisesConfigError("Must specify both codebase and attr",
-                                     lambda: Interpolate("echo '%(src:a)s'"))
+        with self.assertRaisesConfigError(
+                "Must specify both codebase and attr"):
+            Interpolate("echo '%(src:a)s'")
 
 
 class TestInterpolatePositional(unittest.TestCase):
@@ -1688,8 +1700,9 @@ class TestTransform(unittest.TestCase, ConfigErrorsMixin):
         self.props = Properties(propname='propvalue')
 
     def test_invalid_first_arg(self):
-        self.assertRaisesConfigError("function given to Transform neither callable nor renderable",
-                                     lambda: Transform(None))
+        with self.assertRaisesConfigError(
+                "function given to Transform neither callable nor renderable"):
+            Transform(None)
 
     def test_argless(self):
         t = Transform(lambda: 'abc')

--- a/master/buildbot/test/unit/test_reporters_irc.py
+++ b/master/buildbot/test/unit/test_reporters_irc.py
@@ -289,16 +289,16 @@ class TestIRC(config.ConfigErrorsMixin, unittest.TestCase):
         When L{IRCClient} is called with C{allowForce} not a boolean,
         a config error is reported.
         """
-        self.assertRaisesConfigError("allowForce must be boolean, not",
-                                     lambda: self.makeIRC(allowForce=object()))
+        with self.assertRaisesConfigError("allowForce must be boolean, not"):
+            self.makeIRC(allowForce=object())
 
     def test_allowShutdown_notBool(self):
         """
         When L{IRCClient} is called with C{allowShutdown} not a boolean,
         a config error is reported.
         """
-        self.assertRaisesConfigError("allowShutdown must be boolean, not",
-                                     lambda: self.makeIRC(allowShutdown=object()))
+        with self.assertRaisesConfigError("allowShutdown must be boolean, not"):
+            self.makeIRC(allowShutdown=object())
 
     def test_service(self):
         irc = self.makeIRC()

--- a/master/buildbot/test/unit/test_reporters_notifier.py
+++ b/master/buildbot/test/unit/test_reporters_notifier.py
@@ -60,9 +60,9 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase, NotifierTestMixin):
                           tags=['fast', 'slow'], builders=['a', 'b'])
 
     def test_init_warns_notifier_mode_all_in_iter(self):
-        self.assertRaisesConfigError(
-            "mode 'all' is not valid in an iterator and must be passed in as a separate string",
-            lambda: NotifierBase(mode=['all']))
+        with self.assertRaisesConfigError(
+               "mode 'all' is not valid in an iterator and must be passed in as a separate string"):
+            NotifierBase(mode=['all'])
 
     @defer.inlineCallbacks
     def test_buildsetComplete_sends_message(self):

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -258,22 +258,22 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
     def test_bad_codebases(self):
 
         # codebases must be a list of either string or BaseParameter types
-        self.assertRaisesConfigError("ForceScheduler 'foo': 'codebases' must be a "
-                                     "list of strings or CodebaseParameter objects:",
-                                     lambda: ForceScheduler(name='foo', builderNames=['bar'],
-                                                            codebases=[123],))
-        self.assertRaisesConfigError("ForceScheduler 'foo': 'codebases' must be a "
-                                     "list of strings or CodebaseParameter objects:",
-                                     lambda: ForceScheduler(name='foo', builderNames=['bar'],
-                                                            codebases=[IntParameter('foo')],))
+        with self.assertRaisesConfigError(
+                "ForceScheduler 'foo': 'codebases' must be a "
+                "list of strings or CodebaseParameter objects:"):
+            ForceScheduler(name='foo', builderNames=['bar'], codebases=[123],)
+
+        with self.assertRaisesConfigError(
+                "ForceScheduler 'foo': 'codebases' must be a "
+                "list of strings or CodebaseParameter objects:"):
+            ForceScheduler(name='foo', builderNames=['bar'],
+                           codebases=[IntParameter('foo')])
 
         # codebases cannot be empty
-        self.assertRaisesConfigError("ForceScheduler 'foo': 'codebases' cannot be "
-                                     "empty; use [CodebaseParameter(codebase='', hide=True)] if needed:",
-                                     lambda: ForceScheduler(name='foo',
-                                                            builderNames=[
-                                                                'bar'],
-                                                            codebases=[]))
+        with self.assertRaisesConfigError(
+                "ForceScheduler 'foo': 'codebases' cannot be "
+                "empty; use [CodebaseParameter(codebase='', hide=True)] if needed:"):
+            ForceScheduler(name='foo', builderNames=['bar'], codebases=[])
 
         # codebases cannot be a dictionary
         # dictType on Python 3 is: "<class 'dict'>"
@@ -282,10 +282,9 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
         errMsg = ("ForceScheduler 'foo': 'codebases' should be a list "
                   "of strings or CodebaseParameter, "
                   "not {}".format(dictType))
-        self.assertRaisesConfigError(errMsg,
-                                     lambda: ForceScheduler(name='foo',
-                                                            builderNames=['bar'],
-                                                            codebases={'cb': {'branch': 'trunk'}}))
+        with self.assertRaisesConfigError(errMsg):
+            ForceScheduler(name='foo', builderNames=['bar'],
+                           codebases={'cb': {'branch': 'trunk'}})
 
     @defer.inlineCallbacks
     def test_good_codebases(self):
@@ -666,74 +665,84 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                               klass=NestedParameter, fields=fields, name='')
 
     def test_bad_reason(self):
-        self.assertRaisesConfigError("ForceScheduler 'testsched': reason must be a StringParameter",
-                                     lambda: ForceScheduler(name='testsched', builderNames=[],
-                                                            codebases=['bar'], reason="foo"))
+        with self.assertRaisesConfigError(
+                "ForceScheduler 'testsched': reason must be a StringParameter"):
+            ForceScheduler(name='testsched', builderNames=[],
+                           codebases=['bar'], reason="foo")
 
     def test_bad_username(self):
-        self.assertRaisesConfigError("ForceScheduler 'testsched': username must be a StringParameter",
-                                     lambda: ForceScheduler(name='testsched', builderNames=[],
-                                                            codebases=['bar'], username="foo"))
+        with self.assertRaisesConfigError(
+                "ForceScheduler 'testsched': username must be a StringParameter"):
+            ForceScheduler(name='testsched', builderNames=[],
+                           codebases=['bar'], username="foo")
 
     def test_notstring_name(self):
-        self.assertRaisesConfigError("ForceScheduler name must be a unicode string:",
-                                     lambda: ForceScheduler(name=1234, builderNames=[],
-                                                            codebases=['bar'], username="foo"))
+        with self.assertRaisesConfigError(
+                "ForceScheduler name must be a unicode string:"):
+            ForceScheduler(name=1234, builderNames=[], codebases=['bar'],
+                           username="foo")
 
     def test_notidentifier_name(self):
         # FIXME: this test should be removed eventually when bug 3460 gets a
         # real fix
-        self.assertRaisesConfigError("ForceScheduler name must be an identifier: 'my scheduler'",
-                                     lambda: ForceScheduler(name='my scheduler', builderNames=[],
-                                                            codebases=['bar'], username="foo"))
+        with self.assertRaisesConfigError(
+                "ForceScheduler name must be an identifier: 'my scheduler'"):
+            ForceScheduler(name='my scheduler', builderNames=[],
+                           codebases=['bar'], username="foo")
 
     def test_emptystring_name(self):
-        self.assertRaisesConfigError("ForceScheduler name must not be empty:",
-                                     lambda: ForceScheduler(name='', builderNames=[],
-                                                            codebases=['bar'], username="foo"))
+        with self.assertRaisesConfigError(
+                "ForceScheduler name must not be empty:"):
+            ForceScheduler(name='', builderNames=[], codebases=['bar'],
+                           username="foo")
 
     def test_integer_builderNames(self):
-        self.assertRaisesConfigError("ForceScheduler 'testsched': builderNames must be a list of strings:",
-                                     lambda: ForceScheduler(name='testsched', builderNames=1234,
-                                                            codebases=['bar'], username="foo"))
+        with self.assertRaisesConfigError(
+                "ForceScheduler 'testsched': builderNames must be a list of strings:"):
+            ForceScheduler(name='testsched', builderNames=1234,
+                           codebases=['bar'], username="foo")
 
     def test_listofints_builderNames(self):
-        self.assertRaisesConfigError("ForceScheduler 'testsched': builderNames must be a list of strings:",
-                                     lambda: ForceScheduler(name='testsched', builderNames=[1234],
-                                                            codebases=['bar'], username="foo"))
+        with self.assertRaisesConfigError(
+                "ForceScheduler 'testsched': builderNames must be a list of strings:"):
+            ForceScheduler(name='testsched', builderNames=[1234],
+                           codebases=['bar'], username="foo")
 
     def test_listofunicode_builderNames(self):
         ForceScheduler(name='testsched', builderNames=[u'a', u'b'])
 
     def test_listofmixed_builderNames(self):
-        self.assertRaisesConfigError("ForceScheduler 'testsched': builderNames must be a list of strings:",
-                                     lambda: ForceScheduler(name='testsched',
-                                                            builderNames=[
-                                                                'test', 1234],
-                                                            codebases=['bar'], username="foo"))
+        with self.assertRaisesConfigError(
+                "ForceScheduler 'testsched': builderNames must be a list of strings:"):
+            ForceScheduler(name='testsched', builderNames=['test', 1234],
+                           codebases=['bar'], username="foo")
 
     def test_integer_properties(self):
-        self.assertRaisesConfigError("ForceScheduler 'testsched': properties must be a list of BaseParameters:",
-                                     lambda: ForceScheduler(name='testsched', builderNames=[],
-                                                            codebases=['bar'], username="foo",
-                                                            properties=1234))
+        with self.assertRaisesConfigError(
+                "ForceScheduler 'testsched': properties must be a list of BaseParameters:"):
+            ForceScheduler(name='testsched', builderNames=[],
+                           codebases=['bar'], username="foo",
+                           properties=1234)
 
     def test_listofints_properties(self):
-        self.assertRaisesConfigError("ForceScheduler 'testsched': properties must be a list of BaseParameters:",
-                                     lambda: ForceScheduler(name='testsched', builderNames=[],
-                                                            codebases=['bar'], username="foo",
-                                                            properties=[1234, 2345]))
+        with self.assertRaisesConfigError(
+                "ForceScheduler 'testsched': properties must be a list of BaseParameters:"):
+            ForceScheduler(name='testsched', builderNames=[],
+                           codebases=['bar'], username="foo",
+                           properties=[1234, 2345])
 
     def test_listofmixed_properties(self):
-        self.assertRaisesConfigError("ForceScheduler 'testsched': properties must be a list of BaseParameters:",
-                                     lambda: ForceScheduler(name='testsched', builderNames=[],
-                                                            codebases=['bar'], username="foo",
-                                                            properties=[BaseParameter(name="test",),
-                                                                        4567]))
+        with self.assertRaisesConfigError(
+                "ForceScheduler 'testsched': properties must be a list of BaseParameters:"):
+            ForceScheduler(name='testsched', builderNames=[],
+                           codebases=['bar'], username="foo",
+                           properties=[BaseParameter(name="test",),
+                           4567])
 
     def test_novalue_to_parameter(self):
-        self.assertRaisesConfigError("Use default='1234' instead of value=... to give a default Parameter value",
-                                     lambda: BaseParameter(name="test", value="1234"))
+        with self.assertRaisesConfigError(
+                "Use default='1234' instead of value=... to give a default Parameter value"):
+            BaseParameter(name="test", value="1234")
 
 
 class TestWorkerTransition(unittest.TestCase):

--- a/master/buildbot/test/unit/test_secret_in_file.py
+++ b/master/buildbot/test/unit/test_secret_in_file.py
@@ -67,8 +67,8 @@ class TestSecretInFile(ConfigErrorsMixin, unittest.TestCase):
         expctd_msg_error = " on file tempfile2.txt are too " \
                            "open. It is required that your secret files are" \
                            " NOT accessible by others!"
-        self.assertRaisesConfigError(expctd_msg_error,
-                                     lambda: self.srvfile.checkConfig(self.tmp_dir))
+        with self.assertRaisesConfigError(expctd_msg_error):
+            self.srvfile.checkConfig(self.tmp_dir)
         os.remove(filepath)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_secret_in_vault.py
+++ b/master/buildbot/test/unit/test_secret_in_vault.py
@@ -70,12 +70,14 @@ class TestSecretInVaultHttpFake(ConfigErrorsMixin, unittest.TestCase):
         self.assertEqual(self.srvcVault.vaultToken, "someToken")
 
     def testCheckConfigErrorSecretInVaultService(self):
-        self.assertRaisesConfigError("vaultServer must be a string while it is",
-                                     self.srvcVault.checkConfig)
+        with self.assertRaisesConfigError(
+                "vaultServer must be a string while it is"):
+            self.srvcVault.checkConfig()
 
     def testCheckConfigErrorSecretInVaultServiceWrongServerAddress(self):
-        self.assertRaisesConfigError("vaultToken must be a string while it is",
-                                     lambda: self.srvcVault.checkConfig(vaultServer="serveraddr",))
+        with self.assertRaisesConfigError(
+                "vaultToken must be a string while it is"):
+            self.srvcVault.checkConfig(vaultServer="serveraddr")
 
     @defer.inlineCallbacks
     def testReconfigSecretInVaultService(self):

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -71,10 +71,10 @@ class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase, configm
 
     def test_constructor_args_validity(self):
         # this checks that an exception is raised for invalid arguments
-        self.assertRaisesConfigError(
-            "Invalid argument(s) passed to RemoteShellCommand: ",
-            lambda: shell.ShellCommand(workdir='build', command="echo Hello World",
-                                       wrongArg1=1, wrongArg2='two'))
+        with self.assertRaisesConfigError(
+                "Invalid argument(s) passed to RemoteShellCommand: "):
+            shell.ShellCommand(workdir='build', command="echo Hello World",
+                                       wrongArg1=1, wrongArg2='two')
 
     def test_getLegacySummary_from_empty_command(self):
         # this is more of a regression test for a potential failure, really
@@ -316,9 +316,9 @@ class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase, configm
 
     def test_missing_command_error(self):
         # this checks that an exception is raised for invalid arguments
-        self.assertRaisesConfigError(
-            "ShellCommand's `command' argument is not specified",
-            shell.ShellCommand)
+        with self.assertRaisesConfigError(
+                "ShellCommand's `command' argument is not specified"):
+            shell.ShellCommand()
 
 
 class TreeSize(steps.BuildStepMixin, unittest.TestCase):
@@ -1007,10 +1007,10 @@ class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase,
 
     def test_missing_command_error(self):
         # this checks that an exception is raised for invalid arguments
-        self.assertRaisesConfigError(
-            "WarningCountingShellCommand's `command' argument is not "
-            "specified",
-            shell.WarningCountingShellCommand)
+        with self.assertRaisesConfigError(
+                "WarningCountingShellCommand's `command' argument is not "
+                "specified"):
+            shell.WarningCountingShellCommand()
 
 
 class Compile(steps.BuildStepMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_steps_shellsequence.py
+++ b/master/buildbot/test/unit/test_steps_shellsequence.py
@@ -45,17 +45,17 @@ class TestOneShellCommand(steps.BuildStepMixin, unittest.TestCase, configmixin.C
         return self.tearDownBuildStep()
 
     def testShellArgInput(self):
-        self.assertRaisesConfigError(
-            "the 'command' parameter of ShellArg must not be None",
-            lambda: shellsequence.ShellArg(command=None))
+        with self.assertRaisesConfigError(
+             "the 'command' parameter of ShellArg must not be None"):
+            shellsequence.ShellArg(command=None)
         arg1 = shellsequence.ShellArg(command=1)
-        self.assertRaisesConfigError(
-            "1 is an invalid command, it must be a string or a list",
-            arg1.validateAttributes)
+        with self.assertRaisesConfigError(
+                "1 is an invalid command, it must be a string or a list"):
+            arg1.validateAttributes()
         arg2 = shellsequence.ShellArg(command=["make", 1])
-        self.assertRaisesConfigError(
-            "['make', 1] must only have strings in it",
-            arg2.validateAttributes)
+        with self.assertRaisesConfigError(
+                "['make', 1] must only have strings in it"):
+            arg2.validateAttributes()
 
         for goodcmd in ["make p1", ["make", "p1"]]:
             arg = shellsequence.ShellArg(command=goodcmd)

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -2325,9 +2325,10 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         return self.runStep()
 
     def test_mode_full_copy_shallow(self):
-        self.assertRaisesConfigError("shallow only possible with mode 'full' and method 'clobber'", lambda:
-                                     self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
-                                                    mode='full', method='copy', shallow=True))
+        with self.assertRaisesConfigError(
+                "shallow only possible with mode 'full' and method 'clobber'"):
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                        mode='full', method='copy', shallow=True)
 
     def test_mode_incremental_no_existing_repo(self):
         self.setupStep(
@@ -2508,8 +2509,8 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
         return self.runStep()
 
     def test_repourl(self):
-        self.assertRaisesConfigError("must provide repourl", lambda:
-                                     self.stepClass(mode="full"))
+        with self.assertRaisesConfigError("must provide repourl"):
+            self.stepClass(mode="full")
 
     def test_mode_full_fresh_revision(self):
         self.setupStep(

--- a/master/buildbot/test/unit/test_steps_source_mtn.py
+++ b/master/buildbot/test/unit/test_steps_source_mtn.py
@@ -922,22 +922,24 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
         return self.runStep()
 
     def test_incorrect_method(self):
-        self.assertRaisesConfigError("Invalid method for mode == full", lambda:
-                                     mtn.Monotone(repourl='mtn://localhost/monotone',
-                                                  mode='full', method='wrongmethod', branch='master'))
+        with self.assertRaisesConfigError(
+                "Invalid method for mode == full"):
+            mtn.Monotone(repourl='mtn://localhost/monotone',
+                         mode='full', method='wrongmethod', branch='master')
 
     def test_incremental_invalid_method(self):
-        self.assertRaisesConfigError("Incremental mode does not require method", lambda:
-                                     mtn.Monotone(repourl='mtn://localhost/monotone',
-                                                  mode='incremental', method='fresh', branch="master"))
+        with self.assertRaisesConfigError(
+                "Incremental mode does not require method"):
+            mtn.Monotone(repourl='mtn://localhost/monotone',
+                         mode='incremental', method='fresh', branch="master")
 
     def test_repourl(self):
-        self.assertRaisesConfigError("must provide repourl", lambda:
-                                     mtn.Monotone(mode="full", branch="master"))
+        with self.assertRaisesConfigError("must provide repourl"):
+            mtn.Monotone(mode="full", branch="master")
 
     def test_branch(self):
-        self.assertRaisesConfigError("must provide branch", lambda:
-                                     mtn.Monotone(repourl='mtn://localhost/monotone', mode="full",))
+        with self.assertRaisesConfigError("must provide branch"):
+            mtn.Monotone(repourl='mtn://localhost/monotone', mode="full",)
 
     def test_mode_incremental_patched(self):
         self.setupStep(

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -354,17 +354,15 @@ class OAuth2Auth(www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
 
     def test_GitHubAuthBadApiVersion(self):
         for bad_api_version in (2, 5, 'a'):
-            self.assertRaisesConfigError(
-                'GitHubAuth apiVersion must be 3 or 4 not ',
-                lambda api_version=bad_api_version: oauth2.GitHubAuth(
-                    "ghclientID", "clientSECRET", apiVersion=api_version)
-            )
+            with self.assertRaisesConfigError(
+                    'GitHubAuth apiVersion must be 3 or 4 not '):
+                oauth2.GitHubAuth("ghclientID", "clientSECRET",
+                                  apiVersion=bad_api_version)
 
     def test_GitHubAuthRaiseErrorWithApiV3AndGetTeamMembership(self):
-        self.assertRaisesConfigError(
-            'Retrieving team membership information using GitHubAuth is only possible using GitHub api v4.',
-            lambda: oauth2.GitHubAuth("ghclientID", "clientSECRET", apiVersion=3, getTeamsMembership=True)
-        )
+        with self.assertRaisesConfigError(
+                'Retrieving team membership information using GitHubAuth is only possible using GitHub api v4.'):
+            oauth2.GitHubAuth("ghclientID", "clientSECRET", apiVersion=3, getTeamsMembership=True)
 
     @defer.inlineCallbacks
     def test_GitlabVerifyCode(self):

--- a/master/buildbot/test/unit/test_www_roles.py
+++ b/master/buildbot/test/unit/test_www_roles.py
@@ -111,5 +111,5 @@ class RolesFromUsername(unittest.TestCase, ConfigErrorsMixin):
         self.assertEqual(ret, ["developers", "integrators"])
 
     def test_badUsernames(self):
-        self.assertRaisesConfigError('Usernames cannot be None',
-            lambda: roles.RolesFromUsername(roles=[], usernames=[None]))
+        with self.assertRaisesConfigError('Usernames cannot be None'):
+            roles.RolesFromUsername(roles=[], usernames=[None])


### PR DESCRIPTION
The assertRaises in unittest module is most often used as a context manager. The assertRaisesConfigError has been refactored to support this use case. Tests have been updated as this approach is more readable.