### PR TITLE
Latent worker integration test improvements

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -324,6 +324,7 @@ cors
 cowbuilder
 cppcheck
 cpu
+cpython
 cray
 createabsolutesourcestamps
 createmaster

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -193,6 +193,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
             self.workers.append(wfb)
             self.botmaster.maybeStartBuildsForBuilder(self.name)
 
+    @defer.inlineCallbacks
     def attached(self, worker, commands):
         """This is invoked by the Worker when the self.workername bot
         registers their builder.
@@ -224,22 +225,19 @@ class Builder(util_service.ReconfigurableServiceMixin,
         wfb = workerforbuilder.WorkerForBuilder()
         wfb.setBuilder(self)
         self.attaching_workers.append(wfb)
-        d = wfb.attached(worker, commands)
-        d.addCallback(self._attached)
-        d.addErrback(self._not_attached, worker)
-        return d
 
-    def _attached(self, wfb):
-        self.attaching_workers.remove(wfb)
-        self.workers.append(wfb)
+        try:
+            wfb = yield wfb.attached(worker, commands)
+            self.attaching_workers.remove(wfb)
+            self.workers.append(wfb)
+            return self
 
-        return self
-
-    def _not_attached(self, why, worker):
-        # already log.err'ed by WorkerForBuilder._attachFailure
-        # TODO: remove from self.workers (except that detached() should get
-        #       run first, right?)
-        log.err(why, 'worker failed to attach')
+        except Exception as e:
+            # already log.err'ed by WorkerForBuilder._attachFailure
+            # TODO: remove from self.workers (except that detached() should get
+            #       run first, right?)
+            log.err(e, 'worker failed to attach')
+            return None
 
     def detached(self, worker):
         """This is called when the connection to the bot is lost."""

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -232,7 +232,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
             self.workers.append(wfb)
             return self
 
-        except Exception as e:
+        except Exception as e:  # pragma: no-cover
             # already log.err'ed by WorkerForBuilder._attachFailure
             # TODO: remove from self.workers (except that detached() should get
             #       run first, right?)

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -232,7 +232,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
             self.workers.append(wfb)
             return self
 
-        except Exception as e:  # pragma: no-cover
+        except Exception as e:  # pragma: no cover
             # already log.err'ed by WorkerForBuilder._attachFailure
             # TODO: remove from self.workers (except that detached() should get
             #       run first, right?)

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -188,16 +188,15 @@ class WorkerForBuilder(AbstractWorkerForBuilder):
         AbstractWorkerForBuilder.__init__(self)
         self.state = States.DETACHED
 
+    @defer.inlineCallbacks
     def attached(self, worker, commands):
-        d = AbstractWorkerForBuilder.attached(self, worker, commands)
+        wfb = yield AbstractWorkerForBuilder.attached(self, worker, commands)
 
-        @d.addCallback
-        def setAvailable(res):
-            # Only set available on non-latent workers, since latent workers
-            # only attach while a build is in progress.
-            self.state = States.AVAILABLE
-            return res
-        return d
+        # Only set available on non-latent workers, since latent workers
+        # only attach while a build is in progress.
+        self.state = States.AVAILABLE
+
+        return wfb
 
     def detached(self):
         AbstractWorkerForBuilder.detached(self)

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -88,6 +88,7 @@ class AbstractWorkerForBuilder(object):
         if self.worker:
             self.worker.buildFinished(self)
 
+    @defer.inlineCallbacks
     def attached(self, worker, commands):
         """
         @type  worker: L{buildbot.worker.Worker}
@@ -103,14 +104,9 @@ class AbstractWorkerForBuilder(object):
             assert self.worker == worker
         log.msg("Worker %s attached to %s" % (worker.workername,
                                               self.builder_name))
-        d = defer.succeed(None)
 
-        d.addCallback(lambda _:
-                      self.worker.conn.remotePrint(message="attached"))
-
-        d.addCallback(lambda _: self)
-
-        return d
+        yield self.worker.conn.remotePrint(message="attached")
+        return self
 
     def prepare(self, build):
         if not self.worker or not self.worker.acquireLocks():

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -47,6 +47,7 @@ class LatentController(object):
         self.auto_stop_flag = False
         self.auto_start_flag = False
         self.auto_connect_worker = False
+        self.auto_disconnect_worker = True
 
         self.kind = kind
         self._started_kind = None
@@ -82,11 +83,13 @@ class LatentController(object):
         d, self._stop_deferred = self._stop_deferred, None
         d.callback(result)
 
+    @defer.inlineCallbacks
     def do_stop_instance(self):
         assert self.stopping
         self.stopping = False
         self._started_kind = None
-        return self.disconnect_worker()
+        if self.auto_disconnect_worker:
+            yield self.disconnect_worker()
 
     def connect_worker(self):
         if self.remote_worker is not None:

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -115,8 +115,10 @@ class LatentController(SeverWorkerConnectionMixin):
         self.worker.conn, conn = None, self.worker.conn
         self.remote_worker, worker = None, self.remote_worker
 
-        # LocalWorker does actually disconnect, so we must force disconnection via detached
-        conn.notifyDisconnected()
+        # LocalWorker does actually disconnect, so we must force disconnection
+        # via detached. Note that the worker may have already detached
+        if conn is not None:
+            conn.loseConnection()
         return worker.disownServiceParent()
 
     def setup_kind(self, build):

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -109,6 +109,7 @@ class LatentController(SeverWorkerConnectionMixin):
         self.remote_worker.setServiceParent(self.worker)
 
     def disconnect_worker(self):
+        super().disconnect_worker()
         if self.remote_worker is None:
             return
         self.worker.conn, conn = None, self.worker.conn

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -18,6 +18,7 @@ from twisted.internet import defer
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import SkipTest
 
+from buildbot.test.fake.worker import SeverWorkerConnectionMixin
 from buildbot.worker import AbstractLatentWorker
 
 try:
@@ -27,7 +28,7 @@ except ImportError:
     RemoteWorker = None
 
 
-class LatentController(object):
+class LatentController(SeverWorkerConnectionMixin):
 
     """
     A controller for ``ControllableLatentWorker``.

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -74,7 +74,42 @@ class FakeWorker(object):
         pass
 
 
-class WorkerController:
+class SeverWorkerConnectionMixin:
+    def sever_connection(self):
+        # stubs the worker connection so that it appears that the TCP connection
+        # has been severed in a way that no response is ever received, but
+        # messages don't fail immediately.
+        def remotePrint(message):
+            return defer.Deferred()
+        self.worker.conn.remotePrint = remotePrint
+
+        def remoteGetWorkerInfo():
+            return defer.Deferred()
+        self.worker.conn.remoteGetWorkerInfo = remoteGetWorkerInfo
+
+        def remoteSetBuilderList(builders):
+            return defer.Deferred()
+        self.worker.conn.remoteSetBuilderList = remoteSetBuilderList
+
+        def remoteStartCommand(remoteCommand, builderName, commandId,
+                               commandName, args):
+            return defer.Deferred()
+        self.worker.conn.remoteStartCommand = remoteStartCommand
+
+        def remoteShutdown():
+            return defer.Deferred()
+        self.worker.conn.remoteShutdown = remoteShutdown
+
+        def remoteStartBuild(builderName):
+            return defer.Deferred()
+        self.worker.conn.remoteStartBuild = remoteStartBuild
+
+        def remoteInterruptCommand(builderName, commandId, why):
+            return defer.Deferred()
+        self.worker.conn.remoteInterruptCommand = remoteInterruptCommand
+
+
+class WorkerController(SeverWorkerConnectionMixin):
 
     """
     A controller for a ``Worker``.
@@ -112,36 +147,3 @@ class WorkerController:
         ret = self.remote_worker.disownServiceParent()
         self.remote_worker = None
         return ret
-
-    def sever_connection(self):
-        # stubs the worker connection so that it appears that the TCP connection
-        # has been severed in a way that no response is ever received, but
-        # messages don't fail immediately.
-        def remotePrint(message):
-            return defer.Deferred()
-        self.worker.conn.remotePrint = remotePrint
-
-        def remoteGetWorkerInfo():
-            return defer.Deferred()
-        self.worker.conn.remoteGetWorkerInfo = remoteGetWorkerInfo
-
-        def remoteSetBuilderList(builders):
-            return defer.Deferred()
-        self.worker.conn.remoteSetBuilderList = remoteSetBuilderList
-
-        def remoteStartCommand(remoteCommand, builderName, commandId,
-                               commandName, args):
-            return defer.Deferred()
-        self.worker.conn.remoteStartCommand = remoteStartCommand
-
-        def remoteShutdown():
-            return defer.Deferred()
-        self.worker.conn.remoteShutdown = remoteShutdown
-
-        def remoteStartBuild(builderName):
-            return defer.Deferred()
-        self.worker.conn.remoteStartBuild = remoteStartBuild
-
-        def remoteInterruptCommand(builderName, commandId, why):
-            return defer.Deferred()
-        self.worker.conn.remoteInterruptCommand = remoteInterruptCommand

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -325,7 +325,6 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
 
         # The worker succeeds to substantiate.
         controller.start_instance(True)
-        controller.connect_worker()
 
         # We check that there were two builds that finished, and
         # that they both finished with success
@@ -389,7 +388,6 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
         controller.patchBot(self, 'remote_setBuilderList',
                             remote_setBuilderList)
         controller.start_instance(True)
-        controller.connect_worker()
 
         # Flush the errors logged by the failure.
         self.flushLoggedErrors(TestException)
@@ -441,7 +439,6 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
                 raise TestException("can't ping")
         controller.patchBot(self, 'remote_print', remote_print)
         controller.start_instance(True)
-        controller.connect_worker()
 
         # Flush the errors logged by the failure.
         self.flushLoggedErrors(TestException)
@@ -484,7 +481,6 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
 
         self.assertTrue(controller.starting)
         controller.start_instance(True)
-        controller.connect_worker()
 
         builds = yield master.data.get(("builds",))
         self.assertEqual(builds[0]['results'], None)
@@ -495,7 +491,7 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
         # Request one build.
         yield self.createBuildrequest(master, [builder_id])
         controller.start_instance(True)
-        controller.connect_worker()
+
         builds = yield master.data.get(("builds",))
         self.assertEqual(builds[1]['results'], None)
         stepcontroller.finish_step(SUCCESS)
@@ -589,10 +585,8 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
         # kind, so we allow it both to auto start and stop
         self.assertEqual(True, controller.starting)
 
-        controller.auto_connect_worker = True
         controller.auto_start(True)
         yield controller.auto_stop(True)
-        controller.connect_worker()
         self.assertEqual((yield controller.get_started_kind()),
                          'a')
 
@@ -642,10 +636,8 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
         # kind, so we allow it both to auto start and stop
         self.assertEqual(True, controller.starting)
 
-        controller.auto_connect_worker = True
         controller.auto_start(True)
         yield controller.auto_stop(True)
-        controller.connect_worker()
         self.assertEqual((yield controller.get_started_kind()),
                          'a')
 

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -325,7 +325,6 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
 
         # The worker succeeds to substantiate.
         controller.start_instance(True)
-
         controller.connect_worker()
 
         # We check that there were two builds that finished, and
@@ -479,6 +478,7 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
             )
 
         # Request a build and disconnect midway
+        controller.auto_disconnect_worker = False
         yield self.createBuildrequest(master, [builder_id])
         yield controller.auto_stop(True)
 
@@ -501,6 +501,7 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
         stepcontroller.finish_step(SUCCESS)
         builds = yield master.data.get(("builds",))
         self.assertEqual(builds[1]['results'], SUCCESS)
+        yield controller.disconnect_worker()
 
     @defer.inlineCallbacks
     def test_build_stop_with_cancelled_during_substantiation(self):
@@ -589,7 +590,6 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
         self.assertEqual(True, controller.starting)
 
         controller.auto_connect_worker = True
-        controller.auto_disconnect_worker = True
         controller.auto_start(True)
         yield controller.auto_stop(True)
         controller.connect_worker()
@@ -643,7 +643,6 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
         self.assertEqual(True, controller.starting)
 
         controller.auto_connect_worker = True
-        controller.auto_disconnect_worker = True
         controller.auto_start(True)
         yield controller.auto_stop(True)
         controller.connect_worker()

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -80,7 +80,7 @@ class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
         if not controller_kwargs:
             controller_kwargs = {}
 
-        controller = LatentController(self, 'local')
+        controller = LatentController(self, 'local', **controller_kwargs)
         config_dict = {
             'builders': [
                 BuilderConfig(name="testy",

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -16,7 +16,6 @@
 
 from twisted.internet import defer
 from twisted.python.failure import Failure
-from twisted.trial.unittest import TestCase
 
 from buildbot.config import BuilderConfig
 from buildbot.interfaces import LatentWorkerCannotSubstantiate
@@ -34,6 +33,7 @@ from buildbot.test.fake.step import BuildStepController
 from buildbot.test.util.integration import getMaster
 from buildbot.test.util.misc import DebugIntegrationLogsMixin
 from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.util.misc import TimeoutableTestCase
 
 
 class TestException(Exception):
@@ -43,7 +43,7 @@ class TestException(Exception):
     """
 
 
-class Tests(TestCase, TestReactorMixin, DebugIntegrationLogsMixin):
+class Tests(TimeoutableTestCase, TestReactorMixin, DebugIntegrationLogsMixin):
 
     def setUp(self):
         self.setUpTestReactor()

--- a/master/buildbot/test/unit/test_util_patch_delay.py
+++ b/master/buildbot/test/unit/test_util_patch_delay.py
@@ -1,0 +1,97 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.trial.unittest import SynchronousTestCase
+
+from buildbot.test.util.patch_delay import patchForDelay
+
+
+class TestException(Exception):
+    pass
+
+
+def fun_to_patch(*args, **kwargs):
+    return defer.succeed((args, kwargs))
+
+
+def fun_to_patch_exception():
+    raise TestException()
+
+
+non_callable = 1
+
+
+class Tests(SynchronousTestCase):
+
+    def test_raises_not_found(self):
+        with self.assertRaises(Exception):
+            with patchForDelay(__name__ + '.notfound'):
+                pass
+
+    def test_raises_not_callable(self):
+        with self.assertRaises(Exception):
+            with patchForDelay(__name__ + '.non_callable'):
+                pass
+
+    def test_patches_within_context(self):
+        d = fun_to_patch()
+        self.assertTrue(d.called)
+
+        with patchForDelay(__name__ + '.fun_to_patch') as delay:
+            d = fun_to_patch()
+            self.assertEqual(len(delay), 1)
+            self.assertFalse(d.called)
+            delay.fire()
+            self.assertEqual(len(delay), 0)
+            self.assertTrue(d.called)
+
+        d = fun_to_patch()
+        self.assertTrue(d.called)
+
+    def test_auto_fires_unfired_delay(self):
+        with patchForDelay(__name__ + '.fun_to_patch') as delay:
+            d = fun_to_patch()
+            self.assertEqual(len(delay), 1)
+            self.assertFalse(d.called)
+        self.assertTrue(d.called)
+
+    def test_auto_fires_unfired_delay_exception(self):
+        try:
+            with patchForDelay(__name__ + '.fun_to_patch') as delay:
+                d = fun_to_patch()
+                self.assertEqual(len(delay), 1)
+                self.assertFalse(d.called)
+                raise TestException()
+        except TestException:
+            pass
+        self.assertTrue(d.called)
+
+    def test_passes_arguments(self):
+        with patchForDelay(__name__ + '.fun_to_patch') as delay:
+            d = fun_to_patch('arg', kw='kwarg')
+            self.assertEqual(len(delay), 1)
+            delay.fire()
+            args = self.successResultOf(d)
+
+        self.assertEqual(args, (('arg',), {'kw': 'kwarg'}))
+
+    def test_passes_exception(self):
+        with patchForDelay(__name__ + '.fun_to_patch_exception') as delay:
+            d = fun_to_patch_exception()
+            self.assertEqual(len(delay), 1)
+            delay.fire()
+            f = self.failureResultOf(d)
+            f.check(TestException)

--- a/master/buildbot/test/util/patch_delay.py
+++ b/master/buildbot/test/util/patch_delay.py
@@ -1,0 +1,103 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+#
+# Portions of this file include source code of Python 3.7 from
+# cpython/Lib/unittest/mock.py file.
+#
+# It is licensed under PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2.
+# Copyright (c) 2001-2019 Python Software Foundation. All rights reserved.
+
+import contextlib
+import functools
+
+import mock
+
+from twisted.internet import defer
+
+
+def _dot_lookup(thing, comp, import_path):
+    try:
+        return getattr(thing, comp)
+    except AttributeError:
+        __import__(import_path)
+        return getattr(thing, comp)
+
+
+def _importer(target):
+    components = target.split('.')
+    import_path = components.pop(0)
+    thing = __import__(import_path)
+
+    for comp in components:
+        import_path += ".%s" % comp
+        thing = _dot_lookup(thing, comp, import_path)
+    return thing
+
+
+def _get_target(target):
+    try:
+        target, attribute = target.rsplit('.', 1)
+    except (TypeError, ValueError):
+        raise TypeError("Need a valid target to patch. You supplied: %r" %
+                        (target,))
+    return _importer(target), attribute
+
+
+class DelayWrapper:
+    def __init__(self):
+        self._deferreds = []
+
+    def add_new(self):
+        d = defer.Deferred()
+        self._deferreds.append(d)
+        return d
+
+    def __len__(self):
+        return len(self._deferreds)
+
+    def fire(self):
+        deferreds = self._deferreds
+        self._deferreds = []
+        for d in deferreds:
+            d.callback(None)
+
+
+@contextlib.contextmanager
+def patchForDelay(target_name):
+    class Default:
+        pass
+    default = Default()
+
+    target, attribute = _get_target(target_name)
+    original = getattr(target, attribute, default)
+
+    if original is default:
+        raise Exception('Could not find name {}'.format(target_name))
+    if not callable(original):
+        raise Exception('{} is not callable'.format(target_name))
+
+    delay = DelayWrapper()
+
+    @functools.wraps(original)
+    @defer.inlineCallbacks
+    def wrapper(*args, **kwargs):
+        yield delay.add_new()
+        return (yield original(*args, **kwargs))
+
+    with mock.patch(target_name, new=wrapper):
+        try:
+            yield delay
+        finally:
+            delay.fire()

--- a/master/buildbot/worker/protocols/null.py
+++ b/master/buildbot/worker/protocols/null.py
@@ -70,7 +70,7 @@ class Connection(base.Connection):
                base.FileReaderImpl: FileReaderProxy}
 
     def loseConnection(self):
-        pass
+        self.notifyDisconnected()
 
     def remotePrint(self, message):
         return defer.maybeDeferred(self.worker.bot.remote_print, message)

--- a/master/buildbot/www/resource.py
+++ b/master/buildbot/www/resource.py
@@ -79,7 +79,7 @@ class Resource(resource.Resource):
                 if s is not None:
                     request.write(s)
                 request.finish()
-            except RuntimeError:  # pragma: no-cover
+            except RuntimeError:  # pragma: no cover
                 # this occurs when the client has already disconnected; ignore
                 # it (see #2027)
                 log.msg("http client disconnected before results were sent")

--- a/master/setup.py
+++ b/master/setup.py
@@ -129,6 +129,7 @@ def define_plugin_entries(groups):
 
     return result
 
+
 __file__ = inspect.getframeinfo(inspect.currentframe()).filename
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as long_d_f:


### PR DESCRIPTION
This PR includes various small refactorings to the latent worker integration tests. 

One of the more interesting parts is `patchForDelay` which allows patching deferred functions just like `mock.patch`, but instead of full patching, it only wraps them and introduces an arbitrary delay before the function starts. This is a good tool for writing regression tests for race conditions. See `test_util_patch_delay.py` for examples of how it can be used.

Another change is that `LatentController` now automatically connects worker if `start_instance()` was called with `True`, i.e. success. This allows removal of a lot of explicit `connect_worker()` calls from tests which were otherwise potentially easy to miss.

Finally, it looks like that Twisted does not handle timeouts in functions registered to `addCleanup`. This is a big problem for us, because whenever an integration test breaks, it's possible that the shutdown of the master may block on some deferred that may never be called (e.g. due to assertion error) and thus deadlock whole test run. To work around this, a separate class `TimeoutableTestCase` has been added which times out the cleanups too. Ideally this should be fixed in Twisted, but until then we have no other reasonable choice. `TimeoutableTestCase` uses private `_run` API of the `TestCase`, but that code has not changed significantly since 2012, so it should be safe to use.
