### PR TITLE
Allows more UTF-8 characters in builder names, worker names, and step names

### DIFF
--- a/master/buildbot/newsfragments/utf8-identifier.feature
+++ b/master/buildbot/newsfragments/utf8-identifier.feature
@@ -1,0 +1,1 @@
+Identifiers can now contain UTF-8 characters which are not ASCII.  This includes worker names, builder names, and step names.

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -840,7 +840,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
 
     def test_load_workers_not_identifiers(self):
         for name in (u"123 no initial digits", u"spaces not allowed",
-                     u'a/b', u'\N{SNOWMAN}', u"a.b.c.d", u"a-b_c.d9",):
+                     u'a/b', u"a.b.c.d", u"a-b_c.d9",):
             self.cfg.load_workers(self.filename,
                                   dict(workers=[worker.Worker(name, 'x')]))
             self.assertConfigError(self.errors, "is not an identifier")

--- a/master/buildbot/test/unit/test_test_util_validation.py
+++ b/master/buildbot/test/unit/test_test_util_validation.py
@@ -96,9 +96,9 @@ class VerifyDict(unittest.TestCase):
 
         self.doValidationTest(validation.IdentifierValidator(50),
                               good=[
-                                  u"linux", u"Linux", u"abc123", u"a" * 50,
+                                  u"linux", u"Linux", u"abc123", u"a" * 50, u'\N{SNOWMAN}'
         ], bad=[
-                                  None, u'', b'linux', u'a/b', u'\N{SNOWMAN}', u"a.b.c.d",
+                                  None, u'', b'linux', u'a/b', u"a.b.c.d",
                                   u"a-b_c.d9", 'spaces not allowed', u"a" * 51,
                                   u"123 no initial digits",
         ])

--- a/master/buildbot/test/unit/test_util_identifiers.py
+++ b/master/buildbot/test/unit/test_util_identifiers.py
@@ -38,15 +38,15 @@ class Tests(unittest.TestCase):
                 "on this platform with {}".format(os_encoding)))
 
         good = [
-            u"linux", u"Linux", u"abc123", u"a" * 50,
+            u"linux", u"Linux", u"abc123", u"a" * 50, u'\N{SNOWMAN}'
         ]
         for g in good:
             log.msg('expect %r to be good' % (g,))
             self.assertTrue(identifiers.isIdentifier(50, g))
         bad = [
-            None, u'', b'linux', u'a/b', u'\N{SNOWMAN}', u"a.b.c.d",
+            None, u'', b'linux', u'a/b', u"a.b.c.d",
             u"a-b_c.d9", 'spaces not allowed', u"a" * 51,
-            u"123 no initial digits",
+            u"123 no initial digits", u'\N{SNOWMAN}.\N{SNOWMAN}',
         ]
         for b in bad:
             log.msg('expect %r to be bad' % (b,))

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -103,7 +103,7 @@ class IdentifierValidator(Validator):
     name = 'identifier'
     hasArgs = True
 
-    ident_re = re.compile('^[a-zA-Z_-][a-zA-Z0-9_-]*$')
+    ident_re = re.compile(u'^[a-zA-Z\u00a0-\U0010ffff_-][a-zA-Z0-9\u00a0-\U0010ffff_-]*$', flags=re.UNICODE)
 
     def __init__(self, len):
         self.len = len

--- a/master/buildbot/util/identifiers.py
+++ b/master/buildbot/util/identifiers.py
@@ -22,7 +22,7 @@ import re
 
 from buildbot import util
 
-ident_re = re.compile('^[a-zA-Z_-][a-zA-Z0-9_-]*$')
+ident_re = re.compile(u'^[a-zA-Z\u00a0-\U0010ffff_-][a-zA-Z0-9\u00a0-\U0010ffff_-]*$', flags=re.UNICODE)
 initial_re = re.compile('^[^a-zA-Z_-]')
 subsequent_re = re.compile('[^a-zA-Z0-9_-]')
 trailing_digits_re = re.compile('_([0-9]+)$')

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -50,7 +50,7 @@ Identifier
 
 .. _type-identifier:
 
-An "identifier" is a nonempty unicode string of limited length, containing only ASCII alphanumeric characters along with ``-`` (dash) and ``_`` (underscore), and not beginning with a digit
+An "identifier" is a nonempty unicode string of limited length, containing only UTF-8 alphanumeric characters along with ``-`` (dash) and ``_`` (underscore), and not beginning with a digit
 Wherever an identifier is used, the documentation will give the maximum length in characters.
 The function :py:func:`buildbot.util.identifiers.isIdentifier` is useful to verify a well-formed identifier.
 

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -815,7 +815,7 @@ This module makes it easy to manipulate identifiers.
     :param str: string to coerce to an identifier
     :returns: identifier of maximum length ``maxLength``
 
-    Coerce a string (assuming ASCII for bytestrings) into an identifier.
+    Coerce a string (assuming UTF-8 for bytestrings) into an identifier.
     This method will replace any invalid characters with ``_`` and truncate to the given length.
 
 .. py:function:: incrementIdentifier(maxLength, str)

--- a/master/docs/manual/upgrading/nine-upgrade.rst
+++ b/master/docs/manual/upgrading/nine-upgrade.rst
@@ -155,7 +155,7 @@ Identifiers
 
 Many strings in Buildbot must now be identifiers.
 Identifiers are designed to fit easily and unambiguously into URLs, AMQP routes, and the like.
-An "identifier" is a nonempty unicode string of limited length, containing only ASCII alphanumeric characters along with ``-`` (dash) and ``_`` (underscore), and not beginning with a digit
+An "identifier" is a nonempty unicode string of limited length, containing only UTF-8 alphanumeric characters along with ``-`` (dash) and ``_`` (underscore), and not beginning with a digit
 
 Unfortunately, many existing names do not fit this pattern.
 


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

I am reopening this from https://github.com/buildbot/buildbot/pull/3592 because stalebot closed that and I can't reopen it

On Python 3, I was able to use the following:

![image](https://user-images.githubusercontent.com/1895943/30190517-78b305f8-93ef-11e7-841b-17afc3c5039e.png)

On Python 2, I wasn't able to use a builder with Cyrillic characters.
This is due to a bug in Twisted's logger in Python 2 which does not fully support unicode.
An attempt was made to fix it on Python 2 here: https://twistedmatrix.com/trac/ticket/8864 , but it was reverted.  The Twisted logger has no problems with unicode on Python 3.