### PR TITLE
Add support for v2 of the kv engine of vault secret provider

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -730,6 +730,7 @@ keypairs
 keyring
 klass
 knielsen
+kv
 kwarg
 kwargs
 lange

--- a/master/buildbot/newsfragments/vault-kv-v2-support.feature
+++ b/master/buildbot/newsfragments/vault-kv-v2-support.feature
@@ -1,0 +1,1 @@
+Add support for v2 of the Vault key-value secret engine in the `SecretInVault` secret provider.

--- a/master/buildbot/secrets/providers/vault.py
+++ b/master/buildbot/secrets/providers/vault.py
@@ -64,10 +64,14 @@ class HashiCorpVaultSecretProvider(SecretProviderBase):
         """
         if self.apiVersion == 1:
             path = self.secretsmount + '/' + entry
-            proj = yield self._http.get('/v1/{0}'.format(path))
         else:
             path = self.secretsmount + '/data/' + entry
-            proj = yield self._http.get('/v1/{0}'.format(path))
+
+        # note that the HTTP path contains v1 for both versions of the key-value
+        # secret engine. Different versions of the key-value engine are
+        # effectively separate secret engines in vault, with the same base HTTP
+        # API, but with different paths within it.
+        proj = yield self._http.get('/v1/{0}'.format(path))
         code = yield proj.code
         if code != 200:
             raise KeyError("The key %s does not exist in Vault provider: request"

--- a/master/buildbot/test/integration/test_integration_secrets_with_vault.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault.py
@@ -43,7 +43,7 @@ class SecretsConfig(RunMasterBase):
 
         rv = os.system("docker exec vault_for_buildbot /bin/sh -c "
                        "'export VAULT_ADDR=http://127.0.0.1:8200/\n"
-                       "vault write secret/key value=word'")
+                       "vault kv put secret/key value=word'")
         self.assertEqual(rv, 0)
 
     def remove_container(self):
@@ -69,9 +69,12 @@ def masterConfig():
             name="force",
             builderNames=["testy"])]
 
+    # note that as of December 2018, the vault docker image default to kv
+    # version 2 to be enabled by default
     c['secretsProviders'] = [HashiCorpVaultSecretProvider(
         vaultToken='my_vaulttoken',
-        vaultServer="http://localhost:8200"
+        vaultServer="http://localhost:8200",
+        apiVersion=2
     )]
 
     f = BuildFactory()

--- a/master/buildbot/test/integration/test_integration_secrets_with_vault.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault.py
@@ -38,12 +38,15 @@ class SecretsConfig(RunMasterBase):
         if rv != 0:
             raise SkipTest(
                 "Vault integration need docker environment to be setup")
+
+        self.addCleanup(self.remove_container)
+
         rv = os.system("docker exec vault_for_buildbot /bin/sh -c "
                        "'export VAULT_ADDR=http://127.0.0.1:8200/\n"
                        "vault write secret/key value=word'")
         self.assertEqual(rv, 0)
 
-    def tearDown(self):
+    def remove_container(self):
         os.system("docker rm -f vault_for_buildbot")
 
     @defer.inlineCallbacks

--- a/master/docs/developer/secrets.rst
+++ b/master/docs/developer/secrets.rst
@@ -61,12 +61,13 @@ Vault provider
 .. code-block:: python
 
     c['secretsProviders'] = [secrets.SecretInVault(vaultToken=open('VAULT_TOKEN').read(),
-                                                vaultServer="http://localhost:8200"
-                                                )]
+                                                vaultServer="http://localhost:8200",
+                                                apiVersion=2)]
 
 In the master configuration, the provider is instantiated through a Buildbot service secret manager with the Vault token and the Vault server address.
 Vault secrets provider accesses the Vault backend asking the key wanted by Buildbot and returns the contained text value.
 SecretInVAult provider allows Buildbot to read secrets in the Vault.
+Currently only v1 and v2 of the Key-Value backends are supported.
 
 Interpolate secret
 ``````````````````

--- a/master/docs/manual/secretsmanagement.rst
+++ b/master/docs/manual/secretsmanagement.rst
@@ -121,11 +121,13 @@ SecretInVault
 
     c['secretsProviders'] = [secrets.SecretInVault(
                             vaultToken=open('VAULT_TOKEN').read(),
-                            vaultServer="http://localhost:8200"
+                            vaultServer="http://localhost:8200",
+                            apiVersion=2
     )]
 
 Vault secures, stores, and tightly controls access to secrets.
 Vault presents a unified API to access multiple backends.
+At the moment buildbot supports KV v1 and v2 backends.
 To be authenticated in Vault, Buildbot need to send a token to the vault server.
 The token is generated when the Vault instance is initialized for the first time.
 
@@ -206,4 +208,4 @@ To add a new secret:
 
 .. code-block:: shell
 
-      vault write secret/new_secret_key value=new_secret_value
+      vault kv put secret/new_secret_key value=new_secret_value

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -422,6 +422,7 @@ keyring
 keystoneauth
 KiB
 kibibytes
+kv
 kwargs
 latin
 ldap


### PR DESCRIPTION
## Remove this paragraph
This PR adds support for v2 of the Vault key-value secret engine in the `SecretInVault` secret provider. 

I've also clarified documentation that the key-value engine is the only one supported. Looking into the documentation of Vault in does not look that other secret engines are using the same API at all. Supporting them properly needs a separate secret provider.

Fixes #4466.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
