### PR TITLE
Introduce class-level method getResponsibleUsersForBuild (instead of …

### DIFF
--- a/master/buildbot/newsfragments/let-users-override-mail-notifier-getResponsibleUsersForBuild.feature
+++ b/master/buildbot/newsfragments/let-users-override-mail-notifier-getResponsibleUsersForBuild.feature
@@ -1,0 +1,1 @@
+Add method ``getResponsibleUsersForBuild`` in :py:class:`~buildbot.notifier.NotifierBase` so that users can override recipients, for example to skip authors of changes.

--- a/master/buildbot/reporters/notifier.py
+++ b/master/buildbot/reporters/notifier.py
@@ -243,6 +243,10 @@ class NotifierBase(service.BuildbotService):
                 all_logs.append(l)
         defer.returnValue(all_logs)
 
+    def getResponsibleUsersForBuild(self, master, buildid):
+        # Use library method but subclassers may want to override that
+        return utils.getResponsibleUsersForBuild(master, buildid)
+
     @defer.inlineCallbacks
     def buildMessage(self, name, builds, results):
         patches = []
@@ -266,7 +270,7 @@ class NotifierBase(service.BuildbotService):
                 previous_results = build['prev_build']['results']
             else:
                 previous_results = None
-            blamelist = yield utils.getResponsibleUsersForBuild(self.master, build['buildid'])
+            blamelist = yield self.getResponsibleUsersForBuild(self.master, build['buildid'])
             buildmsg = yield self.messageFormatter.formatMessageForBuildResults(
                 self.mode, name, build['buildset'], build, self.master,
                 previous_results, blamelist)

--- a/master/docs/manual/configuration/reporters.rst
+++ b/master/docs/manual/configuration/reporters.rst
@@ -152,6 +152,8 @@ MailNotifier arguments
 ``sendToInterestedUsers``
     (boolean).
     If ``True`` (the default), send mail to all of the Interested Users.
+    Interested Users are authors of changes and users from the ``owners`` build property.
+    Override ``MailNotifier`` ``getResponsibleUsersForBuild`` method to change that.
     If ``False``, only send mail to the ``extraRecipients`` list.
 
 ``extraRecipients``


### PR DESCRIPTION
…performing a call to utils.getResponsibleUsersForBuild) in notifier.py. It was the only way to send mails ONLY to people specified in the owners property (allowing to bypass the changes' users).

## Contributor Checklist:

* [ ] I have updated the unit tests <- Unfortunately I could not get the tests to run. make virtualenv (from http://docs.buildbot.net/latest/developer/tests.html#quick-start) fails. I've tested the patch in my companies' bots though.
* [X] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
