### PR TITLE
bytes2unicode now handles all types correctly. #4636

### DIFF
--- a/master/buildbot/test/unit/test_util.py
+++ b/master/buildbot/test/unit/test_util.py
@@ -288,7 +288,7 @@ class Ascii2Unicode(unittest.TestCase):
         self.assertEqual(type(rv2), text_type)
         self.assertEqual((rv3, type(rv3)), ({}, type({})))
         self.assertEqual((rv4, type(rv4)), ([], type([])))
-        self.assertEqual((rv5, type(rv5)), (None,type(None)))
+        self.assertEqual((rv5, type(rv5)), (None, type(None)))
 
 
 class StringToBoolean(unittest.TestCase):

--- a/master/buildbot/test/unit/test_util.py
+++ b/master/buildbot/test/unit/test_util.py
@@ -280,9 +280,15 @@ class Ascii2Unicode(unittest.TestCase):
     def test_bytes2unicode(self):
         rv1 = util.bytes2unicode(b'abcd')
         rv2 = util.bytes2unicode('efgh')
+        rv3 = util.bytes2unicode({})
+        rv4 = util.bytes2unicode([])
+        rv5 = util.bytes2unicode(None)
 
         self.assertEqual(type(rv1), text_type)
         self.assertEqual(type(rv2), text_type)
+        self.assertEqual((rv3, type(rv3)), ({}, type({})))
+        self.assertEqual((rv4, type(rv4)), ([], type([])))
+        self.assertEqual((rv5, type(rv5)), (None,type(None)))
 
 
 class StringToBoolean(unittest.TestCase):

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -222,9 +222,9 @@ def unicode2bytes(x, encoding='utf-8', errors='strict'):
 
 
 def bytes2unicode(x, encoding='utf-8', errors='strict'):
-    if isinstance(x, (text_type, type(None))):
-        return x
-    return text_type(x, encoding, errors)
+    if isinstance(x, bytes):
+        return text_type(x, encoding, errors)
+    return x
 
 
 _hush_pyflakes = [json]


### PR DESCRIPTION
* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
