### PR TITLE
Bump minimum version of SQLAlchemy to 1.1.0

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -50,7 +50,7 @@ env:
   #- TWISTED=latest SQLALCHEMY=latest TESTS=trial 'BUILDBOT_TEST_DB_URL=postgresql+pg8000:///bbtest?user=buildbot&password=x'
 
   # Test different versions of SQLAlchemy
-  - TWISTED=16.1.0 SQLALCHEMY=0.8.0 TESTS=trial
+  - TWISTED=16.1.0 SQLALCHEMY=1.1.0 TESTS=trial
   - TWISTED=16.1.0 SQLALCHEMY=latest TESTS=trial
 
   # Tests for the worker on old versions of twisted.

--- a/master/buildbot/newsfragments/sqlalchemy-1.1.0.bugfix
+++ b/master/buildbot/newsfragments/sqlalchemy-1.1.0.bugfix
@@ -1,0 +1,1 @@
+SQLAlchemy 1.1.0 or higher is now required for Buildbot, in order to work with Python 3.5+.

--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -68,7 +68,7 @@ Jinja2: http://jinja.pocoo.org/
 
 SQLAlchemy: http://www.sqlalchemy.org/
 
-  Buildbot requires SQLAlchemy version 0.8.0 or higher.
+  Buildbot requires SQLAlchemy version 1.1.0 or higher.
   SQLAlchemy allows Buildbot to build database schemas and queries for a wide variety of database systems.
 
 SQLAlchemy-Migrate: https://sqlalchemy-migrate.readthedocs.io/en/latest/

--- a/master/setup.py
+++ b/master/setup.py
@@ -475,7 +475,7 @@ setup_args['install_requires'] = [
     'zope.interface >= 4.1.1',
     # python-future required for py2/3 compatibility
     'future',
-    'sqlalchemy>=0.8.0',
+    'sqlalchemy>=1.1.0',
     'sqlalchemy-migrate>=0.9',
     'python-dateutil>=1.5',
     'txaio ' + txaio_ver,


### PR DESCRIPTION
This pulls in StopIteration fixes for PEP 479,
which is needed for Python 3.5+.

This pulls in this fix from SQLAlchemy:
https://github.com/sqlalchemy/sqlalchemy/commit/6ab120558078bdcbfbe06d2ca55bd7a0d417bbb4

Without this fix, when running tests on Python 3.7, there are lots of PendingDeprecation warnings for StopIteration