### PR TITLE
Do not build universal wheels since python 2 is unsupported.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ release_notes: $(VENV_NAME)
 	git commit -m "relnotes for $(VERSION)"
 
 $(ALL_PKGS_TARGETS): cleanup_for_tarballs frontend_deps
-	. .venv/bin/activate && ./common/maketarball.sh $(patsubst %_pkg,%,$@)
+	. $(VENV_NAME)/bin/activate && ./common/maketarball.sh $(patsubst %_pkg,%,$@)
 
 cleanup_for_tarballs:
 	find . -name VERSION -exec rm {} \;

--- a/common/smokedist.sh
+++ b/common/smokedist.sh
@@ -18,7 +18,7 @@ do
     . $VE/bin/activate
     pip install -U pip
     pip install  mock requests flask
-    pip install dist/buildbot-1*.$suffix
+    pip install dist/buildbot-2*.$suffix
     pip install dist/buildbot?pkg*.$suffix
     pip install dist/*.$suffix
     smokes/run.sh

--- a/master/buildbot/newsfragments/4593.bugfix
+++ b/master/buildbot/newsfragments/4593.bugfix
@@ -1,0 +1,1 @@
+Do not build universal python wheels now that Python 2 is not supported.

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -75,6 +75,7 @@ def upgradeDatabase(config, master_cfg):
     if not config['quiet']:
         print("upgrading database (%s)"
               % (stripUrlPassword(master_cfg.db['db_url'])))
+        print("Warning: Stopping this process might cause data loss")
 
     master = BuildMaster(config['basedir'])
     master.config = master_cfg

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -14,8 +14,8 @@
 # Copyright Buildbot Team Members
 
 
-from twisted.internet.defer import Deferred
-from twisted.trial.unittest import SynchronousTestCase
+from twisted.internet import defer
+from twisted.trial.unittest import TestCase
 from zope.interface import implementer
 
 from buildbot.config import BuilderConfig
@@ -42,7 +42,7 @@ class StepController(object):
         self.steps = []
 
     def buildStep(self):
-        step_deferred = Deferred()
+        step_deferred = defer.Deferred()
         step = ControllableStep(step_deferred, **self.kwargs)
         self.steps.append((step, step_deferred))
         return step
@@ -61,7 +61,7 @@ class ControllableStep(BuildStep):
         self._step_deferred.callback(CANCELLED)
 
 
-class Tests(SynchronousTestCase, TestReactorMixin):
+class Tests(TestCase, TestReactorMixin):
 
     def setUp(self):
         self.setUpTestReactor()
@@ -69,6 +69,7 @@ class Tests(SynchronousTestCase, TestReactorMixin):
     def tearDown(self):
         self.assertFalse(self.master.running, "master is still running!")
 
+    @defer.inlineCallbacks
     def test_latent_max_builds(self):
         """
         If max_builds is set, only one build is started on a latent
@@ -91,31 +92,28 @@ class Tests(SynchronousTestCase, TestReactorMixin):
             'protocols': {'null': {}},
             'multiMaster': True,
         }
-        self.master = master = self.successResultOf(
-            getMaster(self, self.reactor, config_dict))
+        self.master = master = yield getMaster(self, self.reactor, config_dict)
         builder_ids = [
-            self.successResultOf(master.data.updates.findBuilderId('testy-1')),
-            self.successResultOf(master.data.updates.findBuilderId('testy-2')),
+            (yield master.data.updates.findBuilderId('testy-1')),
+            (yield master.data.updates.findBuilderId('testy-2')),
         ]
 
         started_builds = []
-        self.successResultOf(master.mq.startConsuming(
+        yield master.mq.startConsuming(
             lambda key, build: started_builds.append(build),
-            ('builds', None, 'new')))
+            ('builds', None, 'new'))
 
         # Trigger a buildrequest
-        bsid, brids = self.successResultOf(
-            master.data.updates.addBuildset(
-                waited_for=False,
-                builderids=builder_ids,
-                sourcestamps=[
-                    {'codebase': '',
-                     'repository': '',
-                     'branch': None,
-                     'revision': None,
-                     'project': ''},
-                ],
-            )
+        bsid, brids = yield master.data.updates.addBuildset(
+            waited_for=False,
+            builderids=builder_ids,
+            sourcestamps=[
+                {'codebase': '',
+                 'repository': '',
+                 'branch': None,
+                 'revision': None,
+                 'project': ''},
+            ],
         )
 
         # The worker fails to substantiate.
@@ -124,8 +122,9 @@ class Tests(SynchronousTestCase, TestReactorMixin):
         controller.connect_worker()
 
         self.assertEqual(len(started_builds), 1)
-        controller.auto_stop(True)
+        yield controller.auto_stop(True)
 
+    @defer.inlineCallbacks
     def test_local_worker_max_builds(self):
         """
         If max_builds is set, only one build is started on a worker
@@ -147,31 +146,28 @@ class Tests(SynchronousTestCase, TestReactorMixin):
             'protocols': {'null': {}},
             'multiMaster': True,
         }
-        self.master = master = self.successResultOf(
-            getMaster(self, self.reactor, config_dict))
+        self.master = master = yield getMaster(self, self.reactor, config_dict)
         builder_ids = [
-            self.successResultOf(master.data.updates.findBuilderId('testy-1')),
-            self.successResultOf(master.data.updates.findBuilderId('testy-2')),
+            (yield master.data.updates.findBuilderId('testy-1')),
+            (yield master.data.updates.findBuilderId('testy-2')),
         ]
 
         started_builds = []
-        self.successResultOf(master.mq.startConsuming(
+        yield master.mq.startConsuming(
             lambda key, build: started_builds.append(build),
-            ('builds', None, 'new')))
+            ('builds', None, 'new'))
 
         # Trigger a buildrequest
-        bsid, brids = self.successResultOf(
-            master.data.updates.addBuildset(
-                waited_for=False,
-                builderids=builder_ids,
-                sourcestamps=[
-                    {'codebase': '',
-                     'repository': '',
-                     'branch': None,
-                     'revision': None,
-                     'project': ''},
-                ],
-            )
+        bsid, brids = yield master.data.updates.addBuildset(
+            waited_for=False,
+            builderids=builder_ids,
+            sourcestamps=[
+                {'codebase': '',
+                 'repository': '',
+                 'branch': None,
+                 'revision': None,
+                 'project': ''},
+            ],
         )
 
         self.assertEqual(len(started_builds), 1)

--- a/master/buildbot/www/plugin.py
+++ b/master/buildbot/www/plugin.py
@@ -26,10 +26,10 @@ class Application(object):
     def __init__(self, modulename, description, ui=True):
         self.description = description
         self.version = pkg_resources.resource_string(
-            modulename, "/VERSION").strip()
+            modulename, "VERSION").strip()
         self.version = bytes2unicode(self.version)
         self.static_dir = pkg_resources.resource_filename(
-            modulename, "/static")
+            modulename, "static")
         self.resource = static.File(self.static_dir)
         self.ui = ui
 

--- a/master/setup.cfg
+++ b/master/setup.cfg
@@ -1,4 +1,2 @@
 [aliases]
 test = trial -m buildbot
-[bdist_wheel]
-universal=1

--- a/pkg/setup.cfg
+++ b/pkg/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/www/badges/setup.cfg
+++ b/www/badges/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/www/base/setup.cfg
+++ b/www/base/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/www/codeparameter/setup.cfg
+++ b/www/codeparameter/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/www/console_view/setup.cfg
+++ b/www/console_view/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/www/grid_view/setup.cfg
+++ b/www/grid_view/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/www/nestedexample/setup.cfg
+++ b/www/nestedexample/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/www/waterfall_view/setup.cfg
+++ b/www/waterfall_view/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/www/wsgi_dashboards/setup.cfg
+++ b/www/wsgi_dashboards/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
Fixes #4593

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
