### PR TITLE
test: Make sure all callbacks are executed in tests

### DIFF
--- a/master/buildbot/test/fake/reactor.py
+++ b/master/buildbot/test/fake/reactor.py
@@ -119,3 +119,12 @@ class TestReactor(NonReactor, CoreReactor, Clock):
     def __init__(self):
         Clock.__init__(self)
         CoreReactor.__init__(self)
+
+    def stop(self):
+        # first fire pending calls
+        while self.getDelayedCalls():
+            last = sorted(self.getDelayedCalls(), key=lambda a: a.getTime())[-1]
+            self.advance(last.getTime() - self.seconds())
+
+        # then, fire the shutdown event
+        self.fireSystemEvent('shutdown')

--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -41,6 +41,7 @@ from buildbot.test.fake.reactor import TestReactor
 from buildbot.test.fake.step import BuildStepController
 from buildbot.test.util.integration import getMaster
 from buildbot.test.util.misc import enable_trace
+from buildbot.util.eventual import _setReactor
 
 
 class TestException(Exception):
@@ -55,6 +56,9 @@ class Tests(SynchronousTestCase):
     def setUp(self):
         self.patch(threadpool, 'ThreadPool', NonThreadPool)
         self.reactor = TestReactor()
+        self.addCleanup(self.reactor.stop)
+        _setReactor(self.reactor)
+        self.addCleanup(_setReactor, None)
 
         # to ease debugging we display the error logs in the test log
         origAddCompleteLog = BuildStep.addCompleteLog

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -70,6 +70,7 @@ class Tests(SynchronousTestCase):
     def setUp(self):
         self.patch(threadpool, 'ThreadPool', NonThreadPool)
         self.reactor = TestReactor()
+        self.addCleanup(self.reactor.stop)
 
     def tearDown(self):
         self.assertFalse(self.master.running, "master is still running!")

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -78,8 +78,6 @@ def getMaster(case, reactor, config_dict):
     master.db.setup = lambda: None
 
     yield master.startService()
-    # and shutdown the db threadpool, as is normally done at reactor stop
-    case.addCleanup(master.db.pool.shutdown)
     case.addCleanup(master.stopService)
 
     defer.returnValue(master)


### PR DESCRIPTION
Currently TestReactor can leave a bunch of callbacks that are not executed on test shutdown and are later executed at semi-random times. This includes calls registered via `callLater` and calls registered via `addSystemEventTrigger`. `TestReactor.stop` has been implemented to call these functions. This way, the test teardown does not need to execute random shutdown methods that are otherwise registered to the reactor. Additionally, there are much fewer issues hiding when modifying existing or creating other mocks as all subsystems are cleaned up.

This fixes the issues I've found when trying to remove the following out of `ControllableLatentWorker` mock:

```
def _soft_disconnect(self):
    return defer.succeed(True)
```

The removal itself depends on #4424 landing as there would be merge conflicts.