### PR TITLE
Reduce duplication in tests by introducing TestReactorMixin

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -583,6 +583,7 @@ github
 gitlab
 gitorious
 gitpoller
+globals
 gmail
 gmt
 google

--- a/master/buildbot/test/integration/test_latent.py
+++ b/master/buildbot/test/integration/test_latent.py
@@ -21,7 +21,6 @@ import os
 
 from twisted.internet import defer
 from twisted.python import log
-from twisted.python import threadpool
 from twisted.python.failure import Failure
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -38,12 +37,10 @@ from buildbot.process.results import EXCEPTION
 from buildbot.process.results import RETRY
 from buildbot.process.results import SUCCESS
 from buildbot.test.fake.latent import LatentController
-from buildbot.test.fake.reactor import NonThreadPool
-from buildbot.test.fake.reactor import TestReactor
 from buildbot.test.fake.step import BuildStepController
 from buildbot.test.util.integration import getMaster
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.misc import enable_trace
-from buildbot.util.eventual import _setReactor
 
 
 class TestException(Exception):
@@ -53,14 +50,10 @@ class TestException(Exception):
     """
 
 
-class Tests(SynchronousTestCase):
+class Tests(SynchronousTestCase, TestReactorMixin):
 
     def setUp(self):
-        self.patch(threadpool, 'ThreadPool', NonThreadPool)
-        self.reactor = TestReactor()
-        self.addCleanup(self.reactor.stop)
-        _setReactor(self.reactor)
-        self.addCleanup(_setReactor, None)
+        self.setUpTestReactor()
 
         # to ease debugging we display the error logs in the test log
         origAddCompleteLog = BuildStep.addCompleteLog

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 from twisted.internet.defer import Deferred
-from twisted.python import threadpool
 from twisted.trial.unittest import SynchronousTestCase
 from zope.interface import implementer
 
@@ -27,10 +26,8 @@ from buildbot.process.buildstep import BuildStep
 from buildbot.process.factory import BuildFactory
 from buildbot.process.results import CANCELLED
 from buildbot.test.fake.latent import LatentController
-from buildbot.test.fake.reactor import NonThreadPool
-from buildbot.test.fake.reactor import TestReactor
 from buildbot.test.util.integration import getMaster
-from buildbot.util.eventual import _setReactor
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.worker.local import LocalWorker
 
 try:
@@ -66,14 +63,10 @@ class ControllableStep(BuildStep):
         self._step_deferred.callback(CANCELLED)
 
 
-class Tests(SynchronousTestCase):
+class Tests(SynchronousTestCase, TestReactorMixin):
 
     def setUp(self):
-        self.patch(threadpool, 'ThreadPool', NonThreadPool)
-        self.reactor = TestReactor()
-        self.addCleanup(self.reactor.stop)
-        _setReactor(self.reactor)
-        self.addCleanup(_setReactor, None)
+        self.setUpTestReactor()
 
     def tearDown(self):
         self.assertFalse(self.master.running, "master is still running!")

--- a/master/buildbot/test/unit/test_scripts_logwatcher.py
+++ b/master/buildbot/test/unit/test_scripts_logwatcher.py
@@ -27,18 +27,17 @@ from buildbot.scripts.logwatcher import BuildmasterStartupError
 from buildbot.scripts.logwatcher import BuildmasterTimeoutError
 from buildbot.scripts.logwatcher import LogWatcher
 from buildbot.scripts.logwatcher import ReconfigError
-from buildbot.test.fake.reactor import TestReactor
 from buildbot.test.util import dirs
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestLogWatcher(unittest.TestCase, dirs.DirsMixin):
+class TestLogWatcher(unittest.TestCase, dirs.DirsMixin, TestReactorMixin):
 
     def setUp(self):
         self.setUpDirs('workdir')
         self.addCleanup(self.tearDownDirs)
 
-        self.reactor = TestReactor()
-        self.addCleanup(self.reactor.stop)
+        self.setUpTestReactor()
         self.spawned_process = mock.Mock()
         self.reactor.spawnProcess = mock.Mock(return_value=self.spawned_process)
 

--- a/master/buildbot/test/unit/test_worker_marathon.py
+++ b/master/buildbot/test/unit/test_worker_marathon.py
@@ -23,8 +23,7 @@ from buildbot.process.properties import Properties
 from buildbot.test.fake import fakebuild
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
-from buildbot.test.fake.reactor import TestReactor
-from buildbot.util.eventual import _setReactor
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.worker.marathon import MarathonLatentWorker
 
 
@@ -41,10 +40,9 @@ class FakeBot(object):
         self.n()
 
 
-class TestMarathonLatentWorker(unittest.SynchronousTestCase):
+class TestMarathonLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
     def setUp(self):
-        self.reactor = TestReactor()
-        _setReactor(self.reactor)
+        self.setUpTestReactor()
         self.build = Properties(
             image="busybox:latest", builder="docker_worker")
         self.worker = None
@@ -55,7 +53,6 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase):
                 code = 200
             self._http.delete = lambda _: defer.succeed(FakeResult())
             self.worker.master.stopService()
-        _setReactor(None)
 
     def test_constructor_normal(self):
         worker = MarathonLatentWorker('bot', 'tcp://marathon.local', 'foo',

--- a/smokes/mydashboard.py
+++ b/smokes/mydashboard.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
-import time
 
 from flask import Flask
 from flask import render_template


### PR DESCRIPTION
The duplication of `TestReactor` setup and chance of errors there has been reduced by introducing `TestReactorMixin`.

Also, some minor fixes.