### PR TITLE
Fix changehooks to always provide when_timestamp as integer

### DIFF
--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -29,15 +29,7 @@ from buildbot.test.fake import fakemaster
 
 def fakeMasterForHooks(testcase):
     master = fakemaster.make_master(wantData=True, testcase=testcase)
-    master.addedChanges = []
     master.www = Mock()
-
-    def addChange(**kwargs):
-        if 'isdir' in kwargs or 'is_dir' in kwargs:
-            return defer.fail(AttributeError('isdir/is_dir is not accepted'))
-        master.addedChanges.append(kwargs)
-        return defer.succeed(Mock())
-    master.data.updates.addChange = addChange
     return master
 
 

--- a/master/buildbot/test/unit/test_www_hooks_bitbucket.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucket.py
@@ -17,8 +17,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import calendar
-
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial import unittest
 
@@ -158,14 +156,14 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        commit = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        commit = self.change_hook.master.data.updates.changesAdded[0]
 
         self.assertEqual(commit['files'], ['somefile.py'])
         self.assertEqual(
             commit['repository'], 'https://bitbucket.org/marcus/project-x/')
         self.assertEqual(
-            calendar.timegm(commit['when_timestamp'].utctimetuple()),
+            commit['when_timestamp'],
             1338350336
         )
         self.assertEqual(
@@ -194,7 +192,7 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 0)
         self.assertEqual(request.written, b'no change found')
 
     @inlineCallbacks
@@ -208,14 +206,14 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        commit = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        commit = self.change_hook.master.data.updates.changesAdded[0]
 
         self.assertEqual(commit['files'], ['somefile.py'])
         self.assertEqual(
             commit['repository'], 'https://bitbucket.org/marcus/project-x/')
         self.assertEqual(
-            calendar.timegm(commit['when_timestamp'].utctimetuple()),
+            commit['when_timestamp'],
             1338350336
         )
         self.assertEqual(
@@ -244,7 +242,7 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 0)
         self.assertEqual(request.written, b'no change found')
 
     @inlineCallbacks
@@ -254,7 +252,7 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
         request.method = b'POST'
 
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 0)
         self.assertEqual(request.written, b'Error processing changes.')
         request.setResponseCode.assert_called_with(
             500, b'Error processing changes.')
@@ -272,7 +270,7 @@ class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        commit = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        commit = self.change_hook.master.data.updates.changesAdded[0]
 
         self.assertEqual(commit['project'], 'project-name')

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketcloud.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketcloud.py
@@ -674,8 +674,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPush(change)
         self.assertEqual(change['branch'], 'refs/heads/branch_1496411680')
         self.assertEqual(change['category'], 'push')
@@ -712,8 +712,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPullRequest(change)
         self.assertEqual(change['branch'], 'refs/pull-requests/21/merge')
         self.assertEqual(change['category'], 'pull-created')
@@ -726,8 +726,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPullRequest(change)
         self.assertEqual(change['branch'], 'refs/pull-requests/21/merge')
         self.assertEqual(change['category'], 'pull-updated')
@@ -740,8 +740,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPullRequest(change)
         self.assertEqual(change['branch'], 'refs/heads/branch_1496411680')
         self.assertEqual(change['category'], 'pull-rejected')
@@ -754,8 +754,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPullRequest(change)
         self.assertEqual(change['branch'], 'refs/heads/master')
         self.assertEqual(change['category'], 'pull-fulfilled')
@@ -768,8 +768,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         request = _prepare_request(
             payloads[event_type], headers={_HEADER_EVENT: event_type})
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self.assertEqual(change['codebase'], expected_codebase)
 
     @defer.inlineCallbacks
@@ -805,7 +805,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         request = _prepare_request(
             pushJsonPayload, headers={_HEADER_EVENT: 'invented:event'})
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 0)
         self.assertEqual(request.written, b"Unknown event: invented_event")
 
     @defer.inlineCallbacks
@@ -813,8 +813,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         request = _prepare_request(
             newTagJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPush(change)
         self.assertEqual(change['branch'], 'refs/tags/1.0.0')
         self.assertEqual(change['category'], 'push')
@@ -824,8 +824,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         request = _prepare_request(
             deleteTagJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPush(change)
         self.assertEqual(change['branch'], 'refs/tags/1.0.0')
         self.assertEqual(change['category'], 'ref-deleted')
@@ -835,8 +835,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         request = _prepare_request(
             deleteBranchJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPush(change)
         self.assertEqual(change['branch'], 'refs/heads/branch_1496758965')
         self.assertEqual(change['category'], 'ref-deleted')
@@ -847,6 +847,6 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
             pushJsonPayload, headers={_HEADER_EVENT: b'repo:push'})
         request.received_headers[b'Content-Type'] = b'invalid/content'
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 0)
         self.assertEqual(request.written,
                          b"Unknown content type: invalid/content")

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
@@ -694,8 +694,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPush(change)
         self.assertEqual(change['branch'], 'refs/heads/branch_1496411680')
         self.assertEqual(change['category'], 'push')
@@ -732,8 +732,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPullRequest(change)
         self.assertEqual(change['branch'], 'refs/pull-requests/21/merge')
         self.assertEqual(change['category'], 'pull-created')
@@ -746,8 +746,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPullRequest(change)
         self.assertEqual(change['branch'], 'refs/pull-requests/21/merge')
         self.assertEqual(change['category'], 'pull-updated')
@@ -760,8 +760,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPullRequest(change)
         self.assertEqual(change['branch'], 'refs/heads/branch_1496411680')
         self.assertEqual(change['category'], 'pull-rejected')
@@ -774,8 +774,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
 
         yield request.test_render(self.change_hook)
 
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPullRequest(change)
         self.assertEqual(change['branch'], 'refs/heads/master')
         self.assertEqual(change['category'], 'pull-fulfilled')
@@ -788,8 +788,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         request = _prepare_request(
             payloads[event_type], headers={_HEADER_EVENT: event_type})
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self.assertEqual(change['codebase'], expected_codebase)
 
     @defer.inlineCallbacks
@@ -825,7 +825,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         request = _prepare_request(
             pushJsonPayload, headers={_HEADER_EVENT: 'invented:event'})
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 0)
         self.assertEqual(request.written, b"Unknown event: invented_event")
 
     @defer.inlineCallbacks
@@ -833,8 +833,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         request = _prepare_request(
             newTagJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPush(change)
         self.assertEqual(change['branch'], 'refs/tags/1.0.0')
         self.assertEqual(change['category'], 'push')
@@ -844,8 +844,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         request = _prepare_request(
             deleteTagJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPush(change)
         self.assertEqual(change['branch'], 'refs/tags/1.0.0')
         self.assertEqual(change['category'], 'ref-deleted')
@@ -855,8 +855,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         request = _prepare_request(
             deleteBranchJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 1)
-        change = self.change_hook.master.addedChanges[0]
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
         self._checkPush(change)
         self.assertEqual(change['branch'], 'refs/heads/branch_1496758965')
         self.assertEqual(change['category'], 'ref-deleted')
@@ -867,6 +867,6 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
             pushJsonPayload, headers={_HEADER_EVENT: b'repo:push'})
         request.received_headers[b'Content-Type'] = b'invalid/content'
         yield request.test_render(self.change_hook)
-        self.assertEqual(len(self.change_hook.master.addedChanges), 0)
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 0)
         self.assertEqual(request.written,
                          b"Unknown content type: invalid/content")

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 from future.utils import PY3
 
 import hmac
-from calendar import timegm
 from copy import deepcopy
 from hashlib import sha1
 from io import BytesIO
@@ -596,7 +595,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = _prepare_request(bad_event, gitJsonPayload)
         yield self.request.test_render(self.changeHook)
         expected = b'Unknown event: ' + bad_event
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertEqual(self.request.written, expected)
 
     @defer.inlineCallbacks
@@ -607,14 +606,14 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         })
         yield self.request.test_render(self.changeHook)
         expected = b'Unknown content type: '
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertIn(expected, self.request.written)
 
     @defer.inlineCallbacks
     def _check_ping(self, payload):
         self.request = _prepare_request(b'ping', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
 
     def test_ping_encoded(self):
         self._check_ping([b'{}'])
@@ -627,8 +626,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = _prepare_request(b'push', gitJsonPayloadTag)
         yield self.request.test_render(self.changeHook)
 
-        self.assertEqual(len(self.changeHook.master.addedChanges), 2)
-        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 2)
+        change = self.changeHook.master.data.updates.changesAdded[0]
         self.assertEqual(change["author"],
                          "Fred Flinstone <fred@flinstone.org>")
         self.assertEqual(change["branch"], "v1.0.0")
@@ -639,8 +638,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = _prepare_request(b'push', gitJsonPayloadCreateTag)
         yield self.request.test_render(self.changeHook)
 
-        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
-        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
+        change = self.changeHook.master.data.updates.changesAdded[0]
         self.assertEqual(change["author"],
                          "User <userid@example.com>")
         self.assertEqual(change["branch"], "v0.9.15.post1")
@@ -652,13 +651,13 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def _check_git_with_change(self, payload):
         self.request = _prepare_request(b'push', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 2)
-        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 2)
+        change = self.changeHook.master.data.updates.changesAdded[0]
 
         self.assertEqual(change['files'], ['filepath.rb'])
         self.assertEqual(change["repository"],
                          "http://github.com/defunkt/github")
-        self.assertEqual(timegm(change["when_timestamp"].utctimetuple()),
+        self.assertEqual(change["when_timestamp"],
                          1203116237)
         self.assertEqual(change["author"],
                          "Fred Flinstone <fred@flinstone.org>")
@@ -671,11 +670,11 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
                          "http://github.com/defunkt/github/commit/"
                          "41a212ee83ca127e3c8cf465891ab7216a705f59")
 
-        change = self.changeHook.master.addedChanges[1]
+        change = self.changeHook.master.data.updates.changesAdded[1]
         self.assertEqual(change['files'], ['modfile', 'removedFile'])
         self.assertEqual(change["repository"],
                          "http://github.com/defunkt/github")
-        self.assertEqual(timegm(change["when_timestamp"].utctimetuple()),
+        self.assertEqual(change["when_timestamp"],
                          1203114994)
         self.assertEqual(change["author"],
                          "Fred Flinstone <fred@flinstone.org>")
@@ -711,13 +710,13 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
                                                                         b'"distinct": false,')])
 
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 2)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 2)
 
-        change = self.changeHook.master.addedChanges[0]
+        change = self.changeHook.master.data.updates.changesAdded[0]
         self.assertEqual(change['files'], ['filepath.rb'])
         self.assertEqual(change["repository"],
                          "http://github.com/defunkt/github")
-        self.assertEqual(timegm(change["when_timestamp"].utctimetuple()),
+        self.assertEqual(change["when_timestamp"],
                          1203116237)
         self.assertEqual(change["author"],
                          "Fred Flinstone <fred@flinstone.org>")
@@ -732,11 +731,11 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(change["properties"]["github_distinct"],
                          False)
 
-        change = self.changeHook.master.addedChanges[1]
+        change = self.changeHook.master.data.updates.changesAdded[1]
         self.assertEqual(change['files'], ['modfile', 'removedFile'])
         self.assertEqual(change["repository"],
                          "http://github.com/defunkt/github")
-        self.assertEqual(timegm(change["when_timestamp"].utctimetuple()),
+        self.assertEqual(change["when_timestamp"],
                          1203114994)
         self.assertEqual(change["author"],
                          "Fred Flinstone <fred@flinstone.org>")
@@ -758,7 +757,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
             expected = b"Expecting value: line 1 column 1 (char 0)"
         else:
             expected = b"No JSON object could be decoded"
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertEqual(self.request.written, expected)
         self.request.setResponseCode.assert_called_with(400, expected)
 
@@ -767,7 +766,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = _prepare_request(b'push', payload)
         yield self.request.test_render(self.changeHook)
         expected = b"no change found"
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertEqual(self.request.written, expected)
 
     def test_git_with_no_changes_encoded(self):
@@ -781,7 +780,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request = _prepare_request(b'push', payload)
         yield self.request.test_render(self.changeHook)
         expected = b"no change found"
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertEqual(self.request.written, expected)
 
     def test_git_with_non_branch_changes_encoded(self):
@@ -794,11 +793,11 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def _check_git_with_pull(self, payload):
         self.request = _prepare_request('pull_request', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
-        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
+        change = self.changeHook.master.data.updates.changesAdded[0]
         self.assertEqual(change["repository"],
                          "https://github.com/defunkt/github")
-        self.assertEqual(timegm(change["when_timestamp"].utctimetuple()),
+        self.assertEqual(change["when_timestamp"],
                          1412899790)
         self.assertEqual(change["author"],
                          "defunkt")
@@ -827,7 +826,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def _check_git_push_with_skip_message(self, payload):
         self.request = _prepare_request(b'push', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
 
     def test_git_push_with_skip_message(self):
         gitJsonPayloadCiSkips = [
@@ -843,7 +842,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
     def _check_git_pull_request_with_skip_message(self, payload):
         self.request = _prepare_request(b'pull_request', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
 
     def test_git_pull_request_with_skip_message(self):
         api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
@@ -885,8 +884,8 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(unittest.TestCas
         self._http.expect('get', api_endpoint, content_json=gitJsonPayloadCommit)
         self.request = _prepare_request('pull_request', commit)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
-        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
+        change = self.changeHook.master.data.updates.changesAdded[0]
         self.assertEqual(change["branch"], "refs/pull/50/head")
 
 
@@ -911,7 +910,7 @@ class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase):
     def _check_push_with_skip_message(self, payload):
         self.request = _prepare_request(b'push', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
 
     def test_push_with_skip_message(self):
         gitJsonPayloadCiSkips = [
@@ -926,7 +925,7 @@ class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase):
     def _check_push_no_ci_skip(self, payload):
         self.request = _prepare_request(b'push', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 2)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 2)
 
     def test_push_no_ci_skip(self):
         # user overrode the skip pattern already,
@@ -939,7 +938,7 @@ class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase):
     def _check_pull_request_with_skip_message(self, payload):
         self.request = _prepare_request(b'pull_request', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
 
     def test_pull_request_with_skip_message(self):
         api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
@@ -958,7 +957,7 @@ class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase):
     def _check_pull_request_no_skip(self, payload):
         self.request = _prepare_request(b'pull_request', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request_no_skip(self):
         api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
@@ -992,7 +991,7 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase):
     def _check_pull_request(self, payload):
         self.request = _prepare_request(b'pull_request', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request(self):
         api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
@@ -1022,7 +1021,7 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase):
     def _check_pull_request(self, payload):
         self.request = _prepare_request(b'pull_request', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request(self):
         api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
@@ -1055,7 +1054,7 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase):
     def _check_pull_request(self, payload):
         self.request = _prepare_request(b'pull_request', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request(self):
         api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
@@ -1078,13 +1077,13 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
                                         _secret=self._SECRET)
         yield self.request.test_render(self.changeHook)
         # Can it somehow be merged w/ the same code above in a different class?
-        self.assertEqual(len(self.changeHook.master.addedChanges), 2)
-        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 2)
+        change = self.changeHook.master.data.updates.changesAdded[0]
 
         self.assertEqual(change['files'], ['filepath.rb'])
         self.assertEqual(change["repository"],
                          "http://github.com/defunkt/github")
-        self.assertEqual(timegm(change["when_timestamp"].utctimetuple()),
+        self.assertEqual(change["when_timestamp"],
                          1203116237)
         self.assertEqual(change["author"],
                          "Fred Flinstone <fred@flinstone.org>")
@@ -1097,11 +1096,11 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
                          "http://github.com/defunkt/github/commit/"
                          "41a212ee83ca127e3c8cf465891ab7216a705f59")
 
-        change = self.changeHook.master.addedChanges[1]
+        change = self.changeHook.master.data.updates.changesAdded[1]
         self.assertEqual(change['files'], ['modfile', 'removedFile'])
         self.assertEqual(change["repository"],
                          "http://github.com/defunkt/github")
-        self.assertEqual(timegm(change["when_timestamp"].utctimetuple()),
+        self.assertEqual(change["when_timestamp"],
                          1203114994)
         self.assertEqual(change["author"],
                          "Fred Flinstone <fred@flinstone.org>")
@@ -1122,7 +1121,7 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
         })
         yield self.request.test_render(self.changeHook)
         expected = b'Unknown hash type: ' + bad_hash_type
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertEqual(self.request.written, expected)
 
     @defer.inlineCallbacks
@@ -1133,7 +1132,7 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
         })
         yield self.request.test_render(self.changeHook)
         expected = b'Hash mismatch'
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertEqual(self.request.written, expected)
 
     @defer.inlineCallbacks
@@ -1143,7 +1142,7 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
         self.request = _prepare_request(b'push', gitJsonPayload)
         yield self.request.test_render(self.changeHook)
         expected = b'Strict mode is requested while no secret is provided'
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertEqual(self.request.written, expected)
 
     @defer.inlineCallbacks
@@ -1154,7 +1153,7 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
         })
         yield self.request.test_render(self.changeHook)
         expected = b'Wrong signature format: ' + bad_signature
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertEqual(self.request.written, expected)
 
     @defer.inlineCallbacks
@@ -1162,7 +1161,7 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
         self.request = _prepare_request(b'push', gitJsonPayload)
         yield self.request.test_render(self.changeHook)
         expected = b'Request has no required signature'
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertEqual(self.request.written, expected)
 
 
@@ -1175,8 +1174,8 @@ class TestChangeHookConfiguredWithCodebaseValue(unittest.TestCase):
     def _check_git_with_change(self, payload):
         self.request = _prepare_request(b'push', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 2)
-        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 2)
+        change = self.changeHook.master.data.updates.changesAdded[0]
         self.assertEqual(change['codebase'], 'foobar')
 
     def test_git_with_change_encoded(self):
@@ -1200,8 +1199,8 @@ class TestChangeHookConfiguredWithCodebaseFunction(unittest.TestCase):
     def _check_git_with_change(self, payload):
         self.request = _prepare_request(b'push', payload)
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 2)
-        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 2)
+        change = self.changeHook.master.data.updates.changesAdded[0]
         self.assertEqual(change['codebase'], 'foobar-github')
 
     def test_git_with_change_encoded(self):
@@ -1226,5 +1225,5 @@ class TestChangeHookConfiguredWithCustomEventHandler(unittest.TestCase):
     def test_ping(self):
         self.request = _prepare_request(b'ping', b'{}')
         yield self.request.test_render(self.changeHook)
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertTrue(self.changeHook.master.hook_called)

--- a/master/buildbot/test/unit/test_www_hooks_gitorious.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitorious.py
@@ -16,8 +16,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import calendar
-
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -81,15 +79,15 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.request.method = b"POST"
         yield self.request.test_render(self.changeHook)
 
-        self.assertEqual(len(self.changeHook.master.addedChanges), 1)
-        change = self.changeHook.master.addedChanges[0]
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
+        change = self.changeHook.master.data.updates.changesAdded[0]
 
         # Gitorious doesn't send changed files
         self.assertEqual(change['files'], [])
         self.assertEqual(change["repository"],
                          "http://gitorious.org/q/mainline")
         self.assertEqual(
-            calendar.timegm(change["when_timestamp"].utctimetuple()),
+            change["when_timestamp"],
             1326218547
         )
         self.assertEqual(change["author"], "jason <jason@nospam.org>")
@@ -110,7 +108,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         yield self.request.test_render(self.changeHook)
 
         expected = b"Error processing changes."
-        self.assertEqual(len(self.changeHook.master.addedChanges), 0)
+        self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 0)
         self.assertEqual(self.request.written, expected)
         self.request.setResponseCode.assert_called_with(500, expected)
         self.assertEqual(len(self.flushLoggedErrors()), 1)

--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -78,8 +78,8 @@ class BaseHookHandler(object):
         branch = firstOrNothing(args.get(b'branch'))
         category = firstOrNothing(args.get(b'category'))
         revlink = firstOrNothing(args.get(b'revlink'))
-        repository = firstOrNothing(args.get(b'repository'))
-        project = firstOrNothing(args.get(b'project'))
+        repository = firstOrNothing(args.get(b'repository')) or u''
+        project = firstOrNothing(args.get(b'project')) or u''
         codebase = firstOrNothing(args.get(b'codebase'))
 
         chdict = dict(author=author, files=files, comments=comments,


### PR DESCRIPTION
old addChange api used datetime in its API, now we use epoch integers.
This wasn't tested well, so we go back to fakedata for testing addChange parameters
