### PR TITLE
Don't quote SSH args when not needed

### DIFF
--- a/master/buildbot/test/unit/test_util_git.py
+++ b/master/buildbot/test/unit/test_util_git.py
@@ -16,7 +16,39 @@
 from twisted.trial import unittest
 
 from buildbot.util.git import GitMixin
+from buildbot.util.git import escapeShellArgIfNeeded
 from buildbot.util.git import getSshKnownHostsContents
+
+
+class TestEscapeShellArgIfNeeded(unittest.TestCase):
+
+    def assert_escapes(self, arg):
+        escaped = '"{}"'.format(arg)
+        self.assertEqual(escapeShellArgIfNeeded(arg), escaped)
+
+    def assert_does_not_escape(self, arg):
+        self.assertEqual(escapeShellArgIfNeeded(arg), arg)
+
+    def test_empty(self):
+        self.assert_escapes('')
+
+    def test_spaces(self):
+        self.assert_escapes(' ')
+        self.assert_escapes('a ')
+        self.assert_escapes(' a')
+        self.assert_escapes('a b')
+
+    def test_special(self):
+        self.assert_escapes('a=b')
+        self.assert_escapes('a%b')
+        self.assert_escapes('a(b')
+        self.assert_escapes('a[b')
+
+    def test_no_escape(self):
+        self.assert_does_not_escape('abc')
+        self.assert_does_not_escape('a_b')
+        self.assert_does_not_escape('-opt')
+        self.assert_does_not_escape('--opt')
 
 
 class TestParseGitFeatures(GitMixin, unittest.TestCase):

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+import re
 from distutils.version import LooseVersion
 
 from twisted.internet import defer
@@ -29,14 +30,21 @@ RC_SUCCESS = 0
 def getSshArgsForKeys(keyPath, knownHostsPath):
     args = []
     if keyPath is not None:
-        args += ['-i', '"{0}"'.format(keyPath)]
+        args += ['-i', keyPath]
     if knownHostsPath is not None:
-        args += ['-o', '"UserKnownHostsFile={0}"'.format(knownHostsPath)]
+        args += ['-o', 'UserKnownHostsFile={0}'.format(knownHostsPath)]
     return args
+
+
+def escapeShellArgIfNeeded(arg):
+    if re.match(r"^[a-zA-Z0-9_-]+$", arg):
+        return arg
+    return '"{0}"'.format(arg)
 
 
 def getSshCommand(keyPath, knownHostsPath):
     command = ['ssh'] + getSshArgsForKeys(keyPath, knownHostsPath)
+    command = [escapeShellArgIfNeeded(arg) for arg in command]
     return ' '.join(command)
 
 

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -26,12 +26,17 @@ from buildbot.process.properties import Properties
 RC_SUCCESS = 0
 
 
-def getSshCommand(keyPath, knownHostsPath):
-    command = ['ssh']
+def getSshArgsForKeys(keyPath, knownHostsPath):
+    args = []
     if keyPath is not None:
-        command += ['-i', '"{0}"'.format(keyPath)]
+        args += ['-i', '"{0}"'.format(keyPath)]
     if knownHostsPath is not None:
-        command += ['-o', '"UserKnownHostsFile={0}"'.format(knownHostsPath)]
+        args += ['-o', '"UserKnownHostsFile={0}"'.format(knownHostsPath)]
+    return args
+
+
+def getSshCommand(keyPath, knownHostsPath):
+    command = ['ssh'] + getSshArgsForKeys(keyPath, knownHostsPath)
     return ' '.join(command)
 
 


### PR DESCRIPTION
A small nitpick. The args construction is now simplified a bit as quoting is in another layer.