### PR TITLE
add a preparation step to track latent worker instanciation times

### DIFF
--- a/master/buildbot/newsfragments/preparation_step.feature
+++ b/master/buildbot/newsfragments/preparation_step.feature
@@ -1,0 +1,1 @@
+Each build get a new preparation step which can count the time spend starting latent worker.

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -92,6 +92,8 @@ class Build(properties.PropertiesMixin):
         self.workerEnvironment = {}
         self.buildid = None
         self.number = None
+        self.executedSteps = []
+        self.stepnames = {}
 
         self.terminate = False
 
@@ -301,6 +303,12 @@ class Build(properties.PropertiesMixin):
                                                                      ("control", "builds",
                                                                       str(self.buildid),
                                                                       "stop"))
+
+        # the preparation step counts the time needed for preparing the worker and getting the locks.
+        # we cannot use a real step as we don't have a worker yet.
+        self.preparation_step = buildstep.BuildStep(name="worker_preparation")
+        self.preparation_step.setBuild(self)
+        yield self.preparation_step.addStep()
         self.setupOwnProperties()
 
         # then narrow WorkerLocks down to the right worker
@@ -319,7 +327,7 @@ class Build(properties.PropertiesMixin):
         try:
             self.setupBuild()  # create .steps
         except Exception:
-            yield self.buildPreparationFailure(Failure(), "worker_prepare")
+            yield self.buildPreparationFailure(Failure(), "setupBuild")
             self.buildFinished(['Build.setupBuild', 'failed'], EXCEPTION)
             return
 
@@ -388,6 +396,9 @@ class Build(properties.PropertiesMixin):
         yield self.master.data.updates.setBuildStateString(self.buildid,
                                                            'acquiring locks')
         yield self.acquireLocks()
+        yield self.master.data.updates.setStepStateString(self.preparation_step.stepid,
+                                                          "worker ready")
+        yield self.master.data.updates.finishStep(self.preparation_step.stepid, SUCCESS, False)
 
         yield self.master.data.updates.setBuildStateString(self.buildid,
                                                            'building')
@@ -399,12 +410,11 @@ class Build(properties.PropertiesMixin):
     def buildPreparationFailure(self, why, state_string):
         log.err(why, "while " + state_string)
         self.workerforbuilder.worker.putInQuarantine()
-        step = buildstep.BuildStep(name=state_string)
-        step.setBuild(self)
-        yield step.addStep()
         if isinstance(why, failure.Failure):
-            yield step.addLogWithFailure(why)
-        yield self.master.data.updates.finishStep(step.stepid, EXCEPTION, False)
+            yield self.preparation_step.addLogWithFailure(why)
+        yield self.master.data.updates.setStepStateString(self.preparation_step.stepid,
+                                                          "error while " + state_string)
+        yield self.master.data.updates.finishStep(self.preparation_step.stepid, EXCEPTION, False)
 
     @staticmethod
     def _canAcquireLocks(lockList, workerforbuilder):
@@ -462,8 +472,6 @@ class Build(properties.PropertiesMixin):
 
     def setupBuild(self):
         # create the actual BuildSteps.
-        self.executedSteps = []
-        self.stepnames = {}
 
         self.steps = self.setupBuildSteps(self.stepFactories)
 

--- a/master/buildbot/test/integration/interop/test_interruptcommand.py
+++ b/master/buildbot/test/integration/interop/test_interruptcommand.py
@@ -30,7 +30,7 @@ class InterruptCommand(RunMasterBase):
     def test_setProp(self):
         yield self.setupConfig(masterConfig())
         build = yield self.doForceBuild(wantSteps=True)
-        self.assertEqual(build['steps'][0]['results'], CANCELLED)
+        self.assertEqual(build['steps'][-1]['results'], CANCELLED)
 
 
 class InterruptCommandPb(InterruptCommand):

--- a/master/buildbot/test/integration/test_URLs.py
+++ b/master/buildbot/test/integration/test_URLs.py
@@ -40,7 +40,7 @@ class UrlForBuildMaster(RunMasterBase):
             command = "echo 'http://localhost:8080/#builders/1/builds/1'"
 
         self.assertIn(command,
-                      build['steps'][0]['logs'][0]['contents']['content'])
+                      build['steps'][1]['logs'][0]['contents']['content'])
 
 
 # master configuration

--- a/master/buildbot/test/integration/test_integration_force_with_patch.py
+++ b/master/buildbot/test/integration/test_integration_force_with_patch.py
@@ -64,8 +64,8 @@ class ShellMaster(RunMasterBase):
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
         # if no patch, the source step is happy, but the make step cannot find makefile
-        self.assertEqual(build['steps'][0]['results'], SUCCESS)
-        self.assertEqual(build['steps'][1]['results'], FAILURE)
+        self.assertEqual(build['steps'][1]['results'], SUCCESS)
+        self.assertEqual(build['steps'][2]['results'], FAILURE)
         self.assertEqual(build['results'], FAILURE)
 
 

--- a/master/buildbot/test/integration/test_trigger.py
+++ b/master/buildbot/test/integration/test_trigger.py
@@ -25,6 +25,7 @@ from buildbot.test.util.integration import RunMasterBase
 
 expectedOutputRegex = \
     r"""\*\*\* BUILD 1 \*\*\* ==> build successful \(success\)
+    \*\*\* STEP worker_preparation \*\*\* ==> worker ready \(success\)
     \*\*\* STEP shell \*\*\* ==> 'echo hello' \(success\)
         log:stdio \({loglines}\)
     \*\*\* STEP trigger \*\*\* ==> triggered trigsched \(success\)
@@ -33,6 +34,7 @@ expectedOutputRegex = \
     \*\*\* STEP shell_1 \*\*\* ==> 'echo world' \(success\)
         log:stdio \({loglines}\)
 \*\*\* BUILD 2 \*\*\* ==> build successful \(success\)
+    \*\*\* STEP worker_preparation \*\*\* ==> worker ready \(success\)
     \*\*\* STEP shell \*\*\* ==> 'echo ola' \(success\)
         log:stdio \({loglines}\)
 """
@@ -54,7 +56,7 @@ class TriggeringMaster(RunMasterBase):
         build = yield self.doForceBuild(wantSteps=True, useChange=change, wantLogs=True)
 
         self.assertEqual(
-            build['steps'][1]['state_string'], 'triggered trigsched')
+            build['steps'][2]['state_string'], 'triggered trigsched')
         builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), 2)
         dump = StringIO()
@@ -62,7 +64,7 @@ class TriggeringMaster(RunMasterBase):
             yield self.printBuild(b, dump)
         # depending on the environment the number of lines is different between
         # test hosts
-        loglines = builds[1]['steps'][0]['logs'][0]['num_lines']
+        loglines = builds[1]['steps'][1]['logs'][0]['num_lines']
         self.assertRegex(dump.getvalue(),
                          expectedOutputRegex.format(loglines=loglines))
 

--- a/master/buildbot/test/unit/test_reporter_zulip.py
+++ b/master/buildbot/test/unit/test_reporter_zulip.py
@@ -26,8 +26,8 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.logging import LoggingMixin
-from buildbot.test.util.reporter import ReporterTestMixin
 from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.util.reporter import ReporterTestMixin
 
 
 class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, ConfigErrorsMixin, TestReactorMixin):
@@ -44,7 +44,8 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
 
     @defer.inlineCallbacks
     def setupZulipStatusPush(self, endpoint="http://example.com", token="123", stream=None):
-        self.sp = ZulipStatusPush(endpoint=endpoint, token=token, stream=stream)
+        self.sp = ZulipStatusPush(
+            endpoint=endpoint, token=token, stream=stream)
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
             self.master, self, endpoint, debug=None, verify=None)
         yield self.sp.setServiceParent(self.master)
@@ -60,7 +61,8 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
     def test_build_started(self):
         yield self.setupZulipStatusPush(stream="xyz")
         build = yield self.setupBuildResults()
-        build["started_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
+        build["started_at"] = datetime.datetime(
+            2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
         self._http.expect(
             'post',
             '/api/v1/external/buildbot?api_key=123&stream=xyz',
@@ -78,7 +80,8 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
     def test_build_finished(self):
         yield self.setupZulipStatusPush(stream="xyz")
         build = yield self.setupBuildResults()
-        build["complete_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
+        build["complete_at"] = datetime.datetime(
+            2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
         self._http.expect(
             'post',
             '/api/v1/external/buildbot?api_key=123&stream=xyz',
@@ -97,7 +100,8 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
     def test_stream_none(self):
         yield self.setupZulipStatusPush(stream=None)
         build = yield self.setupBuildResults()
-        build["complete_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
+        build["complete_at"] = datetime.datetime(
+            2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
         self._http.expect(
             'post',
             '/api/v1/external/buildbot?api_key=123',
@@ -126,7 +130,8 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
     def test_invalid_json_data(self):
         yield self.setupZulipStatusPush(stream="xyz")
         build = yield self.setupBuildResults()
-        build["started_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
+        build["started_at"] = datetime.datetime(
+            2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
         self._http.expect(
             'post',
             '/api/v1/external/buildbot?api_key=123&stream=xyz',
@@ -146,7 +151,8 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
     def test_invalid_url(self):
         yield self.setupZulipStatusPush(stream="xyz")
         build = yield self.setupBuildResults()
-        build["started_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
+        build["started_at"] = datetime.datetime(
+            2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
         self._http.expect(
             'post',
             '/api/v1/external/buildbot?api_key=123&stream=xyz',
@@ -166,7 +172,8 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
     def test_invalid_token(self):
         yield self.setupZulipStatusPush(stream="xyz")
         build = yield self.setupBuildResults()
-        build["started_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
+        build["started_at"] = datetime.datetime(
+            2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
         self._http.expect(
             'post',
             '/api/v1/external/buildbot?api_key=123&stream=xyz',


### PR DESCRIPTION

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
