### PR TITLE
BotMaster and BuildRequestDistributor improvements for scalability

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -204,6 +204,7 @@ class MasterConfig(util.ComparableMixin):
         self.collapseRequests = None
         self.codebaseGenerator = None
         self.prioritizeBuilders = None
+        self.buildRequestDistributorClass = None
         self.multiMaster = False
         self.manhole = None
         self.protocols = {}
@@ -250,6 +251,7 @@ class MasterConfig(util.ComparableMixin):
         "buildCacheSize",
         "builders",
         "buildHorizon",
+        "buildRequestDistributor",
         "caches",
         "change_source",
         "codebaseGenerator",
@@ -472,6 +474,18 @@ class MasterConfig(util.ComparableMixin):
             error("prioritizeBuilders must be a callable")
         else:
             self.prioritizeBuilders = prioritizeBuilders
+
+        # local import to avoid circular imports
+        from buildbot.process.buildrequestdistributor import BuildRequestDistributor
+
+        brd_cls = config_dict.get('buildRequestDistributorClass')
+        if brd_cls is not None and (
+                not inspect.isclass(brd_cls) or
+                not issubclass(brd_cls, BuildRequestDistributor)):
+            error('buildRequestDistributorClass must be a subclass of %s'
+                  % BuildRequestDistributor)
+        else:
+            self.buildRequestDistributorClass = brd_cls
 
         protocols = config_dict.get('protocols', {})
         if isinstance(protocols, dict):

--- a/master/buildbot/newsfragments/config-buildrequestdistributor.feature
+++ b/master/buildbot/newsfragments/config-buildrequestdistributor.feature
@@ -1,0 +1,1 @@
+A custom build request distributor class can now be configured via :bb:cfg:`buildRequestDistributorClass`.

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -35,6 +35,7 @@ from buildbot import locks
 from buildbot import revlinks
 from buildbot import worker
 from buildbot.changes import base as changes_base
+from buildbot.process import buildrequestdistributor
 from buildbot.process import factory
 from buildbot.process import properties
 from buildbot.schedulers import base as schedulers_base
@@ -65,6 +66,7 @@ global_defaults = dict(
     properties=properties.Properties(),
     collapseRequests=None,
     prioritizeBuilders=None,
+    buildRequestDistributorClass=None,
     protocols={},
     multiMaster=False,
     manhole=None,
@@ -557,6 +559,24 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.cfg.load_global(self.filename,
                              dict(prioritizeBuilders='yes'))
         self.assertConfigError(self.errors, "must be a callable")
+
+    def test_load_global_buildRequestDistributorClass_valid(self):
+        class MyBrd(buildrequestdistributor.BuildRequestDistributor):
+            pass
+        self.do_test_load_global(dict(buildRequestDistributorClass=MyBrd),
+                                 buildRequestDistributorClass=MyBrd)
+
+    def test_load_global_buildRequestDistributorClass_not_a_class(self):
+        self.cfg.load_global(self.filename,
+                             dict(buildRequestDistributorClass='MyBrd'))
+        self.assertConfigError(self.errors, "must be a subclass of")
+
+    def test_load_global_buildRequestDistributorClass_invalid(self):
+        class MyBrd:
+            pass
+        self.cfg.load_global(self.filename,
+                             dict(buildRequestDistributorClass=MyBrd))
+        self.assertConfigError(self.errors, "must be a subclass of")
 
     def test_load_global_protocols_str(self):
         self.do_test_load_global(dict(protocols={'pb': {'port': 'udp:123'}}),

--- a/master/docs/manual/configuration/global.rst
+++ b/master/docs/manual/configuration/global.rst
@@ -394,6 +394,20 @@ This parameter controls the order that the build master can start builds, and is
 It does not affect the order in which a builder processes the build requests in its queue.
 For that purpose, see :ref:`Prioritizing-Builds`.
 
+.. index:: Builders; priority
+
+.. bb:cfg:: buildRequestDistributorClass
+
+Build Request Distributor
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the default build request distribution algorithm does not fit your needs, you may completely override it with your own class.
+It needs to be a subclass of :py:class:`buildbot.process.buildrequestdistributor.BuildRequestDistributor`.
+
+.. attention::
+
+   Setting this may cause the :bb:cfg:`builders` ``nextWorker`` and ``nextBuild`` functions not to be called.
+
 .. bb:cfg:: protocols
 
 .. _Setting-the-PB-Port-for-Workers:


### PR DESCRIPTION
Allow using a custom `BuildRequestDistributor` class instead of the default one.

This is the first step to address bug #4592. The current implementation of the build request distributor is overly complex and suboptimal. However, modifying the algorithm would make the `BuilderConfig.nextBuild` and `BuilderConfig.nextWorker` functions obsolete.

There may be people using them and we cannot break the API. The idea is to propose multiple built-in `BuildRequestDistributor` implementations (will be done in separate commits).

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation