### PR TITLE
master: decode reconfig error log before printing

### DIFF
--- a/master/buildbot/scripts/logwatcher.py
+++ b/master/buildbot/scripts/logwatcher.py
@@ -27,7 +27,6 @@ from twisted.internet import reactor
 from twisted.protocols.basic import LineOnlyReceiver
 from twisted.python.failure import Failure
 
-from buildbot.util import bytes2NativeString
 from buildbot.util import unicode2bytes
 
 
@@ -132,7 +131,7 @@ class LogWatcher(LineOnlyReceiver):
             self.in_reconfig = True
 
         if self.in_reconfig:
-            print(bytes2NativeString(line))
+            print(line.decode())
 
         # certain lines indicate progress, so we "cancel" the timeout
         # and it will get re-added when it fires

--- a/master/buildbot/scripts/logwatcher.py
+++ b/master/buildbot/scripts/logwatcher.py
@@ -27,6 +27,7 @@ from twisted.internet import reactor
 from twisted.protocols.basic import LineOnlyReceiver
 from twisted.python.failure import Failure
 
+from buildbot.util import bytes2NativeString
 from buildbot.util import unicode2bytes
 
 
@@ -131,7 +132,7 @@ class LogWatcher(LineOnlyReceiver):
             self.in_reconfig = True
 
         if self.in_reconfig:
-            print(line)
+            print(bytes2NativeString(line))
 
         # certain lines indicate progress, so we "cancel" the timeout
         # and it will get re-added when it fires


### PR DESCRIPTION
When there is an error during reconfig, make sure to decode the bytes to native string (i.e. unicode on python 3).

Without this patch, we have this on python 3:

```
% buildbot reconfig
sending SIGHUP to process 8297
b'2019-01-22 14:28:54+0100 [-] beginning configuration update'
b"2019-01-22 14:28:54+0100 [-] Loading configuration from './master.cfg'"
b'2019-01-22 14:28:54+0100 [-] error while parsing config file:'
b'\tTraceback (most recent call last):'
b'\t  File "./.venv/lib/python3.5/site-packages/twisted/python/threadpool.py", line 266, in <lambda>'
b'\t    inContext.theWork = lambda: context.call(ctx, func, *args, **kw)'
b'\t  File "./.venv/lib/python3.5/site-packages/twisted/python/context.py", line 122, in callWithContext'
b'\t    return self.currentContext().callWithContext(ctx, func, *args, **kw)'
b'\t  File "./.venv/lib/python3.5/site-packages/twisted/python/context.py", line 85, in callWithContext'
b'\t    return func(*args,**kw)'
b'\t  File "./.venv/lib/python3.5/site-packages/buildbot/config.py", line 182, in loadConfig'
b'\t    self.basedir, self.configFileName)'
b'\t--- <exception caught here> ---'
b'\t  File "./.venv/lib/python3.5/site-packages/buildbot/config.py", line 140, in loadConfigDict'
b'\t    execfile(filename, localDict)'
b'\t  File "./.venv/lib/python3.5/site-packages/twisted/python/compat.py", line 247, in execfile'
b'\t    exec(code, globals, locals)'
b'\t  File "./buildmaster.cfg", line 30, in <module>'
b'\t    kljsfd'
b"\tbuiltins.NameError: name 'kljsfd' is not defined"
b'\t'
b"2019-01-22 14:28:54+0100 [-] error while parsing config file: name 'kljsfd' is not defined (traceback in logfile)"
b'2019-01-22 14:28:54+0100 [-] reconfig aborted without making any changes'
Reconfiguration failed. Please inspect the master.cfg file for errors, correct
them, then try 'buildbot reconfig' again.
```