### PR TITLE
workers: add defaultProperties support

### DIFF
--- a/master/buildbot/newsfragments/worker-defaultProperties.feature
+++ b/master/buildbot/newsfragments/worker-defaultProperties.feature
@@ -1,0 +1,1 @@
+:bb:cfg:`workers` now have a new ``defaultProperties`` parameter.

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -220,8 +220,7 @@ class Build(properties.PropertiesMixin):
         # get worker properties
         # navigate our way back to the L{buildbot.worker.Worker}
         # object that came from the config, and get its properties
-        worker_properties = workerforbuilder.worker.properties
-        props.updateFromProperties(worker_properties)
+        workerforbuilder.worker.setupProperties(props)
 
     def setupOwnProperties(self):
         # now set some properties of our own, corresponding to the

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -37,6 +37,7 @@ class FakeWorker(object):
         self.master = master
         self.conn = fakeprotocol.FakeConnection(master, self)
         self.properties = properties.Properties()
+        self.defaultProperties = properties.Properties()
         self.workerid = 383
 
     def acquireLocks(self):

--- a/master/buildbot/test/unit/test_worker_base.py
+++ b/master/buildbot/test/unit/test_worker_base.py
@@ -22,6 +22,7 @@ from twisted.trial import unittest
 
 from buildbot import config
 from buildbot import locks
+from buildbot.process import properties
 from buildbot.test.fake import bworkermanager
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
@@ -48,6 +49,9 @@ class WorkerInterfaceTests(interfaces.InterfaceTests):
 
     def test_attr_properties(self):
         self.assertTrue(hasattr(self.wrk, 'properties'))
+
+    def test_attr_defaultProperties(self):
+        self.assertTrue(hasattr(self.wrk, 'defaultProperties'))
 
     @defer.inlineCallbacks
     def test_attr_worker_basedir(self):
@@ -235,6 +239,22 @@ class TestAbstractWorker(unittest.TestCase):
 
         yield self.do_test_reconfigService(old, old)
         self.assertTrue(old.properties.getProperty('workername'), 'bot')
+
+    @defer.inlineCallbacks
+    def test_setupProperties(self):
+        props = properties.Properties()
+        props.setProperty('foo', 1, 'Scheduler')
+        props.setProperty('bar', 'bleh', 'Change')
+        props.setProperty('omg', 'wtf', 'Builder')
+
+        wrkr = yield self.createWorker(
+            'bot', 'passwd',
+            defaultProperties={'bar': 'onoes', 'cuckoo': 42})
+
+        wrkr.setupProperties(props)
+
+        self.assertEquals(props.getProperty('bar'), 'bleh')
+        self.assertEquals(props.getProperty('cuckoo'), 42)
 
     @defer.inlineCallbacks
     def test_reconfigService_initial_registration(self):

--- a/master/docs/manual/configuration/workers.rst
+++ b/master/docs/manual/configuration/workers.rst
@@ -50,6 +50,14 @@ For example::
                       properties={ 'os':'solaris' }),
     ]
 
+:class:`Worker` properties have priority over other sources (:class:`Builder`, :class:`Scheduler`, etc.).
+You may use the ``defaultProperties`` parameter that will only be added to :ref:`Build-Properties` if they are not already set by :ref:`another source <Properties>`::
+
+   c['workers'] = [
+       worker.Worker('fast-bot', 'fast-passwd',
+                     defaultProperties={'parallel_make': 10}),
+   ]
+
 Limiting Concurrency
 ++++++++++++++++++++
 


### PR DESCRIPTION
Add a new defaultProperties field for AbstractWorker. Properties set here will only be exported to builds if they are not already set by builders, changes or schedulers.