### PR TITLE
scripts: ignore signals in upgrade-master

### DIFF
--- a/master/buildbot/newsfragments/upgrade-master-avoid-database-corruption.bugfix
+++ b/master/buildbot/newsfragments/upgrade-master-avoid-database-corruption.bugfix
@@ -1,0 +1,1 @@
+To avoid database corruption, the ``upgrade-master`` command now ignores all signals except ``SIGKILL``. It cannot be interrupted with ``ctrl-c`` (:issue:`4600`).

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -15,6 +15,7 @@
 
 
 import os
+import signal
 import sys
 import traceback
 
@@ -76,6 +77,19 @@ def upgradeDatabase(config, master_cfg):
         print("upgrading database (%s)"
               % (stripUrlPassword(master_cfg.db['db_url'])))
         print("Warning: Stopping this process might cause data loss")
+
+    def sighandler(signum, frame):
+        msg = " ".join("""
+        WARNING: ignoring signal %s.
+        This process should not be interrupted to avoid database corruption.
+        If you really need to terminate it, use SIGKILL.
+        """.split())
+        print(msg % signum)
+
+    for signame in ("SIGTERM", "SIGINT", "SIGQUIT", "SIGHUP",
+                    "SIGUSR1", "SIGUSR2", "SIGBREAK"):
+        if hasattr(signal, signame):
+            signal.signal(getattr(signal, signame), sighandler)
 
     master = BuildMaster(config['basedir'])
     master.config = master_cfg

--- a/master/docs/manual/installation/buildmaster.rst
+++ b/master/docs/manual/installation/buildmaster.rst
@@ -99,6 +99,12 @@ The ``upgrade-master`` command is idempotent.
 It is safe to run it multiple times.
 After each upgrade of the buildbot code, you should use ``upgrade-master`` on all your buildmasters.
 
+.. warning::
+
+   The ``upgrade-master`` command may perform database schema modifications.
+   To avoid any data loss or corruption, it should **not** be interrupted.
+   As a safeguard, it ignores all signals except ``SIGKILL``.
+
 In general, Buildbot workers and masters can be upgraded independently, although some new features will not be available, depending on the master and worker versions.
 
 Beyond this general information, read all of the sections below that apply to versions through which you are upgrading.


### PR DESCRIPTION
This command should not be interrupted to avoid database data (or worse, schema) corruption.

Make sure to trap all possible signals and ignore them. Print an explicit warning so that users are aware that the signal was not lost in translation.

Fixes: #4600