### PR TITLE
docs: Mention that only buildmaster is dropping Python 2.7

### DIFF
--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -138,13 +138,17 @@ def py2Warning(config):
 
         Python 2 is going unmaintained as soon as 2020: https://pythonclock.org/
         To prepare for that transition, we recommend upgrading your buildmaster to run on Python 3.6 now!
-        Buildbot open source project is as well deprecating Python 2 for better maintainability.
+        Buildbot open source project is as well deprecating running buildmaster on Python 2 for better maintainability.
 
         Buildbot 2.0 going to be released in February 2019 will remove support for Python < 3.5
         https://github.com/buildbot/buildbot/issues/4439
 
         On most installations, switching to Python 3 can be accomplished by running the 2to3 tool over the master.cfg file.
         https://docs.python.org/3.7/library/2to3.html
+
+        Note that the above applies only for the buildmaster.
+        Workers will still support running under Python 2.7.
+        Additionally, the buildmaster still supports workers using old versions of Buildbot.
         """))
 
 

--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -101,7 +101,7 @@ blocdiag_transparency = True
 # add a loud note about python 2
 rst_prolog = textwrap.dedent("""\
 .. caution:: Buildbot is deprecating Python 2.7.
-    This is one of the latest release supporting it.
+    This is one of the last releases supporting it on the buildmaster.
     `More info <https://github.com/buildbot/buildbot/issues/4439>`_.
 
 """)


### PR DESCRIPTION
The current message does not always clarify that we're dropping Python 2.7 only for the master. This PR clarifies that.