### PR TITLE
Rephrasing last line of the Reporters section

### DIFF
--- a/master/docs/tutorial/fiveminutes.rst
+++ b/master/docs/tutorial/fiveminutes.rst
@@ -277,7 +277,7 @@ One thing I've found useful is the ability to pass a domain name as the lookup a
     c['reporters'].append(notifier)
 
 The mail notifier can be customized at will by means of the ``messageFormatter`` argument, which is a class that Buildbot calls to format the body of the email, and to which it makes available lots of information about the build.
-Here all the details.
+For more details, look into the :ref:`Reporters` section of the Buildbot manual.
 
 Conclusion
 ----------


### PR DESCRIPTION
Adding fix for #4363. Rephrasing the last line of the reporters section to make it more complete and grammatically correct.

## Contributor Checklist:

* [ ] I have updated the unit tests - No unit tests affected
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory) - Not required as change is too small
* [x] I have updated the appropriate documentation - Yes
