### PR TITLE
Cache claimed counts in BaseLock

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -49,6 +49,7 @@ api
 apimaster
 app
 appdata
+applicative
 apps
 araujo
 arg

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -49,6 +49,14 @@ class BaseLock:
         # maximal number of counting owners
         self.maxCount = maxCount
 
+        # current number of claimed exclusive locks (0 or 1), must match
+        # self.owners
+        self._claimed_excl = 0
+
+        # current number of claimed counting locks (0 to self.maxCount), must
+        # match self.owners
+        self._claimed_counting = 0
+
         # subscriptions to this lock being released
         self.release_subs = subscription.SubscriptionPoint("%r releases"
                                                            % (self,))
@@ -56,27 +64,11 @@ class BaseLock:
     def __repr__(self):
         return self.description
 
-    def _getOwnersCount(self):
-        """ Return the number of current exclusive and counting owners.
-
-            @return: Tuple (number exclusive owners, number counting owners)
-        """
-        num_excl, num_counting = 0, 0
-        for owner in self.owners:
-            if owner[1].mode == 'exclusive':
-                num_excl = num_excl + 1
-            else:  # mode == 'counting'
-                num_counting = num_counting + 1
-
-        assert (num_excl == 1 and num_counting == 0) \
-            or (num_excl == 0 and num_counting <= self.maxCount)
-        return num_excl, num_counting
-
     def isAvailable(self, requester, access):
         """ Return a boolean whether the lock is available for claiming """
         debuglog("%s isAvailable(%s, %s): self.owners=%r"
                  % (self, requester, access, self.owners))
-        num_excl, num_counting = self._getOwnersCount()
+        num_excl, num_counting = self._claimed_excl, self._claimed_counting
 
         # Find all waiters ahead of the requester in the wait queue
         for idx, waiter in enumerate(self.waiting):
@@ -94,6 +86,30 @@ class BaseLock:
         # else Wants exclusive access
         return num_excl == 0 and num_counting == 0 and not ahead
 
+    def _addOwner(self, owner, access):
+        self.owners.append((owner, access))
+        if access.mode == 'counting':
+            self._claimed_counting += 1
+        else:
+            self._claimed_excl += 1
+
+        assert (self._claimed_excl == 1 and self._claimed_counting == 0) \
+            or (self._claimed_excl == 0 and self._claimed_excl <= self.maxCount)
+
+    def _removeOwner(self, owner, access):
+        # returns True if owner removed, False if the lock has been already
+        # released
+        entry = (owner, access)
+        if entry not in self.owners:
+            return False
+
+        self.owners.remove(entry)
+        if access.mode == 'counting':
+            self._claimed_counting -= 1
+        else:
+            self._claimed_excl -= 1
+        return True
+
     def claim(self, owner, access):
         """ Claim the lock (lock must be available) """
         debuglog("%s claim(%s, %s)" % (self, owner, access.mode))
@@ -103,7 +119,8 @@ class BaseLock:
         assert isinstance(access, LockAccess)
         assert access.mode in ['counting', 'exclusive']
         self.waiting = [w for w in self.waiting if w[0] is not owner]
-        self.owners.append((owner, access))
+        self._addOwner(owner, access)
+
         debuglog(" %s is claimed '%s'" % (self, access.mode))
 
     def subscribeToReleases(self, callback):
@@ -116,16 +133,15 @@ class BaseLock:
         assert isinstance(access, LockAccess)
 
         debuglog("%s release(%s, %s)" % (self, owner, access.mode))
-        entry = (owner, access)
-        if entry not in self.owners:
+        if not self._removeOwner(owner, access):
             debuglog("%s already released" % self)
             return
-        self.owners.remove(entry)
+
         # who can we wake up?
         # After an exclusive access, we may need to wake up several waiting.
         # Break out of the loop when the first waiting client should not be
         # awakened.
-        num_excl, num_counting = self._getOwnersCount()
+        num_excl, num_counting = self._claimed_excl, self._claimed_counting
         for i, (w_owner, w_access, d) in enumerate(self.waiting):
             if w_access.mode == 'counting':
                 if num_excl > 0 or num_counting == self.maxCount:

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -144,7 +144,7 @@ class BaseLock:
         num_excl, num_counting = self._claimed_excl, self._claimed_counting
         for i, (w_owner, w_access, d) in enumerate(self.waiting):
             if w_access.mode == 'counting':
-                if num_excl > 0 or num_counting == self.maxCount:
+                if num_excl > 0 or num_counting >= self.maxCount:
                     break
                 else:
                     num_counting = num_counting + 1

--- a/master/buildbot/test/unit/test_locks.py
+++ b/master/buildbot/test/unit/test_locks.py
@@ -1,0 +1,271 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from parameterized import parameterized
+
+import mock
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.locks import BaseLock
+from buildbot.locks import LockAccess
+from buildbot.util.eventual import flushEventualQueue
+
+
+class Requester:
+    pass
+
+
+class LockTests(unittest.TestCase):
+
+    @parameterized.expand(['counting', 'exclusive'])
+    def test_is_available_empty(self, mode):
+        req = Requester()
+        lock = BaseLock('test', maxCount=1)
+        access = mock.Mock(spec=LockAccess)
+        access.mode = mode
+
+        self.assertTrue(lock.isAvailable(req, access))
+
+    @parameterized.expand(['counting', 'exclusive'])
+    def test_is_available_without_waiter(self, mode):
+        req = Requester()
+        req_waiter = Requester()
+
+        lock = BaseLock('test', maxCount=1)
+        access = mock.Mock(spec=LockAccess)
+        access.mode = mode
+
+        lock.claim(req, access)
+        lock.release(req, access)
+        self.assertTrue(lock.isAvailable(req, access))
+        self.assertTrue(lock.isAvailable(req_waiter, access))
+
+    @parameterized.expand(['counting', 'exclusive'])
+    def test_is_available_with_waiter(self, mode):
+        req = Requester()
+        req_waiter = Requester()
+
+        lock = BaseLock('test', maxCount=1)
+        access = mock.Mock(spec=LockAccess)
+        access.mode = mode
+
+        lock.claim(req, access)
+        lock.waitUntilMaybeAvailable(req_waiter, access)
+        lock.release(req, access)
+        self.assertFalse(lock.isAvailable(req, access))
+        self.assertTrue(lock.isAvailable(req_waiter, access))
+
+        lock.claim(req_waiter, access)
+        lock.release(req_waiter, access)
+        self.assertTrue(lock.isAvailable(req, access))
+        self.assertTrue(lock.isAvailable(req_waiter, access))
+
+    @parameterized.expand(['counting', 'exclusive'])
+    def test_is_available_with_multiple_waiters(self, mode):
+        req = Requester()
+        req_waiter1 = Requester()
+        req_waiter2 = Requester()
+
+        lock = BaseLock('test', maxCount=1)
+        access = mock.Mock(spec=LockAccess)
+        access.mode = mode
+
+        lock.claim(req, access)
+        lock.waitUntilMaybeAvailable(req_waiter1, access)
+        lock.waitUntilMaybeAvailable(req_waiter2, access)
+        lock.release(req, access)
+        self.assertFalse(lock.isAvailable(req, access))
+        self.assertTrue(lock.isAvailable(req_waiter1, access))
+        self.assertFalse(lock.isAvailable(req_waiter2, access))
+
+        lock.claim(req_waiter1, access)
+        lock.release(req_waiter1, access)
+        self.assertFalse(lock.isAvailable(req, access))
+        self.assertFalse(lock.isAvailable(req_waiter1, access))
+        self.assertTrue(lock.isAvailable(req_waiter2, access))
+
+        lock.claim(req_waiter2, access)
+        lock.release(req_waiter2, access)
+        self.assertTrue(lock.isAvailable(req, access))
+        self.assertTrue(lock.isAvailable(req_waiter1, access))
+        self.assertTrue(lock.isAvailable(req_waiter2, access))
+
+    def test_is_available_with_multiple_waiters_multiple_counting(self):
+        req1 = Requester()
+        req2 = Requester()
+        req_waiter1 = Requester()
+        req_waiter2 = Requester()
+        req_waiter3 = Requester()
+
+        lock = BaseLock('test', maxCount=2)
+        access = mock.Mock(spec=LockAccess)
+        access.mode = 'counting'
+
+        lock.claim(req1, access)
+        lock.claim(req2, access)
+        lock.waitUntilMaybeAvailable(req_waiter1, access)
+        lock.waitUntilMaybeAvailable(req_waiter2, access)
+        lock.waitUntilMaybeAvailable(req_waiter3, access)
+        lock.release(req1, access)
+        lock.release(req2, access)
+        self.assertFalse(lock.isAvailable(req1, access))
+        self.assertTrue(lock.isAvailable(req_waiter1, access))
+        self.assertTrue(lock.isAvailable(req_waiter2, access))
+        self.assertFalse(lock.isAvailable(req_waiter3, access))
+
+        lock.claim(req_waiter1, access)
+        lock.release(req_waiter1, access)
+        self.assertFalse(lock.isAvailable(req1, access))
+        self.assertFalse(lock.isAvailable(req_waiter1, access))
+        self.assertTrue(lock.isAvailable(req_waiter2, access))
+        self.assertTrue(lock.isAvailable(req_waiter3, access))
+
+        lock.claim(req_waiter2, access)
+        lock.release(req_waiter2, access)
+        self.assertTrue(lock.isAvailable(req1, access))
+        self.assertTrue(lock.isAvailable(req_waiter1, access))
+        self.assertTrue(lock.isAvailable(req_waiter2, access))
+        self.assertTrue(lock.isAvailable(req_waiter2, access))
+
+        lock.claim(req_waiter3, access)
+        lock.release(req_waiter3, access)
+        self.assertTrue(lock.isAvailable(req1, access))
+        self.assertTrue(lock.isAvailable(req_waiter1, access))
+        self.assertTrue(lock.isAvailable(req_waiter2, access))
+        self.assertTrue(lock.isAvailable(req_waiter2, access))
+
+    @parameterized.expand(['counting', 'exclusive'])
+    def test_stop_waiting_raises_after_release(self, mode):
+        req = Requester()
+        req_waiter = Requester()
+
+        lock = BaseLock('test', maxCount=1)
+        access = mock.Mock(spec=LockAccess)
+        access.mode = mode
+
+        lock.claim(req, access)
+        d = lock.waitUntilMaybeAvailable(req_waiter, access)
+        lock.release(req, access)
+        self.assertFalse(lock.isAvailable(req, access))
+        self.assertTrue(lock.isAvailable(req_waiter, access))
+
+        with self.assertRaises(AssertionError):
+            lock.stopWaitingUntilAvailable(req_waiter, access, d)
+
+        lock.claim(req_waiter, access)
+        lock.release(req_waiter, access)
+
+    @parameterized.expand(['counting', 'exclusive'])
+    def test_stop_waiting_removes_non_called_waiter(self, mode):
+        req = Requester()
+        req_waiter1 = Requester()
+        req_waiter2 = Requester()
+
+        lock = BaseLock('test', maxCount=1)
+        access = mock.Mock(spec=LockAccess)
+        access.mode = mode
+
+        lock.claim(req, access)
+        d1 = lock.waitUntilMaybeAvailable(req_waiter1, access)
+        d2 = lock.waitUntilMaybeAvailable(req_waiter2, access)
+        lock.release(req, access)
+        yield flushEventualQueue()
+
+        self.assertFalse(lock.isAvailable(req, access))
+        self.assertTrue(lock.isAvailable(req_waiter1, access))
+        self.assertFalse(lock.isAvailable(req_waiter2, access))
+        self.assertTrue(d1.called)
+
+        lock.stopWaitingUntilAvailable(req_waiter2, access, d2)
+        self.assertFalse(lock.isAvailable(req, access))
+        self.assertTrue(lock.isAvailable(req_waiter1, access))
+        self.assertFalse(lock.isAvailable(req_waiter2, access))
+
+        lock.claim(req_waiter1, access)
+        lock.release(req_waiter1, access)
+        self.assertTrue(lock.isAvailable(req, access))
+        self.assertTrue(lock.isAvailable(req_waiter1, access))
+        self.assertTrue(lock.isAvailable(req_waiter2, access))
+
+    @parameterized.expand([
+        ('counting', 'counting'),
+        ('counting', 'exclusive'),
+        ('exclusive', 'counting'),
+        ('exclusive', 'exclusive'),
+    ])
+    @defer.inlineCallbacks
+    def test_release_calls_waiters_in_fifo_order(self, mode1, mode2):
+        req = Requester()
+
+        req_waiters = [Requester() for _ in range(5)]
+
+        lock = BaseLock('test', maxCount=1)
+        access1 = mock.Mock(spec=LockAccess)
+        access1.mode = mode1
+        access2 = mock.Mock(spec=LockAccess)
+        access2.mode = mode2
+
+        accesses = [access1, access2, access1, access2, access1]
+        expected_called = [False] * 5
+
+        lock.claim(req, access1)
+        deferreds = [lock.waitUntilMaybeAvailable(req_waiter, access)
+                     for req_waiter, access in zip(req_waiters, accesses)]
+        self.assertEqual([d.called for d in deferreds], expected_called)
+
+        lock.release(req, access1)
+        yield flushEventualQueue()
+
+        expected_called[0] = True
+        self.assertEqual([d.called for d in deferreds], expected_called)
+
+        for i in range(4):
+            self.assertTrue(lock.isAvailable(req_waiters[i], accesses[i]))
+
+            lock.claim(req_waiters[i], accesses[i])
+            self.assertEqual([d.called for d in deferreds], expected_called)
+
+            lock.release(req_waiters[i], accesses[i])
+            yield flushEventualQueue()
+
+            expected_called[i + 1] = True
+            self.assertEqual([d.called for d in deferreds], expected_called)
+
+        lock.claim(req_waiters[4], accesses[4])
+        lock.release(req_waiters[4], accesses[4])
+
+    @defer.inlineCallbacks
+    def test_release_calls_multiple_waiters_on_release(self):
+        req = Requester()
+
+        req_waiters = [Requester() for _ in range(5)]
+
+        lock = BaseLock('test', maxCount=5)
+        access_counting = mock.Mock(spec=LockAccess)
+        access_counting.mode = 'counting'
+        access_excl = mock.Mock(spec=LockAccess)
+        access_excl.mode = 'exclusive'
+
+        lock.claim(req, access_excl)
+        deferreds = [lock.waitUntilMaybeAvailable(req_waiter, access_counting)
+                     for req_waiter in req_waiters]
+        self.assertEqual([d.called for d in deferreds], [False] * 5)
+
+        lock.release(req, access_excl)
+        yield flushEventualQueue()
+
+        self.assertEqual([d.called for d in deferreds], [True] * 5)

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -42,6 +42,7 @@ mock==2.0.0
 moto==1.3.7
 olefile==0.46
 packaging==19.0
+parameterized==0.7.0
 pathlib2==2.3.3
 pbr==5.1.2
 pep8==1.7.1


### PR DESCRIPTION
`BaseLock` traverses the list of owners every time it wants to know how many `exclusive` and `counting` accesses have been claimed. This is unnecessary, as we could just introduce two numbers to track that and modify them whenever entries are added or removed from the owners.

For tests, the PR adds parameterized library as a dependency which will allow to reduce code duplication in unit tests.

This PR also adds unit tests for `BaseLock` as they were completely missing before.

## Contributor Checklist:

* [x] I have updated the unit tests
