### PR TITLE
Remove Python 3.4 support from the buildbot master

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -69,8 +69,6 @@ matrix:
       env: TWISTED=latest SQLALCHEMY=latest TESTS=pylint HYPER_SIZE=m3
     - python: "3.6"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=docs
-    - python: "3.4"
-      env: TWISTED=latest SQLALCHEMY=latest TESTS=trial
 
     - python: "3.5"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=coverage

--- a/master/buildbot/newsfragments/python-3.4.removal
+++ b/master/buildbot/newsfragments/python-3.4.removal
@@ -1,0 +1,1 @@
+The ``buildbot`` packages now requires Python 3.5+ -- Python 3.4 is no longer supported.

--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -12,8 +12,8 @@ At a bare minimum, you'll need the following for both the buildmaster and a work
 
 Python: https://www.python.org
 
-  Buildbot master works with Python 2.7 or Python-3.4+.
-  Buildbot worker works with Python 2.7, or Python 3.4+.
+  Buildbot master works with Python 2.7 or Python-3.5+.
+  Buildbot worker works with Python 2.7, or Python 3.5+.
 
   .. note::
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -158,7 +158,6 @@ setup_args = {
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6'
     ],
@@ -438,8 +437,10 @@ if sys.platform == "win32":
 
 py_27 = sys.version_info[0] > 2 or (
     sys.version_info[0] == 2 and sys.version_info[1] >= 7)
-if not py_27:
-    raise RuntimeError("Buildbot master requires at least Python-2.7")
+py_35 = sys.version_info[0] > 3 or (
+    sys.version_info[0] == 3 and sys.version_info[1] >= 5)
+if not py_27 and not py_35:
+    raise RuntimeError("Buildbot master requires at least Python-2.7 or Python-3.5+")
 
 # pip<1.4 doesn't have the --pre flag, and will thus attempt to install alpha
 # and beta versions of Buildbot.  Prevent that from happening.


### PR DESCRIPTION
Fixes https://github.com/buildbot/buildbot/issues/4535

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
