### PR TITLE
change_hooks: fix json decode error on python3

### DIFF
--- a/master/buildbot/newsfragments/change-hook-properties-python3.bugfix
+++ b/master/buildbot/newsfragments/change-hook-properties-python3.bugfix
@@ -1,0 +1,1 @@
+Fixed JSON decoding error when sending build properties to www change hooks on Python 3.

--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -43,23 +43,25 @@ class BaseHookHandler(object):
         def firstOrNothing(value):
             """
             Small helper function to return the first value (if value is a list)
-            or return the whole thing otherwise
+            or return the whole thing otherwise.
+
+            Make sure to properly decode bytes to unicode strings.
             """
             if (isinstance(value, type([]))):
-                return value[0]
-            return value
+                value = value[0]
+            return bytes2unicode(value)
 
         args = request.args
         # first, convert files, links and properties
         files = None
         if args.get(b'files'):
-            files = json.loads(args.get(b'files')[0])
+            files = json.loads(firstOrNothing(args.get(b'files')))
         else:
             files = []
 
         properties = None
         if args.get(b'properties'):
-            properties = json.loads(args.get(b'properties')[0])
+            properties = json.loads(firstOrNothing(args.get(b'properties')))
         else:
             properties = {}
 
@@ -70,7 +72,7 @@ class BaseHookHandler(object):
         author = firstOrNothing(args.get(b'author'))
         if not author:
             author = firstOrNothing(args.get(b'who'))
-        comments = bytes2unicode(firstOrNothing(args.get(b'comments')))
+        comments = firstOrNothing(args.get(b'comments'))
         branch = firstOrNothing(args.get(b'branch'))
         category = firstOrNothing(args.get(b'category'))
         revlink = firstOrNothing(args.get(b'revlink'))


### PR DESCRIPTION
Fix the following error with python3:

```
   File "buildbot/www/change_hook.py", line 107, in getAndSubmitChanges
     changes, src = yield self.getChanges(request)
   File "twisted/internet/defer.py", line 1418, in _inlineCallbacks
     result = g.send(result)
   File "buildbot/www/change_hook.py", line 168, in getChanges
     changes, src = yield handler.getChanges(request)
   File "buildbot/www/hooks/base.py", line 62, in getChanges
     properties = json.loads(args.get(b'properties')[0])
   File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
     s.__class__.__name__))
 builtins.TypeError: the JSON object must be str, not 'bytes'
```

Make sure to properly decode to unicode before parsing JSON data.

While there, also decode all other fields to unicode.

## Contributor Checklist:

* [x] I have updated the unit tests.
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation: *N/A*
