### PR TITLE
Remove unneeded @defer.inlineCallbacks

### DIFF
--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -141,8 +141,8 @@ class Builder(base.ResourceType):
             self.master.mq.produce(('builders', str(builderid), 'started'),
                                    dict(builderid=builderid, masterid=masterid, name=name))
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def _masterDeactivated(self, masterid):
         # called from the masters rtype to indicate that the given master is
         # deactivated
-        yield self.updateBuilderList(masterid, [])
+        return self.updateBuilderList(masterid, [])

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -128,9 +128,9 @@ class Worker(base.ResourceType):
     entityType = EntityType(name)
 
     @base.updateMethod
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def workerConfigured(self, workerid, masterid, builderids):
-        yield self.master.db.workers.workerConfigured(
+        return self.master.db.workers.workerConfigured(
             workerid=workerid,
             masterid=masterid,
             builderids=builderids)

--- a/master/buildbot/db/base.py
+++ b/master/buildbot/db/base.py
@@ -22,8 +22,6 @@ import itertools
 
 import sqlalchemy as sa
 
-from twisted.internet import defer
-
 from buildbot.util import unicode2bytes
 
 
@@ -74,7 +72,7 @@ class DBConnectorComponent(object):
             value = value[:col.type.length // 2] + hashlib.sha1(unicode2bytes(value)).hexdigest()[:col.type.length // 2]
         return value
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def findSomethingId(self, tbl, whereclause, insert_values,
                         _race_hook=None, autoCreate=True):
         def thd(conn, no_recurse=False):
@@ -103,7 +101,7 @@ class DBConnectorComponent(object):
                 if no_recurse:
                     raise
                 return thd(conn, no_recurse=True)
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     def hashColumns(self, *args):
         def encode(x):

--- a/master/buildbot/db/builders.py
+++ b/master/buildbot/db/builders.py
@@ -84,7 +84,7 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
             return None
         return d
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def addBuilderMaster(self, builderid=None, masterid=None):
         def thd(conn, no_recurse=False):
             try:
@@ -93,16 +93,16 @@ class BuildersConnectorComponent(base.DBConnectorComponent):
                 conn.execute(q, builderid=builderid, masterid=masterid)
             except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                 pass
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def removeBuilderMaster(self, builderid=None, masterid=None):
         def thd(conn, no_recurse=False):
             tbl = self.db.model.builder_masters
             conn.execute(tbl.delete(
                 whereclause=((tbl.c.builderid == builderid) &
                              (tbl.c.masterid == masterid))))
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)
 
     def getBuilders(self, masterid=None, _builderid=None):
         def thd(conn):

--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -70,7 +70,7 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
                           builder_tbl.c.name.label('buildername')
                           ]).select_from(from_clause)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getBuildRequest(self, brid):
         def thd(conn):
             reqs_tbl = self.db.model.buildrequests
@@ -83,7 +83,7 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
                 rv = self._brdictFromRow(row, self.db.master.masterid)
             res.close()
             return rv
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     @defer.inlineCallbacks
     def getBuildRequests(self, builderid=None, complete=None, claimed=None,
@@ -160,7 +160,7 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
 
         yield self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def unclaimBuildRequests(self, brids):
         def thd(conn):
             transaction = conn.begin()
@@ -185,7 +185,7 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
                     raise
 
             transaction.commit()
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)
 
     @defer.inlineCallbacks
     def completeBuildRequests(self, brids, results, complete_at=None,

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -158,7 +158,7 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
                 raise AlreadyCompleteError()
         yield self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getBuildset(self, bsid):
         def thd(conn):
             bs_tbl = self.db.model.buildsets
@@ -168,7 +168,7 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
             if not row:
                 return None
             return self._thd_row2dict(conn, row)
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     @defer.inlineCallbacks
     def getBuildsets(self, complete=None, resultSpec=None):
@@ -188,7 +188,7 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
         res = yield self.db.pool.do(thd)
         defer.returnValue(res)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getRecentBuildsets(self, count=None, branch=None, repository=None,
                            complete=None):
         def thd(conn):
@@ -215,10 +215,10 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
             res = conn.execute(q)
             return list(reversed([self._thd_row2dict(conn, row)
                                   for row in res.fetchall()]))
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
+    # returns a Deferred that returns a value
     @base.cached("BuildsetProperties")
-    @defer.inlineCallbacks
     def getBuildsetProperties(self, bsid):
         def thd(conn):
             bsp_tbl = self.db.model.buildset_properties
@@ -234,7 +234,7 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
                 except ValueError:
                     pass
             return BsProps(ret)
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     def _thd_row2dict(self, conn, row):
         # get sourcestamps

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -42,7 +42,7 @@ class ChDict(dict):
 class ChangesConnectorComponent(base.DBConnectorComponent):
     # Documentation is in developer/db.rst
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getParentChangeIds(self, branch, repository, project, codebase):
         def thd(conn):
             changes_tbl = self.db.model.changes
@@ -56,7 +56,7 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
             parent_id = conn.scalar(q)
             return [parent_id] if parent_id else []
 
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     @defer.inlineCallbacks
     def addChange(self, author=None, files=None, comments=None, is_dir=None,
@@ -153,8 +153,8 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
             return changeid
         defer.returnValue((yield self.db.pool.do(thd)))
 
+    # returns a Deferred that returns a value
     @base.cached("chdicts")
-    @defer.inlineCallbacks
     def getChange(self, changeid):
         assert changeid >= 0
 
@@ -170,7 +170,7 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
             # and fetch the ancillary data (files, properties)
             return self._chdict_from_change_row_thd(conn, row)
 
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     @defer.inlineCallbacks
     def getChangesForBuild(self, buildid):
@@ -215,7 +215,7 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
                     changes.append(change)
         defer.returnValue(changes)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getChangeFromSSid(self, sourcestampid):
         assert sourcestampid >= 0
 
@@ -233,9 +233,9 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
                 return None
             # and fetch the ancillary data (files, properties)
             return self._chdict_from_change_row_thd(conn, row)
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getChangeUids(self, changeid):
         assert changeid >= 0
 
@@ -246,7 +246,7 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
             rows = res.fetchall()
             row_uids = [row.uid for row in rows]
             return row_uids
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     def getRecentChanges(self, count):
         def thd(conn):
@@ -286,7 +286,7 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
                                         for changeid in changeids])
         return d
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getChangesCount(self):
         def thd(conn):
             changes_tbl = self.db.model.changes
@@ -297,9 +297,9 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
                 r = row[0]
             rp.close()
             return int(r)
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getLatestChangeid(self):
         def thd(conn):
             changes_tbl = self.db.model.changes
@@ -307,7 +307,7 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
                           order_by=sa.desc(changes_tbl.c.changeid),
                           limit=1)
             return conn.scalar(q)
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     # utility methods
 

--- a/master/buildbot/db/changesources.py
+++ b/master/buildbot/db/changesources.py
@@ -42,7 +42,7 @@ class ChangeSourcesConnectorComponent(base.DBConnectorComponent):
                 name_hash=name_hash,
             ))
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def setChangeSourceMaster(self, changesourceid, masterid):
         def thd(conn):
             cs_mst_tbl = self.db.model.changesource_masters
@@ -63,7 +63,7 @@ class ChangeSourcesConnectorComponent(base.DBConnectorComponent):
                 # someone already owns this changesource.
                 raise ChangeSourceAlreadyClaimedError
 
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     @defer.inlineCallbacks
     def getChangeSource(self, changesourceid):
@@ -71,7 +71,7 @@ class ChangeSourcesConnectorComponent(base.DBConnectorComponent):
         if cs:
             defer.returnValue(cs[0])
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getChangeSources(self, active=None, masterid=None, _changesourceid=None):
         def thd(conn):
             cs_tbl = self.db.model.changesources
@@ -104,4 +104,4 @@ class ChangeSourcesConnectorComponent(base.DBConnectorComponent):
             return [dict(id=row.id, name=row.name,
                          masterid=row.masterid)
                     for row in conn.execute(q).fetchall()]
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -817,12 +817,12 @@ class Model(base.DBConnectorComponent):
         ret = yield self.db.pool.do_with_engine(thd)
         defer.returnValue(ret)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def create(self):
         # this is nice and simple, but used only for tests
         def thd(engine):
             self.metadata.create_all(bind=engine)
-        yield self.db.pool.do_with_engine(thd)
+        return self.db.pool.do_with_engine(thd)
 
     @defer.inlineCallbacks
     def upgrade(self):

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -33,15 +33,15 @@ class SchedulerAlreadyClaimedError(Exception):
 class SchedulersConnectorComponent(base.DBConnectorComponent):
     # Documentation is in developer/db.rst
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def enable(self, schedulerid, v):
         def thd(conn):
             tbl = self.db.model.schedulers
             q = tbl.update(whereclause=(tbl.c.id == schedulerid))
             conn.execute(q, enabled=int(v))
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def classifyChanges(self, schedulerid, classifications):
         def thd(conn):
             tbl = self.db.model.scheduler_changes
@@ -69,9 +69,9 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                                  important=imp_int).close()
 
                 transaction.commit()
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def flushChangeClassifications(self, schedulerid, less_than=None):
         def thd(conn):
             sch_ch_tbl = self.db.model.scheduler_changes
@@ -80,9 +80,9 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                 wc = wc & (sch_ch_tbl.c.changeid < less_than)
             q = sch_ch_tbl.delete(whereclause=wc)
             conn.execute(q).close()
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getChangeClassifications(self, schedulerid, branch=-1,
                                  repository=-1, project=-1,
                                  codebase=-1):
@@ -117,7 +117,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                 whereclause=wc)
             return {r.changeid: [False, True][r.important]
                     for r in conn.execute(q)}
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     def findSchedulerId(self, name):
         tbl = self.db.model.schedulers
@@ -130,7 +130,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                 name_hash=name_hash,
             ))
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def setSchedulerMaster(self, schedulerid, masterid):
         def thd(conn):
             sch_mst_tbl = self.db.model.scheduler_masters
@@ -163,7 +163,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                 raise SchedulerAlreadyClaimedError(
                     "already claimed by {}".format(row['name']))
 
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     @defer.inlineCallbacks
     def getScheduler(self, schedulerid):
@@ -171,7 +171,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
         if sch:
             defer.returnValue(sch[0])
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getSchedulers(self, active=None, masterid=None, _schedulerid=None):
         def thd(conn):
             sch_tbl = self.db.model.schedulers
@@ -204,4 +204,4 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
             return [dict(id=row.id, name=row.name, enabled=bool(row.enabled),
                          masterid=row.masterid)
                     for row in conn.execute(q).fetchall()]
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)

--- a/master/buildbot/db/sourcestamps.py
+++ b/master/buildbot/db/sourcestamps.py
@@ -89,8 +89,8 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
             })
         defer.returnValue(sourcestampid)
 
+    # returns a Deferred that returns a value
     @base.cached("ssdicts")
-    @defer.inlineCallbacks
     def getSourceStamp(self, ssid):
         def thd(conn):
             tbl = self.db.model.sourcestamps
@@ -102,9 +102,9 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
             ssdict = self._rowToSsdict_thd(conn, row)
             res.close()
             return ssdict
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getSourceStampsForBuild(self, buildid):
         assert buildid > 0
 
@@ -131,9 +131,9 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
             return [self._rowToSsdict_thd(conn, row)
                     for row in res.fetchall()]
 
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getSourceStamps(self):
         def thd(conn):
             tbl = self.db.model.sourcestamps
@@ -141,7 +141,7 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
             res = conn.execute(q)
             return [self._rowToSsdict_thd(conn, row)
                     for row in res.fetchall()]
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     def _rowToSsdict_thd(self, conn, row):
         ssid = row.id

--- a/master/buildbot/db/users.py
+++ b/master/buildbot/db/users.py
@@ -19,8 +19,6 @@ from __future__ import print_function
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import and_
 
-from twisted.internet import defer
-
 from buildbot.db import base
 from buildbot.util import identifiers
 
@@ -32,7 +30,7 @@ class UsDict(dict):
 class UsersConnectorComponent(base.DBConnectorComponent):
     # Documentation is in developer/db.rst
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def findUserByAttr(self, identifier, attr_type, attr_data, _race_hook=None):
         # note that since this involves two tables, self.findSomethingId is not
         # helpful
@@ -90,10 +88,10 @@ class UsersConnectorComponent(base.DBConnectorComponent):
                 return thd(conn, no_recurse=no_recurse, identifier=identifier)
 
             return uid
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
+    # returns a Deferred that returns a value
     @base.cached("usdicts")
-    @defer.inlineCallbacks
     def getUser(self, uid):
         def thd(conn):
             tbl = self.db.model.users
@@ -110,7 +108,7 @@ class UsersConnectorComponent(base.DBConnectorComponent):
             rows = conn.execute(q).fetchall()
 
             return self.thd_createUsDict(users_row, rows)
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
     def thd_createUsDict(self, users_row, rows):
         # make UsDict to return
@@ -127,7 +125,7 @@ class UsersConnectorComponent(base.DBConnectorComponent):
 
         return usdict
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getUserByUsername(self, username):
         def thd(conn):
             tbl = self.db.model.users
@@ -144,9 +142,9 @@ class UsersConnectorComponent(base.DBConnectorComponent):
             rows = conn.execute(q).fetchall()
 
             return self.thd_createUsDict(users_row, rows)
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getUsers(self):
         def thd(conn):
             tbl = self.db.model.users
@@ -158,9 +156,9 @@ class UsersConnectorComponent(base.DBConnectorComponent):
                     ud = dict(uid=row.uid, identifier=row.identifier)
                     dicts.append(ud)
             return dicts
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def updateUser(self, uid=None, identifier=None, bb_username=None,
                    bb_password=None, attr_type=None, attr_data=None,
                    _race_hook=None):
@@ -219,9 +217,9 @@ class UsersConnectorComponent(base.DBConnectorComponent):
                         return
 
             transaction.commit()
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def removeUser(self, uid):
         def thd(conn):
             # delete from dependent tables first, followed by 'users'
@@ -231,9 +229,9 @@ class UsersConnectorComponent(base.DBConnectorComponent):
                     self.db.model.users,
             ]:
                 conn.execute(tbl.delete(whereclause=(tbl.c.uid == uid)))
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def identifierToUid(self, identifier):
         def thd(conn):
             tbl = self.db.model.users
@@ -244,4 +242,4 @@ class UsersConnectorComponent(base.DBConnectorComponent):
                 return None
 
             return row.uid
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)

--- a/master/buildbot/db/workers.py
+++ b/master/buildbot/db/workers.py
@@ -53,7 +53,7 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
                 q = q.where(cfg_tbl.c.workerid == workerid)
             conn.execute(q).close()
 
-    @defer.inlineCallbacks
+    # returns a Deferred which returns None
     def deconfigureAllWorkersForMaster(self, masterid):
         def thd(conn):
             # first remove the old configured buildermasterids for this master and worker
@@ -72,9 +72,9 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
             res.close()
             self._deleteFromConfiguredWorkers_thd(conn, buildermasterids)
 
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def workerConfigured(self, workerid, masterid, builderids):
 
         def thd(conn):
@@ -117,7 +117,7 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
 
             transaction.commit()
 
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)
 
     @defer.inlineCallbacks
     def getWorker(self, workerid=None, name=None, masterid=None,
@@ -129,7 +129,7 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
         if workers:
             defer.returnValue(workers[0])
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns a value
     def getWorkers(self, _workerid=None, _name=None, masterid=None,
                    builderid=None, paused=None, graceful=None):
         def thd(conn):
@@ -212,11 +212,11 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
                 rv[row.workerid]['connected_to'].append(row.masterid)
 
             return list(itervalues(rv))
-        defer.returnValue((yield self.db.pool.do(thd)))
+        return self.db.pool.do(thd)
     deprecatedWorkerClassMethod(
         locals(), getWorkers, compat_name="getBuildslaves")
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def workerConnected(self, workerid, masterid, workerinfo):
         def thd(conn):
             conn_tbl = self.db.model.connected_workers
@@ -231,21 +231,21 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
             bs_tbl = self.db.model.workers
             q = bs_tbl.update(whereclause=(bs_tbl.c.id == workerid))
             conn.execute(q, info=workerinfo)
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def workerDisconnected(self, workerid, masterid):
         def thd(conn):
             tbl = self.db.model.connected_workers
             q = tbl.delete(whereclause=(tbl.c.workerid == workerid) &
                                        (tbl.c.masterid == masterid))
             conn.execute(q)
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def setWorkerState(self, workerid, paused, graceful):
         def thd(conn):
             tbl = self.db.model.workers
             q = tbl.update(whereclause=(tbl.c.id == workerid))
             conn.execute(q, paused=int(paused), graceful=int(graceful))
-        yield self.db.pool.do(thd)
+        return self.db.pool.do(thd)

--- a/master/buildbot/reporters/hipchat.py
+++ b/master/buildbot/reporters/hipchat.py
@@ -45,13 +45,13 @@ class HipChatStatusPush(HttpStatusPushBase):
         self.builder_room_map = builder_room_map
         self.builder_user_map = builder_user_map
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def buildStarted(self, key, build):
-        yield self.send(build, key[2])
+        return self.send(build, key[2])
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def buildFinished(self, key, build):
-        yield self.send(build, key[2])
+        return self.send(build, key[2])
 
     @defer.inlineCallbacks
     def getBuildDetailsAndSendMessage(self, build, key):

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -48,7 +48,7 @@ class BuilderMixin(object):
         self.mq = self.master.mq
         self.db = self.master.db
 
-    @defer.inlineCallbacks
+    # returns a Deferred that returns None
     def makeBuilder(self, name="bldr", patch_random=False, noReconfig=False,
                     **config_kwargs):
         """Set up C{self.bldr}"""
@@ -81,7 +81,7 @@ class BuilderMixin(object):
         mastercfg = config.MasterConfig()
         mastercfg.builders = [self.builder_config]
         if not noReconfig:
-            defer.returnValue((yield self.bldr.reconfigServiceWithBuildbotConfig(mastercfg)))
+            return self.bldr.reconfigServiceWithBuildbotConfig(mastercfg)
 
 
 class TestBuilder(BuilderMixin, unittest.TestCase):


### PR DESCRIPTION
Unnecessary use of @defer.inlineCallbacks reduces performance. This PR removes most cases within non-test code.