### PR TITLE
[Docs] Add note to installation docs regarding systemd PATH for worker

### DIFF
--- a/master/docs/manual/installation/misc.rst
+++ b/master/docs/manual/installation/misc.rst
@@ -44,7 +44,8 @@ It is important to remember that the environment provided to cron jobs and init 
 There may be fewer environment variables specified, and the :envvar:`PATH` may be shorter than usual.
 It is a good idea to test out this method of launching the worker by using a cron job with a time in the near future, with the same command, and then check :file:`twistd.log` to make sure the worker actually started correctly.
 Common problems here are for :file:`/usr/local` or :file:`~/bin` to not be on your :envvar:`PATH`, or for :envvar:`PYTHONPATH` to not be set correctly.
-Sometimes :envvar:`HOME` is messed up too.
+Sometimes :envvar:`HOME` is messed up too. If using systemd to launch :command:`buildbot-worker` it may be a good idea to specify a fixed :envvar:`PATH` using the :envvar:`Environment` directive,
+see `systemd unit file example <https://github.com/buildbot/buildbot-contrib/blob/master/master/contrib/systemd/worker.service>`_
 
 Some distributions may include conveniences to make starting buildbot at boot time easy.
 For instance, with the default buildbot package in Debian-based distributions, you may only need to modify :file:`/etc/default/buildbot` (see also :file:`/etc/init.d/buildbot`, which reads the configuration in :file:`/etc/default/buildbot`).

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -777,6 +777,7 @@ synchronisation
 synchronise
 Synchronise
 syntaxes
+systemd
 Systemd
 tac
 tarball


### PR DESCRIPTION
closes #4590

No news required?

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
