### PR TITLE
fix issue #3819

### DIFF
--- a/www/waterfall_view/src/module/scale/scale.service.coffee
+++ b/www/waterfall_view/src/module/scale/scale.service.coffee
@@ -47,5 +47,4 @@ class ScaleService extends Factory
             getBuilderName: (builders) ->
                 @d3.scale.ordinal()
                     .domain(builders.map (builder) -> builder.builderid)
-                    .range(builders.map (builder) -> builder.name
-                                   .sort (name1, name2) -> name1.localeCompare name2)
+                    .range(builders.map (builder) -> builder.name)


### PR DESCRIPTION
The locale-aware sorting introduced in PR #3488 only sorted the _builder names_. Therefore the axis labels (builder names) did not match the builds in the waterfall display. This PR reverses that change.

Fixes #3819 