### PR TITLE
Use inline callbacks where possible (part 3)

### DIFF
--- a/master/buildbot/test/unit/test_data_changesources.py
+++ b/master/buildbot/test/unit/test_data_changesources.py
@@ -52,62 +52,50 @@ class ChangeSourceEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get_existing(self):
         """get an existing changesource by id"""
-        d = self.callGet(('changesources', 14))
+        changesource = yield self.callGet(('changesources', 14))
 
-        @d.addCallback
-        def check(changesource):
-            self.validateData(changesource)
-            self.assertEqual(changesource['name'], 'other:changesource')
-        return d
+        self.validateData(changesource)
+        self.assertEqual(changesource['name'], 'other:changesource')
 
+    @defer.inlineCallbacks
     def test_get_no_master(self):
         """get a changesource with no master"""
-        d = self.callGet(('changesources', 13))
+        changesource = yield self.callGet(('changesources', 13))
 
-        @d.addCallback
-        def check(changesource):
-            self.validateData(changesource)
-            self.assertEqual(changesource['master'], None),
-        return d
+        self.validateData(changesource)
+        self.assertEqual(changesource['master'], None),
 
+    @defer.inlineCallbacks
     def test_get_masterid_existing(self):
         """get an existing changesource by id on certain master"""
-        d = self.callGet(('masters', 22, 'changesources', 14))
+        changesource = yield self.callGet(('masters', 22, 'changesources', 14))
 
-        @d.addCallback
-        def check(changesource):
-            self.validateData(changesource)
-            self.assertEqual(changesource['name'], 'other:changesource')
-        return d
+        self.validateData(changesource)
+        self.assertEqual(changesource['name'], 'other:changesource')
 
+    @defer.inlineCallbacks
     def test_get_masterid_no_match(self):
         """get an existing changesource by id on the wrong master"""
-        d = self.callGet(('masters', 33, 'changesources', 13))
+        changesource = yield self.callGet(('masters', 33, 'changesources', 13))
 
-        @d.addCallback
-        def check(changesource):
-            self.assertEqual(changesource, None)
-        return d
+        self.assertEqual(changesource, None)
 
+    @defer.inlineCallbacks
     def test_get_masterid_missing(self):
         """get an existing changesource by id on an invalid master"""
-        d = self.callGet(('masters', 25, 'changesources', 13))
+        changesource = yield self.callGet(('masters', 25, 'changesources', 13))
 
-        @d.addCallback
-        def check(changesource):
-            self.assertEqual(changesource, None)
-        return d
+        self.assertEqual(changesource, None)
 
+    @defer.inlineCallbacks
     def test_get_missing(self):
         """get an invalid changesource by id"""
-        d = self.callGet(('changesources', 99))
+        changesource = yield self.callGet(('changesources', 99))
 
-        @d.addCallback
-        def check(changesource):
-            self.assertEqual(changesource, None)
-        return d
+        self.assertEqual(changesource, None)
 
 
 class ChangeSourcesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
@@ -133,33 +121,27 @@ class ChangeSourcesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get(self):
-        d = self.callGet(('changesources',))
+        changesources = yield self.callGet(('changesources',))
 
-        @d.addCallback
-        def check(changesources):
-            [self.validateData(cs) for cs in changesources]
-            self.assertEqual(sorted([m['changesourceid'] for m in changesources]),
-                             [13, 14, 15, 16])
-        return d
+        [self.validateData(cs) for cs in changesources]
+        self.assertEqual(sorted([m['changesourceid'] for m in changesources]),
+                         [13, 14, 15, 16])
 
+    @defer.inlineCallbacks
     def test_get_masterid(self):
-        d = self.callGet(('masters', 33, 'changesources'))
+        changesources = yield self.callGet(('masters', 33, 'changesources'))
 
-        @d.addCallback
-        def check(changesources):
-            [self.validateData(cs) for cs in changesources]
-            self.assertEqual(sorted([m['changesourceid'] for m in changesources]),
-                             [15, 16])
-        return d
+        [self.validateData(cs) for cs in changesources]
+        self.assertEqual(sorted([m['changesourceid'] for m in changesources]),
+                         [15, 16])
 
+    @defer.inlineCallbacks
     def test_get_masterid_missing(self):
-        d = self.callGet(('masters', 23, 'changesources'))
+        changesources = yield self.callGet(('masters', 23, 'changesources'))
 
-        @d.addCallback
-        def check(changesources):
-            self.assertEqual(changesources, [])
-        return d
+        self.assertEqual(changesources, [])
 
 
 class ChangeSource(interfaces.InterfaceTests, unittest.TestCase):

--- a/master/buildbot/test/unit/test_data_connector.py
+++ b/master/buildbot/test/unit/test_data_connector.py
@@ -177,54 +177,46 @@ class DataConnector(unittest.TestCase):
         with self.assertRaises(exceptions.InvalidPathError):
             self.data.getEndpoint(('xyz',))
 
+    @defer.inlineCallbacks
     def test_get(self):
         ep = self.patchFooPattern()
-        d = self.data.get(('foo', '10', 'bar'))
+        gotten = yield self.data.get(('foo', '10', 'bar'))
 
-        @d.addCallback
-        def check(gotten):
-            self.assertEqual(gotten, {'val': 9999})
-            ep.get.assert_called_once_with(mock.ANY, {'fooid': 10})
-        return d
+        self.assertEqual(gotten, {'val': 9999})
+        ep.get.assert_called_once_with(mock.ANY, {'fooid': 10})
 
+    @defer.inlineCallbacks
     def test_get_filters(self):
         ep = self.patchFooListPattern()
-        d = self.data.get(('foo',),
+        gotten = yield self.data.get(('foo',),
                           filters=[resultspec.Filter('val', 'lt', [902])])
 
-        @d.addCallback
-        def check(gotten):
-            self.assertEqual(gotten, base.ListResult(
-                [{'val': 900}, {'val': 901}], total=2))
-            ep.get.assert_called_once_with(mock.ANY, {})
-        return d
+        self.assertEqual(gotten, base.ListResult(
+            [{'val': 900}, {'val': 901}], total=2))
+        ep.get.assert_called_once_with(mock.ANY, {})
 
+    @defer.inlineCallbacks
     def test_get_resultSpec_args(self):
         ep = self.patchFooListPattern()
         f = resultspec.Filter('val', 'gt', [909])
-        d = self.data.get(('foo',), filters=[f], fields=['val'],
+        gotten = yield self.data.get(('foo',), filters=[f], fields=['val'],
                           order=['-val'], limit=2)
 
-        @d.addCallback
-        def check(gotten):
-            self.assertEqual(gotten, base.ListResult(
-                [{'val': 919}, {'val': 918}], total=10, limit=2))
-            ep.get.assert_called_once_with(mock.ANY, {})
-        return d
+        self.assertEqual(gotten, base.ListResult(
+            [{'val': 919}, {'val': 918}], total=10, limit=2))
+        ep.get.assert_called_once_with(mock.ANY, {})
 
+    @defer.inlineCallbacks
     def test_control(self):
         ep = self.patchFooPattern()
         ep.control = mock.Mock(name='MyEndpoint.control')
         ep.control.return_value = defer.succeed('controlled')
 
-        d = self.data.control('foo!', {'arg': 2}, ('foo', '10', 'bar'))
+        gotten = yield self.data.control('foo!', {'arg': 2}, ('foo', '10', 'bar'))
 
-        @d.addCallback
-        def check(gotten):
-            self.assertEqual(gotten, 'controlled')
-            ep.control.assert_called_once_with('foo!', {'arg': 2},
-                                               {'fooid': 10})
-        return d
+        self.assertEqual(gotten, 'controlled')
+        ep.control.assert_called_once_with('foo!', {'arg': 2},
+                                           {'fooid': 10})
 
 # classes discovered by test_scanModule, above
 

--- a/master/buildbot/test/unit/test_data_masters.py
+++ b/master/buildbot/test/unit/test_data_masters.py
@@ -55,47 +55,37 @@ class MasterEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get_existing(self):
-        d = self.callGet(('masters', 14))
+        master = yield self.callGet(('masters', 14))
 
-        @d.addCallback
-        def check(master):
-            self.validateData(master)
-            self.assertEqual(master['name'], 'other:master')
-        return d
+        self.validateData(master)
+        self.assertEqual(master['name'], 'other:master')
 
+    @defer.inlineCallbacks
     def test_get_builderid_existing(self):
-        d = self.callGet(('builders', 23, 'masters', 13))
+        master = yield self.callGet(('builders', 23, 'masters', 13))
 
-        @d.addCallback
-        def check(master):
-            self.validateData(master)
-            self.assertEqual(master['name'], 'some:master')
-        return d
+        self.validateData(master)
+        self.assertEqual(master['name'], 'some:master')
 
+    @defer.inlineCallbacks
     def test_get_builderid_no_match(self):
-        d = self.callGet(('builders', 24, 'masters', 13))
+        master = yield self.callGet(('builders', 24, 'masters', 13))
 
-        @d.addCallback
-        def check(master):
-            self.assertEqual(master, None)
-        return d
+        self.assertEqual(master, None)
 
+    @defer.inlineCallbacks
     def test_get_builderid_missing(self):
-        d = self.callGet(('builders', 25, 'masters', 13))
+        master = yield self.callGet(('builders', 25, 'masters', 13))
 
-        @d.addCallback
-        def check(master):
-            self.assertEqual(master, None)
-        return d
+        self.assertEqual(master, None)
 
+    @defer.inlineCallbacks
     def test_get_missing(self):
-        d = self.callGet(('masters', 99))
+        master = yield self.callGet(('masters', 99))
 
-        @d.addCallback
-        def check(master):
-            self.assertEqual(master, None)
-        return d
+        self.assertEqual(master, None)
 
 
 class MastersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
@@ -118,33 +108,27 @@ class MastersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get(self):
-        d = self.callGet(('masters',))
+        masters = yield self.callGet(('masters',))
 
-        @d.addCallback
-        def check(masters):
-            [self.validateData(m) for m in masters]
-            self.assertEqual(sorted([m['masterid'] for m in masters]),
-                             [13, 14])
-        return d
+        [self.validateData(m) for m in masters]
+        self.assertEqual(sorted([m['masterid'] for m in masters]),
+                         [13, 14])
 
+    @defer.inlineCallbacks
     def test_get_builderid(self):
-        d = self.callGet(('builders', 22, 'masters'))
+        masters = yield self.callGet(('builders', 22, 'masters'))
 
-        @d.addCallback
-        def check(masters):
-            [self.validateData(m) for m in masters]
-            self.assertEqual(sorted([m['masterid'] for m in masters]),
-                             [13])
-        return d
+        [self.validateData(m) for m in masters]
+        self.assertEqual(sorted([m['masterid'] for m in masters]),
+                         [13])
 
+    @defer.inlineCallbacks
     def test_get_builderid_missing(self):
-        d = self.callGet(('builders', 23, 'masters'))
+        masters = yield self.callGet(('builders', 23, 'masters'))
 
-        @d.addCallback
-        def check(masters):
-            self.assertEqual(masters, [])
-        return d
+        self.assertEqual(masters, [])
 
 
 class Master(interfaces.InterfaceTests, unittest.TestCase):

--- a/master/buildbot/test/unit/test_data_properties.py
+++ b/master/buildbot/test/unit/test_data_properties.py
@@ -51,13 +51,11 @@ class BuildsetPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get_properties(self):
-        d = self.callGet(('buildsets', 14, 'properties'))
+        props = yield self.callGet(('buildsets', 14, 'properties'))
 
-        @d.addCallback
-        def check(props):
-            self.assertEqual(props, {u'prop': (22, u'fakedb')})
-        return d
+        self.assertEqual(props, {u'prop': (22, u'fakedb')})
 
 
 class BuildPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
@@ -82,14 +80,12 @@ class BuildPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get_properties(self):
-        d = self.callGet(('builds', 786, 'properties'))
+        props = yield self.callGet(('builds', 786, 'properties'))
 
-        @d.addCallback
-        def check(props):
-            self.assertEqual(
-                props, {u'year': (1651, u'Wikipedia'), u'island_name': ("despair", u'Book')})
-        return d
+        self.assertEqual(props, {u'year': (1651, u'Wikipedia'),
+                         u'island_name': ("despair", u'Book')})
 
 
 class Properties(interfaces.InterfaceTests, unittest.TestCase):

--- a/master/buildbot/test/unit/test_data_schedulers.py
+++ b/master/buildbot/test/unit/test_data_schedulers.py
@@ -50,56 +50,44 @@ class SchedulerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get_existing(self):
-        d = self.callGet(('schedulers', 14))
+        scheduler = yield self.callGet(('schedulers', 14))
 
-        @d.addCallback
-        def check(scheduler):
-            self.validateData(scheduler)
-            self.assertEqual(scheduler['name'], 'other:scheduler')
-        return d
+        self.validateData(scheduler)
+        self.assertEqual(scheduler['name'], 'other:scheduler')
 
+    @defer.inlineCallbacks
     def test_get_no_master(self):
-        d = self.callGet(('schedulers', 13))
+        scheduler = yield self.callGet(('schedulers', 13))
 
-        @d.addCallback
-        def check(scheduler):
-            self.validateData(scheduler)
-            self.assertEqual(scheduler['master'], None),
-        return d
+        self.validateData(scheduler)
+        self.assertEqual(scheduler['master'], None),
 
+    @defer.inlineCallbacks
     def test_get_masterid_existing(self):
-        d = self.callGet(('masters', 22, 'schedulers', 14))
+        scheduler = yield self.callGet(('masters', 22, 'schedulers', 14))
 
-        @d.addCallback
-        def check(scheduler):
-            self.validateData(scheduler)
-            self.assertEqual(scheduler['name'], 'other:scheduler')
-        return d
+        self.validateData(scheduler)
+        self.assertEqual(scheduler['name'], 'other:scheduler')
 
+    @defer.inlineCallbacks
     def test_get_masterid_no_match(self):
-        d = self.callGet(('masters', 33, 'schedulers', 13))
+        scheduler = yield self.callGet(('masters', 33, 'schedulers', 13))
 
-        @d.addCallback
-        def check(scheduler):
-            self.assertEqual(scheduler, None)
-        return d
+        self.assertEqual(scheduler, None)
 
+    @defer.inlineCallbacks
     def test_get_masterid_missing(self):
-        d = self.callGet(('masters', 99, 'schedulers', 13))
+        scheduler = yield self.callGet(('masters', 99, 'schedulers', 13))
 
-        @d.addCallback
-        def check(scheduler):
-            self.assertEqual(scheduler, None)
-        return d
+        self.assertEqual(scheduler, None)
 
+    @defer.inlineCallbacks
     def test_get_missing(self):
-        d = self.callGet(('schedulers', 99))
+        scheduler = yield self.callGet(('schedulers', 99))
 
-        @d.addCallback
-        def check(scheduler):
-            self.assertEqual(scheduler, None)
-        return d
+        self.assertEqual(scheduler, None)
 
     @defer.inlineCallbacks
     def test_action_enable(self):
@@ -130,33 +118,27 @@ class SchedulersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get(self):
-        d = self.callGet(('schedulers',))
+        schedulers = yield self.callGet(('schedulers',))
 
-        @d.addCallback
-        def check(schedulers):
-            [self.validateData(m) for m in schedulers]
-            self.assertEqual(sorted([m['schedulerid'] for m in schedulers]),
-                             [13, 14, 15, 16])
-        return d
+        [self.validateData(m) for m in schedulers]
+        self.assertEqual(sorted([m['schedulerid'] for m in schedulers]),
+                         [13, 14, 15, 16])
 
+    @defer.inlineCallbacks
     def test_get_masterid(self):
-        d = self.callGet(('masters', 33, 'schedulers'))
+        schedulers = yield self.callGet(('masters', 33, 'schedulers'))
 
-        @d.addCallback
-        def check(schedulers):
-            [self.validateData(m) for m in schedulers]
-            self.assertEqual(sorted([m['schedulerid'] for m in schedulers]),
-                             [15, 16])
-        return d
+        [self.validateData(m) for m in schedulers]
+        self.assertEqual(sorted([m['schedulerid'] for m in schedulers]),
+                         [15, 16])
 
+    @defer.inlineCallbacks
     def test_get_masterid_missing(self):
-        d = self.callGet(('masters', 23, 'schedulers'))
+        schedulers = yield self.callGet(('masters', 23, 'schedulers'))
 
-        @d.addCallback
-        def check(schedulers):
-            self.assertEqual(schedulers, [])
-        return d
+        self.assertEqual(schedulers, [])
 
 
 class Scheduler(interfaces.InterfaceTests, unittest.TestCase):

--- a/master/buildbot/test/unit/test_data_sourcestamps.py
+++ b/master/buildbot/test/unit/test_data_sourcestamps.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.data import sourcestamps
@@ -41,40 +42,34 @@ class SourceStampEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get_existing(self):
-        d = self.callGet(('sourcestamps', 13))
+        sourcestamp = yield self.callGet(('sourcestamps', 13))
 
-        @d.addCallback
-        def check(sourcestamp):
-            self.validateData(sourcestamp)
-            self.assertEqual(sourcestamp['branch'], u'oak')
-            self.assertEqual(sourcestamp['patch'], None)
-        return d
+        self.validateData(sourcestamp)
+        self.assertEqual(sourcestamp['branch'], u'oak')
+        self.assertEqual(sourcestamp['patch'], None)
 
+    @defer.inlineCallbacks
     def test_get_existing_patch(self):
-        d = self.callGet(('sourcestamps', 14))
+        sourcestamp = yield self.callGet(('sourcestamps', 14))
 
-        @d.addCallback
-        def check(sourcestamp):
-            self.validateData(sourcestamp)
-            self.assertEqual(sourcestamp['branch'], u'poplar')
-            self.assertEqual(sourcestamp['patch'], {
-                'patchid': 99,
-                'author': u'bar',
-                'body': b'hello, world',
-                'comment': u'foo',
-                'level': 3,
-                'subdir': u'/foo',
-            })
-        return d
+        self.validateData(sourcestamp)
+        self.assertEqual(sourcestamp['branch'], u'poplar')
+        self.assertEqual(sourcestamp['patch'], {
+            'patchid': 99,
+            'author': u'bar',
+            'body': b'hello, world',
+            'comment': u'foo',
+            'level': 3,
+            'subdir': u'/foo',
+        })
 
+    @defer.inlineCallbacks
     def test_get_missing(self):
-        d = self.callGet(('sourcestamps', 99))
+        sourcestamp = yield self.callGet(('sourcestamps', 99))
 
-        @d.addCallback
-        def check(sourcestamp):
-            self.assertEqual(sourcestamp, None)
-        return d
+        self.assertEqual(sourcestamp, None)
 
 
 class SourceStampsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
@@ -92,15 +87,13 @@ class SourceStampsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get(self):
-        d = self.callGet(('sourcestamps',))
+        sourcestamps = yield self.callGet(('sourcestamps',))
 
-        @d.addCallback
-        def check(sourcestamps):
-            [self.validateData(m) for m in sourcestamps]
-            self.assertEqual(sorted([m['ssid'] for m in sourcestamps]),
-                             [13, 14])
-        return d
+        [self.validateData(m) for m in sourcestamps]
+        self.assertEqual(sorted([m['ssid'] for m in sourcestamps]),
+                         [13, 14])
 
 
 class SourceStamp(unittest.TestCase):

--- a/master/buildbot/test/unit/test_data_workers.py
+++ b/master/buildbot/test/unit/test_data_workers.py
@@ -119,68 +119,56 @@ class WorkerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get_existing(self):
-        d = self.callGet(('workers', 2))
+        worker = yield self.callGet(('workers', 2))
 
-        @d.addCallback
-        def check(worker):
-            self.validateData(worker)
-            worker['configured_on'] = sorted(
-                worker['configured_on'], key=configuredOnKey)
-            self.assertEqual(worker, w2())
-        return d
+        self.validateData(worker)
+        worker['configured_on'] = sorted(
+            worker['configured_on'], key=configuredOnKey)
+        self.assertEqual(worker, w2())
 
+    @defer.inlineCallbacks
     def test_get_existing_name(self):
-        d = self.callGet(('workers', 'linux'))
+        worker = yield self.callGet(('workers', 'linux'))
 
-        @d.addCallback
-        def check(worker):
-            self.validateData(worker)
-            worker['configured_on'] = sorted(
-                worker['configured_on'], key=configuredOnKey)
-            self.assertEqual(worker, w1())
-        return d
+        self.validateData(worker)
+        worker['configured_on'] = sorted(
+            worker['configured_on'], key=configuredOnKey)
+        self.assertEqual(worker, w1())
 
+    @defer.inlineCallbacks
     def test_get_existing_masterid(self):
-        d = self.callGet(('masters', 14, 'workers', 2))
+        worker = yield self.callGet(('masters', 14, 'workers', 2))
 
-        @d.addCallback
-        def check(worker):
-            self.validateData(worker)
-            worker['configured_on'] = sorted(
-                worker['configured_on'], key=configuredOnKey)
-            self.assertEqual(worker, w2(masterid=14))
-        return d
+        self.validateData(worker)
+        worker['configured_on'] = sorted(
+            worker['configured_on'], key=configuredOnKey)
+        self.assertEqual(worker, w2(masterid=14))
 
+    @defer.inlineCallbacks
     def test_get_existing_builderid(self):
-        d = self.callGet(('builders', 40, 'workers', 2))
+        worker = yield self.callGet(('builders', 40, 'workers', 2))
 
-        @d.addCallback
-        def check(worker):
-            self.validateData(worker)
-            worker['configured_on'] = sorted(
-                worker['configured_on'], key=configuredOnKey)
-            self.assertEqual(worker, w2(builderid=40))
-        return d
+        self.validateData(worker)
+        worker['configured_on'] = sorted(
+            worker['configured_on'], key=configuredOnKey)
+        self.assertEqual(worker, w2(builderid=40))
 
+    @defer.inlineCallbacks
     def test_get_existing_masterid_builderid(self):
-        d = self.callGet(('masters', 13, 'builders', 40, 'workers', 2))
+        worker = yield self.callGet(('masters', 13, 'builders', 40, 'workers', 2))
 
-        @d.addCallback
-        def check(worker):
-            self.validateData(worker)
-            worker['configured_on'] = sorted(
-                worker['configured_on'], key=configuredOnKey)
-            self.assertEqual(worker, w2(masterid=13, builderid=40))
-        return d
+        self.validateData(worker)
+        worker['configured_on'] = sorted(
+            worker['configured_on'], key=configuredOnKey)
+        self.assertEqual(worker, w2(masterid=13, builderid=40))
 
+    @defer.inlineCallbacks
     def test_get_missing(self):
-        d = self.callGet(('workers', 99))
+        worker = yield self.callGet(('workers', 99))
 
-        @d.addCallback
-        def check(worker):
-            self.assertEqual(worker, None)
-        return d
+        self.assertEqual(worker, None)
 
     @defer.inlineCallbacks
     def test_setWorkerState(self):
@@ -215,51 +203,44 @@ class WorkersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def tearDown(self):
         self.tearDownEndpoint()
 
+    @defer.inlineCallbacks
     def test_get(self):
-        d = self.callGet(('workers',))
+        workers = yield self.callGet(('workers',))
 
-        @d.addCallback
-        def check(workers):
-            for b in workers:
-                self.validateData(b)
-                b['configured_on'] = sorted(b['configured_on'],
-                                            key=configuredOnKey)
-            self.assertEqual(sorted(workers, key=configuredOnKey),
-                             sorted([w1(), w2()], key=configuredOnKey))
-        return d
+        for b in workers:
+            self.validateData(b)
+            b['configured_on'] = sorted(b['configured_on'],
+                                        key=configuredOnKey)
+        self.assertEqual(sorted(workers, key=configuredOnKey),
+                         sorted([w1(), w2()], key=configuredOnKey))
 
+    @defer.inlineCallbacks
     def test_get_masterid(self):
-        d = self.callGet(('masters', '13', 'workers',))
+        workers = yield self.callGet(('masters', '13', 'workers',))
 
-        @d.addCallback
-        def check(workers):
-            [self.validateData(b) for b in workers]
-            [sorted(b['configured_on'], key=configuredOnKey) for b in workers]
-            self.assertEqual(sorted(workers, key=configuredOnKey),
-                             sorted([w1(masterid=13), w2(masterid=13)], key=configuredOnKey))
-        return d
+        [self.validateData(b) for b in workers]
+        [sorted(b['configured_on'], key=configuredOnKey) for b in workers]
+        self.assertEqual(sorted(workers, key=configuredOnKey),
+                         sorted([w1(masterid=13), w2(masterid=13)], key=configuredOnKey))
 
+    @defer.inlineCallbacks
     def test_get_builderid(self):
-        d = self.callGet(('builders', '41', 'workers',))
+        workers = yield self.callGet(('builders', '41', 'workers',))
 
-        @d.addCallback
-        def check(workers):
-            [self.validateData(b) for b in workers]
-            [sorted(b['configured_on'], key=configuredOnKey) for b in workers]
-            self.assertEqual(sorted(workers, key=configuredOnKey),
-                             sorted([w2(builderid=41)], key=configuredOnKey))
-        return d
+        [self.validateData(b) for b in workers]
+        [sorted(b['configured_on'], key=configuredOnKey) for b in workers]
+        self.assertEqual(sorted(workers, key=configuredOnKey),
+                         sorted([w2(builderid=41)], key=configuredOnKey))
 
+    @defer.inlineCallbacks
     def test_get_masterid_builderid(self):
-        d = self.callGet(('masters', '13', 'builders', '41', 'workers',))
+        workers = yield self.callGet(('masters', '13', 'builders', '41',
+                                      'workers',))
 
-        @d.addCallback
-        def check(workers):
-            [self.validateData(b) for b in workers]
-            [sorted(b['configured_on'], key=configuredOnKey) for b in workers]
-            self.assertEqual(sorted(workers, key=configuredOnKey),
-                             sorted([w2(masterid=13, builderid=41)], key=configuredOnKey))
-        return d
+        [self.validateData(b) for b in workers]
+        [sorted(b['configured_on'], key=configuredOnKey) for b in workers]
+        self.assertEqual(sorted(workers, key=configuredOnKey),
+                         sorted([w2(masterid=13, builderid=41)], key=configuredOnKey))
 
     @defer.inlineCallbacks
     def test_setWorkerStateFindByPaused(self):

--- a/master/buildbot/test/unit/test_db_buildrequests.py
+++ b/master/buildbot/test/unit/test_db_buildrequests.py
@@ -71,8 +71,9 @@ class Tests(interfaces.InterfaceTests):
 
     # tests
 
+    @defer.inlineCallbacks
     def test_getBuildRequest(self):
-        d = self.insertTestData([
+        yield self.insertTestData([
             fakedb.BuildRequest(id=44, buildsetid=self.BSID, builderid=self.BLDRID1,
                                 complete=1, results=75, priority=7,
                                 submitted_at=self.SUBMITTED_AT_EPOCH,
@@ -81,12 +82,9 @@ class Tests(interfaces.InterfaceTests):
                 brid=44, masterid=self.MASTER_ID,
                 claimed_at=self.CLAIMED_AT_EPOCH),
         ])
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequest(44))
+        brdict = yield self.db.buildrequests.getBuildRequest(44)
 
-        @d.addCallback
-        def check(brdict):
-            self.assertEqual(brdict,
+        yield self.assertEqual(brdict,
                              dict(buildrequestid=44, buildsetid=self.BSID,
                                   builderid=self.BLDRID1, buildername="builder1",
                                   priority=7, claimed=True,
@@ -94,19 +92,17 @@ class Tests(interfaces.InterfaceTests):
                                   results=75, claimed_at=self.CLAIMED_AT,
                                   submitted_at=self.SUBMITTED_AT,
                                   complete_at=self.COMPLETE_AT, waited_for=False))
-        return d
 
+    @defer.inlineCallbacks
     def test_getBuildRequest_missing(self):
-        d = self.db.buildrequests.getBuildRequest(44)
+        brdict = yield self.db.buildrequests.getBuildRequest(44)
 
-        @d.addCallback
-        def check(brdict):
-            self.assertEqual(brdict, None)
-        return d
+        self.assertEqual(brdict, None)
 
+    @defer.inlineCallbacks
     def do_test_getBuildRequests_claim_args(self, **kwargs):
         expected = kwargs.pop('expected')
-        d = self.insertTestData([
+        yield self.insertTestData([
             # 50: claimed by this master
             fakedb.BuildRequest(
                 id=50, buildsetid=self.BSID, builderid=self.BLDRID1),
@@ -127,14 +123,10 @@ class Tests(interfaces.InterfaceTests):
             fakedb.BuildRequest(
                 id=53, buildsetid=self.BSID, builderid=self.BLDRID1, complete=1),
         ])
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequests(**kwargs))
+        brlist = yield self.db.buildrequests.getBuildRequests(**kwargs)
 
-        @d.addCallback
-        def check(brlist):
-            self.assertEqual(sorted([br['buildrequestid'] for br in brlist]),
-                             sorted(expected))
-        return d
+        self.assertEqual(sorted([br['buildrequestid'] for br in brlist]),
+                         sorted(expected))
 
     def test_getBuildRequests_no_claimed_arg(self):
         return self.do_test_getBuildRequests_claim_args(
@@ -155,9 +147,10 @@ class Tests(interfaces.InterfaceTests):
             claimed=False,
             expected=[52])
 
+    @defer.inlineCallbacks
     def do_test_getBuildRequests_buildername_arg(self, **kwargs):
         expected = kwargs.pop('expected')
-        d = self.insertTestData([
+        yield self.insertTestData([
             # 8: 'bb'
             fakedb.BuildRequest(
                 id=8, buildsetid=self.BSID, builderid=self.BLDRID1),
@@ -168,18 +161,15 @@ class Tests(interfaces.InterfaceTests):
             fakedb.BuildRequest(
                 id=10, buildsetid=self.BSID, builderid=self.BLDRID2),
         ])
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequests(**kwargs))
+        brlist = yield self.db.buildrequests.getBuildRequests(**kwargs)
 
-        @d.addCallback
-        def check(brlist):
-            self.assertEqual(sorted([br['buildrequestid'] for br in brlist]),
-                             sorted(expected))
-        return d
+        self.assertEqual(sorted([br['buildrequestid'] for br in brlist]),
+                         sorted(expected))
 
+    @defer.inlineCallbacks
     def do_test_getBuildRequests_complete_arg(self, **kwargs):
         expected = kwargs.pop('expected')
-        d = self.insertTestData([
+        yield self.insertTestData([
             # 70: incomplete
             fakedb.BuildRequest(id=70, buildsetid=self.BSID,
                                 builderid=self.BLDRID1,
@@ -197,14 +187,10 @@ class Tests(interfaces.InterfaceTests):
                                 complete=0,
                                 complete_at=self.COMPLETE_AT_EPOCH),
         ])
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequests(**kwargs))
+        brlist = yield self.db.buildrequests.getBuildRequests(**kwargs)
 
-        @d.addCallback
-        def check(brlist):
-            self.assertEqual(sorted([br['buildrequestid'] for br in brlist]),
-                             sorted(expected))
-        return d
+        self.assertEqual(sorted([br['buildrequestid'] for br in brlist]),
+                         sorted(expected))
 
     def test_getBuildRequests_complete_none(self):
         return self.do_test_getBuildRequests_complete_arg(
@@ -220,8 +206,9 @@ class Tests(interfaces.InterfaceTests):
             complete=False,
             expected=[70, 82])
 
+    @defer.inlineCallbacks
     def test_getBuildRequests_bsid_arg(self):
-        d = self.insertTestData([
+        yield self.insertTestData([
             # the buildset that we are *not* looking for
             fakedb.Buildset(id=self.BSID + 1),
 
@@ -232,17 +219,14 @@ class Tests(interfaces.InterfaceTests):
             fakedb.BuildRequest(id=72, buildsetid=self.BSID, builderid=self.BLDRID1,
                                 complete=0, complete_at=None),
         ])
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequests(bsid=self.BSID))
+        brlist = yield self.db.buildrequests.getBuildRequests(bsid=self.BSID)
 
-        @d.addCallback
-        def check(brlist):
-            self.assertEqual(sorted([br['buildrequestid'] for br in brlist]),
-                             sorted([70, 72]))
-        return d
+        self.assertEqual(sorted([br['buildrequestid'] for br in brlist]),
+                         sorted([70, 72]))
 
+    @defer.inlineCallbacks
     def test_getBuildRequests_combo(self):
-        d = self.insertTestData([
+        yield self.insertTestData([
             # 44: everything we want
             fakedb.BuildRequest(id=44, buildsetid=self.BSID, builderid=self.BLDRID1,
                                 complete=1, results=92,
@@ -284,19 +268,16 @@ class Tests(interfaces.InterfaceTests):
             fakedb.BuildRequestClaim(brid=49, masterid=self.MASTER_ID,
                                      claimed_at=self.CLAIMED_AT_EPOCH),
         ])
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequests(builderid=self.BLDRID1,
-                                                             claimed=self.MASTER_ID,
-                                                             complete=True, bsid=self.BSID))
+        brlist = yield self.db.buildrequests.getBuildRequests(
+            builderid=self.BLDRID1, claimed=self.MASTER_ID,
+            complete=True, bsid=self.BSID)
 
-        @d.addCallback
-        def check(brlist):
-            self.assertEqual([br['buildrequestid'] for br in brlist], [44])
-        return d
+        self.assertEqual([br['buildrequestid'] for br in brlist], [44])
 
+    @defer.inlineCallbacks
     def do_test_getBuildRequests_branch_arg(self, **kwargs):
         expected = kwargs.pop('expected')
-        d = self.insertTestData([
+        yield self.insertTestData([
             fakedb.Buildset(id=self.BSID + 1),
             fakedb.BuildRequest(
                 id=70, buildsetid=self.BSID + 1, builderid=self.BLDRID1),
@@ -326,14 +307,10 @@ class Tests(interfaces.InterfaceTests):
             fakedb.BuildsetSourceStamp(buildsetid=self.BSID + 3,
                                        sourcestampid=self.BSID + 4),
         ])
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequests(**kwargs))
+        brlist = yield self.db.buildrequests.getBuildRequests(**kwargs)
 
-        @d.addCallback
-        def check(brlist):
-            self.assertEqual(sorted([br['buildrequestid'] for br in brlist]),
-                             sorted(expected))
-        return d
+        self.assertEqual(sorted([br['buildrequestid'] for br in brlist]),
+                         sorted(expected))
 
     def test_getBuildRequests_branch(self):
         return self.do_test_getBuildRequests_branch_arg(branch='branch_A',
@@ -358,38 +335,35 @@ class Tests(interfaces.InterfaceTests):
     def test_getBuildRequests_no_repository_nor_branch(self):
         return self.do_test_getBuildRequests_branch_arg(expected=[70, 80, 90])
 
-    def failWithExpFailure(self, expfailure=None):
-        def fail(f):
-            if not expfailure:
-                raise f
-            self.flushLoggedErrors(expfailure)
-            f.trap(expfailure)
-        return fail
+    def failWithExpFailure(self, exc, expfailure=None):
+        if not expfailure:
+            raise exc
+        self.flushLoggedErrors(expfailure)
+        if isinstance(exc, expfailure):
+            return
+        raise exc
 
+    @defer.inlineCallbacks
     def do_test_claimBuildRequests(self, rows, now, brids, expected=None,
                                    expfailure=None, claimed_at=None):
         clock = task.Clock()
         clock.advance(now)
 
-        d = self.insertTestData(rows)
-        d.addCallback(lambda _:
-                      self.db.buildrequests.claimBuildRequests(brids=brids,
-                                                               claimed_at=claimed_at,
-                                                               _reactor=clock))
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequests())
+        try:
+            yield self.insertTestData(rows)
+            yield self.db.buildrequests.claimBuildRequests(brids=brids,
+                                                           claimed_at=claimed_at,
+                                                           _reactor=clock)
+            results = yield self.db.buildrequests.getBuildRequests()
 
-        @d.addCallback
-        def check(results):
             self.assertNotEqual(expected, None,
                                 "unexpected success from claimBuildRequests")
             self.assertEqual(
                 sorted([(r['buildrequestid'], r['claimed_at'], r['claimed_by_masterid'])
                         for r in results]),
                 sorted(expected))
-
-        d.addErrback(self.failWithExpFailure(expfailure))
-        return d
+        except Exception as e:
+            self.failWithExpFailure(e, expfailure)
 
     def test_claimBuildRequests_single(self):
         return self.do_test_claimBuildRequests([
@@ -448,8 +422,9 @@ class Tests(interfaces.InterfaceTests):
             expfailure=buildrequests.AlreadyClaimedError)
 
     @db.skip_for_dialect('mysql')
+    @defer.inlineCallbacks
     def test_claimBuildRequests_other_master_claim_stress(self):
-        d = self.do_test_claimBuildRequests(
+        yield self.do_test_claimBuildRequests(
             [fakedb.BuildRequest(id=id, buildsetid=self.BSID, builderid=self.BLDRID1)
              for id in range(1, 1000)] +
             [
@@ -457,49 +432,42 @@ class Tests(interfaces.InterfaceTests):
                     id=1000, buildsetid=self.BSID, builderid=self.BLDRID1),
                 # the fly in the ointment..
                 fakedb.BuildRequestClaim(brid=1000,
-                                         masterid=self.OTHER_MASTER_ID, claimed_at=1300103810),
+                                         masterid=self.OTHER_MASTER_ID,
+                                         claimed_at=1300103810),
             ], 1300305712, lrange(1, 1001),
             expfailure=buildrequests.AlreadyClaimedError)
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequests(claimed=True))
+        results = yield self.db.buildrequests.getBuildRequests(claimed=True)
 
-        @d.addCallback
-        def check(results):
-            # check that [1,1000) were not claimed, and 1000 is still claimed
-            self.assertEqual([
-                (r['buildrequestid'], r[
-                 'claimed_by_masterid'], r['claimed_at'])
-                for r in results
-            ][:10], [
-                (1000, self.OTHER_MASTER_ID, epoch2datetime(1300103810))
-            ])
-        return d
+        # check that [1,1000) were not claimed, and 1000 is still claimed
+        self.assertEqual([
+            (r['buildrequestid'], r[
+             'claimed_by_masterid'], r['claimed_at'])
+            for r in results
+        ][:10], [
+            (1000, self.OTHER_MASTER_ID, epoch2datetime(1300103810))
+        ])
 
+    @defer.inlineCallbacks
     def test_claimBuildRequests_sequential(self):
         now = 120350934
         clock = task.Clock()
         clock.advance(now)
 
-        d = self.insertTestData([
+        yield self.insertTestData([
             fakedb.BuildRequest(
                 id=44, buildsetid=self.BSID, builderid=self.BLDRID1),
             fakedb.BuildRequest(
                 id=45, buildsetid=self.BSID, builderid=self.BLDRID1),
         ])
-        d.addCallback(lambda _:
-                      self.db.buildrequests.claimBuildRequests(brids=[44],
-                                                               _reactor=clock))
-        d.addCallback(lambda _:
-                      self.db.buildrequests.claimBuildRequests(brids=[45],
-                                                               _reactor=clock))
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequests(claimed=False))
+        yield self.db.buildrequests.claimBuildRequests(brids=[44],
+                                                       _reactor=clock)
+        yield self.db.buildrequests.claimBuildRequests(brids=[45],
+                                                       _reactor=clock)
+        results = yield self.db.buildrequests.getBuildRequests(claimed=False)
 
-        @d.addCallback
-        def check(results):
-            self.assertEqual(results, [])
-        return d
+        self.assertEqual(results, [])
 
+    @defer.inlineCallbacks
     def do_test_completeBuildRequests(self, rows, now, expected=None,
                                       expfailure=None, brids=None,
                                       complete_at=None):
@@ -508,17 +476,14 @@ class Tests(interfaces.InterfaceTests):
         clock = task.Clock()
         clock.advance(now)
 
-        d = self.insertTestData(rows)
-        d.addCallback(lambda _:
-                      self.db.buildrequests.completeBuildRequests(brids=brids,
-                                                                  results=7,
-                                                                  complete_at=complete_at,
-                                                                  _reactor=clock))
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequests())
+        try:
+            yield self.insertTestData(rows)
+            yield self.db.buildrequests.completeBuildRequests(brids=brids,
+                                                           results=7,
+                                                           complete_at=complete_at,
+                                                          _reactor=clock)
+            results = yield self.db.buildrequests.getBuildRequests()
 
-        @d.addCallback
-        def check(results):
             self.assertNotEqual(expected, None,
                                 "unexpected success from completeBuildRequests")
             self.assertEqual(sorted(
@@ -527,8 +492,8 @@ class Tests(interfaces.InterfaceTests):
                 for r in results
             ), sorted(expected))
 
-        d.addErrback(self.failWithExpFailure(expfailure))
-        return d
+        except Exception as e:
+            self.failWithExpFailure(e, expfailure)
 
     def test_completeBuildRequests(self):
         return self.do_test_completeBuildRequests([
@@ -616,8 +581,9 @@ class Tests(interfaces.InterfaceTests):
         ], 1300305712,
             expfailure=buildrequests.NotClaimedError)
 
+    @defer.inlineCallbacks
     def do_test_unclaimMethod(self, method, expected):
-        d = self.insertTestData([
+        yield self.insertTestData([
             # 44: a complete build (should not be unclaimed)
             fakedb.BuildRequest(id=44, buildsetid=self.BSID, builderid=self.BLDRID1,
                                 complete=1, results=92,
@@ -653,16 +619,12 @@ class Tests(interfaces.InterfaceTests):
             fakedb.BuildRequestClaim(brid=49, masterid=self.OTHER_MASTER_ID,
                                      claimed_at=self.CLAIMED_AT_EPOCH - 1000),
         ])
-        d.addCallback(lambda _: method())
+        yield method()
         # just select the unclaimed requests
-        d.addCallback(lambda _:
-                      self.db.buildrequests.getBuildRequests(claimed=False))
+        results = yield self.db.buildrequests.getBuildRequests(claimed=False)
 
-        @d.addCallback
-        def check(results):
-            self.assertEqual(sorted([r['buildrequestid'] for r in results]),
-                             sorted(expected))
-        return d
+        self.assertEqual(sorted([r['buildrequestid'] for r in results]),
+                         sorted(expected))
 
     def test_unclaimBuildRequests(self):
         to_unclaim = [

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -143,82 +143,71 @@ class Tests(interfaces.InterfaceTests):
         "returns an empty dict even if no such buildset exists"
         return self.do_test_getBuildsetProperties(91, [], dict())
 
+    @defer.inlineCallbacks
     def test_getBuildset_incomplete_None(self):
-        d = self.insertTestData([
+        yield self.insertTestData([
             fakedb.Buildset(id=91, complete=0,
                             complete_at=None, results=-1, submitted_at=266761875,
                             external_idstring='extid', reason='rsn'),
             fakedb.BuildsetSourceStamp(buildsetid=91, sourcestampid=234),
         ])
-        d.addCallback(lambda _:
-                      self.db.buildsets.getBuildset(91))
+        bsdict = yield self.db.buildsets.getBuildset(91)
 
-        def check(bsdict):
-            validation.verifyDbDict(self, 'bsdict', bsdict)
-            self.assertEqual(bsdict, dict(external_idstring='extid',
-                                          reason='rsn', sourcestamps=[234],
-                                          submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
-                                                                         tzinfo=UTC),
-                                          complete=False, complete_at=None, results=-1,
-                                          bsid=91,
-                                          parent_buildid=None, parent_relationship=None))
-        d.addCallback(check)
-        return d
+        validation.verifyDbDict(self, 'bsdict', bsdict)
+        self.assertEqual(bsdict, dict(external_idstring='extid',
+                                      reason='rsn', sourcestamps=[234],
+                                      submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
+                                                                     tzinfo=UTC),
+                                      complete=False, complete_at=None, results=-1,
+                                      bsid=91,
+                                      parent_buildid=None, parent_relationship=None))
 
+    @defer.inlineCallbacks
     def test_getBuildset_incomplete_zero(self):
-        d = self.insertTestData([
+        yield self.insertTestData([
             fakedb.Buildset(id=91, complete=0,
                             complete_at=0, results=-1, submitted_at=266761875,
                             external_idstring='extid', reason='rsn'),
             fakedb.BuildsetSourceStamp(buildsetid=91, sourcestampid=234),
         ])
-        d.addCallback(lambda _:
-                      self.db.buildsets.getBuildset(91))
+        bsdict = yield self.db.buildsets.getBuildset(91)
 
-        def check(bsdict):
-            validation.verifyDbDict(self, 'bsdict', bsdict)
-            self.assertEqual(bsdict, dict(external_idstring='extid',
-                                          reason='rsn', sourcestamps=[234],
-                                          submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
-                                                                         tzinfo=UTC),
-                                          complete=False, complete_at=None, results=-1,
-                                          bsid=91,
-                                          parent_buildid=None, parent_relationship=None))
-        d.addCallback(check)
-        return d
+        validation.verifyDbDict(self, 'bsdict', bsdict)
+        self.assertEqual(bsdict, dict(external_idstring='extid',
+                                      reason='rsn', sourcestamps=[234],
+                                      submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
+                                                                     tzinfo=UTC),
+                                      complete=False, complete_at=None, results=-1,
+                                      bsid=91,
+                                      parent_buildid=None, parent_relationship=None))
 
+    @defer.inlineCallbacks
     def test_getBuildset_complete(self):
-        d = self.insertTestData([
+        yield self.insertTestData([
             fakedb.Buildset(id=91, complete=1,
                             complete_at=298297875, results=-1, submitted_at=266761875,
                             external_idstring='extid', reason='rsn'),
             fakedb.BuildsetSourceStamp(buildsetid=91, sourcestampid=234),
         ])
-        d.addCallback(lambda _:
-                      self.db.buildsets.getBuildset(91))
+        bsdict = yield self.db.buildsets.getBuildset(91)
 
-        def check(bsdict):
-            validation.verifyDbDict(self, 'bsdict', bsdict)
-            self.assertEqual(bsdict, dict(external_idstring='extid',
-                                          reason='rsn', sourcestamps=[234],
-                                          submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
-                                                                         tzinfo=UTC),
-                                          complete=True,
-                                          complete_at=datetime.datetime(1979, 6, 15, 12, 31, 15,
-                                                                        tzinfo=UTC),
-                                          results=-1,
-                                          bsid=91,
-                                          parent_buildid=None, parent_relationship=None))
-        d.addCallback(check)
-        return d
+        validation.verifyDbDict(self, 'bsdict', bsdict)
+        self.assertEqual(bsdict, dict(external_idstring='extid',
+                                      reason='rsn', sourcestamps=[234],
+                                      submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
+                                                                     tzinfo=UTC),
+                                      complete=True,
+                                      complete_at=datetime.datetime(1979, 6, 15, 12, 31, 15,
+                                                                    tzinfo=UTC),
+                                      results=-1,
+                                      bsid=91,
+                                      parent_buildid=None, parent_relationship=None))
 
+    @defer.inlineCallbacks
     def test_getBuildset_nosuch(self):
-        d = self.db.buildsets.getBuildset(91)
+        bsdict = yield self.db.buildsets.getBuildset(91)
 
-        def check(bsdict):
-            self.assertEqual(bsdict, None)
-        d.addCallback(check)
-        return d
+        self.assertEqual(bsdict, None)
 
     def insert_test_getBuildsets_data(self):
         return self.insertTestData([
@@ -232,83 +221,72 @@ class Tests(interfaces.InterfaceTests):
             fakedb.BuildsetSourceStamp(buildsetid=92, sourcestampid=234),
         ])
 
+    @defer.inlineCallbacks
     def test_getBuildsets_empty(self):
-        d = self.db.buildsets.getBuildsets()
+        bsdictlist = yield self.db.buildsets.getBuildsets()
 
-        def check(bsdictlist):
-            self.assertEqual(bsdictlist, [])
-        d.addCallback(check)
-        return d
+        self.assertEqual(bsdictlist, [])
 
+    @defer.inlineCallbacks
     def test_getBuildsets_all(self):
-        d = self.insert_test_getBuildsets_data()
-        d.addCallback(lambda _:
-                      self.db.buildsets.getBuildsets())
+        yield self.insert_test_getBuildsets_data()
+        bsdictlist = yield self.db.buildsets.getBuildsets()
 
-        def check(bsdictlist):
-            def bsdictKey(bsdict):
-                return bsdict['reason']
+        def bsdictKey(bsdict):
+            return bsdict['reason']
 
-            for bsdict in bsdictlist:
-                validation.verifyDbDict(self, 'bsdict', bsdict)
-            self.assertEqual(sorted(bsdictlist, key=bsdictKey), sorted([
-                dict(external_idstring='extid', reason='rsn1', sourcestamps=[234],
-                     submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
-                                                    tzinfo=UTC),
-                     complete_at=datetime.datetime(1979, 6, 15, 12, 31, 15,
-                                                   tzinfo=UTC),
-                     complete=False, results=-1, bsid=91,
-                     parent_buildid=None, parent_relationship=None),
-                dict(external_idstring='extid', reason='rsn2', sourcestamps=[234],
-                     submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 16,
-                                                    tzinfo=UTC),
-                     complete_at=datetime.datetime(1979, 6, 15, 12, 31, 16,
-                                                   tzinfo=UTC),
-                     complete=True, results=7, bsid=92,
-                     parent_buildid=None, parent_relationship=None),
-            ], key=bsdictKey))
-        d.addCallback(check)
-        return d
+        for bsdict in bsdictlist:
+            validation.verifyDbDict(self, 'bsdict', bsdict)
+        self.assertEqual(sorted(bsdictlist, key=bsdictKey), sorted([
+            dict(external_idstring='extid', reason='rsn1', sourcestamps=[234],
+                 submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
+                                                tzinfo=UTC),
+                 complete_at=datetime.datetime(1979, 6, 15, 12, 31, 15,
+                                               tzinfo=UTC),
+                 complete=False, results=-1, bsid=91,
+                 parent_buildid=None, parent_relationship=None),
+            dict(external_idstring='extid', reason='rsn2', sourcestamps=[234],
+                 submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 16,
+                                                tzinfo=UTC),
+                 complete_at=datetime.datetime(1979, 6, 15, 12, 31, 16,
+                                               tzinfo=UTC),
+                 complete=True, results=7, bsid=92,
+                 parent_buildid=None, parent_relationship=None),
+        ], key=bsdictKey))
 
+    @defer.inlineCallbacks
     def test_getBuildsets_complete(self):
-        d = self.insert_test_getBuildsets_data()
-        d.addCallback(lambda _:
-                      self.db.buildsets.getBuildsets(complete=True))
+        yield self.insert_test_getBuildsets_data()
+        bsdictlist = yield self.db.buildsets.getBuildsets(complete=True)
 
-        def check(bsdictlist):
-            for bsdict in bsdictlist:
-                validation.verifyDbDict(self, 'bsdict', bsdict)
-            self.assertEqual(bsdictlist, [
-                dict(external_idstring='extid', reason='rsn2', sourcestamps=[234],
-                     submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 16,
-                                                    tzinfo=UTC),
-                     complete_at=datetime.datetime(1979, 6, 15, 12, 31, 16,
-                                                   tzinfo=UTC),
-                     complete=True, results=7, bsid=92,
-                     parent_buildid=None, parent_relationship=None),
-            ])
-        d.addCallback(check)
-        return d
+        for bsdict in bsdictlist:
+            validation.verifyDbDict(self, 'bsdict', bsdict)
+        self.assertEqual(bsdictlist, [
+            dict(external_idstring='extid', reason='rsn2', sourcestamps=[234],
+                 submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 16,
+                                                tzinfo=UTC),
+                 complete_at=datetime.datetime(1979, 6, 15, 12, 31, 16,
+                                               tzinfo=UTC),
+                 complete=True, results=7, bsid=92,
+                 parent_buildid=None, parent_relationship=None),
+        ])
 
+    @defer.inlineCallbacks
     def test_getBuildsets_incomplete(self):
-        d = self.insert_test_getBuildsets_data()
-        d.addCallback(lambda _:
-                      self.db.buildsets.getBuildsets(complete=False))
+        yield self.insert_test_getBuildsets_data()
+        bsdictlist = yield self.db.buildsets.getBuildsets(complete=False)
 
-        def check(bsdictlist):
-            for bsdict in bsdictlist:
-                validation.verifyDbDict(self, 'bsdict', bsdict)
-            self.assertEqual(bsdictlist, [
-                dict(external_idstring='extid', reason='rsn1', sourcestamps=[234],
-                     submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
-                                                    tzinfo=UTC),
-                     complete_at=datetime.datetime(1979, 6, 15, 12, 31, 15,
-                                                   tzinfo=UTC),
-                     complete=False, results=-1, bsid=91,
-                     parent_buildid=None, parent_relationship=None),
-            ])
-        d.addCallback(check)
-        return d
+        for bsdict in bsdictlist:
+            validation.verifyDbDict(self, 'bsdict', bsdict)
+        self.assertEqual(bsdictlist, [
+            dict(external_idstring='extid', reason='rsn1', sourcestamps=[234],
+                 submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
+                                                tzinfo=UTC),
+                 complete_at=datetime.datetime(1979, 6, 15, 12, 31, 15,
+                                               tzinfo=UTC),
+                 complete=False, results=-1, bsid=91,
+                 parent_buildid=None, parent_relationship=None),
+        ])
 
     def test_completeBuildset_already_completed(self):
         d = self.insert_test_getBuildsets_data()
@@ -324,43 +302,35 @@ class Tests(interfaces.InterfaceTests):
                                                          _reactor=self.clock))
         return self.assertFailure(d, buildsets.AlreadyCompleteError)
 
+    @defer.inlineCallbacks
     def test_completeBuildset(self):
-        d = self.insert_test_getBuildsets_data()
-        d.addCallback(lambda _:
-                      self.db.buildsets.completeBuildset(bsid=91, results=6,
-                                                         _reactor=self.clock))
-        d.addCallback(lambda _:
-                      self.db.buildsets.getBuildsets())
+        yield self.insert_test_getBuildsets_data()
+        yield self.db.buildsets.completeBuildset(bsid=91, results=6,
+                                                 _reactor=self.clock)
+        bsdicts = yield self.db.buildsets.getBuildsets()
 
-        def check(bsdicts):
-            bsdicts = [(bsdict['bsid'], bsdict['complete'],
-                        datetime2epoch(bsdict['complete_at']),
-                        bsdict['results'])
-                       for bsdict in bsdicts]
-            self.assertEqual(sorted(bsdicts), sorted([
-                (91, 1, self.now, 6),
-                (92, 1, 298297876, 7)]))
-        d.addCallback(check)
-        return d
+        bsdicts = [(bsdict['bsid'], bsdict['complete'],
+                    datetime2epoch(bsdict['complete_at']),
+                    bsdict['results'])
+                   for bsdict in bsdicts]
+        self.assertEqual(sorted(bsdicts), sorted([
+            (91, 1, self.now, 6),
+            (92, 1, 298297876, 7)]))
 
+    @defer.inlineCallbacks
     def test_completeBuildset_explicit_complete_at(self):
-        d = self.insert_test_getBuildsets_data()
-        d.addCallback(lambda _:
-                      self.db.buildsets.completeBuildset(bsid=91, results=6,
-                                                         complete_at=epoch2datetime(72759)))
-        d.addCallback(lambda _:
-                      self.db.buildsets.getBuildsets())
+        yield self.insert_test_getBuildsets_data()
+        yield self.db.buildsets.completeBuildset(bsid=91, results=6,
+                                             complete_at=epoch2datetime(72759))
+        bsdicts = yield self.db.buildsets.getBuildsets()
 
-        def check(bsdicts):
-            bsdicts = [(bsdict['bsid'], bsdict['complete'],
-                        datetime2epoch(bsdict['complete_at']),
-                        bsdict['results'])
-                       for bsdict in bsdicts]
-            self.assertEqual(sorted(bsdicts), sorted([
-                (91, 1, 72759, 6),
-                (92, 1, 298297876, 7)]))
-        d.addCallback(check)
-        return d
+        bsdicts = [(bsdict['bsid'], bsdict['complete'],
+                    datetime2epoch(bsdict['complete_at']),
+                    bsdict['results'])
+                   for bsdict in bsdicts]
+        self.assertEqual(sorted(bsdicts), sorted([
+            (91, 1, 72759, 6),
+            (92, 1, 298297876, 7)]))
 
     def insert_test_getRecentBuildsets_data(self):
         return self.insertTestData([
@@ -381,175 +351,161 @@ class Tests(interfaces.InterfaceTests):
                             external_idstring='extid', reason='rsn2'),
         ])
 
+    @defer.inlineCallbacks
     def test_getRecentBuildsets_all(self):
-        d = self.insert_test_getRecentBuildsets_data()
-        d.addCallback(lambda _:
-                      self.db.buildsets.getRecentBuildsets(2, branch='branch_a',
-                                                           repository='repo_a'))
+        yield self.insert_test_getRecentBuildsets_data()
+        bsdictlist = yield self.db.buildsets.getRecentBuildsets(2,
+                                                            branch='branch_a',
+                                                            repository='repo_a')
 
-        def check(bsdictlist):
-            self.assertEqual(bsdictlist, [
-                dict(external_idstring='extid', reason='rsn1', sourcestamps=[91],
-                     submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
-                                                    tzinfo=UTC),
-                     complete_at=datetime.datetime(1979, 6, 15, 12, 31, 15,
-                                                   tzinfo=UTC),
-                     complete=False, results=-1, bsid=91,
-                     parent_buildid=None, parent_relationship=None),
-                dict(external_idstring='extid', reason='rsn2', sourcestamps=[91],
-                     submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 16,
-                                                    tzinfo=UTC),
-                     complete_at=datetime.datetime(1979, 6, 15, 12, 31, 16,
-                                                   tzinfo=UTC),
-                     complete=True, results=7, bsid=92,
-                     parent_buildid=None, parent_relationship=None)
-            ])
-        d.addCallback(check)
-        return d
+        self.assertEqual(bsdictlist, [
+            dict(external_idstring='extid', reason='rsn1', sourcestamps=[91],
+                 submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
+                                                tzinfo=UTC),
+                 complete_at=datetime.datetime(1979, 6, 15, 12, 31, 15,
+                                               tzinfo=UTC),
+                 complete=False, results=-1, bsid=91,
+                 parent_buildid=None, parent_relationship=None),
+            dict(external_idstring='extid', reason='rsn2', sourcestamps=[91],
+                 submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 16,
+                                                tzinfo=UTC),
+                 complete_at=datetime.datetime(1979, 6, 15, 12, 31, 16,
+                                               tzinfo=UTC),
+                 complete=True, results=7, bsid=92,
+                 parent_buildid=None, parent_relationship=None)
+        ])
 
+    @defer.inlineCallbacks
     def test_getRecentBuildsets_one(self):
-        d = self.insert_test_getRecentBuildsets_data()
-        d.addCallback(lambda _:
-                      self.db.buildsets.getRecentBuildsets(1, branch='branch_a',
-                                                           repository='repo_a'))
+        yield self.insert_test_getRecentBuildsets_data()
+        bsdictlist = yield self.db.buildsets.getRecentBuildsets(1,
+                                                            branch='branch_a',
+                                                            repository='repo_a')
 
-        def check(bsdictlist):
-            self.assertEqual(bsdictlist, [
-                dict(external_idstring='extid', reason='rsn2', sourcestamps=[91],
-                     submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 16,
-                                                    tzinfo=UTC),
-                     complete_at=datetime.datetime(1979, 6, 15, 12, 31, 16,
-                                                   tzinfo=UTC),
-                     complete=True, results=7, bsid=92,
-                     parent_buildid=None, parent_relationship=None),
-            ])
-        d.addCallback(check)
-        return d
+        self.assertEqual(bsdictlist, [
+            dict(external_idstring='extid', reason='rsn2', sourcestamps=[91],
+                 submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 16,
+                                                tzinfo=UTC),
+                 complete_at=datetime.datetime(1979, 6, 15, 12, 31, 16,
+                                               tzinfo=UTC),
+                 complete=True, results=7, bsid=92,
+                 parent_buildid=None, parent_relationship=None),
+        ])
 
+    @defer.inlineCallbacks
     def test_getRecentBuildsets_zero(self):
-        d = self.insert_test_getRecentBuildsets_data()
-        d.addCallback(lambda _:
-                      self.db.buildsets.getRecentBuildsets(0, branch='branch_a',
-                                                           repository='repo_a'))
+        yield self.insert_test_getRecentBuildsets_data()
+        bsdictlist = yield self.db.buildsets.getRecentBuildsets(0,
+                                                            branch='branch_a',
+                                                            repository='repo_a')
 
-        def check(bsdictlist):
-            self.assertEqual(bsdictlist, [])
-        d.addCallback(check)
-        return d
+        self.assertEqual(bsdictlist, [])
 
+    @defer.inlineCallbacks
     def test_getRecentBuildsets_noBranchMatch(self):
-        d = self.insert_test_getRecentBuildsets_data()
-        d.addCallback(lambda _:
-                      self.db.buildsets.getRecentBuildsets(2, branch='bad_branch',
-                                                           repository='repo_a'))
+        yield self.insert_test_getRecentBuildsets_data()
+        bsdictlist = yield self.db.buildsets.getRecentBuildsets(2,
+                                                            branch='bad_branch',
+                                                            repository='repo_a')
 
-        def check(bsdictlist):
-            self.assertEqual(bsdictlist, [])
-        d.addCallback(check)
-        return d
+        self.assertEqual(bsdictlist, [])
 
+    @defer.inlineCallbacks
     def test_getRecentBuildsets_noRepoMatch(self):
-        d = self.insert_test_getRecentBuildsets_data()
-        d.addCallback(lambda _:
-                      self.db.buildsets.getRecentBuildsets(2, branch='branch_a',
-                                                           repository='bad_repo'))
+        yield self.insert_test_getRecentBuildsets_data()
+        bsdictlist = yield self.db.buildsets.getRecentBuildsets(2,
+                                                          branch='branch_a',
+                                                          repository='bad_repo')
 
-        def check(bsdictlist):
-            self.assertEqual(bsdictlist, [])
-        d.addCallback(check)
-        return d
+        self.assertEqual(bsdictlist, [])
 
 
 class RealTests(Tests):
 
+    @defer.inlineCallbacks
     def test_addBuildset_simple(self):
-        d = defer.succeed(None)
-        d.addCallback(lambda _:
-                      self.db.buildsets.addBuildset(sourcestamps=[234], reason='because',
-                                                    properties={}, builderids=[2], external_idstring='extid',
-                                                    waited_for=True, _reactor=self.clock))
+        (bsid, brids) = yield self.db.buildsets.addBuildset(
+                                            sourcestamps=[234], reason='because',
+                                            properties={}, builderids=[2],
+                                            external_idstring='extid',
+                                            waited_for=True,
+                                            _reactor=self.clock)
 
-        def check(xxx_todo_changeme):
-            (bsid, brids) = xxx_todo_changeme
+        def thd(conn):
+            # we should only have one brid
+            self.assertEqual(len(brids), 1)
 
-            def thd(conn):
-                # we should only have one brid
-                self.assertEqual(len(brids), 1)
+            # should see one buildset row
+            r = conn.execute(self.db.model.buildsets.select())
+            rows = [(row.id, row.external_idstring, row.reason,
+                     row.complete, row.complete_at,
+                     row.submitted_at, row.results) for row in r.fetchall()]
+            self.assertEqual(rows,
+                             [(bsid, 'extid', 'because', 0, None, self.now, -1)])
 
-                # should see one buildset row
-                r = conn.execute(self.db.model.buildsets.select())
-                rows = [(row.id, row.external_idstring, row.reason,
-                         row.complete, row.complete_at,
-                         row.submitted_at, row.results) for row in r.fetchall()]
-                self.assertEqual(rows,
-                                 [(bsid, 'extid', 'because', 0, None, self.now, -1)])
+            # one buildrequests row
+            r = conn.execute(self.db.model.buildrequests.select())
+            self.assertEqual(r.keys(),
+                             [u'id', u'buildsetid', u'builderid', u'priority',
+                              u'complete', u'results', u'submitted_at',
+                              u'complete_at', u'waited_for'])
+            self.assertEqual(r.fetchall(),
+                             [(bsid, brids[2], 2, 0, 0,
+                               -1, self.now, None, 1)])
 
-                # one buildrequests row
-                r = conn.execute(self.db.model.buildrequests.select())
-                self.assertEqual(r.keys(),
-                                 [u'id', u'buildsetid', u'builderid', u'priority',
-                                  u'complete', u'results', u'submitted_at',
-                                  u'complete_at', u'waited_for'])
-                self.assertEqual(r.fetchall(),
-                                 [(bsid, brids[2], 2, 0, 0,
-                                   -1, self.now, None, 1)])
+            # one buildset_sourcestamps row
+            r = conn.execute(self.db.model.buildset_sourcestamps.select())
+            self.assertEqual(
+                list(r.keys()), [u'id', u'buildsetid', u'sourcestampid'])
+            self.assertEqual(r.fetchall(), [(1, bsid, 234)])
+        yield self.db.pool.do(thd)
 
-                # one buildset_sourcestamps row
-                r = conn.execute(self.db.model.buildset_sourcestamps.select())
-                self.assertEqual(
-                    list(r.keys()), [u'id', u'buildsetid', u'sourcestampid'])
-                self.assertEqual(r.fetchall(), [(1, bsid, 234)])
-            return self.db.pool.do(thd)
-        d.addCallback(check)
-        return d
-
+    @defer.inlineCallbacks
     def test_addBuildset_bigger(self):
         props = dict(prop=(['list'], 'test'))
-        d = defer.succeed(None)
-        d.addCallback(lambda _:
-                      self.db.buildsets.addBuildset(sourcestamps=[234], reason='because',
-                                                    waited_for=False, properties=props, builderids=[1, 2]))
+        yield defer.succeed(None)
+        xxx_todo_changeme1 = yield self.db.buildsets.addBuildset(
+                                        sourcestamps=[234], reason='because',
+                                        waited_for=False, properties=props,
+                                        builderids=[1, 2])
 
-        def check(xxx_todo_changeme1):
-            (bsid, brids) = xxx_todo_changeme1
+        (bsid, brids) = xxx_todo_changeme1
 
-            def thd(conn):
-                self.assertEqual(len(brids), 2)
+        def thd(conn):
+            self.assertEqual(len(brids), 2)
 
-                # should see one buildset row
-                r = conn.execute(self.db.model.buildsets.select())
-                rows = [(row.id, row.external_idstring, row.reason,
-                         row.complete, row.complete_at, row.results)
-                        for row in r.fetchall()]
-                self.assertEqual(rows,
-                                 [(bsid, None, u'because', 0, None, -1)])
+            # should see one buildset row
+            r = conn.execute(self.db.model.buildsets.select())
+            rows = [(row.id, row.external_idstring, row.reason,
+                     row.complete, row.complete_at, row.results)
+                    for row in r.fetchall()]
+            self.assertEqual(rows,
+                             [(bsid, None, u'because', 0, None, -1)])
 
-                # one property row
-                r = conn.execute(self.db.model.buildset_properties.select())
-                rows = [(row.buildsetid, row.property_name, row.property_value)
-                        for row in r.fetchall()]
-                self.assertEqual(rows,
-                                 [(bsid, 'prop', json.dumps([['list'], 'test']))])
+            # one property row
+            r = conn.execute(self.db.model.buildset_properties.select())
+            rows = [(row.buildsetid, row.property_name, row.property_value)
+                    for row in r.fetchall()]
+            self.assertEqual(rows,
+                             [(bsid, 'prop', json.dumps([['list'], 'test']))])
 
-                # one buildset_sourcestamps row
-                r = conn.execute(self.db.model.buildset_sourcestamps.select())
-                rows = [(row.buildsetid, row.sourcestampid)
-                        for row in r.fetchall()]
-                self.assertEqual(rows, [(bsid, 234)])
+            # one buildset_sourcestamps row
+            r = conn.execute(self.db.model.buildset_sourcestamps.select())
+            rows = [(row.buildsetid, row.sourcestampid)
+                    for row in r.fetchall()]
+            self.assertEqual(rows, [(bsid, 234)])
 
-                # and two buildrequests rows (and don't re-check the default
-                # columns)
-                r = conn.execute(self.db.model.buildrequests.select())
-                rows = [(row.buildsetid, row.id, row.builderid)
-                        for row in r.fetchall()]
+            # and two buildrequests rows (and don't re-check the default
+            # columns)
+            r = conn.execute(self.db.model.buildrequests.select())
+            rows = [(row.buildsetid, row.id, row.builderid)
+                    for row in r.fetchall()]
 
-                # we don't know which of the brids is assigned to which
-                # buildername, but either one will do
-                self.assertEqual(sorted(rows),
-                                 [(bsid, brids[1], 1), (bsid, brids[2], 2)])
-            return self.db.pool.do(thd)
-        d.addCallback(check)
-        return d
+            # we don't know which of the brids is assigned to which
+            # buildername, but either one will do
+            self.assertEqual(sorted(rows),
+                             [(bsid, brids[1], 1), (bsid, brids[2], 2)])
+        yield self.db.pool.do(thd)
 
 
 class TestFakeDB(unittest.TestCase, Tests):

--- a/master/buildbot/test/unit/test_db_changesources.py
+++ b/master/buildbot/test/unit/test_db_changesources.py
@@ -291,17 +291,14 @@ class TestRealDB(db.TestCase,
                  connector_component.ConnectorComponentMixin,
                  RealTests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        d = self.setUpConnectorComponent(
+        yield self.setUpConnectorComponent(
             table_names=['changes', 'changesources', 'masters',
                          'patches', 'sourcestamps', 'changesource_masters'])
 
-        def finish_setup(_):
-            self.db.changesources = \
-                changesources.ChangeSourcesConnectorComponent(self.db)
-        d.addCallback(finish_setup)
-
-        return d
+        self.db.changesources = \
+            changesources.ChangeSourcesConnectorComponent(self.db)
 
     def tearDown(self):
         return self.tearDownConnectorComponent()


### PR DESCRIPTION
Use of defer.inlineCallbacks leads to more readable code.