### PR TITLE
patch_base64 should be unicode, patch_body should be bytes

### DIFF
--- a/master/buildbot/db/sourcestamps.py
+++ b/master/buildbot/db/sourcestamps.py
@@ -25,6 +25,7 @@ from twisted.internet import reactor
 from twisted.python import log
 
 from buildbot.db import base
+from buildbot.util import bytes2unicode
 from buildbot.util import epoch2datetime
 from buildbot.util import unicode2bytes
 
@@ -61,10 +62,11 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
             patchid = None
             if patch_body:
                 patch_body_bytes = unicode2bytes(patch_body)
+                patch_base64_bytes = base64.b64encode(patch_body_bytes)
                 ins = self.db.model.patches.insert()
                 r = conn.execute(ins, dict(
                     patchlevel=patch_level,
-                    patch_base64=base64.b64encode(patch_body_bytes),
+                    patch_base64=bytes2unicode(patch_base64_bytes),
                     patch_author=patch_author,
                     patch_comment=patch_comment,
                     subdir=patch_subdir))
@@ -166,8 +168,7 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
                 ssdict['patch_subdir'] = row.subdir
                 ssdict['patch_author'] = row.patch_author
                 ssdict['patch_comment'] = row.patch_comment
-                body = base64.b64decode(row.patch_base64)
-                ssdict['patch_body'] = body
+                ssdict['patch_body'] = base64.b64decode(row.patch_base64)
             else:
                 log.msg('patchid %d, referenced from ssid %d, not found'
                         % (patchid, ssid))

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -323,7 +323,7 @@ class Patch(Row):
     defaults = dict(
         id=None,
         patchlevel=0,
-        patch_base64='aGVsbG8sIHdvcmxk',  # 'hello, world',
+        patch_base64=u'aGVsbG8sIHdvcmxk',  # 'hello, world',
         patch_author=None,
         patch_comment=None,
         subdir=None,

--- a/master/buildbot/test/unit/test_data_sourcestamps.py
+++ b/master/buildbot/test/unit/test_data_sourcestamps.py
@@ -33,7 +33,7 @@ class SourceStampEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.setUpEndpoint()
         self.db.insertTestData([
             fakedb.SourceStamp(id=13, branch=u'oak'),
-            fakedb.Patch(id=99, patch_base64='aGVsbG8sIHdvcmxk',
+            fakedb.Patch(id=99, patch_base64=u'aGVsbG8sIHdvcmxk',
                          patch_author='bar', patch_comment='foo', subdir='/foo',
                          patchlevel=3),
             fakedb.SourceStamp(id=14, patchid=99, branch=u'poplar'),

--- a/master/buildbot/test/unit/test_db_sourcestamps.py
+++ b/master/buildbot/test/unit/test_db_sourcestamps.py
@@ -181,7 +181,7 @@ class Tests(interfaces.InterfaceTests):
     @defer.inlineCallbacks
     def test_getSourceStamp_patch(self):
         yield self.insertTestData([
-            fakedb.Patch(id=99, patch_base64='aGVsbG8sIHdvcmxk',
+            fakedb.Patch(id=99, patch_base64=u'aGVsbG8sIHdvcmxk',
                          patch_author='bar', patch_comment='foo', subdir='/foo',
                          patchlevel=3),
             fakedb.SourceStamp(id=234, patchid=99),
@@ -206,7 +206,7 @@ class Tests(interfaces.InterfaceTests):
     @defer.inlineCallbacks
     def test_getSourceStamps(self):
         yield self.insertTestData([
-            fakedb.Patch(id=99, patch_base64='aGVsbG8sIHdvcmxk',
+            fakedb.Patch(id=99, patch_base64=u'aGVsbG8sIHdvcmxk',
                          patch_author='bar', patch_comment='foo', subdir='/foo',
                          patchlevel=3),
             fakedb.SourceStamp(id=234, revision='r', project='p',

--- a/master/buildbot/test/unit/test_process_buildrequest.py
+++ b/master/buildbot/test/unit/test_process_buildrequest.py
@@ -160,7 +160,7 @@ class TestBuildRequestCollapser(unittest.TestCase):
                               )
         if patchid:
             rows.append(
-                fakedb.Patch(id=patchid, patch_base64='aGVsbG8sIHdvcmxk',
+                fakedb.Patch(id=patchid, patch_base64=u'aGVsbG8sIHdvcmxk',
                  patch_author='bar', patch_comment='foo', subdir='/foo',
                  patchlevel=3))
 

--- a/master/buildbot/test/unit/test_reporters_utils.py
+++ b/master/buildbot/test/unit/test_reporters_utils.py
@@ -64,7 +64,7 @@ class TestDataUtils(unittest.TestCase, logging.LoggingMixin):
             fakedb.Change(changeid=13, branch=u'trunk', revision=u'9283', author='me@foo',
                           repository=u'svn://...', codebase=u'cbsvn',
                           project=u'world-domination', sourcestampid=234),
-            fakedb.Patch(id=99, patch_base64='aGVsbG8sIHdvcmxk',
+            fakedb.Patch(id=99, patch_base64=u'aGVsbG8sIHdvcmxk',
                          patch_author='him@foo', patch_comment='foo', subdir='/foo',
                          patchlevel=3),
             fakedb.SourceStamp(id=235, patchid=99),

--- a/master/buildbot/test/util/notifier.py
+++ b/master/buildbot/test/util/notifier.py
@@ -47,7 +47,7 @@ class NotifierTestMixin(object):
                        num_lines=7),
             fakedb.LogChunk(logid=60, first_line=0, last_line=1, compressed=0,
                             content=u'Unicode log with non-ascii (\u00E5\u00E4\u00F6).'),
-            fakedb.Patch(id=99, patch_base64='aGVsbG8sIHdvcmxk',
+            fakedb.Patch(id=99, patch_base64=u'aGVsbG8sIHdvcmxk',
                          patch_author='him@foo', patch_comment='foo', subdir='/foo',
                          patchlevel=3),
         ])


### PR DESCRIPTION
This fixes Python 3.

`patch_base64` is of type `sa.Text` which is unicode: https://github.com/buildbot/buildbot/blob/master/master/buildbot/db/model.py#L426

`patch_body` is of type `types.Binary`: https://github.com/buildbot/buildbot/blob/master/master/buildbot/data/patches.py#L34

Some other notes:
`base64.b64decode()` can take an argument of `bytes` or `unicode` but always returns `bytes`
`base64.b64encode()` can only take an argument of `bytes`, and always returns `bytes`