### PR TITLE
Add internal way to change maxCount for locks

### DIFF
--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -201,7 +201,11 @@ class RealMasterLock(BaseLock):
 
     def __init__(self, lockid):
         super().__init__(lockid.name, lockid.maxCount)
-        self.description = "<MasterLock(%s, %s)>" % (self.name, self.maxCount)
+        self._updateDescription()
+
+    def _updateDescription(self):
+        self.description = "<MasterLock({}, {})>".format(self.name,
+                                                         self.maxCount)
 
     def getLock(self, worker):
         return self
@@ -213,9 +217,7 @@ class RealWorkerLock:
         self.name = lockid.name
         self.maxCount = lockid.maxCount
         self.maxCountForWorker = lockid.maxCountForWorker
-        self.description = "<WorkerLock(%s, %s, %s)>" % (self.name,
-                                                         self.maxCount,
-                                                         self.maxCountForWorker)
+        self._updateDescription()
         self.locks = {}
 
     def __repr__(self):
@@ -227,11 +229,19 @@ class RealWorkerLock:
             maxCount = self.maxCountForWorker.get(workername,
                                                   self.maxCount)
             lock = self.locks[workername] = BaseLock(self.name, maxCount)
-            desc = "<WorkerLock(%s, %s)[%s] %d>" % (self.name, maxCount,
-                                                    workername, id(lock))
-            lock.description = desc
+            self._updateDescriptionForLock(lock, workername)
             self.locks[workername] = lock
         return self.locks[workername]
+
+    def _updateDescription(self):
+        self.description = \
+            "<WorkerLock({}, {}, {})>".format(self.name, self.maxCount,
+                                              self.maxCountForWorker)
+
+    def _updateDescriptionForLock(self, lock, workername):
+        lock.description = \
+            "<WorkerLock({}, {})[{}] {}>".format(lock.name, lock.maxCount,
+                                                 workername, id(lock))
 
 
 class LockAccess(util.ComparableMixin):

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -137,7 +137,12 @@ class BaseLock:
             debuglog("%s already released" % self)
             return
 
-        # who can we wake up?
+        self._tryWakeUp()
+
+        # notify any listeners
+        self.release_subs.deliver()
+
+    def _tryWakeUp(self):
         # After an exclusive access, we may need to wake up several waiting.
         # Break out of the loop when the first waiting client should not be
         # awakened.
@@ -160,9 +165,6 @@ class BaseLock:
             if d:
                 self.waiting[i] = (w_owner, w_access, None)
                 eventually(d.callback, self)
-
-        # notify any listeners
-        self.release_subs.deliver()
 
     def waitUntilMaybeAvailable(self, owner, access):
         """Fire when the lock *might* be available. The caller will need to

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -219,6 +219,11 @@ class RealMasterLock(BaseLock):
     def getLockForWorker(self, workername):
         return self
 
+    def updateFromLockId(self, lockid):
+        assert self.name == lockid.name
+        self.setMaxCount(lockid.maxCount)
+        self._updateDescription()
+
 
 class RealWorkerLock:
 
@@ -250,6 +255,19 @@ class RealWorkerLock:
         lock.description = \
             "<WorkerLock({}, {})[{}] {}>".format(lock.name, lock.maxCount,
                                                  workername, id(lock))
+
+    def updateFromLockId(self, lockid):
+        assert self.name == lockid.name
+
+        self.maxCount = lockid.maxCount
+        self.maxCountForWorker = lockid.maxCountForWorker
+
+        self._updateDescription()
+
+        for workername, lock in self.locks.items():
+            maxCount = self.maxCountForWorker.get(workername, self.maxCount)
+            lock.setMaxCount(maxCount)
+            self._updateDescriptionForLock(lock, workername)
 
 
 class LockAccess(util.ComparableMixin):

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -54,7 +54,9 @@ class BaseLock:
         self._claimed_excl = 0
 
         # current number of claimed counting locks (0 to self.maxCount), must
-        # match self.owners
+        # match self.owners. Note that self.maxCount is not a strict limit, the
+        # number of claimed counting locks may be higher than self.maxCount if
+        # it was lowered by
         self._claimed_counting = 0
 
         # subscriptions to this lock being released
@@ -63,6 +65,13 @@ class BaseLock:
 
     def __repr__(self):
         return self.description
+
+    def setMaxCount(self, count):
+        old_max_count = self.maxCount
+        self.maxCount = count
+
+        if count > old_max_count:
+            self._tryWakeUp()
 
     def isAvailable(self, requester, access):
         """ Return a boolean whether the lock is available for claiming """

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -216,7 +216,7 @@ class RealMasterLock(BaseLock):
         self.description = "<MasterLock({}, {})>".format(self.name,
                                                          self.maxCount)
 
-    def getLock(self, worker):
+    def getLockForWorker(self, workername):
         return self
 
 
@@ -232,8 +232,7 @@ class RealWorkerLock:
     def __repr__(self):
         return self.description
 
-    def getLock(self, worker):
-        workername = worker.workername
+    def getLockForWorker(self, workername):
         if workername not in self.locks:
             maxCount = self.maxCountForWorker.get(workername,
                                                   self.maxCount)

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -304,7 +304,8 @@ class Build(properties.PropertiesMixin):
         self.setupOwnProperties()
 
         # then narrow WorkerLocks down to the right worker
-        self.locks = [(l.getLock(workerforbuilder.worker), a)
+        self.locks = [(l.getLockForWorker(workerforbuilder.worker.workername),
+                       a)
                       for l, a in self.locks]
         metrics.MetricCountEvent.log('active_builds', 1)
 
@@ -408,7 +409,8 @@ class Build(properties.PropertiesMixin):
     @staticmethod
     def _canAcquireLocks(lockList, workerforbuilder):
         for lock, access in lockList:
-            worker_lock = lock.getLock(workerforbuilder.worker)
+            worker_lock = lock.getLockForWorker(
+                workerforbuilder.worker.workername)
             if not worker_lock.isAvailable(None, access):
                 return False
         return True

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -521,7 +521,8 @@ class BuildStep(results.ResultComputingConfigMixin,
                       for access in self.locks]
         # then narrow WorkerLocks down to the worker that this build is being
         # run on
-        self.locks = [(l.getLock(self.build.workerforbuilder.worker), la)
+        self.locks = [(l.getLockForWorker(self.build.workerforbuilder.worker),
+                       la)
                       for l, la in self.locks]
 
         for l, la in self.locks:

--- a/master/buildbot/test/unit/test_locks.py
+++ b/master/buildbot/test/unit/test_locks.py
@@ -22,6 +22,10 @@ from twisted.trial import unittest
 
 from buildbot.locks import BaseLock
 from buildbot.locks import LockAccess
+from buildbot.locks import MasterLock
+from buildbot.locks import RealMasterLock
+from buildbot.locks import RealWorkerLock
+from buildbot.locks import WorkerLock
 from buildbot.util.eventual import flushEventualQueue
 
 
@@ -29,7 +33,7 @@ class Requester:
     pass
 
 
-class LockTests(unittest.TestCase):
+class BaseLockTests(unittest.TestCase):
 
     @parameterized.expand(['counting', 'exclusive'])
     def test_is_available_empty(self, mode):
@@ -366,3 +370,118 @@ class LockTests(unittest.TestCase):
         yield flushEventualQueue()
 
         self.assertEqual([d.called for d in deferreds], [True] * 5)
+
+
+class RealLockTests(unittest.TestCase):
+
+    def test_master_lock_init_from_lockid(self):
+        lockid = MasterLock('lock1', maxCount=3)
+        lock = RealMasterLock(lockid)
+
+        self.assertEqual(lock.name, 'lock1')
+        self.assertEqual(lock.maxCount, 3)
+        self.assertEqual(lock.description, '<MasterLock(lock1, 3)>')
+
+    def test_master_lock_update_from_lockid(self):
+        lockid = MasterLock('lock1', maxCount=3)
+        lock = RealMasterLock(lockid)
+
+        lockid = MasterLock('lock1', maxCount=4)
+        lock.updateFromLockId(lockid)
+
+        self.assertEqual(lock.name, 'lock1')
+        self.assertEqual(lock.maxCount, 4)
+        self.assertEqual(lock.description, '<MasterLock(lock1, 4)>')
+
+        with self.assertRaises(AssertionError):
+            lockid = MasterLock('lock2', maxCount=4)
+            lock.updateFromLockId(lockid)
+
+    def test_worker_lock_init_from_lockid(self):
+        lockid = WorkerLock('lock1', maxCount=3)
+        lock = RealWorkerLock(lockid)
+
+        self.assertEqual(lock.name, 'lock1')
+        self.assertEqual(lock.maxCount, 3)
+        self.assertEqual(lock.description, '<WorkerLock(lock1, 3, {})>')
+
+        worker_lock = lock.getLockForWorker('worker1')
+        self.assertEqual(worker_lock.name, 'lock1')
+        self.assertEqual(worker_lock.maxCount, 3)
+        self.assertTrue(worker_lock.description.startswith(
+            '<WorkerLock(lock1, 3)[worker1]'))
+
+    def test_worker_lock_init_from_lockid_count_for_worker(self):
+        lockid = WorkerLock('lock1', maxCount=3,
+                            maxCountForWorker={'worker2': 5})
+        lock = RealWorkerLock(lockid)
+
+        self.assertEqual(lock.name, 'lock1')
+        self.assertEqual(lock.maxCount, 3)
+
+        worker_lock = lock.getLockForWorker('worker1')
+        self.assertEqual(worker_lock.maxCount, 3)
+        worker_lock = lock.getLockForWorker('worker2')
+        self.assertEqual(worker_lock.maxCount, 5)
+
+    def test_worker_lock_update_from_lockid(self):
+        lockid = WorkerLock('lock1', maxCount=3)
+        lock = RealWorkerLock(lockid)
+
+        worker_lock = lock.getLockForWorker('worker1')
+        self.assertEqual(worker_lock.maxCount, 3)
+
+        lockid = WorkerLock('lock1', maxCount=5)
+        lock.updateFromLockId(lockid)
+
+        self.assertEqual(lock.name, 'lock1')
+        self.assertEqual(lock.maxCount, 5)
+        self.assertEqual(lock.description, '<WorkerLock(lock1, 5, {})>')
+
+        self.assertEqual(worker_lock.name, 'lock1')
+        self.assertEqual(worker_lock.maxCount, 5)
+        self.assertTrue(worker_lock.description.startswith(
+            '<WorkerLock(lock1, 5)[worker1]'))
+
+        with self.assertRaises(AssertionError):
+            lockid = WorkerLock('lock2', maxCount=4)
+            lock.updateFromLockId(lockid)
+
+    @parameterized.expand([
+        (True, True, True),
+        (True, True, False),
+        (True, False, True),
+        (True, False, False),
+        (False, True, True),
+        (False, True, False),
+        (False, False, True),
+        (False, False, False),
+    ])
+    def test_worker_lock_update_from_lockid_count_for_worker(
+            self, acquire_before, worker_count_before, worker_count_after):
+
+        max_count_before = {}
+        if worker_count_before:
+            max_count_before = {'worker1': 5}
+        max_count_after = {}
+        if worker_count_after:
+            max_count_after = {'worker1': 7}
+
+        lockid = WorkerLock('lock1', maxCount=3,
+                            maxCountForWorker=max_count_before)
+        lock = RealWorkerLock(lockid)
+
+        if acquire_before:
+            worker_lock = lock.getLockForWorker('worker1')
+            self.assertEqual(worker_lock.maxCount,
+                             5 if worker_count_before else 3)
+
+        lockid = WorkerLock('lock1', maxCount=4,
+                            maxCountForWorker=max_count_after)
+        lock.updateFromLockId(lockid)
+
+        if not acquire_before:
+            worker_lock = lock.getLockForWorker('worker1')
+
+        self.assertEqual(worker_lock.maxCount,
+                         7 if worker_count_after else 4)

--- a/master/buildbot/test/unit/test_locks.py
+++ b/master/buildbot/test/unit/test_locks.py
@@ -139,14 +139,14 @@ class LockTests(unittest.TestCase):
         self.assertTrue(lock.isAvailable(req1, access))
         self.assertTrue(lock.isAvailable(req_waiter1, access))
         self.assertTrue(lock.isAvailable(req_waiter2, access))
-        self.assertTrue(lock.isAvailable(req_waiter2, access))
+        self.assertTrue(lock.isAvailable(req_waiter3, access))
 
         lock.claim(req_waiter3, access)
         lock.release(req_waiter3, access)
         self.assertTrue(lock.isAvailable(req1, access))
         self.assertTrue(lock.isAvailable(req_waiter1, access))
         self.assertTrue(lock.isAvailable(req_waiter2, access))
-        self.assertTrue(lock.isAvailable(req_waiter2, access))
+        self.assertTrue(lock.isAvailable(req_waiter3, access))
 
     @parameterized.expand(['counting', 'exclusive'])
     def test_stop_waiting_raises_after_release(self, mode):

--- a/master/buildbot/test/unit/test_locks.py
+++ b/master/buildbot/test/unit/test_locks.py
@@ -201,6 +201,23 @@ class LockTests(unittest.TestCase):
         self.assertTrue(lock.isAvailable(req_waiter1, access))
         self.assertTrue(lock.isAvailable(req_waiter2, access))
 
+    @parameterized.expand(['counting', 'exclusive'])
+    def test_can_release_non_waited_lock(self, mode):
+        req = Requester()
+        req_not_waited = Requester()
+
+        lock = BaseLock('test', maxCount=1)
+        access = mock.Mock(spec=LockAccess)
+        access.mode = mode
+
+        lock.release(req_not_waited, access)
+
+        lock.claim(req, access)
+        lock.release(req, access)
+        yield flushEventualQueue()
+
+        lock.release(req_not_waited, access)
+
     @parameterized.expand([
         ('counting', 'counting'),
         ('counting', 'exclusive'),

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -327,8 +327,10 @@ class TestBuild(unittest.TestCase):
         self.assertTrue(
             Build._canAcquireLocks(lock_list, workerforbuilder2))
 
-        worker_lock_1 = real_lock.getLock(workerforbuilder1.worker)
-        worker_lock_2 = real_lock.getLock(workerforbuilder2.worker)
+        worker_lock_1 = real_lock.getLockForWorker(
+            workerforbuilder1.worker.workername)
+        worker_lock_2 = real_lock.getLockForWorker(
+            workerforbuilder2.worker.workername)
 
         # then have workerforbuilder2 claim its lock:
         worker_lock_2.claim(workerforbuilder2, counting_access)
@@ -382,7 +384,7 @@ class TestBuild(unittest.TestCase):
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
         real_lock = b.builder.botmaster.getLockByID(lock) \
-            .getLock(self.workerforbuilder.worker)
+            .getLockForWorker(self.workerforbuilder.worker.workername)
 
         def claim(owner, access):
             claimCount[0] += 1
@@ -418,7 +420,8 @@ class TestBuild(unittest.TestCase):
 
         lock = WorkerLock('lock', 2)
         claimLog = []
-        realLock = self.master.botmaster.getLockByID(lock).getLock(self.worker)
+        realLock = self.master.botmaster.getLockByID(lock) \
+            .getLockForWorker(self.worker.workername)
 
         def claim(owner, access):
             claimLog.append(owner)
@@ -459,7 +462,7 @@ class TestBuild(unittest.TestCase):
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
         real_lock = b.builder.botmaster.getLockByID(lock) \
-            .getLock(self.workerforbuilder.worker)
+            .getLockForWorker(self.workerforbuilder.worker.workername)
 
         def claim(owner, access):
             claimCount[0] += 1
@@ -486,7 +489,7 @@ class TestBuild(unittest.TestCase):
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
         real_lock = b.builder.botmaster.getLockByID(lock) \
-            .getLock(self.workerforbuilder.worker)
+            .getLockForWorker(self.workerforbuilder.worker.workername)
         b.setLocks([lock_access])
 
         step = FakeBuildStep()
@@ -513,7 +516,7 @@ class TestBuild(unittest.TestCase):
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
         real_lock = b.builder.botmaster.getLockByID(lock) \
-            .getLock(self.workerforbuilder.worker)
+            .getLockForWorker(self.workerforbuilder.worker.workername)
         b.setLocks([lock_access])
 
         step = FakeBuildStep()
@@ -543,7 +546,7 @@ class TestBuild(unittest.TestCase):
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
         real_lock = b.builder.botmaster.getLockByID(lock) \
-            .getLock(self.workerforbuilder.worker)
+            .getLockForWorker(self.workerforbuilder.worker.workername)
 
         step = LoggingBuildStep(locks=[lock_access])
         b.setStepFactories([FakeStepFactory(step)])

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -154,7 +154,8 @@ class AbstractWorker(service.BuildbotService):
         # convert locks into their real form
         locks = [(self.botmaster.getLockFromLockAccess(a), a)
                  for a in self.access]
-        self.locks = [(l.getLock(self), la) for l, la in locks]
+        self.locks = [(l.getLockForWorker(self.workername), la)
+                      for l, la in locks]
         self.lock_subscriptions = [l.subscribeToReleases(self._lockReleased)
                                    for l, la in self.locks]
 


### PR DESCRIPTION
This PR adds an internal way to change maxCount of BaseLock. This will be required to fix broken locks during reconfig (identified in #4634).

## Contributor Checklist:

* [x] I have updated the unit tests

