### PR TITLE
re-enable global parameter "logMaxSize"

### DIFF
--- a/master/buildbot/newsfragments/logMaxSize.bugfix
+++ b/master/buildbot/newsfragments/logMaxSize.bugfix
@@ -1,0 +1,1 @@
+bugfix global parameter `logMaxSize` did no longer work


### PR DESCRIPTION
The global parameter "logMaxSize" seems to be defunctional for
quite a while (at least back to 1.1). It simply is ignored. This
can trigger out of memory conditions and buildbot aborts/system
hangs when build steps generate overly large log files.

This patch re-enables it. However, this patch does NOT re-enable
the "logMaxTailSize" global parameter, which is also defunctional.
This may be done by a later PR (my current understanding of Python
is too weak to do this reliable in a single shot).

Many thanks to @alorbach for helping with the implementation and
@tardyp for pointing me to the right spot.

closes https://github.com/buildbot/buildbot/issues/4504

I have not updated the unit tests, as they also seem desfunctional and I do not know how to make them work. I still think the PR is worth merging as it fixes a critical problem.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
