### PR TITLE
ec2: Don't require test runner to set dummy credentials in environment

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -142,13 +142,8 @@ script:
 
   - title: master and worker tests
     condition: TESTS == "trial"
-    # Current moto (1.3.7) requires dummy credentials to work
-    # https://github.com/spulec/moto/issues/1924
-    cmd: |
-      export AWS_SECRET_ACCESS_KEY=foobar_secret
-      export AWS_ACCESS_KEY_ID=foobar_key
-      trial  --reporter=text --rterrors buildbot.test buildbot_worker.test
- 
+    cmd: trial  --reporter=text --rterrors buildbot.test buildbot_worker.test
+
   - title: interop tests
     condition: TESTS == "interop"
     cmd: SANDBOXED_WORKER_PATH=/tmp/workerenv/bin/buildbot-worker coverage run --rcfile=.coveragerc $(which trial) --reporter=text --rterrors buildbot.test.integration.interop
@@ -160,10 +155,7 @@ script:
   # run tests under coverage for latest only (it's slower..)
   - title: coverage tests
     condition: TESTS == "coverage"
-    cmd: |
-      export AWS_SECRET_ACCESS_KEY=foobar_secret
-      export AWS_ACCESS_KEY_ID=foobar_key
-      coverage run --rcfile=.coveragerc $(which trial) --reporter=text --rterrors buildbot.test buildbot_worker.test
+    cmd: coverage run --rcfile=.coveragerc $(which trial) --reporter=text --rterrors buildbot.test buildbot_worker.test
 
   # Run additional tests in their separate job
   - title: pylint

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,6 @@ python:
   - "2.7"
 
 env:
-  global:
-    # Current moto (1.3.7) requires dummy credentials to work
-    # https://github.com/spulec/moto/issues/1924
-    - AWS_SECRET_ACCESS_KEY=foobar_secret
-    - AWS_ACCESS_KEY_ID=foobar_key
   matrix:
     # we now use travis only for real database testing
     # travis containers do have much more optimized db installations

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,6 @@
 # https://www.appveyor.com/docs
 
 environment:
-  # Current moto (1.3.7) requires dummy credentials to work
-  # https://github.com/spulec/moto/issues/1924
-  AWS_SECRET_ACCESS_KEY: foobar_secret
-  AWS_ACCESS_KEY_ID: foobar_key
-
   matrix:
     # For Python versions available on AppVeyor, see
     # http://www.appveyor.com/docs/installed-software#python

--- a/master/buildbot/test/unit/test_worker_ec2.py
+++ b/master/buildbot/test/unit/test_worker_ec2.py
@@ -41,6 +41,12 @@ if boto3 is not None:
     from buildbot.worker import ec2  # pylint: disable=ungrouped-imports
 
 
+# Current moto (1.3.7) requires dummy credentials to work
+# https://github.com/spulec/moto/issues/1924
+os.environ['AWS_SECRET_ACCESS_KEY'] = 'foobar_secret'
+os.environ['AWS_ACCESS_KEY_ID'] = 'foobar_key'
+
+
 # redefine the mock_ec2 decorator to skip the test if boto3 or moto
 # isn't installed
 def skip_ec2(f):


### PR DESCRIPTION
PR #4415 added an additional step required for running unit tests, namely requiring specific environment variables for unit tests. This PR sets them inside the tests themselves.