### PR TITLE
Use super() instead of explicit parent class methods

### DIFF
--- a/master/buildbot/changes/base.py
+++ b/master/buildbot/changes/base.py
@@ -57,7 +57,7 @@ class ReconfigurablePollingChangeSource(ChangeSource):
     pollAtLaunch = None
 
     def checkConfig(self, name=None, pollInterval=60 * 10, pollAtLaunch=False):
-        ChangeSource.checkConfig(self, name=name)
+        super().checkConfig(name=name)
         if pollInterval < 0:
             config.error("interval must be >= 0: {}".format(pollInterval))
 
@@ -65,7 +65,7 @@ class ReconfigurablePollingChangeSource(ChangeSource):
     def reconfigService(self, name=None, pollInterval=60 * 10, pollAtLaunch=False):
         self.pollInterval, prevPollInterval = pollInterval, self.pollInterval
         self.pollAtLaunch = pollAtLaunch
-        yield ChangeSource.reconfigService(self, name=name)
+        yield super().reconfigService(name=name)
 
         # pollInterval change is the only value which makes sense to reconfigure check.
         if prevPollInterval != pollInterval and self.doPoll.started:
@@ -99,7 +99,7 @@ class PollingChangeSource(ReconfigurablePollingChangeSource):
     # instead of porting everything at once, we make a class to support legacy
 
     def checkConfig(self, name=None, pollInterval=60 * 10, pollAtLaunch=False, **kwargs):
-        ReconfigurablePollingChangeSource.checkConfig(self, name=name, pollInterval=60 * 10, pollAtLaunch=False)
+        super().checkConfig(name=name, pollInterval=60 * 10, pollAtLaunch=False)
         self.pollInterval = pollInterval
         self.pollAtLaunch = pollAtLaunch
 

--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -52,8 +52,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
         self.owner = owner
         self.slug = slug
         self.branch = branch
-        base.PollingChangeSource.__init__(
-            self, name='/'.join([owner, slug]), pollInterval=pollInterval, pollAtLaunch=pollAtLaunch)
+        super().__init__(name='/'.join([owner, slug]), pollInterval=pollInterval, pollAtLaunch=pollAtLaunch)
         self.encoding = encoding
 
         if hasattr(pullrequest_filter, '__call__'):

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -35,7 +35,7 @@ class GerritChangeFilter(ChangeFilter):
 
     def __init__(self,
                  eventtype=None, eventtype_re=None, eventtype_fn=None, **kw):
-        ChangeFilter.__init__(self, **kw)
+        super().__init__(**kw)
 
         self.checks.update(
             self.createChecks(
@@ -223,7 +223,7 @@ class GerritChangeSource(GerritChangeSourceBase):
                 username, gerritserver, gerritport)
         if 'gitBaseURL' not in kwargs:
             kwargs['gitBaseURL'] = "automatic at reconfigure"
-        GerritChangeSourceBase.checkConfig(self, **kwargs)
+        super().checkConfig(**kwargs)
 
     def reconfigService(self,
                         gerritserver,
@@ -241,7 +241,7 @@ class GerritChangeSource(GerritChangeSourceBase):
         self.process = None
         self.wantProcess = False
         self.streamProcessTimeout = self.STREAM_BACKOFF_MIN
-        return GerritChangeSourceBase.reconfigService(self, **kwargs)
+        return super().reconfigService(**kwargs)
 
     class LocalPP(ProcessProtocol):
 
@@ -342,7 +342,7 @@ class GerritEventLogPoller(GerritChangeSourceBase):
                     **kwargs):
         if self.name is None:
             self.name = "GerritEventLogPoller:{}".format(baseURL)
-        GerritChangeSourceBase.checkConfig(self, **kwargs)
+        super().checkConfig(**kwargs)
 
     @defer.inlineCallbacks
     def reconfigService(self,
@@ -352,7 +352,7 @@ class GerritEventLogPoller(GerritChangeSourceBase):
                         pollAtLaunch=True,
                         **kwargs):
 
-        yield GerritChangeSourceBase.reconfigService(self, **kwargs)
+        yield super().reconfigService(**kwargs)
         if baseURL.endswith('/'):
             baseURL = baseURL[:-1]
 
@@ -382,7 +382,7 @@ class GerritEventLogPoller(GerritChangeSourceBase):
 
     @defer.inlineCallbacks
     def eventReceived(self, event):
-        res = yield GerritChangeSourceBase.eventReceived(self, event)
+        res = yield super().eventReceived(event)
         if 'eventCreatedOn' in event:
             yield self.master.db.state.setState(self._oid, 'last_event_ts', event['eventCreatedOn'])
         return res

--- a/master/buildbot/changes/github.py
+++ b/master/buildbot/changes/github.py
@@ -80,8 +80,7 @@ class GitHubPullrequestPoller(base.ReconfigurablePollingChangeSource,
         if repository_type not in ["https", "svn", "git", "ssh"]:
             config.error(
                 "repository_type must be one of {https, svn, git, ssh}")
-        base.ReconfigurablePollingChangeSource.checkConfig(
-            self, name=self.name, **kwargs)
+        super().checkConfig(name=self.name, **kwargs)
 
     @defer.inlineCallbacks
     def reconfigService(self,
@@ -98,8 +97,7 @@ class GitHubPullrequestPoller(base.ReconfigurablePollingChangeSource,
                         repository_type="https",
                         github_property_whitelist=None,
                         **kwargs):
-        yield base.ReconfigurablePollingChangeSource.reconfigService(
-            self, name=self.name, **kwargs)
+        yield super().reconfigService(name=self.name, **kwargs)
 
         if baseURL is None:
             baseURL = HOSTED_BASE_URL

--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -70,11 +70,11 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
                          'use sshHostKey')
             sshPrivateKey = None
 
-        base.PollingChangeSource.__init__(self, name=name,
-                                          pollInterval=pollInterval,
-                                          pollAtLaunch=pollAtLaunch,
-                                          sshPrivateKey=sshPrivateKey,
-                                          sshHostKey=sshHostKey)
+        super().__init__(name=name,
+                         pollInterval=pollInterval,
+                         pollAtLaunch=pollAtLaunch,
+                         sshPrivateKey=sshPrivateKey,
+                         sshHostKey=sshHostKey)
 
         if project is None:
             project = ''
@@ -136,7 +136,7 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
         try:
             self.lastRev = yield self.getState('lastRev', {})
 
-            base.PollingChangeSource.activate(self)
+            super().activate()
         except Exception as e:
             log.err(e, 'while initializing GitPoller repository')
 

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -54,8 +54,7 @@ class HgPoller(base.PollingChangeSource):
 
         self.repourl = repourl
         self.branch = branch
-        base.PollingChangeSource.__init__(
-            self, name=name, pollInterval=pollInterval, pollAtLaunch=pollAtLaunch)
+        super().__init__(name=name, pollInterval=pollInterval, pollAtLaunch=pollAtLaunch)
         self.encoding = encoding
         self.lastChange = time.time()
         self.lastPoll = time.time()

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -44,6 +44,7 @@ class MaildirSource(MaildirService, util.ComparableMixin):
     """Generic base class for Maildir-based change sources"""
 
     compare_attrs = ("basedir", "pollinterval", "prefix")
+    name = 'MaildirSource'
 
     def __init__(self, maildir, prefix=None, category='', repository=''):
         super().__init__(maildir)

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -46,7 +46,7 @@ class MaildirSource(MaildirService, util.ComparableMixin):
     compare_attrs = ("basedir", "pollinterval", "prefix")
 
     def __init__(self, maildir, prefix=None, category='', repository=''):
-        MaildirService.__init__(self, maildir)
+        super().__init__(maildir)
         self.prefix = prefix
         self.category = category
         self.repository = repository
@@ -89,7 +89,7 @@ class CVSMaildirSource(MaildirSource):
 
     def __init__(self, maildir, prefix=None, category='',
                  repository='', properties=None):
-        MaildirSource.__init__(self, maildir, prefix, category, repository)
+        super().__init__(maildir, prefix, category, repository)
         if properties is None:
             properties = {}
         self.properties = properties
@@ -426,7 +426,7 @@ class BzrLaunchpadEmailMaildirSource(MaildirSource):
     def __init__(self, maildir, prefix=None, branchMap=None, defaultBranch=None, **kwargs):
         self.branchMap = branchMap
         self.defaultBranch = defaultBranch
-        MaildirSource.__init__(self, maildir, prefix, **kwargs)
+        super().__init__(maildir, prefix, **kwargs)
 
     def parse(self, m, prefix=None):
         """Parse branch notification messages sent by Launchpad.

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -132,9 +132,9 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
         if name is None:
             name = "P4Source:%s:%s" % (p4port, p4base)
 
-        base.PollingChangeSource.__init__(self, name=name,
-                                          pollInterval=pollInterval,
-                                          pollAtLaunch=pollAtLaunch)
+        super().__init__(name=name,
+                         pollInterval=pollInterval,
+                         pollAtLaunch=pollAtLaunch)
 
         if project is None:
             project = ''

--- a/master/buildbot/changes/pb.py
+++ b/master/buildbot/changes/pb.py
@@ -19,7 +19,6 @@ from twisted.python import log
 from buildbot import config
 from buildbot.changes import base
 from buildbot.pbutil import NewCredPerspective
-from buildbot.util import service
 
 
 class ChangePerspective(NewCredPerspective):
@@ -107,7 +106,7 @@ class PBChangeSource(base.ChangeSource):
             else:
                 name = "PBChangeSource:%s" % (port,)
 
-        base.ChangeSource.__init__(self, name=name)
+        super().__init__(name=name)
 
         self.user = user
         self.passwd = passwd
@@ -143,8 +142,7 @@ class PBChangeSource(base.ChangeSource):
             yield self._unregister()
             self._register(port)
 
-        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(
-            self, new_config)
+        yield super().reconfigServiceWithBuildbotConfig(new_config)
 
     def activate(self):
         port = self._calculatePort(self.master.config)

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -98,10 +98,10 @@ class SVNPoller(base.PollingChangeSource, util.ComparableMixin):
         if name is None:
             name = repourl
 
-        base.PollingChangeSource.__init__(self, name=name,
-                                          pollInterval=pollInterval,
-                                          pollAtLaunch=pollAtLaunch,
-                                          svnuser=svnuser, svnpasswd=svnpasswd)
+        super().__init__(name=name,
+                         pollInterval=pollInterval,
+                         pollAtLaunch=pollAtLaunch,
+                         svnuser=svnuser, svnpasswd=svnpasswd)
 
         if repourl.endswith("/"):
             repourl = repourl[:-1]  # strip the trailing slash

--- a/master/buildbot/configurators/janitor.py
+++ b/master/buildbot/configurators/janitor.py
@@ -43,7 +43,7 @@ class LogChunksJanitor(BuildStep):
     renderables = ["logHorizon"]
 
     def __init__(self, logHorizon):
-        BuildStep.__init__(self)
+        super().__init__()
         self.logHorizon = logHorizon
 
     @defer.inlineCallbacks
@@ -56,7 +56,7 @@ class LogChunksJanitor(BuildStep):
 
 class JanitorConfigurator(ConfiguratorBase):
     def __init__(self, logHorizon=None, hour=0, **kwargs):
-        ConfiguratorBase.__init__(self)
+        super().__init__()
         self.logHorizon = logHorizon
         self.hour = hour
         self.kwargs = kwargs
@@ -68,7 +68,7 @@ class JanitorConfigurator(ConfiguratorBase):
         hour = self.hour
         kwargs = self.kwargs
 
-        ConfiguratorBase.configure(self, config_dict)
+        super().configure(config_dict)
         nightly_kwargs = {}
 
         # we take the defaults of Nightly, except for hour

--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -146,7 +146,7 @@ class ListResult(UserList):
 
     def __init__(self, values,
                  offset=None, total=None, limit=None):
-        UserList.__init__(self, values)
+        super().__init__(values)
 
         # if set, this is the index in the overall results of the first element of
         # this list

--- a/master/buildbot/data/builders.py
+++ b/master/buildbot/data/builders.py
@@ -87,9 +87,6 @@ class Builder(base.ResourceType):
         tags = types.List(of=types.String())
     entityType = EntityType(name)
 
-    def __init__(self, master):
-        base.ResourceType.__init__(self, master)
-
     @defer.inlineCallbacks
     def generateEvent(self, _id, event):
         builder = yield self.master.data.get(('builders', str(_id)))

--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -66,7 +66,7 @@ class DataConnector(service.AsyncService):
 
     @defer.inlineCallbacks
     def setServiceParent(self, parent):
-        yield service.AsyncService.setServiceParent(self, parent)
+        yield super().setServiceParent(parent)
         self._setup()
 
     def _scanModule(self, mod, _noSetattr=False):

--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -163,7 +163,7 @@ class Identifier(Type):
     ramlType = "string"
 
     def __init__(self, len=None, **kwargs):
-        Type.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.len = len
 
     def valueFromString(self, arg):
@@ -198,7 +198,7 @@ class List(Type):
         return self.of.ramlname
 
     def __init__(self, of=None, **kwargs):
-        Type.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.of = of
 
     def validate(self, name, object):

--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -68,7 +68,7 @@ class DBConnector(service.ReconfigurableServiceMixin,
     CLEANUP_PERIOD = 3600
 
     def __init__(self, basedir):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.setName('db')
         self.basedir = basedir
 
@@ -81,7 +81,7 @@ class DBConnector(service.ReconfigurableServiceMixin,
         self.pool = None  # set up in reconfigService
 
     def setServiceParent(self, p):
-        d = service.AsyncMultiService.setServiceParent(self, p)
+        d = super().setServiceParent(p)
         self.model = model.Model(self)
         self.changes = changes.ChangesConnectorComponent(self)
         self.changesources = changesources.ChangeSourcesConnectorComponent(
@@ -137,8 +137,7 @@ class DBConnector(service.ReconfigurableServiceMixin,
         # double-check -- the master ensures this in config checks
         assert self.configured_url == new_config.db['db_url']
 
-        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                    new_config)
+        return super().reconfigServiceWithBuildbotConfig(new_config)
 
     def _doCleanup(self):
         """

--- a/master/buildbot/db/enginestrategy.py
+++ b/master/buildbot/db/enginestrategy.py
@@ -273,8 +273,7 @@ class BuildbotEngineStrategy(strategies.ThreadLocalEngineStrategy):
             max_conns = kwargs.get(
                 'pool_size', 5) + kwargs.get('max_overflow', 10)
         strategy = self.get_drivers_strategy(u.drivername)
-        engine = strategies.ThreadLocalEngineStrategy.create(self,
-                                                             u, **kwargs)
+        engine = super().create(u, **kwargs)
         strategy.set_up(u, engine)
         engine.should_retry = strategy.should_retry
         # annotate the engine with the optimal thread pool size; this is used

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -198,7 +198,7 @@ class BaseLock:
 class RealMasterLock(BaseLock):
 
     def __init__(self, lockid):
-        BaseLock.__init__(self, lockid.name, lockid.maxCount)
+        super().__init__(lockid.name, lockid.maxCount)
         self.description = "<MasterLock(%s, %s)>" % (self.name, self.maxCount)
 
     def getLock(self, worker):

--- a/master/buildbot/manhole.py
+++ b/master/buildbot/manhole.py
@@ -158,7 +158,7 @@ class _BaseManhole(service.AsyncMultiService):
         # c = conchc.SSHPublicKeyDatabase() # ~/.ssh/authorized_keys
         # and I can't get UNIXPasswordDatabase to work
 
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         if isinstance(port, int):
             port = "tcp:%d" % port
         self.port = port  # for comparison later
@@ -207,7 +207,7 @@ class _BaseManhole(service.AsyncMultiService):
         else:
             via = "via telnet"
         log.msg("Manhole listening %s on port %s" % (via, self.port))
-        return service.AsyncMultiService.startService(self)
+        return super().startService()
 
 
 class TelnetManhole(_BaseManhole, ComparableMixin):
@@ -237,7 +237,7 @@ class TelnetManhole(_BaseManhole, ComparableMixin):
         c = checkers.InMemoryUsernamePasswordDatabaseDontUse()
         c.addUser(unicode2bytes(username), unicode2bytes(password))
 
-        _BaseManhole.__init__(self, port, c)
+        super().__init__(port, c)
 
 
 class PasswordManhole(_BaseManhole, ComparableMixin):
@@ -273,7 +273,7 @@ class PasswordManhole(_BaseManhole, ComparableMixin):
         c = checkers.InMemoryUsernamePasswordDatabaseDontUse()
         c.addUser(unicode2bytes(username), unicode2bytes(password))
 
-        _BaseManhole.__init__(self, port, c, ssh_hostkey_dir)
+        super().__init__(port, c, ssh_hostkey_dir)
 
 
 class AuthorizedKeysManhole(_BaseManhole, ComparableMixin):
@@ -309,7 +309,7 @@ class AuthorizedKeysManhole(_BaseManhole, ComparableMixin):
         # basedir
         self.keyfile = keyfile
         c = AuthorizedKeysChecker(keyfile)
-        _BaseManhole.__init__(self, port, c, ssh_hostkey_dir)
+        super().__init__(port, c, ssh_hostkey_dir)
 
 
 class ArbitraryCheckerManhole(_BaseManhole, ComparableMixin):
@@ -334,7 +334,7 @@ class ArbitraryCheckerManhole(_BaseManhole, ComparableMixin):
         if not manhole_ssh:
             config.error("cryptography required for ssh mahole.")
 
-        _BaseManhole.__init__(self, port, checker)
+        super().__init__(port, checker)
 
 # utility functions for the manhole
 

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -65,7 +65,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
     UNCLAIMED_BUILD_FACTOR = 6
 
     def __init__(self, basedir, configFileName=None, umask=None, reactor=None, config_loader=None):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
 
         if reactor is None:
             from twisted.internet import reactor
@@ -280,7 +280,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
                                                   masterid=self.masterid)
 
             # call the parent method
-            yield service.AsyncMultiService.startService(self)
+            yield super().startService()
 
             # We make sure the housekeeping is done before configuring in order to cleanup
             # any remaining claimed schedulers or change sources from zombie
@@ -331,7 +331,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
             if self.running:
                 yield self.botmaster.cleanShutdown(
                     quickMode=True, stopReactor=False)
-                yield service.AsyncMultiService.stopService(self)
+                yield super().stopService()
 
             log.msg("BuildMaster is stopped")
             self._master_initialized = False
@@ -426,8 +426,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
                 "Cannot change c['mq']['type'] after the master has started",
             ])
 
-        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                    new_config)
+        return super().reconfigServiceWithBuildbotConfig(new_config)
 
     # informational methods
     def allSchedulers(self):

--- a/master/buildbot/mq/connector.py
+++ b/master/buildbot/mq/connector.py
@@ -34,7 +34,7 @@ class MQConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
     name = 'mq'
 
     def __init__(self):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.impl = None  # set in setup
         self.impl_type = None  # set in setup
 
@@ -64,8 +64,7 @@ class MQConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         # double-check -- the master ensures this in config checks
         assert self.impl_type == new_config.mq['type']
 
-        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                    new_config)
+        return super().reconfigServiceWithBuildbotConfig(new_config)
 
     def produce(self, routing_key, data):
         # will be patched after configuration to point to the running

--- a/master/buildbot/mq/simple.py
+++ b/master/buildbot/mq/simple.py
@@ -27,15 +27,14 @@ from buildbot.util import tuplematch
 class SimpleMQ(service.ReconfigurableServiceMixin, base.MQBase):
 
     def __init__(self):
-        base.MQBase.__init__(self)
+        super().__init__()
         self.qrefs = []
         self.persistent_qrefs = {}
         self.debug = False
 
     def reconfigServiceWithBuildbotConfig(self, new_config):
         self.debug = new_config.mq.get('debug', False)
-        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                    new_config)
+        return super().reconfigServiceWithBuildbotConfig(new_config)
 
     def produce(self, routingKey, data):
         if self.debug:
@@ -66,7 +65,7 @@ class QueueRef(base.QueueRef):
     __slots__ = ['mq', 'filter']
 
     def __init__(self, mq, callback, filter):
-        base.QueueRef.__init__(self, callback)
+        super().__init__(callback)
         self.mq = mq
         self.filter = filter
 
@@ -83,7 +82,7 @@ class PersistentQueueRef(QueueRef):
     __slots__ = ['active', 'queue']
 
     def __init__(self, mq, callback, filter):
-        QueueRef.__init__(self, mq, callback, filter)
+        super().__init__(mq, callback, filter)
         self.queue = []
 
     def startConsuming(self, callback):

--- a/master/buildbot/mq/wamp.py
+++ b/master/buildbot/mq/wamp.py
@@ -30,9 +30,6 @@ from buildbot.util import toJson
 class WampMQ(service.ReconfigurableServiceMixin, base.MQBase):
     NAMESPACE = "org.buildbot.mq"
 
-    def __init__(self):
-        base.MQBase.__init__(self)
-
     def produce(self, routingKey, data):
         d = self._produce(routingKey, data)
         d.addErrback(

--- a/master/buildbot/mq/wamp.py
+++ b/master/buildbot/mq/wamp.py
@@ -74,7 +74,7 @@ class WampMQ(service.ReconfigurableServiceMixin, base.MQBase):
 class QueueRef(base.QueueRef):
 
     def __init__(self, callback):
-        base.QueueRef.__init__(self, callback)
+        super().__init__(callback)
         self.unreg = None
 
     @defer.inlineCallbacks
@@ -97,7 +97,7 @@ class QueueRef(base.QueueRef):
         else:
             # in the case of an exact match, then we can use our own topic
             topic = self.filter
-        return base.QueueRef.invoke(self, topic, msg)
+        return super().invoke(topic, msg)
 
     @defer.inlineCallbacks
     def stopConsuming(self):

--- a/master/buildbot/pbmanager.py
+++ b/master/buildbot/pbmanager.py
@@ -137,13 +137,13 @@ class Dispatcher(service.AsyncService):
         self.port = strports.listen(self.portstr, self.serverFactory)
         return super().startService()
 
+    @defer.inlineCallbacks
     def stopService(self):
         # stop listening on the port when shut down
         assert self.port
         port, self.port = self.port, None
-        d = defer.maybeDeferred(port.stopListening)
-        d.addCallback(lambda _: service.AsyncService.stopService(self))
-        return d
+        yield defer.maybeDeferred(port.stopListening)
+        yield super().stopService()
 
     def register(self, username, password, pfactory):
         if debug:

--- a/master/buildbot/pbmanager.py
+++ b/master/buildbot/pbmanager.py
@@ -43,7 +43,7 @@ class PBManager(service.AsyncMultiService):
     """
 
     def __init__(self):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.setName('pbmanager')
         self.dispatchers = {}
 
@@ -135,7 +135,7 @@ class Dispatcher(service.AsyncService):
     def startService(self):
         assert not self.port
         self.port = strports.listen(self.portstr, self.serverFactory)
-        return service.AsyncService.startService(self)
+        return super().startService()
 
     def stopService(self):
         # stop listening on the port when shut down

--- a/master/buildbot/pbutil.py
+++ b/master/buildbot/pbutil.py
@@ -65,12 +65,12 @@ class ReconnectingPBClientFactory(PBClientFactory,
     """
 
     def __init__(self):
-        PBClientFactory.__init__(self)
+        super().__init__()
         self._doingLogin = False
         self._doingGetPerspective = False
 
     def clientConnectionFailed(self, connector, reason):
-        PBClientFactory.clientConnectionFailed(self, connector, reason)
+        super().clientConnectionFailed(connector, reason)
         # Twisted-1.3 erroneously abandons the connection on non-UserErrors.
         # To avoid this bug, don't upcall, and implement the correct version
         # of the method here.
@@ -79,14 +79,13 @@ class ReconnectingPBClientFactory(PBClientFactory,
             self.retry()
 
     def clientConnectionLost(self, connector, reason):
-        PBClientFactory.clientConnectionLost(self, connector, reason,
-                                             reconnecting=True)
+        super().clientConnectionLost(connector, reason, reconnecting=True)
         RCF = protocol.ReconnectingClientFactory
         RCF.clientConnectionLost(self, connector, reason)
 
     def clientConnectionMade(self, broker):
         self.resetDelay()
-        PBClientFactory.clientConnectionMade(self, broker)
+        super().clientConnectionMade(broker)
         if self._doingLogin:
             self.doLogin(self._root)
         if self._doingGetPerspective:

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -38,7 +38,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
     name = "botmaster"
 
     def __init__(self):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
 
         self.builders = {}
         self.builderNames = []
@@ -178,7 +178,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         self.buildrequest_consumer_unclaimed = yield startConsuming(
             buildRequestAdded,
             ('buildrequests', None, 'unclaimed'))
-        yield service.AsyncMultiService.startService(self)
+        yield super().startService()
 
     @defer.inlineCallbacks
     def reconfigServiceWithBuildbotConfig(self, new_config):
@@ -189,8 +189,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         yield self.reconfigServiceBuilders(new_config)
 
         # call up
-        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                   new_config)
+        yield super().reconfigServiceWithBuildbotConfig(new_config)
 
         # try to start a build for every builder; this is necessary at master
         # startup, and a good idea in any other case
@@ -255,7 +254,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         if self.buildrequest_consumer_unclaimed:
             self.buildrequest_consumer_unclaimed.stopConsuming()
             self.buildrequest_consumer_unclaimed = None
-        return service.AsyncMultiService.stopService(self)
+        return super().stopService()
 
     def getLockByID(self, lockid):
         """Convert a Lock identifier into an actual Lock instance.

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -57,7 +57,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
         return None
 
     def __init__(self, name):
-        service.MultiService.__init__(self)
+        super().__init__()
         self.name = name
 
         # this is filled on demand by getBuilderId; don't access it directly

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -155,7 +155,7 @@ class BasicBuildChooser(BuildChooserBase):
     # must have the locks available.
 
     def __init__(self, bldr, master):
-        BuildChooserBase.__init__(self, bldr, master)
+        super().__init__(bldr, master)
 
         self.nextWorker = self.bldr.config.nextWorker
         if not self.nextWorker:
@@ -284,7 +284,7 @@ class BuildRequestDistributor(service.AsyncMultiService):
     BuildChooser = BasicBuildChooser
 
     def __init__(self, botmaster):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.botmaster = botmaster
 
         # lock to ensure builders are only sorted once at any time

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -934,7 +934,7 @@ class LoggingBuildStep(BuildStep):
 
     def __init__(self, logfiles=None, lazylogfiles=False, log_eval_func=None,
                  *args, **kwargs):
-        BuildStep.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         if logfiles is None:
             logfiles = {}

--- a/master/buildbot/process/cache.py
+++ b/master/buildbot/process/cache.py
@@ -64,8 +64,7 @@ class CacheManager(service.ReconfigurableServiceMixin, service.AsyncService):
             cache.set_max_size(new_config.caches.get(name,
                                                      self.DEFAULT_CACHE_SIZE))
 
-        return service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                    new_config)
+        return super().reconfigServiceWithBuildbotConfig(new_config)
 
     def get_metrics(self):
         return {

--- a/master/buildbot/process/debug.py
+++ b/master/buildbot/process/debug.py
@@ -23,7 +23,7 @@ class DebugServices(service.ReconfigurableServiceMixin, service.AsyncMultiServic
     name = 'debug_services'
 
     def __init__(self):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
 
         self.debug_port = None
         self.debug_password = None
@@ -42,13 +42,12 @@ class DebugServices(service.ReconfigurableServiceMixin, service.AsyncMultiServic
                 yield self.manhole.setServiceParent(self)
 
         # chain up
-        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                   new_config)
+        yield super().reconfigServiceWithBuildbotConfig(new_config)
 
     @defer.inlineCallbacks
     def stopService(self):
         # manhole will get stopped as a sub-service
-        yield service.AsyncMultiService.stopService(self)
+        yield super().stopService()
 
         # clean up
         if self.manhole:

--- a/master/buildbot/process/factory.py
+++ b/master/buildbot/process/factory.py
@@ -124,7 +124,7 @@ class GNUAutoconf(BuildFactory):
         if distcheck is _DefaultCommand:
             distcheck = ["make", "distcheck"]
 
-        BuildFactory.__init__(self, [source])
+        super().__init__([source])
 
         if reconf is True:
             reconf = ["autoreconf", "-si"]
@@ -157,7 +157,7 @@ class GNUAutoconf(BuildFactory):
 class CPAN(BuildFactory):
 
     def __init__(self, source, perl="perl"):
-        BuildFactory.__init__(self, [source])
+        super().__init__([source])
         self.addStep(Configure(command=[perl, "Makefile.PL"]))
         self.addStep(Compile(command=["make"]))
         self.addStep(PerlModuleTest(command=["make", "test"]))
@@ -166,7 +166,7 @@ class CPAN(BuildFactory):
 class Distutils(BuildFactory):
 
     def __init__(self, source, python="python", test=None):
-        BuildFactory.__init__(self, [source])
+        super().__init__([source])
         self.addStep(Compile(command=[python, "./setup.py", "build"]))
         if test is not None:
             self.addStep(Test(command=test))
@@ -192,7 +192,7 @@ class Trial(BuildFactory):
                  buildpython=None, trialpython=None, trial=None,
                  testpath=".", randomly=None, recurse=None,
                  tests=None, useTestCaseNames=False, env=None):
-        BuildFactory.__init__(self, [source])
+        super().__init__([source])
         assert tests or useTestCaseNames, "must use one or the other"
         if buildpython is None:
             buildpython = ["python"]
@@ -240,10 +240,10 @@ class BasicBuildFactory(GNUAutoconf):
             method = "copy"
         source = CVS(
             cvsroot=cvsroot, cvsmodule=cvsmodule, mode=mode, method=method)
-        GNUAutoconf.__init__(self, source,
-                             configure=configure, configureEnv=configureEnv,
-                             compile=compile,
-                             test=test)
+        super().__init__(source,
+                         configure=configure, configureEnv=configureEnv,
+                         compile=compile,
+                         test=test)
 
 
 class QuickBuildFactory(BasicBuildFactory):
@@ -257,10 +257,10 @@ class QuickBuildFactory(BasicBuildFactory):
             configureEnv = {}
         mode = "incremental"
         source = CVS(cvsroot=cvsroot, cvsmodule=cvsmodule, mode=mode)
-        GNUAutoconf.__init__(self, source,
-                             configure=configure, configureEnv=configureEnv,
-                             compile=compile,
-                             test=test)
+        super().__init__(source,
+                         configure=configure, configureEnv=configureEnv,
+                         compile=compile,
+                         test=test)
 
 
 class BasicSVN(GNUAutoconf):
@@ -272,7 +272,7 @@ class BasicSVN(GNUAutoconf):
         if configureEnv is None:
             configureEnv = {}
         source = SVN(svnurl=svnurl, mode="incremental")
-        GNUAutoconf.__init__(self, source,
-                             configure=configure, configureEnv=configureEnv,
-                             compile=compile,
-                             test=test)
+        super().__init__(source,
+                         configure=configure, configureEnv=configureEnv,
+                         compile=compile,
+                         test=test)

--- a/master/buildbot/process/logobserver.py
+++ b/master/buildbot/process/logobserver.py
@@ -57,6 +57,7 @@ class LogLineObserver(LogObserver):
     headerDelimiter = "\n"
 
     def __init__(self):
+        super().__init__()
         self.max_length = 16384
 
     def setMaxLineLength(self, max_length):
@@ -98,7 +99,7 @@ class LogLineObserver(LogObserver):
 class LineConsumerLogObserver(LogLineObserver):
 
     def __init__(self, consumerFunction):
-        LogLineObserver.__init__(self)
+        super().__init__()
         self.generator = None
         self.consumerFunction = consumerFunction
 

--- a/master/buildbot/process/logobserver.py
+++ b/master/buildbot/process/logobserver.py
@@ -141,7 +141,7 @@ class OutputProgressObserver(LogObserver):
 class BufferLogObserver(LogObserver):
 
     def __init__(self, wantStdout=True, wantStderr=False):
-        LogObserver.__init__(self)
+        super().__init__()
         self.stdout = [] if wantStdout else None
         self.stderr = [] if wantStderr else None
 

--- a/master/buildbot/process/metrics.py
+++ b/master/buildbot/process/metrics.py
@@ -150,7 +150,7 @@ class FiniteList(deque):
 
     def __init__(self, maxlen=10):
         self._maxlen = maxlen
-        deque.__init__(self)
+        super().__init__()
 
     def append(self, o):
         deque.append(self, o)
@@ -161,11 +161,11 @@ class FiniteList(deque):
 class AveragingFiniteList(FiniteList):
 
     def __init__(self, maxlen=10):
-        FiniteList.__init__(self, maxlen)
+        super().__init__(maxlen)
         self.average = 0
 
     def append(self, o):
-        FiniteList.append(self, o)
+        super().append(o)
         self._calc()
 
     def _calc(self):
@@ -379,7 +379,7 @@ class MetricLogObserver(util_service.ReconfigurableServiceMixin,
     _reactor = reactor
 
     def __init__(self):
-        service.MultiService.__init__(self)
+        super().__init__()
         self.setName('metrics')
 
         self.enabled = False
@@ -432,12 +432,11 @@ class MetricLogObserver(util_service.ReconfigurableServiceMixin,
                     self.periodic_task.start(periodic_interval)
 
         # upcall
-        return util_service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                         new_config)
+        return super().reconfigServiceWithBuildbotConfig(new_config)
 
     def stopService(self):
         self.disable()
-        service.MultiService.stopService(self)
+        super().stopService()
 
     def enable(self):
         if self.enabled:

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -391,10 +391,10 @@ class RemoteShellCommand(RemoteCommand):
                 }
         if interruptSignal is not None:
             args['interruptSignal'] = interruptSignal
-        RemoteCommand.__init__(self, "shell", args, collectStdout=collectStdout,
-                               collectStderr=collectStderr,
-                               decodeRC=decodeRC,
-                               stdioLogName=stdioLogName)
+        super().__init__("shell", args, collectStdout=collectStdout,
+                         collectStderr=collectStderr,
+                         decodeRC=decodeRC,
+                         stdioLogName=stdioLogName)
 
     def _start(self):
         if self.args['usePTY'] is None:
@@ -417,7 +417,7 @@ class RemoteShellCommand(RemoteCommand):
         what = "command '%s' in dir '%s'" % (self.fake_command,
                                              self.args['workdir'])
         log.msg(what)
-        return RemoteCommand._start(self)
+        return super()._start()
 
     def __repr__(self):
         return "<RemoteShellCommand '%s'>" % repr(self.fake_command)

--- a/master/buildbot/process/remotetransfer.py
+++ b/master/buildbot/process/remotetransfer.py
@@ -109,7 +109,7 @@ class DirectoryWriter(FileWriter):
         self.fd, self.tarname = tempfile.mkstemp()
         os.close(self.fd)
 
-        FileWriter.__init__(self, self.tarname, maxsize, mode)
+        super().__init__(self.tarname, maxsize, mode)
 
     def remote_unpack(self):
         """
@@ -197,4 +197,4 @@ class StringFileReader(FileReader):
 
     def __init__(self, s):
         s = unicode2bytes(s)
-        FileReader.__init__(self, BytesIO(s))
+        super().__init__(BytesIO(s))

--- a/master/buildbot/process/users/manager.py
+++ b/master/buildbot/process/users/manager.py
@@ -25,7 +25,7 @@ class UserManagerManager(util_service.ReconfigurableServiceMixin,
     # this class manages a fleet of user managers; hence the name..
 
     def __init__(self, master):
-        service.MultiService.__init__(self)
+        super().__init__()
         self.setName('user_manager_manager')
         self.master = master
 
@@ -42,5 +42,4 @@ class UserManagerManager(util_service.ReconfigurableServiceMixin,
             yield mgr.setServiceParent(self)
 
         # reconfig any newly-added change sources, as well as existing
-        yield util_service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                        new_config)
+        yield super().reconfigServiceWithBuildbotConfig(new_config)

--- a/master/buildbot/process/users/manual.py
+++ b/master/buildbot/process/users/manual.py
@@ -197,7 +197,7 @@ class CommandlineUserManager(service.AsyncMultiService):
     """
 
     def __init__(self, username=None, passwd=None, port=None):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         assert username and passwd, ("A username and password pair must be given "
                                      "to connect and use `buildbot user`")
         self.username = username
@@ -215,7 +215,7 @@ class CommandlineUserManager(service.AsyncMultiService):
                                                            self.username,
                                                            self.passwd,
                                                            factory)
-        return service.AsyncMultiService.startService(self)
+        return super().startService()
 
     def stopService(self):
         d = defer.maybeDeferred(service.AsyncMultiService.stopService, self)

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -185,12 +185,12 @@ class Ping:
 class WorkerForBuilder(AbstractWorkerForBuilder):
 
     def __init__(self):
-        AbstractWorkerForBuilder.__init__(self)
+        super().__init__()
         self.state = States.DETACHED
 
     @defer.inlineCallbacks
     def attached(self, worker, commands):
-        wfb = yield AbstractWorkerForBuilder.attached(self, worker, commands)
+        wfb = yield super().attached(worker, commands)
 
         # Only set available on non-latent workers, since latent workers
         # only attach while a build is in progress.
@@ -199,7 +199,7 @@ class WorkerForBuilder(AbstractWorkerForBuilder):
         return wfb
 
     def detached(self):
-        AbstractWorkerForBuilder.detached(self)
+        super().detached()
         if self.worker:
             self.worker.removeWorkerForBuilder(self)
         self.worker = None
@@ -209,7 +209,7 @@ class WorkerForBuilder(AbstractWorkerForBuilder):
 class LatentWorkerForBuilder(AbstractWorkerForBuilder):
 
     def __init__(self, worker, builder):
-        AbstractWorkerForBuilder.__init__(self)
+        super().__init__()
         self.worker = worker
         self.state = States.AVAILABLE
         self.setBuilder(builder)
@@ -231,7 +231,7 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
         # thus building and not available like for normal worker
         if self.state == States.DETACHED:
             self.state = States.BUILDING
-        return AbstractWorkerForBuilder.attached(self, worker, commands)
+        return super().attached(worker, commands)
 
     def substantiate(self, build):
         return self.worker.substantiate(self, build)
@@ -239,4 +239,4 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
     def ping(self, status=None):
         if not self.worker.substantiated:
             return defer.fail(PingException("worker is not substantiated"))
-        return AbstractWorkerForBuilder.ping(self, status)
+        return super().ping(status)

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -45,7 +45,7 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
                         oauth_url=_OAUTH_URL,
                         **kwargs):
         oauth_key, oauth_secret = yield self.renderSecrets(oauth_key, oauth_secret)
-        yield http.HttpStatusPushBase.reconfigService(self, **kwargs)
+        yield super().reconfigService(**kwargs)
 
         if base_url.endswith('/'):
             base_url = base_url[:-1]

--- a/master/buildbot/reporters/bitbucketserver.py
+++ b/master/buildbot/reporters/bitbucketserver.py
@@ -45,8 +45,7 @@ class BitbucketServerStatusPush(http.HttpStatusPushBase):
                         statusName=None, startDescription=None,
                         endDescription=None, verbose=False, **kwargs):
         user, password = yield self.renderSecrets(user, password)
-        yield http.HttpStatusPushBase.reconfigService(
-            self, wantProperties=True, **kwargs)
+        yield super().reconfigService(wantProperties=True, **kwargs)
         self.key = key or Interpolate('%(prop:buildername)s')
         self.context = statusName
         self.endDescription = endDescription or 'Build done.'
@@ -131,8 +130,8 @@ class BitbucketServerPRCommentPush(notifier.NotifierBase):
     def reconfigService(self, base_url, user, password, messageFormatter=None,
                         verbose=False, debug=None, verify=None, **kwargs):
         user, password = yield self.renderSecrets(user, password)
-        yield notifier.NotifierBase.reconfigService(
-            self, messageFormatter=messageFormatter, watchedWorkers=None,
+        yield super().reconfigService(
+            messageFormatter=messageFormatter, watchedWorkers=None,
             messageFormatterMissingWorker=None, subject='', addLogs=False,
             addPatch=False, **kwargs)
         self.verbose = verbose
@@ -143,18 +142,17 @@ class BitbucketServerPRCommentPush(notifier.NotifierBase):
     def checkConfig(self, base_url, user, password, messageFormatter=None,
                     verbose=False, debug=None, verify=None, **kwargs):
 
-        notifier.NotifierBase.checkConfig(self,
-                                          messageFormatter=messageFormatter,
-                                          watchedWorkers=None,
-                                          messageFormatterMissingWorker=None,
-                                          subject='',
-                                          addLogs=False,
-                                          addPatch=False,
-                                          **kwargs)
+        super().checkConfig(messageFormatter=messageFormatter,
+                            watchedWorkers=None,
+                            messageFormatterMissingWorker=None,
+                            subject='',
+                            addLogs=False,
+                            addPatch=False,
+                            **kwargs)
 
     def isMessageNeeded(self, build):
         if 'pullrequesturl' in build['properties']:
-            return notifier.NotifierBase.isMessageNeeded(self, build)
+            return super().isMessageNeeded(build)
         return False
 
     def workerMissing(self, key, worker):

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -261,7 +261,7 @@ class GerritStatusPush(service.BuildbotService):
 
     @defer.inlineCallbacks
     def startService(self):
-        yield service.BuildbotService.startService(self)
+        yield super().startService()
         startConsuming = self.master.mq.startConsuming
         self._buildsetCompleteConsumer = yield startConsuming(
             self.buildsetComplete,

--- a/master/buildbot/reporters/gerrit_verify_status.py
+++ b/master/buildbot/reporters/gerrit_verify_status.py
@@ -61,7 +61,7 @@ class GerritVerifyStatusPush(http.HttpStatusPushBase):
                         verbose=False,
                         **kwargs):
         auth = yield self.renderSecrets(auth)
-        yield http.HttpStatusPushBase.reconfigService(self, **kwargs)
+        yield super().reconfigService(**kwargs)
 
         if baseURL.endswith('/'):
             baseURL = baseURL[:-1]

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -44,7 +44,7 @@ class GitHubStatusPush(http.HttpStatusPushBase):
                         startDescription=None, endDescription=None,
                         context=None, baseURL=None, verbose=False, **kwargs):
         token = yield self.renderSecrets(token)
-        yield http.HttpStatusPushBase.reconfigService(self, **kwargs)
+        yield super().reconfigService(**kwargs)
 
         self.setDefaults(context, startDescription, endDescription)
         if baseURL is None:

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -44,7 +44,7 @@ class GitLabStatusPush(http.HttpStatusPushBase):
                         context=None, baseURL=None, verbose=False, **kwargs):
 
         token = yield self.renderSecrets(token)
-        yield http.HttpStatusPushBase.reconfigService(self, **kwargs)
+        yield super().reconfigService(**kwargs)
 
         self.context = context or Interpolate('buildbot/%(prop:buildername)s')
         self.startDescription = startDescription or 'Build started.'

--- a/master/buildbot/reporters/hipchat.py
+++ b/master/buildbot/reporters/hipchat.py
@@ -34,7 +34,7 @@ class HipChatStatusPush(HttpStatusPushBase):
                         builder_room_map=None, builder_user_map=None,
                         event_messages=None, **kwargs):
         auth_token = yield self.renderSecrets(auth_token)
-        yield HttpStatusPushBase.reconfigService(self, **kwargs)
+        yield super().reconfigService(**kwargs)
         self._http = yield httpclientservice.HTTPClientService.getService(
             self.master, endpoint,
             debug=self.debug, verify=self.verify)

--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -29,14 +29,14 @@ class HttpStatusPushBase(service.BuildbotService):
     neededDetails = dict()
 
     def checkConfig(self, *args, **kwargs):
-        service.BuildbotService.checkConfig(self)
+        super().checkConfig()
         httpclientservice.HTTPClientService.checkAvailable(self.__class__.__name__)
         if not isinstance(kwargs.get('builders'), (type(None), list)):
             config.error("builders must be a list or None")
 
     @defer.inlineCallbacks
     def reconfigService(self, builders=None, debug=None, verify=None, **kwargs):
-        yield service.BuildbotService.reconfigService(self)
+        yield super().reconfigService()
         self.debug = debug
         self.verify = verify
         self.builders = builders
@@ -47,7 +47,7 @@ class HttpStatusPushBase(service.BuildbotService):
 
     @defer.inlineCallbacks
     def startService(self):
-        yield service.BuildbotService.startService(self)
+        yield super().startService()
 
         startConsuming = self.master.mq.startConsuming
         self._buildCompleteConsumer = yield startConsuming(
@@ -98,11 +98,11 @@ class HttpStatusPush(HttpStatusPushBase):
             config.warnDeprecated("0.9.1", "user/password is deprecated, use 'auth=(user, password)'")
         if (format_fn is not None) and not callable(format_fn):
             config.error("format_fn must be a function")
-        HttpStatusPushBase.checkConfig(self, **kwargs)
+        super().checkConfig(**kwargs)
 
     @defer.inlineCallbacks
     def reconfigService(self, serverUrl, user=None, password=None, auth=None, format_fn=None, **kwargs):
-        yield HttpStatusPushBase.reconfigService(self, **kwargs)
+        yield super().reconfigService(**kwargs)
         if user is not None:
             auth = (user, password)
         if format_fn is None:

--- a/master/buildbot/reporters/irc.py
+++ b/master/buildbot/reporters/irc.py
@@ -28,8 +28,13 @@ from buildbot.util import ssl
 
 class UsageError(ValueError):
 
+    # pylint: disable=useless-super-delegation
     def __init__(self, string="Invalid usage", *more):
-        ValueError.__init__(self, string, *more)
+        # This is not useless as we change the default value of an argument.
+        # This bug is reported as "fixed" but apparently, it is not.
+        # https://github.com/PyCQA/pylint/issues/1085
+        # (Maybe there is a problem with builtin exceptions).
+        super().__init__(string, *more)
 
 
 class IrcStatusBot(StatusBot, irc.IRCClient):

--- a/master/buildbot/reporters/irc.py
+++ b/master/buildbot/reporters/irc.py
@@ -39,7 +39,7 @@ class IrcStatusBot(StatusBot, irc.IRCClient):
 
     def __init__(self, nickname, password, channels, pm_to_nicks,
                  noticeOnChannel, *args, **kwargs):
-        StatusBot.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.nickname = nickname
         self.channels = channels
         self.pm_to_nicks = pm_to_nicks
@@ -50,13 +50,13 @@ class IrcStatusBot(StatusBot, irc.IRCClient):
             lambda: self.ping(self.nickname))
 
     def connectionMade(self):
-        irc.IRCClient.connectionMade(self)
+        super().connectionMade()
         self._keepAliveCall.start(60)
 
     def connectionLost(self, reason):
         if self._keepAliveCall.running:
             self._keepAliveCall.stop()
-        irc.IRCClient.connectionLost(self, reason)
+        super().connectionLost(reason)
 
     # The following methods are called when we write something.
     def groupChat(self, channel, message):
@@ -77,7 +77,7 @@ class IrcStatusBot(StatusBot, irc.IRCClient):
             user = user.lower()
         if channel:
             channel = channel.lower()
-        return StatusBot.getContact(self, user, channel)
+        return super().getContact(user, channel)
 
     # the following irc.IRCClient methods are called when we have input
     def privmsg(self, user, channel, message):
@@ -142,8 +142,7 @@ class IrcStatusFactory(ThrottledClientFactory):
                  useRevisions=False, showBlameList=False,
                  parent=None,
                  lostDelay=None, failedDelay=None, useColors=True, allowShutdown=False):
-        ThrottledClientFactory.__init__(self, lostDelay=lostDelay,
-                                        failedDelay=failedDelay)
+        super().__init__(lostDelay=lostDelay, failedDelay=failedDelay)
         self.nickname = nickname
         self.password = password
         self.channels = channels
@@ -190,13 +189,13 @@ class IrcStatusFactory(ThrottledClientFactory):
         if self.shuttingDown:
             log.msg("not scheduling reconnection attempt")
             return
-        ThrottledClientFactory.clientConnectionLost(self, connector, reason)
+        super().clientConnectionLost(connector, reason)
 
     def clientConnectionFailed(self, connector, reason):
         if self.shuttingDown:
             log.msg("not scheduling reconnection attempt")
             return
-        ThrottledClientFactory.clientConnectionFailed(self, connector, reason)
+        super().clientConnectionFailed(connector, reason)
 
 
 class IRC(service.BuildbotService):

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -95,11 +95,12 @@ class MessageFormatter(MessageFormatterBase):
         if template_name is not None:
             config.warnDeprecated('0.9.1', "template_name is deprecated, use template_filename")
             template_filename = template_name
-        MessageFormatterBase.__init__(self,
-                                      template_dir=template_dir,
-                                      template_filename=template_filename, template=template,
-                                      subject_filename=subject_filename, subject=subject,
-                                      template_type=template_type, ctx=ctx)
+        super().__init__(template_dir=template_dir,
+                         template_filename=template_filename,
+                         template=template,
+                         subject_filename=subject_filename,
+                         subject=subject,
+                         template_type=template_type, ctx=ctx)
         self.wantProperties = wantProperties
         self.wantSteps = wantSteps
         self.wantLogs = wantLogs

--- a/master/buildbot/reporters/notifier.py
+++ b/master/buildbot/reporters/notifier.py
@@ -124,7 +124,7 @@ class NotifierBase(service.BuildbotService):
 
     @defer.inlineCallbacks
     def startService(self):
-        yield service.BuildbotService.startService(self)
+        yield super().startService()
         startConsuming = self.master.mq.startConsuming
         self._buildsetCompleteConsumer = yield startConsuming(
             self.buildsetComplete,
@@ -138,7 +138,7 @@ class NotifierBase(service.BuildbotService):
 
     @defer.inlineCallbacks
     def stopService(self):
-        yield service.BuildbotService.stopService(self)
+        yield super().stopService()
         if self._buildsetCompleteConsumer is not None:
             yield self._buildsetCompleteConsumer.stopConsuming()
             self._buildsetCompleteConsumer = None

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -86,8 +86,13 @@ def maybeColorize(text, color, useColors):
 
 class UsageError(ValueError):
 
+    # pylint: disable=useless-super-delegation
     def __init__(self, string="Invalid usage", *more):
-        ValueError.__init__(self, string, *more)
+        # This is not useless as we change the default value of an argument.
+        # This bug is reported as "fixed" but apparently, it is not.
+        # https://github.com/PyCQA/pylint/issues/1085
+        # (Maybe there is a problem with builtin exceptions).
+        super().__init__(string, *more)
 
 
 class ForceOptions(usage.Options):

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -171,7 +171,7 @@ class Contact(service.AsyncService):
             self.name = "Contact(channel=%s)" % (channel,)
         elif user:
             self.name = "Contact(name=%s)" % (user,)
-        service.AsyncService.__init__(self)
+        super().__init__()
         self.bot = bot
         self.notify_events = {}
         self.subscribed = []
@@ -199,7 +199,7 @@ class Contact(service.AsyncService):
     def startService(self):
         if self.channel and not self.user:
             self.add_notification_events(self.bot.notify_events)
-        return service.AsyncService.startService(self)
+        return super().startService()
 
     def stopService(self):
         self.remove_all_notification_events()
@@ -1032,7 +1032,7 @@ class StatusBot(service.AsyncMultiService):
                  useRevisions=False, showBlameList=False, useColors=True,
                  categories=None  # deprecated
                  ):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.tags = tags or categories
         self.notify_events = notify_events
         self.useColors = useColors

--- a/master/buildbot/revlinks.py
+++ b/master/buildbot/revlinks.py
@@ -45,8 +45,8 @@ GithubRevlink = RevlinkMatch(
 class GitwebMatch(RevlinkMatch):
 
     def __init__(self, repo_urls, revlink):
-        RevlinkMatch.__init__(self, repo_urls=repo_urls,
-                              revlink=revlink + r'?p=\g<repo>;a=commit;h=%s')
+        super().__init__(repo_urls=repo_urls,
+                         revlink=revlink + r'?p=\g<repo>;a=commit;h=%s')
 
 
 SourceforgeGitRevlink = GitwebMatch(

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -62,7 +62,7 @@ class BaseBasicScheduler(base.BaseScheduler):
                 "fileIsImportant must be a callable")
 
         # initialize parent classes
-        base.BaseScheduler.__init__(self, name, builderNames, **kwargs)
+        super().__init__(name, builderNames, **kwargs)
 
         self.treeStableTimer = treeStableTimer
         if fileIsImportant is not None:
@@ -86,7 +86,7 @@ class BaseBasicScheduler(base.BaseScheduler):
 
     @defer.inlineCallbacks
     def activate(self):
-        yield base.BaseScheduler.activate(self)
+        yield super().activate()
 
         if not self.enabled:
             return
@@ -109,7 +109,7 @@ class BaseBasicScheduler(base.BaseScheduler):
     @defer.inlineCallbacks
     def deactivate(self):
         # the base deactivate will unsubscribe from new changes
-        yield base.BaseScheduler.deactivate(self)
+        yield super().deactivate()
 
         if not self.enabled:
             return
@@ -254,7 +254,7 @@ class Scheduler(SingleBranchScheduler):
                 "buildbot.schedulers.basic.SingleBranchScheduler instead " +
                 "(note that this may require you to change your import " +
                 "statement)")
-        SingleBranchScheduler.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class AnyBranchScheduler(BaseBasicScheduler):

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -206,22 +206,22 @@ class BaseBasicScheduler(base.BaseScheduler):
             self.serviceid, less_than=max_changeid + 1)
 
 
-class SingleBranchScheduler(BaseBasicScheduler, AbsoluteSourceStampsMixin):
+class SingleBranchScheduler(AbsoluteSourceStampsMixin, BaseBasicScheduler):
 
     def __init__(self, name, createAbsoluteSourceStamps=False, **kwargs):
         self.createAbsoluteSourceStamps = createAbsoluteSourceStamps
-        BaseBasicScheduler.__init__(self, name, **kwargs)
+        super().__init__(name, **kwargs)
 
     @defer.inlineCallbacks
     def gotChange(self, change, important):
         if self.createAbsoluteSourceStamps:
             yield self.recordChange(change)
 
-        yield BaseBasicScheduler.gotChange(self, change, important)
+        yield super().gotChange(change, important)
 
     def getCodebaseDict(self, codebase):
         if self.createAbsoluteSourceStamps:
-            return AbsoluteSourceStampsMixin.getCodebaseDict(self, codebase)
+            return super().getCodebaseDict(codebase)
         return self.codebases[codebase]
 
     def getChangeFilter(self, branch, branches, change_filter, categories):

--- a/master/buildbot/schedulers/dependent.py
+++ b/master/buildbot/schedulers/dependent.py
@@ -29,7 +29,7 @@ class Dependent(base.BaseScheduler):
     compare_attrs = ('upstream_name',)
 
     def __init__(self, name, upstream, builderNames, **kwargs):
-        base.BaseScheduler.__init__(self, name, builderNames, **kwargs)
+        super().__init__(name, builderNames, **kwargs)
         if not interfaces.IScheduler.providedBy(upstream):
             config.error(
                 "upstream must be another Scheduler instance")
@@ -45,7 +45,7 @@ class Dependent(base.BaseScheduler):
 
     @defer.inlineCallbacks
     def activate(self):
-        yield base.BaseScheduler.activate(self)
+        yield super().activate()
 
         if not self.enabled:
             return
@@ -65,7 +65,7 @@ class Dependent(base.BaseScheduler):
     @defer.inlineCallbacks
     def deactivate(self):
         # the base deactivate will unsubscribe from new changes
-        yield base.BaseScheduler.deactivate(self)
+        yield super().deactivate()
 
         if not self.enabled:
             return

--- a/master/buildbot/schedulers/dependent.py
+++ b/master/buildbot/schedulers/dependent.py
@@ -45,7 +45,7 @@ class Dependent(base.BaseScheduler):
 
     @defer.inlineCallbacks
     def activate(self):
-        yield base.BaseScheduler.deactivate(self)
+        yield base.BaseScheduler.activate(self)
 
         if not self.enabled:
             return

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -36,8 +36,7 @@ class CollectedValidationError(ValueError):
 
     def __init__(self, errors):
         self.errors = errors
-        ValueError.__init__(
-            self, "\n".join([k + ":" + v for k, v in errors.items()]))
+        super().__init__("\n".join([k + ":" + v for k, v in errors.items()]))
 
 
 class ValidationErrorCollector:
@@ -264,7 +263,7 @@ class UserNameParameter(StringParameter):
     need_email = True
 
     def __init__(self, name="username", label="Your name:", **kw):
-        BaseParameter.__init__(self, name, label, **kw)
+        super().__init__(name, label, **kw)
 
     def parse_from_arg(self, s):
         if not s and not self.required:
@@ -349,14 +348,14 @@ class WorkerChoiceParameter(ChoiceStringParameter):
     strict = False
 
     def __init__(self, name='workername', **kwargs):
-        ChoiceStringParameter.__init__(self, name, **kwargs)
+        super().__init__(name, **kwargs)
 
     def updateFromKwargs(self, kwargs, **unused):
         workername = self.getFromKwargs(kwargs)
         if workername == self.anySentinel:
             # no preference, so don't set a parameter at all
             return
-        ChoiceStringParameter.updateFromKwargs(self, kwargs=kwargs, **unused)
+        super().updateFromKwargs(kwargs=kwargs, **unused)
 
     def getChoices(self, master, scheduler, buildername):
         if buildername is None:
@@ -403,7 +402,7 @@ class NestedParameter(BaseParameter):
     columns = None
 
     def __init__(self, name, fields, **kwargs):
-        BaseParameter.__init__(self, fields=fields, name=name, **kwargs)
+        super().__init__(fields=fields, name=name, **kwargs)
         # reasonable defaults for the number of columns
         if self.columns is None:
             num_visible_fields = len(
@@ -420,7 +419,7 @@ class NestedParameter(BaseParameter):
         self.setParent(None)
 
     def setParent(self, parent):
-        BaseParameter.setParent(self, parent)
+        super().setParent(parent)
         for field in self.fields:  # pylint: disable=not-an-iterable
             field.setParent(self)
 
@@ -456,7 +455,7 @@ class NestedParameter(BaseParameter):
         d.update(kwargs[self.fullName])
 
     def getSpec(self):
-        ret = BaseParameter.getSpec(self)
+        ret = super().getSpec()
         # pylint: disable=not-an-iterable
         ret['fields'] = [field.getSpec() for field in self.fields]
         return ret
@@ -476,7 +475,7 @@ class AnyPropertyParameter(NestedParameter):
             StringParameter(name='name', label="Name:"),
             StringParameter(name='value', label="Value:"),
         ]
-        NestedParameter.__init__(self, name, label='', fields=fields, **kw)
+        super().__init__(name, label='', fields=fields, **kw)
 
     def getFromKwargs(self, kwargs):
         raise ValidationError(
@@ -563,9 +562,9 @@ class CodebaseParameter(NestedParameter):
             if self.columns is None and 'columns' not in kwargs:
                 self.columns = 1
 
-        NestedParameter.__init__(self, name=name, label=label,
-                                 codebase=codebase,
-                                 fields=fields, **kwargs)
+        super().__init__(name=name, label=label,
+                         codebase=codebase,
+                         fields=fields, **kwargs)
 
     def createSourcestamp(self, properties, kwargs):
         # default, just return the things we put together
@@ -612,7 +611,7 @@ class PatchParameter(NestedParameter):
             kwargs.pop(field.name, field)
             for field in default_fields
         ]
-        NestedParameter.__init__(self, name, fields=fields, **kwargs)
+        super().__init__(name, fields=fields, **kwargs)
 
 
 class ForceScheduler(base.BaseScheduler):
@@ -731,11 +730,10 @@ class ForceScheduler(base.BaseScheduler):
             codebase_dict[codebase.codebase] = dict(
                 branch='', repository='', revision='')
 
-        base.BaseScheduler.__init__(self,
-                                    name=name,
-                                    builderNames=builderNames,
-                                    properties={},
-                                    codebases=codebase_dict)
+        super().__init__(name=name,
+                         builderNames=builderNames,
+                         properties={},
+                         codebases=codebase_dict)
 
         if properties:
             self.forcedProperties.extend(properties)

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -31,7 +31,7 @@ from buildbot.util import croniter
 from buildbot.util.codebase import AbsoluteSourceStampsMixin
 
 
-class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
+class Timed(AbsoluteSourceStampsMixin, base.BaseScheduler):
 
     """
     Parent class for timed schedulers.  This takes care of the (surprisingly
@@ -50,7 +50,7 @@ class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
                  createAbsoluteSourceStamps=False, onlyIfChanged=False,
                  branch=NoBranch, change_filter=None, fileIsImportant=None,
                  onlyImportant=False, **kwargs):
-        base.BaseScheduler.__init__(self, name, builderNames, **kwargs)
+        super().__init__(name, builderNames, **kwargs)
 
         # tracking for when to start the next build
         self.lastActuated = None
@@ -78,7 +78,7 @@ class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
 
     @defer.inlineCallbacks
     def activate(self):
-        yield base.BaseScheduler.activate(self)
+        yield super().activate()
 
         if not self.enabled:
             return None
@@ -102,7 +102,7 @@ class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
 
     @defer.inlineCallbacks
     def deactivate(self):
-        yield base.BaseScheduler.deactivate(self)
+        yield super().deactivate()
 
         if not self.enabled:
             return None
@@ -174,7 +174,7 @@ class Timed(base.BaseScheduler, AbsoluteSourceStampsMixin):
 
     def getCodebaseDict(self, codebase):
         if self.createAbsoluteSourceStamps:
-            return AbsoluteSourceStampsMixin.getCodebaseDict(self, codebase)
+            return super().getCodebaseDict(codebase)
         return self.codebases[codebase]
 
     # Timed methods
@@ -265,7 +265,7 @@ class Periodic(Timed):
     def __init__(self, name, builderNames, periodicBuildTimer,
                  reason="The Periodic scheduler named '%(name)s' triggered this build",
                  **kwargs):
-        Timed.__init__(self, name, builderNames, reason=reason, **kwargs)
+        super().__init__(name, builderNames, reason=reason, **kwargs)
         if periodicBuildTimer <= 0:
             config.error("periodicBuildTimer must be positive")
         self.periodicBuildTimer = periodicBuildTimer
@@ -282,7 +282,7 @@ class NightlyBase(Timed):
     def __init__(self, name, builderNames, minute=0, hour='*',
                  dayOfMonth='*', month='*', dayOfWeek='*',
                  **kwargs):
-        Timed.__init__(self, name, builderNames, **kwargs)
+        super().__init__(name, builderNames, **kwargs)
 
         self.minute = minute
         self.hour = hour
@@ -339,10 +339,10 @@ class Nightly(NightlyBase):
                  dayOfMonth='*', month='*', dayOfWeek='*',
                  reason="The Nightly scheduler named '%(name)s' triggered this build",
                  **kwargs):
-        NightlyBase.__init__(self, name=name, builderNames=builderNames,
-                             minute=minute, hour=hour, dayOfMonth=dayOfMonth,
-                             month=month, dayOfWeek=dayOfWeek, reason=reason,
-                             **kwargs)
+        super().__init__(name=name, builderNames=builderNames,
+                         minute=minute, hour=hour, dayOfMonth=dayOfMonth,
+                         month=month, dayOfWeek=dayOfWeek, reason=reason,
+                         **kwargs)
 
 
 @implementer(ITriggerableScheduler)
@@ -352,16 +352,16 @@ class NightlyTriggerable(NightlyBase):
                  dayOfMonth='*', month='*', dayOfWeek='*',
                  reason="The NightlyTriggerable scheduler named '%(name)s' triggered this build",
                  **kwargs):
-        NightlyBase.__init__(self, name=name, builderNames=builderNames,
-                             minute=minute, hour=hour, dayOfMonth=dayOfMonth,
-                             month=month, dayOfWeek=dayOfWeek, reason=reason,
-                             **kwargs)
+        super().__init__(name=name, builderNames=builderNames,
+                         minute=minute, hour=hour, dayOfMonth=dayOfMonth,
+                         month=month, dayOfWeek=dayOfWeek, reason=reason,
+                         **kwargs)
 
         self._lastTrigger = None
 
     @defer.inlineCallbacks
     def activate(self):
-        yield NightlyBase.activate(self)
+        yield super().activate()
 
         if not self.enabled:
             return

--- a/master/buildbot/schedulers/triggerable.py
+++ b/master/buildbot/schedulers/triggerable.py
@@ -29,7 +29,7 @@ class Triggerable(base.BaseScheduler):
     compare_attrs = base.BaseScheduler.compare_attrs + ('reason',)
 
     def __init__(self, name, builderNames, reason=None, **kwargs):
-        base.BaseScheduler.__init__(self, name, builderNames, **kwargs)
+        super().__init__(name, builderNames, **kwargs)
         self._waiters = {}
         self._buildset_complete_consumer = None
         self.reason = reason
@@ -76,7 +76,7 @@ class Triggerable(base.BaseScheduler):
 
     @defer.inlineCallbacks
     def startService(self):
-        yield base.BaseScheduler.startService(self)
+        yield super().startService()
         self._updateWaiters.start()
 
     @defer.inlineCallbacks
@@ -96,7 +96,7 @@ class Triggerable(base.BaseScheduler):
                 d.errback(failure.Failure(RuntimeError(msg)))
             self._waiters = {}
 
-        yield base.BaseScheduler.stopService(self)
+        yield super().stopService()
 
     @debounce.method(wait=0)
     @defer.inlineCallbacks

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -64,6 +64,7 @@ class JobdirService(MaildirService):
     # NOTE: tightly coupled with Try_Jobdir, below. We used to track it as a "parent"
     # via the MultiService API, but now we just track it as the member
     # "self.scheduler"
+    name = 'JobdirService'
 
     def __init__(self, scheduler, basedir=None):
         self.scheduler = scheduler

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -67,7 +67,7 @@ class JobdirService(MaildirService):
 
     def __init__(self, scheduler, basedir=None):
         self.scheduler = scheduler
-        MaildirService.__init__(self, basedir)
+        super().__init__(basedir)
 
     def messageReceived(self, filename):
         with self.moveToCurDir(filename) as f:
@@ -80,7 +80,7 @@ class Try_Jobdir(TryBase):
     compare_attrs = ('jobdir',)
 
     def __init__(self, name, builderNames, jobdir, **kwargs):
-        TryBase.__init__(self, name, builderNames, **kwargs)
+        super().__init__(name, builderNames, **kwargs)
         self.jobdir = jobdir
         self.watcher = JobdirService(scheduler=self)
 
@@ -98,7 +98,7 @@ class Try_Jobdir(TryBase):
 
     @defer.inlineCallbacks
     def activate(self):
-        yield TryBase.activate(self)
+        yield super().activate()
 
         if not self.enabled:
             return
@@ -116,7 +116,7 @@ class Try_Jobdir(TryBase):
 
     @defer.inlineCallbacks
     def deactivate(self):
-        yield TryBase.deactivate(self)
+        yield super().deactivate()
 
         if not self.enabled:
             return
@@ -430,14 +430,14 @@ class Try_Userpass(TryBase):
     compare_attrs = ('name', 'builderNames', 'port', 'userpass', 'properties')
 
     def __init__(self, name, builderNames, port, userpass, **kwargs):
-        TryBase.__init__(self, name, builderNames, **kwargs)
+        super().__init__(name, builderNames, **kwargs)
         self.port = port
         self.userpass = userpass
         self.registrations = []
 
     @defer.inlineCallbacks
     def activate(self):
-        yield TryBase.activate(self)
+        yield super().activate()
 
         if not self.enabled:
             return
@@ -452,7 +452,7 @@ class Try_Userpass(TryBase):
 
     @defer.inlineCallbacks
     def deactivate(self):
-        yield TryBase.deactivate(self)
+        yield super().deactivate()
 
         if not self.enabled:
             return

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -198,7 +198,7 @@ class SubcommandOptions(usage.Options):
                                 optfile_name in optfile):
                             op[i] = list(op[i])
                             op[i][2] = optfile[optfile_name]
-        usage.Options.__init__(self, *args)
+        super().__init__(*args)
         if hasattr(cls, 'optParameters'):
             cls.optParameters = old_optParameters
 

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -146,7 +146,7 @@ class CreateMasterOptions(base.BasedirMixin, base.SubcommandOptions):
     """)
 
     def postOptions(self):
-        base.BasedirMixin.postOptions(self)
+        super().postOptions()
 
         # validate 'log-count' parameter
         if self['log-count'] == 'None':
@@ -226,7 +226,7 @@ class SendChangeOptions(base.SubcommandOptions):
     subcommandFunction = "buildbot.scripts.sendchange.sendchange"
 
     def __init__(self):
-        base.SubcommandOptions.__init__(self)
+        super().__init__()
         self['properties'] = {}
 
     optParameters = [
@@ -277,7 +277,7 @@ class SendChangeOptions(base.SubcommandOptions):
         self['properties'][name] = value
 
     def postOptions(self):
-        base.SubcommandOptions.postOptions(self)
+        super().postOptions()
 
         if self.get("revision_file"):
             with open(self["revision_file"], "r") as f:
@@ -423,7 +423,7 @@ class TryOptions(base.SubcommandOptions):
     ]
 
     def __init__(self):
-        base.SubcommandOptions.__init__(self)
+        super().__init__()
         self['builders'] = []
         self['properties'] = {}
 
@@ -449,7 +449,7 @@ class TryOptions(base.SubcommandOptions):
         return "Usage:    buildbot try [options]"
 
     def postOptions(self):
-        base.SubcommandOptions.postOptions(self)
+        super().postOptions()
         opts = self.optionsFile
         if not self['builders']:
             self['builders'] = opts.get('try_builders', [])
@@ -545,7 +545,7 @@ class UserOptions(base.SubcommandOptions):
     """)
 
     def __init__(self):
-        base.SubcommandOptions.__init__(self)
+        super().__init__()
         self['ids'] = []
         self['info'] = []
 
@@ -589,7 +589,7 @@ class UserOptions(base.SubcommandOptions):
                         % ', '.join(valid))
 
     def postOptions(self):
-        base.SubcommandOptions.postOptions(self)
+        super().postOptions()
 
         validateMasterOption(self.get('master'))
 
@@ -737,7 +737,7 @@ class Options(usage.Options):
 
     def opt_version(self):
         print("Buildbot version: %s" % buildbot.version)
-        usage.Options.opt_version(self)
+        super().opt_version()
 
     def opt_verbose(self):
         from twisted.python import log

--- a/master/buildbot/scripts/windows_service.py
+++ b/master/buildbot/scripts/windows_service.py
@@ -109,7 +109,7 @@ class BBService(win32serviceutil.ServiceFramework):
                         'see http://buildbot.net'
 
     def __init__(self, args):
-        win32serviceutil.ServiceFramework.__init__(self, args)
+        super().__init__(args)
 
         # Create an event which we will use to wait on. The "service stop"
         # request will set this event.

--- a/master/buildbot/statistics/capture.py
+++ b/master/buildbot/statistics/capture.py
@@ -74,7 +74,7 @@ class CapturePropertyBase(Capture):
         if not callback:
             callback = default_callback
 
-        Capture.__init__(self, routingKey, callback)
+        super().__init__(routingKey, callback)
 
     @defer.inlineCallbacks
     def consume(self, routingKey, msg):
@@ -127,7 +127,7 @@ class CaptureProperty(CapturePropertyBase):
     def __init__(self, builder_name, property_name, callback=None, regex=False):
         self._builder_name = builder_name
 
-        CapturePropertyBase.__init__(self, property_name, callback, regex)
+        super().__init__(property_name, callback, regex)
 
     def _builder_name_matches(self, builder_info):
         return self._builder_name == builder_info['name']
@@ -154,7 +154,7 @@ class CaptureBuildTimes(Capture):
         self._builder_name = builder_name
         routingKey = ("builders", None, "builds", None, "finished")
         self._time_type = time_type
-        Capture.__init__(self, routingKey, callback)
+        super().__init__(routingKey, callback)
 
     @defer.inlineCallbacks
     def consume(self, routingKey, msg):
@@ -207,7 +207,7 @@ class CaptureBuildStartTime(CaptureBuildTimes):
             return start_time.isoformat()
         if not callback:
             callback = default_callback
-        CaptureBuildTimes.__init__(self, builder_name, callback, "start-time")
+        super().__init__(builder_name, callback, "start-time")
 
     def _retValParams(self, msg):
         return [msg['started_at']]
@@ -223,7 +223,7 @@ class CaptureBuildStartTimeAllBuilders(CaptureBuildStartTime):
     """
 
     def __init__(self, callback=None):
-        CaptureBuildStartTime.__init__(self, None, callback)
+        super().__init__(None, callback)
 
     def _builder_name_matches(self, builder_info):
         # Match all builders so simply return True
@@ -241,7 +241,7 @@ class CaptureBuildEndTime(CaptureBuildTimes):
             return end_time.isoformat()
         if not callback:
             callback = default_callback
-        CaptureBuildTimes.__init__(self, builder_name, callback, "end-time")
+        super().__init__(builder_name, callback, "end-time")
 
     def _retValParams(self, msg):
         return [msg['complete_at']]
@@ -257,7 +257,7 @@ class CaptureBuildEndTimeAllBuilders(CaptureBuildEndTime):
     """
 
     def __init__(self, callback=None):
-        CaptureBuildEndTime.__init__(self, None, callback)
+        super().__init__(None, callback)
 
     def _builder_name_matches(self, builder_info):
         # Match all builders so simply return True
@@ -291,7 +291,7 @@ class CaptureBuildDuration(CaptureBuildTimes):
 
         if not callback:
             callback = default_callback
-        CaptureBuildTimes.__init__(self, builder_name, callback, "duration")
+        super().__init__(builder_name, callback, "duration")
 
     def _retValParams(self, msg):
         return [msg['started_at'], msg['complete_at']]
@@ -307,7 +307,7 @@ class CaptureBuildDurationAllBuilders(CaptureBuildDuration):
     """
 
     def __init__(self, report_in='seconds', callback=None):
-        CaptureBuildDuration.__init__(self, None, report_in, callback)
+        super().__init__(None, report_in, callback)
 
     def _builder_name_matches(self, builder_info):
         # Match all builders so simply return True
@@ -333,7 +333,7 @@ class CaptureDataBase(Capture):
         # this following key created in StatsService.yieldMetricsValue and used
         # here
         routingKey = ("stats-yieldMetricsValue", "stats-yield-data")
-        Capture.__init__(self, routingKey, callback)
+        super().__init__(routingKey, callback)
 
     @defer.inlineCallbacks
     def consume(self, routingKey, msg):
@@ -371,7 +371,7 @@ class CaptureData(CaptureDataBase):
     def __init__(self, data_name, builder_name, callback=None):
         self._builder_name = builder_name
 
-        CaptureDataBase.__init__(self, data_name, callback)
+        super().__init__(data_name, callback)
 
     def _builder_name_matches(self, builder_info):
         return self._builder_name == builder_info['name']

--- a/master/buildbot/statistics/stats_service.py
+++ b/master/buildbot/statistics/stats_service.py
@@ -60,7 +60,7 @@ class StatsService(service.BuildbotService):
 
     @defer.inlineCallbacks
     def stopService(self):
-        yield service.BuildbotService.stopService(self)
+        yield super().stopService()
         self.removeConsumers()
 
     @defer.inlineCallbacks

--- a/master/buildbot/status/base.py
+++ b/master/buildbot/status/base.py
@@ -94,9 +94,7 @@ class StatusReceiverBase:
 
 class StatusReceiverMultiService(StatusReceiverBase, service.AsyncMultiService,
                                  util.ComparableMixin):
-
-    def __init__(self):
-        service.AsyncMultiService.__init__(self)
+    pass
 
 
 class StatusReceiverService(StatusReceiverBase, service.AsyncService,

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -36,7 +36,7 @@ from buildbot.util.eventual import eventually
 class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
     def __init__(self):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.watchers = []
         # No default limit to the log size
         self.logMaxSize = None
@@ -75,7 +75,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         self._change_consumer = yield self.master.mq.startConsuming(
             self.change_consumer_cb, ('changes', None, 'new'))
 
-        yield service.AsyncMultiService.startService(self)
+        yield super().startService()
 
     @defer.inlineCallbacks
     def reconfigServiceWithBuildbotConfig(self, new_config):
@@ -87,8 +87,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             yield sr.setServiceParent(self)
 
         # reconfig any newly-added change sources, as well as existing
-        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                   new_config)
+        yield super().reconfigServiceWithBuildbotConfig(new_config)
 
     def stopService(self):
         if self._buildset_complete_consumer:
@@ -103,7 +102,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             self._change_consumer.stopConsuming()
             self._change_consumer = None
 
-        return service.AsyncMultiService.stopService(self)
+        return super().stopService()
 
     # clean shutdown
 

--- a/master/buildbot/steps/cppcheck.py
+++ b/master/buildbot/steps/cppcheck.py
@@ -44,7 +44,7 @@ class Cppcheck(ShellCommand):
                               ('extra_args', [])]:
             setattr(self, name, kwargs.pop(name, default))
 
-        ShellCommand.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.addLogObserver(
             'stdio', logobserver.LineConsumerLogObserver(self.logConsumer))
 

--- a/master/buildbot/steps/http.py
+++ b/master/buildbot/steps/http.py
@@ -83,7 +83,7 @@ class HTTPStep(BuildStep):
         for param in HTTPStep.requestsParams:
             setattr(self, param, kwargs.pop(param, None))
 
-        BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     def start(self):
         d = self.doRequest()
@@ -176,34 +176,34 @@ class HTTPStep(BuildStep):
 class POST(HTTPStep):
 
     def __init__(self, url, **kwargs):
-        HTTPStep.__init__(self, url, method='POST', **kwargs)
+        super().__init__(url, method='POST', **kwargs)
 
 
 class GET(HTTPStep):
 
     def __init__(self, url, **kwargs):
-        HTTPStep.__init__(self, url, method='GET', **kwargs)
+        super().__init__(url, method='GET', **kwargs)
 
 
 class PUT(HTTPStep):
 
     def __init__(self, url, **kwargs):
-        HTTPStep.__init__(self, url, method='PUT', **kwargs)
+        super().__init__(url, method='PUT', **kwargs)
 
 
 class DELETE(HTTPStep):
 
     def __init__(self, url, **kwargs):
-        HTTPStep.__init__(self, url, method='DELETE', **kwargs)
+        super().__init__(url, method='DELETE', **kwargs)
 
 
 class HEAD(HTTPStep):
 
     def __init__(self, url, **kwargs):
-        HTTPStep.__init__(self, url, method='HEAD', **kwargs)
+        super().__init__(url, method='HEAD', **kwargs)
 
 
 class OPTIONS(HTTPStep):
 
     def __init__(self, url, **kwargs):
-        HTTPStep.__init__(self, url, method='OPTIONS', **kwargs)
+        super().__init__(url, method='OPTIONS', **kwargs)

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -51,7 +51,7 @@ class MasterShellCommand(BuildStep):
         self.interruptSignal = kwargs.pop('interruptSignal', 'KILL')
         self.logEnviron = kwargs.pop('logEnviron', True)
 
-        BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         self.command = command
         self.masterWorkdir = self.workdir
@@ -169,7 +169,7 @@ class MasterShellCommand(BuildStep):
             pass
         except error.ProcessExitedAlready:
             pass
-        BuildStep.interrupt(self, reason)
+        super().interrupt(reason)
 
 
 class SetProperty(BuildStep):
@@ -179,7 +179,7 @@ class SetProperty(BuildStep):
     renderables = ['property', 'value']
 
     def __init__(self, property, value, **kwargs):
-        BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.property = property
         self.value = value
 
@@ -197,7 +197,7 @@ class SetProperties(BuildStep):
     renderables = ['properties']
 
     def __init__(self, properties=None, **kwargs):
-        BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.properties = properties
 
     def run(self):
@@ -215,7 +215,7 @@ class Assert(BuildStep):
     renderables = ['check']
 
     def __init__(self, check, **kwargs):
-        BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.check = check
         self.descriptionDone = ["checked {}".format(repr(self.check))]
 
@@ -232,7 +232,7 @@ class LogRenderable(BuildStep):
     renderables = ['content']
 
     def __init__(self, content, **kwargs):
-        BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.content = content
 
     def start(self):

--- a/master/buildbot/steps/maxq.py
+++ b/master/buildbot/steps/maxq.py
@@ -24,7 +24,7 @@ from buildbot.steps.shell import ShellCommand
 class MaxQObserver(buildstep.LogLineObserver):
 
     def __init__(self):
-        buildstep.LogLineObserver.__init__(self)
+        super().__init__()
         self.failures = 0
 
     def outLineReceived(self, line):
@@ -40,7 +40,7 @@ class MaxQ(ShellCommand):
         if not testdir:
             config.error("please pass testdir")
         kwargs['command'] = 'run_maxq.py %s' % (testdir,)
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.observer = MaxQObserver()
         self.addLogObserver('stdio', self.observer)
 

--- a/master/buildbot/steps/mswin.py
+++ b/master/buildbot/steps/mswin.py
@@ -67,7 +67,7 @@ class Robocopy(ShellCommand):
         self.custom_opts = kwargs.pop('custom_opts', None)
         self.verbose = kwargs.pop('verbose', False)
 
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     def start(self):
         command = ['robocopy', self.source, self.destination]
@@ -91,7 +91,7 @@ class Robocopy(ShellCommand):
             command += self.custom_opts
         command += ['/TEE', '/NP']
         self.setCommand(command)
-        ShellCommand.start(self)
+        super().start()
 
     def evaluateCommand(self, cmd):
         # If we have a "clean" return code, it's good.

--- a/master/buildbot/steps/mtrlogobserver.py
+++ b/master/buildbot/steps/mtrlogobserver.py
@@ -43,9 +43,7 @@ are more suitable for use in MTR.
 
     def __init__(self, *args, **kwargs):
         self._eqKey = (args, kwargs)
-        adbapi.ConnectionPool.__init__(self,
-                                       cp_reconnect=True, cp_min=1, cp_max=3,
-                                       *args, **kwargs)
+        super().__init__(cp_reconnect=True, cp_min=1, cp_max=3, *args, **kwargs)
 
     def __eq__(self, other):
         if isinstance(other, EqConnectionPool):
@@ -106,10 +104,10 @@ class MtrLogObserver(LogLineObserver):
         self.testFail = None
         self.failList = []
         self.warnList = []
-        LogLineObserver.__init__(self)
+        super().__init__()
 
     def setLog(self, loog):
-        LogLineObserver.setLog(self, loog)
+        super().setLog(loog)
         d = loog.waitUntilFinished()
         d.addCallback(lambda l: self.closeTestFail())
 
@@ -300,7 +298,7 @@ class MTR(Test):
             descriptionDone = ["test"]
             if test_type:
                 descriptionDone.append(test_type)
-        Test.__init__(self, logfiles=logfiles, lazylogfiles=lazylogfiles,
+        super().__init__(logfiles=logfiles, lazylogfiles=lazylogfiles,
                       description=description, descriptionDone=descriptionDone,
                       warningPattern=warningPattern, **kwargs)
         self.dbpool = dbpool
@@ -449,7 +447,7 @@ VALUES (%s, %s, %s, CURRENT_TIMESTAMP(), %s, %s, %s)
         self.setProperty("mtr_id", insert_id)
         self.setProperty("mtr_warn_id", 0)
 
-        Test.start(self)
+        super().start()
 
     def reportError(self, err):
         log.msg("Error in async insert into database: %s" % err)

--- a/master/buildbot/steps/package/deb/lintian.py
+++ b/master/buildbot/steps/package/deb/lintian.py
@@ -30,7 +30,7 @@ from buildbot.steps.shell import ShellCommand
 class MaxQObserver(buildstep.LogLineObserver):
 
     def __init__(self):
-        buildstep.LogLineObserver.__init__(self)
+        super().__init__()
         self.failures = 0
 
     def outLineReceived(self, line):
@@ -63,7 +63,7 @@ class DebLintian(ShellCommand):
         @type kwargs: dict
         @param kwargs: all other keyword arguments.
         """
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         if fileloc:
             self.fileloc = fileloc
         if suppressTags:

--- a/master/buildbot/steps/package/deb/pbuilder.py
+++ b/master/buildbot/steps/package/deb/pbuilder.py
@@ -84,7 +84,7 @@ class DebPbuilder(WarningCountingShellCommand):
         @type kwargs: dict
         @param kwargs: All further keyword arguments.
         """
-        WarningCountingShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         if architecture:
             self.architecture = architecture
@@ -187,7 +187,7 @@ class DebPbuilder(WarningCountingShellCommand):
             log.msg("Failure when running %s." % cmd)
             self.finished(FAILURE)
         else:
-            return WarningCountingShellCommand.start(self)
+            return super().start()
 
     def logConsumer(self):
         r = re.compile(r"dpkg-genchanges  >\.\./(.+\.changes)")

--- a/master/buildbot/steps/package/rpm/mock.py
+++ b/master/buildbot/steps/package/rpm/mock.py
@@ -101,10 +101,12 @@ class Mock(ShellCommand):
                                                     [self.build.path_module.join('build', self.logfiles[l])
                                                      for l in self.mock_logfiles]})
         d = self.runCommand(cmd)
+        # must resolve super() outside of the callback context.
+        super_ = super()
 
         @d.addCallback
         def removeDone(cmd):
-            ShellCommand.start(self)
+            super_.start()
         d.addErrback(self.failed)
 
 

--- a/master/buildbot/steps/package/rpm/mock.py
+++ b/master/buildbot/steps/package/rpm/mock.py
@@ -71,7 +71,7 @@ class Mock(ShellCommand):
         @type kwargs: dict
         @param kwargs: All further keyword arguments.
         """
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         if root:
             self.root = root
         if resultdir:
@@ -134,7 +134,7 @@ class MockBuildSRPM(Mock):
         @type kwargs: dict
         @param kwargs: All further keyword arguments.
         """
-        Mock.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         if spec:
             self.spec = spec
         if sources:
@@ -179,7 +179,7 @@ class MockRebuild(Mock):
         @type kwargs: dict
         @param kwargs: All further keyword arguments.
         """
-        Mock.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         if srpm:
             self.srpm = srpm
 

--- a/master/buildbot/steps/package/rpm/rpmbuild.py
+++ b/master/buildbot/steps/package/rpm/rpmbuild.py
@@ -75,7 +75,7 @@ class RpmBuild(ShellCommand):
         @type vcsRevision: boolean
         @param vcsRevision: Use vcs version number as revision number.
         """
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         self.dist = dist
 

--- a/master/buildbot/steps/package/rpm/rpmlint.py
+++ b/master/buildbot/steps/package/rpm/rpmlint.py
@@ -50,7 +50,7 @@ class RpmLint(Test):
         @type kwargs: dict
         @param fileloc: all other keyword arguments.
         """
-        Test.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         if fileloc:
             self.fileloc = fileloc
         if config:

--- a/master/buildbot/steps/package/rpm/rpmspec.py
+++ b/master/buildbot/steps/package/rpm/rpmspec.py
@@ -44,7 +44,7 @@ class RpmSpec(ShellCommand):
         @type kwargs: dict
         @param kwargs: All further keyword arguments.
         """
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         self.specfile = specfile
         self._pkg_name = None

--- a/master/buildbot/steps/package/util.py
+++ b/master/buildbot/steps/package/util.py
@@ -21,7 +21,7 @@ from buildbot.process import logobserver
 class WEObserver(logobserver.LogLineObserver):
 
     def __init__(self):
-        logobserver.LogLineObserver.__init__(self)
+        super().__init__()
         self.warnings = []
         self.errors = []
 

--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -30,7 +30,7 @@ class BuildEPYDoc(ShellCommand):
     descriptionDone = ["epydoc"]
 
     def __init__(self, **kwargs):
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.addLogObserver(
             'stdio', logobserver.LineConsumerLogObserver(self.logConsumer))
 
@@ -82,7 +82,7 @@ class PyFlakes(ShellCommand):
         # categorize this initially as WARNINGS so that
         # evaluateCommand below can inspect the results more closely.
         kwargs['decodeRC'] = {0: SUCCESS, 1: WARNINGS}
-        ShellCommand.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.addLogObserver(
             'stdio', logobserver.LineConsumerLogObserver(self.logConsumer))
 
@@ -209,7 +209,7 @@ class PyLint(ShellCommand):
         r'[^:]+:\d+: \[%s(\d{4})?(\([a-z-]+\))?[,\]] .+' % _msgtypes_re_str)
 
     def __init__(self, **kwargs):
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.counts = {}
         self.summaries = {}
         self.addLogObserver(
@@ -290,7 +290,7 @@ class Sphinx(ShellCommand):
                          "'full' is required")
 
         self.success = False
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         # build the command
         command = [sphinx]

--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -46,7 +46,7 @@ class HLint(ShellCommand):
     warnings = 0
 
     def __init__(self, python=None, **kwargs):
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.python = python
         self.warningLines = []
         self.addLogObserver(
@@ -72,7 +72,7 @@ class HLint(ShellCommand):
         # add an extra log file to show the .html files we're checking
         self.addCompleteLog("files", "\n".join(self.hlintFiles) + "\n")
 
-        ShellCommand.start(self)
+        super().start()
 
     def logConsumer(self):
         while True:
@@ -103,7 +103,7 @@ class TrialTestCaseCounter(logobserver.LogLineObserver):
     _line_re = re.compile(r'^(?:Doctest: )?([\w\.]+) \.\.\. \[([^\]]+)\]$')
 
     def __init__(self):
-        logobserver.LogLineObserver.__init__(self)
+        super().__init__()
         self.numTests = 0
         self.finished = False
         self.counts = {'total': None,
@@ -283,7 +283,7 @@ class Trial(ShellCommand):
                        warnOnWarnings, warnOnFailure, want_stdout, want_stderr,
                        timeout.
         """
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         if python:
             self.python = python
@@ -374,7 +374,7 @@ class Trial(ShellCommand):
         self.text = 'running'
 
     def setupEnvironment(self, cmd):
-        ShellCommand.setupEnvironment(self, cmd)
+        super().setupEnvironment(cmd)
         if self.testpath is not None:
             e = cmd.args['env']
             if e is None:
@@ -420,7 +420,7 @@ class Trial(ShellCommand):
             self.command.extend(self.tests)
         log.msg("Trial.start: command is", self.command)
 
-        ShellCommand.start(self)
+        super().start()
 
     def commandComplete(self, cmd):
         # figure out all status, then let the various hook functions return

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -126,7 +126,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
             if k in self.__class__.parms:
                 buildstep_kwargs[k] = kwargs[k]
                 del kwargs[k]
-        buildstep.LoggingBuildStep.__init__(self, **buildstep_kwargs)
+        super().__init__(**buildstep_kwargs)
 
         # check validity of arguments being passed to RemoteShellCommand
         invalid_args = []
@@ -147,7 +147,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
         self.remote_kwargs['workdir'] = workdir
 
     def setBuild(self, build):
-        buildstep.LoggingBuildStep.setBuild(self, build)
+        super().setBuild(build)
         # Set this here, so it gets rendered when we start the step
         self.workerEnvironment = self.build.workerEnvironment
 
@@ -233,7 +233,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
             # dictionary, so we shouldn't be affecting anyone but ourselves.
 
     def buildCommandKwargs(self, warnings):
-        kwargs = buildstep.LoggingBuildStep.buildCommandKwargs(self)
+        kwargs = super().buildCommandKwargs()
         kwargs.update(self.remote_kwargs)
         kwargs['workdir'] = self.workdir
 
@@ -276,7 +276,7 @@ class TreeSize(ShellCommand):
     kib = None
 
     def __init__(self, **kwargs):
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.observer = logobserver.BufferLogObserver(wantStdout=True,
                                                       wantStderr=True)
         self.addLogObserver('stdio', self.observer)
@@ -317,7 +317,7 @@ class SetPropertyFromCommand(ShellCommand):
             config.error(
                 "Exactly one of property and extract_fn must be set")
 
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         if self.extract_fn:
             self.includeStderr = True
@@ -360,7 +360,7 @@ class SetPropertyFromCommand(ShellCommand):
             return ["property '%s' set" % list(self.property_changes)[0]]
         # else:
         # let ShellCommand describe
-        return ShellCommand.describe(self, done)
+        return super().describe(done)
 
 
 SetProperty = SetPropertyFromCommand
@@ -425,7 +425,7 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
         self.maxWarnCount = maxWarnCount
 
         # And upcall to let the base class do its work
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         if self.__class__ is WarningCountingShellCommand and \
                 not kwargs.get('command'):
@@ -556,7 +556,7 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
         if self.suppressionList is not None:
             self.addSuppression(self.suppressionList)
         if self.suppressionFile is None:
-            return ShellCommand.start(self)
+            return super().start()
         d = self.getFileContentFromWorker(
             self.suppressionFile, abandonOnFailure=True)
         d.addCallback(self.uploadDone)
@@ -581,7 +581,7 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
                 list.append((file, test, start, end))
 
         self.addSuppression(list)
-        return ShellCommand.start(self)
+        return super().start()
 
     def createSummary(self, log):
         """
@@ -645,7 +645,7 @@ class Test(WarningCountingShellCommand):
         self.setStatistic('tests-passed', passed)
 
     def describe(self, done=False):
-        description = WarningCountingShellCommand.describe(self, done)
+        description = super().describe(done)
         if done:
             if not description:
                 description = []
@@ -672,7 +672,7 @@ class Test(WarningCountingShellCommand):
 class PerlModuleTestObserver(logobserver.LogLineObserver):
 
     def __init__(self, warningPattern):
-        logobserver.LogLineObserver.__init__(self)
+        super().__init__()
         if warningPattern:
             self.warningPattern = re.compile(warningPattern)
         else:
@@ -721,7 +721,7 @@ class PerlModuleTest(Test):
     total = 0
 
     def __init__(self, *args, **kwargs):
-        Test.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.observer = PerlModuleTestObserver(
             warningPattern=self.warningPattern)
         self.addLogObserver('stdio', self.observer)

--- a/master/buildbot/steps/shellsequence.py
+++ b/master/buildbot/steps/shellsequence.py
@@ -76,7 +76,7 @@ class ShellSequence(buildstep.ShellMixin, buildstep.BuildStep):
     def __init__(self, commands=None, **kwargs):
         self.commands = commands
         kwargs = self.setupShellMixin(kwargs, prohibitArgs=['command'])
-        buildstep.BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     def shouldRunTheCommand(self, cmd):
         return bool(cmd)

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -109,9 +109,10 @@ class Source(LoggingBuildStep, CompositeStepMixin):
         if not descriptionSuffix and codebase:
             descriptionSuffix = [codebase]
 
-        LoggingBuildStep.__init__(self, description=description,
-                                  descriptionDone=descriptionDone, descriptionSuffix=descriptionSuffix,
-                                  **kwargs)
+        super().__init__(description=description,
+                         descriptionDone=descriptionDone,
+                         descriptionSuffix=descriptionSuffix,
+                         **kwargs)
 
         # This will get added to args later, after properties are rendered
         self.workdir = workdir
@@ -175,12 +176,12 @@ class Source(LoggingBuildStep, CompositeStepMixin):
                 % self.name
             property_dict = self.getProperty(name, {})
             property_dict[self.codebase] = value
-            LoggingBuildStep.setProperty(self, name, property_dict, source)
+            super().setProperty(name, property_dict, source)
         else:
             assert not isinstance(self.getProperty(name, None), dict), \
                 "Sourcestep %s does not have a codebase, other sourcesteps do" \
                 % self.name
-            LoggingBuildStep.setProperty(self, name, value, source)
+            super().setProperty(name, value, source)
 
     def describe(self, done=False):
         desc = self.descriptionDone if done else self.description

--- a/master/buildbot/steps/source/bzr.py
+++ b/master/buildbot/steps/source/bzr.py
@@ -39,7 +39,7 @@ class Bzr(Source):
         self.branch = defaultBranch
         self.mode = mode
         self.method = method
-        Source.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         if repourl and baseURL:
             raise ValueError("you must provide exactly one of repourl and"
                              " baseURL")

--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -56,7 +56,7 @@ class CVS(Source):
         if not self._hasAttrGroupMember('mode', self.mode):
             raise ValueError("mode %s is not one of %s" %
                              (self.mode, self._listAttrGroupMembers('mode')))
-        Source.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     def startVC(self, branch, revision, patch):
         self.branch = branch

--- a/master/buildbot/steps/source/darcs.py
+++ b/master/buildbot/steps/source/darcs.py
@@ -44,7 +44,7 @@ class Darcs(Source):
         self.repourl = repourl
         self.method = method
         self.mode = mode
-        Source.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         errors = []
 
         if not self._hasAttrGroupMember('mode', self.mode):

--- a/master/buildbot/steps/source/gerrit.py
+++ b/master/buildbot/steps/source/gerrit.py
@@ -19,9 +19,6 @@ from buildbot.steps.source.git import Git
 
 class Gerrit(Git):
 
-    def __init__(self, **kwargs):
-        Git.__init__(self, **kwargs)
-
     def startVC(self, branch, revision, patch):
         gerrit_branch = None
 

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -157,7 +157,7 @@ class Git(Source, GitStepMixin):
         self.srcdir = 'source'
         self.origin = origin
 
-        Source.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         self.setupGitStep()
 
@@ -661,7 +661,7 @@ class GitPush(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
         self.sshHostKey = sshHostKey
         self.config = config
 
-        buildstep.BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         self.setupGitStep()
 

--- a/master/buildbot/steps/source/mercurial.py
+++ b/master/buildbot/steps/source/mercurial.py
@@ -75,7 +75,7 @@ class Mercurial(Source):
         self.method = method
         self.clobberOnBranchChange = clobberOnBranchChange
         self.mode = mode
-        Source.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         errors = []
         if not self._hasAttrGroupMember('mode', self.mode):

--- a/master/buildbot/steps/source/mtn.py
+++ b/master/buildbot/steps/source/mtn.py
@@ -48,7 +48,7 @@ class Monotone(Source):
         self.sourcedata = "%s?%s" % (self.repourl, self.branch)
         self.database = 'db.mtn'
         self.progress = progress
-        Source.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         errors = []
 
         if not self._hasAttrGroupMember('mode', self.mode):

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -79,7 +79,7 @@ class P4(Source):
         self.p4extra_args = p4extra_args
         self.use_tickets = use_tickets
 
-        Source.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         if self.mode not in self.possible_modes and not interfaces.IRenderable.providedBy(self.mode):
             config.error("mode %s is not an IRenderable, or one of %s" % (

--- a/master/buildbot/steps/source/repo.py
+++ b/master/buildbot/steps/source/repo.py
@@ -169,7 +169,7 @@ class Repo(Source):
         self.repoDownloads = repoDownloads
         self.depth = depth
         self.syncQuietly = syncQuietly
-        Source.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         assert self.manifestURL is not None
 

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -54,7 +54,7 @@ class SVN(Source):
         self.method = method
         self.mode = mode
         self.preferLastChangedRev = preferLastChangedRev
-        Source.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         errors = []
         if not self._hasAttrGroupMember('mode', self.mode):
             errors.append("mode %s is not one of %s" %

--- a/master/buildbot/steps/subunit.py
+++ b/master/buildbot/steps/subunit.py
@@ -33,8 +33,7 @@ class SubunitLogObserver(logobserver.LogLineObserver, TestResult):
     """
 
     def __init__(self):
-        logobserver.LogLineObserver.__init__(self)
-        TestResult.__init__(self)
+        super().__init__()
         try:
             from subunit import TestProtocolServer, PROGRESS_CUR, PROGRESS_SET
             from subunit import PROGRESS_PUSH, PROGRESS_POP

--- a/master/buildbot/steps/subunit.py
+++ b/master/buildbot/steps/subunit.py
@@ -60,7 +60,7 @@ class SubunitLogObserver(logobserver.LogLineObserver, TestResult):
         self.protocol.lineReceived(line + '\n')
 
     def stopTest(self, test):
-        TestResult.stopTest(self, test)
+        super().stopTest(test)
         self.step.setProgress('tests', self.testsRun)
 
     def addSuccess(self, test):
@@ -68,16 +68,16 @@ class SubunitLogObserver(logobserver.LogLineObserver, TestResult):
 
     def addSkip(self, test, detail):
         if hasattr(TestResult, 'addSkip'):
-            TestResult.addSkip(self, test, detail)
+            super().addSkip(test, detail)
         else:
             self.skips.append((test, detail))
 
     def addError(self, test, err):
-        TestResult.addError(self, test, err)
+        super().addError(test, err)
         self.issue(test, err)
 
     def addFailure(self, test, err):
-        TestResult.addFailure(self, test, err)
+        super().addFailure(test, err)
         self.issue(test, err)
 
     def issue(self, test, err):
@@ -96,7 +96,7 @@ class SubunitShellCommand(ShellCommand):
     """
 
     def __init__(self, failureOnNoTests=False, *args, **kwargs):
-        ShellCommand.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.failureOnNoTests = failureOnNoTests
 
         self.ioObserver = SubunitLogObserver()

--- a/master/buildbot/steps/subunit.py
+++ b/master/buildbot/steps/subunit.py
@@ -63,9 +63,6 @@ class SubunitLogObserver(logobserver.LogLineObserver, TestResult):
         super().stopTest(test)
         self.step.setProgress('tests', self.testsRun)
 
-    def addSuccess(self, test):
-        TestResult.addSuccess(self, test)
-
     def addSkip(self, test, detail):
         if hasattr(TestResult, 'addSkip'):
             super().addSkip(test, detail)

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -425,9 +425,6 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
 
         d.addCallback(self.finished).addErrback(self.failed)
 
-    def finished(self, result):
-        return super().finished(result)
-
 
 class FileDownload(_TransferBuildStep):
 

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -54,7 +54,7 @@ class _TransferBuildStep(BuildStep):
     flunkOnFailure = True
 
     def __init__(self, workdir=None, **buildstep_kwargs):
-        BuildStep.__init__(self, **buildstep_kwargs)
+        super().__init__(**buildstep_kwargs)
         self.workdir = workdir
 
     def runTransferCommand(self, cmd, writer=None):
@@ -103,7 +103,7 @@ class FileUpload(_TransferBuildStep):
         if workersrc is None or masterdest is None:
             raise TypeError("__init__() takes at least 3 arguments")
 
-        _TransferBuildStep.__init__(self, workdir=workdir, **buildstep_kwargs)
+        super().__init__(workdir=workdir, **buildstep_kwargs)
 
         self.workersrc = workersrc
         self.masterdest = masterdest
@@ -121,7 +121,7 @@ class FileUpload(_TransferBuildStep):
         log.msg("File '{}' upload finished with results {}".format(
             os.path.basename(self.workersrc), str(results)))
         self.step_status.setText(self.descriptionDone)
-        _TransferBuildStep.finished(self, results)
+        super().finished(results)
 
     def start(self):
         self.checkWorkerHasCommand("uploadFile")
@@ -195,7 +195,7 @@ class DirectoryUpload(_TransferBuildStep):
         if workersrc is None or masterdest is None:
             raise TypeError("__init__() takes at least 3 arguments")
 
-        _TransferBuildStep.__init__(self, workdir=workdir, **buildstep_kwargs)
+        super().__init__(workdir=workdir, **buildstep_kwargs)
 
         self.workersrc = workersrc
         self.masterdest = masterdest
@@ -269,7 +269,7 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
         if workersrcs is None or masterdest is None:
             raise TypeError("__init__() takes at least 3 arguments")
 
-        _TransferBuildStep.__init__(self, workdir=workdir, **buildstep_kwargs)
+        super().__init__(workdir=workdir, **buildstep_kwargs)
 
         self.workersrcs = workersrcs
         self.masterdest = masterdest
@@ -426,7 +426,7 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
         d.addCallback(self.finished).addErrback(self.failed)
 
     def finished(self, result):
-        return BuildStep.finished(self, result)
+        return super().finished(result)
 
 
 class FileDownload(_TransferBuildStep):
@@ -442,7 +442,7 @@ class FileDownload(_TransferBuildStep):
         if workerdest is None:
             raise TypeError("__init__() takes at least 3 arguments")
 
-        _TransferBuildStep.__init__(self, workdir=workdir, **buildstep_kwargs)
+        super().__init__(workdir=workdir, **buildstep_kwargs)
 
         self.mastersrc = mastersrc
         self.workerdest = workerdest
@@ -511,7 +511,7 @@ class StringDownload(_TransferBuildStep):
         if workerdest is None:
             raise TypeError("__init__() takes at least 3 arguments")
 
-        _TransferBuildStep.__init__(self, workdir=workdir, **buildstep_kwargs)
+        super().__init__(workdir=workdir, **buildstep_kwargs)
 
         self.s = s
         self.workerdest = workerdest
@@ -571,8 +571,7 @@ class JSONStringDownload(StringDownload):
         if 's' in buildstep_kwargs:
             del buildstep_kwargs['s']
         s = json.dumps(o)
-        StringDownload.__init__(
-            self, s=s, workerdest=workerdest, **buildstep_kwargs)
+        super().__init__(s=s, workerdest=workerdest, **buildstep_kwargs)
 
 
 class JSONPropertiesDownload(StringDownload):
@@ -588,8 +587,7 @@ class JSONPropertiesDownload(StringDownload):
         self.super_class = StringDownload
         if 's' in buildstep_kwargs:
             del buildstep_kwargs['s']
-        StringDownload.__init__(
-            self, s=None, workerdest=workerdest, **buildstep_kwargs)
+        super().__init__(s=None, workerdest=workerdest, **buildstep_kwargs)
 
     def start(self):
         properties = self.build.getProperties()

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -98,7 +98,7 @@ class Trigger(BuildStep):
         self.brids = []
         self.triggeredNames = None
         self.waitForFinishDeferred = None
-        BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     def interrupt(self, reason):
         # We cancel the buildrequests, as the data api handles

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -320,6 +320,7 @@ class VC8(VC7):
         super().__init__(**kwargs)
 
     def setupEnvironment(self, cmd):
+        # Do not use super() here. We want to override VC7.setupEnvironment().
         VisualStudio.setupEnvironment(self, cmd)
 
         VSInstallDir = self.installdir
@@ -381,6 +382,7 @@ class VCExpress9(VC8):
             command.append("/Project")
             command.append(self.project)
         self.setCommand(command)
+        # Do not use super() here. We want to override VC7.start().
         return VisualStudio.start(self)
 
 

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -58,7 +58,7 @@ class MSLogLineObserver(LogLineObserver):
     logerrors = None
 
     def __init__(self, logwarnings, logerrors, **kwargs):
-        LogLineObserver.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.logwarnings = logwarnings
         self.logerrors = logerrors
 
@@ -141,21 +141,21 @@ class VisualStudio(ShellCommand):
         if PATH:
             self.PATH = PATH
         # always upcall !
-        ShellCommand.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     def setupLogfiles(self, cmd, logfiles):
         logwarnings = self.addLog("warnings")
         logerrors = self.addLog("errors")
         self.logobserver = MSLogLineObserver(logwarnings, logerrors)
         self.addLogObserver('stdio', self.logobserver)
-        ShellCommand.setupLogfiles(self, cmd, logfiles)
+        super().setupLogfiles(cmd, logfiles)
 
     def setupInstalldir(self):
         if not self.installdir:
             self.installdir = self.default_installdir
 
     def setupEnvironment(self, cmd):
-        ShellCommand.setupEnvironment(self, cmd)
+        super().setupEnvironment(cmd)
         if cmd.args['env'] is None:
             cmd.args['env'] = {}
 
@@ -170,7 +170,7 @@ class VisualStudio(ShellCommand):
         self.setupInstalldir()
 
     def describe(self, done=False):
-        description = ShellCommand.describe(self, done)
+        description = super().describe(done)
         if done:
             if not description:
                 description = ['compile']
@@ -203,7 +203,7 @@ class VisualStudio(ShellCommand):
     def finished(self, result):
         self.getLog("warnings").finish()
         self.getLog("errors").finish()
-        ShellCommand.finished(self, result)
+        super().finished(result)
 
 
 class VC6(VisualStudio):
@@ -211,7 +211,7 @@ class VC6(VisualStudio):
     default_installdir = 'C:\\Program Files\\Microsoft Visual Studio'
 
     def setupEnvironment(self, cmd):
-        VisualStudio.setupEnvironment(self, cmd)
+        super().setupEnvironment(cmd)
 
         # Root of Visual Developer Studio Common files.
         VSCommonDir = self.installdir + '\\Common'
@@ -249,14 +249,14 @@ class VC6(VisualStudio):
         if self.useenv:
             command.append("/USEENV")
         self.setCommand(command)
-        return VisualStudio.start(self)
+        return super().start()
 
 
 class VC7(VisualStudio):
     default_installdir = 'C:\\Program Files\\Microsoft Visual Studio .NET 2003'
 
     def setupEnvironment(self, cmd):
-        VisualStudio.setupEnvironment(self, cmd)
+        super().setupEnvironment(cmd)
 
         VSInstallDir = self.installdir + '\\Common7\\IDE'
         VCInstallDir = self.installdir
@@ -298,7 +298,7 @@ class VC7(VisualStudio):
             command.append("/Project")
             command.append(self.project)
         self.setCommand(command)
-        return VisualStudio.start(self)
+        return super().start()
 
 
 # alias VC7 as VS2003
@@ -317,7 +317,7 @@ class VC8(VC7):
         self.arch = arch
 
         # always upcall !
-        VisualStudio.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     def setupEnvironment(self, cmd):
         VisualStudio.setupEnvironment(self, cmd)
@@ -438,10 +438,10 @@ class MsBuild4(VisualStudio):
 
     def __init__(self, platform, **kwargs):
         self.platform = platform
-        VisualStudio.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     def setupEnvironment(self, cmd):
-        VisualStudio.setupEnvironment(self, cmd)
+        super().setupEnvironment(cmd)
         cmd.args['env']['VCENV_BAT'] = self.vcenv_bat
 
     def describe(self, done=False):
@@ -476,7 +476,7 @@ class MsBuild4(VisualStudio):
 
         self.setCommand(command)
 
-        return VisualStudio.start(self)
+        return super().start()
 
 
 MsBuild = MsBuild4
@@ -497,10 +497,10 @@ class MsBuild141(VisualStudio):
 
     def __init__(self, platform, **kwargs):
         self.platform = platform
-        VisualStudio.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     def setupEnvironment(self, cmd):
-        VisualStudio.setupEnvironment(self, cmd)
+        super().setupEnvironment(cmd)
         cmd.args['env']['VCENV_BAT'] = self.vcenv_bat
         addEnvPath(cmd.args['env'], "PATH", 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\')
         addEnvPath(cmd.args['env'], "PATH", r'${PATH}')
@@ -537,4 +537,4 @@ class MsBuild141(VisualStudio):
 
         self.setCommand(command)
 
-        return VisualStudio.start(self)
+        return super().start()

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -41,7 +41,7 @@ class SetPropertiesFromEnv(WorkerBuildStep):
     descriptionDone = ['Set']
 
     def __init__(self, variables, source="WorkerEnvironment", **kwargs):
-        buildstep.BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.variables = variables
         self.source = source
 
@@ -83,7 +83,7 @@ class FileExists(WorkerBuildStep):
     flunkOnFailure = True
 
     def __init__(self, file, **kwargs):
-        buildstep.BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.file = file
 
     def start(self):
@@ -122,7 +122,7 @@ class CopyDirectory(WorkerBuildStep):
     flunkOnFailure = True
 
     def __init__(self, src, dest, timeout=None, maxTime=None, **kwargs):
-        buildstep.BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.src = src
         self.dest = dest
         self.timeout = timeout
@@ -177,7 +177,7 @@ class RemoveDirectory(WorkerBuildStep):
     flunkOnFailure = True
 
     def __init__(self, dir, **kwargs):
-        buildstep.BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.dir = dir
 
     def start(self):
@@ -210,7 +210,7 @@ class MakeDirectory(WorkerBuildStep):
     flunkOnFailure = True
 
     def __init__(self, dir, **kwargs):
-        buildstep.BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.dir = dir
 
     def start(self):

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -22,7 +22,7 @@ from buildbot.util import service
 class FakeBotMaster(service.AsyncMultiService):
 
     def __init__(self):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.setName("fake-botmaster")
         self.locks = {}
         self.builders = {}  # dictionary mapping worker names to builders

--- a/master/buildbot/test/fake/bworkermanager.py
+++ b/master/buildbot/test/fake/bworkermanager.py
@@ -22,7 +22,7 @@ from buildbot.util import service
 class FakeWorkerManager(service.AsyncMultiService):
 
     def __init__(self):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.setName('workers')
 
         # WorkerRegistration instances keyed by worker name

--- a/master/buildbot/test/fake/change.py
+++ b/master/buildbot/test/fake/change.py
@@ -28,7 +28,7 @@ class Change(State):
     properties = {}
 
     def __init__(self, **kw):
-        State.__init__(self, **kw)
+        super().__init__(**kw)
         # change.properties is a IProperties
         props = Properties()
         props.update(self.properties, "test")

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -433,7 +433,7 @@ class FakeDataConnector(service.AsyncMultiService):
     # relevant updates with fake methods, though.
 
     def __init__(self, master, testcase):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.setServiceParent(master)
         self.updates = FakeUpdates(testcase)
         self.updates.setServiceParent(self)

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -2495,7 +2495,7 @@ class FakeDBConnector(service.AsyncMultiService):
     """
 
     def __init__(self, testcase):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         # reset the id generator, for stable id's
         Row._next_id = 1000
         self.t = testcase

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -165,7 +165,7 @@ class FakeMaster(service.MasterService):
     """
 
     def __init__(self, master_id=fakedb.FakeBuildRequestsComponent.MASTER_ID):
-        service.MasterService.__init__(self)
+        super().__init__()
         self._master_id = master_id
         self.reactor = reactor
         self.objectids = {}

--- a/master/buildbot/test/fake/fakemq.py
+++ b/master/buildbot/test/fake/fakemq.py
@@ -32,7 +32,7 @@ class FakeMQConnector(service.AsyncMultiService, base.MQBase):
     verifyMessages = True
 
     def __init__(self, testcase):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.testcase = testcase
         self.setup_called = False
         self.productions = []

--- a/master/buildbot/test/fake/fakeprotocol.py
+++ b/master/buildbot/test/fake/fakeprotocol.py
@@ -22,7 +22,7 @@ from buildbot.worker.protocols import base
 class FakeConnection(base.Connection):
 
     def __init__(self, master, worker):
-        base.Connection.__init__(self, master, worker)
+        super().__init__(master, worker)
         self._connected = True
         self.remoteCalls = []
         self.builders = {}  # { name : isBusy }

--- a/master/buildbot/test/fake/fakestats.py
+++ b/master/buildbot/test/fake/fakestats.py
@@ -68,7 +68,7 @@ class FakeStatsService(stats_service.StatsService):
     """
 
     def __init__(self, master=None, *args, **kwargs):
-        stats_service.StatsService.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.master = master
 
     @property

--- a/master/buildbot/test/fake/httpclientservice.py
+++ b/master/buildbot/test/fake/httpclientservice.py
@@ -62,7 +62,7 @@ class HTTPClientService(service.SharedService):
 
     def __init__(self, base_url, auth=None, headers=None, debug=None, verify=None):
         assert not base_url.endswith("/"), "baseurl should not end with /"
-        service.SharedService.__init__(self)
+        super().__init__()
         self._base_url = base_url
         self._auth = auth
 

--- a/master/buildbot/test/fake/kube.py
+++ b/master/buildbot/test/fake/kube.py
@@ -27,8 +27,7 @@ class KubeClientService(fakehttpclientservice.HTTPClientService):
 
     def __init__(self, kube_config=None, *args, **kwargs):
         c = kube_config.getConfig()
-        fakehttpclientservice.HTTPClientService.__init__(
-            self, c['master_url'], *args, **kwargs)
+        super().__init__(c['master_url'], *args, **kwargs)
         self.namespace = c['namespace']
         self.addService(kube_config)
         self.pods = {}

--- a/master/buildbot/test/fake/openstack.py
+++ b/master/buildbot/test/fake/openstack.py
@@ -82,7 +82,7 @@ class Item():
 class Image(Item):
 
     def __init__(self, *args, **kwargs):
-        Item.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         setattr(self, 'OS-EXT-IMG-SIZE:size', self.size)
 
 

--- a/master/buildbot/test/fake/pbmanager.py
+++ b/master/buildbot/test/fake/pbmanager.py
@@ -22,7 +22,7 @@ from buildbot.util import service
 class FakePBManager(service.AsyncMultiService):
 
     def __init__(self):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.setName("fake-pbmanager")
         self._registrations = []
         self._unregistrations = []

--- a/master/buildbot/test/fake/reactor.py
+++ b/master/buildbot/test/fake/reactor.py
@@ -44,6 +44,7 @@ class CoreReactor:
     """
 
     def __init__(self):
+        super().__init__()
         self._triggers = {}
 
     def addSystemEventTrigger(self, phase, eventType, f, *args, **kw):
@@ -118,8 +119,7 @@ class NonReactor:
 class TestReactor(NonReactor, CoreReactor, Clock):
 
     def __init__(self):
-        Clock.__init__(self)
-        CoreReactor.__init__(self)
+        super().__init__()
 
         # whether there are calls that should run right now
         self._pendingCurrentCalls = False
@@ -160,8 +160,8 @@ class TestReactor(NonReactor, CoreReactor, Clock):
         if when <= 0 and not self._pendingCurrentCalls:
             reactor.callLater(0, self._executeCurrentDelayedCalls)
 
-        return Clock.callLater(self, when, self._catchPrintExceptions,
-                               what, *a, **kw)
+        return super().callLater(when, self._catchPrintExceptions,
+                                 what, *a, **kw)
 
     def stop(self):
         # first fire pending calls until the current time. Note that the real

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -102,11 +102,11 @@ class FakeRemoteShellCommand(FakeRemoteCommand):
                     initial_stdin=initialStdin,
                     timeout=timeout, maxTime=maxTime, logfiles=logfiles,
                     usePTY=usePTY, logEnviron=logEnviron)
-        FakeRemoteCommand.__init__(self, "shell", args,
-                                   collectStdout=collectStdout,
-                                   collectStderr=collectStderr,
-                                   decodeRC=decodeRC,
-                                   stdioLogName=stdioLogName)
+        super().__init__("shell", args,
+                         collectStdout=collectStdout,
+                         collectStderr=collectStderr,
+                         decodeRC=decodeRC,
+                         stdioLogName=stdioLogName)
 
 
 class ExpectRemoteRef:
@@ -314,7 +314,7 @@ class ExpectShell(Expect):
                     initial_stdin=initialStdin,
                     timeout=timeout, maxTime=maxTime, logfiles=logfiles,
                     usePTY=usePTY, logEnviron=logEnviron)
-        Expect.__init__(self, "shell", args)
+        super().__init__("shell", args)
 
     def __repr__(self):
         return "ExpectShell(" + repr(self.remote_command) + repr(self.args['command']) + ")"

--- a/master/buildbot/test/fake/step.py
+++ b/master/buildbot/test/fake/step.py
@@ -53,7 +53,7 @@ class ControllableBuildStep(BuildStep):
     name = "controllableStep"
 
     def __init__(self, controller):
-        BuildStep.__init__(self)
+        super().__init__()
         self._controller = controller
 
     def run(self):

--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -45,7 +45,7 @@ class FakeRequest(Mock):
     failure = None
 
     def __init__(self, args=None, content=b''):
-        Mock.__init__(self)
+        super().__init__()
 
         if args is None:
             args = {}

--- a/master/buildbot/test/integration/interop/test_commandmixin.py
+++ b/master/buildbot/test/integration/interop/test_commandmixin.py
@@ -49,9 +49,6 @@ class CommandMixinMasterPB(CommandMixinMaster):
 
 class TestCommandMixinStep(BuildStep, CommandMixin):
 
-    def __init__(self, *args, **kwargs):
-        BuildStep.__init__(self, *args, **kwargs)
-
     @defer.inlineCallbacks
     def run(self):
         contents = yield self.runGlob('*')

--- a/master/buildbot/test/integration/interop/test_compositestepmixin.py
+++ b/master/buildbot/test/integration/interop/test_compositestepmixin.py
@@ -50,7 +50,7 @@ class CompositeStepMixinMasterPb(CompositeStepMixinMaster):
 class TestCompositeMixinStep(BuildStep, CompositeStepMixin):
 
     def __init__(self, *args, **kwargs):
-        BuildStep.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.logEnviron = False
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -48,7 +48,7 @@ class TestLogObserver(buildstep.LogObserver):
 class OldStyleCustomBuildStep(buildstep.BuildStep):
 
     def __init__(self, arg1, arg2, doFail=False, **kwargs):
-        buildstep.BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.arg1 = arg1
         self.arg2 = arg2
         self.doFail = doFail
@@ -104,7 +104,7 @@ class FailingCustomStep(buildstep.LoggingBuildStep):
     flunkOnFailure = True
 
     def __init__(self, exception=buildstep.BuildStepFailed, *args, **kwargs):
-        buildstep.LoggingBuildStep.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.exception = exception
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/integration/test_integration_secrets_with_vault.py
+++ b/master/buildbot/test/integration/test_integration_secrets_with_vault.py
@@ -13,7 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
-import os
+import subprocess
 from unittest.case import SkipTest
 
 from twisted.internet import defer
@@ -30,22 +30,31 @@ from buildbot.test.util.integration import RunMasterBase
 class SecretsConfig(RunMasterBase):
 
     def setUp(self):
-        rv = os.system("docker run -d -e SKIP_SETCAP=yes -e "
-                       "'VAULT_DEV_ROOT_TOKEN_ID=my_vaulttoken' -e 'VAULT_TOKEN=my_vaulttoken'"
-                       " --name=vault_for_buildbot -p 8200:8200 vault")
-        if rv != 0:
+        try:
+            rv = subprocess.call(['docker', 'pull', 'vault'])
+            if rv != 0:
+                raise FileNotFoundError('docker')
+        except FileNotFoundError:
             raise SkipTest(
                 "Vault integration need docker environment to be setup")
 
+        rv = subprocess.call(['docker', 'run', '-d',
+                              '-e', 'SKIP_SETCAP=yes',
+                              '-e', 'VAULT_DEV_ROOT_TOKEN_ID=my_vaulttoken',
+                              '-e', 'VAULT_TOKEN=my_vaulttoken',
+                              '--name=vault_for_buildbot',
+                              '-p', '8200:8200', 'vault'])
+        self.assertEqual(rv, 0)
         self.addCleanup(self.remove_container)
 
-        rv = os.system("docker exec vault_for_buildbot /bin/sh -c "
-                       "'export VAULT_ADDR=http://127.0.0.1:8200/\n"
-                       "vault kv put secret/key value=word'")
+        rv = subprocess.call(['docker', 'exec',
+                              '-e', 'VAULT_ADDR=http://127.0.0.1:8200/',
+                              'vault_for_buildbot',
+                              'vault', 'kv', 'put', 'secret/key', 'value=word'])
         self.assertEqual(rv, 0)
 
     def remove_container(self):
-        os.system("docker rm -f vault_for_buildbot")
+        subprocess.call(['docker', 'rm', '-f', 'vault_for_buildbot'])
 
     @defer.inlineCallbacks
     def test_secret(self):

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -54,7 +54,7 @@ class ControllableStep(BuildStep):
         return self._step_deferred
 
     def __init__(self, step_deferred, **kwargs):
-        BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self._step_deferred = step_deferred
 
     def interrupt(self, reason):

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -112,7 +112,7 @@ class FakeWorkerWorker(pb.Referenceable):
 class FakeBuilder(builder.Builder):
 
     def __init__(self, name):
-        builder.Builder.__init__(self, name)
+        super().__init__(name)
         self.builder_status = mock.Mock()
 
     def attached(self, worker, commands):
@@ -132,10 +132,10 @@ class MyWorker(worker.Worker):
 
     def attached(self, conn):
         self.detach_d = defer.Deferred()
-        return worker.Worker.attached(self, conn)
+        return super().attached(conn)
 
     def detached(self):
-        worker.Worker.detached(self)
+        super().detached()
         self.detach_d, d = None, self.detach_d
         d.callback(None)
 

--- a/master/buildbot/test/integration/test_worker_kubernetes.py
+++ b/master/buildbot/test/integration/test_worker_kubernetes.py
@@ -78,7 +78,7 @@ class KubernetesMaster(RunMasterBase):
 
 class KubernetesMasterTReq(KubernetesMaster):
     def setup(self):
-        KubernetesMaster.setUp(self)
+        super().setUp()
         self.patch(kubernetes.KubeClientService, 'PREFER_TREQ', True)
 
 

--- a/master/buildbot/test/integration/test_worker_workerside.py
+++ b/master/buildbot/test/integration/test_worker_workerside.py
@@ -47,7 +47,7 @@ DEFAULT_PORT = os.environ.get("BUILDBOT_TEST_DEFAULT_PORT", "0")
 class FakeBuilder(builder.Builder):
 
     def __init__(self, name):
-        builder.Builder.__init__(self, name)
+        super().__init__(name)
         self.builder_status = mock.Mock()
 
     def attached(self, worker, commands):
@@ -69,10 +69,10 @@ class MasterSideWorker(worker.Worker):
 
     def attached(self, conn):
         self.detach_d = defer.Deferred()
-        return worker.Worker.attached(self, conn)
+        return super().attached(conn)
 
     def detached(self):
-        worker.Worker.detached(self)
+        super().detached()
         self.detach_d, d = None, self.detach_d
         d.callback(None)
 

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -79,7 +79,7 @@ global_defaults = dict(
 class FakeChangeSource(changes_base.ChangeSource):
 
     def __init__(self):
-        changes_base.ChangeSource.__init__(self, name='FakeChangeSource')
+        super().__init__(name='FakeChangeSource')
 
 
 class FakeStatusReceiver(status_base.StatusReceiver):
@@ -1497,8 +1497,7 @@ class FakeService(service.ReconfigurableServiceMixin,
     def reconfigServiceWithBuildbotConfig(self, new_config):
         self.called = FakeService.call_index
         FakeService.call_index += 1
-        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(
-            self, new_config)
+        yield super().reconfigServiceWithBuildbotConfig(new_config)
         if not self.succeed:
             raise ValueError("oh noes")
 
@@ -1508,8 +1507,7 @@ class FakeMultiService(service.ReconfigurableServiceMixin,
 
     def reconfigServiceWithBuildbotConfig(self, new_config):
         self.called = True
-        d = service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(
-            self, new_config)
+        d = super().reconfigServiceWithBuildbotConfig(new_config)
         return d
 
 

--- a/master/buildbot/test/unit/test_db_pool.py
+++ b/master/buildbot/test/unit/test_db_pool.py
@@ -153,11 +153,11 @@ class BasicWithDebug(Basic):
 
     def setUp(self):
         pool.debug = True
-        return Basic.setUp(self)
+        return super().setUp()
 
     def tearDown(self):
         pool.debug = False
-        return Basic.tearDown(self)
+        return super().tearDown()
 
 
 class Native(unittest.TestCase, db.RealDatabaseMixin):

--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -251,8 +251,7 @@ class TestBuildbotPlugins(unittest.TestCase):
 class SimpleFakeEntry(FakeEntry):
 
     def __init__(self, name, value):
-        FakeEntry.__init__(self, name, 'non-existent', 'irrelevant', False,
-                           value)
+        super().__init__(name, 'non-existent', 'irrelevant', False, value)
 
 
 _WORKER_FAKE_ENTRIES = {

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -84,8 +84,7 @@ class FakeRequest:
 class FakeBuildStep(BuildStep):
 
     def __init__(self):
-        BuildStep.__init__(
-            self, haltOnFailure=False, flunkOnWarnings=False, flunkOnFailure=True,
+        super().__init__(haltOnFailure=False, flunkOnWarnings=False, flunkOnFailure=True,
             warnOnWarnings=True, warnOnFailure=False, alwaysRun=False, name='fake')
         self._summary = {'step': 'result', 'build': 'build result'}
         self._expected_results = SUCCESS
@@ -162,7 +161,7 @@ class _StepController():
 class _ControllableStep(BuildStep):
 
     def __init__(self):
-        BuildStep.__init__(self)
+        super().__init__()
         self._deferred = defer.Deferred()
 
     def run(self):

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -99,8 +99,7 @@ class TestBuilder(BuilderMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def makeBuilder(self, patch_random=False, startBuildsForSucceeds=True, **config_kwargs):
-        yield BuilderMixin.makeBuilder(
-            self, patch_random=patch_random, **config_kwargs)
+        yield super().makeBuilder(patch_random=patch_random, **config_kwargs)
 
         # patch into the _startBuildsFor method
         self.builds_started = []

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -365,7 +365,7 @@ class TestMaybeStartBuilds(TestBRDBase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        TestBRDBase.setUp(self)
+        super().setUp()
 
         self.startedBuilds = []
 

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -936,7 +936,7 @@ class ShellMixinExample(buildstep.ShellMixin, buildstep.BuildStep):
     def __init__(self, cleanupScript='./cleanup.sh', **kwargs):
         self.cleanupScript = cleanupScript
         kwargs = self.setupShellMixin(kwargs, prohibitArgs=['command'])
-        buildstep.BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     @defer.inlineCallbacks
     def run(self):
@@ -957,7 +957,7 @@ class SimpleShellCommand(buildstep.ShellMixin, buildstep.BuildStep):
         self.makeRemoteShellCommandKwargs = makeRemoteShellCommandKwargs or {}
 
         kwargs = self.setupShellMixin(kwargs)
-        buildstep.BuildStep.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     @defer.inlineCallbacks
     def run(self):

--- a/master/buildbot/test/unit/test_process_logobserver.py
+++ b/master/buildbot/test/unit/test_process_logobserver.py
@@ -74,7 +74,7 @@ class TestLogObserver(unittest.TestCase):
 class MyLogLineObserver(logobserver.LogLineObserver):
 
     def __init__(self):
-        logobserver.LogLineObserver.__init__(self)
+        super().__init__()
         self.obs = []
 
     def outLineReceived(self, data):

--- a/master/buildbot/test/unit/test_reporter_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucketserver.py
@@ -205,7 +205,7 @@ class TestBitbucketServerPRCommentPush(unittest.TestCase, NotifierTestMixin, Log
 
     @defer.inlineCallbacks
     def setupBuildResults(self, buildResults, set_pr=True):
-        buildset, builds = yield NotifierTestMixin.setupBuildResults(self, buildResults)
+        buildset, builds = yield super().setupBuildResults(buildResults)
         if set_pr:
             yield self.master.db.builds.setBuildProperty(
                 20, "pullrequesturl", PR_URL, "test")

--- a/master/buildbot/test/unit/test_reporters_irc.py
+++ b/master/buildbot/test/unit/test_reporters_irc.py
@@ -30,7 +30,7 @@ from buildbot.util import service
 class FakeContact(service.AsyncService):
 
     def __init__(self, bot, user=None, channel=None):
-        service.AsyncService.__init__(self)
+        super().__init__()
         self.bot = bot
         self.user = user
         self.channel = channel

--- a/master/buildbot/test/unit/test_reporters_notifier.py
+++ b/master/buildbot/test/unit/test_reporters_notifier.py
@@ -319,7 +319,7 @@ class TestMailNotifier(ConfigErrorsMixin, unittest.TestCase, NotifierTestMixin):
         class NoPatchSourcestamp(SourceStamp):
 
             def __init__(self, id, patchid):
-                SourceStamp.__init__(self, id=id)
+                super().__init__(id=id)
         self.patch(fakedb, 'SourceStamp', NoPatchSourcestamp)
         mn, builds = yield self.setupBuildMessage(mode=("change",), addPatch=True)
         self.assertEqual(mn.sendMessage.call_count, 1)

--- a/master/buildbot/test/unit/test_schedulers_dependent.py
+++ b/master/buildbot/test/unit/test_schedulers_dependent.py
@@ -80,11 +80,13 @@ class Dependent(scheduler.SchedulerMixin, unittest.TestCase):
 
         self.assertEqual(
             sorted([q.filter for q in sched.master.mq.qrefs]),
-            [('buildsets', None, 'complete',), ('buildsets', None, 'new',)])
+            [('buildsets', None, 'complete',), ('buildsets', None, 'new',),
+             ('schedulers', '133', 'updated')])
 
         yield sched.deactivate()
 
-        self.assertEqual([q.filter for q in sched.master.mq.qrefs], [])
+        self.assertEqual([q.filter for q in sched.master.mq.qrefs],
+                         [('schedulers', '133', 'updated')])
 
     def sendBuildsetMessage(self, scheduler_name=None, results=-1,
                             complete=False):

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -68,11 +68,11 @@ class SchedulerManager(unittest.TestCase):
             assert self.master is not None
             assert self.objectid is not None
             self.already_started = True
-            return base.BaseScheduler.startService(self)
+            return super().startService()
 
         @defer.inlineCallbacks
         def stopService(self):
-            yield base.BaseScheduler.stopService(self)
+            yield super().stopService()
 
             assert self.master is not None
             assert self.objectid is not None
@@ -85,7 +85,7 @@ class SchedulerManager(unittest.TestCase):
         def reconfigServiceWithSibling(self, new_config):
             self.reconfig_count += 1
             self.attr = new_config.attr
-            return base.BaseScheduler.reconfigServiceWithSibling(self, new_config)
+            return super().reconfigServiceWithSibling(new_config)
 
     class ReconfigSched2(ReconfigSched):
         pass

--- a/master/buildbot/test/unit/test_scripts_start.py
+++ b/master/buildbot/test/unit/test_scripts_start.py
@@ -49,7 +49,7 @@ from twisted.python import log
 application = service.Application('highscore')
 class App(service.Service):
     def startService(self):
-        service.Service.startService(self)
+        super().startService()
         log.msg("BuildMaster is running") # heh heh heh
         reactor.callLater(0, reactor.stop)
 app = App()

--- a/master/buildbot/test/unit/test_secret_in_vault.py
+++ b/master/buildbot/test/unit/test_secret_in_vault.py
@@ -43,7 +43,7 @@ class TestSecretInVaultHttpFakeBase(ConfigErrorsMixin, unittest.TestCase):
 class TestSecretInVaultV1(TestSecretInVaultHttpFakeBase):
 
     def setUp(self):
-        TestSecretInVaultHttpFakeBase.setUp(self, version=1)
+        super().setUp(version=1)
 
     @defer.inlineCallbacks
     def testGetValue(self):
@@ -104,7 +104,7 @@ class TestSecretInVaultV1(TestSecretInVaultHttpFakeBase):
 class TestSecretInVaultV2(TestSecretInVaultHttpFakeBase):
 
     def setUp(self):
-        TestSecretInVaultHttpFakeBase.setUp(self, version=2)
+        super().setUp(version=2)
 
     @defer.inlineCallbacks
     def testGetValue(self):

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -185,7 +185,7 @@ class TestStatsServicesConsumers(steps.BuildStepMixin, TestStatsServicesBase):
     """
 
     def setUp(self):
-        TestStatsServicesBase.setUp(self)
+        super().setUp()
         self.routingKey = (
             "builders", self.BUILDER_IDS[0], "builds", 1, "finished")
         self.master.mq.verifyMessages = False

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -924,7 +924,7 @@ class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase,
 
             def start(self):
                 self.addSuppression([('.*', '.*unseen.*', None, None)])
-                return shell.WarningCountingShellCommand.start(self)
+                return super().start()
 
         def warningExtractor(step, line, match):
             return line.split(':', 2)

--- a/master/buildbot/test/unit/test_steps_source_cvs.py
+++ b/master/buildbot/test/unit/test_steps_source_cvs.py
@@ -46,7 +46,7 @@ class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
         return self.tearDownSourceStep()
 
     def setupStep(self, step, *args, **kwargs):
-        sourcesteps.SourceStepMixin.setupStep(self, step, *args, **kwargs)
+        super().setupStep(step, *args, **kwargs)
 
         # make parseGotRevision return something consistent, patching the class
         # instead of the object since a new object is constructed by runTest.

--- a/master/buildbot/test/unit/test_steps_source_gitlab.py
+++ b/master/buildbot/test/unit/test_steps_source_gitlab.py
@@ -31,7 +31,7 @@ class TestGitLab(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest
         return self.setUpSourceStep()
 
     def setupStep(self, step, args, **kwargs):
-        step = sourcesteps.SourceStepMixin.setupStep(self, step, args, **kwargs)
+        step = super().setupStep(step, args, **kwargs)
         step.build.properties.setProperty("source_branch", "ms-viewport", "gitlab source branch")
         step.build.properties.setProperty("source_git_ssh_url",
             "git@gitlab.example.com:build/awesome_project.git",

--- a/master/buildbot/test/unit/test_steps_source_p4.py
+++ b/master/buildbot/test/unit/test_steps_source_p4.py
@@ -44,8 +44,7 @@ class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
     def setupStep(self, step, args=None, patch=None, **kwargs):
         if args is None:
             args = {}
-        step = sourcesteps.SourceStepMixin.setupStep(
-            self, step, args={}, patch=None, **kwargs)
+        step = super().setupStep(step, args={}, patch=None, **kwargs)
         self.build.getSourceStamp().revision = args.get('revision', None)
 
         # builddir property used to create absolute path required in perforce

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -108,7 +108,7 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
         sourcestamps = sourcestampsInBuild or []
         got_revisions = gotRevisionsInBuild or {}
 
-        steps.BuildStepMixin.setupStep(self, step, *args, **kwargs)
+        super().setupStep(step, *args, **kwargs)
 
         # This step reaches deeply into a number of parts of Buildbot.  That
         # should be fixed!
@@ -185,7 +185,7 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
         if self.step.waitForFinish:
             for i in [11, 22, 33, 44]:
                 yield self.master.db.builds.finishBuild(BRID_TO_BID(i), results_dict.get(i, SUCCESS))
-        d = steps.BuildStepMixin.runStep(self)
+        d = super().runStep()
         # the build doesn't finish until after a callLater, so this has the
         # effect of checking whether the deferred has been fired already;
         if self.step.waitForFinish:

--- a/master/buildbot/test/unit/test_steps_vstudio.py
+++ b/master/buildbot/test/unit/test_steps_vstudio.py
@@ -194,7 +194,7 @@ class VCx(vstudio.VisualStudio):
     def start(self):
         command = ["command", "here"]
         self.setCommand(command)
-        return vstudio.VisualStudio.start(self)
+        return super().start()
 
 
 class VisualStudio(steps.BuildStepMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_steps_worker.py
+++ b/master/buildbot/test/unit/test_steps_worker.py
@@ -282,7 +282,7 @@ class CompositeUser(buildstep.LoggingBuildStep, worker.CompositeStepMixin):
     def __init__(self, payload):
         self.payload = payload
         self.logEnviron = False
-        buildstep.LoggingBuildStep.__init__(self)
+        super().__init__()
 
     @defer.inlineCallbacks
     def start(self):

--- a/master/buildbot/test/unit/test_util_httpclientservice.py
+++ b/master/buildbot/test/unit/test_util_httpclientservice.py
@@ -62,7 +62,7 @@ class HTTPClientServiceTestBase(unittest.SynchronousTestCase):
 class HTTPClientServiceTestTxRequest(HTTPClientServiceTestBase):
 
     def setUp(self):
-        HTTPClientServiceTestBase.setUp(self)
+        super().setUp()
         self._http = self.successResultOf(
             httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
                                                            headers=self.base_headers))
@@ -128,7 +128,7 @@ class HTTPClientServiceTestTxRequest(HTTPClientServiceTestBase):
 class HTTPClientServiceTestTReq(HTTPClientServiceTestBase):
 
     def setUp(self):
-        HTTPClientServiceTestBase.setUp(self)
+        super().setUp()
         self.patch(httpclientservice.HTTPClientService, 'PREFER_TREQ', True)
         self._http = self.successResultOf(
             httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
@@ -364,7 +364,7 @@ class HTTPClientServiceTestTReqE2E(HTTPClientServiceTestTxRequestE2E):
 
     def setUp(self):
         self.patch(httpclientservice.HTTPClientService, 'PREFER_TREQ', True)
-        return HTTPClientServiceTestTxRequestE2E.setUp(self)
+        return super().setUp()
 
 
 class HTTPClientServiceTestFakeE2E(HTTPClientServiceTestTxRequestE2E):

--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -73,9 +73,6 @@ class KubeClientServiceTestClusterConfig(
         self.patch(kubeclientservice.os, 'environ',
                    {'KUBERNETES_PORT': 'tcp://foo'})
 
-    def tearDown(self):
-        return super().tearDown()
-
     def patchExist(self, val):
         self.patch(kubeclientservice.os.path, 'exists', lambda x: val)
 

--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -69,12 +69,12 @@ class KubeClientServiceTestClusterConfig(
     }
 
     def setUp(self):
-        MockFileBase.setUp(self)
+        super().setUp()
         self.patch(kubeclientservice.os, 'environ',
                    {'KUBERNETES_PORT': 'tcp://foo'})
 
     def tearDown(self):
-        return MockFileBase.tearDown(self)
+        return super().tearDown()
 
     def patchExist(self, val):
         self.patch(kubeclientservice.os.path, 'exists', lambda x: val)

--- a/master/buildbot/test/unit/test_util_service.py
+++ b/master/buildbot/test/unit/test_util_service.py
@@ -742,7 +742,7 @@ class BuildbotServiceManager(unittest.TestCase):
 
 class UnderTestSharedService(service.SharedService):
     def __init__(self, arg1=None):
-        service.SharedService.__init__(self)
+        super().__init__()
 
 
 class UnderTestDependentService(service.AsyncService):

--- a/master/buildbot/test/unit/test_wamp_connector.py
+++ b/master/buildbot/test/unit/test_wamp_connector.py
@@ -34,7 +34,7 @@ class FakeService(service.AsyncMultiService):
 
     def __init__(self, url, realm, make, extra=None,
                  debug=False, debug_wamp=False, debug_app=False):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.make = make
         self.extra = extra
 

--- a/master/buildbot/test/unit/test_worker_manager.py
+++ b/master/buildbot/test/unit/test_worker_manager.py
@@ -32,7 +32,7 @@ class FakeWorker(service.BuildbotService):
     reconfig_count = 0
 
     def __init__(self, workername):
-        service.BuildbotService.__init__(self, name=workername)
+        super().__init__(name=workername)
 
     def reconfigService(self):
         self.reconfig_count += 1

--- a/master/buildbot/test/unit/test_www_endpointmatchers.py
+++ b/master/buildbot/test/unit/test_www_endpointmatchers.py
@@ -134,7 +134,7 @@ class ForceBuildEndpointMatcherBranch(EndpointBase, ValidEndpointMixin):
         return endpointmatchers.ForceBuildEndpointMatcher(builder="builder", role="owner")
 
     def insertData(self):
-        EndpointBase.insertData(self)
+        super().insertData()
         self.master.allSchedulers = lambda: [
             ForceScheduler(name="sched1", builderNames=["builder"])]
 

--- a/master/buildbot/test/util/querylog.py
+++ b/master/buildbot/test/util/querylog.py
@@ -27,7 +27,7 @@ from twisted.python import log
 class _QueryToTwistedHandler(logging.Handler):
 
     def __init__(self, log_query_result=False, record_mode=False):
-        logging.Handler.__init__(self)
+        super().__init__()
 
         self._log_query_result = log_query_result
         self.recordMode = record_mode

--- a/master/buildbot/test/util/sandboxed_worker.py
+++ b/master/buildbot/test/util/sandboxed_worker.py
@@ -62,7 +62,7 @@ class SandboxedWorker(AsyncService):
             processProtocol, self.sandboxed_worker_path, args=['bbw', 'start', '--nodaemon', self.workerdir])
 
         self.worker = self.master.workers.getWorkerByName(self.workername)
-        return AsyncService.startService(self)
+        return super().startService()
 
     @defer.inlineCallbacks
     def shutdownWorker(self):
@@ -74,4 +74,4 @@ class SandboxedWorker(AsyncService):
         yield self.processprotocol.waitForFinish()
 
     def stopService(self):
-        return AsyncService.stopService(self)
+        return super().stopService()

--- a/master/buildbot/test/util/sandboxed_worker.py
+++ b/master/buildbot/test/util/sandboxed_worker.py
@@ -72,6 +72,3 @@ class SandboxedWorker(AsyncService):
         yield self.worker.shutdown()
         # wait for process to disappear
         yield self.processprotocol.waitForFinish()
-
-    def stopService(self):
-        return super().stopService()

--- a/master/buildbot/test/util/sourcesteps.py
+++ b/master/buildbot/test/util/sourcesteps.py
@@ -34,10 +34,10 @@ class SourceStepMixin(steps.BuildStepMixin):
     """
 
     def setUpSourceStep(self):
-        return steps.BuildStepMixin.setUpBuildStep(self)
+        return super().setUpBuildStep()
 
     def tearDownSourceStep(self):
-        return steps.BuildStepMixin.tearDownBuildStep(self)
+        return super().tearDownBuildStep()
 
     # utilities
 
@@ -46,7 +46,7 @@ class SourceStepMixin(steps.BuildStepMixin):
         Set up C{step} for testing.  This calls L{BuildStepMixin}'s C{setupStep}
         and then does setup specific to a Source step.
         """
-        step = steps.BuildStepMixin.setupStep(self, step, **kwargs)
+        step = super().setupStep(step, **kwargs)
 
         if args is None:
             args = {}

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -206,7 +206,7 @@ class StringListValidator(ListValidator):
     name = 'string-list'
 
     def __init__(self):
-        ListValidator.__init__(self, StringValidator())
+        super().__init__(StringValidator())
 
 
 class SourcedPropertiesValidator(Validator):

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -89,7 +89,7 @@ class HTTPClientService(service.SharedService):
     def __init__(self, base_url, auth=None, headers=None, verify=None, debug=False):
         assert not base_url.endswith(
             "/"), "baseurl should not end with /: " + base_url
-        service.SharedService.__init__(self)
+        super().__init__()
         self._base_url = base_url
         self._auth = auth
         self._headers = headers
@@ -129,7 +129,7 @@ class HTTPClientService(service.SharedService):
             self._pool = HTTPConnectionPool(self.master.reactor)
             self._pool.maxPersistentPerHost = self.MAX_THREADS
             self._agent = Agent(self.master.reactor, pool=self._pool)
-        return service.SharedService.startService(self)
+        return super().startService()
 
     @defer.inlineCallbacks
     def stopService(self):
@@ -137,7 +137,7 @@ class HTTPClientService(service.SharedService):
             yield self._session.close()
         if self._pool:
             yield self._pool.closeCachedConnections()
-        yield service.SharedService.stopService(self)
+        yield super().stopService()
 
     def _prepareRequest(self, ep, kwargs):
         assert ep == "" or ep.startswith("/"), "ep should start with /: " + ep

--- a/master/buildbot/util/kubeclientservice.py
+++ b/master/buildbot/util/kubeclientservice.py
@@ -205,7 +205,7 @@ class KubeInClusterConfigLoader(KubeConfigLoaderBase):
 
 class KubeError(RuntimeError):
     def __init__(self, response_json):
-        RuntimeError.__init__(self, response_json['message'])
+        super().__init__(response_json['message'])
         self.json = response_json
         self.reason = response_json.get('reason')
 
@@ -213,7 +213,7 @@ class KubeError(RuntimeError):
 class KubeClientService(HTTPClientService):
     def __init__(self, kube_config=None):
         self.config = kube_config
-        HTTPClientService.__init__(self, '')
+        super().__init__('')
         self._namespace = None
         kube_config.setServiceParent(self)
 
@@ -221,7 +221,7 @@ class KubeClientService(HTTPClientService):
     def _prepareRequest(self, ep, kwargs):
         config = self.config.getConfig()
         self._base_url = config['master_url']
-        url, req_kwargs = HTTPClientService._prepareRequest(self, ep, kwargs)
+        url, req_kwargs = super()._prepareRequest(ep, kwargs)
 
         if 'headers' not in req_kwargs:
             req_kwargs['headers'] = {}

--- a/master/buildbot/util/lru.py
+++ b/master/buildbot/util/lru.py
@@ -176,7 +176,7 @@ class AsyncLRUCache(LRUCache):
     __slots__ = ['concurrent']
 
     def __init__(self, miss_fn, max_size=50):
-        LRUCache.__init__(self, miss_fn, max_size=max_size)
+        super().__init__(miss_fn, max_size=max_size)
         self.concurrent = {}
 
     def get(self, key, **miss_fn_kwargs):

--- a/master/buildbot/util/maildir.py
+++ b/master/buildbot/util/maildir.py
@@ -44,9 +44,10 @@ class NoSuchMaildir(Exception):
 
 class MaildirService(service.BuildbotService):
     pollinterval = 10  # only used if we don't have DNotify
+    name = 'MaildirService'
 
     def __init__(self, basedir=None):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         if basedir:
             self.setBasedir(basedir)
         self.files = []
@@ -82,7 +83,7 @@ class MaildirService(service.BuildbotService):
                 self.pollinterval, self.poll)
             self.timerService.setServiceParent(self)
         self.poll()
-        return service.AsyncMultiService.startService(self)
+        return super().startService()
 
     def dnotify_callback(self):
         log.msg("dnotify noticed something, now polling")
@@ -105,7 +106,7 @@ class MaildirService(service.BuildbotService):
         if self.timerService is not None:
             self.timerService.disownServiceParent()
             self.timerService = None
-        return service.AsyncMultiService.stopService(self)
+        return super().stopService()
 
     @defer.inlineCallbacks
     def poll(self):

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -72,6 +72,9 @@ class AsyncService(service.Service):
 class AsyncMultiService(AsyncService, service.MultiService):
 
     def startService(self):
+        # Do NOT use super() here.
+        # The method resolution order would cause MultiService.startService() to
+        # be called which we explicitly want to override with this method.
         service.Service.startService(self)
         dl = []
         # if a service attaches another service during the reconfiguration
@@ -84,6 +87,9 @@ class AsyncMultiService(AsyncService, service.MultiService):
 
     @defer.inlineCallbacks
     def stopService(self):
+        # Do NOT use super() here.
+        # The method resolution order would cause MultiService.stopService() to
+        # be called which we explicitly want to override with this method.
         service.Service.stopService(self)
         services = list(self)
         services.reverse()

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -178,7 +178,7 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
         self._config_args = args
         self._config_kwargs = kwargs
         self.rendered = False
-        AsyncMultiService.__init__(self)
+        super().__init__()
 
     def getConfigDict(self):
         _type = type(self)
@@ -227,7 +227,7 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
                 yield self.configureService()
             except NotImplementedError:
                 pass
-        yield AsyncMultiService.startService(self)
+        yield super().startService()
 
     def checkConfig(self, *args, **kwargs):
         return defer.succeed(True)
@@ -272,7 +272,7 @@ class ClusteredBuildbotService(BuildbotService):
         self.active = False
         self._activityPollCall = None
         self._activityPollDeferred = None
-        super(ClusteredBuildbotService, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     # activity handling
 
@@ -314,7 +314,7 @@ class ClusteredBuildbotService(BuildbotService):
         # subclasses should override startService only to perform actions that should
         # run on all instances, even if they never get activated on this
         # master.
-        yield super(ClusteredBuildbotService, self).startService()
+        yield super().startService()
         self._startServiceDeferred = defer.Deferred()
         self._startActivityPolling()
         yield self._startServiceDeferred
@@ -340,7 +340,7 @@ class ClusteredBuildbotService(BuildbotService):
             except Exception as e:
                 log.err(e, _why="Caught exception while deactivating ClusteredService(%s)" % self.name)
 
-        yield super(ClusteredBuildbotService, self).stopService()
+        yield super().stopService()
 
     def _startActivityPolling(self):
         self._activityPollCall = task.LoopingCall(self._activityPoll)

--- a/master/buildbot/wamp/connector.py
+++ b/master/buildbot/wamp/connector.py
@@ -83,7 +83,7 @@ class WampConnector(service.ReconfigurableServiceMixin, service.AsyncMultiServic
     name = "wamp"
 
     def __init__(self):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
         self.app = self.router_url = None
         self.serviceDeferred = defer.Deferred()
         self.service = None
@@ -103,7 +103,7 @@ class WampConnector(service.ReconfigurableServiceMixin, service.AsyncMultiServic
         if self.service is not None:
             self.service.leaving = True
 
-        service.AsyncMultiService.stopService(self)
+        super().stopService()
 
     @defer.inlineCallbacks
     def publish(self, topic, data, options=None):
@@ -147,5 +147,4 @@ class WampConnector(service.ReconfigurableServiceMixin, service.AsyncMultiServic
         wamp_debug_level = wamp.get('wamp_debug_level', 'error')
         txaio.set_global_log_level(wamp_debug_level)
         yield self.app.setServiceParent(self)
-        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                   new_config)
+        yield super().reconfigServiceWithBuildbotConfig(new_config)

--- a/master/buildbot/wamp/connector.py
+++ b/master/buildbot/wamp/connector.py
@@ -33,6 +33,8 @@ class MasterService(ApplicationSession, service.AsyncMultiService):
     """
 
     def __init__(self, config):
+        # Cannot use super() here.
+        # We must explicitly call both parent constructors.
         ApplicationSession.__init__(self)
         service.AsyncMultiService.__init__(self)
         self.config = config

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -221,7 +221,7 @@ class AbstractWorker(service.BuildbotService):
         # startService
 
         self.manager = parent
-        return service.BuildbotService.setServiceParent(self, parent)
+        return super().setServiceParent(parent)
 
     @defer.inlineCallbacks
     def startService(self):
@@ -235,7 +235,7 @@ class AbstractWorker(service.BuildbotService):
                                                                         None))
 
         yield self._getWorkerInfo()
-        yield service.BuildbotService.startService(self)
+        yield super().startService()
 
         # startMissingTimer wants the service to be running to really start
         if self.start_missing_on_startup:
@@ -288,7 +288,7 @@ class AbstractWorker(service.BuildbotService):
     def reconfigServiceWithSibling(self, sibling):
         # reconfigServiceWithSibling will only reconfigure the worker when it is configured differently.
         # However, the worker configuration depends on which builder it is configured
-        yield service.BuildbotService.reconfigServiceWithSibling(self, sibling)
+        yield super().reconfigServiceWithSibling(sibling)
 
         # update the attached worker's notion of which builders are attached.
         # This assumes that the relevant builders have already been configured,
@@ -311,7 +311,7 @@ class AbstractWorker(service.BuildbotService):
         self.stopQuarantineTimer()
         # mark this worker as configured for zero builders in this master
         yield self.master.data.updates.workerConfigured(self.workerid, self.master.masterid, [])
-        yield service.BuildbotService.stopService(self)
+        yield super().stopService()
 
     def isCompatibleWithBuild(self, build_props):
         # given a build properties object, determines whether the build is
@@ -640,21 +640,21 @@ class AbstractWorker(service.BuildbotService):
 class Worker(AbstractWorker):
 
     def detached(self):
-        AbstractWorker.detached(self)
+        super().detached()
         self.botmaster.workerLost(self)
         self.startMissingTimer()
 
     @defer.inlineCallbacks
     def attached(self, bot):
         try:
-            yield AbstractWorker.attached(self, bot)
+            yield super().attached(bot)
         except Exception as e:
             log.err(e, "worker %s cannot attach" % (self.name,))
             return
 
     def buildFinished(self, wfb):
         """This is called when a build on this worker is finished."""
-        AbstractWorker.buildFinished(self, wfb)
+        super().buildFinished(wfb)
 
         # If we're gracefully shutting down, and we have no more active
         # builders, then it's safe to disconnect

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -73,7 +73,7 @@ class DockerBaseWorker(AbstractLatentWorker):
             if not hasattr(image, 'getRenderingFor'):
                 config.error("image must be a string")
 
-        AbstractLatentWorker.checkConfig(self, name, password, **kwargs)
+        super().checkConfig(name, password, **kwargs)
 
     def reconfigService(self, name, password=None, image=None,
                         masterFQDN=None, **kwargs):
@@ -89,7 +89,7 @@ class DockerBaseWorker(AbstractLatentWorker):
         self.image = image
         masterName = unicode2bytes(self.master.name)
         self.masterhash = hashlib.sha1(masterName).hexdigest()[:6]
-        return AbstractLatentWorker.reconfigService(self, name, password, **kwargs)
+        return super().reconfigService(name, password, **kwargs)
 
     def getContainerName(self):
         return ('buildbot-{worker}-{hash}'.format(worker=self.workername, hash=self.masterhash)).replace("_", "-")
@@ -133,7 +133,7 @@ class DockerLatentWorker(DockerBaseWorker,
                     volumes=None, dockerfile=None, version=None, tls=None, followStartupLogs=False,
                     masterFQDN=None, hostconfig=None, autopull=False, alwaysPull=False, **kwargs):
 
-        DockerBaseWorker.checkConfig(self, name, password, image, masterFQDN, **kwargs)
+        super().checkConfig(name, password, image, masterFQDN, **kwargs)
 
         if not client:
             config.error("The python module 'docker>=2.0' is needed to use a"
@@ -161,7 +161,7 @@ class DockerLatentWorker(DockerBaseWorker,
                         volumes=None, dockerfile=None, version=None, tls=None, followStartupLogs=False,
                         masterFQDN=None, hostconfig=None, autopull=False, alwaysPull=False, **kwargs):
 
-        yield DockerBaseWorker.reconfigService(self, name, password, image, masterFQDN, **kwargs)
+        yield super().reconfigService(name, password, image, masterFQDN, **kwargs)
         self.volumes = volumes or []
         self.followStartupLogs = followStartupLogs
 

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -88,7 +88,7 @@ class EC2LatentWorker(AbstractLatentWorker):
         if tags is None:
             tags = {}
 
-        AbstractLatentWorker.__init__(self, name, password, **kwargs)
+        super().__init__(name, password, **kwargs)
 
         if security_name and subnet_id:
             raise ValueError(

--- a/master/buildbot/worker/kubernetes.py
+++ b/master/buildbot/worker/kubernetes.py
@@ -79,7 +79,7 @@ class KubeLatentWorker(DockerBaseWorker, CompatibleLatentWorkerMixin):
                     kube_config=None,
                     **kwargs):
 
-        DockerBaseWorker.checkConfig(self, name, None, **kwargs)
+        super().checkConfig(name, None, **kwargs)
         kubeclientservice.KubeClientService.checkAvailable(
             self.__class__.__name__)
 
@@ -100,8 +100,7 @@ class KubeLatentWorker(DockerBaseWorker, CompatibleLatentWorkerMixin):
             masterFQDN = self.get_ip
         if callable(masterFQDN):
             masterFQDN = masterFQDN()
-        yield DockerBaseWorker.reconfigService(
-            self, name, image=image, masterFQDN=masterFQDN, **kwargs)
+        yield super().reconfigService(name, image=image, masterFQDN=masterFQDN, **kwargs)
         self._kube = yield kubeclientservice.KubeClientService.getService(
             self.master, kube_config=kube_config)
         self.namespace = namespace or self._kube.namespace

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -118,7 +118,7 @@ class AbstractLatentWorker(AbstractWorker):
     def checkConfig(self, name, password,
                     build_wait_timeout=60 * 10,
                     **kwargs):
-        AbstractWorker.checkConfig(self, name, password, **kwargs)
+        super().checkConfig(name, password, **kwargs)
 
     def reconfigService(self, name, password,
                         build_wait_timeout=60 * 10,
@@ -126,7 +126,7 @@ class AbstractLatentWorker(AbstractWorker):
         self._substantiation_notifier = Notifier()
         self._insubstantiation_notifier = Notifier()
         self.build_wait_timeout = build_wait_timeout
-        return AbstractWorker.reconfigService(self, name, password, **kwargs)
+        return super().reconfigService(name, password, **kwargs)
 
     def getRandomPass(self):
         """
@@ -254,7 +254,7 @@ class AbstractLatentWorker(AbstractWorker):
             raise RuntimeError(msg)
 
         try:
-            yield AbstractWorker.attached(self, bot)
+            yield super().attached(bot)
         except Exception:
             self._substantiation_failed(failure.Failure())
             return
@@ -297,7 +297,7 @@ class AbstractLatentWorker(AbstractWorker):
         # we were disconnected, but all the builds are not yet cleaned up.
         if self.conn is None and self.building:
             return False
-        return AbstractWorker.canStartBuild(self)
+        return super().canStartBuild()
 
     def buildStarted(self, wfb):
         assert wfb.isBusy()
@@ -317,7 +317,7 @@ class AbstractLatentWorker(AbstractWorker):
 
         # AbstractWorker.buildFinished() will try to start the next build for
         # that worker
-        AbstractWorker.buildFinished(self, wfb)
+        super().buildFinished(wfb)
 
     def _clearBuildWaitTimer(self):
         if self.build_wait_timer is not None:
@@ -391,7 +391,7 @@ class AbstractLatentWorker(AbstractWorker):
         # a negative build_wait_timeout means the worker should never be shut
         # down, so just disconnect.
         if self.build_wait_timeout < 0:
-            yield AbstractWorker.disconnect(self)
+            yield super().disconnect()
             return
 
         self.stopMissingTimer()
@@ -406,7 +406,7 @@ class AbstractLatentWorker(AbstractWorker):
             log.msg("Substantiation complete, immediately terminating.")
 
         yield defer.DeferredList([
-            AbstractWorker.disconnect(self),
+            super().disconnect(),
             self.insubstantiate(fast)
         ], consumeErrors=True, fireOnOneErrback=True)
 
@@ -428,7 +428,7 @@ class AbstractLatentWorker(AbstractWorker):
                                                    States.SUBSTANTIATED]:
             yield self._soft_disconnect()
         self._clearBuildWaitTimer()
-        res = yield AbstractWorker.stopService(self)
+        res = yield super().stopService()
         return res
 
     def updateWorker(self):
@@ -441,4 +441,4 @@ class AbstractLatentWorker(AbstractWorker):
         for b in self.botmaster.getBuildersForWorker(self.name):
             if b.name not in self.workerforbuilders:
                 b.addLatentWorker(self)
-        return AbstractWorker.updateWorker(self)
+        return super().updateWorker()

--- a/master/buildbot/worker/libvirt.py
+++ b/master/buildbot/worker/libvirt.py
@@ -26,7 +26,6 @@ from twisted.python import log
 from buildbot import config
 from buildbot.util.eventual import eventually
 from buildbot.worker import AbstractLatentWorker
-from buildbot.worker import AbstractWorker
 
 try:
     import libvirt
@@ -159,7 +158,7 @@ class LibVirtWorker(AbstractLatentWorker):
 
     def __init__(self, name, password, connection, hd_image, base_image=None, xml=None,
                  **kwargs):
-        AbstractLatentWorker.__init__(self, name, password, **kwargs)
+        super().__init__(name, password, **kwargs)
         if not libvirt:
             config.error(
                 "The python module 'libvirt' is needed to use a LibVirtWorker")
@@ -204,7 +203,7 @@ class LibVirtWorker(AbstractLatentWorker):
                 "Not accepting builds as existing domain but worker not connected")
             return False
 
-        return AbstractLatentWorker.canStartBuild(self)
+        return super().canStartBuild()
 
     def _prepare_base_image(self):
         """
@@ -300,7 +299,7 @@ class LibVirtWorker(AbstractLatentWorker):
         def _disconnect(res):
             log.msg("VM destroyed (%s): Forcing its connection closed." %
                     self.workername)
-            return AbstractWorker.disconnect(self)
+            return super().disconnect()
 
         @d.addBoth
         def _disconnected(res):

--- a/master/buildbot/worker/local.py
+++ b/master/buildbot/worker/local.py
@@ -26,7 +26,7 @@ class LocalWorker(Worker):
 
     def checkConfig(self, name, workdir=None, **kwargs):
         kwargs['password'] = None
-        Worker.checkConfig(self, name, **kwargs)
+        super().checkConfig(name, **kwargs)
         self.LocalWorkerFactory = None
         try:
             # importing here to avoid dependency on buildbot worker package
@@ -40,7 +40,7 @@ class LocalWorker(Worker):
     @defer.inlineCallbacks
     def reconfigService(self, name, workdir=None, **kwargs):
         kwargs['password'] = None
-        Worker.reconfigService(self, name, **kwargs)
+        super().reconfigService(name, **kwargs)
         if workdir is None:
             workdir = name
         workdir = os.path.abspath(

--- a/master/buildbot/worker/manager.py
+++ b/master/buildbot/worker/manager.py
@@ -19,7 +19,6 @@ from twisted.python import log
 
 from buildbot.process.measured_service import MeasuredBuildbotServiceManager
 from buildbot.util import misc
-from buildbot.util import service
 from buildbot.worker.protocols import pb as bbpb
 
 
@@ -65,7 +64,7 @@ class WorkerManager(MeasuredBuildbotServiceManager):
     reconfig_priority = 127
 
     def __init__(self, master):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
 
         self.pb = bbpb.Listener()
         self.pb.setServiceParent(master)

--- a/master/buildbot/worker/marathon.py
+++ b/master/buildbot/worker/marathon.py
@@ -43,8 +43,7 @@ class MarathonLatentWorker(DockerBaseWorker,
                     masterFQDN=None,
                     **kwargs):
 
-        DockerBaseWorker.checkConfig(
-            self, name, image=image, masterFQDN=masterFQDN, **kwargs)
+        super().checkConfig(name, image=image, masterFQDN=masterFQDN, **kwargs)
         HTTPClientService.checkAvailable(self.__class__.__name__)
 
     @defer.inlineCallbacks
@@ -63,8 +62,7 @@ class MarathonLatentWorker(DockerBaseWorker,
 
         if 'build_wait_timeout' not in kwargs:
             kwargs['build_wait_timeout'] = 0
-        yield DockerBaseWorker.reconfigService(
-            self, name, image=image, masterFQDN=masterFQDN, **kwargs)
+        yield super().reconfigService(name, image=image, masterFQDN=masterFQDN, **kwargs)
 
         self._http = yield HTTPClientService.getService(
             self.master, marathon_url, auth=marathon_auth)

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -82,7 +82,7 @@ class OpenStackLatentWorker(AbstractLatentWorker,
         if not block_devices and not image:
             raise ValueError('One of block_devices or image must be given')
 
-        AbstractLatentWorker.__init__(self, name, password, **kwargs)
+        super().__init__(name, password, **kwargs)
 
         self.flavor = flavor
         self.client_version = client_version

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -28,7 +28,7 @@ class Listener(base.Listener):
     name = "pbListener"
 
     def __init__(self):
-        base.Listener.__init__(self)
+        super().__init__()
 
         # username : (password, portstr, PBManager registration)
         self._registrations = {}
@@ -128,7 +128,7 @@ class Connection(base.Connection, pb.Avatar):
     info = None
 
     def __init__(self, master, worker, mind):
-        base.Connection.__init__(self, master, worker)
+        super().__init__(master, worker)
         self.mind = mind
 
     # methods called by the PBManager

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -47,7 +47,7 @@ class AuthRootResource(resource.Resource):
             return self.master.www.auth.getLoginResource()
         elif path == b'logout':
             return self.master.www.auth.getLogoutResource()
-        return resource.Resource.getChild(self, path, request)
+        return super().getChild(path, request)
 
 
 class AuthBase(config.ConfiguredMixin):
@@ -105,7 +105,7 @@ class RemoteUserAuth(AuthBase):
     headerRegex = re.compile(br"(?P<username>[^ @]+)@(?P<realm>[^ @]+)")
 
     def __init__(self, header=None, headerRegex=None, **kwargs):
-        AuthBase.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         if self.userInfoProvider is None:
             self.userInfoProvider = UserInfoProviderBase()
         if header is not None:
@@ -147,7 +147,7 @@ class AuthRealm:
 class TwistedICredAuthBase(AuthBase):
 
     def __init__(self, credentialFactories, checkers, **kwargs):
-        AuthBase.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         if self.userInfoProvider is None:
             self.userInfoProvider = UserInfoProviderBase()
         self.credentialFactories = credentialFactories
@@ -162,9 +162,7 @@ class TwistedICredAuthBase(AuthBase):
 class HTPasswdAuth(TwistedICredAuthBase):
 
     def __init__(self, passwdFile, **kwargs):
-        TwistedICredAuthBase.__init__(
-            self,
-            [DigestCredentialFactory(b"md5", b"buildbot"),
+        super().__init__([DigestCredentialFactory(b"md5", b"buildbot"),
              BasicCredentialFactory(b"buildbot")],
             [FilePasswordDB(passwdFile)],
             **kwargs)
@@ -177,9 +175,7 @@ class UserPasswordAuth(TwistedICredAuthBase):
             users = {user: unicode2bytes(pw) for user, pw in users.items()}
         elif isinstance(users, list):
             users = [(user, unicode2bytes(pw)) for user, pw in users]
-        TwistedICredAuthBase.__init__(
-            self,
-            [DigestCredentialFactory(b"md5", b"buildbot"),
+        super().__init__([DigestCredentialFactory(b"md5", b"buildbot"),
              BasicCredentialFactory(b"buildbot")],
             [InMemoryUsernamePasswordDatabaseDontUse(**dict(users))],
             **kwargs)
@@ -191,9 +187,7 @@ class CustomAuth(TwistedICredAuthBase):
     credentialInterfaces = [IUsernamePassword]
 
     def __init__(self, **kwargs):
-        TwistedICredAuthBase.__init__(
-            self,
-            [BasicCredentialFactory(b"buildbot")],
+        super().__init__([BasicCredentialFactory(b"buildbot")],
             [self],
             **kwargs)
 
@@ -218,7 +212,7 @@ class PreAuthenticatedLoginResource(LoginResource):
     # HTTPAuthSessionWrapper
 
     def __init__(self, master, username):
-        LoginResource.__init__(self, master)
+        super().__init__(master)
         self.username = username
 
     @defer.inlineCallbacks

--- a/master/buildbot/www/authz/authz.py
+++ b/master/buildbot/www/authz/authz.py
@@ -29,7 +29,7 @@ from buildbot.www.authz.roles import RolesFromOwner
 class Forbidden(Error):
 
     def __init__(self, msg):
-        Error.__init__(self, 403, msg)
+        super().__init__(403, msg)
 
 
 # fnmatch and re.match are reversed API, we cannot just rename them

--- a/master/buildbot/www/authz/endpointmatchers.py
+++ b/master/buildbot/www/authz/endpointmatchers.py
@@ -118,7 +118,7 @@ class StopBuildEndpointMatcher(EndpointMatcherBase):
 
     def __init__(self, builder=None, **kwargs):
         self.builder = builder
-        EndpointMatcherBase.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     @defer.inlineCallbacks
     def matchFromBuilderId(self, builderid):
@@ -158,7 +158,7 @@ class ForceBuildEndpointMatcher(EndpointMatcherBase):
 
     def __init__(self, builder=None, **kwargs):
         self.builder = builder
-        EndpointMatcherBase.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     @defer.inlineCallbacks
     def match_ForceSchedulerEndpoint_force(self, epobject, epdict, options):
@@ -180,7 +180,7 @@ class RebuildBuildEndpointMatcher(EndpointMatcherBase):
 
     def __init__(self, builder=None, **kwargs):
         self.builder = builder
-        EndpointMatcherBase.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
     @defer.inlineCallbacks
     def match_BuildEndpoint_rebuild(self, epobject, epdict, options):
@@ -200,7 +200,7 @@ class EnableSchedulerEndpointMatcher(EndpointMatcherBase):
 class ViewBuildsEndpointMatcher(EndpointMatcherBase):
 
     def __init__(self, branch=None, project=None, builder=None, **kwargs):
-        EndpointMatcherBase.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.branch = branch
         self.project = project
         self.builder = builder
@@ -210,4 +210,4 @@ class BranchEndpointMatcher(EndpointMatcherBase):
 
     def __init__(self, branch, **kwargs):
         self.branch = branch
-        EndpointMatcherBase.__init__(self, **kwargs)
+        super().__init__(**kwargs)

--- a/master/buildbot/www/authz/endpointmatchers.py
+++ b/master/buildbot/www/authz/endpointmatchers.py
@@ -96,17 +96,11 @@ class Match:
 
 class AnyEndpointMatcher(EndpointMatcherBase):
 
-    def __init__(self, **kwargs):
-        EndpointMatcherBase.__init__(self, **kwargs)
-
     def match(self, ep, action="get", options=None):
         return defer.succeed(Match(self.master))
 
 
 class AnyControlEndpointMatcher(EndpointMatcherBase):
-
-    def __init__(self, **kwargs):
-        EndpointMatcherBase.__init__(self, **kwargs)
 
     def match(self, ep, action="", options=None):
         if bytes2unicode(action).lower() != "get":

--- a/master/buildbot/www/authz/roles.py
+++ b/master/buildbot/www/authz/roles.py
@@ -30,7 +30,7 @@ class RolesFromBase:
 class RolesFromGroups(RolesFromBase):
 
     def __init__(self, groupPrefix=""):
-        RolesFromBase.__init__(self)
+        super().__init__()
         self.groupPrefix = groupPrefix
 
     def getRolesFromUser(self, userDetails):
@@ -45,7 +45,7 @@ class RolesFromGroups(RolesFromBase):
 class RolesFromEmails(RolesFromBase):
 
     def __init__(self, **kwargs):
-        RolesFromBase.__init__(self)
+        super().__init__()
         self.roles = {}
         for role, emails in kwargs.items():
             for email in emails:
@@ -60,7 +60,7 @@ class RolesFromEmails(RolesFromBase):
 class RolesFromDomain(RolesFromEmails):
 
     def __init__(self, **kwargs):
-        RolesFromBase.__init__(self)
+        super().__init__()
 
         self.domain_roles = {}
         for role, domains in kwargs.items():
@@ -78,7 +78,7 @@ class RolesFromDomain(RolesFromEmails):
 class RolesFromOwner(RolesFromBase):
 
     def __init__(self, role):
-        RolesFromBase.__init__(self)
+        super().__init__()
         self.role = role
 
     def getRolesFromUser(self, userDetails, owner):

--- a/master/buildbot/www/change_hook.py
+++ b/master/buildbot/www/change_hook.py
@@ -45,7 +45,7 @@ class ChangeHookResource(resource.Resource):
         The value is passed to the module's getChanges function, providing
         configuration options to the dialect.
         """
-        resource.Resource.__init__(self, master)
+        super().__init__(master)
 
         if dialects is None:
             dialects = {}

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -34,7 +34,7 @@ class IndexResource(resource.Resource):
     needsReconfig = True
 
     def __init__(self, master, staticdir):
-        resource.Resource.__init__(self, master)
+        super().__init__(master)
         loader = jinja2.FileSystemLoader(staticdir)
         self.jinja = jinja2.Environment(
             loader=loader, undefined=jinja2.StrictUndefined)

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -326,7 +326,7 @@ class GitHubHandler(BaseHookHandler):
     def __init__(self, master, options):
         if options is None:
             options = {}
-        BaseHookHandler.__init__(self, master, options)
+        super().__init__(master, options)
 
         klass = options.get('class', GitHubEventHandler)
         klass_kwargs = {

--- a/master/buildbot/www/ldapuserinfo.py
+++ b/master/buildbot/www/ldapuserinfo.py
@@ -50,8 +50,6 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
                  avatarPattern=None,
                  avatarData=None,
                  accountExtraFields=None):
-        avatar.AvatarBase.__init__(self)
-        auth.UserInfoProviderBase.__init__(self)
         self.uri = uri
         self.bindUser = bindUser
         self.bindPw = bindPw

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -40,7 +40,7 @@ class OAuth2LoginResource(auth.LoginResource):
     needsReconfig = False
 
     def __init__(self, master, _auth):
-        auth.LoginResource.__init__(self, master)
+        super().__init__(master)
         self.auth = _auth
 
     def render_POST(self, request):
@@ -86,7 +86,7 @@ class OAuth2Auth(auth.AuthBase):
 
     def __init__(self,
                  clientId, clientSecret, autologin=False, **kwargs):
-        auth.AuthBase.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.clientId = clientId
         self.clientSecret = clientSecret
         self.autologin = autologin
@@ -224,7 +224,7 @@ class GitHubAuth(OAuth2Auth):
                  apiVersion=3, getTeamsMembership=False, debug=False,
                  **kwargs):
 
-        OAuth2Auth.__init__(self, clientId, clientSecret, autologin, **kwargs)
+        super().__init__(clientId, clientSecret, autologin, **kwargs)
         if serverURL is not None:
             # setup for enterprise github
             if serverURL.endswith("/"):

--- a/master/buildbot/www/resource.py
+++ b/master/buildbot/www/resource.py
@@ -33,7 +33,7 @@ def protect_redirect_url(url):
 
 class Redirect(Error):
     def __init__(self, url):
-        Error.__init__(self, 302, "redirect")
+        super().__init__(302, "redirect")
         self.url = protect_redirect_url(unicode2bytes(url))
 
 
@@ -52,7 +52,7 @@ class Resource(resource.Resource):
         return self.master.config.buildbotURL
 
     def __init__(self, master):
-        resource.Resource.__init__(self)
+        super().__init__()
         self.master = master
         if self.needsReconfig and master is not None:
             master.www.resourceNeedsReconfigs(self)
@@ -115,7 +115,7 @@ class Resource(resource.Resource):
 class RedirectResource(Resource):
 
     def __init__(self, master, basepath):
-        Resource.__init__(self, master)
+        super().__init__(master)
         self.basepath = basepath
 
     def render(self, request):

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -71,7 +71,7 @@ class RestRootResource(resource.Resource):
         version_cls.apiVersion = version
 
     def __init__(self, master):
-        resource.Resource.__init__(self, master)
+        super().__init__(master)
 
         min_vers = master.config.www.get('rest_minimum_version', 0)
         latest = max(list(self.version_classes))

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -138,7 +138,7 @@ class BuildbotSite(server.Site):
     """
 
     def __init__(self, root, logPath, rotateLength, maxRotatedFiles):
-        server.Site.__init__(self, root, logPath=logPath)
+        super().__init__(root, logPath=logPath)
         self.rotateLength = rotateLength
         self.maxRotatedFiles = maxRotatedFiles
         self.session_secret = None
@@ -173,7 +173,7 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
     name = 'www'
 
     def __init__(self):
-        service.AsyncMultiService.__init__(self)
+        super().__init__()
 
         self.port = None
         self.port_service = None
@@ -244,8 +244,7 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         if not self.port_service:
             log.msg("No web server configured on this master")
 
-        yield service.ReconfigurableServiceMixin.reconfigServiceWithBuildbotConfig(self,
-                                                                                   new_config)
+        yield super().reconfigServiceWithBuildbotConfig(new_config)
 
     def getPortnum(self):
         # for tests, when the configured port is 0 and the kernel selects a

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -64,6 +64,9 @@ class BuildbotSession(server.Session):
         """
         self.site = site
         assert self.site.session_secret is not None, "site.session_secret is not configured yet!"
+        # Cannot use super() here as it would call server.Session.__init__
+        # which we explicitly want to override. However, we still want to call
+        # server.Session parent class constructor
         components.Componentized.__init__(self)
         if token:
             self._fromToken(token)

--- a/master/buildbot/www/sse.py
+++ b/master/buildbot/www/sse.py
@@ -57,7 +57,7 @@ class EventResource(resource.Resource):
     isLeaf = True
 
     def __init__(self, master):
-        resource.Resource.__init__(self)
+        super().__init__()
 
         self.master = master
         self.consumers = {}

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -31,7 +31,7 @@ from buildbot.util import unicode2bytes
 class WsProtocol(WebSocketServerProtocol):
 
     def __init__(self, master):
-        WebSocketServerProtocol.__init__(self)
+        super().__init__()
         self.master = master
         self.qrefs = {}
         self.debug = self.master.config.www.get('debug', False)
@@ -129,7 +129,7 @@ class WsProtocol(WebSocketServerProtocol):
 class WsProtocolFactory(WebSocketServerFactory):
 
     def __init__(self, master):
-        WebSocketServerFactory.__init__(self)
+        super().__init__()
         self.master = master
 
     def buildProtocol(self, addr):
@@ -141,4 +141,4 @@ class WsProtocolFactory(WebSocketServerFactory):
 class WsResource(WebSocketResource):
 
     def __init__(self, master):
-        WebSocketResource.__init__(self, WsProtocolFactory(master))
+        super().__init__(WsProtocolFactory(master))

--- a/master/docs/developer/schedulers.rst
+++ b/master/docs/developer/schedulers.rst
@@ -31,7 +31,7 @@ The remaining arguments are keyword arguments, and the subclass's constructor sh
 
     class MyScheduler(base.BaseScheduler):
         def __init__(self, name, builderNames, arg1=None, arg2=None, **kwargs):
-            base.BaseScheduler.__init__(self, name, builderNames, **kwargs)
+            super().__init__(name, builderNames, **kwargs)
             self.arg1 = arg1
             self.arg2 = arg2
 

--- a/master/docs/manual/configuration/buildfactories.rst
+++ b/master/docs/manual/configuration/buildfactories.rst
@@ -108,7 +108,7 @@ Each stage is then run in this example using ``./build.sh --run-stage <stage nam
 
         def __init__(self, **kwargs):
             kwargs = self.setupShellMixin(kwargs)
-            steps.BuildStep.__init__(self, **kwargs)
+            super().__init__(**kwargs)
             self.observer = logobserver.BufferLogObserver()
             self.addLogObserver('stdio', self.observer)
 

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -713,7 +713,7 @@ The whole thing looks like this::
             kwargs['parentOpt'] = 'xyz'
 
             # call parent
-            LoggingBuildStep.__init__(self, **kwargs)
+            super().__init__(**kwargs)
 
             # set Frobnify attributes
             self.frob_what = frob_what
@@ -724,7 +724,7 @@ The whole thing looks like this::
         def __init__(self,
                 speed=5,
                 **kwargs):
-            Frobnify.__init__(self, **kwargs)
+            super().__init__(**kwargs)
             self.speed = speed
 
 Step Execution Process
@@ -758,7 +758,7 @@ A simple example of a step using the shell mixin is::
         def __init__(self, cleanupScript='./cleanup.sh', **kwargs):
             self.cleanupScript = cleanupScript
             kwargs = self.setupShellMixin(kwargs, prohibitArgs=['command'])
-            buildstep.BuildStep.__init__(self, **kwargs)
+            super().__init__(**kwargs)
 
         @defer.inlineCallbacks
         def run(self):
@@ -959,7 +959,7 @@ For example::
                 self.setCommand([ ... ]) # windows-only command
             else:
                 self.setCommand([ ... ]) # equivalent for other systems
-            ShellCommand.start(self)
+            super().start()
 
 Remember that properties set in a step may not be available until the next step begins.
 In particular, any :class:`Property` or :class:`Interpolate` instances for the current step are interpolated before the step starts, so they cannot use the value of any properties determined in that step.
@@ -1065,7 +1065,7 @@ If the path does not exist (or anything fails) we mark the step as failed; if th
     class MyBuildStep(steps.BuildStep):
 
         def __init__(self, dirname, **kwargs):
-            buildstep.BuildStep.__init__(self, **kwargs)
+            super().__init__(**kwargs)
             self.dirname = dirname
 
         def start(self):
@@ -1230,7 +1230,7 @@ The :class:`BuildStep` class definition itself will look something like this::
         command = ["framboozler"]
 
         def __init__(self, **kwargs):
-            steps.ShellCommand.__init__(self, **kwargs)   # always upcall!
+            super().__init__(**kwargs)   # always upcall!
             counter = FNURRRGHCounter()
             self.addLogObserver('stdio', counter)
             self.progressMetrics += ('tests',)

--- a/master/setup.py
+++ b/master/setup.py
@@ -66,10 +66,10 @@ class install_data_twisted(install_data):
         self.set_undefined_options('install',
                                    ('install_lib', 'install_dir'),
                                    )
-        install_data.finalize_options(self)
+        super().finalize_options()
 
     def run(self):
-        install_data.run(self)
+        super().run()
         # ensure there's a buildbot/VERSION file
         fn = os.path.join(self.install_dir, 'buildbot', 'VERSION')
         open(fn, 'w').write(version)

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -251,7 +251,7 @@ class BuildPyCommand(setuptools.command.build_py.build_py):
 
     def run(self):
         self.run_command('build_js')
-        setuptools.command.build_py.build_py.run(self)
+        super().run()
 
 
 class EggInfoCommand(setuptools.command.egg_info.egg_info):
@@ -259,7 +259,7 @@ class EggInfoCommand(setuptools.command.egg_info.egg_info):
 
     def run(self):
         self.run_command('build_js')
-        setuptools.command.egg_info.egg_info.run(self)
+        super().run()
 
 
 def setup_www_plugin(**kw):


### PR DESCRIPTION
Starting a pull request to open the discussion based on something concrete...

I wanted to do this to make the code easier to read (and to write). However, it breaks almost everything (the tests do not even start, `trial` stops after 3 seconds). I have no idea why.

Reverting to old-style for `buildbot.util.service` fixes some of the tests but they eventually crash as well.

If anyone has an idea why this occurs, I am all ears :) Is there a problem with our code? Or with twisted? Is this caused by `zope.interface` stuff?