### PR TITLE
Try to issue builds on lock release (case 4491)

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1096,6 +1096,7 @@ regexs
 registeradapter
 reid
 rejectedworkers
+releaselocks
 releasers
 remoteaddresses
 remotecommand
@@ -1444,6 +1445,7 @@ unabbreviated
 unambiguity
 unclaim
 unclaimedbrdicts
+unclosed
 unconfigure
 underpowered
 unencrypted
@@ -1559,6 +1561,7 @@ whitespace
 wiki
 wikipedia
 wildcard
+winerror
 wkdir
 workdir
 workdirs

--- a/master/buildbot/newsfragments/fix-buildrequests-waiting-for-locks-not-scheduled.bugfix
+++ b/master/buildbot/newsfragments/fix-buildrequests-waiting-for-locks-not-scheduled.bugfix
@@ -1,0 +1,1 @@
+Fix a regression since 1.6.0 which caused buildrequests waiting for a lock that got released by an unrelated build not be scheduled (:issue:`4491`)

--- a/master/buildbot/newsfragments/fix-buildrequests-waiting-for-locks-not-scheduled.bugfix
+++ b/master/buildbot/newsfragments/fix-buildrequests-waiting-for-locks-not-scheduled.bugfix
@@ -1,1 +1,1 @@
-Fix a regression since 1.6.0 which caused buildrequests waiting for a lock that got released by an unrelated build not be scheduled (:issue:`4491`)
+Fix a regression present in v1.7.0 which caused buildrequests waiting for a lock that got released by an unrelated build not be scheduled (:issue:`4491`)

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -27,7 +27,7 @@ class FakeBotMaster(service.AsyncMultiService):
         service.AsyncMultiService.__init__(self)
         self.setName("fake-botmaster")
         self.locks = {}
-        self.builders = {}
+        self.builders = {}  # dictionary mapping worker names to builders
         self.buildsStartedForWorkers = []
         self.delayShutdown = False
 
@@ -48,6 +48,9 @@ class FakeBotMaster(service.AsyncMultiService):
 
     def maybeStartBuildsForWorker(self, workername):
         self.buildsStartedForWorkers.append(workername)
+
+    def maybeStartBuildsForAllBuilders(self):
+        self.buildsStartedForWorkers += self.builders.keys()
 
     def workerLost(self, bot):
         pass

--- a/master/buildbot/test/fake/reactor.py
+++ b/master/buildbot/test/fake/reactor.py
@@ -120,6 +120,9 @@ class TestReactor(NonReactor, CoreReactor, Clock):
         Clock.__init__(self)
         CoreReactor.__init__(self)
 
+    def fireCurrentDelayedCalls(self):
+        self.advance(0)
+
     def stop(self):
         # first fire pending calls
         while self.getDelayedCalls():

--- a/master/buildbot/test/integration/test_locks.py
+++ b/master/buildbot/test/integration/test_locks.py
@@ -1,0 +1,149 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from twisted.internet import defer
+from twisted.python import log
+from twisted.python import threadpool
+from twisted.python.filepath import FilePath
+from twisted.trial.unittest import TestCase
+
+from buildbot.config import BuilderConfig
+from buildbot.plugins import util
+from buildbot.process.buildstep import BuildStep
+from buildbot.process.factory import BuildFactory
+from buildbot.process.results import SUCCESS
+from buildbot.test.fake.reactor import NonThreadPool
+from buildbot.test.fake.reactor import TestReactor
+from buildbot.test.fake.step import BuildStepController
+from buildbot.test.util.integration import getMaster
+from buildbot.util.eventual import _setReactor
+from buildbot.util.eventual import flushEventualQueue
+from buildbot.worker.local import LocalWorker
+
+
+class Tests(TestCase):
+
+    def setUp(self):
+        self.patch(threadpool, 'ThreadPool', NonThreadPool)
+        self.reactor = TestReactor()
+        self.addCleanup(self.reactor.stop)
+        _setReactor(self.reactor)
+        self.addCleanup(_setReactor, None)
+
+        # to ease debugging we display the error logs in the test log
+        origAddCompleteLog = BuildStep.addCompleteLog
+
+        def addCompleteLog(self, name, _log):
+            if name.endswith("err.text"):
+                log.msg("got error log!", name, _log)
+            return origAddCompleteLog(self, name, _log)
+        self.patch(BuildStep, "addCompleteLog", addCompleteLog)
+
+    def tearDown(self):
+        self.assertFalse(self.master.running, "master is still running!")
+
+    @defer.inlineCallbacks
+    def getMaster(self, config_dict):
+        self.master = master = yield getMaster(self, self.reactor, config_dict)
+        defer.returnValue(master)
+
+    def createLocalWorker(self, name):
+        workdir = FilePath(self.mktemp())
+        workdir.createDirectory()
+        return LocalWorker(name, workdir.path)
+
+    def createBuildrequest(self, master, builder_ids, properties=None):
+        # returns a Deferred
+
+        properties = properties.asDict() if properties is not None else None
+        return master.data.updates.addBuildset(
+            waited_for=False,
+            builderids=builder_ids,
+            sourcestamps=[
+                {'codebase': '',
+                 'repository': '',
+                 'branch': None,
+                 'revision': None,
+                 'project': ''},
+            ],
+            properties=properties,
+        )
+
+    @defer.inlineCallbacks
+    def test_builder_lock_release_wakes_builds_for_another_builder(self):
+        """
+        If a builder locks a master lock then the build request distributor
+        must retry running any buildrequests that might have been not scheduled
+        due to unavailability of that lock when the lock becomes available.
+        """
+
+        stepcontroller1 = BuildStepController()
+        stepcontroller2 = BuildStepController()
+
+        master_lock = util.MasterLock("lock1", maxCount=1)
+
+        config_dict = {
+            'builders': [
+                BuilderConfig(name='builder1',
+                              workernames=['worker1'],
+                              factory=BuildFactory([stepcontroller1.step]),
+                              locks=[master_lock.access('counting')]),
+                BuilderConfig(name='builder2',
+                              workernames=['worker2'],
+                              factory=BuildFactory([stepcontroller2.step]),
+                              locks=[master_lock.access('counting')]),
+            ],
+            'workers': [
+                self.createLocalWorker('worker1'),
+                self.createLocalWorker('worker2'),
+            ],
+            'protocols': {'null': {}},
+            'multiMaster': True,
+        }
+        master = yield self.getMaster(config_dict)
+        builder1_id = yield master.data.updates.findBuilderId('builder1')
+        builder2_id = yield master.data.updates.findBuilderId('builder2')
+
+        # start two builds and verify that a second build starts after the
+        # first is finished
+        yield self.createBuildrequest(master, [builder1_id])
+        yield self.createBuildrequest(master, [builder2_id])
+
+        builds = yield master.data.get(("builds",))
+        self.assertEqual(len(builds), 1)
+        self.assertEqual(builds[0]['results'], None)
+        self.assertEqual(builds[0]['builderid'], builder1_id)
+
+        stepcontroller1.finish_step(SUCCESS)
+
+        # execute Build.releaseLocks which is called eventually
+        yield flushEventualQueue()
+
+        builds = yield master.data.get(("builds",))
+        self.assertEqual(len(builds), 2)
+        self.assertEqual(builds[0]['results'], SUCCESS)
+        self.assertEqual(builds[1]['results'], None)
+        self.assertEqual(builds[1]['builderid'], builder2_id)
+
+        stepcontroller2.finish_step(SUCCESS)
+
+        builds = yield master.data.get(("builds",))
+        self.assertEqual(len(builds), 2)
+        self.assertEqual(builds[0]['results'], SUCCESS)
+        self.assertEqual(builds[1]['results'], SUCCESS)

--- a/master/buildbot/util/eventual.py
+++ b/master/buildbot/util/eventual.py
@@ -59,6 +59,14 @@ class _SimpleCallQueue(object):
                 o.callback(None)
 
     def flush(self):
+        if hasattr(self._reactor, 'fireCurrentDelayedCalls'):
+            # if _reactor is TestReactor then firing the delayed calls manually
+            # is the only way to invoke _turn, as the reactor won't do that on
+            # its own. In this case we execute all events synchronously.
+            while self._events:
+                self._reactor.fireCurrentDelayedCalls()
+            return defer.succeed(None)
+
         if not self._events and not self._in_turn:
             return defer.succeed(None)
         d = defer.Deferred()


### PR DESCRIPTION
Fixes bug #4491. The regression has been caused by changes in #4416. Before that PR we always started buildrequests even if they had unsatisfied locks. After the PR the BuildRequestDistributor started to check whether the build to be issued could satisfy the lock requirements. Unfortunately, we didn't notify BuildRequestDistributor about released locks in all cases, e.g. when build finishes we just notified it to run builders on the same worker. If a buildrequest uses completely unrelated builder, then it won't be scheduled.

This PR fixes this in a bit hacky way - we just inform the botmaster to recheck all builders for buildrequests to be scheduled whenever a build with locks finishes. That could be a performance problem for larger setups.

A better solution would be to track the locks that caused a buildrequest to be not scheduled and only recheck the buildrequest whenever that specific lock got released.

I plan to look into the performance of the BuildRequestDistributor in the case of a large number of pending build requests being present. Performance problems in this specific scenario is one of the reasons why Unity Technologies is moving away from buildbot. It's not the only setup experiencing problems as I remember more reports of that in the issues list.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] (n/a) I have updated the appropriate documentation
