### PR TITLE
Use inline callbacks where possible (part 7)

### DIFF
--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -212,11 +212,12 @@ class RealDatabaseMixin(object):
         yield self.db_pool.do(self.__thd_clean_database)
         yield self.db_pool.do(self.__thd_create_tables, table_names)
 
+    @defer.inlineCallbacks
     def tearDownRealDatabase(self):
         if self.__want_pool:
-            return self.db_pool.do(self.__thd_clean_database)
-        return defer.succeed(None)
+            yield self.db_pool.do(self.__thd_clean_database)
 
+    @defer.inlineCallbacks
     def insertTestData(self, rows):
         """Insert test data into the database for use during the test.
 
@@ -240,7 +241,7 @@ class RealDatabaseMixin(object):
                     except Exception:
                         log.msg("while inserting %s - %s" % (row, row.values))
                         raise
-        return self.db_pool.do(thd)
+        yield self.db_pool.do(thd)
 
 
 class TestCase(unittest.TestCase):

--- a/master/buildbot/test/util/gpo.py
+++ b/master/buildbot/test/util/gpo.py
@@ -88,20 +88,18 @@ class GetProcessOutputMixin:
         self.assertEqual(self._expected_commands, [],
                          "assert all expected commands were run")
 
+    @defer.inlineCallbacks
     def patched_getProcessOutput(self, bin, args, env=None,
                                  errortoo=False, path=None):
-        d = self.patched_getProcessOutputAndValue(bin, args, env=env,
-                                                  path=path)
-
-        @d.addCallback
-        def cb(res):
-            stdout, stderr, exit = res
-            if errortoo:
-                return defer.succeed(stdout + stderr)
-            if stderr:
-                return defer.fail(IOError("got stderr: %r" % (stderr,)))
-            return defer.succeed(stdout)
-        return d
+        stdout, stderr, exit = \
+            yield self.patched_getProcessOutputAndValue(bin, args, env=env,
+                                                        path=path)
+        if errortoo:
+            defer.returnValue(stdout + stderr)
+            return  # pragma: no cover
+        if stderr:
+            raise IOError("got stderr: %r" % (stderr,))
+        defer.returnValue(stdout)
 
     def patched_getProcessOutputAndValue(self, bin, args, env=None,
                                          path=None):

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -41,19 +41,17 @@ from buildbot.util import sautils
 
 class MigrateTestMixin(db.RealDatabaseMixin, dirs.DirsMixin):
 
+    @defer.inlineCallbacks
     def setUpMigrateTest(self):
         self.basedir = os.path.abspath("basedir")
         self.setUpDirs('basedir')
 
-        d = self.setUpRealDatabase()
+        yield self.setUpRealDatabase()
 
-        @d.addCallback
-        def make_dbc(_):
-            master = fakemaster.make_master()
-            self.db = connector.DBConnector(self.basedir)
-            self.db.setServiceParent(master)
-            self.db.pool = self.db_pool
-        return d
+        master = fakemaster.make_master()
+        self.db = connector.DBConnector(self.basedir)
+        self.db.setServiceParent(master)
+        self.db.pool = self.db_pool
 
     def tearDownMigrateTest(self):
         self.tearDownDirs()

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -241,14 +241,11 @@ class Connection(base.Connection, pb.Avatar):
 
             defer.returnValue(decode(info))
 
+    @defer.inlineCallbacks
     def remoteSetBuilderList(self, builders):
-        d = self.mind.callRemote('setBuilderList', builders)
-
-        @d.addCallback
-        def cache_builders(builders):
-            self.builders = builders
-            return builders
-        return d
+        builders = yield self.mind.callRemote('setBuilderList', builders)
+        self.builders = builders
+        defer.returnValue(builders)
 
     def remoteStartCommand(self, remoteCommand, builderName, commandId, commandName, args):
         workerforbuilder = self.builders.get(builderName)

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -232,14 +232,12 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
                     if hasattr(self.port_service, 'endpoint'):
                         old_listen = self.port_service.endpoint.listen
 
+                        @defer.inlineCallbacks
                         def listen(factory):
-                            d = old_listen(factory)
+                            port = yield old_listen(factory)
+                            self._getPort = lambda: port
+                            defer.returnValue(port)
 
-                            @d.addCallback
-                            def keep(port):
-                                self._getPort = lambda: port
-                                return port
-                            return d
                         self.port_service.endpoint.listen = listen
                     else:
                         # older twisted's just have the port sitting there

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -107,17 +107,15 @@ class WorkerFileUploadCommand(TransferCommand):
         d = defer.Deferred()
         self._reactor.callLater(0, self._loop, d)
 
+        @defer.inlineCallbacks
         def _close_ok(res):
             if self.fp:
                 self.fp.close()
             self.fp = None
-            d1 = self.writer.callRemote("close")
+            yield self.writer.callRemote("close")
 
-            def _utime_ok(res):
-                return self.writer.callRemote("utime", accessed_modified)
             if self.keepstamp:
-                d1.addCallback(_utime_ok)
-            return d1
+                yield self.writer.callRemote("utime", accessed_modified)
 
         def _close_err(f):
             self.rc = 1

--- a/worker/buildbot_worker/test/unit/test_bot_Worker.py
+++ b/worker/buildbot_worker/test/unit/test_bot_Worker.py
@@ -57,18 +57,15 @@ class MasterRealm(object):
         self.perspective = perspective
         self.on_attachment = on_attachment
 
+    @defer.inlineCallbacks
     def requestAvatar(self, avatarId, mind, *interfaces):
         assert pb.IPerspective in interfaces
         self.mind = mind
         self.perspective.mind = mind
-        d = defer.succeed(None)
         if self.on_attachment:
-            d.addCallback(lambda _: self.on_attachment(mind))
+            yield self.on_attachment(mind)
 
-        def returnAvatar(_):
-            return pb.IPerspective, self.perspective, lambda: None
-        d.addCallback(returnAvatar)
-        return d
+        defer.returnValue((pb.IPerspective, self.perspective, lambda: None))
 
     def shutdown(self):
         return self.mind.broker.transport.loseConnection()
@@ -86,17 +83,16 @@ class TestWorker(misc.PatcherMixin, unittest.TestCase):
             shutil.rmtree(self.basedir)
         os.makedirs(self.basedir)
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        d = defer.succeed(None)
         if self.realm:
-            d.addCallback(lambda _: self.realm.shutdown())
+            yield self.realm.shutdown()
         if self.worker and self.worker.running:
-            d.addCallback(lambda _: self.worker.stopService())
+            yield self.worker.stopService()
         if self.listeningport:
-            d.addCallback(lambda _: self.listeningport.stopListening())
+            yield self.listeningport.stopListening()
         if os.path.exists(self.basedir):
             shutil.rmtree(self.basedir)
-        return d
 
     def start_master(self, perspective, on_attachment=None):
         self.realm = MasterRealm(perspective, on_attachment)

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -130,6 +130,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
         if os.path.exists(self.datadir):
             shutil.rmtree(self.datadir)
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.fakemaster.count_writes = True    # get actual byte counts
 
@@ -142,17 +143,16 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
             keepstamp=False,
         ))
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertUpdates([
-                {'header': 'sending {0}'.format(self.datafile)},
-                'write 64', 'write 64', 'write 52', 'close',
-                {'rc': 0}
-            ])
-        d.addCallback(check)
-        return d
+        self.assertUpdates([
+            {'header': 'sending {0}'.format(self.datafile)},
+            'write 64', 'write 64', 'write 52', 'close',
+            {'rc': 0}
+        ])
 
+
+    @defer.inlineCallbacks
     def test_truncated(self):
         self.fakemaster.count_writes = True    # get actual byte counts
 
@@ -165,18 +165,16 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
             keepstamp=False,
         ))
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertUpdates([
-                {'header': 'sending {0}'.format(self.datafile)},
-                'write 64', 'write 36', 'close',
-                {'rc': 1,
-                 'stderr': "Maximum filesize reached, truncating file '{0}'".format(self.datafile)}
-            ])
-        d.addCallback(check)
-        return d
+        self.assertUpdates([
+            {'header': 'sending {0}'.format(self.datafile)},
+            'write 64', 'write 36', 'close',
+            {'rc': 1,
+             'stderr': "Maximum filesize reached, truncating file '{0}'".format(self.datafile)}
+        ])
 
+    @defer.inlineCallbacks
     def test_missing(self):
         self.make_command(transfer.WorkerFileUploadCommand, dict(
             workdir='workdir',
@@ -187,18 +185,15 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
             keepstamp=False,
         ))
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            df = self.datafile + "-nosuch"
-            self.assertUpdates([
-                {'header': 'sending {0}'.format(df)},
-                'close',
-                {'rc': 1,
-                 'stderr': "Cannot open file '{0}' for upload".format(df)}
-            ])
-        d.addCallback(check)
-        return d
+        df = self.datafile + "-nosuch"
+        self.assertUpdates([
+            {'header': 'sending {0}'.format(df)},
+            'close',
+            {'rc': 1,
+             'stderr': "Cannot open file '{0}' for upload".format(df)}
+        ])
 
     @defer.inlineCallbacks
     def test_out_of_space(self):
@@ -222,6 +217,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
             {'rc': 1}
         ])
 
+    @defer.inlineCallbacks
     def test_interrupted(self):
         self.fakemaster.delay_write = True  # write very slowly
 
@@ -245,16 +241,14 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
             return self.cmd.interrupt()
         interrupt_d.addCallback(do_interrupt)
 
-        dl = defer.DeferredList([d, interrupt_d])
+        yield defer.DeferredList([d, interrupt_d])
 
-        def check(_):
-            self.assertUpdates([
-                {'header': 'sending {0}'.format(self.datafile)},
-                'write(s)', 'close', {'rc': 1}
-            ])
-        dl.addCallback(check)
-        return dl
+        self.assertUpdates([
+            {'header': 'sending {0}'.format(self.datafile)},
+            'write(s)', 'close', {'rc': 1}
+        ])
 
+    @defer.inlineCallbacks
     def test_timestamp(self):
         self.fakemaster.count_writes = True    # get actual byte counts
         timestamp = (os.path.getatime(self.datafile),
@@ -269,17 +263,14 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
             keepstamp=True,
         ))
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertUpdates([
-                {'header': 'sending {0}'.format(self.datafile)},
-                'write 64', 'write 64', 'write 52',
-                'close', 'utime - {0}'.format(timestamp[0]),
-                {'rc': 0}
-            ])
-        d.addCallback(check)
-        return d
+        self.assertUpdates([
+            {'header': 'sending {0}'.format(self.datafile)},
+            'write 64', 'write 64', 'write 52',
+            'close', 'utime - {0}'.format(timestamp[0]),
+            {'rc': 0}
+        ])
 
 
 class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
@@ -305,6 +296,7 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
         if os.path.exists(self.datadir):
             shutil.rmtree(self.datadir)
 
+    @defer.inlineCallbacks
     def test_simple(self, compress=None):
         self.fakemaster.keep_data = True
 
@@ -317,29 +309,23 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
             compress=compress,
         ))
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertUpdates([
-                {'header': 'sending {0}'.format(self.datadir)},
-                'write(s)', 'unpack',  # note no 'close"
-                {'rc': 0}
-            ])
-        d.addCallback(check)
+        self.assertUpdates([
+            {'header': 'sending {0}'.format(self.datadir)},
+            'write(s)', 'unpack',  # note no 'close"
+            {'rc': 0}
+        ])
 
-        def check_tarfile(_):
-            f = io.BytesIO(self.fakemaster.data)
-            a = tarfile.open(fileobj=f, name='check.tar', mode="r")
-            exp_names = ['.', 'aa', 'bb']
-            got_names = [n.rstrip('/') for n in a.getnames()]
-            # py27 uses '' instead of '.'
-            got_names = sorted([n or '.' for n in got_names])
-            self.assertEqual(got_names, exp_names, "expected archive contents")
-            a.close()
-            f.close()
-        d.addCallback(check_tarfile)
-
-        return d
+        f = io.BytesIO(self.fakemaster.data)
+        a = tarfile.open(fileobj=f, name='check.tar', mode="r")
+        exp_names = ['.', 'aa', 'bb']
+        got_names = [n.rstrip('/') for n in a.getnames()]
+        # py27 uses '' instead of '.'
+        got_names = sorted([n or '.' for n in got_names])
+        self.assertEqual(got_names, exp_names, "expected archive contents")
+        a.close()
+        f.close()
 
     # try it again with bz2 and gzip
     def test_simple_bz2(self):
@@ -393,6 +379,7 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
         if os.path.exists(self.basedir):
             shutil.rmtree(self.basedir)
 
+    @defer.inlineCallbacks
     def test_simple(self):
         self.fakemaster.count_reads = True    # get actual byte counts
         self.fakemaster.data = test_data = b'1234' * 13
@@ -407,23 +394,21 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
             mode=0o777,
         ))
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertUpdates([
-                'read 32', 'read 32', 'read 32', 'close',
-                {'rc': 0}
-            ])
-            datafile = os.path.join(self.basedir, 'data')
-            self.assertTrue(os.path.exists(datafile))
-            with open(datafile, mode="rb") as f:
-                datafileContent = f.read()
-            self.assertEqual(datafileContent, test_data)
-            if runtime.platformType != 'win32':
-                self.assertEqual(os.stat(datafile).st_mode & 0o777, 0o777)
-        d.addCallback(check)
-        return d
+        self.assertUpdates([
+            'read 32', 'read 32', 'read 32', 'close',
+            {'rc': 0}
+        ])
+        datafile = os.path.join(self.basedir, 'data')
+        self.assertTrue(os.path.exists(datafile))
+        with open(datafile, mode="rb") as f:
+            datafileContent = f.read()
+        self.assertEqual(datafileContent, test_data)
+        if runtime.platformType != 'win32':
+            self.assertEqual(os.stat(datafile).st_mode & 0o777, 0o777)
 
+    @defer.inlineCallbacks
     def test_mkdir(self):
         self.fakemaster.data = test_data = b'hi'
 
@@ -436,21 +421,19 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
             mode=0o777,
         ))
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertUpdates([
-                'read(s)', 'close',
-                {'rc': 0}
-            ])
-            datafile = os.path.join(self.basedir, 'workdir', 'subdir', 'data')
-            self.assertTrue(os.path.exists(datafile))
-            with open(datafile, mode="rb") as f:
-                datafileContent = f.read()
-            self.assertEqual(datafileContent, test_data)
-        d.addCallback(check)
-        return d
+        self.assertUpdates([
+            'read(s)', 'close',
+            {'rc': 0}
+        ])
+        datafile = os.path.join(self.basedir, 'workdir', 'subdir', 'data')
+        self.assertTrue(os.path.exists(datafile))
+        with open(datafile, mode="rb") as f:
+            datafileContent = f.read()
+        self.assertEqual(datafileContent, test_data)
 
+    @defer.inlineCallbacks
     def test_failure(self):
         self.fakemaster.data = 'hi'
 
@@ -464,17 +447,14 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
             mode=0o777,
         ))
 
-        d = self.run_command()
+        yield self.run_command()
 
-        def check(_):
-            self.assertUpdates([
-                'close',
-                {'rc': 1,
-                 'stderr': "Cannot open file '{0}' for download".format(
-                 os.path.join(self.basedir, '.', 'dir'))}
-            ])
-        d.addCallback(check)
-        return d
+        self.assertUpdates([
+            'close',
+            {'rc': 1,
+             'stderr': "Cannot open file '{0}' for download".format(
+             os.path.join(self.basedir, '.', 'dir'))}
+        ])
 
     @defer.inlineCallbacks
     def test_truncated(self):
@@ -503,6 +483,7 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
             data = f.read()
         self.assertEqual(data, test_data[:50])
 
+    @defer.inlineCallbacks
     def test_interrupted(self):
         self.fakemaster.data = b'tenchars--' * 100  # 1k
         self.fakemaster.delay_read = True  # read very slowly
@@ -527,11 +508,8 @@ class TestDownloadFile(CommandTestMixin, unittest.TestCase):
             return self.cmd.interrupt()
         interrupt_d.addCallback(do_interrupt)
 
-        dl = defer.DeferredList([d, interrupt_d])
+        yield defer.DeferredList([d, interrupt_d])
 
-        def check(_):
-            self.assertUpdates([
-                'read(s)', 'close', {'rc': 1}
-            ])
-        dl.addCallback(check)
-        return dl
+        self.assertUpdates([
+            'read(s)', 'close', {'rc': 1}
+        ])

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -656,6 +656,7 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         return self.do_test_pgroup(usePTY=False, useProcGroup=False,
                                    expectChildSurvival=True)
 
+    @defer.inlineCallbacks
     def do_test_pgroup(self, usePTY, useProcGroup=True,
                        expectChildSurvival=False):
         # test that a process group gets killed
@@ -687,16 +688,13 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         pidfiles_d.addCallback(kill)
 
         # check that both processes are dead after RunProcess is done
-        d = defer.gatherResults([pidfiles_d, runproc_d])
+        yield defer.gatherResults([pidfiles_d, runproc_d])
 
-        def check_dead(_):
-            self.assertDead(self.parent_pid)
-            if expectChildSurvival:
-                self.assertAlive(self.child_pid)
-            else:
-                self.assertDead(self.child_pid)
-        d.addCallback(check_dead)
-        return d
+        self.assertDead(self.parent_pid)
+        if expectChildSurvival:
+            self.assertAlive(self.child_pid)
+        else:
+            self.assertDead(self.child_pid)
 
     def test_double_fork_usePTY(self):
         return self.do_test_double_fork(usePTY=True)
@@ -710,6 +708,7 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         return self.do_test_double_fork(usePTY=False, useProcGroup=False,
                                         expectChildSurvival=True)
 
+    @defer.inlineCallbacks
     def do_test_double_fork(self, usePTY, useProcGroup=True,
                             expectChildSurvival=False):
         # when a spawned process spawns another process, and then dies itself
@@ -743,16 +742,13 @@ class TestPOSIXKilling(BasedirMixin, unittest.TestCase):
         pidfiles_d.addCallback(kill)
 
         # check that both processes are dead after RunProcess is done
-        d = defer.gatherResults([pidfiles_d, runproc_d])
+        yield defer.gatherResults([pidfiles_d, runproc_d])
 
-        def check_dead(_):
-            self.assertDead(self.parent_pid)
-            if expectChildSurvival:
-                self.assertAlive(self.child_pid)
-            else:
-                self.assertDead(self.child_pid)
-        d.addCallback(check_dead)
-        return d
+        self.assertDead(self.parent_pid)
+        if expectChildSurvival:
+            self.assertAlive(self.child_pid)
+        else:
+            self.assertDead(self.child_pid)
 
 
 class TestLogging(BasedirMixin, unittest.TestCase):


### PR DESCRIPTION
Use of defer.inlineCallbacks leads to more readable code.