### PR TITLE
Feature/expand logs

### DIFF
--- a/master/buildbot/newsfragments/expand_logs.feature
+++ b/master/buildbot/newsfragments/expand_logs.feature
@@ -1,0 +1,1 @@
+Adding 'expand_logs' option for LogPreview related settings.

--- a/www/base/src/app/builders/builds/build.route.coffee
+++ b/www/base/src/app/builders/builds/build.route.coffee
@@ -27,4 +27,9 @@ class State extends Config
                 name:'maxlines'
                 caption:'Maximum number of lines to show'
                 default_value: 40
+            ,
+                type:'text'
+                name:'expand_logs'
+                caption:'Expand logs with these names (use ; as separator)'
+                default_value: 'summary'
             ]

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.coffee
@@ -12,7 +12,7 @@ class Buildsummary extends Directive('common')
         }
 
 class _buildsummary extends Controller('common')
-    constructor: ($scope, dataService, resultsService, buildersService, $urlMatcherFactory, $location, $interval, RESULTS) ->
+    constructor: ($scope, dataService, resultsService, buildersService, $urlMatcherFactory, $location, $interval, RESULTS, bbSettingsService) ->
         self = this
         # make resultsService utilities available in the template
         _.mixin($scope, resultsService)
@@ -28,6 +28,7 @@ class _buildsummary extends Controller('common')
             @now = moment().unix()
         , 1000
         $scope.$on("$destroy", -> $interval.cancel(stop))
+        $scope.settings = bbSettingsService.getSettingsGroup("LogPreview")
 
         NONE = 0
         ONLY_NOT_SUCCESS = 1
@@ -70,6 +71,9 @@ class _buildsummary extends Controller('common')
 
         @isSummaryLog = (log) -> 
             return log.name.toLowerCase() == "summary"
+
+        @expandByName = (log) ->
+            return log.num_lines > 0 && log.name.toLowerCase() in $scope.settings.expand_logs.value.toLowerCase().split(";")
 
         # Returns the logs, sorted with the "Summary" log first, if it exists in the step's list of logs
         @getLogs = (step) -> 

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -50,6 +50,6 @@
             buildrequestsummary(style="margin-left:30px;margin-top:8px",buildrequestid='buildsummary.getBuildRequestIDFromURL(url.url)')
         div.anim-stepdetails(ng-if="step.fulldisplay")
           logpreview(ng-repeat="log in buildsummary.getLogs(step)", log="log",
-                     fulldisplay="step.logs.length == 1 || buildsummary.isSummaryLog(log)",
+                     fulldisplay="step.logs.length == 1 || buildsummary.expandByName(log)",
                      builderid="buildsummary.build.builderid", buildnumber="buildsummary.build.number",
                      step="step")


### PR DESCRIPTION
Hi,
I have a little webUI patch to enable configuration of logs, that should be expanded (unless they are empty).
By default it expands "summary" logs, to honor the current behavior.

---
* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
