### PR TITLE
Use inline callbacks where possible (part 5)

### DIFF
--- a/master/buildbot/test/unit/test_process_users_users.py
+++ b/master/buildbot/test/unit/test_process_users_users.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.users import users
@@ -30,137 +31,118 @@ class UsersTests(unittest.TestCase):
         self.db = self.master.db
         self.test_sha = users.encrypt("cancer")
 
+    @defer.inlineCallbacks
     def test_createUserObject_no_src(self):
-        d = users.createUserObject(self.master, "Tyler Durden", None)
+        yield users.createUserObject(self.master, "Tyler Durden", None)
 
-        def check(_):
-            self.assertEqual(self.db.users.users, {})
-            self.assertEqual(self.db.users.users_info, {})
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.db.users.users, {})
+        self.assertEqual(self.db.users.users_info, {})
 
+    @defer.inlineCallbacks
     def test_createUserObject_unrecognized_src(self):
-        d = users.createUserObject(self.master, "Tyler Durden", 'blah')
+        yield users.createUserObject(self.master, "Tyler Durden", 'blah')
 
-        def check(_):
-            self.assertEqual(self.db.users.users, {})
-            self.assertEqual(self.db.users.users_info, {})
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.db.users.users, {})
+        self.assertEqual(self.db.users.users_info, {})
 
+    @defer.inlineCallbacks
     def test_createUserObject_git(self):
-        d = users.createUserObject(self.master,
+        yield users.createUserObject(self.master,
                                    "Tyler Durden <tyler@mayhem.net>", 'git')
 
-        def check(_):
-            self.assertEqual(self.db.users.users,
-                             {1: dict(identifier='Tyler Durden <tyler@mayhem.net>',
-                                      bb_username=None, bb_password=None)})
-            self.assertEqual(self.db.users.users_info,
-                             {1: [dict(attr_type="git",
-                                       attr_data="Tyler Durden <tyler@mayhem.net>")]})
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.db.users.users,
+                         {1: dict(identifier='Tyler Durden <tyler@mayhem.net>',
+                                  bb_username=None, bb_password=None)})
+        self.assertEqual(self.db.users.users_info,
+                         {1: [dict(attr_type="git",
+                                   attr_data="Tyler Durden <tyler@mayhem.net>")]})
 
+    @defer.inlineCallbacks
     def test_createUserObject_svn(self):
-        d = users.createUserObject(self.master, "tdurden", 'svn')
+        yield users.createUserObject(self.master, "tdurden", 'svn')
 
-        def check(_):
-            self.assertEqual(self.db.users.users,
-                             {1: dict(identifier='tdurden',
-                                      bb_username=None, bb_password=None)})
-            self.assertEqual(self.db.users.users_info,
-                             {1: [dict(attr_type="svn",
-                                       attr_data="tdurden")]})
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.db.users.users,
+                         {1: dict(identifier='tdurden',
+                                  bb_username=None, bb_password=None)})
+        self.assertEqual(self.db.users.users_info,
+                         {1: [dict(attr_type="svn",
+                                   attr_data="tdurden")]})
 
+    @defer.inlineCallbacks
     def test_createUserObject_hg(self):
-        d = users.createUserObject(self.master,
+        yield users.createUserObject(self.master,
                                    "Tyler Durden <tyler@mayhem.net>", 'hg')
 
-        def check(_):
-            self.assertEqual(self.db.users.users,
-                             {1: dict(identifier='Tyler Durden <tyler@mayhem.net>',
-                                      bb_username=None, bb_password=None)})
-            self.assertEqual(self.db.users.users_info,
-                             {1: [dict(attr_type="hg",
-                                       attr_data="Tyler Durden <tyler@mayhem.net>")]})
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.db.users.users,
+                         {1: dict(identifier='Tyler Durden <tyler@mayhem.net>',
+                                  bb_username=None, bb_password=None)})
+        self.assertEqual(self.db.users.users_info,
+                         {1: [dict(attr_type="hg",
+                                   attr_data="Tyler Durden <tyler@mayhem.net>")]})
 
+    @defer.inlineCallbacks
     def test_createUserObject_cvs(self):
-        d = users.createUserObject(self.master, "tdurden", 'cvs')
+        yield users.createUserObject(self.master, "tdurden", 'cvs')
 
-        def check(_):
-            self.assertEqual(self.db.users.users,
-                             {1: dict(identifier='tdurden',
-                                      bb_username=None, bb_password=None)})
-            self.assertEqual(self.db.users.users_info,
-                             {1: [dict(attr_type="cvs",
-                                       attr_data="tdurden")]})
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.db.users.users,
+                         {1: dict(identifier='tdurden',
+                                  bb_username=None, bb_password=None)})
+        self.assertEqual(self.db.users.users_info,
+                         {1: [dict(attr_type="cvs",
+                                   attr_data="tdurden")]})
 
+    @defer.inlineCallbacks
     def test_createUserObject_darcs(self):
-        d = users.createUserObject(self.master, "tyler@mayhem.net", 'darcs')
+        yield users.createUserObject(self.master, "tyler@mayhem.net", 'darcs')
 
-        def check(_):
-            self.assertEqual(self.db.users.users,
-                             {1: dict(identifier='tyler@mayhem.net',
-                                      bb_username=None, bb_password=None)})
-            self.assertEqual(self.db.users.users_info,
-                             {1: [dict(attr_type="darcs",
-                                       attr_data="tyler@mayhem.net")]})
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.db.users.users,
+                         {1: dict(identifier='tyler@mayhem.net',
+                                  bb_username=None, bb_password=None)})
+        self.assertEqual(self.db.users.users_info,
+                         {1: [dict(attr_type="darcs",
+                                   attr_data="tyler@mayhem.net")]})
 
+    @defer.inlineCallbacks
     def test_createUserObject_bzr(self):
-        d = users.createUserObject(self.master, "Tyler Durden", 'bzr')
+        yield users.createUserObject(self.master, "Tyler Durden", 'bzr')
 
-        def check(_):
-            self.assertEqual(self.db.users.users,
-                             {1: dict(identifier='Tyler Durden',
-                                      bb_username=None, bb_password=None)})
-            self.assertEqual(self.db.users.users_info,
-                             {1: [dict(attr_type="bzr",
-                                       attr_data="Tyler Durden")]})
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.db.users.users,
+                         {1: dict(identifier='Tyler Durden',
+                                  bb_username=None, bb_password=None)})
+        self.assertEqual(self.db.users.users_info,
+                         {1: [dict(attr_type="bzr",
+                                   attr_data="Tyler Durden")]})
 
+    @defer.inlineCallbacks
     def test_getUserContact_found(self):
         self.db.insertTestData([fakedb.User(uid=1, identifier='tdurden'),
                                 fakedb.UserInfo(uid=1, attr_type='svn',
                                                 attr_data='tdurden'),
                                 fakedb.UserInfo(uid=1, attr_type='email',
                                                 attr_data='tyler@mayhem.net')])
-        d = users.getUserContact(self.master, contact_types=['email'], uid=1)
+        contact = yield users.getUserContact(self.master,
+                                             contact_types=['email'], uid=1)
 
-        def check(contact):
-            self.assertEqual(contact, 'tyler@mayhem.net')
-        d.addCallback(check)
-        return d
+        self.assertEqual(contact, 'tyler@mayhem.net')
 
+    @defer.inlineCallbacks
     def test_getUserContact_key_not_found(self):
         self.db.insertTestData([fakedb.User(uid=1, identifier='tdurden'),
                                 fakedb.UserInfo(uid=1, attr_type='svn',
                                                 attr_data='tdurden'),
                                 fakedb.UserInfo(uid=1, attr_type='email',
                                                 attr_data='tyler@mayhem.net')])
-        d = users.getUserContact(self.master, contact_types=['blargh'], uid=1)
+        contact = yield users.getUserContact(self.master,
+                                             contact_types=['blargh'], uid=1)
 
-        def check(contact):
-            self.assertEqual(contact, None)
-        d.addCallback(check)
-        return d
+        self.assertEqual(contact, None)
 
+    @defer.inlineCallbacks
     def test_getUserContact_uid_not_found(self):
-        d = users.getUserContact(self.master, contact_types=['email'], uid=1)
+        contact = yield users.getUserContact(self.master,
+                                             contact_types=['email'], uid=1)
 
-        def check(contact):
-            self.assertEqual(contact, None)
-        d.addCallback(check)
-        return d
+        self.assertEqual(contact, None)
 
     def test_check_passwd(self):
         res = users.check_passwd("cancer", self.test_sha)

--- a/master/buildbot/test/unit/test_schedulers_basic.py
+++ b/master/buildbot/test/unit/test_schedulers_basic.py
@@ -122,7 +122,7 @@ class BaseBasicScheduler(CommonStuffMixin,
         self.assertConsumingChanges(fileIsImportant=fII, change_filter=cf,
                                     onlyImportant=False)
         self.db.schedulers.assertClassifications(self.SCHEDULERID, {})
-        sched.deactivate()
+        yield sched.deactivate()
 
     def test_subclass_fileIsImportant(self):
         class Subclass(self.Subclass):
@@ -158,7 +158,7 @@ class BaseBasicScheduler(CommonStuffMixin,
                 self.SCHEDULERID, {20: True})
         self.assertTrue(sched.timer_started)
         self.clock.advance(10)
-        sched.deactivate()
+        yield sched.deactivate()
 
     @defer.inlineCallbacks
     def test_gotChange_no_treeStableTimer_unimportant(self):
@@ -172,7 +172,7 @@ class BaseBasicScheduler(CommonStuffMixin,
 
         self.assertEqual(self.events, [])
 
-        sched.deactivate()
+        yield sched.deactivate()
 
     @defer.inlineCallbacks
     def test_gotChange_no_treeStableTimer_important(self):
@@ -186,7 +186,7 @@ class BaseBasicScheduler(CommonStuffMixin,
 
         self.assertEqual(self.events, ['B[13]@0'])
 
-        sched.deactivate()
+        yield sched.deactivate()
 
     @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_unimportant(self):
@@ -202,7 +202,7 @@ class BaseBasicScheduler(CommonStuffMixin,
         self.clock.advance(10)
         self.assertEqual(self.events, [])
 
-        sched.deactivate()
+        yield sched.deactivate()
 
     @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_important(self):
@@ -217,7 +217,7 @@ class BaseBasicScheduler(CommonStuffMixin,
 
         self.assertEqual(self.events, ['B[13]@10'])
 
-        sched.deactivate()
+        yield sched.deactivate()
 
     @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_sequence(self):
@@ -398,7 +398,7 @@ class SingleBranchScheduler(CommonStuffMixin,
 
         self.assertEqual(self.events, ['B[13]@10'])
 
-        sched.deactivate()
+        yield sched.deactivate()
 
     @defer.inlineCallbacks
     def test_gotChange_createAbsoluteSourceStamps_saveCodebase(self):
@@ -513,7 +513,7 @@ class AnyBranchScheduler(CommonStuffMixin,
 
         self.assertEqual(self.events, ['B[13,14]@11', 'B[16]@15'])
 
-        sched.deactivate()
+        yield sched.deactivate()
 
     @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_multiple_repositories(self):
@@ -542,7 +542,7 @@ class AnyBranchScheduler(CommonStuffMixin,
 
         self.assertEqual(self.events, ['B[13,14]@11', 'B[15,17]@15'])
 
-        sched.deactivate()
+        yield sched.deactivate()
 
     @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_multiple_projects(self):

--- a/master/buildbot/test/unit/test_schedulers_basic.py
+++ b/master/buildbot/test/unit/test_schedulers_basic.py
@@ -106,6 +106,7 @@ class BaseBasicScheduler(CommonStuffMixin,
         with self.assertRaises(config.ConfigErrors):
             self.Subclass("tsched", "master", 60)
 
+    @defer.inlineCallbacks
     def test_activate_no_treeStableTimer(self):
         cf = mock.Mock('cf')
         fII = mock.Mock('fII')
@@ -114,17 +115,14 @@ class BaseBasicScheduler(CommonStuffMixin,
 
         self.db.schedulers.fakeClassifications(self.SCHEDULERID, {20: True})
 
-        d = sched.activate()
+        yield sched.activate()
 
         # check that the scheduler has started to consume changes, and the
         # classifications *have* been flushed, since they will not be used
-        def check(_):
-            self.assertConsumingChanges(fileIsImportant=fII, change_filter=cf,
-                                        onlyImportant=False)
-            self.db.schedulers.assertClassifications(self.SCHEDULERID, {})
-        d.addCallback(check)
-        d.addCallback(lambda _: sched.deactivate())
-        return d
+        self.assertConsumingChanges(fileIsImportant=fII, change_filter=cf,
+                                    onlyImportant=False)
+        self.db.schedulers.assertClassifications(self.SCHEDULERID, {})
+        sched.deactivate()
 
     def test_subclass_fileIsImportant(self):
         class Subclass(self.Subclass):
@@ -135,6 +133,7 @@ class BaseBasicScheduler(CommonStuffMixin,
         self.assertEqual(
             Subclass.fileIsImportant.__get__(sched), sched.fileIsImportant)
 
+    @defer.inlineCallbacks
     def test_activate_treeStableTimer(self):
         cf = mock.Mock()
         sched = self.makeScheduler(
@@ -147,85 +146,78 @@ class BaseBasicScheduler(CommonStuffMixin,
                                    changeid=20, important=1)
         ])
 
-        d = sched.activate()
+        yield sched.activate()
 
         # check that the scheduler has started to consume changes, and no
         # classifications have been flushed.  Furthermore, the existing
         # classification should have been acted on, so the timer should be
         # running
-        def check(_):
-            self.assertConsumingChanges(fileIsImportant=None, change_filter=cf,
-                                        onlyImportant=False)
-            self.db.schedulers.assertClassifications(
+        self.assertConsumingChanges(fileIsImportant=None, change_filter=cf,
+                                    onlyImportant=False)
+        self.db.schedulers.assertClassifications(
                 self.SCHEDULERID, {20: True})
-            self.assertTrue(sched.timer_started)
-            self.clock.advance(10)
-        d.addCallback(check)
-        d.addCallback(lambda _: sched.deactivate())
-        return d
+        self.assertTrue(sched.timer_started)
+        self.clock.advance(10)
+        sched.deactivate()
 
+    @defer.inlineCallbacks
     def test_gotChange_no_treeStableTimer_unimportant(self):
         sched = self.makeScheduler(
             self.Subclass, treeStableTimer=None, branch='master')
 
         sched.activate()
 
-        d = sched.gotChange(
+        yield sched.gotChange(
             self.makeFakeChange(branch='master', number=13), False)
 
-        def check(_):
-            self.assertEqual(self.events, [])
-        d.addCallback(check)
+        self.assertEqual(self.events, [])
 
-        d.addCallback(lambda _: sched.deactivate())
+        sched.deactivate()
 
+    @defer.inlineCallbacks
     def test_gotChange_no_treeStableTimer_important(self):
         sched = self.makeScheduler(
             self.Subclass, treeStableTimer=None, branch='master')
 
         sched.activate()
 
-        d = sched.gotChange(
+        yield sched.gotChange(
             self.makeFakeChange(branch='master', number=13), True)
 
-        def check(_):
-            self.assertEqual(self.events, ['B[13]@0'])
-        d.addCallback(check)
+        self.assertEqual(self.events, ['B[13]@0'])
 
-        d.addCallback(lambda _: sched.deactivate())
+        sched.deactivate()
 
+    @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_unimportant(self):
         sched = self.makeScheduler(
             self.Subclass, treeStableTimer=10, branch='master')
 
         sched.activate()
 
-        d = sched.gotChange(
+        yield sched.gotChange(
             self.makeFakeChange(branch='master', number=13), False)
 
-        def check(_):
-            self.assertEqual(self.events, [])
-        d.addCallback(check)
-        d.addCallback(lambda _: self.clock.advance(10))
-        d.addCallback(check)  # should still be empty
+        self.assertEqual(self.events, [])
+        self.clock.advance(10)
+        self.assertEqual(self.events, [])
 
-        d.addCallback(lambda _: sched.deactivate())
+        sched.deactivate()
 
+    @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_important(self):
         sched = self.makeScheduler(
             self.Subclass, treeStableTimer=10, branch='master')
 
         sched.activate()
 
-        d = sched.gotChange(
+        yield sched.gotChange(
             self.makeFakeChange(branch='master', number=13), True)
-        d.addCallback(lambda _: self.clock.advance(10))
+        self.clock.advance(10)
 
-        def check(_):
-            self.assertEqual(self.events, ['B[13]@10'])
-        d.addCallback(check)
+        self.assertEqual(self.events, ['B[13]@10'])
 
-        d.addCallback(lambda _: sched.deactivate())
+        sched.deactivate()
 
     @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_sequence(self):
@@ -391,6 +383,7 @@ class SingleBranchScheduler(CommonStuffMixin,
             basic.SingleBranchScheduler(name="tsched", treeStableTimer=60,
                                         branches='x')
 
+    @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_important(self):
         # this looks suspiciously like the same test above, because SingleBranchScheduler
         # is about the same as the test subclass used above
@@ -399,15 +392,13 @@ class SingleBranchScheduler(CommonStuffMixin,
 
         sched.activate()
 
-        d = sched.gotChange(
+        yield sched.gotChange(
             self.makeFakeChange(branch='master', number=13), True)
-        d.addCallback(lambda _: self.clock.advance(10))
+        self.clock.advance(10)
 
-        def check(_):
-            self.assertEqual(self.events, ['B[13]@10'])
-        d.addCallback(check)
+        self.assertEqual(self.events, ['B[13]@10'])
 
-        d.addCallback(lambda _: sched.deactivate())
+        sched.deactivate()
 
     @defer.inlineCallbacks
     def test_gotChange_createAbsoluteSourceStamps_saveCodebase(self):
@@ -499,6 +490,7 @@ class AnyBranchScheduler(CommonStuffMixin,
             basic.SingleBranchScheduler(name="tsched", treeStableTimer=60,
                                         branch='x')
 
+    @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_multiple_branches(self):
         """Two changes with different branches get different treeStableTimers"""
         sched = self.makeScheduler(basic.AnyBranchScheduler,
@@ -511,61 +503,48 @@ class AnyBranchScheduler(CommonStuffMixin,
             self.db.changes.fakeAddChangeInstance(ch)
             return ch
 
-        d = defer.succeed(None)
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', number=13), True))
-        d.addCallback(lambda _:
-                      self.clock.advance(1))  # time is now 1
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', number=14), False))
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='boring', number=15), False))
-        d.addCallback(lambda _:
-                      self.clock.pump([1] * 4))  # time is now 5
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='devel', number=16), True))
-        d.addCallback(lambda _:
-                      self.clock.pump([1] * 10))  # time is now 15
+        yield sched.gotChange(mkch(branch='master', number=13), True)
+        yield self.clock.advance(1)  # time is now 1
+        yield sched.gotChange(mkch(branch='master', number=14), False)
+        yield sched.gotChange(mkch(branch='boring', number=15), False)
+        yield self.clock.pump([1] * 4)  # time is now 5
+        yield sched.gotChange(mkch(branch='devel', number=16), True)
+        yield self.clock.pump([1] * 10)  # time is now 15
 
-        def check(_):
-            self.assertEqual(self.events, ['B[13,14]@11', 'B[16]@15'])
-        d.addCallback(check)
+        self.assertEqual(self.events, ['B[13,14]@11', 'B[16]@15'])
 
-        d.addCallback(lambda _: sched.deactivate())
+        sched.deactivate()
 
+    @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_multiple_repositories(self):
         """Two repositories, even with the same branch name, have different treeStableTimers"""
         sched = self.makeScheduler(basic.AnyBranchScheduler,
                                    treeStableTimer=10, branches=['master'])
 
-        d = sched.activate()
+        yield sched.activate()
 
         def mkch(**kwargs):
             ch = self.makeFakeChange(**kwargs)
             self.db.changes.fakeAddChangeInstance(ch)
             return ch
 
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', repository="repo", number=13), True))
-        d.addCallback(lambda _:
-                      self.clock.advance(1))  # time is now 1
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', repository="repo", number=14), False))
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', repository="other_repo", number=15), False))
-        d.addCallback(lambda _:
-                      self.clock.pump([1] * 4))  # time is now 5
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', repository="other_repo", number=17), True))
-        d.addCallback(lambda _:
-                      self.clock.pump([1] * 10))  # time is now 15
+        yield sched.gotChange(mkch(branch='master', repository="repo",
+                                   number=13), True)
+        yield self.clock.advance(1)  # time is now 1
+        yield sched.gotChange(mkch(branch='master', repository="repo",
+                                   number=14), False)
+        yield sched.gotChange(mkch(branch='master', repository="other_repo",
+                                   number=15), False)
+        yield self.clock.pump([1] * 4)  # time is now 5
+        yield sched.gotChange(mkch(branch='master', repository="other_repo",
+                                   number=17), True)
+        yield self.clock.pump([1] * 10)  # time is now 15
 
-        def check(_):
-            self.assertEqual(self.events, ['B[13,14]@11', 'B[15,17]@15'])
-        d.addCallback(check)
+        self.assertEqual(self.events, ['B[13,14]@11', 'B[15,17]@15'])
 
-        d.addCallback(lambda _: sched.deactivate())
+        sched.deactivate()
 
+    @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_multiple_projects(self):
         """Two projects, even with the same branch name, have different treeStableTimers"""
         sched = self.makeScheduler(basic.AnyBranchScheduler,
@@ -578,28 +557,23 @@ class AnyBranchScheduler(CommonStuffMixin,
             self.db.changes.fakeAddChangeInstance(ch)
             return ch
 
-        d = defer.succeed(None)
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', project="proj", number=13), True))
-        d.addCallback(lambda _:
-                      self.clock.advance(1))  # time is now 1
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', project="proj", number=14), False))
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', project="other_proj", number=15), False))
-        d.addCallback(lambda _:
-                      self.clock.pump([1] * 4))  # time is now 5
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', project="other_proj", number=17), True))
-        d.addCallback(lambda _:
-                      self.clock.pump([1] * 10))  # time is now 15
+        yield sched.gotChange(mkch(branch='master', project="proj", number=13),
+                              True)
+        yield self.clock.advance(1)  # time is now 1
+        yield sched.gotChange(mkch(branch='master', project="proj",
+                                   number=14), False)
+        yield sched.gotChange(mkch(branch='master', project="other_proj",
+                                   number=15), False)
+        yield self.clock.pump([1] * 4)  # time is now 5
+        yield sched.gotChange(mkch(branch='master', project="other_proj",
+                                   number=17), True)
+        yield self.clock.pump([1] * 10)  # time is now 15
 
-        def check(_):
-            self.assertEqual(self.events, ['B[13,14]@11', 'B[15,17]@15'])
-        d.addCallback(check)
+        self.assertEqual(self.events, ['B[13,14]@11', 'B[15,17]@15'])
 
-        d.addCallback(lambda _: sched.deactivate())
+        yield sched.deactivate()
 
+    @defer.inlineCallbacks
     def test_gotChange_treeStableTimer_multiple_codebases(self):
         """Two codebases, even with the same branch name, have different treeStableTimers"""
         sched = self.makeScheduler(basic.AnyBranchScheduler,
@@ -612,24 +586,14 @@ class AnyBranchScheduler(CommonStuffMixin,
             self.db.changes.fakeAddChangeInstance(ch)
             return ch
 
-        d = defer.succeed(None)
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', codebase="base", number=13), True))
-        d.addCallback(lambda _:
-                      self.clock.advance(1))  # time is now 1
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', codebase="base", number=14), False))
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', codebase="other_base", number=15), False))
-        d.addCallback(lambda _:
-                      self.clock.pump([1] * 4))  # time is now 5
-        d.addCallback(lambda _:
-                      sched.gotChange(mkch(branch='master', codebase="other_base", number=17), True))
-        d.addCallback(lambda _:
-                      self.clock.pump([1] * 10))  # time is now 15
+        yield sched.gotChange(mkch(branch='master', codebase="base", number=13), True)
+        self.clock.advance(1)  # time is now 1
+        yield sched.gotChange(mkch(branch='master', codebase="base", number=14), False)
+        yield sched.gotChange(mkch(branch='master', codebase="other_base", number=15), False)
+        self.clock.pump([1] * 4)  # time is now 5
+        yield sched.gotChange(mkch(branch='master', codebase="other_base", number=17), True)
+        self.clock.pump([1] * 10)  # time is now 15
 
-        def check(_):
-            self.assertEqual(self.events, ['B[13,14]@11', 'B[15,17]@15'])
-        d.addCallback(check)
+        self.assertEqual(self.events, ['B[13,14]@11', 'B[15,17]@15'])
 
-        d.addCallback(lambda _: sched.deactivate())
+        yield sched.deactivate()

--- a/master/buildbot/test/unit/test_schedulers_dependent.py
+++ b/master/buildbot/test/unit/test_schedulers_dependent.py
@@ -75,6 +75,7 @@ class Dependent(scheduler.SchedulerMixin, unittest.TestCase):
         with self.assertRaises(config.ConfigErrors):
             self.makeScheduler(upstream='foo')
 
+    @defer.inlineCallbacks
     def test_activate(self):
         sched = self.makeScheduler()
         sched.activate()
@@ -83,12 +84,9 @@ class Dependent(scheduler.SchedulerMixin, unittest.TestCase):
             sorted([q.filter for q in sched.master.mq.qrefs]),
             [('buildsets', None, 'complete',), ('buildsets', None, 'new',)])
 
-        d = sched.deactivate()
+        yield sched.deactivate()
 
-        def check(_):
-            self.assertEqual([q.filter for q in sched.master.mq.qrefs], [])
-        d.addCallback(check)
-        return d
+        self.assertEqual([q.filter for q in sched.master.mq.qrefs], [])
 
     def sendBuildsetMessage(self, scheduler_name=None, results=-1,
                             complete=False):

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -73,14 +73,12 @@ class SchedulerManager(unittest.TestCase):
             self.already_started = True
             return base.BaseScheduler.startService(self)
 
+        @defer.inlineCallbacks
         def stopService(self):
-            d = base.BaseScheduler.stopService(self)
+            yield base.BaseScheduler.stopService(self)
 
-            def still_set(_):
-                assert self.master is not None
-                assert self.objectid is not None
-            d.addCallback(still_set)
-            return d
+            assert self.master is not None
+            assert self.objectid is not None
 
         def __repr__(self):
             return "{}(attr={})".format(self.__class__.__name__, self.attr)

--- a/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
@@ -173,21 +173,21 @@ class Periodic(scheduler.SchedulerMixin, unittest.TestCase):
         d = sched.deactivate()
         return d
 
+    @defer.inlineCallbacks
     def test_getNextBuildTime_None(self):
         sched = self.makeScheduler(name='test', builderNames=['test'],
                                    periodicBuildTimer=13)
         # given None, build right away
-        d = sched.getNextBuildTime(None)
-        d.addCallback(lambda t: self.assertEqual(t, 0))
-        return d
+        t = yield sched.getNextBuildTime(None)
+        self.assertEqual(t, 0)
 
+    @defer.inlineCallbacks
     def test_getNextBuildTime_given(self):
         sched = self.makeScheduler(name='test', builderNames=['test'],
                                    periodicBuildTimer=13)
         # given a time, add the periodicBuildTimer to it
-        d = sched.getNextBuildTime(20)
-        d.addCallback(lambda t: self.assertEqual(t, 33))
-        return d
+        t = yield sched.getNextBuildTime(20)
+        self.assertEqual(t, 33)
 
     @defer.inlineCallbacks
     def test_enabled_callback(self):

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -577,113 +577,103 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
         pj.update(overrides)
         return pj
 
+    @defer.inlineCallbacks
     def test_handleJobFile(self):
-        d = self.call_handleJobFile(lambda f: self.makeSampleParsedJob())
+        yield self.call_handleJobFile(lambda f: self.makeSampleParsedJob())
 
-        def check(_):
-            self.assertEqual(self.addBuildsetCalls, [
-                ('addBuildsetForSourceStamps', dict(
-                    builderNames=['buildera', 'builderb'],
-                    external_idstring=u'extid',
-                    properties={},
-                    reason=u"'try' job by user who",
-                    sourcestamps=[
-                        dict(
-                            branch='trunk',
-                            codebase='',
-                            patch_author='who',
-                            patch_body='this is my diff, -- ++, etc.',
-                            patch_comment='comment',
-                            patch_level=1,
-                            patch_subdir='',
-                            project='proj',
-                            repository='repo',
-                            revision='1234'),
-                    ])),
-            ])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.addBuildsetCalls, [
+            ('addBuildsetForSourceStamps', dict(
+                builderNames=['buildera', 'builderb'],
+                external_idstring=u'extid',
+                properties={},
+                reason=u"'try' job by user who",
+                sourcestamps=[
+                    dict(
+                        branch='trunk',
+                        codebase='',
+                        patch_author='who',
+                        patch_body='this is my diff, -- ++, etc.',
+                        patch_comment='comment',
+                        patch_level=1,
+                        patch_subdir='',
+                        project='proj',
+                        repository='repo',
+                        revision='1234'),
+                ])),
+        ])
 
+    @defer.inlineCallbacks
     def test_handleJobFile_exception(self):
         def parseJob(f):
             raise trysched.BadJobfile
-        d = self.call_handleJobFile(parseJob)
+        yield self.call_handleJobFile(parseJob)
 
-        def check(bsid):
-            self.assertEqual(self.addBuildsetCalls, [])
-            self.assertEqual(
-                1, len(self.flushLoggedErrors(trysched.BadJobfile)))
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.addBuildsetCalls, [])
+        self.assertEqual(
+            1, len(self.flushLoggedErrors(trysched.BadJobfile)))
     if twisted.version.major <= 9 and sys.version_info[:2] >= (2, 7):
         test_handleJobFile_exception.skip = (
             "flushLoggedErrors does not work correctly on 9.0.0 "
             "and earlier with Python-2.7")
 
+    @defer.inlineCallbacks
     def test_handleJobFile_bad_builders(self):
-        d = self.call_handleJobFile(
+        yield self.call_handleJobFile(
             lambda f: self.makeSampleParsedJob(builderNames=['xxx']))
 
-        def check(_):
-            self.assertEqual(self.addBuildsetCalls, [])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.addBuildsetCalls, [])
 
+    @defer.inlineCallbacks
     def test_handleJobFile_subset_builders(self):
-        d = self.call_handleJobFile(
+        yield self.call_handleJobFile(
             lambda f: self.makeSampleParsedJob(builderNames=['buildera']))
 
-        def check(_):
-            self.assertEqual(self.addBuildsetCalls, [
-                ('addBuildsetForSourceStamps', dict(
-                    builderNames=['buildera'],
-                    external_idstring=u'extid',
-                    properties={},
-                    reason=u"'try' job by user who",
-                    sourcestamps=[
-                        dict(
-                            branch='trunk',
-                            codebase='',
-                            patch_author='who',
-                            patch_body='this is my diff, -- ++, etc.',
-                            patch_comment='comment',
-                            patch_level=1,
-                            patch_subdir='',
-                            project='proj',
-                            repository='repo',
-                            revision='1234'),
-                    ])),
-            ])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.addBuildsetCalls, [
+            ('addBuildsetForSourceStamps', dict(
+                builderNames=['buildera'],
+                external_idstring=u'extid',
+                properties={},
+                reason=u"'try' job by user who",
+                sourcestamps=[
+                    dict(
+                        branch='trunk',
+                        codebase='',
+                        patch_author='who',
+                        patch_body='this is my diff, -- ++, etc.',
+                        patch_comment='comment',
+                        patch_level=1,
+                        patch_subdir='',
+                        project='proj',
+                        repository='repo',
+                        revision='1234'),
+                ])),
+        ])
 
+    @defer.inlineCallbacks
     def test_handleJobFile_with_try_properties(self):
-        d = self.call_handleJobFile(
-            lambda f: self.makeSampleParsedJob(properties={'foo': 'bar'}))
+        yield self.call_handleJobFile(
+                lambda f: self.makeSampleParsedJob(properties={'foo': 'bar'}))
 
-        def check(_):
-            self.assertEqual(self.addBuildsetCalls, [
-                ('addBuildsetForSourceStamps', dict(
-                    builderNames=['buildera', 'builderb'],
-                    external_idstring=u'extid',
-                    properties={'foo': ('bar', u'try build')},
-                    reason=u"'try' job by user who",
-                    sourcestamps=[
-                        dict(
-                            branch='trunk',
-                            codebase='',
-                            patch_author='who',
-                            patch_body='this is my diff, -- ++, etc.',
-                            patch_comment='comment',
-                            patch_level=1,
-                            patch_subdir='',
-                            project='proj',
-                            repository='repo',
-                            revision='1234'),
-                    ])),
-            ])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.addBuildsetCalls, [
+            ('addBuildsetForSourceStamps', dict(
+                builderNames=['buildera', 'builderb'],
+                external_idstring=u'extid',
+                properties={'foo': ('bar', u'try build')},
+                reason=u"'try' job by user who",
+                sourcestamps=[
+                    dict(
+                        branch='trunk',
+                        codebase='',
+                        patch_author='who',
+                        patch_body='this is my diff, -- ++, etc.',
+                        patch_comment='comment',
+                        patch_level=1,
+                        patch_subdir='',
+                        project='proj',
+                        repository='repo',
+                        revision='1234'),
+                ])),
+        ])
 
     def test_handleJobFile_with_invalid_try_properties(self):
         d = self.call_handleJobFile(
@@ -712,9 +702,11 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, unittest.TestCase):
         sched.master.status = mock.Mock()
         return sched
 
+    @defer.inlineCallbacks
     def call_perspective_try(self, *args, **kwargs):
         sched = self.makeScheduler(name='tsched', builderNames=['a', 'b'],
-                                   port='xxx', userpass=[('a', 'b')], properties=dict(frm='schd'))
+                                   port='xxx', userpass=[('a', 'b')],
+                                   properties=dict(frm='schd'))
         persp = trysched.Try_Userpass_Perspective(sched, 'a')
 
         # patch out all of the handling after addBuildsetForSourceStamp
@@ -722,93 +714,83 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, unittest.TestCase):
             return dict(bsid=bsid)
         self.db.buildsets.getBuildset = getBuildset
 
-        d = persp.perspective_try(*args, **kwargs)
+        rbss = yield persp.perspective_try(*args, **kwargs)
 
-        def check(rbss):
-            if rbss is None:
-                return
-            self.assertIsInstance(rbss, trysched.RemoteBuildSetStatus)
-        d.addCallback(check)
-        return d
+        if rbss is None:
+            return
+        self.assertIsInstance(rbss, trysched.RemoteBuildSetStatus)
 
+    @defer.inlineCallbacks
     def test_perspective_try(self):
-        d = self.call_perspective_try(
+        yield self.call_perspective_try(
             'default', 'abcdef', (1, '-- ++'), 'repo', 'proj', ['a'],
             properties={'pr': 'op'})
 
-        def check(_):
-            self.assertEqual(self.addBuildsetCalls, [
-                ('addBuildsetForSourceStamps', dict(
-                    builderNames=['a'],
-                    external_idstring=None,
-                    properties={'pr': ('op', u'try build')},
-                    reason=u"'try' job",
-                    sourcestamps=[
-                        dict(
-                            branch='default',
-                            codebase='',
-                            patch_author='',
-                            patch_body='-- ++',
-                            patch_comment='',
-                            patch_level=1,
-                            patch_subdir='',
-                            project='proj',
-                            repository='repo',
-                            revision='abcdef'),
-                    ])),
-            ])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.addBuildsetCalls, [
+            ('addBuildsetForSourceStamps', dict(
+                builderNames=['a'],
+                external_idstring=None,
+                properties={'pr': ('op', u'try build')},
+                reason=u"'try' job",
+                sourcestamps=[
+                    dict(
+                        branch='default',
+                        codebase='',
+                        patch_author='',
+                        patch_body='-- ++',
+                        patch_comment='',
+                        patch_level=1,
+                        patch_subdir='',
+                        project='proj',
+                        repository='repo',
+                        revision='abcdef'),
+                ])),
+        ])
 
+    @defer.inlineCallbacks
     def test_perspective_try_who(self):
-        d = self.call_perspective_try(
-            'default', 'abcdef', (1, '-- ++'), 'repo', 'proj', ['a'],
-            who='who', comment='comment', properties={'pr': 'op'})
+        yield self.call_perspective_try(
+                'default', 'abcdef', (1, '-- ++'), 'repo', 'proj', ['a'],
+                who='who', comment='comment', properties={'pr': 'op'})
 
-        def check(_):
-            self.assertEqual(self.addBuildsetCalls, [
-                ('addBuildsetForSourceStamps', dict(
-                    builderNames=['a'],
-                    external_idstring=None,
-                    properties={'pr': ('op', u'try build')},
-                    reason=u"'try' job by user who (comment)",
-                    sourcestamps=[
-                        dict(
-                            branch='default',
-                            codebase='',
-                            patch_author='who',
-                            patch_body='-- ++',
-                            patch_comment='comment',
-                            patch_level=1,
-                            patch_subdir='',
-                            project='proj',
-                            repository='repo',
-                            revision='abcdef'),
-                    ])),
-            ])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.addBuildsetCalls, [
+            ('addBuildsetForSourceStamps', dict(
+                builderNames=['a'],
+                external_idstring=None,
+                properties={'pr': ('op', u'try build')},
+                reason=u"'try' job by user who (comment)",
+                sourcestamps=[
+                    dict(
+                        branch='default',
+                        codebase='',
+                        patch_author='who',
+                        patch_body='-- ++',
+                        patch_comment='comment',
+                        patch_level=1,
+                        patch_subdir='',
+                        project='proj',
+                        repository='repo',
+                        revision='abcdef'),
+                ])),
+        ])
 
+    @defer.inlineCallbacks
     def test_perspective_try_bad_builders(self):
-        d = self.call_perspective_try(
-            'default', 'abcdef', (1, '-- ++'), 'repo', 'proj', ['xxx'],
-            properties={'pr': 'op'})
+        yield self.call_perspective_try(
+                'default', 'abcdef', (1, '-- ++'), 'repo', 'proj', ['xxx'],
+                properties={'pr': 'op'})
 
-        def check(_):
-            self.assertEqual(self.addBuildsetCalls, [])
-        d.addCallback(check)
-        return d
+        self.assertEqual(self.addBuildsetCalls, [])
 
+    @defer.inlineCallbacks
     def test_getAvailableBuilderNames(self):
         sched = self.makeScheduler(name='tsched', builderNames=['a', 'b'],
                                    port='xxx', userpass=[('a', 'b')])
         persp = trysched.Try_Userpass_Perspective(sched, 'a')
-        d = defer.maybeDeferred(persp.perspective_getAvailableBuilderNames)
+        buildernames = yield defer.maybeDeferred(
+                                persp.perspective_getAvailableBuilderNames)
 
-        def check(buildernames):
-            self.assertEqual(buildernames, ['a', 'b'])
-        d.addCallback(check)
-        return d
+        self.assertEqual(buildernames, ['a', 'b'])
 
 
 class Try_Userpass(scheduler.SchedulerMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_scripts_create_master.py
+++ b/master/buildbot/test/unit/test_scripts_create_master.py
@@ -52,6 +52,7 @@ class TestCreateMaster(misc.StdoutAssertionsMixin, unittest.TestCase):
 
     # tests
 
+    @defer.inlineCallbacks
     def do_test_createMaster(self, config):
         # mock out everything that createMaster calls, then check that
         # they are called, in order
@@ -65,15 +66,12 @@ class TestCreateMaster(misc.StdoutAssertionsMixin, unittest.TestCase):
             self.patch(create_master, fn, repl)
         repls['createDB'].side_effect = (lambda config:
                                          calls.append(fn) or defer.succeed(None))
-        d = create_master.createMaster(config)
+        rc = yield create_master.createMaster(config)
 
-        @d.addCallback
-        def check(rc):
-            self.assertEqual(rc, 0)
-            self.assertEqual(calls, functions)
-            for repl in itervalues(repls):
-                repl.assert_called_with(config)
-        return d
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls, functions)
+        for repl in itervalues(repls):
+            repl.assert_called_with(config)
 
     @defer.inlineCallbacks
     def test_createMaster_quiet(self):

--- a/master/buildbot/test/unit/test_scripts_processwwwindex.py
+++ b/master/buildbot/test/unit/test_scripts_processwwwindex.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import json
 import tempfile
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.scripts import processwwwindex
@@ -31,22 +32,19 @@ class TestUsersClient(unittest.TestCase):
         self.patch(processwwwindex, 'processwwwindex',
                    processwwwindex.processwwwindex._orig)
 
+    @defer.inlineCallbacks
     def test_no_input_file(self):
-        d = processwwwindex.processwwwindex({})
+        ret = yield processwwwindex.processwwwindex({})
 
-        def check(ret):
-            self.assertEqual(ret, 1)
-        d.addCallback(check)
-        return d
+        self.assertEqual(ret, 1)
 
+    @defer.inlineCallbacks
     def test_invalid_input_file(self):
-        d = processwwwindex.processwwwindex({'index-file': '/some/no/where'})
+        ret = yield processwwwindex.processwwwindex({'index-file': '/some/no/where'})
 
-        def check(ret):
-            self.assertEqual(ret, 2)
-        d.addCallback(check)
-        return d
+        self.assertEqual(ret, 2)
 
+    @defer.inlineCallbacks
     def test_output_config(self):
         # Get temporary file ending with ".html" that has visible to other
         # operations name.
@@ -56,13 +54,9 @@ class TestUsersClient(unittest.TestCase):
         with open(tmpf_name, 'w') as f:
             f.write('{{ configjson|safe }}')
 
-        d = processwwwindex.processwwwindex({'index-file': tmpf_name})
+        ret = yield processwwwindex.processwwwindex({'index-file': tmpf_name})
 
-        def check(ret):
-            self.assertEqual(ret, 0)
-            with open(tmpf_name) as f:
-                config = json.loads(f.read())
-                self.assertTrue(isinstance(config, dict))
-
-        d.addCallback(check)
-        return d
+        self.assertEqual(ret, 0)
+        with open(tmpf_name) as f:
+            config = json.loads(f.read())
+            self.assertTrue(isinstance(config, dict))

--- a/master/buildbot/test/unit/test_scripts_sendchange.py
+++ b/master/buildbot/test/unit/test_scripts_sendchange.py
@@ -61,70 +61,64 @@ class TestSendChange(misc.StdoutAssertionsMixin, unittest.TestCase):
 
         self.setUpStdoutAssertions()
 
+    @defer.inlineCallbacks
     def test_sendchange_config(self):
-        d = sendchange.sendchange(dict(encoding='utf16', who='me',
+        rc = yield sendchange.sendchange(dict(encoding='utf16', who='me',
                                        auth=['a', 'b'], master='m', branch='br', category='cat',
                                        revision='rr', properties={'a': 'b'}, repository='rep',
                                        project='prj', vc='git', revlink='rl', when=1234.0,
                                        comments='comm', files=('a', 'b'), codebase='cb'))
 
-        def check(rc):
-            self.assertEqual((self.sender.master, self.sender.auth,
-                              self.sender.encoding, self.sender.send_kwargs,
-                              self.getStdout(), rc),
-                             ('m', ['a', 'b'], 'utf16', {
-                                 'branch': 'br',
-                                 'category': 'cat',
-                                 'codebase': 'cb',
-                                 'comments': 'comm',
-                                 'files': ('a', 'b'),
-                                 'project': 'prj',
-                                 'properties': {'a': 'b'},
-                                 'repository': 'rep',
-                                 'revision': 'rr',
-                                 'revlink': 'rl',
-                                 'when': 1234.0,
-                                 'who': 'me',
-                                 'vc': 'git'},
-                                 'change sent successfully', 0))
-        d.addCallback(check)
-        return d
+        self.assertEqual((self.sender.master, self.sender.auth,
+                          self.sender.encoding, self.sender.send_kwargs,
+                          self.getStdout(), rc),
+                         ('m', ['a', 'b'], 'utf16', {
+                             'branch': 'br',
+                             'category': 'cat',
+                             'codebase': 'cb',
+                             'comments': 'comm',
+                             'files': ('a', 'b'),
+                             'project': 'prj',
+                             'properties': {'a': 'b'},
+                             'repository': 'rep',
+                             'revision': 'rr',
+                             'revlink': 'rl',
+                             'when': 1234.0,
+                             'who': 'me',
+                             'vc': 'git'},
+                             'change sent successfully', 0))
 
+    @defer.inlineCallbacks
     def test_sendchange_config_no_codebase(self):
-        d = sendchange.sendchange(dict(encoding='utf16', who='me',
+        rc = yield sendchange.sendchange(dict(encoding='utf16', who='me',
                                        auth=['a', 'b'], master='m', branch='br', category='cat',
                                        revision='rr', properties={'a': 'b'}, repository='rep',
                                        project='prj', vc='git', revlink='rl', when=1234.0,
                                        comments='comm', files=('a', 'b')))
 
-        def check(rc):
-            self.assertEqual((self.sender.master, self.sender.auth,
-                              self.sender.encoding, self.sender.send_kwargs,
-                              self.getStdout(), rc),
-                             ('m', ['a', 'b'], 'utf16', {
-                                 'branch': 'br',
-                                 'category': 'cat',
-                                 'codebase': None,
-                                 'comments': 'comm',
-                                 'files': ('a', 'b'),
-                                 'project': 'prj',
-                                 'properties': {'a': 'b'},
-                                 'repository': 'rep',
-                                 'revision': 'rr',
-                                 'revlink': 'rl',
-                                 'when': 1234.0,
-                                 'who': 'me',
-                                 'vc': 'git'},
-                                 'change sent successfully', 0))
-        d.addCallback(check)
-        return d
+        self.assertEqual((self.sender.master, self.sender.auth,
+                          self.sender.encoding, self.sender.send_kwargs,
+                          self.getStdout(), rc),
+                         ('m', ['a', 'b'], 'utf16', {
+                             'branch': 'br',
+                             'category': 'cat',
+                             'codebase': None,
+                             'comments': 'comm',
+                             'files': ('a', 'b'),
+                             'project': 'prj',
+                             'properties': {'a': 'b'},
+                             'repository': 'rep',
+                             'revision': 'rr',
+                             'revlink': 'rl',
+                             'when': 1234.0,
+                             'who': 'me',
+                             'vc': 'git'},
+                             'change sent successfully', 0))
 
+    @defer.inlineCallbacks
     def test_sendchange_fail(self):
         self.fail = True
-        d = sendchange.sendchange({})
+        rc = yield sendchange.sendchange({})
 
-        def check(rc):
-            self.assertEqual((self.getStdout().split('\n')[0], rc),
-                             ('change not sent:', 1))
-        d.addCallback(check)
-        return d
+        self.assertEqual((self.getStdout().split('\n')[0], rc),
+                         ('change not sent:', 1))


### PR DESCRIPTION
Use of defer.inlineCallbacks leads to more readable code.