### PR TITLE
Allow building www plugins with yarn only

### DIFF
--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -205,10 +205,13 @@ class BuildJsCommand(distutils.cmd.Command):
             yarn_version = check_output("yarn --version")
             npm_version = check_output("npm -v")
             print("yarn:", yarn_version, "npm: ", npm_version)
-            npm_bin = check_output("npm bin").strip()
-            assert npm_version != "", "need nodejs and npm installed in current PATH"
-            assert LooseVersion(npm_version) >= LooseVersion(
-                "1.4"), "npm < 1.4 (%s)" % (npm_version)
+            if yarn_version != "":
+                npm_bin = check_output("yarn bin").strip()
+            else:
+                assert npm_version != "", "need nodejs and one of npm or yarn installed in current PATH"
+                assert LooseVersion(npm_version) >= LooseVersion(
+                    "1.4"), "npm < 1.4 (%s)" % (npm_version)
+                npm_bin = check_output("npm bin").strip()
 
             commands = []
 


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
