### PR TITLE
Fix logwatcher tests

### DIFF
--- a/master/buildbot/test/unit/test_scripts_logwatcher.py
+++ b/master/buildbot/test/unit/test_scripts_logwatcher.py
@@ -31,7 +31,7 @@ from buildbot.test.fake.reactor import TestReactor
 from buildbot.test.util import dirs
 
 
-class TestLogWatcher(unittest.SynchronousTestCase, dirs.DirsMixin):
+class TestLogWatcher(unittest.TestCase, dirs.DirsMixin):
 
     def setUp(self):
         self.setUpDirs('workdir')


### PR DESCRIPTION
Fixes logwatcher tests as they used `SynchronousTestCase` even though the functions returned a Deferred. This causes any assertion errors to be ignored on python3.