### PR TITLE
db: fix foreign key constraints for "nullable" columns

### DIFF
--- a/master/buildbot/db/migrate/versions/052_cascading_set_null.py
+++ b/master/buildbot/db/migrate/versions/052_cascading_set_null.py
@@ -1,0 +1,95 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+from future.utils import iteritems
+
+import sqlalchemy as sa
+from migrate.changeset.constraint import ForeignKeyConstraint
+from migrate.exceptions import NotSupportedError
+
+from buildbot.util import sautils
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+
+    table_names = set(TABLES_FKEYS_SET_NULL.keys())
+    table_names.update(TABLES_COLUMNS_NOT_NULL.keys())
+
+    tables = {}
+    for t in table_names:
+        tables[t] = sautils.Table(t, metadata, autoload=True)
+
+    fks_to_change = []
+    # We need to parse the reflected model in order to find the automatic
+    # fk name that was put.
+    # Mysql and postgres have different naming convention so this is not very
+    # easy to have generic code working.
+    for t, keys in iteritems(TABLES_FKEYS_SET_NULL):
+        table = tables[t]
+        for fk in table.constraints:
+            if not isinstance(fk, sa.ForeignKeyConstraint):
+                continue
+            for c in fk.elements:
+                if str(c.column) in keys:
+                    # migrate.xx.ForeignKeyConstraint is changing the model
+                    # so initializing here would break the iteration
+                    # (Set changed size during iteration)
+                    fks_to_change.append((
+                        table, (fk.columns, [c.column]),
+                        dict(name=fk.name, ondelete='SET NULL')))
+
+    for table, args, kwargs in fks_to_change:
+        fk = ForeignKeyConstraint(*args, **kwargs)
+        table.append_constraint(fk)
+        try:
+            fk.drop()
+        except NotSupportedError:
+            # some versions of sqlite do not support drop,
+            # but will still update the fk
+            pass
+        fk.create()
+
+    for t, cols in iteritems(TABLES_COLUMNS_NOT_NULL):
+        table = tables[t]
+        if table.dialect_options.get('mysql', {}).get('engine') == 'InnoDB':
+            migrate_engine.execute('SET FOREIGN_KEY_CHECKS = 0;')
+        try:
+            for c in table.columns:
+                if c.name in cols:
+                    c.alter(nullable=False)
+        finally:
+            if table.dialect_options.get('mysql', {}).get('engine') == 'InnoDB':
+                migrate_engine.execute('SET FOREIGN_KEY_CHECKS = 1;')
+
+
+TABLES_FKEYS_SET_NULL = {
+    'builds': ['workers.id'],
+    'buildsets': ['parent_buildid'],
+    'changes': ['changes.changeid'],
+}
+
+TABLES_COLUMNS_NOT_NULL = {
+    'buildrequest_claims': ['masterid'],
+    'builds': ['builderid'],
+    'changes': ['sourcestampid'],
+    'logchunks': ['logid'],
+    'logs': ['stepid'],
+    'scheduler_changes': ['schedulerid', 'changeid'],
+    'steps': ['buildid'],
+}

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -112,7 +112,7 @@ class Model(base.DBConnectorComponent):
                   nullable=False),
         sa.Column('masterid', sa.Integer,
                   sa.ForeignKey('masters.id', ondelete='CASCADE'),
-                  index=True, nullable=True),
+                  index=True, nullable=False),
         sa.Column('claimed_at', sa.Integer, nullable=False),
     )
 
@@ -136,7 +136,8 @@ class Model(base.DBConnectorComponent):
         sa.Column('id', sa.Integer, primary_key=True),
         sa.Column('number', sa.Integer, nullable=False),
         sa.Column('builderid', sa.Integer,
-                  sa.ForeignKey('builders.id', ondelete='CASCADE')),
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                  nullable=False),
         # note that there is 1:N relationship here.
         # In case of worker loss, build has results RETRY
         # and buildrequest is unclaimed.
@@ -150,7 +151,8 @@ class Model(base.DBConnectorComponent):
         # worker which performed this build
         # keep nullable to support worker-free builds
         sa.Column('workerid', sa.Integer,
-                  sa.ForeignKey('workers.id', ondelete='CASCADE')),
+                  sa.ForeignKey('workers.id', ondelete='SET NULL'),
+                  nullable=True),
         # master which controlled this build
         sa.Column('masterid', sa.Integer,
                   sa.ForeignKey('masters.id', ondelete='CASCADE'),
@@ -170,7 +172,8 @@ class Model(base.DBConnectorComponent):
         sa.Column('number', sa.Integer, nullable=False),
         sa.Column('name', sa.String(50), nullable=False),
         sa.Column('buildid', sa.Integer,
-                  sa.ForeignKey('builds.id', ondelete='CASCADE')),
+                  sa.ForeignKey('builds.id', ondelete='CASCADE'),
+                  nullable=False),
         sa.Column('started_at', sa.Integer),
         sa.Column('complete_at', sa.Integer),
         sa.Column('state_string', sa.Text, nullable=False),
@@ -188,7 +191,8 @@ class Model(base.DBConnectorComponent):
         sa.Column('name', sa.Text, nullable=False),
         sa.Column('slug', sa.String(50), nullable=False),
         sa.Column('stepid', sa.Integer,
-                  sa.ForeignKey('steps.id', ondelete='CASCADE')),
+                  sa.ForeignKey('steps.id', ondelete='CASCADE'),
+                  nullable=False),
         sa.Column('complete', sa.SmallInteger, nullable=False),
         sa.Column('num_lines', sa.Integer, nullable=False),
         # 's' = stdio, 't' = text, 'h' = html, 'd' = deleted
@@ -198,7 +202,8 @@ class Model(base.DBConnectorComponent):
     logchunks = sautils.Table(
         'logchunks', metadata,
         sa.Column('logid', sa.Integer,
-                  sa.ForeignKey('logs.id', ondelete='CASCADE')),
+                  sa.ForeignKey('logs.id', ondelete='CASCADE'),
+                  nullable=False),
         # 0-based line number range in this chunk (inclusive); note that for
         # HTML logs, this counts lines of HTML, not lines of rendered output
         sa.Column('first_line', sa.Integer, nullable=False),
@@ -249,7 +254,8 @@ class Model(base.DBConnectorComponent):
         # http://docs.sqlalchemy.org/en/latest/orm/relationships.html#rows-that-point-to-themselves-mutually-dependent-rows
         sa.Column('parent_buildid', sa.Integer,
                   sa.ForeignKey('builds.id', use_alter=True,
-                                name='parent_buildid', ondelete='CASCADE')),
+                                name='parent_buildid', ondelete='SET NULL'),
+                  nullable=True),
         # text describing what is the relationship with the build
         # could be 'triggered from', 'rebuilt from', 'inherited from'
         sa.Column('parent_relationship', sa.Text),
@@ -401,14 +407,15 @@ class Model(base.DBConnectorComponent):
 
         # the sourcestamp this change brought the codebase to
         sa.Column('sourcestampid', sa.Integer,
-                  sa.ForeignKey('sourcestamps.id', ondelete='CASCADE')),
+                  sa.ForeignKey('sourcestamps.id', ondelete='CASCADE'),
+                  nullable=False),
 
         # The parent of the change
         # Even if for the moment there's only 1 parent for a change, we use plural here because
         # somedays a change will have multiple parent. This way we don't need
         # to change the API
         sa.Column('parent_changeids', sa.Integer,
-                  sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                  sa.ForeignKey('changes.changeid', ondelete='SET NULL'),
                   nullable=True),
     )
 
@@ -456,7 +463,8 @@ class Model(base.DBConnectorComponent):
 
         # the patch to apply to generate this source code
         sa.Column('patchid', sa.Integer,
-                  sa.ForeignKey('patches.id', ondelete='CASCADE')),
+                  sa.ForeignKey('patches.id', ondelete='CASCADE'),
+                  nullable=True),
 
         # the repository from which this source should be checked out
         sa.Column('repository', sa.String(length=512), nullable=False,
@@ -528,9 +536,11 @@ class Model(base.DBConnectorComponent):
     scheduler_changes = sautils.Table(
         'scheduler_changes', metadata,
         sa.Column('schedulerid', sa.Integer,
-                  sa.ForeignKey('schedulers.id', ondelete='CASCADE')),
+                  sa.ForeignKey('schedulers.id', ondelete='CASCADE'),
+                  nullable=False),
         sa.Column('changeid', sa.Integer,
-                  sa.ForeignKey('changes.changeid', ondelete='CASCADE')),
+                  sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                  nullable=False),
         # true (nonzero) if this change is important to this scheduler
         sa.Column('important', sa.Integer),
     )

--- a/master/buildbot/newsfragments/master-db-integrity.bugfix
+++ b/master/buildbot/newsfragments/master-db-integrity.bugfix
@@ -1,0 +1,1 @@
+Various database integrity problems were fixed. Most notably, it is now possible to delete old changes without wiping all "child" changes in cascade.

--- a/master/buildbot/test/unit/test_db_migrate_versions_052_cascading_set_null.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_052_cascading_set_null.py
@@ -1,0 +1,498 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+import sqlalchemy.exc as saexc
+
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_and_insert_data(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        # create tables (prior to schema migration)
+        masters = sautils.Table(
+            "masters", metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        masters.create()
+
+        users = sautils.Table(
+            "users", metadata,
+            sa.Column("uid", sa.Integer, primary_key=True),
+        )
+        users.create()
+
+        workers = sautils.Table(
+            "workers", metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        workers.create()
+
+        sourcestamps = sautils.Table(
+            'sourcestamps', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        sourcestamps.create()
+
+        schedulers = sautils.Table(
+            'schedulers', metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        schedulers.create()
+
+        buildsets = sautils.Table(
+            'buildsets', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        buildsets.create()
+
+        builders = sautils.Table(
+            'builders', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        builders.create()
+
+        tags = sautils.Table(
+            'tags', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+        )
+        tags.create()
+
+        changesources = sautils.Table(
+            'changesources', metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        changesources.create()
+
+        buildrequests = sautils.Table(
+            'buildrequests', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('buildsetid', sa.Integer,
+                      sa.ForeignKey("buildsets.id", ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('builderid', sa.Integer,
+                      sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                      nullable=False),
+        )
+        buildrequests.create()
+
+        builds = sautils.Table(
+            'builds', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('builderid', sa.Integer,
+                      sa.ForeignKey('builders.id', ondelete='CASCADE')),
+            sa.Column('buildrequestid', sa.Integer,
+                      sa.ForeignKey(
+                          'buildrequests.id', use_alter=True,
+                          name='buildrequestid', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('workerid', sa.Integer,
+                      sa.ForeignKey('workers.id', ondelete='CASCADE')),
+            sa.Column('masterid', sa.Integer,
+                      sa.ForeignKey('masters.id', ondelete='CASCADE'),
+                      nullable=False),
+        )
+        builds.create()
+
+        buildrequest_claims = sautils.Table(
+            'buildrequest_claims', metadata,
+            sa.Column('brid', sa.Integer,
+                      sa.ForeignKey('buildrequests.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('masterid', sa.Integer,
+                      sa.ForeignKey('masters.id', ondelete='CASCADE'),
+                      index=True, nullable=True),
+        )
+        buildrequest_claims.create()
+
+        build_properties = sautils.Table(
+            'build_properties', metadata,
+            sa.Column('buildid', sa.Integer,
+                      sa.ForeignKey('builds.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('name', sa.String(256), nullable=False),
+        )
+        build_properties.create()
+
+        steps = sautils.Table(
+            'steps', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('buildid', sa.Integer,
+                      sa.ForeignKey('builds.id', ondelete='CASCADE')),
+        )
+        steps.create()
+
+        logs = sautils.Table(
+            'logs', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('stepid', sa.Integer,
+                      sa.ForeignKey('steps.id', ondelete='CASCADE')),
+        )
+        logs.create()
+
+        logchunks = sautils.Table(
+            'logchunks', metadata,
+            sa.Column('logid', sa.Integer,
+                      sa.ForeignKey('logs.id', ondelete='CASCADE')),
+            sa.Column('first_line', sa.Integer, nullable=False),
+            sa.Column('last_line', sa.Integer, nullable=False),
+        )
+        logchunks.create()
+
+        buildset_properties = sautils.Table(
+            'buildset_properties', metadata,
+            sa.Column('buildsetid', sa.Integer,
+                      sa.ForeignKey('buildsets.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('property_name', sa.String(256), nullable=False),
+        )
+        buildset_properties.create()
+
+        changesource_masters = sautils.Table(
+            'changesource_masters', metadata,
+            sa.Column('changesourceid', sa.Integer,
+                      sa.ForeignKey('changesources.id', ondelete='CASCADE'),
+                      nullable=False, primary_key=True),
+            sa.Column('masterid', sa.Integer,
+                      sa.ForeignKey('masters.id', ondelete='CASCADE'),
+                      nullable=False),
+        )
+        changesource_masters.create()
+
+        buildset_sourcestamps = sautils.Table(
+            'buildset_sourcestamps', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('buildsetid', sa.Integer,
+                      sa.ForeignKey('buildsets.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('sourcestampid', sa.Integer,
+                      sa.ForeignKey('sourcestamps.id', ondelete='CASCADE'),
+                      nullable=False),
+        )
+        buildset_sourcestamps.create()
+
+        connected_workers = sautils.Table(
+            'connected_workers', metadata,
+            sa.Column('id', sa.Integer, primary_key=True, nullable=False),
+            sa.Column('masterid', sa.Integer,
+                      sa.ForeignKey('masters.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('workerid', sa.Integer,
+                      sa.ForeignKey('workers.id', ondelete='CASCADE'),
+                      nullable=False),
+        )
+        connected_workers.create()
+
+        changes = sautils.Table(
+            'changes', metadata,
+            sa.Column('changeid', sa.Integer, primary_key=True),
+            sa.Column('sourcestampid', sa.Integer,
+                      sa.ForeignKey('sourcestamps.id', ondelete='CASCADE')),
+            sa.Column('parent_changeids', sa.Integer,
+                      sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                      nullable=True),
+        )
+        changes.create()
+
+        change_files = sautils.Table(
+            'change_files', metadata,
+            sa.Column('changeid', sa.Integer,
+                      sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('filename', sa.String(1024), nullable=False),
+        )
+        change_files.create()
+
+        change_properties = sautils.Table(
+            'change_properties', metadata,
+            sa.Column('changeid', sa.Integer,
+                      sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('property_name', sa.String(256), nullable=False),
+        )
+        change_properties.create()
+
+        change_users = sautils.Table(
+            "change_users", metadata,
+            sa.Column("changeid", sa.Integer,
+                      sa.ForeignKey('changes.changeid', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column("uid", sa.Integer,
+                      sa.ForeignKey('users.uid', ondelete='CASCADE'),
+                      nullable=False),
+        )
+        change_users.create()
+
+        scheduler_masters = sautils.Table(
+            'scheduler_masters', metadata,
+            sa.Column('schedulerid', sa.Integer,
+                      sa.ForeignKey('schedulers.id', ondelete='CASCADE'),
+                      nullable=False, primary_key=True),
+            sa.Column('masterid', sa.Integer,
+                      sa.ForeignKey('masters.id', ondelete='CASCADE'),
+                      nullable=False),
+        )
+        scheduler_masters.create()
+
+        scheduler_changes = sautils.Table(
+            'scheduler_changes', metadata,
+            sa.Column('schedulerid', sa.Integer,
+                      sa.ForeignKey('schedulers.id', ondelete='CASCADE')),
+            sa.Column('changeid', sa.Integer,
+                      sa.ForeignKey('changes.changeid', ondelete='CASCADE')),
+        )
+        scheduler_changes.create()
+
+        builders_tags = sautils.Table(
+            'builders_tags', metadata,
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('builderid', sa.Integer,
+                      sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column('tagid', sa.Integer,
+                      sa.ForeignKey('tags.id', ondelete='CASCADE'),
+                      nullable=False),
+        )
+        builders_tags.create()
+
+        objects = sautils.Table(
+            "objects", metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+        )
+        objects.create()
+
+        object_state = sautils.Table(
+            "object_state", metadata,
+            sa.Column("objectid", sa.Integer,
+                      sa.ForeignKey('objects.id', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=False),
+        )
+        object_state.create()
+
+        users_info = sautils.Table(
+            "users_info", metadata,
+            sa.Column("uid", sa.Integer,
+                      sa.ForeignKey('users.uid', ondelete='CASCADE'),
+                      nullable=False),
+            sa.Column("attr_type", sa.String(128), nullable=False),
+        )
+        users_info.create()
+
+        # insert data
+        conn.execute(masters.insert(), [
+            dict(id=1),
+        ])
+        conn.execute(objects.insert(), [
+            dict(id=1),
+        ])
+        conn.execute(object_state.insert(), [
+            dict(objectid=1, name='size'),
+        ])
+        conn.execute(users.insert(), [
+            dict(uid=1),
+            dict(uid=2),
+        ])
+        conn.execute(users_info.insert(), [
+            dict(uid=1, attr_type='first_name'),
+            dict(uid=1, attr_type='last_name'),
+            dict(uid=2, attr_type='first_name'),
+            dict(uid=2, attr_type='last_name'),
+        ])
+        conn.execute(builders.insert(), [
+            dict(id=1),
+            dict(id=2),
+        ])
+        conn.execute(tags.insert(), [
+            dict(id=1),
+            dict(id=2),
+        ])
+        conn.execute(builders_tags.insert(), [
+            dict(id=1, builderid=1, tagid=1),
+            dict(id=2, builderid=2, tagid=1),
+            dict(id=3, builderid=2, tagid=2),
+        ])
+        conn.execute(workers.insert(), [
+            dict(id=1),
+            dict(id=2),
+        ])
+        conn.execute(connected_workers.insert(), [
+            dict(id=1, masterid=1, workerid=1),
+            dict(id=2, masterid=1, workerid=2),
+        ])
+        conn.execute(changesources.insert(), [
+            dict(id=1),
+        ])
+        conn.execute(changesource_masters.insert(), [
+            dict(changesourceid=1, masterid=1),
+        ])
+        conn.execute(sourcestamps.insert(), [
+            dict(id=1),
+            dict(id=2),
+        ])
+        conn.execute(changes.insert(), [
+            dict(changeid=1, sourcestampid=1),
+            dict(changeid=2, sourcestampid=2, parent_changeids=1),
+        ])
+        conn.execute(change_users.insert(), [
+            dict(changeid=1, uid=1),
+            dict(changeid=2, uid=2),
+        ])
+        conn.execute(change_properties.insert(), [
+            dict(changeid=1, property_name='release_lvl'),
+            dict(changeid=2, property_name='release_lvl'),
+        ])
+        conn.execute(change_files.insert(), [
+            dict(changeid=1, filename='README'),
+            dict(changeid=2, filename='setup.py'),
+        ])
+        conn.execute(schedulers.insert(), [
+            dict(changeid=1),
+        ])
+        conn.execute(scheduler_masters.insert(), [
+            dict(schedulerid=1, masterid=1),
+        ])
+        conn.execute(scheduler_changes.insert(), [
+            dict(schedulerid=1, changeid=1),
+            dict(schedulerid=1, changeid=2),
+        ])
+        conn.execute(buildsets.insert(), [
+            dict(id=1),
+            dict(id=2),
+        ])
+        conn.execute(buildset_properties.insert(), [
+            dict(buildsetid=1, property_name='color'),
+            dict(buildsetid=2, property_name='smell'),
+        ])
+        conn.execute(buildset_sourcestamps.insert(), [
+            dict(id=1, buildsetid=1, sourcestampid=1),
+            dict(id=2, buildsetid=2, sourcestampid=2),
+        ])
+        conn.execute(buildrequests.insert(), [
+            dict(id=1, buildsetid=1, builderid=1),
+            dict(id=2, buildsetid=1, builderid=2),
+            dict(id=3, buildsetid=2, builderid=1),
+            dict(id=4, buildsetid=2, builderid=2),
+        ])
+        conn.execute(buildrequest_claims.insert(), [
+            dict(brid=1, masterid=1),
+            dict(brid=2, masterid=1),
+            dict(brid=3, masterid=1),
+            dict(brid=4, masterid=1),
+        ])
+        conn.execute(builds.insert(), [
+            dict(id=1, builderid=1, buildrequestid=1, workerid=2, masterid=1),
+            dict(id=2, builderid=2, buildrequestid=2, workerid=1, masterid=1),
+            dict(id=3, builderid=1, buildrequestid=3, workerid=1, masterid=1),
+            dict(id=4, builderid=2, buildrequestid=4, workerid=2, masterid=1),
+        ])
+        conn.execute(build_properties.insert(), [
+            dict(buildid=1, name='buildername'),
+            dict(buildid=2, name='buildername'),
+            dict(buildid=3, name='buildername'),
+            dict(buildid=4, name='buildername'),
+        ])
+        conn.execute(steps.insert(), [
+            dict(id=1, buildid=1),
+            dict(id=2, buildid=1),
+            dict(id=3, buildid=2),
+            dict(id=4, buildid=2),
+            dict(id=5, buildid=1),
+            dict(id=6, buildid=1),
+            dict(id=7, buildid=2),
+            dict(id=8, buildid=2),
+        ])
+        conn.execute(logs.insert(), [
+            dict(id=1, stepid=1),
+            dict(id=2, stepid=2),
+            dict(id=3, stepid=3),
+            dict(id=4, stepid=4),
+            dict(id=5, stepid=5),
+            dict(id=6, stepid=6),
+            dict(id=7, stepid=7),
+            dict(id=8, stepid=8),
+        ])
+        conn.execute(logchunks.insert(), [
+            dict(logid=1, first_line=0, last_line=100),
+            dict(logid=2, first_line=0, last_line=100),
+            dict(logid=3, first_line=0, last_line=100),
+            dict(logid=4, first_line=0, last_line=100),
+            dict(logid=5, first_line=0, last_line=100),
+            dict(logid=6, first_line=0, last_line=100),
+            dict(logid=7, first_line=0, last_line=100),
+            dict(logid=8, first_line=0, last_line=100),
+        ])
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_and_insert_data(conn)
+
+        def verify_thd(conn):
+            """Can't verify much under SQLite
+
+            Even with PRAGMA foreign_keys=ON, the cascading deletes are
+            actually ignored with SQLite, so we can't really test the behaviour
+            in that environment.
+            """
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            changes = sautils.Table('changes', metadata, autoload=True)
+            builds = sautils.Table('builds', metadata, autoload=True)
+            workers = sautils.Table('workers', metadata, autoload=True)
+            sourcestamps = sautils.Table('sourcestamps', metadata, autoload=True)
+
+            conn.execute(sourcestamps.delete().where(sourcestamps.c.id == 1))
+
+            if conn.dialect.name not in ('mysql', 'sqlite'):
+                q = sa.select([changes.c.changeid])
+                self.assertEqual(conn.execute(q).fetchall(), [(2,)])
+
+            q = sa.select([changes.c.parent_changeids]).where(
+                    changes.c.changeid == 2)
+            self.assertEqual(conn.execute(q).fetchall(), [(None,)])
+
+            conn.execute(workers.delete().where(workers.c.id == 1))
+
+            if conn.dialect.name not in ('mysql', 'sqlite'):
+                q = sa.select([builds.c.id, builds.c.workerid]).order_by(
+                        builds.c.id)
+                self.assertEqual(conn.execute(q).fetchall(),
+                                 [(1, 2), (2, None), (3, None), (4, 2)])
+
+            with self.assertRaises(saexc.DatabaseError):
+                conn.execute(builds.insert(), [
+                    dict(id=5, builderid=None, buildrequestid=4,
+                         workerid=2, masterid=1),
+                ])
+
+        return self.do_test_migration(51, 52, setup_thd, verify_thd)


### PR DESCRIPTION
Some foreign key columns have `nullable=True` (which is the default). When a record on which such a foreign key points to is deleted, it should not be deleted in cascade (since it is valid to have a `NULL` value).

Update the `ondelete` fields of all these `nullable` foreign keys to `'SET NULL'`. To make things clearer, explicitly add `nullable=True` statements where missing. Also, some foreign keys columns were missing `nullable=False` statements. Add them.

Add a migration script and a unit test.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
