### PR TITLE
Use inline callbacks where possible (part 4)

### DIFF
--- a/master/buildbot/test/unit/test_db_model.py
+++ b/master/buildbot/test/unit/test_db_model.py
@@ -34,36 +34,34 @@ class DBConnector_Basic(db.RealDatabaseMixin, unittest.TestCase):
     Basic tests of the DBConnector class - all start with an empty DB
     """
 
+    @defer.inlineCallbacks
     def setUp(self):
-        d = self.setUpRealDatabase()
+        yield self.setUpRealDatabase()
 
-        def make_fake_pool(_):
-            engine = enginestrategy.create_engine(self.db_url,
-                                                  basedir=os.path.abspath('basedir'))
+        engine = enginestrategy.create_engine(self.db_url,
+                                              basedir=os.path.abspath('basedir'))
 
-            # mock out the pool, and set up the model
-            self.db = mock.Mock()
-            self.db.pool.do_with_engine = lambda thd: defer.maybeDeferred(
-                thd, engine)
-            self.db.model = model.Model(self.db)
-            self.db.start()
-        d.addCallback(make_fake_pool)
-        return d
+        # mock out the pool, and set up the model
+        self.db = mock.Mock()
+        self.db.pool.do_with_engine = lambda thd: defer.maybeDeferred(
+            thd, engine)
+        self.db.model = model.Model(self.db)
+        self.db.start()
 
     def tearDown(self):
         self.db.stop()
         return self.tearDownRealDatabase()
 
+    @defer.inlineCallbacks
     def test_is_current_empty(self):
-        d = self.db.model.is_current()
-        d.addCallback(self.assertFalse)
-        return d
+        res = yield self.db.model.is_current()
+        self.assertFalse(res)
 
+    @defer.inlineCallbacks
     def test_is_current_full(self):
-        d = self.db.model.upgrade()
-        d.addCallback(lambda _: self.db.model.is_current())
-        d.addCallback(self.assertTrue)
-        return d
+        yield self.db.model.upgrade()
+        res = yield self.db.model.is_current()
+        self.assertTrue(res)
 
     # the upgrade method is very well-tested by the integration tests; the
     # remainder of the object is just tables.

--- a/master/buildbot/test/unit/test_db_pool.py
+++ b/master/buildbot/test/unit/test_db_pool.py
@@ -43,16 +43,14 @@ class Basic(unittest.TestCase):
     def tearDown(self):
         self.pool.shutdown()
 
+    @defer.inlineCallbacks
     def test_do(self):
         def add(conn, addend1, addend2):
             rp = conn.execute("SELECT %d + %d" % (addend1, addend2))
             return rp.scalar()
-        d = self.pool.do(add, 10, 11)
+        res = yield self.pool.do(add, 10, 11)
 
-        def check(res):
-            self.assertEqual(res, 21)
-        d.addCallback(check)
-        return d
+        self.assertEqual(res, 21)
 
     @defer.inlineCallbacks
     def expect_failure(self, d, expected_exception, expect_logged_error=False):
@@ -80,16 +78,14 @@ class Basic(unittest.TestCase):
         return self.expect_failure(self.pool.do(raise_something), RuntimeError,
                                    expect_logged_error=True)
 
+    @defer.inlineCallbacks
     def test_do_with_engine(self):
         def add(engine, addend1, addend2):
             rp = engine.execute("SELECT %d + %d" % (addend1, addend2))
             return rp.scalar()
-        d = self.pool.do_with_engine(add, 10, 11)
+        res = yield self.pool.do_with_engine(add, 10, 11)
 
-        def check(res):
-            self.assertEqual(res, 21)
-        d.addCallback(check)
-        return d
+        self.assertEqual(res, 21)
 
     def test_do_with_engine_exception(self):
         def fail(engine):
@@ -97,6 +93,7 @@ class Basic(unittest.TestCase):
             return rp.scalar()
         return self.expect_failure(self.pool.do_with_engine(fail), sa.exc.OperationalError)
 
+    @defer.inlineCallbacks
     def test_persistence_across_invocations(self):
         # NOTE: this assumes that both methods are called with the same
         # connection; if they run in parallel threads then it is not valid to
@@ -104,16 +101,13 @@ class Basic(unittest.TestCase):
         # transaction (and thus created the table) by the time the second
         # transaction runs.  This is why we set optimal_thread_pool_size in
         # setUp.
-        d = defer.succeed(None)
-
         def create_table(engine):
             engine.execute("CREATE TABLE tmp ( a integer )")
-        d.addCallback(lambda r: self.pool.do_with_engine(create_table))
+        yield self.pool.do_with_engine(create_table)
 
         def insert_into_table(engine):
             engine.execute("INSERT INTO tmp values ( 1 )")
-        d.addCallback(lambda r: self.pool.do_with_engine(insert_into_table))
-        return d
+        yield self.pool.do_with_engine(insert_into_table)
 
 
 class Stress(unittest.TestCase):
@@ -172,14 +166,13 @@ class Native(unittest.TestCase, db.RealDatabaseMixin):
 
     # similar tests, but using the BUILDBOT_TEST_DB_URL
 
+    @defer.inlineCallbacks
     def setUp(self):
-        d = self.setUpRealDatabase(want_pool=False)
+        yield self.setUpRealDatabase(want_pool=False)
 
-        def make_pool(_):
-            self.pool = pool.DBThreadPool(self.db_engine, reactor=reactor)
-        d.addCallback(make_pool)
-        return d
+        self.pool = pool.DBThreadPool(self.db_engine, reactor=reactor)
 
+    @defer.inlineCallbacks
     def tearDown(self):
         # try to delete the 'native_tests' table
         meta = sa.MetaData()
@@ -187,11 +180,11 @@ class Native(unittest.TestCase, db.RealDatabaseMixin):
 
         def thd(conn):
             native_tests.drop(bind=self.db_engine, checkfirst=True)
-        d = self.pool.do(thd)
-        d.addCallback(lambda _: self.pool.shutdown())
-        d.addCallback(lambda _: self.tearDownRealDatabase())
-        return d
+        yield self.pool.do(thd)
+        yield self.pool.shutdown()
+        yield self.tearDownRealDatabase()
 
+    @defer.inlineCallbacks
     def test_ddl_and_queries(self):
         meta = sa.MetaData()
         native_tests = sautils.Table("native_tests", meta,
@@ -204,10 +197,8 @@ class Native(unittest.TestCase, db.RealDatabaseMixin):
             t = conn.begin()
             native_tests.create(bind=conn)
             t.commit()
-        d = self.pool.do(ddl)
+        yield self.pool.do(ddl)
 
         def access(conn):
             native_tests.insert(bind=conn).execute([{'name': 'foo'}])
-        d.addCallback(lambda _:
-                      self.pool.do(access))
-        return d
+        yield self.pool.do(access)

--- a/master/buildbot/test/unit/test_db_users.py
+++ b/master/buildbot/test/unit/test_db_users.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import sqlalchemy
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.db import users
@@ -28,15 +29,13 @@ from buildbot.test.util import connector_component
 class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
                                   unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        d = self.setUpConnectorComponent(
+        yield self.setUpConnectorComponent(
             table_names=['users', 'users_info', 'changes', 'change_users',
                          'sourcestamps', 'patches'])
 
-        def finish_setup(_):
-            self.db.users = users.UsersConnectorComponent(self.db)
-        d.addCallback(finish_setup)
-        return d
+        self.db.users = users.UsersConnectorComponent(self.db)
 
     def tearDown(self):
         return self.tearDownConnectorComponent()
@@ -86,87 +85,82 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
 
     # tests
 
+    @defer.inlineCallbacks
     def test_addUser_new(self):
-        d = self.db.users.findUserByAttr(identifier='soap',
+        uid = yield self.db.users.findUserByAttr(identifier='soap',
                                          attr_type='subspace_net_handle',
                                          attr_data='Durden0924')
 
-        def check_user(uid):
-            def thd(conn):
-                users_tbl = self.db.model.users
-                users_info_tbl = self.db.model.users_info
-                users = conn.execute(users_tbl.select()).fetchall()
-                infos = conn.execute(users_info_tbl.select()).fetchall()
-                self.assertEqual(len(users), 1)
-                self.assertEqual(users[0].uid, uid)
-                self.assertEqual(users[0].identifier, 'soap')
-                self.assertEqual(len(infos), 1)
-                self.assertEqual(infos[0].uid, uid)
-                self.assertEqual(infos[0].attr_type, 'subspace_net_handle')
-                self.assertEqual(infos[0].attr_data, 'Durden0924')
-            return self.db.pool.do(thd)
-        d.addCallback(check_user)
-        return d
+        def thd(conn):
+            users_tbl = self.db.model.users
+            users_info_tbl = self.db.model.users_info
+            users = conn.execute(users_tbl.select()).fetchall()
+            infos = conn.execute(users_info_tbl.select()).fetchall()
+            self.assertEqual(len(users), 1)
+            self.assertEqual(users[0].uid, uid)
+            self.assertEqual(users[0].identifier, 'soap')
+            self.assertEqual(len(infos), 1)
+            self.assertEqual(infos[0].uid, uid)
+            self.assertEqual(infos[0].attr_type, 'subspace_net_handle')
+            self.assertEqual(infos[0].attr_data, 'Durden0924')
+        yield self.db.pool.do(thd)
 
+    @defer.inlineCallbacks
     def test_addUser_existing(self):
-        d = self.insertTestData(self.user1_rows)
-        d.addCallback(lambda _: self.db.users.findUserByAttr(
+        yield self.insertTestData(self.user1_rows)
+        uid = yield self.db.users.findUserByAttr(
             identifier='soapy',
             attr_type='IPv9',
-            attr_data='0578cc6.8db024'))
+            attr_data='0578cc6.8db024')
 
-        def check_user(uid):
-            self.assertEqual(uid, 1)
+        self.assertEqual(uid, 1)
 
-            def thd(conn):
-                users_tbl = self.db.model.users
-                users_info_tbl = self.db.model.users_info
-                users = conn.execute(users_tbl.select()).fetchall()
-                infos = conn.execute(users_info_tbl.select()).fetchall()
-                self.assertEqual(len(users), 1)
-                self.assertEqual(users[0].uid, uid)
-                self.assertEqual(users[0].identifier, 'soap')  # not changed!
-                self.assertEqual(len(infos), 1)
-                self.assertEqual(infos[0].uid, uid)
-                self.assertEqual(infos[0].attr_type, 'IPv9')
-                self.assertEqual(infos[0].attr_data, '0578cc6.8db024')
-            return self.db.pool.do(thd)
-        d.addCallback(check_user)
-        return d
+        def thd(conn):
+            users_tbl = self.db.model.users
+            users_info_tbl = self.db.model.users_info
+            users = conn.execute(users_tbl.select()).fetchall()
+            infos = conn.execute(users_info_tbl.select()).fetchall()
+            self.assertEqual(len(users), 1)
+            self.assertEqual(users[0].uid, uid)
+            self.assertEqual(users[0].identifier, 'soap')  # not changed!
+            self.assertEqual(len(infos), 1)
+            self.assertEqual(infos[0].uid, uid)
+            self.assertEqual(infos[0].attr_type, 'IPv9')
+            self.assertEqual(infos[0].attr_data, '0578cc6.8db024')
+        yield self.db.pool.do(thd)
 
+    @defer.inlineCallbacks
     def test_findUser_existing(self):
-        d = self.insertTestData(
+        yield self.insertTestData(
             self.user1_rows + self.user2_rows + self.user3_rows)
-        d.addCallback(lambda _: self.db.users.findUserByAttr(
+        uid = yield self.db.users.findUserByAttr(
             identifier='lye',
             attr_type='git',
-            attr_data='Tyler Durden <tyler@mayhem.net>'))
+            attr_data='Tyler Durden <tyler@mayhem.net>')
 
-        def check_user(uid):
-            self.assertEqual(uid, 2)
+        self.assertEqual(uid, 2)
 
-            def thd(conn):
-                users_tbl = self.db.model.users
-                users_info_tbl = self.db.model.users_info
-                users = conn.execute(users_tbl.select()).fetchall()
-                infos = conn.execute(users_info_tbl.select()).fetchall()
-                self.assertEqual((
-                    sorted([tuple(u) for u in users]),
-                    sorted([tuple(i) for i in infos])
-                ), (
-                    [
-                        (1, u'soap', None, None),
-                        (2, u'lye', None, None),
-                        (3, u'marla', u'marla', u'cancer'),
-                    ], [
-                        (1, u'IPv9', u'0578cc6.8db024'),
-                        (2, u'git', u'Tyler Durden <tyler@mayhem.net>'),
-                        (2, u'irc', u'durden')
-                    ]))
-            return self.db.pool.do(thd)
-        d.addCallback(check_user)
-        return d
+        def thd(conn):
+            users_tbl = self.db.model.users
+            users_info_tbl = self.db.model.users_info
+            users = conn.execute(users_tbl.select()).fetchall()
+            infos = conn.execute(users_info_tbl.select()).fetchall()
+            self.assertEqual((
+                sorted([tuple(u) for u in users]),
+                sorted([tuple(i) for i in infos])
+            ), (
+                [
+                    (1, u'soap', None, None),
+                    (2, u'lye', None, None),
+                    (3, u'marla', u'marla', u'cancer'),
+                ], [
+                    (1, u'IPv9', u'0578cc6.8db024'),
+                    (2, u'git', u'Tyler Durden <tyler@mayhem.net>'),
+                    (2, u'irc', u'durden')
+                ]))
+        yield self.db.pool.do(thd)
 
+    @defer.inlineCallbacks
     def test_addUser_race(self):
         def race_thd(conn):
             # note that this assumes that both inserts can happen "at once".
@@ -178,260 +172,191 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
             conn.execute(self.db.model.users_info.insert(),
                          uid=99, attr_type='subspace_net_handle',
                          attr_data='Durden0924')
-        d = self.db.users.findUserByAttr(identifier='soap',
+        uid = yield self.db.users.findUserByAttr(identifier='soap',
                                          attr_type='subspace_net_handle',
                                          attr_data='Durden0924',
                                          _race_hook=race_thd)
 
-        def check_user(uid):
-            self.assertEqual(uid, 99)
+        self.assertEqual(uid, 99)
 
-            def thd(conn):
-                users_tbl = self.db.model.users
-                users_info_tbl = self.db.model.users_info
-                users = conn.execute(users_tbl.select()).fetchall()
-                infos = conn.execute(users_info_tbl.select()).fetchall()
-                self.assertEqual(len(users), 1)
-                self.assertEqual(users[0].uid, uid)
-                self.assertEqual(users[0].identifier, 'soap')
-                self.assertEqual(len(infos), 1)
-                self.assertEqual(infos[0].uid, uid)
-                self.assertEqual(infos[0].attr_type, 'subspace_net_handle')
-                self.assertEqual(infos[0].attr_data, 'Durden0924')
-            return self.db.pool.do(thd)
-        d.addCallback(check_user)
-        return d
+        def thd(conn):
+            users_tbl = self.db.model.users
+            users_info_tbl = self.db.model.users_info
+            users = conn.execute(users_tbl.select()).fetchall()
+            infos = conn.execute(users_info_tbl.select()).fetchall()
+            self.assertEqual(len(users), 1)
+            self.assertEqual(users[0].uid, uid)
+            self.assertEqual(users[0].identifier, 'soap')
+            self.assertEqual(len(infos), 1)
+            self.assertEqual(infos[0].uid, uid)
+            self.assertEqual(infos[0].attr_type, 'subspace_net_handle')
+            self.assertEqual(infos[0].attr_data, 'Durden0924')
+        yield self.db.pool.do(thd)
 
+    @defer.inlineCallbacks
     def test_addUser_existing_identifier(self):
         # see http://trac.buildbot.net/ticket/2587
-        d = self.insertTestData(self.user1_rows)
-        d.addCallback(lambda _: self.db.users.findUserByAttr(
-            identifier='soap',  # same identifier
-            attr_type='IPv9',
-            attr_data='fffffff.ffffff'))  # different attr
+        yield self.insertTestData(self.user1_rows)
+        uid = yield self.db.users.findUserByAttr(
+                                identifier='soap',  # same identifier
+                                attr_type='IPv9',
+                                attr_data='fffffff.ffffff')  # different attr
 
-        def check_user(uid):
-            # creates a new user
-            self.assertNotEqual(uid, 1)
+        # creates a new user
+        self.assertNotEqual(uid, 1)
 
-            def thd(conn):
-                users_tbl = self.db.model.users
-                users_info_tbl = self.db.model.users_info
-                users = conn.execute(
-                    users_tbl.select(order_by=users_tbl.c.identifier)).fetchall()
-                infos = conn.execute(
-                    users_info_tbl.select(users_info_tbl.c.uid == uid)).fetchall()
-                self.assertEqual(len(users), 2)
-                self.assertEqual(users[1].uid, uid)
-                self.assertEqual(users[1].identifier, 'soap_2')  # unique'd
-                self.assertEqual(len(infos), 1)
-                self.assertEqual(infos[0].attr_type, 'IPv9')
-                self.assertEqual(infos[0].attr_data, 'fffffff.ffffff')
-            return self.db.pool.do(thd)
-        d.addCallback(check_user)
-        return d
+        def thd(conn):
+            users_tbl = self.db.model.users
+            users_info_tbl = self.db.model.users_info
+            users = conn.execute(
+                users_tbl.select(order_by=users_tbl.c.identifier)).fetchall()
+            infos = conn.execute(
+                users_info_tbl.select(users_info_tbl.c.uid == uid)).fetchall()
+            self.assertEqual(len(users), 2)
+            self.assertEqual(users[1].uid, uid)
+            self.assertEqual(users[1].identifier, 'soap_2')  # unique'd
+            self.assertEqual(len(infos), 1)
+            self.assertEqual(infos[0].attr_type, 'IPv9')
+            self.assertEqual(infos[0].attr_data, 'fffffff.ffffff')
+        yield self.db.pool.do(thd)
 
+    @defer.inlineCallbacks
     def test_getUser(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def get1(_):
-            return self.db.users.getUser(1)
-        d.addCallback(get1)
+        usdict = yield self.db.users.getUser(1)
 
-        def check1(usdict):
-            self.assertEqual(usdict, self.user1_dict)
-        d.addCallback(check1)
-        return d
+        self.assertEqual(usdict, self.user1_dict)
 
+    @defer.inlineCallbacks
     def test_getUser_bb(self):
-        d = self.insertTestData(self.user3_rows)
+        yield self.insertTestData(self.user3_rows)
 
-        def get3(_):
-            return self.db.users.getUser(3)
-        d.addCallback(get3)
+        usdict = yield self.db.users.getUser(3)
 
-        def check3(usdict):
-            self.assertEqual(usdict, self.user3_dict)
-        d.addCallback(check3)
-        return d
+        self.assertEqual(usdict, self.user3_dict)
 
+    @defer.inlineCallbacks
     def test_getUser_multi_attr(self):
-        d = self.insertTestData(self.user2_rows)
+        yield self.insertTestData(self.user2_rows)
 
-        def get1(_):
-            return self.db.users.getUser(2)
-        d.addCallback(get1)
+        usdict = yield self.db.users.getUser(2)
 
-        def check1(usdict):
-            self.assertEqual(usdict, self.user2_dict)
-        d.addCallback(check1)
-        return d
+        self.assertEqual(usdict, self.user2_dict)
 
+    @defer.inlineCallbacks
     def test_getUser_no_match(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def get3(_):
-            return self.db.users.getUser(3)
-        d.addCallback(get3)
+        none = yield self.db.users.getUser(3)
 
-        def check3(none):
-            self.assertEqual(none, None)
-        d.addCallback(check3)
-        return d
+        self.assertEqual(none, None)
 
+    @defer.inlineCallbacks
     def test_getUsers_none(self):
-        d = self.db.users.getUsers()
+        res = yield self.db.users.getUsers()
 
-        def check(res):
-            self.assertEqual(res, [])
-        d.addCallback(check)
-        return d
+        self.assertEqual(res, [])
 
+    @defer.inlineCallbacks
     def test_getUsers(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def get(_):
-            return self.db.users.getUsers()
-        d.addCallback(get)
+        res = yield self.db.users.getUsers()
 
-        def check(res):
-            self.assertEqual(res, [dict(uid=1, identifier='soap')])
-        d.addCallback(check)
-        return d
+        self.assertEqual(res, [dict(uid=1, identifier='soap')])
 
+    @defer.inlineCallbacks
     def test_getUsers_multiple(self):
-        d = self.insertTestData(self.user1_rows + self.user2_rows)
+        yield self.insertTestData(self.user1_rows + self.user2_rows)
 
-        def get(_):
-            return self.db.users.getUsers()
-        d.addCallback(get)
+        res = yield self.db.users.getUsers()
 
-        def check(res):
-            self.assertEqual(res, [dict(uid=1, identifier='soap'),
-                                   dict(uid=2, identifier='lye')])
-        d.addCallback(check)
-        return d
+        self.assertEqual(res, [dict(uid=1, identifier='soap'),
+                         dict(uid=2, identifier='lye')])
 
+    @defer.inlineCallbacks
     def test_getUserByUsername(self):
-        d = self.insertTestData(self.user3_rows)
+        yield self.insertTestData(self.user3_rows)
 
-        def get3(_):
-            return self.db.users.getUserByUsername("marla")
-        d.addCallback(get3)
+        res = yield self.db.users.getUserByUsername("marla")
 
-        def check3(res):
-            self.assertEqual(res, self.user3_dict)
-        d.addCallback(check3)
-        return d
+        self.assertEqual(res, self.user3_dict)
 
+    @defer.inlineCallbacks
     def test_getUserByUsername_no_match(self):
-        d = self.insertTestData(self.user3_rows)
+        yield self.insertTestData(self.user3_rows)
 
-        def get3(_):
-            return self.db.users.getUserByUsername("tyler")
-        d.addCallback(get3)
+        none = yield self.db.users.getUserByUsername("tyler")
 
-        def check3(none):
-            self.assertEqual(none, None)
-        d.addCallback(check3)
-        return d
+        self.assertEqual(none, None)
 
+    @defer.inlineCallbacks
     def test_updateUser_existing_type(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def update1(_):
-            return self.db.users.updateUser(
-                uid=1, attr_type='IPv9', attr_data='abcd.1234')
-        d.addCallback(update1)
+        yield self.db.users.updateUser(uid=1, attr_type='IPv9',
+                                       attr_data='abcd.1234')
 
-        def get1(_):
-            return self.db.users.getUser(1)
-        d.addCallback(get1)
+        usdict = yield self.db.users.getUser(1)
 
-        def check1(usdict):
-            self.assertEqual(usdict['IPv9'], 'abcd.1234')
-            self.assertEqual(usdict['identifier'], 'soap')  # no change
-        d.addCallback(check1)
-        return d
+        self.assertEqual(usdict['IPv9'], 'abcd.1234')
+        self.assertEqual(usdict['identifier'], 'soap')  # no change
 
+    @defer.inlineCallbacks
     def test_updateUser_new_type(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def update1(_):
-            return self.db.users.updateUser(
-                uid=1, attr_type='IPv4', attr_data='123.134.156.167')
-        d.addCallback(update1)
+        yield self.db.users.updateUser(uid=1, attr_type='IPv4',
+                                       attr_data='123.134.156.167')
 
-        def get1(_):
-            return self.db.users.getUser(1)
-        d.addCallback(get1)
+        usdict = yield self.db.users.getUser(1)
 
-        def check1(usdict):
-            self.assertEqual(usdict['IPv4'], '123.134.156.167')
-            self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
-            self.assertEqual(usdict['identifier'], 'soap')  # no change
-        d.addCallback(check1)
-        return d
+        self.assertEqual(usdict['IPv4'], '123.134.156.167')
+        self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
+        self.assertEqual(usdict['identifier'], 'soap')  # no change
 
+    @defer.inlineCallbacks
     def test_updateUser_identifier(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def update1(_):
-            return self.db.users.updateUser(
-                uid=1, identifier='lye')
-        d.addCallback(update1)
+        yield self.db.users.updateUser(uid=1, identifier='lye')
 
-        def get1(_):
-            return self.db.users.getUser(1)
-        d.addCallback(get1)
+        usdict = yield self.db.users.getUser(1)
 
-        def check1(usdict):
-            self.assertEqual(usdict['identifier'], 'lye')
-            self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
-        d.addCallback(check1)
-        return d
+        self.assertEqual(usdict['identifier'], 'lye')
+        self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
 
+    @defer.inlineCallbacks
     def test_updateUser_bb(self):
-        d = self.insertTestData(self.user3_rows)
+        yield self.insertTestData(self.user3_rows)
 
-        def update3(_):
-            return self.db.users.updateUser(
-                uid=3, bb_username='boss', bb_password='fired')
-        d.addCallback(update3)
+        yield self.db.users.updateUser(uid=3, bb_username='boss',
+                                       bb_password='fired')
 
-        def get3(_):
-            return self.db.users.getUser(3)
-        d.addCallback(get3)
+        usdict = yield self.db.users.getUser(3)
 
-        def check3(usdict):
-            self.assertEqual(usdict['bb_username'], 'boss')
-            self.assertEqual(usdict['bb_password'], 'fired')
-            self.assertEqual(usdict['identifier'], 'marla')  # no change
-        d.addCallback(check3)
-        return d
+        self.assertEqual(usdict['bb_username'], 'boss')
+        self.assertEqual(usdict['bb_password'], 'fired')
+        self.assertEqual(usdict['identifier'], 'marla')  # no change
 
+    @defer.inlineCallbacks
     def test_updateUser_all(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def update1(_):
-            return self.db.users.updateUser(
-                uid=1, identifier='lye', bb_username='marla',
-                bb_password='cancer', attr_type='IPv4', attr_data='123.134.156.167')
-        d.addCallback(update1)
+        yield self.db.users.updateUser(
+            uid=1, identifier='lye', bb_username='marla',
+            bb_password='cancer', attr_type='IPv4', attr_data='123.134.156.167')
 
-        def get1(_):
-            return self.db.users.getUser(1)
-        d.addCallback(get1)
+        usdict = yield self.db.users.getUser(1)
 
-        def check1(usdict):
-            self.assertEqual(usdict['identifier'], 'lye')
-            self.assertEqual(usdict['bb_username'], 'marla')
-            self.assertEqual(usdict['bb_password'], 'cancer')
-            self.assertEqual(usdict['IPv4'], '123.134.156.167')
-            self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
-        d.addCallback(check1)
-        return d
+        self.assertEqual(usdict['identifier'], 'lye')
+        self.assertEqual(usdict['bb_username'], 'marla')
+        self.assertEqual(usdict['bb_password'], 'cancer')
+        self.assertEqual(usdict['IPv4'], '123.134.156.167')
+        self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
 
+    @defer.inlineCallbacks
     def test_updateUser_race(self):
         # called from the db thread, this opens a *new* connection (to avoid
         # the existing transaction) and executes a conflicting insert in that
@@ -458,119 +383,81 @@ class TestUsersConnectorComponent(connector_component.ConnectorComponentMixin,
                 # some engine (mysql innodb) will enforce lock until the transaction is over
                 transaction_wins.append(True)
                 # scope variable, we modify a list so that modification is visible in parent scope
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def update1(_):
-            return self.db.users.updateUser(
-                uid=1, attr_type='IPv4', attr_data='123.134.156.167',
-                _race_hook=race_thd)
-        d.addCallback(update1)
+        yield self.db.users.updateUser(uid=1, attr_type='IPv4',
+                                       attr_data='123.134.156.167',
+                                       _race_hook=race_thd)
 
-        def get1(_):
-            return self.db.users.getUser(1)
-        d.addCallback(get1)
+        usdict = yield self.db.users.getUser(1)
 
-        def check1(usdict):
-            self.assertEqual(usdict['identifier'], 'soap')
-            if transaction_wins:
-                self.assertEqual(usdict['IPv4'], '123.134.156.167')
-            else:
-                self.assertEqual(usdict['IPv4'], '8.8.8.8')
-            self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
-        d.addCallback(check1)
-        return d
+        self.assertEqual(usdict['identifier'], 'soap')
+        if transaction_wins:
+            self.assertEqual(usdict['IPv4'], '123.134.156.167')
+        else:
+            self.assertEqual(usdict['IPv4'], '8.8.8.8')
+        self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
 
+    @defer.inlineCallbacks
     def test_update_NoMatch_identifier(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def update3(_):
-            return self.db.users.updateUser(
-                uid=3, identifier='abcd')
-        d.addCallback(update3)
+        yield self.db.users.updateUser(uid=3, identifier='abcd')
 
-        def get1(_):
-            return self.db.users.getUser(1)
-        d.addCallback(get1)
+        usdict = yield self.db.users.getUser(1)
 
-        def check1(usdict):
-            self.assertEqual(usdict['identifier'], 'soap')  # no change
-        d.addCallback(check1)
-        return d
+        self.assertEqual(usdict['identifier'], 'soap')  # no change
 
+    @defer.inlineCallbacks
     def test_update_NoMatch_attribute(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def update3(_):
-            return self.db.users.updateUser(
-                uid=3, attr_type='abcd', attr_data='efgh')
-        d.addCallback(update3)
+        yield self.db.users.updateUser(uid=3, attr_type='abcd',
+                                       attr_data='efgh')
 
-        def get1(_):
-            return self.db.users.getUser(1)
-        d.addCallback(get1)
+        usdict = yield self.db.users.getUser(1)
 
-        def check1(usdict):
-            self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
-        d.addCallback(check1)
-        return d
+        self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
 
+    @defer.inlineCallbacks
     def test_update_NoMatch_bb(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def update3(_):
-            return self.db.users.updateUser(
+        yield self.db.users.updateUser(
                 uid=3, attr_type='marla', attr_data='cancer')
-        d.addCallback(update3)
 
-        def get1(_):
-            return self.db.users.getUser(1)
-        d.addCallback(get1)
+        usdict = yield self.db.users.getUser(1)
 
-        def check1(usdict):
-            self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
-        d.addCallback(check1)
-        return d
+        self.assertEqual(usdict['IPv9'], '0578cc6.8db024')  # no change
 
+    @defer.inlineCallbacks
     def test_removeUser_uid(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def remove1(_):
-            return self.db.users.removeUser(1)
-        d.addCallback(remove1)
+        yield self.db.users.removeUser(1)
 
-        def check1(_):
-            def thd(conn):
-                r = conn.execute(self.db.model.users.select())
-                r = r.fetchall()
-                self.assertEqual(len(r), 0)
-            return self.db.pool.do(thd)
-        d.addCallback(check1)
-        return d
+        def thd(conn):
+            r = conn.execute(self.db.model.users.select())
+            r = r.fetchall()
+            self.assertEqual(len(r), 0)
+        yield self.db.pool.do(thd)
 
+    @defer.inlineCallbacks
     def test_removeNoMatch(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def check(_):
-            return self.db.users.removeUser(uid=3)
-        d.addCallback(check)
-        return d
+        yield self.db.users.removeUser(uid=3)
 
+    @defer.inlineCallbacks
     def test_identifierToUid_NoMatch(self):
-        d = self.db.users.identifierToUid(identifier="soap")
+        res = yield self.db.users.identifierToUid(identifier="soap")
 
-        def check(res):
-            self.assertEqual(res, None)
-        d.addCallback(check)
-        return d
+        self.assertEqual(res, None)
 
+    @defer.inlineCallbacks
     def test_identifierToUid_match(self):
-        d = self.insertTestData(self.user1_rows)
+        yield self.insertTestData(self.user1_rows)
 
-        def ident2uid(_):
-            return self.db.users.identifierToUid(identifier="soap")
-        d.addCallback(ident2uid)
+        res = yield self.db.users.identifierToUid(identifier="soap")
 
-        def check(res):
-            self.assertEqual(res, 1)
-        d.addCallback(check)
-        return d
+        self.assertEqual(res, 1)

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -80,6 +80,7 @@ class OldTriggeringMethods(unittest.TestCase):
             return defer.succeed(self.fake_Change)
         self.patch(Change, 'fromChdict', staticmethod(fromChdict))
 
+    @defer.inlineCallbacks
     def do_test_addChange_args(self, args=(), kwargs=None, exp_data_kwargs=None):
         # add default arguments
         if kwargs is None:
@@ -104,14 +105,11 @@ class OldTriggeringMethods(unittest.TestCase):
         default_data_kwargs.update(exp_data_kwargs)
         exp_data_kwargs = default_data_kwargs
 
-        d = self.master.addChange(*args, **kwargs)
+        change = yield self.master.addChange(*args, **kwargs)
 
-        @d.addCallback
-        def check(change):
-            self.assertIdentical(change, self.fake_Change)
-            self.assertEqual(self.master.data.updates.changesAdded,
-                             [exp_data_kwargs])
-        return d
+        self.assertIdentical(change, self.fake_Change)
+        self.assertEqual(self.master.data.updates.changesAdded,
+                         [exp_data_kwargs])
 
     def test_addChange_args_author(self):
         # who should come through as author
@@ -141,13 +139,14 @@ class OldTriggeringMethods(unittest.TestCase):
             kwargs=dict(when_timestamp=datetime.datetime(1998, 4, 11, 11, 24, 35)),
             exp_data_kwargs=dict(when_timestamp=892293875))
 
+    @defer.inlineCallbacks
     def test_addChange_args_new_and_old(self):
         func = self.do_test_addChange_args
         kwargs = (dict(who='author',
                        author='author'),)
         exp_data_kwargs = dict(author='author')
         with self.assertRaises(TypeError):
-            func(kwargs=kwargs, exp_data_kwargs=exp_data_kwargs)
+            yield func(kwargs=kwargs, exp_data_kwargs=exp_data_kwargs)
 
     def test_addChange_args_properties(self):
         # properties should not be qualified with a source

--- a/master/buildbot/test/unit/test_pbmanager.py
+++ b/master/buildbot/test/unit/test_pbmanager.py
@@ -66,6 +66,7 @@ class TestPBManager(unittest.TestCase):
         self.assertEqual(
             repr(reg), '<pbmanager.Registration for x on tcp:0:interface=127.0.0.1>')
 
+    @defer.inlineCallbacks
     def test_register_unregister(self):
         portstr = "tcp:0:interface=127.0.0.1"
         reg = self.pbm.register(
@@ -80,23 +81,18 @@ class TestPBManager(unittest.TestCase):
         # dynamically allocated port number which is buried out of reach;
         # however, we can try the requestAvatar and requestAvatarId methods.
 
-        d = disp.requestAvatarId(credentials.UsernamePassword(b'boris', b'pass'))
+        username = yield disp.requestAvatarId(credentials.UsernamePassword(b'boris', b'pass'))
 
-        def check_avatarid(username):
-            self.assertEqual(username, b'boris')
-        d.addCallback(check_avatarid)
-        d.addCallback(lambda _:
-                      disp.requestAvatar(b'boris', mock.Mock(), pb.IPerspective))
+        self.assertEqual(username, b'boris')
+        avatar = yield disp.requestAvatar(b'boris', mock.Mock(), pb.IPerspective)
 
-        def check_avatar(avatar):
-            (iface, persp, detach_fn) = avatar
-            self.assertTrue(persp.is_my_persp)
-            self.assertIn('boris', self.connections)
-        d.addCallback(check_avatar)
+        (iface, persp, detach_fn) = avatar
+        self.assertTrue(persp.is_my_persp)
+        self.assertIn('boris', self.connections)
 
-        d.addCallback(lambda _: reg.unregister())
-        return d
+        yield reg.unregister()
 
+    @defer.inlineCallbacks
     def test_double_register_unregister(self):
         portstr = "tcp:0:interface=127.0.0.1"
         reg1 = self.pbm.register(portstr, "boris", "pass", None)
@@ -109,21 +105,16 @@ class TestPBManager(unittest.TestCase):
         self.assertIn('boris', disp.users)
         self.assertIn('ivona', disp.users)
 
-        d = reg1.unregister()
+        yield reg1.unregister()
 
-        def check_boris_gone(_):
-            self.assertEqual(len(self.pbm.dispatchers), 1)
-            self.assertIn(portstr, self.pbm.dispatchers)
-            disp = self.pbm.dispatchers[portstr]
-            self.assertNotIn('boris', disp.users)
-            self.assertIn('ivona', disp.users)
-        d.addCallback(check_boris_gone)
-        d.addCallback(lambda _: reg2.unregister())
+        self.assertEqual(len(self.pbm.dispatchers), 1)
+        self.assertIn(portstr, self.pbm.dispatchers)
+        disp = self.pbm.dispatchers[portstr]
+        self.assertNotIn('boris', disp.users)
+        self.assertIn('ivona', disp.users)
+        yield reg2.unregister()
 
-        def check_dispatcher_gone(_):
-            self.assertEqual(len(self.pbm.dispatchers), 0)
-        d.addCallback(check_dispatcher_gone)
-        return d
+        self.assertEqual(len(self.pbm.dispatchers), 0)
 
     @defer.inlineCallbacks
     def test_requestAvatarId_noinitLock(self):

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -272,6 +272,7 @@ class TestBuild(unittest.TestCase):
         d.callback(False)
         self.assertEqual(b.results, RETRY)
 
+    @defer.inlineCallbacks
     def testAlwaysRunStepStopBuild(self):
         """Test that steps marked with alwaysRun=True still get run even if
         the build is stopped."""
@@ -306,14 +307,11 @@ class TestBuild(unittest.TestCase):
         step2.startStep = startStep2
         step1.stepDone = lambda: False
 
-        d = b.startBuild(FakeBuildStatus(), self.workerforbuilder)
+        yield b.startBuild(FakeBuildStatus(), self.workerforbuilder)
 
-        def check(ign):
-            self.assertEqual(b.results, CANCELLED)
-            self.assertIn('stop it', step1.interrupted)
-            self.assertTrue(step2Started[0])
-        d.addCallback(check)
-        return d
+        self.assertEqual(b.results, CANCELLED)
+        self.assertIn('stop it', step1.interrupted)
+        self.assertTrue(step2Started[0])
 
     def testBuildcanStartWithWorkerForBuilder(self):
         b = self.build

--- a/master/buildbot/test/unit/test_process_buildrequest.py
+++ b/master/buildbot/test/unit/test_process_buildrequest.py
@@ -291,6 +291,7 @@ class TestBuildRequestCollapser(unittest.TestCase):
 
 class TestBuildRequest(unittest.TestCase):
 
+    @defer.inlineCallbacks
     def test_fromBrdict(self):
         master = fakemaster.make_master(testcase=self,
                                         wantData=True, wantDb=True)
@@ -313,26 +314,23 @@ class TestBuildRequest(unittest.TestCase):
         ])
         # use getBuildRequest to minimize the risk from changes to the format
         # of the brdict
-        d = master.db.buildrequests.getBuildRequest(288)
-        d.addCallback(lambda brdict:
-                      buildrequest.BuildRequest.fromBrdict(master, brdict))
+        brdict = yield master.db.buildrequests.getBuildRequest(288)
+        br = yield buildrequest.BuildRequest.fromBrdict(master, brdict)
 
-        def check(br):
-            # check enough of the source stamp to verify it found the changes
-            self.assertEqual([ss.ssid for ss in itervalues(br.sources)], [234])
+        # check enough of the source stamp to verify it found the changes
+        self.assertEqual([ss.ssid for ss in itervalues(br.sources)], [234])
 
-            self.assertEqual(br.reason, 'triggered')
+        self.assertEqual(br.reason, 'triggered')
 
-            self.assertEqual(br.properties.getProperty('x'), 1)
-            self.assertEqual(br.properties.getProperty('y'), 2)
-            self.assertEqual(br.submittedAt, 1200000000)
-            self.assertEqual(br.buildername, 'bldr')
-            self.assertEqual(br.priority, 13)
-            self.assertEqual(br.id, 288)
-            self.assertEqual(br.bsid, 539)
-        d.addCallback(check)
-        return d
+        self.assertEqual(br.properties.getProperty('x'), 1)
+        self.assertEqual(br.properties.getProperty('y'), 2)
+        self.assertEqual(br.submittedAt, 1200000000)
+        self.assertEqual(br.buildername, 'bldr')
+        self.assertEqual(br.priority, 13)
+        self.assertEqual(br.id, 288)
+        self.assertEqual(br.bsid, 539)
 
+    @defer.inlineCallbacks
     def test_fromBrdict_submittedAt_NULL(self):
         master = fakemaster.make_master(testcase=self,
                                         wantData=True, wantDb=True)
@@ -348,15 +346,11 @@ class TestBuildRequest(unittest.TestCase):
         ])
         # use getBuildRequest to minimize the risk from changes to the format
         # of the brdict
-        d = master.db.buildrequests.getBuildRequest(288)
-        d.addCallback(lambda brdict:
-                      buildrequest.BuildRequest.fromBrdict(master, brdict))
+        brdict = yield master.db.buildrequests.getBuildRequest(288)
+        br = yield buildrequest.BuildRequest.fromBrdict(master, brdict)
 
-        def check(br):
-            # remaining fields assumed to be checked in test_fromBrdict
-            self.assertEqual(br.submittedAt, None)
-        d.addCallback(check)
-        return d
+        # remaining fields assumed to be checked in test_fromBrdict
+        self.assertEqual(br.submittedAt, None)
 
     def test_fromBrdict_no_sourcestamps(self):
         master = fakemaster.make_master(testcase=self,
@@ -375,6 +369,7 @@ class TestBuildRequest(unittest.TestCase):
                       buildrequest.BuildRequest.fromBrdict(master, brdict))
         return self.assertFailure(d, AssertionError)
 
+    @defer.inlineCallbacks
     def test_fromBrdict_multiple_sourcestamps(self):
         master = fakemaster.make_master(testcase=self,
                                         wantData=True, wantDb=True)
@@ -405,23 +400,20 @@ class TestBuildRequest(unittest.TestCase):
         ])
         # use getBuildRequest to minimize the risk from changes to the format
         # of the brdict
-        d = master.db.buildrequests.getBuildRequest(288)
-        d.addCallback(lambda brdict:
-                      buildrequest.BuildRequest.fromBrdict(master, brdict))
+        brdict = yield master.db.buildrequests.getBuildRequest(288)
+        br = yield buildrequest.BuildRequest.fromBrdict(master, brdict)
 
-        def check(br):
-            self.assertEqual(br.reason, 'triggered')
+        self.assertEqual(br.reason, 'triggered')
 
-            self.assertEqual(br.properties.getProperty('x'), 1)
-            self.assertEqual(br.properties.getProperty('y'), 2)
-            self.assertEqual(br.submittedAt, 1200000000)
-            self.assertEqual(br.buildername, 'bldr')
-            self.assertEqual(br.priority, 13)
-            self.assertEqual(br.id, 288)
-            self.assertEqual(br.bsid, 539)
-        d.addCallback(check)
-        return d
+        self.assertEqual(br.properties.getProperty('x'), 1)
+        self.assertEqual(br.properties.getProperty('y'), 2)
+        self.assertEqual(br.submittedAt, 1200000000)
+        self.assertEqual(br.buildername, 'bldr')
+        self.assertEqual(br.priority, 13)
+        self.assertEqual(br.id, 288)
+        self.assertEqual(br.bsid, 539)
 
+    @defer.inlineCallbacks
     def test_mergeSourceStampsWith_common_codebases(self):
         """ This testcase has two buildrequests
             Request Change Codebase Revision Comment
@@ -480,35 +472,29 @@ class TestBuildRequest(unittest.TestCase):
         ])
         # use getBuildRequest to minimize the risk from changes to the format
         # of the brdict
-        d = master.db.buildrequests.getBuildRequest(288)
-        d.addCallback(lambda brdict:
-                      buildrequest.BuildRequest.fromBrdict(master, brdict))
-        d.addCallback(brs.append)
-        d.addCallback(lambda _:
-                      master.db.buildrequests.getBuildRequest(289))
-        d.addCallback(lambda brdict:
-                      buildrequest.BuildRequest.fromBrdict(master, brdict))
-        d.addCallback(brs.append)
+        brdict = yield master.db.buildrequests.getBuildRequest(288)
+        res = yield buildrequest.BuildRequest.fromBrdict(master, brdict)
+        brs.append(res)
+        brdict = yield master.db.buildrequests.getBuildRequest(289)
+        res = yield buildrequest.BuildRequest.fromBrdict(master, brdict)
+        brs.append(res)
 
-        def check(_):
-            sources = brs[0].mergeSourceStampsWith(brs[1:])
+        sources = brs[0].mergeSourceStampsWith(brs[1:])
 
-            source1 = source2 = None
-            for source in sources:
-                if source.codebase == 'A':
-                    source1 = source
-                if source.codebase == 'B':
-                    source2 = source
+        source1 = source2 = None
+        for source in sources:
+            if source.codebase == 'A':
+                source1 = source
+            if source.codebase == 'B':
+                source2 = source
 
-            self.assertFalse(source1 is None)
-            self.assertEqual(source1.revision, '9284')
+        self.assertFalse(source1 is None)
+        self.assertEqual(source1.revision, '9284')
 
-            self.assertFalse(source2 is None)
-            self.assertEqual(source2.revision, '9201')
+        self.assertFalse(source2 is None)
+        self.assertEqual(source2.revision, '9201')
 
-        d.addCallback(check)
-        return d
-
+    @defer.inlineCallbacks
     def test_canBeCollapsed_different_codebases_raises_error(self):
         """ This testcase has two buildrequests
             Request Change Codebase   Revision Comment
@@ -548,16 +534,12 @@ class TestBuildRequest(unittest.TestCase):
         ])
         # use getBuildRequest to minimize the risk from changes to the format
         # of the brdict
-        d = master.db.buildrequests.getBuildRequest(288)
-        d.addCallback(brDicts.append)
-        d.addCallback(lambda _:
-                      master.db.buildrequests.getBuildRequest(289))
-        d.addCallback(brDicts.append)
-        d.addCallback(lambda _: buildrequest.BuildRequest.canBeCollapsed(
-            master, brDicts[0], brDicts[1]))
+        req = yield master.db.buildrequests.getBuildRequest(288)
+        brDicts.append(req)
+        req = yield master.db.buildrequests.getBuildRequest(289)
+        brDicts.append(req)
+        can_collapse = \
+            yield buildrequest.BuildRequest.canBeCollapsed(master, brDicts[0],
+                                                           brDicts[1])
 
-        def check(canBeCollapsed):
-            self.assertEqual(canBeCollapsed, False)
-
-        d.addCallback(check)
-        return d
+        self.assertEqual(can_collapse, False)

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -288,6 +288,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
         self._setupWaterfallTest(True, True)
         return self.runStep()
 
+    @defer.inlineCallbacks
     def test_hideStepIf_Callable_False(self):
         called = [False]
 
@@ -299,10 +300,10 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
 
         self._setupWaterfallTest(shouldHide, False)
 
-        d = self.runStep()
-        d.addCallback(lambda _: self.assertTrue(called[0]))
-        return d
+        yield self.runStep()
+        self.assertTrue(called[0])
 
+    @defer.inlineCallbacks
     def test_hideStepIf_Callable_True(self):
         called = [False]
 
@@ -314,9 +315,8 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
 
         self._setupWaterfallTest(shouldHide, True)
 
-        d = self.runStep()
-        d.addCallback(lambda _: self.assertTrue(called[0]))
-        return d
+        yield self.runStep()
+        self.assertTrue(called[0])
 
     @defer.inlineCallbacks
     def test_hideStepIf_fails(self):
@@ -328,6 +328,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
         yield self.runStep()
         self.assertEqual(len(self.flushLoggedErrors(ZeroDivisionError)), 1)
 
+    @defer.inlineCallbacks
     def test_hideStepIf_Callable_Exception(self):
         called = [False]
 
@@ -346,12 +347,12 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
                            state_string='finished (exception)')
         self.expectHidden(True)
 
-        d = self.runStep()
-        d.addErrback(log.err)
-        d.addCallback(lambda _:
-                      self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1))
-        d.addCallback(lambda _: self.assertTrue(called[0]))
-        return d
+        try:
+            yield self.runStep()
+        except Exception as e:
+            log.err(e)
+        self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1)
+        self.assertTrue(called[0])
 
     @defer.inlineCallbacks
     def test_step_getLog(self):


### PR DESCRIPTION
Use of defer.inlineCallbacks leads to more readable code.