### PR TITLE
Improve behavior of AbstractLatentWorker by implementing a state machine

### DIFF
--- a/master/buildbot/newsfragments/fix-latent-worker-states.bugfix
+++ b/master/buildbot/newsfragments/fix-latent-worker-states.bugfix
@@ -1,0 +1,1 @@
+Fixed incorrect tracking of latent worker states that could sometimes result in duplicate ``stop_instance`` calls and so on.

--- a/master/buildbot/newsfragments/fix-latent-worker-substantiation-race.bugfix
+++ b/master/buildbot/newsfragments/fix-latent-worker-substantiation-race.bugfix
@@ -1,0 +1,1 @@
+Fixed a race condition that could manifest in cancelled substantiations if builds were created during insubstantiation of a latent worker.

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -75,6 +75,10 @@ class LatentController(SeverWorkerConnectionMixin):
     def stopping(self):
         return self.state == self.STATE_STOPPING
 
+    @property
+    def stopped(self):
+        return self.state == self.STATE_NOT_STARTED
+
     def auto_start(self, result):
         self.auto_start_flag = result
         if self.auto_start_flag and self.state == self.STATE_STARTING:

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 
 
+import enum
+
 from twisted.internet import defer
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import SkipTest
@@ -26,6 +28,13 @@ try:
     from buildbot_worker.base import BotBase
 except ImportError:
     RemoteWorker = None
+
+
+class States(enum.Enum):
+    STOPPED = 0
+    STARTING = 1
+    STARTED = 2
+    STOPPING = 3
 
 
 class LatentController(SeverWorkerConnectionMixin):
@@ -42,18 +51,13 @@ class LatentController(SeverWorkerConnectionMixin):
     stop_instance() is executed.
     """
 
-    STATE_NOT_STARTED = 0
-    STATE_STARTING = 1
-    STATE_STARTED = 2
-    STATE_STOPPING = 3
-
     def __init__(self, case, name, kind=None, build_wait_timeout=600, **kwargs):
         self.case = case
         self.build_wait_timeout = build_wait_timeout
         self.worker = ControllableLatentWorker(name, self, **kwargs)
         self.remote_worker = None
 
-        self.state = self.STATE_NOT_STARTED
+        self.state = States.STOPPED
         self.auto_stop_flag = False
         self.auto_start_flag = False
         self.auto_connect_worker = True
@@ -65,23 +69,23 @@ class LatentController(SeverWorkerConnectionMixin):
 
     @property
     def starting(self):
-        return self.state == self.STATE_STARTING
+        return self.state == States.STARTING
 
     @property
     def started(self):
-        return self.state == self.STATE_STARTED
+        return self.state == States.STARTED
 
     @property
     def stopping(self):
-        return self.state == self.STATE_STOPPING
+        return self.state == States.STOPPING
 
     @property
     def stopped(self):
-        return self.state == self.STATE_NOT_STARTED
+        return self.state == States.STOPPED
 
     def auto_start(self, result):
         self.auto_start_flag = result
-        if self.auto_start_flag and self.state == self.STATE_STARTING:
+        if self.auto_start_flag and self.state == States.STARTING:
             self.start_instance(True)
 
     def start_instance(self, result):
@@ -90,15 +94,15 @@ class LatentController(SeverWorkerConnectionMixin):
         d.callback(result)
 
     def do_start_instance(self, result):
-        assert self.state == self.STATE_STARTING
-        self.state = self.STATE_STARTED
+        assert self.state == States.STARTING
+        self.state = States.STARTED
         if self.auto_connect_worker and result is True:
             self.connect_worker()
 
     @defer.inlineCallbacks
     def auto_stop(self, result):
         self.auto_stop_flag = result
-        if self.auto_stop_flag and self.state == self.STATE_STOPPING:
+        if self.auto_stop_flag and self.state == States.STOPPING:
             yield self.stop_instance(True)
 
     @defer.inlineCallbacks
@@ -109,8 +113,8 @@ class LatentController(SeverWorkerConnectionMixin):
 
     @defer.inlineCallbacks
     def do_stop_instance(self):
-        assert self.state == self.STATE_STOPPING
-        self.state = self.STATE_NOT_STARTED
+        assert self.state == States.STOPPING
+        self.state = States.STOPPED
         self._started_kind = None
         if self.auto_disconnect_worker:
             yield self.disconnect_worker()
@@ -177,7 +181,7 @@ class ControllableLatentWorker(AbstractLatentWorker):
 
     @defer.inlineCallbacks
     def isCompatibleWithBuild(self, build_props):
-        if self._controller.state == LatentController.STATE_NOT_STARTED:
+        if self._controller.state == States.STOPPED:
             return True
 
         requested_kind = yield build_props.render((self._controller.kind))
@@ -187,8 +191,8 @@ class ControllableLatentWorker(AbstractLatentWorker):
     def start_instance(self, build):
         self._controller.setup_kind(build)
 
-        assert self._controller.state == LatentController.STATE_NOT_STARTED
-        self._controller.state = LatentController.STATE_STARTING
+        assert self._controller.state == States.STOPPED
+        self._controller.state = States.STARTING
 
         if self._controller.auto_start_flag:
             self._controller.do_start_instance(True)
@@ -199,14 +203,13 @@ class ControllableLatentWorker(AbstractLatentWorker):
 
     @defer.inlineCallbacks
     def stop_instance(self, build):
-        assert self._controller.state in [LatentController.STATE_STARTED,
-                                          LatentController.STATE_STARTING]
+        assert self._controller.state in [States.STARTED, States.STARTING]
         # if we did not succeed starting, at least call back the failure result
-        if self._controller.state == LatentController.STATE_STARTING:
-            self._controller.state = LatentController.STATE_NOT_STARTED
+        if self._controller.state == States.STARTING:
+            self._controller.state = States.STOPPED
             d, self._controller._start_deferred = self._controller._start_deferred, None
             d.callback(False)
-        self._controller.state = LatentController.STATE_STOPPING
+        self._controller.state = States.STOPPING
 
         if self._controller.auto_stop_flag:
             yield self._controller.do_stop_instance()

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -91,7 +91,6 @@ class LatentController(SeverWorkerConnectionMixin):
 
     def do_start_instance(self, result):
         assert self.state == self.STATE_STARTING
-        assert not self.remote_worker
         self.state = self.STATE_STARTED
         if self.auto_connect_worker and result is True:
             self.connect_worker()

--- a/master/buildbot/test/unit/test_worker_marathon.py
+++ b/master/buildbot/test/unit/test_worker_marathon.py
@@ -17,6 +17,7 @@
 from twisted.internet import defer
 from twisted.trial import unittest
 
+from buildbot.interfaces import LatentWorkerSubstantiatiationCancelled
 from buildbot.process.properties import Properties
 from buildbot.test.fake import fakebuild
 from buildbot.test.fake import fakemaster
@@ -51,6 +52,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
                 code = 200
             self._http.delete = lambda _: defer.succeed(FakeResult())
             self.worker.master.stopService()
+        self.flushLoggedErrors(LatentWorkerSubstantiatiationCancelled)
 
     def test_constructor_normal(self):
         worker = MarathonLatentWorker('bot', 'tcp://marathon.local', 'foo',

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -229,7 +229,12 @@ class AbstractLatentWorker(AbstractWorker):
             return
         log.msg(r"Worker %s substantiated \o/" % (self.name,))
 
-        self.state = self.STATE_SUBSTANTIATED
+        # only change state when we are actually substantiating. We could
+        # end up at this point in different state than STATE_SUBSTANTIATING
+        # if build_wait_timeout is negative. When build_wait_timeout is not
+        # negative, we throw an error (see above)
+        if self.state == self.STATE_SUBSTANTIATING:
+            self.state = self.STATE_SUBSTANTIATED
         if not self._substantiation_notifier:
             log.msg("No substantiation deferred for %s" % (self.name,))
         else:

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -312,7 +312,7 @@ class AbstractLatentWorker(AbstractWorker):
             return
 
         if self.state == self.STATE_INSUBSTANTIATING:
-            # TODO: wait until stop_instance completes just like when substantiating
+            yield self._insubstantiation_notifier.wait()
             return
 
         notify_cancel = self.state == self.STATE_SUBSTANTIATING

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -277,10 +277,6 @@ class AbstractLatentWorker(AbstractWorker):
         # we were disconnected, but all the builds are not yet cleaned up.
         if self.conn is None and self.building:
             return False
-        # wait until any insubstantiation completes
-        if self.state in [self.STATE_INSUBSTANTIATING,
-                          self.STATE_INSUBSTANTIATING_SUBSTANTIATING]:
-            return False
         return AbstractWorker.canStartBuild(self)
 
     def buildStarted(self, wfb):

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -543,8 +543,8 @@ Writing a new latent worker should only require subclassing :class:`buildbot.wor
 
 .. bb:worker:: AbstractWorkerController
 
-AbstractLatentController
-~~~~~~~~~~~~~~~~~~~~~~~~
+AbstractLatentWorker
+~~~~~~~~~~~~~~~~~~~~
 
 .. py:class:: buildbot.worker.AbstractLatentWorker
 
@@ -563,6 +563,8 @@ Overriding these members ensures that builds aren't ran on incompatible workers 
         A deferred should be returned.
         Any problems should use an errback.
         The callback value can be ``None``, or can be an iterable of short strings to include in the "substantiate success" status message, such as identifying the instance that started.
+        Buildbot will ensure that a single worker will never have its ``start_instance`` called before any previous calls to ``start_instance`` or ``stop_instance`` finish.
+        Additionally, for each ``start_instance`` call, exactly one corresponding call to ``stop_instance`` will be done eventually.
 
     .. py:method:: stop_instance(self, fast=False)
 
@@ -570,6 +572,8 @@ Overriding these members ensures that builds aren't ran on incompatible workers 
         A deferred should be returned.
         If ``fast`` is ``True`` then the function should call back as soon as it is safe to do so, as, for example, the master may be shutting down.
         The value returned by the callback is ignored.
+        Buildbot will ensure that a single worker will never have its ``stop_instance`` called before any previous calls to ``stop_instance`` finish.
+        ``stop_instance`` may be called before ``start_instance`` finishes only if ``start_instance`` takes a long time and the worker times out.
 
     .. py:attribute:: builds_may_be_incompatible
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -383,6 +383,7 @@ inlineCallbacks
 inrepo
 inrepos
 instantiation
+insubstantiation
 integrators
 interCaps
 internet


### PR DESCRIPTION
Previously the latent worker tracked its state implicitly by looking into the following variables: self.conn, self._substantiation_notifier, self.insubstantiating. As a result, the implementation was seemingly simple, but it didn't handle the edge cases well. For example, in a lot of cases `stop_instance()` was called incorrect number of times and integration tests didn't even check that. The latent worker implementations were less robust as a result (e.g. causing issues like #4412).

This PR switches `AbstractLatentWorker` to a state machine and additionally enables proper tracking of latent worker state in its integration tests. This has led to more robust behavior which is covered by 10 new latent worker integration tests. We now document what the LatentWorker implementations may expect in terms of guarantees of when `start_instance()` and `stop_instance()` is called.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
