### PR TITLE
Improve latent worker integration tests

### DIFF
--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -100,11 +100,11 @@ class LatentController(object):
         if self.remote_worker is None:
             return
         self.worker.conn, conn = None, self.worker.conn
+        self.remote_worker, worker = None, self.remote_worker
+
         # LocalWorker does actually disconnect, so we must force disconnection via detached
         conn.notifyDisconnected()
-        ret = self.remote_worker.disownServiceParent()
-        self.remote_worker = None
-        return ret
+        return worker.disownServiceParent()
 
     def setup_kind(self, build):
         self._started_kind_deferred = build.render(self.kind)

--- a/master/buildbot/test/integration/test_process_botmaster.py
+++ b/master/buildbot/test/integration/test_process_botmaster.py
@@ -31,7 +31,6 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
     def setUp(self):
         self.setUpTestReactor()
         self.setupDebugIntegrationLogs()
-        self.timeout = 5
 
     def tearDown(self):
         self.assertFalse(self.master.running, "master is still running!")

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -542,7 +542,7 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
 
         builds = yield master.data.get(("builds",))
         self.assertEqual(builds[0]['results'], None)
-        controller.disconnect_worker()
+        yield controller.disconnect_worker()
         builds = yield master.data.get(("builds",))
         self.assertEqual(builds[0]['results'], RETRY)
 


### PR DESCRIPTION
Small refactoring and deduplication of latent worker integration tests before addition of new tests for edge cases. Also some latent worker code has been rewritten to use inlineCallbacks.