### PR TITLE
Fix RemoteUserAuth.maybeAutLogin consumes bytes object as str

### DIFF
--- a/master/buildbot/newsfragments/fix_remoteuserauth_typestr.bugfix
+++ b/master/buildbot/newsfragments/fix_remoteuserauth_typestr.bugfix
@@ -1,4 +1,1 @@
-:issue:`4402`
-
-Fix RemoteUserAuth.maybeAutLogin consumes bytes object as str leading to 
-TypeError during JSON serialization. 
+Fix RemoteUserAuth.maybeAutLogin consumes bytes object as str leading to TypeError during JSON serialization. :issue:`4402`

--- a/master/buildbot/newsfragments/fix_remoteuserauth_typestr.bugfix
+++ b/master/buildbot/newsfragments/fix_remoteuserauth_typestr.bugfix
@@ -1,0 +1,4 @@
+:issue:`4402`
+
+Fix RemoteUserAuth.maybeAutLogin consumes bytes object as str leading to 
+TypeError during JSON serialization. 

--- a/master/buildbot/test/unit/test_www_auth.py
+++ b/master/buildbot/test/unit/test_www_auth.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+import json
 import mock
 
 from twisted.cred.checkers import InMemoryUsernamePasswordDatabaseDontUse
@@ -117,6 +118,7 @@ class RemoteUserAuth(www.WwwTestMixin, unittest.TestCase):
                          'username': 'rachel',
                          'realm': 'foo.com',
                          'email': 'rachel'})
+        _ = json.dumps(self.request.session.user_info)
 
     @defer.inlineCallbacks
     def test_maybeAutoLogin_no_header(self):

--- a/master/buildbot/test/unit/test_www_auth.py
+++ b/master/buildbot/test/unit/test_www_auth.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-import json
 import mock
 
 from twisted.cred.checkers import InMemoryUsernamePasswordDatabaseDontUse
@@ -118,7 +117,6 @@ class RemoteUserAuth(www.WwwTestMixin, unittest.TestCase):
                          'username': 'rachel',
                          'realm': 'foo.com',
                          'email': 'rachel'})
-        _ = json.dumps(self.request.session.user_info)
 
     @defer.inlineCallbacks
     def test_maybeAutoLogin_no_header(self):

--- a/master/buildbot/test/unit/test_www_auth.py
+++ b/master/buildbot/test/unit/test_www_auth.py
@@ -114,9 +114,9 @@ class RemoteUserAuth(www.WwwTestMixin, unittest.TestCase):
         self.request.input_headers[b'HDR'] = b'rachel@foo.com'
         yield self.auth.maybeAutoLogin(self.request)
         self.assertEqual(self.request.session.user_info, {
-                         'username': b'rachel',
-                         'realm': b'foo.com',
-                         'email': b'rachel'})
+                         'username': 'rachel',
+                         'realm': 'foo.com',
+                         'email': 'rachel'})
 
     @defer.inlineCallbacks
     def test_maybeAutoLogin_no_header(self):

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -123,8 +123,9 @@ class RemoteUserAuth(AuthBase):
             raise Error(
                 403, b'http header does not match regex! "' + header + b'" not matching ' + self.headerRegex.pattern)
         session = request.getSession()
-        if session.user_info != dict(res.groupdict()):
-            session.user_info = dict(res.groupdict())
+        user_info = {k: bytes2unicode(v) for k, v in res.groupdict().items()}
+        if session.user_info != user_info:
+            session.user_info = user_info
             yield self.updateUserInfo(request)
 
 


### PR DESCRIPTION
The headerRegex is held as a bytes object so the output of match() is a bytes object. Prior to this change it was consumed as if it were a str object, resulting in a `TypeError` later on when trying to serialize to JSON.

Closes #4402
Also related to #4299 I think.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
