### PR TITLE
Fix latent worker integration tests

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -199,6 +199,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService,
                                                      masterid=self.masterid)
             yield self.data.updates.expireMasters()
         self.masterHeartbeatService = internet.TimerService(60, heartbeat)
+        self.masterHeartbeatService.clock = self.reactor
         # we do setServiceParent only when the master is configured
         # master should advertise itself only at that time
 

--- a/master/buildbot/util/eventual.py
+++ b/master/buildbot/util/eventual.py
@@ -59,14 +59,6 @@ class _SimpleCallQueue(object):
                 o.callback(None)
 
     def flush(self):
-        if hasattr(self._reactor, 'fireCurrentDelayedCalls'):
-            # if _reactor is TestReactor then firing the delayed calls manually
-            # is the only way to invoke _turn, as the reactor won't do that on
-            # its own. In this case we execute all events synchronously.
-            while self._events:
-                self._reactor.fireCurrentDelayedCalls()
-            return defer.succeed(None)
-
         if not self._events and not self._in_turn:
             return defer.succeed(None)
         d = defer.Deferred()


### PR DESCRIPTION
Looks like some latent worker integration tests returned a Deferred. Since they derived the `SynchronousTestCase` test case class, that meant that any assertion errors got silently ignored.

This PR fixes this by expanding TestReactor to support `callLater(0, ...)` and not lead to deadlocks in tests even if the reactor is not manually kicked for iteration. Additionally, the latent worker integration tests were fixed to not return a Deferred.

The changes to the reactor undo the changes in #4525.

## Contributor Checklist:

* [x] I have updated the unit tests
