### PR TITLE
Remove unused code in eventGenerator

### DIFF
--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -243,8 +243,7 @@ class BuilderStatus(styles.Versioned):
                     return
 
     def eventGenerator(self, branches=None, categories=None, committers=None, projects=None, minTime=0):
-        if False:  # pylint: disable=using-constant-test
-            yield
+        """ Not implemented """
 
     def subscribe(self, receiver):
         # will get builderChangedState, buildStarted, buildFinished,


### PR DESCRIPTION
The code for eventGenerator was removed in https://github.com/buildbot/buildbot/commit/eab934713a952c26f7ea8d0b772f0c4bd5722af1 by @tomprince 

The yield statement is never hit, as revealed by codecov.