### PR TITLE
Don't start builds on incompatible latent worker instances

### DIFF
--- a/master/buildbot/newsfragments/latent-worker-build-compatibility.bugfix
+++ b/master/buildbot/newsfragments/latent-worker-build-compatibility.bugfix
@@ -1,0 +1,1 @@
+Don't run builds that request an instance with incompatible properties on Docker, Marathon and OpenStack latent workers.

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -123,3 +123,14 @@ class FakeBuild(properties.PropertiesMixin):
 components.registerAdapter(
     lambda build: build.build_status.properties,
     FakeBuild, interfaces.IProperties)
+
+
+class FakeBuildForRendering(object):
+    def render(self, r):
+        if isinstance(r, str):
+            return "rendered:" + r
+        if isinstance(r, list):
+            return list(self.render(i) for i in r)
+        if isinstance(r, tuple):
+            return tuple(self.render(i) for i in r)
+        return r

--- a/master/buildbot/test/unit/test_worker_marathon.py
+++ b/master/buildbot/test/unit/test_worker_marathon.py
@@ -20,18 +20,12 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.properties import Properties
+from buildbot.test.fake import fakebuild
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake.reactor import TestReactor
 from buildbot.util.eventual import _setReactor
 from buildbot.worker.marathon import MarathonLatentWorker
-
-
-class FakeBuild(object):
-    def render(self, r):
-        if isinstance(r, str):
-            return "rendered:" + r
-        return r
 
 
 class FakeBot(object):
@@ -119,7 +113,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
             },
             code=201,
             content_json={'Id': 'id'})
-        d = worker.substantiate(None, FakeBuild())
+        d = worker.substantiate(None, fakebuild.FakeBuildForRendering())
         # we simulate a connection
         worker.attached(FakeBot())
         self.successResultOf(d)
@@ -157,7 +151,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
             code=201,
             content_json={'Id': 'id'})
 
-        worker.substantiate(None, FakeBuild())
+        worker.substantiate(None, fakebuild.FakeBuildForRendering())
         self.assertEqual(worker.instance, {'Id': 'id'})
         # teardown makes sure all containers are cleaned up
 
@@ -191,7 +185,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
         self._http.expect(
             method='delete',
             ep='/v2/apps/buildbot-worker/buildbot-bot-masterhash')
-        d = worker.substantiate(None, FakeBuild())
+        d = worker.substantiate(None, fakebuild.FakeBuildForRendering())
         self.reactor.advance(.1)
         self.failureResultOf(d)
         self.assertEqual(worker.instance, None)
@@ -237,7 +231,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
             },
             code=201,
             content_json={'Id': 'id'})
-        d = worker.substantiate(None, FakeBuild())
+        d = worker.substantiate(None, fakebuild.FakeBuildForRendering())
         # we simulate a connection
         worker.attached(FakeBot())
         self.successResultOf(d)

--- a/master/buildbot/util/latent.py
+++ b/master/buildbot/util/latent.py
@@ -1,0 +1,53 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import copy
+
+from twisted.internet import defer
+
+
+class CompatibleLatentWorkerMixin:
+
+    builds_may_be_incompatible = True
+    _actual_build_props = None
+
+    def renderWorkerProps(self, build):
+        # Deriving classes should implement this method to render and return
+        # a Deferred that will have all properties that are needed to start a
+        # worker as its result. The Deferred should result in data that can
+        # be copied via copy.deepcopy
+        #
+        # During actual startup, renderWorkerPropsOnStart should be called
+        # which will invoke renderWorkerProps, store a copy of the results for
+        # later comparison and return them.
+        raise NotImplementedError()
+
+    @defer.inlineCallbacks
+    def renderWorkerPropsOnStart(self, build):
+        props = yield self.renderWorkerProps(build)
+        self._actual_build_props = copy.deepcopy(props)
+        defer.returnValue(props)
+
+    @defer.inlineCallbacks
+    def isCompatibleWithBuild(self, build):
+        if self._actual_build_props is None:
+            defer.returnValue(True)
+
+        requested_props = yield self.renderWorkerProps(build)
+
+        defer.returnValue(requested_props == self._actual_build_props)


### PR DESCRIPTION
This PR fixes a bug that caused builds to be started on worker instances with incompatible properties when there's no free latent worker. A similar bug has already been fixed for hyper; this PR fixes openstack, marathon and docker backends.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] (n/a) I have updated the appropriate documentation
