### PR TITLE
fix and improve usage of KubeHardcodedConf

### DIFF
--- a/master/buildbot/test/unit/test_util_httpclientservice.py
+++ b/master/buildbot/test/unit/test_util_httpclientservice.py
@@ -21,18 +21,18 @@ import mock
 
 from twisted.internet import defer
 from twisted.internet import reactor
+from twisted.python import components
 from twisted.python.compat import intToBytes
 from twisted.trial import unittest
 from twisted.web import resource
 from twisted.web import server
 
+from buildbot import interfaces
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
 from buildbot.util import service
 from buildbot.util import unicode2bytes
-from buildbot import interfaces
-from twisted.python import components
 
 try:
     from requests.auth import HTTPDigestAuth
@@ -44,6 +44,7 @@ except ImportError:
 components.registerAdapter(
     lambda m: m,
     mock.Mock, interfaces.IHttpResponse)
+
 
 class HTTPClientServiceTestBase(unittest.SynchronousTestCase):
 

--- a/master/buildbot/test/unit/test_util_httpclientservice.py
+++ b/master/buildbot/test/unit/test_util_httpclientservice.py
@@ -31,12 +31,19 @@ from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
 from buildbot.util import service
 from buildbot.util import unicode2bytes
+from buildbot import interfaces
+from twisted.python import components
 
 try:
     from requests.auth import HTTPDigestAuth
 except ImportError:
     pass
 
+# There is no way to unregister an adapter, so we have no other option
+# than registering it as a module side effect :-(
+components.registerAdapter(
+    lambda m: m,
+    mock.Mock, interfaces.IHttpResponse)
 
 class HTTPClientServiceTestBase(unittest.SynchronousTestCase):
 

--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -143,6 +143,18 @@ class KubeClientServiceTestKubeHardcodedConfig(config.ConfigErrorsMixin,
         url, kwargs = yield service._prepareRequest("/test", {})
         self.assertEqual('/path/to/pem', kwargs['verify'])
 
+    @defer.inlineCallbacks
+    def test_verify_headers_are_passed_to_the_query(self):
+        self.config = config = kubeclientservice.KubeHardcodedConfig(
+            master_url="http://localhost:8001",
+            namespace="default",
+            verify="/path/to/pem",
+            headers={'Test': '10'}
+        )
+        service = kubeclientservice.KubeClientService(config)
+        url, kwargs = yield service._prepareRequest("/test", {})
+        self.assertEqual({'Test': '10'}, kwargs['headers'])
+
 class KubeClientServiceTestKubeCtlProxyConfig(config.ConfigErrorsMixin,
                                               unittest.TestCase):
     def patchProxyCmd(self, cmd):

--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -119,6 +119,30 @@ sys.exit(1)
 """
 
 
+class KubeClientServiceTestKubeHardcodedConfig(config.ConfigErrorsMixin,
+                                              unittest.TestCase):
+    def test_basic(self):
+        self.config = config = kubeclientservice.KubeHardcodedConfig(
+            master_url="http://localhost:8001",
+            namespace="default"
+        )
+        self.assertEqual(config.getConfig(), {
+            'master_url': 'http://localhost:8001',
+            'namespace': 'default',
+            'headers': {}
+        })
+
+    @defer.inlineCallbacks
+    def test_verify_is_forwarded_to_keywords(self):
+        self.config = config = kubeclientservice.KubeHardcodedConfig(
+            master_url="http://localhost:8001",
+            namespace="default",
+            verify="/path/to/pem"
+        )
+        service = kubeclientservice.KubeClientService(config)
+        url, kwargs = yield service._prepareRequest("/test", {})
+        self.assertEqual('/path/to/pem', kwargs['verify'])
+
 class KubeClientServiceTestKubeCtlProxyConfig(config.ConfigErrorsMixin,
                                               unittest.TestCase):
     def patchProxyCmd(self, cmd):

--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import base64
 import copy
 import os
 import sys
@@ -189,10 +190,12 @@ class KubeClientServiceTestKubeHardcodedConfig(config.ConfigErrorsMixin,
             master_url="http://localhost:8001",
             namespace="default",
             verify="/path/to/pem",
-            basicAuth=Interpolate("%(kw:test)s", test=10))
+            basicAuth={'user': 'name', 'password': Interpolate("%(kw:test)s", test=10)})
         service = kubeclientservice.KubeClientService(config)
         url, kwargs = yield service._prepareRequest("/test", {})
-        self.assertEqual("Basic 10", kwargs['headers']['Authorization'])
+
+        expected = "Basic {0}".format(base64.b64encode("name:10".encode('utf-8')))
+        self.assertEqual(expected, kwargs['headers']['Authorization'])
 
 
 class KubeClientServiceTestKubeCtlProxyConfig(config.ConfigErrorsMixin,

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -1,4 +1,4 @@
-# This file is part of Buildbot. Buildbot is free software: you can)uth
+# This file is part of Buildbot. Buildbot is free software: you can)
 # redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation, version 2.
 #

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -178,7 +178,7 @@ class HTTPClientService(service.SharedService):
             kwargs['verify'] = False
 
         res = yield self._session.request(method, url, **kwargs)
-        return defer.returnValue(IHttpResponse(TxRequestsResponseWrapper(res)))
+        return IHttpResponse(TxRequestsResponseWrapper(res))
 
     @defer.inlineCallbacks
     def _doTReq(self, method, ep, **kwargs):
@@ -189,7 +189,7 @@ class HTTPClientService(service.SharedService):
         kwargs['agent'] = self._agent
 
         res = yield getattr(treq, method)(url, **kwargs)
-        return defer.returnValue(IHttpResponse(res))
+        return IHttpResponse(res)
 
     # lets be nice to the auto completers, and don't generate that code
     def get(self, ep, **kwargs):

--- a/master/buildbot/util/kubeclientservice.py
+++ b/master/buildbot/util/kubeclientservice.py
@@ -70,7 +70,7 @@ class KubeHardcodedConfig(KubeConfigLoaderBase):
                         cert=None,
                         verify=None,
                         namespace="default"):
-        self.config = {'master_url': master_url, 'namespace': namespace}
+        self.config = {'master_url': master_url, 'namespace': namespace, 'headers': {}}
         if headers is not None:
             self.config['headers'] = headers
         if cert is not None:
@@ -197,6 +197,13 @@ class KubeClientService(HTTPClientService):
         config = self.config.getConfig()
         self._base_url = config['master_url']
         url, req_kwargs = HTTPClientService._prepareRequest(self, ep, kwargs)
+
+        if config['headers']:
+            if not req_kwargs['headers']:
+                req_kwargs['headers'] = {}
+            else:
+                req_kwargs['headers'] = req_kwargs['headers'].dup
+            req_kwargs['headers'].update(config['headers'])
 
         # warning: this only works with txrequests! not treq
         for arg in ['cert', 'verify']:

--- a/master/buildbot/util/kubeclientservice.py
+++ b/master/buildbot/util/kubeclientservice.py
@@ -201,7 +201,7 @@ class KubeClientService(HTTPClientService):
         # warning: this only works with txrequests! not treq
         for arg in ['cert', 'verify']:
             if arg in config:
-                req_kwargs[arg] = self.config[arg]
+                req_kwargs[arg] = config[arg]
 
         return url, req_kwargs
 

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -381,7 +381,7 @@ There are three options you may use to connect to your clusters.
 
 When running both the master and slaves run on the same Kubernetes cluster, you
 should use the KubeInClusterConfigLoader. If not, but having a configured
-kubectl tool available to the build master is an option for you, you should use
+``kubectl`` tool available to the build master is an option for you, you should use
 KubeCtlProxyConfigLoader. If neither of these options is convenient, use
 KubeHardcodedConfig.
 
@@ -429,7 +429,7 @@ With :class:`KubeHardcodedConfig`, you just configure the necessary parameters t
     Basic authorization info to connect to the cluster, as a `{'user':
     'username', 'password': 'psw' }` dict.
 
-    Unlike the headers argument, this argument supports secret providers, e.g.
+    Unlike the headers argument, this argument supports secret providers, e.g::
 
         basicAuth={'user': 'username', 'password': Secret('k8spassword')}
 
@@ -444,6 +444,8 @@ With :class:`KubeHardcodedConfig`, you just configure the necessary parameters t
     When using the Google Kubernetes Engine (GKE), a bearer token for the
     default service account can be had with:
 
+    .. code-block:: bash
+
         gcloud container clusters get-credentials --region [YOURREGION] YOURCLUSTER
         kubectl describe sa
         kubectl describe secret [SECRET_ID]
@@ -452,6 +454,8 @@ With :class:`KubeHardcodedConfig`, you just configure the necessary parameters t
     account does not have rights on the cluster (to create/delete pods), which
     is required by BuildBot's integration. You may give it this right by making
     it a cluster admin with
+
+    .. code-block:: bash
 
         kubectl create clusterrolebinding service-account-admin \
             --clusterrole=cluster-admin \

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -417,10 +417,34 @@ With :class:`KubeHardcodedConfig`, you just configure the necessary parameters t
 
 ``headers``
     (optional)
-    The headers necessary for authentication if needed.
-    For example, for BasicAuth, you would say::
+    Additional headers to be passed to the HTTP request
 
-        headers={"Authorization": "Basic %s" % base64.b64encode("userid:password")}
+``authorization``
+    (optional)
+    Authorization header, for instance:
+
+        authorization="Basic %s" % base64.b64encode("userid:password")
+
+    Unlike the headers argument, this argument supports secret providers, so
+    you could store e.g. a bearer token in a secret provider and do
+
+        authorization=util.Interpolate("Bearer %(secret:k8s-token)")
+
+    When using the Google Kubernetes Engine (GKE), a bearer token for the
+    default service account can be had with:
+
+        gcloud container clusters get-credentials --region [YOURREGION] YOURCLUSTER
+        kubectl describe sa
+        kubectl describe secret [SECRET_ID]
+
+    Where SECRET_ID is displayed by the "describe sa" line. The default service
+    account does not have rights on the cluster (to create/delete pods), which
+    is required by BuildBot's integration. You may give it this right by making
+    it a cluster admin with
+
+        kubectl create clusterrolebinding service-account-admin \
+            --clusterrole=cluster-admin \
+            --serviceaccount default:default
 
 ``cert``
     (optional)
@@ -434,6 +458,10 @@ With :class:`KubeHardcodedConfig`, you just configure the necessary parameters t
     Path to server certificate authenticate the server::
 
         verify='/path/to/kube_server_certificate.crt'
+
+    When using the Google Kubernetes Engine (GKE), this certificate is available
+    from the admin console, on the Cluster page. Verify that it is valid (i.e. no
+    copy/paste errors) with ``openssl verify PATH_TO_PEM``.
 
 ``namespace``
     (optional defaults to ``"default"``

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -377,8 +377,13 @@ Kubernetes provides many options to connect to a cluster.
 It is especially more complicated as some cloud providers use specific methods to connect to their managed kubernetes.
 Config loaders objects can be shared between LatentWorker.
 
-Here are the options you can use to connect to your clusters:
+There are three options you may use to connect to your clusters.
 
+When running both the master and slaves run on the same Kubernetes cluster, you
+should use the KubeInClusterConfigLoader. If not, but having a configured
+kubectl tool available to the build master is an option for you, you should use
+KubeCtlProxyConfigLoader. If neither of these options is convenient, use
+KubeHardcodedConfig.
 
 .. py:class:: buildbot.util.kubeclientservice.KubeCtlProxyConfigLoader
 .. py:class:: buildbot.plugins.util.KubeCtlProxyConfigLoader

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -424,16 +424,22 @@ With :class:`KubeHardcodedConfig`, you just configure the necessary parameters t
     (optional)
     Additional headers to be passed to the HTTP request
 
-``authorization``
+``basicAuth``
     (optional)
-    Authorization header, for instance:
+    Basic authorization info to connect to the cluster, as a `{'user':
+    'username', 'password': 'psw' }` dict.
 
-        authorization="Basic %s" % base64.b64encode("userid:password")
+    Unlike the headers argument, this argument supports secret providers, e.g.
 
-    Unlike the headers argument, this argument supports secret providers, so
-    you could store e.g. a bearer token in a secret provider and do
+        basicAuth={'user': 'username', 'password': Secret('k8spassword')}
 
-        authorization=util.Interpolate("Bearer %(secret:k8s-token)")
+``bearerToken``
+    (optional)
+
+    A bearer token to authenticate to the cluster, as a string. Unlike the
+    headers argument, this argument supports secret providers, e.g.
+
+        bearerToken=Secret('k8s-token')
 
     When using the Google Kubernetes Engine (GKE), a bearer token for the
     default service account can be had with:

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -379,11 +379,9 @@ Config loaders objects can be shared between LatentWorker.
 
 There are three options you may use to connect to your clusters.
 
-When running both the master and slaves run on the same Kubernetes cluster, you
-should use the KubeInClusterConfigLoader. If not, but having a configured
-``kubectl`` tool available to the build master is an option for you, you should use
-KubeCtlProxyConfigLoader. If neither of these options is convenient, use
-KubeHardcodedConfig.
+When running both the master and slaves run on the same Kubernetes cluster, you should use the KubeInClusterConfigLoader.
+If not, but having a configured ``kubectl`` tool available to the build master is an option for you, you should use KubeCtlProxyConfigLoader.
+If neither of these options is convenient, use KubeHardcodedConfig.
 
 .. py:class:: buildbot.util.kubeclientservice.KubeCtlProxyConfigLoader
 .. py:class:: buildbot.plugins.util.KubeCtlProxyConfigLoader
@@ -426,8 +424,7 @@ With :class:`KubeHardcodedConfig`, you just configure the necessary parameters t
 
 ``basicAuth``
     (optional)
-    Basic authorization info to connect to the cluster, as a `{'user':
-    'username', 'password': 'psw' }` dict.
+    Basic authorization info to connect to the cluster, as a `{'user': 'username', 'password': 'psw' }` dict.
 
     Unlike the headers argument, this argument supports secret providers, e.g::
 
@@ -436,13 +433,12 @@ With :class:`KubeHardcodedConfig`, you just configure the necessary parameters t
 ``bearerToken``
     (optional)
 
-    A bearer token to authenticate to the cluster, as a string. Unlike the
-    headers argument, this argument supports secret providers, e.g.
+    A bearer token to authenticate to the cluster, as a string.
+    Unlike the headers argument, this argument supports secret providers, e.g::
 
         bearerToken=Secret('k8s-token')
 
-    When using the Google Kubernetes Engine (GKE), a bearer token for the
-    default service account can be had with:
+    When using the Google Kubernetes Engine (GKE), a bearer token for the default service account can be had with:
 
     .. code-block:: bash
 
@@ -450,10 +446,9 @@ With :class:`KubeHardcodedConfig`, you just configure the necessary parameters t
         kubectl describe sa
         kubectl describe secret [SECRET_ID]
 
-    Where SECRET_ID is displayed by the "describe sa" line. The default service
-    account does not have rights on the cluster (to create/delete pods), which
-    is required by BuildBot's integration. You may give it this right by making
-    it a cluster admin with
+    Where SECRET_ID is displayed by the ``describe sa`` command line.
+    The default service account does not have rights on the cluster (to create/delete pods), which is required by BuildBot's integration.
+    You may give it this right by making it a cluster admin with
 
     .. code-block:: bash
 
@@ -474,9 +469,8 @@ With :class:`KubeHardcodedConfig`, you just configure the necessary parameters t
 
         verify='/path/to/kube_server_certificate.crt'
 
-    When using the Google Kubernetes Engine (GKE), this certificate is available
-    from the admin console, on the Cluster page. Verify that it is valid (i.e. no
-    copy/paste errors) with ``openssl verify PATH_TO_PEM``.
+    When using the Google Kubernetes Engine (GKE), this certificate is available from the admin console, on the Cluster page.
+    Verify that it is valid (i.e. no copy/paste errors) with ``openssl verify PATH_TO_PEM``.
 
 ``namespace``
     (optional defaults to ``"default"``


### PR DESCRIPTION
This pull request fixes the usage of the `verify` argument in KubeHardcodedConf, and of the passing of the Authorization header - which was not forwarded to the HTTP layer.

In addition, it improves the usage of the authorization token, by creating a separate dedicated `authorization` keyword arg, and allowing usage of a secret provider.

The documentation is updated, with some GKE-specific info (since that's what we use, I hope that's OK, it's hard to get when you're not used to Kubernetes).