### PR TITLE
tests: fix python executable name/path

### DIFF
--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import copy
 import os
+import sys
 import textwrap
 from io import BytesIO
 from unittest.case import SkipTest
@@ -126,7 +127,7 @@ class KubeClientServiceTestKubeCtlProxyConfig(config.ConfigErrorsMixin,
             self.config = None
             raise SkipTest('only posix platform is supported by this test')
         self.patch(kubeclientservice.KubeCtlProxyConfigLoader,
-                   'kube_ctl_proxy_cmd', ["python", "-c", cmd])
+                   'kube_ctl_proxy_cmd', [sys.executable, "-c", cmd])
 
     def tearDown(self):
         if self.config is not None:

--- a/pkg/test_buildbot_pkg.py
+++ b/pkg/test_buildbot_pkg.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import os
 import shutil
+import sys
 from subprocess import call
 from subprocess import check_call
 from textwrap import dedent
@@ -57,13 +58,13 @@ class BuildbotWWWPkg(unittest.TestCase):
         self.rmtree(os.path.join(self.path, "static"))
 
     def run_setup(self, cmd):
-        check_call("python setup.py " + cmd, shell=True, cwd=self.path)
+        check_call([sys.executable, 'setup.py', cmd], cwd=self.path)
 
     def check_correct_installation(self):
         # assert we can import buildbot_www
         # and that it has an endpoint with resource containing file "script.js"
         check_call([
-            'python', '-c', self.loadTestScript % dict(epName=self.epName)])
+            sys.executable, '-c', self.loadTestScript % dict(epName=self.epName)])
 
     def test_install(self):
         self.run_setup("install")


### PR DESCRIPTION
Do not assume that the current interpreter is named "python". On some systems (i.e. Debian) the default interpreter ("python") is python 2 and when running the tests on python 3, "python" is not available.

Use the full current interpreter executable path instead.