### PR TITLE
Replace range(len(foo)) with enumerate(foo).

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.builtins import range
 from future.moves.collections import UserList
 
 import copy
@@ -53,8 +52,7 @@ class ResourceType(object):
 
     def getEndpoints(self):
         endpoints = self.endpoints[:]
-        for i in range(len(endpoints)):
-            ep = endpoints[i]
+        for i, ep in enumerate(endpoints):
             if not issubclass(ep, Endpoint):
                 raise TypeError("Not an Endpoint subclass")
             endpoints[i] = ep(self, self.master)

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.builtins import range
 from future.utils import PY3
 from future.utils import iteritems
 
@@ -690,7 +689,7 @@ class Interpolate(util.ComparableMixin, object):
     @staticmethod
     def _splitBalancedParen(delim, arg):
         parenCount = 0
-        for i in range(0, len(arg)):
+        for i, val in enumerate(arg):
             if arg[i] == "(":
                 parenCount += 1
             if arg[i] == ")":

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -18,7 +18,6 @@ Push events to Gerrit
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.builtins import range
 from future.utils import iteritems
 
 import time
@@ -371,9 +370,9 @@ class GerritStatusPush(service.BuildbotService):
         if downloads is not None and downloaded is not None:
             downloaded = downloaded.split(" ")
             if downloads and 2 * len(downloads) == len(downloaded):
-                for i in range(0, len(downloads)):
+                for i, download in enumerate(downloads):
                     try:
-                        project, change1 = downloads[i].split(" ")
+                        project, change1 = download.split(" ")
                     except ValueError:
                         return  # something is wrong, abort
                     change2 = downloaded[2 * i]

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -17,7 +17,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from future.builtins import range
 from future.utils import PY3
 from future.utils import text_type
 
@@ -688,8 +687,8 @@ class Contact(service.AsyncService):
             # split props into name:value dict
             pdict = {}
             propertylist = props.split(",")
-            for i in range(0, len(propertylist)):
-                splitproperty = propertylist[i].split("=", 1)
+            for prop in propertylist:
+                splitproperty = prop.split("=", 1)
                 pdict[splitproperty[0]] = splitproperty[1]
 
             # set properties

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -16,7 +16,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from future.builtins import range
 
 import copy
 import errno
@@ -199,7 +198,7 @@ class SubcommandOptions(usage.Options):
                 optfile = self.optionsFile = self.loadOptionsFile()
                 # pylint: disable=not-an-iterable
                 for optfile_name, option_name in self.buildbotOptions:
-                    for i in range(len(op)):
+                    for i, val in enumerate(op):
                         if (op[i][0] == option_name and
                                 optfile_name in optfile):
                             op[i] = list(op[i])

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -22,7 +22,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from future.builtins import range
 
 import sys
 import textwrap
@@ -439,8 +438,8 @@ class TryOptions(base.SubcommandOptions):
         # We need to split the value of this option
         # into a dictionary of properties
         propertylist = option.split(",")
-        for i in range(0, len(propertylist)):
-            splitproperty = propertylist[i].split("=", 1)
+        for prop in propertylist:
+            splitproperty = prop.split("=", 1)
             self['properties'][splitproperty[0]] = splitproperty[1]
 
     def opt_property(self, option):
@@ -567,8 +566,8 @@ class UserOptions(base.SubcommandOptions):
             info_elem["identifier"] = info_list[0]
             self['info'].append(info_elem)
         else:
-            for i in range(0, len(info_list)):
-                split_info = info_list[i].split("=", 1)
+            for info_item in info_list:
+                split_info = info_item.split("=", 1)
 
                 # pull identifier from update --info
                 if ":" in split_info[0]:

--- a/master/buildbot/test/unit/test_data_logchunks.py
+++ b/master/buildbot/test/unit/test_data_logchunks.py
@@ -90,7 +90,7 @@ class LogChunkEndpointBase(endpoint.EndpointMixin, unittest.TestCase):
                          {'logid': logid, 'firstline': 0, 'content': expContent})
 
         # line-by-line
-        for i in range(len(expLines)):
+        for i, expLine in enumerate(expLines):
             logchunk = yield self.callGet(path,
                                           resultSpec=resultspec.ResultSpec(offset=i, limit=1))
             self.validateData(logchunk)

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.builtins import range
 
 import json
 import os
@@ -55,7 +54,7 @@ class FakeWampConnector(object):
         owntopic = self.topic.split(".")
         if len(topic) != len(owntopic):
             return False
-        for i in range(len(topic)):
+        for i, topic_item in enumerate(topic):
             if owntopic[i] != "" and topic[i] != owntopic[i]:
                 return False
         return True

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.builtins import range
 
 import warnings
 from distutils.version import LooseVersion
@@ -179,7 +178,7 @@ class TestGerritStatusPush(unittest.TestCase, ReporterTestMixin):
 
     def makeBuildInfo(self, buildResults, resultText, builds):
         info = []
-        for i in range(len(buildResults)):
+        for i, buildResult in enumerate(buildResults):
             info.append({'name': u"Builder%d" % i, 'result': buildResults[i],
                          'resultText': resultText[i], 'text': u'buildText',
                          'url': "http://localhost:8080/#builders/%d/builds/%d" % (79 + i, i),

--- a/master/buildbot/test/unit/test_steps_source_repo.py
+++ b/master/buildbot/test/unit/test_steps_source_repo.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.builtins import range
 
 from twisted.trial import unittest
 
@@ -136,8 +135,8 @@ class TestRepo(sourcesteps.SourceStepMixin, unittest.TestCase):
             self.ExpectShell(
                 command=['repo', 'manifest', '-r', '-o', 'manifest-original.xml'])
         ]
-        for i in range(len(commands)):
-            self.expectCommands(commands[i] + (which_fail == i and 1 or 0))
+        for i, command in enumerate(commands):
+            self.expectCommands(command + (which_fail == i and 1 or 0))
             if which_fail == i and breakatfail:
                 break
 

--- a/master/buildbot/test/unit/test_www_ldapuserinfo.py
+++ b/master/buildbot/test/unit/test_www_ldapuserinfo.py
@@ -16,7 +16,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from future.builtins import range
 
 import sys
 import types
@@ -83,7 +82,7 @@ class CommonTestCase(unittest.TestCase):
     def assertSearchCalledWith(self, exp):
         got = self.userInfoProvider.search.call_args_list
         self.assertEqual(len(exp), len(got))
-        for i in range(len(exp)):
+        for i, val in enumerate(exp):
             self.assertEqual(exp[i][0][0], got[i][0][1])
             self.assertEqual(exp[i][0][1], got[i][0][2])
             self.assertEqual(exp[i][0][2], got[i][1]['attributes'])


### PR DESCRIPTION
This eliminates some pylint warnings on Python 3.

This is a subset of the changes in #4470