### PR TITLE
Unpin towncrier as buildbot is now py3 only

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -528,7 +528,7 @@ setup_args['extras_require'] = {
         'pyenchant',
         'docutils>=0.8',
         'sphinx-jinja',
-        'towncrier<=18.5.0', # towncrier 18.6.0 does not support python 2.7
+        'towncrier',
     ],
 }
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -75,7 +75,7 @@ sqlparse==0.2.4
 Tempita==0.5.2
 termcolor==1.1.0
 toml==0.10.0
-towncrier==18.5.0 # pyup: ignore
+towncrier==18.5.0
 treq==18.6.0
 Twisted==18.9.0
 txaio==18.8.1

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -4,4 +4,4 @@ sphinxcontrib-blockdiag==1.5.5
 sphinxcontrib-spelling==4.2.0
 sphinxcontrib-websupport==1.1.0
 Pygments==2.3.1
-towncrier==18.5.0 # pyup: ignore
+towncrier==18.5.0


### PR DESCRIPTION
Unpin towncrier as buildbot is now py3 only.