### PR TITLE
Use inline callbacks where possible (part 6)

### DIFF
--- a/master/buildbot/test/unit/test_scripts_upgrade_master.py
+++ b/master/buildbot/test/unit/test_scripts_upgrade_master.py
@@ -77,43 +77,35 @@ class TestUpgradeMaster(dirs.DirsMixin, misc.StdoutAssertionsMixin,
 
     # tests
 
+    @defer.inlineCallbacks
     def test_upgradeMaster_success(self):
         self.patchFunctions()
-        d = upgrade_master.upgradeMaster(mkconfig(), _noMonkey=True)
+        rv = yield upgrade_master.upgradeMaster(mkconfig(), _noMonkey=True)
 
-        @d.addCallback
-        def check(rv):
-            self.assertEqual(rv, 0)
-            self.assertInStdout('upgrade complete')
-        return d
+        self.assertEqual(rv, 0)
+        self.assertInStdout('upgrade complete')
 
+    @defer.inlineCallbacks
     def test_upgradeMaster_quiet(self):
         self.patchFunctions()
-        d = upgrade_master.upgradeMaster(mkconfig(quiet=True), _noMonkey=True)
+        rv = yield upgrade_master.upgradeMaster(mkconfig(quiet=True), _noMonkey=True)
 
-        @d.addCallback
-        def check(rv):
-            self.assertEqual(rv, 0)
-            self.assertWasQuiet()
-        return d
+        self.assertEqual(rv, 0)
+        self.assertWasQuiet()
 
+    @defer.inlineCallbacks
     def test_upgradeMaster_bad_basedir(self):
         self.patchFunctions(basedirOk=False)
-        d = upgrade_master.upgradeMaster(mkconfig(), _noMonkey=True)
+        rv = yield upgrade_master.upgradeMaster(mkconfig(), _noMonkey=True)
 
-        @d.addCallback
-        def check(rv):
-            self.assertEqual(rv, 1)
-        return d
+        self.assertEqual(rv, 1)
 
+    @defer.inlineCallbacks
     def test_upgradeMaster_bad_config(self):
         self.patchFunctions(configOk=False)
-        d = upgrade_master.upgradeMaster(mkconfig(), _noMonkey=True)
+        rv = yield upgrade_master.upgradeMaster(mkconfig(), _noMonkey=True)
 
-        @d.addCallback
-        def check(rv):
-            self.assertEqual(rv, 1)
-        return d
+        self.assertEqual(rv, 1)
 
 
 class TestUpgradeMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,

--- a/master/buildbot/test/unit/test_scripts_user.py
+++ b/master/buildbot/test/unit/test_scripts_user.py
@@ -58,53 +58,47 @@ class TestUsersClient(unittest.TestCase):
         # un-do the effects of @in_reactor
         self.patch(user, 'user', user.user._orig)
 
+    @defer.inlineCallbacks
     def test_usersclient_send_ids(self):
-        d = user.user(dict(master='a:9990', username="x",
+        yield user.user(dict(master='a:9990', username="x",
                            passwd="y", op='get', bb_username=None,
                            bb_password=None, ids=['me', 'you'],
                            info=None))
 
-        def check(_):
-            c = self.usersclient
-            self.assertEqual((c.master, c.port, c.username, c.passwd, c.op,
-                              c.ids, c.info),
-                             ('a', 9990, "x", "y", 'get', ['me', 'you'], None))
-        d.addCallback(check)
-        return d
+        c = self.usersclient
+        self.assertEqual((c.master, c.port, c.username, c.passwd, c.op,
+                          c.ids, c.info),
+                         ('a', 9990, "x", "y", 'get', ['me', 'you'], None))
 
+    @defer.inlineCallbacks
     def test_usersclient_send_update_info(self):
         def _fake_encrypt(passwd):
             assert passwd == 'day'
             return 'ENCRY'
         self.patch(users, 'encrypt', _fake_encrypt)
 
-        d = user.user(dict(master='a:9990', username="x",
+        yield user.user(dict(master='a:9990', username="x",
                            passwd="y", op='update', bb_username='bud',
                            bb_password='day', ids=None,
                            info=[{'identifier': 'x', 'svn': 'x'}]))
 
-        def check(_):
-            c = self.usersclient
-            self.assertEqual((c.master, c.port, c.username, c.passwd, c.op,
-                              c.bb_username, c.bb_password, c.ids, c.info),
-                             ('a', 9990, "x", "y", 'update', 'bud', 'ENCRY',
-                              None, [{'identifier': 'x', 'svn': 'x'}]))
-        d.addCallback(check)
-        return d
+        c = self.usersclient
+        self.assertEqual((c.master, c.port, c.username, c.passwd, c.op,
+                          c.bb_username, c.bb_password, c.ids, c.info),
+                         ('a', 9990, "x", "y", 'update', 'bud', 'ENCRY',
+                          None, [{'identifier': 'x', 'svn': 'x'}]))
 
+    @defer.inlineCallbacks
     def test_usersclient_send_add_info(self):
-        d = user.user(dict(master='a:9990', username="x",
+        yield user.user(dict(master='a:9990', username="x",
                            passwd="y", op='add', bb_username=None,
                            bb_password=None, ids=None,
                            info=[{'git': 'x <h@c>', 'irc': 'aaa'}]))
 
-        def check(_):
-            c = self.usersclient
-            self.assertEqual((c.master, c.port, c.username, c.passwd, c.op,
-                              c.bb_username, c.bb_password, c.ids, c.info),
-                             ('a', 9990, "x", "y", 'add', None, None, None,
-                                 [{'identifier': 'aaa',
-                                   'git': 'x <h@c>',
-                                   'irc': 'aaa'}]))
-        d.addCallback(check)
-        return d
+        c = self.usersclient
+        self.assertEqual((c.master, c.port, c.username, c.passwd, c.op,
+                          c.bb_username, c.bb_password, c.ids, c.info),
+                         ('a', 9990, "x", "y", 'add', None, None, None,
+                             [{'identifier': 'aaa',
+                               'git': 'x <h@c>',
+                               'irc': 'aaa'}]))

--- a/master/buildbot/test/unit/test_steps_python.py
+++ b/master/buildbot/test/unit/test_steps_python.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
@@ -499,6 +500,7 @@ class TestSphinx(steps.BuildStepMixin, unittest.TestCase):
                            state_string="sphinx 0 warnings")
         return self.runStep()
 
+    @defer.inlineCallbacks
     def test_warnings(self):
         self.setupStep(python.Sphinx(sphinx_builddir="_build"))
         self.expectCommands(
@@ -511,12 +513,9 @@ class TestSphinx(steps.BuildStepMixin, unittest.TestCase):
         self.expectOutcome(result=WARNINGS,
                            state_string="sphinx 2 warnings (warnings)")
         self.expectLogfile("warnings", warnings)
-        d = self.runStep()
+        yield self.runStep()
 
-        def check(_):
-            self.assertEqual(self.step.statistics, {'warnings': 2})
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.step.statistics, {'warnings': 2})
 
     def test_constr_args(self):
         self.setupStep(python.Sphinx(sphinx_sourcedir='src',

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from twisted.internet import defer
 from twisted.internet import error
 from twisted.python.reflect import namedModule
 from twisted.trial import unittest
@@ -181,6 +182,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
         self.expectOutcome(result=FAILURE)
         return self.runStep()
 
+    @defer.inlineCallbacks
     def test_revision_noninteger(self):
         svnTestStep = svn.SVN(repourl='http://svn.local/app/trunk')
         self.setupStep(svnTestStep)
@@ -213,14 +215,11 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
         )
         self.expectOutcome(result=SUCCESS)
         self.expectProperty('got_revision', 'a10', 'SVN')
-        d = self.runStep()
+        yield self.runStep()
 
-        def _checkType():
-            revision = self.step.getProperty('got_revision')
-            with self.assertRaises(ValueError):
-                int(revision)
-        d.addCallback(lambda _: _checkType())
-        return d
+        revision = self.step.getProperty('got_revision')
+        with self.assertRaises(ValueError):
+            int(revision)
 
     def test_revision_missing(self):
         """Fail if 'revision' tag isn't there"""

--- a/master/buildbot/test/unit/test_steps_vstudio.py
+++ b/master/buildbot/test/unit/test_steps_vstudio.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 from mock import Mock
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.properties import Property
@@ -226,6 +227,7 @@ class VisualStudio(steps.BuildStepMixin, unittest.TestCase):
                            state_string="compile 0 projects 0 files")
         return self.runStep()
 
+    @defer.inlineCallbacks
     def test_installdir(self):
         self.setupStep(VCx(installdir=r'C:\I'))
         self.step.exp_installdir = r'C:\I'
@@ -236,12 +238,8 @@ class VisualStudio(steps.BuildStepMixin, unittest.TestCase):
         )
         self.expectOutcome(result=SUCCESS,
                            state_string="compile 0 projects 0 files")
-        d = self.runStep()
-
-        def check_installdir(_):
-            self.assertEqual(self.step.installdir, r'C:\I')
-        d.addCallback(check_installdir)
-        return d
+        yield self.runStep()
+        self.assertEqual(self.step.installdir, r'C:\I')
 
     def test_evaluateCommand_failure(self):
         self.setupStep(VCx())
@@ -316,6 +314,7 @@ class VisualStudio(steps.BuildStepMixin, unittest.TestCase):
                            state_string="compile 0 projects 0 files")
         return self.runStep()
 
+    @defer.inlineCallbacks
     def test_rendering(self):
         self.setupStep(VCx(
             projectfile=Property('a'),
@@ -331,14 +330,11 @@ class VisualStudio(steps.BuildStepMixin, unittest.TestCase):
         )
         self.expectOutcome(result=SUCCESS,
                            state_string="compile 0 projects 0 files")
-        d = self.runStep()
+        yield self.runStep()
 
-        def check_props(_):
-            self.assertEqual(
+        self.assertEqual(
                 [self.step.projectfile, self.step.config, self.step.project],
                 ['aa', 'bb', 'cc'])
-        d.addCallback(check_props)
-        return d
 
 
 class TestVC6(steps.BuildStepMixin, unittest.TestCase):
@@ -637,6 +633,7 @@ class TestVC8(VC8ExpectedEnvMixin, steps.BuildStepMixin, unittest.TestCase):
                            state_string="compile 0 projects 0 files")
         return self.runStep()
 
+    @defer.inlineCallbacks
     def test_rendering(self):
         self.setupStep(vstudio.VC8(projectfile='pf', config='cfg',
                                    arch=Property('a')))
@@ -651,12 +648,9 @@ class TestVC8(VC8ExpectedEnvMixin, steps.BuildStepMixin, unittest.TestCase):
         )
         self.expectOutcome(result=SUCCESS,
                            state_string="compile 0 projects 0 files")
-        d = self.runStep()
+        yield self.runStep()
 
-        def check_props(_):
-            self.assertEqual(self.step.arch, 'x64')
-        d.addCallback(check_props)
-        return d
+        self.assertEqual(self.step.arch, 'x64')
 
 
 class TestVCExpress9(VC8ExpectedEnvMixin, steps.BuildStepMixin,

--- a/master/buildbot/test/unit/test_steps_worker.py
+++ b/master/buildbot/test/unit/test_steps_worker.py
@@ -291,11 +291,14 @@ class CompositeUser(buildstep.LoggingBuildStep, worker.CompositeStepMixin):
         self.logEnviron = False
         buildstep.LoggingBuildStep.__init__(self)
 
+    @defer.inlineCallbacks
     def start(self):
         self.addLogForRemoteCommands('stdio')
-        d = self.payload(self)
-        d.addCallback(self.payloadComplete)
-        d.addErrback(self.failed)
+        try:
+            res = yield self.payload(self)
+            self.payloadComplete(res)
+        except Exception as e:
+            self.failed(e)
 
     def payloadComplete(self, res):
         self.finished(FAILURE if res else SUCCESS)

--- a/master/buildbot/test/unit/test_www_authz.py
+++ b/master/buildbot/test/unit/test_www_authz.py
@@ -202,7 +202,6 @@ class Authz(www.WwwTestMixin, unittest.TestCase):
         ]
 
         self.setAllowRules(allow_rules)
-
         # check if action is denied and last check was exact against not-exist3
         with self.assertRaisesRegex(authz.Forbidden, '.+not-exists3.+'):
             yield self.assertUserAllowed("builds/13", "rebuild", {}, "nineuser")


### PR DESCRIPTION
Use of defer.inlineCallbacks leads to more readable code.