### PR TITLE
Use inline callbacks where possible (part 2)

### DIFF
--- a/master/buildbot/db/pool.py
+++ b/master/buildbot/db/pool.py
@@ -23,6 +23,7 @@ import traceback
 
 import sqlalchemy as sa
 
+from twisted.internet import defer
 from twisted.internet import threads
 from twisted.python import log
 from twisted.python import threadpool
@@ -216,13 +217,19 @@ class DBThreadPool(object):
             break
         return rv
 
+    @defer.inlineCallbacks
     def do(self, callable, *args, **kwargs):
-        return threads.deferToThreadPool(self.reactor, self._pool,
-                                         self.__thd, False, callable, args, kwargs)
+        ret = yield threads.deferToThreadPool(self.reactor, self._pool,
+                                              self.__thd, False, callable,
+                                              args, kwargs)
+        defer.returnValue(ret)
 
+    @defer.inlineCallbacks
     def do_with_engine(self, callable, *args, **kwargs):
-        return threads.deferToThreadPool(self.reactor, self._pool,
-                                         self.__thd, True, callable, args, kwargs)
+        ret = yield threads.deferToThreadPool(self.reactor, self._pool,
+                                              self.__thd, True, callable,
+                                              args, kwargs)
+        defer.returnValue(ret)
 
     def get_sqlite_version(self):
         import sqlite3

--- a/master/buildbot/db/sourcestamps.py
+++ b/master/buildbot/db/sourcestamps.py
@@ -90,6 +90,7 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
         defer.returnValue(sourcestampid)
 
     @base.cached("ssdicts")
+    @defer.inlineCallbacks
     def getSourceStamp(self, ssid):
         def thd(conn):
             tbl = self.db.model.sourcestamps
@@ -101,8 +102,9 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
             ssdict = self._rowToSsdict_thd(conn, row)
             res.close()
             return ssdict
-        return self.db.pool.do(thd)
+        defer.returnValue((yield self.db.pool.do(thd)))
 
+    @defer.inlineCallbacks
     def getSourceStampsForBuild(self, buildid):
         assert buildid > 0
 
@@ -129,8 +131,9 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
             return [self._rowToSsdict_thd(conn, row)
                     for row in res.fetchall()]
 
-        return self.db.pool.do(thd)
+        defer.returnValue((yield self.db.pool.do(thd)))
 
+    @defer.inlineCallbacks
     def getSourceStamps(self):
         def thd(conn):
             tbl = self.db.model.sourcestamps
@@ -138,7 +141,7 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
             res = conn.execute(q)
             return [self._rowToSsdict_thd(conn, row)
                     for row in res.fetchall()]
-        return self.db.pool.do(thd)
+        defer.returnValue((yield self.db.pool.do(thd)))
 
     def _rowToSsdict_thd(self, conn, row):
         ssid = row.id

--- a/master/buildbot/test/unit/test_data_builders.py
+++ b/master/buildbot/test/unit/test_data_builders.py
@@ -46,55 +46,43 @@ class BuilderEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get_existing(self):
-        d = self.callGet(('builders', 2))
+        builder = yield self.callGet(('builders', 2))
 
-        @d.addCallback
-        def check(builder):
-            self.validateData(builder)
-            self.assertEqual(builder['name'], u'builderb')
-        return d
+        self.validateData(builder)
+        self.assertEqual(builder['name'], u'builderb')
 
+    @defer.inlineCallbacks
     def test_get_missing(self):
-        d = self.callGet(('builders', 99))
+        builder = yield self.callGet(('builders', 99))
 
-        @d.addCallback
-        def check(builder):
-            self.assertEqual(builder, None)
-        return d
+        self.assertEqual(builder, None)
 
+    @defer.inlineCallbacks
     def test_get_missing_with_name(self):
-        d = self.callGet(('builders', 'builderc'))
+        builder = yield self.callGet(('builders', 'builderc'))
 
-        @d.addCallback
-        def check(builder):
-            self.assertEqual(builder, None)
-        return d
+        self.assertEqual(builder, None)
 
+    @defer.inlineCallbacks
     def test_get_existing_with_master(self):
-        d = self.callGet(('masters', 13, 'builders', 2))
+        builder = yield self.callGet(('masters', 13, 'builders', 2))
 
-        @d.addCallback
-        def check(builder):
-            self.validateData(builder)
-            self.assertEqual(builder['name'], u'builderb')
-        return d
+        self.validateData(builder)
+        self.assertEqual(builder['name'], u'builderb')
 
+    @defer.inlineCallbacks
     def test_get_existing_with_different_master(self):
-        d = self.callGet(('masters', 14, 'builders', 2))
+        builder = yield self.callGet(('masters', 14, 'builders', 2))
 
-        @d.addCallback
-        def check(builder):
-            self.assertEqual(builder, None)
-        return d
+        self.assertEqual(builder, None)
 
+    @defer.inlineCallbacks
     def test_get_missing_with_master(self):
-        d = self.callGet(('masters', 13, 'builders', 99))
+        builder = yield self.callGet(('masters', 13, 'builders', 99))
 
-        @d.addCallback
-        def check(builder):
-            self.assertEqual(builder, None)
-        return d
+        self.assertEqual(builder, None)
 
 
 class BuildersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
@@ -123,73 +111,60 @@ class BuildersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get(self):
-        d = self.callGet(('builders',))
+        builders = yield self.callGet(('builders',))
 
-        @d.addCallback
-        def check(builders):
-            [self.validateData(b) for b in builders]
-            self.assertEqual(sorted([b['builderid'] for b in builders]),
-                             [1, 2, 3, 4, 5])
-        return d
+        [self.validateData(b) for b in builders]
+        self.assertEqual(sorted([b['builderid'] for b in builders]),
+                         [1, 2, 3, 4, 5])
 
+    @defer.inlineCallbacks
     def test_get_masterid(self):
-        d = self.callGet(('masters', 13, 'builders'))
+        builders = yield self.callGet(('masters', 13, 'builders'))
 
-        @d.addCallback
-        def check(builders):
-            [self.validateData(b) for b in builders]
-            self.assertEqual(sorted([b['builderid'] for b in builders]),
-                             [2])
-        return d
+        [self.validateData(b) for b in builders]
+        self.assertEqual(sorted([b['builderid'] for b in builders]),
+                         [2])
 
+    @defer.inlineCallbacks
     def test_get_masterid_missing(self):
-        d = self.callGet(('masters', 14, 'builders'))
+        builders = yield self.callGet(('masters', 14, 'builders'))
 
-        @d.addCallback
-        def check(builders):
-            self.assertEqual(sorted([b['builderid'] for b in builders]),
-                             [])
-        return d
+        self.assertEqual(sorted([b['builderid'] for b in builders]), [])
 
+    @defer.inlineCallbacks
     def test_get_contains_one_tag(self):
         resultSpec = resultspec.ResultSpec(
             filters=[resultspec.Filter('tags', 'contains', ["tagA"])])
-        d = self.callGet(('builders',))
+        builders = yield self.callGet(('builders',))
 
-        @d.addCallback
-        def check(builders):
-            builders = resultSpec.apply(builders)
-            [self.validateData(b) for b in builders]
-            self.assertEqual(sorted([b['builderid'] for b in builders]),
-                             [3, 5])
-        return d
+        builders = resultSpec.apply(builders)
+        [self.validateData(b) for b in builders]
+        self.assertEqual(sorted([b['builderid'] for b in builders]),
+                         [3, 5])
 
+    @defer.inlineCallbacks
     def test_get_contains_two_tags(self):
         resultSpec = resultspec.ResultSpec(
             filters=[resultspec.Filter('tags', 'contains', ["tagA", "tagB"])])
-        d = self.callGet(('builders',))
+        builders = yield self.callGet(('builders',))
 
-        @d.addCallback
-        def check(builders):
-            builders = resultSpec.apply(builders)
-            [self.validateData(b) for b in builders]
-            self.assertEqual(sorted([b['builderid'] for b in builders]),
-                             [3, 4, 5])
-        return d
+        builders = resultSpec.apply(builders)
+        [self.validateData(b) for b in builders]
+        self.assertEqual(sorted([b['builderid'] for b in builders]),
+                         [3, 4, 5])
 
+    @defer.inlineCallbacks
     def test_get_contains_two_tags_one_unknown(self):
         resultSpec = resultspec.ResultSpec(
             filters=[resultspec.Filter('tags', 'contains', ["tagA", "tagC"])])
-        d = self.callGet(('builders',))
+        builders = yield self.callGet(('builders',))
 
-        @d.addCallback
-        def check(builders):
-            builders = resultSpec.apply(builders)
-            [self.validateData(b) for b in builders]
-            self.assertEqual(sorted([b['builderid'] for b in builders]),
-                             [3, 5])
-        return d
+        builders = resultSpec.apply(builders)
+        [self.validateData(b) for b in builders]
+        self.assertEqual(sorted([b['builderid'] for b in builders]),
+                         [3, 5])
 
 
 class Builder(interfaces.InterfaceTests, unittest.TestCase):

--- a/master/buildbot/test/unit/test_data_buildsets.py
+++ b/master/buildbot/test/unit/test_data_buildsets.py
@@ -58,31 +58,25 @@ class BuildsetEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get_existing(self):
-        d = self.callGet(('buildsets', 13))
+        buildset = yield self.callGet(('buildsets', 13))
 
-        @d.addCallback
-        def check(buildset):
-            self.validateData(buildset)
-            self.assertEqual(buildset['reason'], 'because I said so')
-        return d
+        self.validateData(buildset)
+        self.assertEqual(buildset['reason'], 'because I said so')
 
+    @defer.inlineCallbacks
     def test_get_existing_no_sourcestamps(self):
-        d = self.callGet(('buildsets', 14))
+        buildset = yield self.callGet(('buildsets', 14))
 
-        @d.addCallback
-        def check(buildset):
-            self.validateData(buildset)
-            self.assertEqual(buildset['sourcestamps'], [])
-        return d
+        self.validateData(buildset)
+        self.assertEqual(buildset['sourcestamps'], [])
 
+    @defer.inlineCallbacks
     def test_get_missing(self):
-        d = self.callGet(('buildsets', 99))
+        buildset = yield self.callGet(('buildsets', 99))
 
-        @d.addCallback
-        def check(buildset):
-            self.assertEqual(buildset, None)
-        return d
+        self.assertEqual(buildset, None)
 
 
 class BuildsetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
@@ -103,40 +97,34 @@ class BuildsetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get(self):
-        d = self.callGet(('buildsets',))
+        buildsets = yield self.callGet(('buildsets',))
 
-        @d.addCallback
-        def check(buildsets):
-            self.validateData(buildsets[0])
-            self.assertEqual(buildsets[0]['bsid'], 13)
-            self.validateData(buildsets[1])
-            self.assertEqual(buildsets[1]['bsid'], 14)
-        return d
+        self.validateData(buildsets[0])
+        self.assertEqual(buildsets[0]['bsid'], 13)
+        self.validateData(buildsets[1])
+        self.assertEqual(buildsets[1]['bsid'], 14)
 
+    @defer.inlineCallbacks
     def test_get_complete(self):
         f = resultspec.Filter('complete', 'eq', [True])
-        d = self.callGet(('buildsets',),
+        buildsets = yield self.callGet(('buildsets',),
                          resultSpec=resultspec.ResultSpec(filters=[f]))
 
-        @d.addCallback
-        def check(buildsets):
-            self.assertEqual(len(buildsets), 1)
-            self.validateData(buildsets[0])
-            self.assertEqual(buildsets[0]['bsid'], 13)
-        return d
+        self.assertEqual(len(buildsets), 1)
+        self.validateData(buildsets[0])
+        self.assertEqual(buildsets[0]['bsid'], 13)
 
+    @defer.inlineCallbacks
     def test_get_incomplete(self):
         f = resultspec.Filter('complete', 'eq', [False])
-        d = self.callGet(('buildsets',),
+        buildsets = yield self.callGet(('buildsets',),
                          resultSpec=resultspec.ResultSpec(filters=[f]))
 
-        @d.addCallback
-        def check(buildsets):
-            self.assertEqual(len(buildsets), 1)
-            self.validateData(buildsets[0])
-            self.assertEqual(buildsets[0]['bsid'], 14)
-        return d
+        self.assertEqual(len(buildsets), 1)
+        self.validateData(buildsets[0])
+        self.assertEqual(buildsets[0]['bsid'], 14)
 
 
 class Buildset(util_interfaces.InterfaceTests, unittest.TestCase):
@@ -166,6 +154,7 @@ class Buildset(util_interfaces.InterfaceTests, unittest.TestCase):
                         parent_buildid=None, parent_relationship=None):
             pass
 
+    @defer.inlineCallbacks
     def do_test_addBuildset(self, kwargs, expectedReturn,
                             expectedMessages, expectedBuildset):
         """Run a test of addBuildset.
@@ -181,18 +170,15 @@ class Buildset(util_interfaces.InterfaceTests, unittest.TestCase):
         """
         clock = task.Clock()
         clock.advance(A_TIMESTAMP)
-        d = self.rtype.addBuildset(_reactor=clock, **kwargs)
+        xxx_todo_changeme = yield self.rtype.addBuildset(_reactor=clock, **kwargs)
 
-        def check(xxx_todo_changeme):
-            (bsid, brids) = xxx_todo_changeme
-            self.assertEqual((bsid, brids), expectedReturn)
-            # check the correct message was received
-            self.master.mq.assertProductions(
-                expectedMessages, orderMatters=False)
-            # and that the correct data was inserted into the db
-            self.master.db.buildsets.assertBuildset(bsid, expectedBuildset)
-        d.addCallback(check)
-        return d
+        (bsid, brids) = xxx_todo_changeme
+        self.assertEqual((bsid, brids), expectedReturn)
+        # check the correct message was received
+        self.master.mq.assertProductions(
+            expectedMessages, orderMatters=False)
+        # and that the correct data was inserted into the db
+        self.master.db.buildsets.assertBuildset(bsid, expectedBuildset)
 
     def _buildRequestMessageDict(self, brid, bsid, builderid):
         return {'builderid': builderid,


### PR DESCRIPTION
Use of defer.inlineCallbacks leads to more readable code.