### PR TITLE
Suspendable latent workers

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1096,6 +1096,7 @@ reconfiguring
 reconnection
 recurse
 redhat
+reentrant
 refactor
 refcount
 refetch

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -191,17 +191,11 @@ class ISuspendableMachine(Interface):
     pass
 
 
-class IMachineWakeAction(Interface):
-    def wake(self, manager):
-        """ Wake the machine managed by manager. Returns a deferred evaluating
-            to True if it was possible to execute the wake action.
-        """
-
-
-class IMachineSuspendAction(Interface):
-    def suspend(self, manager):
-        """ Suspend or shut down the machine managed by manager.
-            Returns a deferred.
+class IMachineAction(Interface):
+    def perform(self, manager):
+        """ Perform an action on the machine managed by manager. Returns a
+            deferred evaluating to True if it was possible to execute the
+            action.
         """
 
 

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -191,6 +191,20 @@ class ISuspendableMachine(Interface):
     pass
 
 
+class IMachineWakeAction(Interface):
+    def wake(self, manager):
+        """ Wake the machine managed by manager. Returns a deferred evaluating
+            to True if it was possible to execute the wake action.
+        """
+
+
+class IMachineSuspendAction(Interface):
+    def suspend(self, manager):
+        """ Suspend or shut down the machine managed by manager.
+            Returns a deferred.
+        """
+
+
 class ISuspendableWorker(Interface):
     pass
 

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -187,6 +187,14 @@ class ILatentWorker(IWorker):
         """
 
 
+class ISuspendableMachine(Interface):
+    pass
+
+
+class ISuspendableWorker(Interface):
+    pass
+
+
 class IRenderable(Interface):
 
     """An object that can be interpolated with properties from a build.

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -48,6 +48,7 @@ from buildbot.util import service
 from buildbot.util.eventual import eventually
 from buildbot.wamp import connector as wampconnector
 from buildbot.worker import manager as workermanager
+from buildbot.worker.suspendable import SuspendableMachineManager
 from buildbot.www import service as wwwservice
 
 
@@ -150,6 +151,9 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
         self.botmaster = BotMaster()
         self.botmaster.setServiceParent(self)
+
+        self.machine_manager = SuspendableMachineManager()
+        self.machine_manager.setServiceParent(self)
 
         self.scheduler_manager = SchedulerManager()
         self.scheduler_manager.setServiceParent(self)

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -143,7 +143,10 @@ class LatentController(SeverWorkerConnectionMixin):
         return worker.disownServiceParent()
 
     def setup_kind(self, build):
-        self._started_kind_deferred = build.render(self.kind)
+        if build:
+            self._started_kind_deferred = build.render(self.kind)
+        else:
+            self._started_kind_deferred = self.kind
 
     @defer.inlineCallbacks
     def get_started_kind(self):

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -51,10 +51,14 @@ class LatentController(SeverWorkerConnectionMixin):
     stop_instance() is executed.
     """
 
-    def __init__(self, case, name, kind=None, build_wait_timeout=600, **kwargs):
+    def __init__(self, case, name, kind=None, build_wait_timeout=600,
+                 worker_class=None, **kwargs):
+        if worker_class is None:
+            worker_class = ControllableLatentWorker
+
         self.case = case
         self.build_wait_timeout = build_wait_timeout
-        self.worker = ControllableLatentWorker(name, self, **kwargs)
+        self.worker = worker_class(name, self, **kwargs)
         self.remote_worker = None
 
         self.state = States.STOPPED
@@ -159,7 +163,7 @@ class LatentController(SeverWorkerConnectionMixin):
         case.patch(BotBase, remoteMethod, patch)
 
 
-class ControllableLatentWorker(AbstractLatentWorker):
+class ControllableLatentWorkerMixin(object):
 
     """
     A latent worker that can be controlled by tests.
@@ -168,19 +172,8 @@ class ControllableLatentWorker(AbstractLatentWorker):
 
     def __init__(self, name, controller, **kwargs):
         self._controller = controller
-        AbstractLatentWorker.__init__(self, name, None, **kwargs)
-
-    def checkConfig(self, name, _, **kwargs):
-        AbstractLatentWorker.checkConfig(
-            self, name, None,
-            build_wait_timeout=self._controller.build_wait_timeout,
-            **kwargs)
-
-    def reconfigService(self, name, _, **kwargs):
-        AbstractLatentWorker.reconfigService(
-            self, name, None,
-            build_wait_timeout=self._controller.build_wait_timeout,
-            **kwargs)
+        super(ControllableLatentWorkerMixin, self).__init__(
+            name, None, **kwargs)
 
     @defer.inlineCallbacks
     def isCompatibleWithBuild(self, build_props):
@@ -219,3 +212,18 @@ class ControllableLatentWorker(AbstractLatentWorker):
             return True
         self._controller._stop_deferred = defer.Deferred()
         return (yield self._controller._stop_deferred)
+
+
+class ControllableLatentWorker(ControllableLatentWorkerMixin,
+                               AbstractLatentWorker):
+    def checkConfig(self, name, _, **kwargs):
+        AbstractLatentWorker.checkConfig(
+            self, name, None,
+            build_wait_timeout=self._controller.build_wait_timeout,
+            **kwargs)
+
+    def reconfigService(self, name, _, **kwargs):
+        AbstractLatentWorker.reconfigService(
+            self, name, None,
+            build_wait_timeout=self._controller.build_wait_timeout,
+            **kwargs)

--- a/master/buildbot/test/integration/test_worker_suspendable.py
+++ b/master/buildbot/test/integration/test_worker_suspendable.py
@@ -1,0 +1,460 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Portions Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from zope.interface import implementer
+
+from buildbot import interfaces
+from buildbot.config import BuilderConfig
+from buildbot.process.factory import BuildFactory
+from buildbot.process.results import FAILURE
+from buildbot.process.results import SUCCESS
+from buildbot.test.fake.latent import ControllableLatentWorkerMixin
+from buildbot.test.fake.latent import LatentController
+from buildbot.test.fake.step import BuildStepController
+from buildbot.test.util.integration import getMaster
+from buildbot.test.util.misc import DebugIntegrationLogsMixin
+from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.util.misc import TimeoutableTestCase
+from buildbot.worker.suspendable import SuspendableMachine
+from buildbot.worker.suspendable import SuspendableWorker
+
+
+class ControllableSuspendableWorker(ControllableLatentWorkerMixin,
+                                    SuspendableWorker):
+
+    def checkConfig(self, name, _, **kwargs):
+        SuspendableWorker.checkConfig(self, name, None, **kwargs)
+
+    def reconfigService(self, name, _, **kwargs):
+        SuspendableWorker.reconfigService(self, name, None, **kwargs)
+
+    @defer.inlineCallbacks
+    def start_instance(self, build):
+        yield ControllableLatentWorkerMixin.start_instance(self, build)
+        ret = yield SuspendableWorker.start_instance(self, build)
+        defer.returnValue(ret)
+
+    @defer.inlineCallbacks
+    def stop_instance(self, fast=False):
+        yield ControllableLatentWorkerMixin.stop_instance(self, fast)
+        ret = yield SuspendableWorker.stop_instance(self, fast)
+        defer.returnValue(ret)
+
+
+@implementer(interfaces.IMachineWakeAction)
+class FakeWakeAction(object):
+    def __init__(self, controller):
+        self._controller = controller
+
+    def wake(self, manager):
+        self._controller._wake_deferred = defer.Deferred()
+        return self._controller._wake_deferred
+
+
+@implementer(interfaces.IMachineSuspendAction)
+class FakeSuspendAction(object):
+    def __init__(self, controller):
+        self._controller = controller
+
+    def suspend(self, manager):
+        self._controller._suspend_deferred = defer.Deferred()
+        return self._controller._suspend_deferred
+
+
+class SuspendableMachineController(object):
+    ''' A controller for ``SuspendableMachine``
+    '''
+
+    def __init__(self, name, **kwargs):
+        self._suspend_action = FakeSuspendAction(self)
+        self._wake_action = FakeWakeAction(self)
+        self._suspend_deferred = None
+        self._wake_deferred = None
+        self.manager = SuspendableMachine(
+            name,
+            wake_action=self._wake_action,
+            suspend_action=self._suspend_action,
+            **kwargs)
+
+    def wake(self, result):
+        assert self.manager.state == SuspendableMachine.STATE_STARTING
+        d, self._wake_deferred = self._wake_deferred, None
+        if isinstance(result, Exception):
+            d.errback(result)
+        else:
+            d.callback(result)
+
+    def suspend(self, result=None):
+        assert self.manager.state == SuspendableMachine.STATE_SUSPENDING
+        d, self._suspend_deferred = self._suspend_deferred, None
+        if isinstance(result, Exception):
+            d.errback(result)
+        else:
+            d.callback(result)
+
+
+class TestSuspendable(TimeoutableTestCase, TestReactorMixin,
+                      DebugIntegrationLogsMixin):
+
+    def setUp(self):
+        self.setUpTestReactor()
+        self.setupDebugIntegrationLogs()
+
+    def tearDown(self):
+        # Flush the errors logged by the master stop cancelling the builds.
+        self.flushLoggedErrors(interfaces.LatentWorkerSubstantiatiationCancelled)
+        self.assertFalse(self.master.running, "master is still running!")
+
+    @defer.inlineCallbacks
+    def getMaster(self, config_dict):
+        self.master = master = yield getMaster(self, self.reactor, config_dict)
+        return master
+
+    # returns Deferred
+    def createBuildrequest(self, master, builder_ids):
+        return master.data.updates.addBuildset(
+            waited_for=False,
+            builderids=builder_ids,
+            sourcestamps=[
+                {'codebase': '',
+                 'repository': '',
+                 'branch': None,
+                 'revision': None,
+                 'project': ''},
+            ],
+        )
+
+    def createLatentController(self, name):
+        return LatentController(self, name,
+                                worker_class=ControllableSuspendableWorker)
+
+    @defer.inlineCallbacks
+    def create_single_worker_config(self, build_wait_timeout=0):
+        manager_controller = SuspendableMachineController(
+            name='a', workernames=['worker1'],
+            build_wait_timeout=build_wait_timeout)
+
+        worker_controller = self.createLatentController('worker1')
+        step_controller = BuildStepController()
+
+        config_dict = {
+            'suspendableMachines': [
+                manager_controller.manager
+            ],
+            'builders': [
+                BuilderConfig(name="builder1",
+                              workernames=["worker1"],
+                              factory=BuildFactory([step_controller.step]),
+                              ),
+            ],
+            'workers': [worker_controller.worker],
+            'protocols': {'null': {}},
+            # Disable checks about missing scheduler.
+            'multiMaster': True,
+        }
+
+        master = yield self.getMaster(config_dict)
+        builder_id = yield master.data.updates.findBuilderId('builder1')
+
+        return (manager_controller, worker_controller, step_controller,
+                master, builder_id)
+
+    @defer.inlineCallbacks
+    def create_two_worker_config(self, build_wait_timeout=0):
+        manager_controller = SuspendableMachineController(
+            name='a', workernames=['worker1', 'worker2'],
+            build_wait_timeout=build_wait_timeout)
+
+        worker1_controller = self.createLatentController('worker1')
+        worker2_controller = self.createLatentController('worker2')
+        step1_controller = BuildStepController()
+        step2_controller = BuildStepController()
+
+        config_dict = {
+            'suspendableMachines': [
+                manager_controller.manager
+            ],
+            'builders': [
+                BuilderConfig(name="builder1",
+                              workernames=["worker1"],
+                              factory=BuildFactory([step1_controller.step]),
+                              ),
+                BuilderConfig(name="builder2",
+                              workernames=["worker2"],
+                              factory=BuildFactory([step2_controller.step]),
+                              ),
+            ],
+            'workers': [worker1_controller.worker,
+                        worker2_controller.worker],
+            'protocols': {'null': {}},
+            # Disable checks about missing scheduler.
+            'multiMaster': True,
+        }
+
+        master = yield self.getMaster(config_dict)
+        builder1_id = yield master.data.updates.findBuilderId('builder1')
+        builder2_id = yield master.data.updates.findBuilderId('builder2')
+
+        return (manager_controller,
+                [worker1_controller, worker2_controller],
+                [step1_controller, step2_controller],
+                master,
+                [builder1_id, builder2_id])
+
+    @defer.inlineCallbacks
+    def test_1worker_wakes_and_suspends_after_single_build_success(self):
+        manager_controller, worker_controller, step_controller, \
+            master, builder_id = yield self.create_single_worker_config()
+
+        worker_controller.auto_start(True)
+        worker_controller.auto_stop(True)
+
+        yield self.createBuildrequest(master, [builder_id])
+        # test explicitly that worker is substantiated before machine is woken
+        self.assertTrue(worker_controller.started)
+
+        manager_controller.wake(True)
+        step_controller.finish_step(SUCCESS)
+        self.reactor.advance(0)  # force deferred suspend call to be executed
+        manager_controller.suspend()
+
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDED)
+
+    @defer.inlineCallbacks
+    def test_1worker_wakes_and_suspends_after_single_build_failure(self):
+        manager_controller, worker_controller, step_controller, \
+            master, builder_id = yield self.create_single_worker_config()
+
+        worker_controller.auto_start(True)
+        worker_controller.auto_stop(True)
+
+        yield self.createBuildrequest(master, [builder_id])
+        self.assertTrue(worker_controller.started)
+
+        manager_controller.wake(True)
+        step_controller.finish_step(FAILURE)
+        self.reactor.advance(0)  # force deferred suspend call to be executed
+        manager_controller.suspend()
+
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDED)
+
+    @defer.inlineCallbacks
+    def test_1worker_suspends_machine_after_timeout(self):
+        manager_controller, worker_controller, step_controller, \
+            master, builder_id = yield self.create_single_worker_config(
+                build_wait_timeout=5)
+
+        worker_controller.auto_start(True)
+        worker_controller.auto_stop(True)
+
+        yield self.createBuildrequest(master, [builder_id])
+
+        manager_controller.wake(True)
+        self.reactor.advance(10.0)
+        step_controller.finish_step(SUCCESS)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_STARTED)
+
+        self.reactor.advance(4.9)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_STARTED)
+
+        # put clock 5s after step finish, machine should start suspending
+        self.reactor.advance(0.1)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDING)
+
+        manager_controller.suspend()
+
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDED)
+
+    @defer.inlineCallbacks
+    def test_1worker_does_not_suspend_machine_after_timeout_during_build(self):
+        manager_controller, worker_controller, step_controller, \
+            master, builder_id = yield self.create_single_worker_config(
+                build_wait_timeout=5)
+
+        worker_controller.auto_start(True)
+        worker_controller.auto_stop(True)
+
+        yield self.createBuildrequest(master, [builder_id])
+
+        manager_controller.wake(True)
+        self.reactor.advance(10.0)
+        step_controller.finish_step(SUCCESS)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_STARTED)
+
+        # create build request while machine is still awake. It should not
+        # suspend regardless of how much time passes
+        self.reactor.advance(4.9)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_STARTED)
+        yield self.createBuildrequest(master, [builder_id])
+
+        self.reactor.advance(5.1)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_STARTED)
+
+        step_controller.finish_step(SUCCESS)
+        self.reactor.advance(4.9)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_STARTED)
+
+        # put clock 5s after step finish, machine should start suspending
+        self.reactor.advance(0.1)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDING)
+
+        manager_controller.suspend()
+
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDED)
+
+    @defer.inlineCallbacks
+    def test_1worker_insubstantiated_after_wake_failure(self):
+        manager_controller, worker_controller, step_controller, \
+            master, builder_id = yield self.create_single_worker_config()
+
+        worker_controller.auto_connect_worker = False
+        worker_controller.auto_start(True)
+        worker_controller.auto_stop(True)
+
+        yield self.createBuildrequest(master, [builder_id])
+
+        manager_controller.wake(False)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDED)
+        self.assertEqual(worker_controller.started, False)
+
+    @defer.inlineCallbacks
+    def test_1worker_eats_exception_from_wake(self):
+        manager_controller, worker_controller, step_controller, \
+            master, builder_id = yield self.create_single_worker_config()
+
+        worker_controller.auto_connect_worker = False
+        worker_controller.auto_start(True)
+        worker_controller.auto_stop(True)
+
+        yield self.createBuildrequest(master, [builder_id])
+
+        class FakeWakeError(Exception):
+            pass
+
+        manager_controller.wake(FakeWakeError('wake error'))
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDED)
+        self.assertEqual(worker_controller.started, False)
+
+        self.flushLoggedErrors(FakeWakeError)
+
+    @defer.inlineCallbacks
+    def test_1worker_eats_exception_from_suspend(self):
+        manager_controller, worker_controller, step_controller, \
+            master, builder_id = yield self.create_single_worker_config()
+
+        worker_controller.auto_start(True)
+        worker_controller.auto_stop(True)
+
+        yield self.createBuildrequest(master, [builder_id])
+
+        manager_controller.wake(True)
+        step_controller.finish_step(SUCCESS)
+        self.reactor.advance(0)  # force deferred suspend call to be executed
+
+        class FakeSuspendError(Exception):
+            pass
+
+        manager_controller.suspend(FakeSuspendError('wake error'))
+
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDED)
+        self.flushLoggedErrors(FakeSuspendError)
+
+    @defer.inlineCallbacks
+    def test_2workers_build_substantiates_insubstantiates_both_workers(self):
+        manager_controller, worker_controllers, step_controllers, \
+            master, builder_ids = yield self.create_two_worker_config()
+
+        for wc in worker_controllers:
+            wc.auto_start(True)
+            wc.auto_stop(True)
+
+        yield self.createBuildrequest(master, [builder_ids[0]])
+
+        manager_controller.wake(True)
+        for wc in worker_controllers:
+            self.assertTrue(wc.started)
+
+        step_controllers[0].finish_step(SUCCESS)
+        self.reactor.advance(0)  # force deferred suspend call to be executed
+        manager_controller.suspend()
+
+        for wc in worker_controllers:
+            self.assertFalse(wc.started)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDED)
+
+    @defer.inlineCallbacks
+    def test_2workers_two_builds_wake_machine_concurrently(self):
+        manager_controller, worker_controllers, step_controllers, \
+            master, builder_ids = yield self.create_two_worker_config()
+
+        for wc in worker_controllers:
+            wc.auto_start(True)
+            wc.auto_stop(True)
+
+        yield self.createBuildrequest(master, [builder_ids[0]])
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_STARTING)
+
+        yield self.createBuildrequest(master, [builder_ids[1]])
+
+        manager_controller.wake(True)
+        for wc in worker_controllers:
+            self.assertTrue(wc.started)
+
+        step_controllers[0].finish_step(SUCCESS)
+        step_controllers[1].finish_step(SUCCESS)
+        self.reactor.advance(0)  # force deferred suspend call to be executed
+        manager_controller.suspend()
+
+        for wc in worker_controllers:
+            self.assertFalse(wc.started)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDED)
+
+    @defer.inlineCallbacks
+    def test_2workers_insubstantiated_after_one_wake_failure(self):
+        manager_controller, worker_controllers, step_controllers, \
+            master, builder_ids = yield self.create_two_worker_config()
+
+        for wc in worker_controllers:
+            wc.auto_connect_worker = False
+            wc.auto_start(True)
+            wc.auto_stop(True)
+
+        yield self.createBuildrequest(master, [builder_ids[0]])
+
+        manager_controller.wake(False)
+        self.assertEqual(manager_controller.manager.state,
+                         SuspendableMachine.STATE_SUSPENDED)
+
+        for wc in worker_controllers:
+            self.assertEqual(wc.started, False)

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -99,6 +99,12 @@ class FakeBuilder:
         self.__dict__.update(kwargs)
 
 
+@implementer(interfaces.ISuspendableMachine)
+class FakeSuspendableMachine(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
 class ConfigErrors(unittest.TestCase):
 
     def test_constr(self):
@@ -362,6 +368,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
         self.assertTrue(rv.load_builders.called)
         self.assertTrue(rv.load_workers.called)
         self.assertTrue(rv.load_change_sources.called)
+        self.assertTrue(rv.load_suspendable_machines.called)
         self.assertTrue(rv.load_user_managers.called)
 
         self.assertTrue(rv.check_single_master.called)
@@ -369,6 +376,7 @@ class MasterConfig(ConfigErrorsMixin, dirs.DirsMixin, unittest.TestCase):
         self.assertTrue(rv.check_locks.called)
         self.assertTrue(rv.check_builders.called)
         self.assertTrue(rv.check_ports.called)
+        self.assertTrue(rv.check_suspendable_machines.called)
 
     def test_preChangeGenerator(self):
         cfg = config.MasterConfig()
@@ -857,6 +865,27 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
                                      dict(change_source=[chsrc]))
         self.assertResults(change_sources=[chsrc])
 
+    def test_load_suspendable_machines_defaults(self):
+        self.cfg.load_suspendable_machines(self.filename, {})
+        self.assertResults(suspendable_machines=[])
+
+    def test_load_suspendable_machines_not_instance(self):
+        self.cfg.load_suspendable_machines(self.filename,
+                                           dict(suspendableMachines=[mock.Mock()]))
+        self.assertConfigError(self.errors, "must be a list of")
+
+    def test_load_suspendable_machines_single(self):
+        mm = FakeSuspendableMachine(name='a')
+        self.cfg.load_suspendable_machines(self.filename,
+                                           dict(suspendableMachines=mm))
+        self.assertConfigError(self.errors, "must be a list of")
+
+    def test_load_suspendable_machines_list(self):
+        mm = FakeSuspendableMachine()
+        self.cfg.load_suspendable_machines(self.filename,
+                                       dict(suspendableMachines=[mm]))
+        self.assertResults(suspendable_machines=[mm])
+
     def test_load_user_managers_defaults(self):
         self.cfg.load_user_managers(self.filename, {})
         self.assertResults(user_managers=[])
@@ -1223,6 +1252,36 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
         self.cfg.check_ports()
         self.assertConfigError(self.errors,
                                "Some of ports in c['protocols'] duplicated")
+
+    def test_check_suspendable_machines_unknown_worker(self):
+        wrk = mock.Mock()
+        wrk.workername = 'a'
+        self.cfg.workers = [wrk]
+        self.cfg.suspendable_machines = [
+            FakeSuspendableMachine(name='a', workernames=['b'])
+        ]
+        self.cfg.check_suspendable_machines()
+        self.assertConfigError(self.errors, 'uses unknown workers')
+
+    def test_check_suspendable_machines_duplicate_name(self):
+        self.cfg.suspendable_machines = [
+            FakeSuspendableMachine(name='a', workernames=[]),
+            FakeSuspendableMachine(name='a', workernames=[])
+        ]
+        self.cfg.check_suspendable_machines()
+        self.assertConfigError(self.errors,
+                               'duplicate suspendable machine controller name')
+
+    def test_check_suspendable_machines_duplicate_worker(self):
+        wrk = mock.Mock()
+        wrk.workername = 'b'
+        self.cfg.workers = [wrk]
+        self.cfg.suspendable_machines = [
+            FakeSuspendableMachine(name='a', workernames=['b']),
+            FakeSuspendableMachine(name='b', workernames=['b'])
+        ]
+        self.cfg.check_suspendable_machines()
+        self.assertConfigError(self.errors, 'uses duplicate workers')
 
 
 class MasterConfig_old_worker_api(unittest.TestCase):

--- a/master/buildbot/test/unit/test_worker_suspendable.py
+++ b/master/buildbot/test/unit/test_worker_suspendable.py
@@ -59,8 +59,8 @@ class TestActions(unittest.TestCase, gpo.GetProcessOutputMixin,
 
         manager = FakeManager()
         action = LocalWakeAction(['cmd', 'arg1', 'arg2'])
-        self.assertFalse((yield action.wake(manager)))
-        self.assertTrue((yield action.wake(manager)))
+        self.assertFalse((yield action.perform(manager)))
+        self.assertTrue((yield action.perform(manager)))
         self.assertAllCommandsRan()
 
     def test_local_wake_action_command_not_list(self):
@@ -78,10 +78,10 @@ class TestActions(unittest.TestCase, gpo.GetProcessOutputMixin,
 
         manager = FakeManager()
         action = LocalWOLAction('00:11:22:33:44:55', wolBin='wol')
-        self.assertFalse((yield action.wake(manager)))
+        self.assertFalse((yield action.perform(manager)))
 
         action = LocalWOLAction('00:11:22:33:44:55')
-        self.assertTrue((yield action.wake(manager)))
+        self.assertTrue((yield action.perform(manager)))
         self.assertAllCommandsRan()
 
     @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
@@ -99,8 +99,8 @@ class TestActions(unittest.TestCase, gpo.GetProcessOutputMixin,
 
         manager = FakeManager()
         action = RemoteSshWakeAction('remote_host', ['remotebin', 'arg1'])
-        self.assertFalse((yield action.wake(manager)))
-        self.assertTrue((yield action.wake(manager)))
+        self.assertFalse((yield action.perform(manager)))
+        self.assertTrue((yield action.perform(manager)))
         self.assertAllCommandsRan()
 
         self.assertEqual(temp_dir_mock.dirs, [])
@@ -127,7 +127,7 @@ class TestActions(unittest.TestCase, gpo.GetProcessOutputMixin,
         action = RemoteSshWakeAction('remote_host', ['remotebin', 'arg1'],
                                      sshKey='ssh_key',
                                      sshHostKey='ssh_host_key')
-        self.assertTrue((yield action.wake(manager)))
+        self.assertTrue((yield action.perform(manager)))
 
         self.assertAllCommandsRan()
 
@@ -167,11 +167,11 @@ class TestActions(unittest.TestCase, gpo.GetProcessOutputMixin,
 
         manager = FakeManager()
         action = RemoteSshWOLAction('remote_host', '00:11:22:33:44:55')
-        self.assertTrue((yield action.wake(manager)))
+        self.assertTrue((yield action.perform(manager)))
 
         action = RemoteSshWOLAction('remote_host', '00:11:22:33:44:55',
                                     wolBin='wolbin')
-        self.assertTrue((yield action.wake(manager)))
+        self.assertTrue((yield action.perform(manager)))
         self.assertAllCommandsRan()
 
         self.assertEqual(temp_dir_mock.dirs, [])
@@ -192,11 +192,11 @@ class TestActions(unittest.TestCase, gpo.GetProcessOutputMixin,
 
         manager = FakeManager()
         action = RemoteSshSuspendAction('remote_host')
-        self.assertTrue((yield action.suspend(manager)))
+        self.assertTrue((yield action.perform(manager)))
 
         action = RemoteSshSuspendAction('remote_host',
                                         remoteCommand=['dosuspend', 'arg1'])
-        self.assertTrue((yield action.suspend(manager)))
+        self.assertTrue((yield action.perform(manager)))
         self.assertAllCommandsRan()
 
         self.assertEqual(temp_dir_mock.dirs, [])

--- a/master/buildbot/test/unit/test_worker_suspendable.py
+++ b/master/buildbot/test/unit/test_worker_suspendable.py
@@ -1,0 +1,203 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import os
+from unittest import mock
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.test.fake.private_tempdir import MockPrivateTemporaryDirectory
+from buildbot.test.util import config
+from buildbot.test.util import gpo
+from buildbot.worker.suspendable import LocalWakeAction
+from buildbot.worker.suspendable import LocalWOLAction
+from buildbot.worker.suspendable import RemoteSshSuspendAction
+from buildbot.worker.suspendable import RemoteSshWakeAction
+from buildbot.worker.suspendable import RemoteSshWOLAction
+
+
+class FakeManager:
+
+    def __init__(self, basedir=None):
+        self.master = mock.Mock()
+        self.master.basedir = basedir
+
+    def renderSecrets(self, args):
+        return defer.succeed(args)
+
+
+class TestActions(unittest.TestCase, gpo.GetProcessOutputMixin,
+                  config.ConfigErrorsMixin):
+    def setUp(self):
+        self.setUpGetProcessOutput()
+
+    def tearDown(self):
+        pass
+
+    @defer.inlineCallbacks
+    def test_local_wake_action(self):
+        self.expectCommands(
+            gpo.Expect('cmd', 'arg1', 'arg2')
+            .exit(1),
+            gpo.Expect('cmd', 'arg1', 'arg2')
+            .exit(0),
+        )
+
+        manager = FakeManager()
+        action = LocalWakeAction(['cmd', 'arg1', 'arg2'])
+        self.assertFalse((yield action.wake(manager)))
+        self.assertTrue((yield action.wake(manager)))
+        self.assertAllCommandsRan()
+
+    def test_local_wake_action_command_not_list(self):
+        with self.assertRaisesConfigError('command parameter must be a list'):
+            LocalWakeAction('not-list')
+
+    @defer.inlineCallbacks
+    def test_local_wol_action(self):
+        self.expectCommands(
+            gpo.Expect('wol', '00:11:22:33:44:55')
+            .exit(1),
+            gpo.Expect('wakeonlan', '00:11:22:33:44:55')
+            .exit(0),
+        )
+
+        manager = FakeManager()
+        action = LocalWOLAction('00:11:22:33:44:55', wolBin='wol')
+        self.assertFalse((yield action.wake(manager)))
+
+        action = LocalWOLAction('00:11:22:33:44:55')
+        self.assertTrue((yield action.wake(manager)))
+        self.assertAllCommandsRan()
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch('buildbot.util.misc.writeLocalFile')
+    @defer.inlineCallbacks
+    def test_remote_ssh_wake_action_no_keys(self, write_local_file_mock,
+                                            temp_dir_mock):
+        self.expectCommands(
+            gpo.Expect('ssh', 'remote_host', 'remotebin', 'arg1')
+            .exit(1),
+            gpo.Expect('ssh', 'remote_host', 'remotebin', 'arg1')
+            .exit(0),
+        )
+
+        manager = FakeManager()
+        action = RemoteSshWakeAction('remote_host', ['remotebin', 'arg1'])
+        self.assertFalse((yield action.wake(manager)))
+        self.assertTrue((yield action.wake(manager)))
+        self.assertAllCommandsRan()
+
+        self.assertEqual(temp_dir_mock.dirs, [])
+        write_local_file_mock.assert_not_called()
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch('buildbot.util.misc.writeLocalFile')
+    @defer.inlineCallbacks
+    def test_remote_ssh_wake_action_with_keys(self, write_local_file_mock,
+                                              temp_dir_mock):
+        temp_dir_path = os.path.join('path-to-master', 'ssh-@@@')
+        ssh_key_path = os.path.join(temp_dir_path, 'ssh-key')
+        ssh_known_hosts_path = os.path.join(temp_dir_path, 'ssh-known-hosts')
+
+        self.expectCommands(
+            gpo.Expect('ssh', '-i', ssh_key_path,
+                       '-o', 'UserKnownHostsFile={0}'.format(ssh_known_hosts_path),
+                       'remote_host', 'remotebin', 'arg1')
+            .exit(0),
+        )
+
+        manager = FakeManager('path-to-master')
+        action = RemoteSshWakeAction('remote_host', ['remotebin', 'arg1'],
+                                     sshKey='ssh_key',
+                                     sshHostKey='ssh_host_key')
+        self.assertTrue((yield action.wake(manager)))
+
+        self.assertAllCommandsRan()
+
+        self.assertEqual(temp_dir_mock.dirs,
+                         [(temp_dir_path, 0o700)])
+
+        self.assertSequenceEqual(write_local_file_mock.call_args_list, [
+            mock.call(ssh_key_path, 'ssh_key', mode=0o400),
+            mock.call(ssh_known_hosts_path, '* ssh_host_key'),
+        ])
+
+    def test_remote_ssh_wake_action_sshBin_not_str(self):
+        with self.assertRaisesConfigError('sshBin parameter must be a string'):
+            RemoteSshWakeAction('host', ['cmd'], sshBin=123)
+
+    def test_remote_ssh_wake_action_host_not_str(self):
+        with self.assertRaisesConfigError('host parameter must be a string'):
+            RemoteSshWakeAction(123, ['cmd'])
+
+    def test_remote_ssh_wake_action_command_not_list(self):
+        with self.assertRaisesConfigError(
+                'remoteCommand parameter must be a list'):
+            RemoteSshWakeAction('host', 'cmd')
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch('buildbot.util.misc.writeLocalFile')
+    @defer.inlineCallbacks
+    def test_remote_ssh_wol_action_no_keys(self, write_local_file_mock,
+                                           temp_dir_mock):
+        self.expectCommands(
+            gpo.Expect('ssh', 'remote_host', 'wakeonlan', '00:11:22:33:44:55')
+            .exit(0),
+            gpo.Expect('ssh', 'remote_host', 'wolbin', '00:11:22:33:44:55')
+            .exit(0),
+        )
+
+        manager = FakeManager()
+        action = RemoteSshWOLAction('remote_host', '00:11:22:33:44:55')
+        self.assertTrue((yield action.wake(manager)))
+
+        action = RemoteSshWOLAction('remote_host', '00:11:22:33:44:55',
+                                    wolBin='wolbin')
+        self.assertTrue((yield action.wake(manager)))
+        self.assertAllCommandsRan()
+
+        self.assertEqual(temp_dir_mock.dirs, [])
+        write_local_file_mock.assert_not_called()
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch('buildbot.util.misc.writeLocalFile')
+    @defer.inlineCallbacks
+    def test_remote_ssh_suspend_action_no_keys(self, write_local_file_mock,
+                                               temp_dir_mock):
+        self.expectCommands(
+            gpo.Expect('ssh', 'remote_host', 'systemctl', 'suspend')
+            .exit(0),
+            gpo.Expect('ssh', 'remote_host', 'dosuspend', 'arg1')
+            .exit(0),
+        )
+
+        manager = FakeManager()
+        action = RemoteSshSuspendAction('remote_host')
+        self.assertTrue((yield action.suspend(manager)))
+
+        action = RemoteSshSuspendAction('remote_host',
+                                        remoteCommand=['dosuspend', 'arg1'])
+        self.assertTrue((yield action.suspend(manager)))
+        self.assertAllCommandsRan()
+
+        self.assertEqual(temp_dir_mock.dirs, [])
+        write_local_file_mock.assert_not_called()

--- a/master/buildbot/worker/suspendable.py
+++ b/master/buildbot/worker/suspendable.py
@@ -20,22 +20,53 @@ from twisted.internet import reactor
 from twisted.internet import utils
 from twisted.python import log
 
+from twisted.internet import defer
+from twisted.python import log
 from zope.interface import implementer
 
 from buildbot import interfaces
+from buildbot.util import Notifier
 from buildbot.util import service
+from buildbot.worker import AbstractWorker
 from buildbot.worker.latent import AbstractLatentWorker
 
 
 @implementer(interfaces.ISuspendableWorker)
 class SuspendableWorker(AbstractLatentWorker):
 
-    def checkConfig(name, password, **kwargs):
-        AbstractLatentWorker.checkConfig(name, password, **kwargs)
+    def checkConfig(self, name, password, **kwargs):
+        self.machine_manager = None
+        AbstractLatentWorker.checkConfig(self, name, password,
+                                         build_wait_timeout=-1,
+                                         **kwargs)
 
     def reconfigService(self, name, password, **kwargs):
         return AbstractLatentWorker.reconfigService(self, name, password,
+                                                    build_wait_timeout=-1,
                                                     **kwargs)
+
+    @defer.inlineCallbacks
+    def start_instance(self, build):
+        if not self.machine_manager:
+            log.err(('SuspendableWorker {} does not have a manager and could '
+                     'not start build').format(self.name))
+            ret = False
+        else:
+            ret = yield self.machine_manager.start_instance(self)
+        defer.returnValue(ret)
+
+    def stop_instance(self, fast=False):
+        return defer.succeed(None)
+
+    def buildStarted(self, wfb):
+        AbstractLatentWorker.buildStarted(self, wfb)
+        if self.machine_manager:
+            self.machine_manager.notifyBuildStarted()
+
+    def buildFinished(self, wfb):
+        AbstractLatentWorker.buildFinished(self, wfb)
+        if self.machine_manager:
+            self.machine_manager.notifyBuildFinished()
 
 
 class SuspendableMachineManager(service.BuildbotServiceManager):
@@ -48,12 +79,167 @@ class SuspendableMachineManager(service.BuildbotServiceManager):
 @implementer(interfaces.ISuspendableMachine)
 class SuspendableMachine(service.BuildbotService, object):
 
-    def checkConfig(self, **kwargs):
-        pass
+    DEFAULT_MISSING_TIMEOUT = 20 * 60
 
-    def reconfigService(self, name=None, workernames=None):
+    STATE_SUSPENDED = 0
+    STATE_STARTING = 1
+    STATE_STARTED = 2
+    STATE_SUSPENDING = 3
+
+    def checkConfig(self, name, workernames, wake_action, suspend_action,
+                    build_wait_timeout=0,
+                    missing_timeout=DEFAULT_MISSING_TIMEOUT, **kwargs):
+        self.name = name
+        self.workernames = workernames
+        self.state = self.STATE_SUSPENDED
+        self.workers = []
+
+        if not interfaces.IMachineWakeAction.providedBy(wake_action):
+            msg = "wake_action of {} does not implement required " \
+                  "interface".format(self.name)
+            raise Exception(msg)
+
+        if not interfaces.IMachineSuspendAction.providedBy(suspend_action):
+            msg = "suspend_action of {} does not implement required " \
+                  "interface".format(self.name)
+            raise Exception(msg)
+
+    def reconfigService(self, name, workernames, wake_action, suspend_action,
+                        build_wait_timeout=0,
+                        missing_timeout=DEFAULT_MISSING_TIMEOUT):
         assert self.name == name
         self.workernames = workernames
+        self.wake_action = wake_action
+        self.suspend_action = suspend_action
+        self.build_wait_timeout = build_wait_timeout
+        self.missing_timeout = missing_timeout
+
+        for worker in self.workers:
+            worker.machine_manager = None
+
+        self.workers = [self.master.workers.workers[name]
+                        for name in self.workernames]
+
+        for worker in self.workers:
+            if not interfaces.ISuspendableWorker.providedBy(worker):
+                raise Exception('Worker is not suspendable {0}'.format(
+                    worker.name))
+            worker.machine_manager = self
+
+        self.state = self.STATE_SUSPENDED
+        self._start_notifier = Notifier()
+        self._suspend_notifier = Notifier()
+        self._build_wait_timer = None
+        self._missing_timer = None
+
+    @defer.inlineCallbacks
+    def start_instance(self, starting_worker):
+        if self.state == self.STATE_SUSPENDING:
+            # wait until suspend action finishes
+            yield self._suspend_notifier.wait()
+
+        if self.state == self.STATE_STARTED:
+            # may happen if we waited for suspend to complete and in the mean
+            # time the machine was successfully woken.
+            defer.returnValue(True)
+            return  # pragma: no cover
+
+        # wait for already proceeding startup to finish, if any
+        if self.state == self.STATE_STARTING:
+            ret = yield self._start_notifier.wait()
+            defer.returnValue(ret)
+            return  # pragma: no cover
+
+        self.state = self.STATE_STARTING
+
+        # substantiate all workers. We must do so before waking the machine to
+        # guarantee that we're already waiting for worker connection as waking
+        # may take time confirming machine came online. We'll call substantiate
+        # on the worker that invoked this function again, but that's okay as
+        # that function is reentrant. Note that we substantiate without
+        # gathering results because the original call to substantiate will get
+        # them anyway and we don't want to be slowed down by other workers on
+        # the machine.
+        for worker in self.workers:
+            worker.substantiate(None, None)
+
+        # Wake the machine. We don't need to wait for any workers to actually
+        # come online as that's handled in their substantiate() functions.
+        try:
+            ret = yield self.wake_action.wake(self)
+        except Exception as e:
+            log.err(e, 'while waking suspendable machine {0}'.format(self.name))
+            ret = False
+
+        if not ret:
+            yield defer.DeferredList([worker.insubstantiate()
+                                      for worker in self.workers],
+                                     consumeErrors=True)
+        else:
+            self._setMissingTimer()
+
+        self.state = self.STATE_STARTED if ret else self.STATE_SUSPENDED
+        self._start_notifier.notify(ret)
+
+        defer.returnValue(ret)
+
+    @defer.inlineCallbacks
+    def _suspend(self):
+        if any(worker.building for worker in self.workers) or \
+                self.state == self.STATE_STARTING:
+            defer.returnValue(None)
+            return  # pragma: no cover
+
+        if self.state == self.STATE_SUSPENDING:
+            yield self._suspend_notifier.wait()
+            defer.returnValue(None)
+            return  # pragma: no cover
+
+        self.state = self.STATE_SUSPENDING
+
+        # wait until workers insubstantiate, then suspend
+        yield defer.DeferredList([worker.insubstantiate()
+                                  for worker in self.workers],
+                                 consumeErrors=True)
+        try:
+            yield self.suspend_action.suspend(self)
+        except Exception as e:
+            log.err(e, 'while suspending suspendable machine {0}'.format(
+                self.name))
+
+        self.state = self.STATE_SUSPENDED
+        self._suspend_notifier.notify(None)
+
+    def notifyBuildStarted(self):
+        self._clearMissingTimer()
+
+    def notifyBuildFinished(self):
+        if any(worker.building for worker in self.workers):
+            self._clearBuildWaitTimer()
+        else:
+            self._setBuildWaitTimer()
+
+    def _clearMissingTimer(self):
+        if self._missing_timer is not None:
+            if self._missing_timer.active():
+                self._missing_timer.cancel()
+            self._missing_timer = None
+
+    def _setMissingTimer(self):
+        self._clearMissingTimer()
+        self._missing_timer = self.master.reactor.callLater(
+            self.missing_timeout, self._suspend)
+
+    def _clearBuildWaitTimer(self):
+        if self._build_wait_timer is not None:
+            if self._build_wait_timer.active():
+                self._build_wait_timer.cancel()
+            self._build_wait_timer = None
+
+    def _setBuildWaitTimer(self):
+        self._clearBuildWaitTimer()
+        self._build_wait_timer = self.master.reactor.callLater(
+            self.build_wait_timeout, self._suspend)
 
     def __repr__(self):
         return "<SuspendableMachine '%r' at %d>" % (

--- a/master/buildbot/worker/suspendable.py
+++ b/master/buildbot/worker/suspendable.py
@@ -1,0 +1,53 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Portions Copyright Buildbot Team Members
+
+import tempfile
+
+from twisted.internet import defer
+from twisted.internet import reactor
+from twisted.internet import utils
+from twisted.python import log
+
+from zope.interface import implementer
+
+from buildbot import interfaces
+from buildbot.util import service
+from buildbot.worker.latent import AbstractLatentWorker
+
+
+@implementer(interfaces.ISuspendableWorker)
+class SuspendableWorker(AbstractLatentWorker):
+
+    def checkConfig(name, password, **kwargs):
+        AbstractLatentWorker.checkConfig(name, password, **kwargs)
+
+    def reconfigService(self, name, password, **kwargs):
+        return AbstractLatentWorker.reconfigService(self, name, password,
+                                                    **kwargs)
+
+
+@implementer(interfaces.ISuspendableMachine)
+class SuspendableMachine(service.BuildbotService, object):
+
+    def checkConfig(self, **kwargs):
+        pass
+
+    def reconfigService(self, name=None, workernames=None):
+        assert self.name == name
+        self.workernames = workernames
+
+    def __repr__(self):
+        return "<SuspendableMachine '%r' at %d>" % (
+            self.name, id(self))

--- a/master/buildbot/worker/suspendable.py
+++ b/master/buildbot/worker/suspendable.py
@@ -13,20 +13,22 @@
 #
 # Portions Copyright Buildbot Team Members
 
-import tempfile
+import os
+import stat
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.internet import utils
-from twisted.python import log
-
-from twisted.internet import defer
 from twisted.python import log
 from zope.interface import implementer
 
+from buildbot import config
 from buildbot import interfaces
 from buildbot.util import Notifier
+from buildbot.util import misc
+from buildbot.util import private_tempdir
 from buildbot.util import service
+from buildbot.util.git import getSshArgsForKeys
+from buildbot.util.git import getSshKnownHostsContents
 from buildbot.worker import AbstractWorker
 from buildbot.worker.latent import AbstractLatentWorker
 
@@ -74,6 +76,124 @@ class SuspendableMachineManager(service.BuildbotServiceManager):
     name = 'SuspendableMachineManager'
     managed_services_name = 'suspendable_machines'
     config_attr = 'suspendable_machines'
+
+
+class _LocalMachineActionMixin(object):
+    def setupLocal(self, command):
+        if not isinstance(command, list):
+            config.error('command parameter must be a list')
+        self._command = command
+
+    @defer.inlineCallbacks
+    def execute(self, manager):
+        args = yield manager.renderSecrets(self._command)
+        _, _, code = yield utils.getProcessOutputAndValue(args[0], args[1:])
+        defer.returnValue(code == 0)
+
+
+class _SshActionMixin(object):
+    def setupSsh(self, sshBin, host, remoteCommand, sshKey=None,
+                 sshHostKey=None):
+        if not isinstance(sshBin, str):
+            config.error('sshBin parameter must be a string')
+        if not isinstance(host, str):
+            config.error('host parameter must be a string')
+        if not isinstance(remoteCommand, list):
+            config.error('remoteCommand parameter must be a list')
+
+        self._sshBin = sshBin
+        self._host = host
+        self._remoteCommand = remoteCommand
+        self._sshKey = sshKey
+        self._sshHostKey = sshHostKey
+
+    @defer.inlineCallbacks
+    def _executeImpl(self, manager, key_path, known_hosts_path):
+        args = getSshArgsForKeys(key_path, known_hosts_path)
+        args.append((yield manager.renderSecrets(self._host)))
+        args.extend((yield manager.renderSecrets(self._remoteCommand)))
+        _, _, code = yield utils.getProcessOutputAndValue(self._sshBin, args)
+        defer.returnValue(code == 0)
+
+    @defer.inlineCallbacks
+    def _prepareSshKeys(self, manager, temp_dir_path):
+        key_path = None
+        if self._sshKey is not None:
+            ssh_key_data = yield manager.renderSecrets(self._sshKey)
+
+            key_path = os.path.join(temp_dir_path, 'ssh-key')
+            misc.writeLocalFile(key_path, ssh_key_data,
+                                mode=stat.S_IRUSR)
+
+        known_hosts_path = None
+        if self._sshHostKey is not None:
+            ssh_host_key_data = yield manager.renderSecrets(self._sshHostKey)
+            ssh_host_key_data = getSshKnownHostsContents(ssh_host_key_data)
+
+            known_hosts_path = os.path.join(temp_dir_path, 'ssh-known-hosts')
+            misc.writeLocalFile(known_hosts_path, ssh_host_key_data)
+
+        defer.returnValue((key_path, known_hosts_path))
+
+    @defer.inlineCallbacks
+    def execute(self, manager):
+        if self._sshKey is not None or self._sshHostKey is not None:
+            with private_tempdir.PrivateTemporaryDirectory(
+                    prefix='ssh-', dir=manager.master.basedir) as temp_dir:
+
+                key_path, hosts_path = yield self._prepareSshKeys(manager,
+                                                                  temp_dir)
+
+                ret = yield self._executeImpl(manager, key_path, hosts_path)
+        else:
+            ret = yield self._executeImpl(manager, None, None)
+        defer.returnValue(ret)
+
+
+@implementer(interfaces.IMachineWakeAction)
+class LocalWakeAction(_LocalMachineActionMixin):
+    def __init__(self, command):
+        self.setupLocal(command)
+
+    def wake(self, manager):
+        return self.execute(manager)
+
+
+class LocalWOLAction(LocalWakeAction):
+    def __init__(self, wakeMac, wolBin='wakeonlan'):
+        LocalWakeAction.__init__(self, [wolBin, wakeMac])
+
+
+@implementer(interfaces.IMachineWakeAction)
+class RemoteSshWakeAction(_SshActionMixin):
+    def __init__(self, host, remoteCommand, sshBin='ssh',
+                 sshKey=None, sshHostKey=None):
+        self.setupSsh(sshBin, host, remoteCommand,
+                      sshKey=sshKey, sshHostKey=sshHostKey)
+
+    def wake(self, manager):
+        return self.execute(manager)
+
+
+class RemoteSshWOLAction(RemoteSshWakeAction):
+    def __init__(self, host, wakeMac, wolBin='wakeonlan', sshBin='ssh',
+                 sshKey=None, sshHostKey=None):
+        RemoteSshWakeAction.__init__(self, host, [wolBin, wakeMac],
+                                     sshBin=sshBin,
+                                     sshKey=sshKey, sshHostKey=sshHostKey)
+
+
+@implementer(interfaces.IMachineSuspendAction)
+class RemoteSshSuspendAction(_SshActionMixin):
+    def __init__(self, host, remoteCommand=None, sshBin='ssh',
+                 sshKey=None, sshHostKey=None):
+        if remoteCommand is None:
+            remoteCommand = ['systemctl', 'suspend']
+        self.setupSsh(sshBin, host, remoteCommand,
+                      sshKey=sshKey, sshHostKey=sshHostKey)
+
+    def suspend(self, manager):
+        return self.execute(manager)
 
 
 @implementer(interfaces.ISuspendableMachine)

--- a/master/buildbot/worker/suspendable.py
+++ b/master/buildbot/worker/suspendable.py
@@ -38,6 +38,13 @@ class SuspendableWorker(AbstractLatentWorker):
                                                     **kwargs)
 
 
+class SuspendableMachineManager(service.BuildbotServiceManager):
+    reconfig_priority = AbstractWorker.reconfig_priority - 1
+    name = 'SuspendableMachineManager'
+    managed_services_name = 'suspendable_machines'
+    config_attr = 'suspendable_machines'
+
+
 @implementer(interfaces.ISuspendableMachine)
 class SuspendableMachine(service.BuildbotService, object):
 


### PR DESCRIPTION
This PR implements a new latent worker class first suggested in #4434. The new backends allows users to run latent workers on physical infrastructure they control. The machines can be shut down or suspended when not used and woken using wakeonlan functionality. This makes Buildbot much more efficient in test farms with low utilization rate allowing use of old and/or cheap equipment that is not energy-efficient. Most old server or desktop computers use at least 60W when idle, so suspending them when not needed yields cost savings of at least 80$ per year per instance at electricity cost of 0.15$/kWh.

The PR also adds groundwork for implementing on-demand shutdown/reboot of workers requested in #4578.

## Comments and questions for reviewers
In #4434 I have been advised that the functionality may be better implemented as a plugin. Unfortunately after researching the problem it seems that suspendable workers couple too much into Buildbot, so making it a plugin would be counter-productive. Additionally, given limited developer resources of Buildbot ecosystem, it could be a wise idea to include even relatively rarely used functionality into Buildbot proper as long as it does not compromise its architecture. Splitting functionality into multiple repositories increases maintenance overhead a lot due to the need to coordinate releases and also the user confidence is decreased because from their point of view there's much higher risk that the plugin won't be maintained.

Additionally, it looks like that it could make sense to introduce a new concept of a "machine" within Buildbot. A machine is a physical host that runs one or more workers that share processing resources. If a single machine runs a lot of workers the maximum number of builds often needs to be limited. This currently can only be done by using master locks. I think this could be streamlined by introducing "machine locks". If this point makes sense to explore in the future, then the `suspendableMachines` configuration key in this PR should probably be renamed just to `machines` and perhaps the workers should be assigned a machine in their own configuration instead of having a list of all workers as a parameter to `SuspendableMachine`.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not yet] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [not yet] I have updated the appropriate documentation
