### PR TITLE
Unpin CairoSVG as buildbot is now py3 only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             env
             python3 -m venv .venv
             . .venv/bin/activate
-            pip install -U pip setuptools
+            pip install -U 'pip<19' setuptools
             pip install -r requirements-ci.txt
             pip install -r requirements-cidocs.txt
             pip install pyinstaller

--- a/www/badges/setup.py
+++ b/www/badges/setup.py
@@ -38,7 +38,7 @@ setup_www_plugin(
     packages=['buildbot_badges'],
     install_requires=[
         'klein',
-        'CairoSVG==1.0.22',  # cairoSVG 2+ is not py2 compatible
+        'CairoSVG',
         'cairocffi', 'Jinja2'
     ],
     package_data={


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

Upstream an Arch Linux patch https://git.archlinux.org/svntogit/community.git/tree/trunk/cairosvg2.patch?h=packages/buildbot-www

I've used that patch for 2 months. PNG rendering works just fine :)