### PR TITLE
Deprecate master.addChange and master.addBuildset

### DIFF
--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -87,7 +87,7 @@ class IChangeSource(IPlugin):
     directories are changed in version control, this object should represent
     the changes as a change dictionary and call::
 
-      self.master.addChange(who=.., rev=.., ..)
+      self.master.data.updates.addChange(who=.., rev=.., ..)
 
     See 'Writing Change Sources' in the manual for more information.
     """
@@ -1001,15 +1001,6 @@ class IStatusReceiver(IPlugin):
         @type  otherStatusReceivers: A list of L{IStatusReceiver} objects which
         will contain self.
         """
-
-
-class IControl(Interface):
-
-    def addChange(change):
-        """Add a change to the change queue, for analysis by schedulers."""
-
-    def getBuilder(name):
-        """Retrieve the IBuilderControl object for the given Builder."""
 
 
 class IBuilderControl(Interface):

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -15,9 +15,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.utils import iteritems
 
-import datetime
 import os
 import signal
 import socket
@@ -26,18 +24,14 @@ from twisted.application import internet
 from twisted.internet import defer
 from twisted.internet import task
 from twisted.internet import threads
-from twisted.python import components
 from twisted.python import failure
 from twisted.python import log
-from zope.interface import implementer
 
 import buildbot
 import buildbot.pbmanager
 from buildbot import config
-from buildbot import interfaces
 from buildbot import monkeypatches
 from buildbot.buildbot_net_usage_data import sendBuildbotNetUsageData
-from buildbot.changes import changes
 from buildbot.changes.manager import ChangeManager
 from buildbot.data import connector as dataconnector
 from buildbot.db import connector as dbconnector
@@ -47,14 +41,11 @@ from buildbot.process import cache
 from buildbot.process import debug
 from buildbot.process import metrics
 from buildbot.process.botmaster import BotMaster
-from buildbot.process.builder import BuilderControl
 from buildbot.process.users.manager import UserManagerManager
 from buildbot.schedulers.manager import SchedulerManager
 from buildbot.secrets.manager import SecretManager
 from buildbot.status.master import Status
-from buildbot.util import bytes2unicode
 from buildbot.util import check_functional_environment
-from buildbot.util import datetime2epoch
 from buildbot.util import service
 from buildbot.util.eventual import eventually
 from buildbot.wamp import connector as wampconnector
@@ -451,67 +442,6 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
         """
         return self.status
 
-    # triggering methods
-
-    @defer.inlineCallbacks
-    def addChange(self, who=None, files=None, comments=None, **kwargs):
-        # deprecated in 0.9.0; will be removed in 1.0.0
-        log.msg("WARNING: change source is using deprecated "
-                "self.master.addChange method; this method will disappear in "
-                "Buildbot-1.0.0")
-        # handle positional arguments
-        kwargs['who'] = who
-        kwargs['files'] = files
-        kwargs['comments'] = comments
-
-        def handle_deprec(oldname, newname):
-            if oldname in kwargs:
-                old = kwargs.pop(oldname)
-                if old is not None:
-                    if kwargs.get(newname) is None:
-                        log.msg("WARNING: change source is using deprecated "
-                                "addChange parameter '%s'" % oldname)
-                        return old
-                    raise TypeError("Cannot provide '%s' and '%s' to addChange"
-                                    % (oldname, newname))
-            return kwargs.get(newname)
-
-        kwargs['author'] = handle_deprec("who", "author")
-        kwargs['when_timestamp'] = handle_deprec("when", "when_timestamp")
-
-        # timestamp must be an epoch timestamp now
-        if isinstance(kwargs.get('when_timestamp'), datetime.datetime):
-            kwargs['when_timestamp'] = datetime2epoch(kwargs['when_timestamp'])
-
-        # unicodify stuff
-        for k in ('comments', 'author', 'revision', 'branch', 'category',
-                  'revlink', 'repository', 'codebase', 'project'):
-            if k in kwargs:
-                kwargs[k] = bytes2unicode(kwargs[k])
-        if kwargs.get('files'):
-            kwargs['files'] = [bytes2unicode(f)
-                               for f in kwargs['files']]
-        if kwargs.get('properties'):
-            kwargs['properties'] = dict((bytes2unicode(k), v)
-                                        for k, v in iteritems(kwargs['properties']))
-
-        # pass the converted call on to the data API
-        changeid = yield self.data.updates.addChange(**kwargs)
-
-        # and turn that changeid into a change object, since that's what
-        # callers expected (and why this method was deprecated)
-        chdict = yield self.db.changes.getChange(changeid)
-        change = yield changes.Change.fromChdict(self, chdict)
-        defer.returnValue(change)
-
-    @defer.inlineCallbacks
-    def addBuildset(self, scheduler, **kwargs):
-        log.msg("WARNING: master.addBuildset is deprecated; "
-                "use the data API update method")
-        bsid, brids = yield self.data.updates.addBuildset(
-            scheduler=scheduler, **kwargs)
-        defer.returnValue((bsid, brids))
-
     # state maintenance (private)
     def getObjectId(self):
         """
@@ -553,23 +483,3 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
         def set(objectid):
             return self.db.state.setState(objectid, name, value)
         return d
-
-
-@implementer(interfaces.IControl)
-class Control:
-
-    def __init__(self, master):
-        self.master = master
-
-    def addChange(self, change):
-        self.master.addChange(change)
-
-    def addBuildset(self, **kwargs):
-        return self.master.addBuildset(**kwargs)
-
-    def getBuilder(self, name):
-        b = self.master.botmaster.builders[name]
-        return BuilderControl(b, self)
-
-
-components.registerAdapter(Control, BuildMaster, interfaces.IControl)

--- a/master/buildbot/newsfragments/master-addBuildset.removal
+++ b/master/buildbot/newsfragments/master-addBuildset.removal
@@ -1,0 +1,1 @@
+The deprecated ``BuildMaster.addBuildset`` method has been removed. Use ``BuildMaster.data.updates.addBuildset`` instead.

--- a/master/buildbot/newsfragments/master-addChange.removal
+++ b/master/buildbot/newsfragments/master-addChange.removal
@@ -1,0 +1,1 @@
+The deprecated ``BuildMaster.addChange`` method has been removed. Use ``BuildMaster.data.updates.addChange`` instead.

--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -27,8 +27,8 @@ from twisted.web import server
 from buildbot.test.fake import fakemaster
 
 
-def fakeMasterForHooks():
-    master = fakemaster.make_master()
+def fakeMasterForHooks(testcase):
+    master = fakemaster.make_master(wantData=True, testcase=testcase)
     master.addedChanges = []
     master.www = Mock()
 
@@ -37,7 +37,7 @@ def fakeMasterForHooks():
             return defer.fail(AttributeError('isdir/is_dir is not accepted'))
         master.addedChanges.append(kwargs)
         return defer.succeed(Mock())
-    master.addChange = addChange
+    master.data.updates.addChange = addChange
     return master
 
 

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -17,7 +17,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import datetime
 import os
 import signal
 
@@ -32,7 +31,6 @@ from zope.interface import implementer
 from buildbot import config
 from buildbot import master
 from buildbot import monkeypatches
-from buildbot.changes.changes import Change
 from buildbot.db import exceptions
 from buildbot.interfaces import IConfigLoader
 from buildbot.test.fake import fakedata
@@ -55,117 +53,6 @@ class DefaultLoader(object):
 
     def loadConfig(self):
         return config.MasterConfig()
-
-
-class OldTriggeringMethods(unittest.TestCase):
-
-    def setUp(self):
-        self.patch(master.BuildMaster, 'create_child_services',
-                   lambda self: None)
-        self.master = master.BuildMaster(basedir=None)
-
-        self.master.data = fakedata.FakeDataConnector(self.master, self)
-        self.master.data.setServiceParent(self.master)
-        self.db = self.master.db = fakedb.FakeDBConnector(self)
-        self.db.setServiceParent(self.master)
-        self.master.db.insertTestData([
-            fakedb.Change(changeid=1, author='this is a test'),
-        ])
-
-        self.fake_Change = mock.Mock(name='fake_Change')
-
-        def fromChdict(master, chdict):
-            if chdict['author'] != 'this is a test':
-                raise AssertionError("did not get expected chdict")
-            return defer.succeed(self.fake_Change)
-        self.patch(Change, 'fromChdict', staticmethod(fromChdict))
-
-    @defer.inlineCallbacks
-    def do_test_addChange_args(self, args=(), kwargs=None, exp_data_kwargs=None):
-        # add default arguments
-        if kwargs is None:
-            kwargs = {}
-        if exp_data_kwargs is None:
-            exp_data_kwargs = {}
-        default_data_kwargs = {
-            'author': None,
-            'branch': None,
-            'category': None,
-            'codebase': None,
-            'comments': None,
-            'files': None,
-            'project': '',
-            'properties': {},
-            'repository': '',
-            'revision': None,
-            'revlink': '',
-            'src': None,
-            'when_timestamp': None,
-        }
-        default_data_kwargs.update(exp_data_kwargs)
-        exp_data_kwargs = default_data_kwargs
-
-        change = yield self.master.addChange(*args, **kwargs)
-
-        self.assertIdentical(change, self.fake_Change)
-        self.assertEqual(self.master.data.updates.changesAdded,
-                         [exp_data_kwargs])
-
-    def test_addChange_args_author(self):
-        # who should come through as author
-        return self.do_test_addChange_args(
-            kwargs=dict(who='me'),
-            exp_data_kwargs=dict(author='me'))
-
-    def test_addChange_args_cyrillic(self):
-        return self.do_test_addChange_args(
-            kwargs=dict(who=b'\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82',
-                        files=[b'\xd0\xbd\xd0\xb5'],
-                        properties={b'\xd1\x80\xd0\xb0\xd0\xb1\xd0\xbe\xd1\x82\xd0\xb0\xd0\xb5\xd1\x82':
-                                    'a'}),
-            exp_data_kwargs=dict(author=u'привет',
-                                 files=[u'не'],
-                                 properties={u'работает': 'a'}))
-
-    def test_addChange_args_when(self):
-        # when should come through as when_timestamp, as a datetime
-        return self.do_test_addChange_args(
-            kwargs=dict(when=892293875),
-            exp_data_kwargs=dict(when_timestamp=892293875))
-
-    def test_addChange_args_when_timestamp(self):
-        # when_timestamp should come through as an epoch time.
-        return self.do_test_addChange_args(
-            kwargs=dict(when_timestamp=datetime.datetime(1998, 4, 11, 11, 24, 35)),
-            exp_data_kwargs=dict(when_timestamp=892293875))
-
-    @defer.inlineCallbacks
-    def test_addChange_args_new_and_old(self):
-        func = self.do_test_addChange_args
-        kwargs = (dict(who='author',
-                       author='author'),)
-        exp_data_kwargs = dict(author='author')
-        with self.assertRaises(TypeError):
-            yield func(kwargs=kwargs, exp_data_kwargs=exp_data_kwargs)
-
-    def test_addChange_args_properties(self):
-        # properties should not be qualified with a source
-        return self.do_test_addChange_args(
-            kwargs=dict(properties={'a': 'b'}),
-            exp_data_kwargs=dict(properties={u'a': u'b'}))
-
-    def test_addChange_args_properties_tuple(self):
-        # properties should not be qualified with a source
-        return self.do_test_addChange_args(
-            kwargs=dict(properties={'a': ('b', 'Change')}),
-            exp_data_kwargs=dict(properties={'a': ('b', 'Change')}))
-
-    def test_addChange_args_positional(self):
-        # master.addChange can take author, files, comments as positional
-        # arguments
-        return self.do_test_addChange_args(
-            args=('me', ['a'], 'com'),
-            exp_data_kwargs=dict(author='me', files=['a'], comments='com'))
 
 
 class InitTests(unittest.SynchronousTestCase):

--- a/master/buildbot/test/unit/test_www_hooks_base.py
+++ b/master/buildbot/test/unit/test_www_hooks_base.py
@@ -11,10 +11,10 @@ from buildbot.www.change_hook import ChangeHookResource
 from buildbot.www.hooks.base import BaseHookHandler
 
 
-def _prepare_base_change_hook(**options):
+def _prepare_base_change_hook(testcase, **options):
     return ChangeHookResource(dialects={
         'base': options
-    }, master=fakeMasterForHooks())
+    }, master=fakeMasterForHooks(testcase))
 
 
 def _prepare_request(payload, headers=None):
@@ -40,7 +40,7 @@ def _prepare_request(payload, headers=None):
 
 class TestChangeHookConfiguredWithBase(unittest.TestCase):
     def setUp(self):
-        self.changeHook = _prepare_base_change_hook()
+        self.changeHook = _prepare_base_change_hook(self)
 
     @defer.inlineCallbacks
     def _check_base_with_change(self, payload):
@@ -75,7 +75,7 @@ class TestChangeHookConfiguredWithCustomBase(unittest.TestCase):
                               project=args.get(b'project'),
                               codebase=args.get(b'codebase'))
                 return ([chdict], None)
-        self.changeHook = _prepare_base_change_hook(custom_class=CustomBase)
+        self.changeHook = _prepare_base_change_hook(self, custom_class=CustomBase)
 
     @defer.inlineCallbacks
     def _check_base_with_change(self, payload):

--- a/master/buildbot/test/unit/test_www_hooks_bitbucket.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucket.py
@@ -145,7 +145,7 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
 
     def setUp(self):
         self.change_hook = change_hook.ChangeHookResource(
-            dialects={'bitbucket': True}, master=fakeMasterForHooks())
+            dialects={'bitbucket': True}, master=fakeMasterForHooks(self))
 
     @inlineCallbacks
     def testGitWithChange(self):

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketcloud.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketcloud.py
@@ -648,7 +648,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
     def setUp(self):
         self.change_hook = change_hook.ChangeHookResource(
-            dialects={'bitbucketcloud': {}}, master=fakeMasterForHooks())
+            dialects={'bitbucketcloud': {}}, master=fakeMasterForHooks(self))
 
     def _checkPush(self, change):
         self.assertEqual(

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
@@ -668,7 +668,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
     def setUp(self):
         self.change_hook = change_hook.ChangeHookResource(
-            dialects={'bitbucketserver': {}}, master=fakeMasterForHooks())
+            dialects={'bitbucketserver': {}}, master=fakeMasterForHooks(self))
 
     def _checkPush(self, change):
         self.assertEqual(

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -524,10 +524,10 @@ _CT_ENCODED = b'application/x-www-form-urlencoded'
 _CT_JSON = b'application/json'
 
 
-def _prepare_github_change_hook(**params):
+def _prepare_github_change_hook(testcase, **params):
     return ChangeHookResource(dialects={
         'github': params
-    }, master=fakeMasterForHooks())
+    }, master=fakeMasterForHooks(testcase))
 
 
 def _prepare_request(event, payload, _secret=None, headers=None):
@@ -571,7 +571,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         self.changeHook = _prepare_github_change_hook(
-            strict=False, github_property_whitelist=["github.*"])
+            self, strict=False, github_property_whitelist=["github.*"])
         self.master = self.changeHook.master
         fake_headers = {'User-Agent': 'Buildbot'}
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
@@ -865,7 +865,8 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(unittest.TestCas
     @defer.inlineCallbacks
     def setUp(self):
         self.changeHook = _prepare_github_change_hook(
-            strict=False, github_property_whitelist=["github.*"], pullrequest_ref="head")
+            self, strict=False, github_property_whitelist=["github.*"],
+            pullrequest_ref="head")
         self.master = self.changeHook.master
         fake_headers = {'User-Agent': 'Buildbot'}
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
@@ -894,7 +895,7 @@ class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         self.changeHook = _prepare_github_change_hook(
-            strict=False, skips=[r'\[ *bb *skip *\]'])
+            self, strict=False, skips=[r'\[ *bb *skip *\]'])
         self.master = self.changeHook.master
         fake_headers = {'User-Agent': 'Buildbot'}
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
@@ -974,7 +975,7 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase):
     def setUp(self):
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = _prepare_github_change_hook(
-            strict=False, token=_token)
+            self, strict=False, token=_token)
         self.master = self.changeHook.master
         fake_headers = {'User-Agent': 'Buildbot',
                 'Authorization': 'token ' + _token}
@@ -1005,7 +1006,7 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         self.changeHook = _prepare_github_change_hook(
-            strict=False, github_api_endpoint='https://black.magic.io')
+            self, strict=False, github_api_endpoint='https://black.magic.io')
         self.master = self.changeHook.master
         fake_headers = {'User-Agent': 'Buildbot'}
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
@@ -1036,7 +1037,7 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase):
     def setUp(self):
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = _prepare_github_change_hook(
-            strict=False, github_api_endpoint='https://black.magic.io',
+            self, strict=False, github_api_endpoint='https://black.magic.io',
             token=_token)
         self.master = self.changeHook.master
         fake_headers = {'User-Agent': 'Buildbot',
@@ -1068,7 +1069,7 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
     _SECRET = 'somethingreallysecret'
 
     def setUp(self):
-        self.changeHook = _prepare_github_change_hook(strict=True,
+        self.changeHook = _prepare_github_change_hook(self, strict=True,
                                                       secret=self._SECRET)
 
     @defer.inlineCallbacks
@@ -1138,7 +1139,7 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
     @defer.inlineCallbacks
     def test_missing_secret(self):
         # override the value assigned in setUp
-        self.changeHook = _prepare_github_change_hook(strict=True)
+        self.changeHook = _prepare_github_change_hook(self, strict=True)
         self.request = _prepare_request(b'push', gitJsonPayload)
         yield self.request.test_render(self.changeHook)
         expected = b'Strict mode is requested while no secret is provided'
@@ -1168,7 +1169,7 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
 class TestChangeHookConfiguredWithCodebaseValue(unittest.TestCase):
 
     def setUp(self):
-        self.changeHook = _prepare_github_change_hook(codebase='foobar')
+        self.changeHook = _prepare_github_change_hook(self, codebase='foobar')
 
     @defer.inlineCallbacks
     def _check_git_with_change(self, payload):
@@ -1193,7 +1194,7 @@ class TestChangeHookConfiguredWithCodebaseFunction(unittest.TestCase):
 
     def setUp(self):
         self.changeHook = _prepare_github_change_hook(
-            codebase=_codebase_function)
+            self, codebase=_codebase_function)
 
     @defer.inlineCallbacks
     def _check_git_with_change(self, payload):
@@ -1219,7 +1220,7 @@ class TestChangeHookConfiguredWithCustomEventHandler(unittest.TestCase):
                 return [], None
 
         self.changeHook = _prepare_github_change_hook(
-            **{'class': CustomGitHubEventHandler})
+            self, **{'class': CustomGitHubEventHandler})
 
     @defer.inlineCallbacks
     def test_ping(self):

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -811,7 +811,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
     def setUp(self):
         self.changeHook = change_hook.ChangeHookResource(
-            dialects={'gitlab': True}, master=fakeMasterForHooks())
+            dialects={'gitlab': True}, master=fakeMasterForHooks(self))
 
     def check_changes_tag_event(self, r, project='', codebase=None):
         self.assertEqual(len(self.changeHook.master.addedChanges), 2)
@@ -1005,7 +1005,7 @@ class TestChangeHookConfiguredWithSecret(unittest.TestCase):
     def setUp(self):
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'gitlab': {'secret': self._SECRET}},
-            master=fakeMasterForHooks())
+            master=fakeMasterForHooks(self))
 
     @defer.inlineCallbacks
     def test_missing_secret(self):

--- a/master/buildbot/test/unit/test_www_hooks_gitorious.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitorious.py
@@ -69,7 +69,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def setUp(self):
         dialects = {'gitorious': True}
         self.changeHook = change_hook.ChangeHookResource(
-            dialects=dialects, master=fakeMasterForHooks())
+            dialects=dialects, master=fakeMasterForHooks(self))
 
     # Test 'base' hook with attributes. We should get a json string
     # representing a Change object as a dictionary. All values show be set.

--- a/master/buildbot/test/unit/test_www_service.py
+++ b/master/buildbot/test/unit/test_www_service.py
@@ -180,9 +180,9 @@ class Test(www.WwwTestMixin, unittest.TestCase):
         rsrc = self.svc.site.resource.getChildWithDefault(b'change_hook', mock.Mock())
         path = b'/change_hook/base'
         request = test_www_hooks_base._prepare_request({})
-        self.master.addChange = mock.Mock()
+        self.master.data.updates.addChange = mock.Mock()
         yield self.render_resource(rsrc, path, request=request)
-        self.master.addChange.assert_called()
+        self.master.data.updates.addChange.assert_called()
 
     @defer.inlineCallbacks
     def test_setupSiteWithHookAndAuth(self):

--- a/master/buildbot/www/change_hook.py
+++ b/master/buildbot/www/change_hook.py
@@ -171,5 +171,5 @@ class ChangeHookResource(resource.Resource):
     @defer.inlineCallbacks
     def submitChanges(self, changes, request, src):
         for chdict in changes:
-            change = yield self.master.addChange(src=src, **chdict)
-            log.msg("injected change %s" % change)
+            chid = yield self.master.data.updates.addChange(src=src, **chdict)
+            log.msg("injected change %s" % chid)

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -520,7 +520,7 @@ A custom change source must implement :class:`buildbot.interfaces.IChangeSource`
 The easiest way to do this is to subclass :class:`buildbot.changes.base.ChangeSource`, implementing the :meth:`describe` method to describe the instance.
 :class:`ChangeSource` is a Twisted service, so you will need to implement the :meth:`startService` and :meth:`stopService` methods to control the means by which your change source receives notifications.
 
-When the class does receive a change, it should call ``self.master.addChange(..)`` to submit it to the buildmaster.
+When the class does receive a change, it should call ``self.master.data.updates.addChange(..)`` to submit it to the buildmaster.
 This method shares the same parameters as ``master.db.changes.addChange``, so consult the API documentation for that function for details on the available arguments.
 
 You will probably also want to set ``compare_attrs`` to the list of object attributes which Buildbot will use to compare one change source to another when reconfiguring.


### PR DESCRIPTION
These methods have been deprecated since 0.9 and were scheduled for removal for 1.0.

1.0 has been out for a while now. Remove them and update change hooks and unit tests accordingly.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
