### PR TITLE
Don't allow extra claims on changed locks during reconfig

### DIFF
--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -41,7 +41,7 @@ class BaseLock:
 
     def __init__(self, name, maxCount=1):
         # Name of the lock
-        self.name = name
+        self.lockName = name
         # Current queue, tuples (waiter, LockAccess, deferred)
         self.waiting = []
         # Current owners, tuples (owner, LockAccess)
@@ -214,14 +214,14 @@ class RealMasterLock(BaseLock):
         self._updateDescription()
 
     def _updateDescription(self):
-        self.description = "<MasterLock({}, {})>".format(self.name,
+        self.description = "<MasterLock({}, {})>".format(self.lockName,
                                                          self.maxCount)
 
     def getLockForWorker(self, workername):
         return self
 
     def updateFromLockId(self, lockid, config_version):
-        assert self.name == lockid.name
+        assert self.lockName == lockid.name
         assert isinstance(config_version, int)
 
         self.config_version = config_version
@@ -232,7 +232,7 @@ class RealMasterLock(BaseLock):
 class RealWorkerLock:
 
     def __init__(self, lockid):
-        self.name = lockid.name
+        self.lockName = lockid.name
         self.maxCount = lockid.maxCount
         self.maxCountForWorker = lockid.maxCountForWorker
         self.config_version = 0
@@ -246,23 +246,23 @@ class RealWorkerLock:
         if workername not in self.locks:
             maxCount = self.maxCountForWorker.get(workername,
                                                   self.maxCount)
-            lock = self.locks[workername] = BaseLock(self.name, maxCount)
+            lock = self.locks[workername] = BaseLock(self.lockName, maxCount)
             self._updateDescriptionForLock(lock, workername)
             self.locks[workername] = lock
         return self.locks[workername]
 
     def _updateDescription(self):
         self.description = \
-            "<WorkerLock({}, {}, {})>".format(self.name, self.maxCount,
+            "<WorkerLock({}, {}, {})>".format(self.lockName, self.maxCount,
                                               self.maxCountForWorker)
 
     def _updateDescriptionForLock(self, lock, workername):
         lock.description = \
-            "<WorkerLock({}, {})[{}] {}>".format(lock.name, lock.maxCount,
+            "<WorkerLock({}, {})[{}] {}>".format(lock.lockName, lock.maxCount,
                                                  workername, id(lock))
 
     def updateFromLockId(self, lockid, config_version):
-        assert self.name == lockid.name
+        assert self.lockName == lockid.name
         assert isinstance(config_version, int)
 
         self.config_version = config_version

--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -210,6 +210,7 @@ class RealMasterLock(BaseLock):
 
     def __init__(self, lockid):
         super().__init__(lockid.name, lockid.maxCount)
+        self.config_version = 0
         self._updateDescription()
 
     def _updateDescription(self):
@@ -219,8 +220,11 @@ class RealMasterLock(BaseLock):
     def getLockForWorker(self, workername):
         return self
 
-    def updateFromLockId(self, lockid):
+    def updateFromLockId(self, lockid, config_version):
         assert self.name == lockid.name
+        assert isinstance(config_version, int)
+
+        self.config_version = config_version
         self.setMaxCount(lockid.maxCount)
         self._updateDescription()
 
@@ -231,6 +235,7 @@ class RealWorkerLock:
         self.name = lockid.name
         self.maxCount = lockid.maxCount
         self.maxCountForWorker = lockid.maxCountForWorker
+        self.config_version = 0
         self._updateDescription()
         self.locks = {}
 
@@ -256,8 +261,11 @@ class RealWorkerLock:
             "<WorkerLock({}, {})[{}] {}>".format(lock.name, lock.maxCount,
                                                  workername, id(lock))
 
-    def updateFromLockId(self, lockid):
+    def updateFromLockId(self, lockid, config_version):
         assert self.name == lockid.name
+        assert isinstance(config_version, int)
+
+        self.config_version = config_version
 
         self.maxCount = lockid.maxCount
         self.maxCountForWorker = lockid.maxCountForWorker

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -103,6 +103,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
         # configuration / reconfiguration handling
         self.config = config.MasterConfig()
+        self.config_version = 0  # increased by one on each reconfig
         self.reconfig_active = False
         self.reconfig_requested = False
         self.reconfig_notifier = None
@@ -389,6 +390,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
                 self.reactor, self.reactor.getThreadPool(),
                 self.config_loader.loadConfig)
             changes_made = True
+            self.config_version += 1
             self.config = new_config
 
             yield self.reconfigServiceWithBuildbotConfig(new_config)

--- a/master/buildbot/newsfragments/locks-reconfig-no-extra-claims.bugfix
+++ b/master/buildbot/newsfragments/locks-reconfig-no-extra-claims.bugfix
@@ -1,1 +1,1 @@
-Locks will no longer allow extra counting or exclusive claims to be taken if the `maxCount` parameter is changed and the master is reconfigured.
+Locks will no longer allow being acquired more times than the `maxCount` parameter if this parameter is changed during master reconfiguration.

--- a/master/buildbot/newsfragments/locks-reconfig-no-extra-claims.bugfix
+++ b/master/buildbot/newsfragments/locks-reconfig-no-extra-claims.bugfix
@@ -1,0 +1,1 @@
+Locks will no longer allow extra counting or exclusive claims to be taken if the `maxCount` parameter is changed and the master is reconfigured.

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -63,12 +63,12 @@ class BotLockTracker:
     def _getLockByIDForType(self, lockid, name_to_lock, config_version):
         if lockid.name not in name_to_lock:
             lock = lockid.lockClass(lockid)
-            name_to_lock[lockid.name] = (lock, config_version)
+            lock.updateFromLockId(lockid, config_version)
+            name_to_lock[lockid.name] = lock
         else:
-            lock, prev_config_version = name_to_lock[lockid.name]
-            if config_version > prev_config_version:
-                lock.updateFromLockId(lockid)
-                name_to_lock[lockid.name] = (lock, config_version)
+            lock = name_to_lock[lockid.name]
+            if config_version > lock.config_version:
+                lock.updateFromLockId(lockid, config_version)
         return lock
 
 

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -107,6 +107,9 @@ class Build(properties.PropertiesMixin):
         self._locks_released = False
         self._build_finished = False
 
+        # tracks the config version for locks
+        self.config_version = None
+
     def setBuilder(self, builder):
         """
         Set the given builder as our builder.
@@ -115,10 +118,12 @@ class Build(properties.PropertiesMixin):
         """
         self.builder = builder
         self.master = builder.master
+        self.config_version = builder.config_version
 
     def setLocks(self, lockList):
         # convert all locks into their real forms
-        self.locks = [(self.builder.botmaster.getLockFromLockAccess(access), access)
+        self.locks = [(self.builder.botmaster.getLockFromLockAccess(access, self.config_version),
+                       access)
                       for access in lockList]
 
     def setWorkerEnvironment(self, env):

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -120,11 +120,10 @@ class Build(properties.PropertiesMixin):
         self.master = builder.master
         self.config_version = builder.config_version
 
+    @defer.inlineCallbacks
     def setLocks(self, lockList):
-        # convert all locks into their real forms
-        self.locks = [(self.builder.botmaster.getLockFromLockAccess(access, self.config_version),
-                       access)
-                      for access in lockList]
+        self.locks = yield self.builder.botmaster.getLockFromLockAccesses(lockList,
+                                                                          self.config_version)
 
     def setWorkerEnvironment(self, env):
         # TODO: remove once we don't have anything depending on this method or attribute

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -78,6 +78,9 @@ class Builder(util_service.ReconfigurableServiceMixin,
         self.config = None
         self.builder_status = None
 
+        # Tracks config version for locks
+        self.config_version = None
+
     @defer.inlineCallbacks
     def reconfigServiceWithBuildbotConfig(self, new_config):
         # find this builder in the config
@@ -96,6 +99,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
                 description=builder_config.description)
 
         self.config = builder_config
+        self.config_version = self.master.config_version
 
         # allocate  builderid now, so that the builder is visible in the web
         # UI; without this, the builder wouldn't appear until it preformed a
@@ -295,7 +299,8 @@ class Builder(util_service.ReconfigurableServiceMixin,
             props = setupPropsIfNeeded(props)
             locks = yield props.render(locks)
 
-        locks = [(self.botmaster.getLockFromLockAccess(access), access)
+        locks = [(self.botmaster.getLockFromLockAccess(access, self.config_version),
+                  access)
                  for access in locks]
         if locks:
             can_start = Build._canAcquireLocks(locks, workerforbuilder)

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -299,9 +299,8 @@ class Builder(util_service.ReconfigurableServiceMixin,
             props = setupPropsIfNeeded(props)
             locks = yield props.render(locks)
 
-        locks = [(self.botmaster.getLockFromLockAccess(access, self.config_version),
-                  access)
-                 for access in locks]
+        locks = yield self.botmaster.getLockFromLockAccesses(locks, self.config_version)
+
         if locks:
             can_start = Build._canAcquireLocks(locks, workerforbuilder)
             if can_start is False:

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -515,7 +515,8 @@ class BuildStep(results.ResultComputingConfigMixin,
         self.locks = yield self.build.render(self.locks)
 
         # convert all locks into their real form
-        self.locks = [(self.build.builder.botmaster.getLockFromLockAccess(access), access)
+        self.locks = [(self.build.builder.botmaster.getLockFromLockAccess(
+                           access, self.build.config_version), access)
                       for access in self.locks]
         # then narrow WorkerLocks down to the worker that this build is being
         # run on

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -515,9 +515,9 @@ class BuildStep(results.ResultComputingConfigMixin,
         self.locks = yield self.build.render(self.locks)
 
         # convert all locks into their real form
-        self.locks = [(self.build.builder.botmaster.getLockFromLockAccess(
-                           access, self.build.config_version), access)
-                      for access in self.locks]
+        botmaster = self.build.builder.botmaster
+        self.locks = yield botmaster.getLockFromLockAccesses(self.locks, self.build.config_version)
+
         # then narrow WorkerLocks down to the worker that this build is being
         # run on
         self.locks = [(l.getLockForWorker(self.build.workerforbuilder.worker),

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -30,11 +30,11 @@ class FakeBotMaster(service.AsyncMultiService):
         self.buildsStartedForWorkers = []
         self.delayShutdown = False
 
-    def getLockByID(self, lockid):
-        return self.lock_tracker.getLockByID(lockid)
+    def getLockByID(self, lockid, config_version):
+        return self.lock_tracker.getLockByID(lockid, config_version)
 
-    def getLockFromLockAccess(self, access):
-        return self.getLockByID(access.lockid)
+    def getLockFromLockAccess(self, access, config_version):
+        return self.getLockByID(access.lockid, config_version)
 
     def getBuildersForWorker(self, workername):
         return self.builders.get(workername, [])

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -16,25 +16,18 @@
 
 from twisted.internet import defer
 
-from buildbot.process.botmaster import BotLockTracker
+from buildbot.process import botmaster
 from buildbot.util import service
 
 
-class FakeBotMaster(service.AsyncMultiService):
+class FakeBotMaster(service.AsyncMultiService, botmaster.LockRetrieverMixin):
 
     def __init__(self):
         super().__init__()
         self.setName("fake-botmaster")
-        self.lock_tracker = BotLockTracker()
         self.builders = {}  # dictionary mapping worker names to builders
         self.buildsStartedForWorkers = []
         self.delayShutdown = False
-
-    def getLockByID(self, lockid, config_version):
-        return self.lock_tracker.getLockByID(lockid, config_version)
-
-    def getLockFromLockAccess(self, access, config_version):
-        return self.getLockByID(access.lockid, config_version)
 
     def getBuildersForWorker(self, workername):
         return self.builders.get(workername, [])

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -91,6 +91,7 @@ class FakeBuild(properties.PropertiesMixin):
         self.build_status.properties = props
         self.properties = props
         self.master = None
+        self.config_version = 0
 
     def getSourceStamp(self, codebase):
         if codebase in self.sources:

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -189,6 +189,7 @@ class FakeMaster(service.MasterService):
         self.log_rotation = FakeLogRotation()
         self.db = mock.Mock()
         self.next_objectid = 0
+        self.config_version = 0
 
         def getObjectId(sched_name, class_name):
             k = (sched_name, class_name)

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -164,7 +164,10 @@ class RunSteps(unittest.TestCase, TestReactorMixin):
 
         self.builder = builder.Builder('test')
         self.builder._builderid = 80
+        self.builder.config_version = 0
         self.builder.master = self.master
+        self.builder.botmaster = mock.Mock()
+        self.builder.botmaster.getLockFromLockAccesses = lambda l, c: []
         yield self.builder.startService()
 
         self.factory = factory.BuildFactory()  # will have steps added later

--- a/master/buildbot/test/integration/test_locks.py
+++ b/master/buildbot/test/integration/test_locks.py
@@ -312,20 +312,19 @@ class TestReconfig(RunFakeMasterTestCase):
         return stepcontrollers, master, config_dict, lock, builder_ids
 
     @parameterized.expand([
-        (3, util.MasterLock, 'counting', 1, 2, 1, 3),
-        (3, util.WorkerLock, 'counting', 1, 2, 1, 3),
-        (3, util.MasterLock, 'counting', 2, 1, 2, 3),
-        (3, util.WorkerLock, 'counting', 2, 1, 2, 3),
-        (2, util.MasterLock, 'exclusive', 1, 2, 1, 2),
-        (2, util.WorkerLock, 'exclusive', 1, 2, 1, 2),
-        (2, util.MasterLock, 'exclusive', 2, 1, 1, 2),
-        (2, util.WorkerLock, 'exclusive', 2, 1, 1, 2),
+        (3, util.MasterLock, 'counting', 1, 2, 1, 2),
+        (3, util.WorkerLock, 'counting', 1, 2, 1, 2),
+        (3, util.MasterLock, 'counting', 2, 1, 2, 2),
+        (3, util.WorkerLock, 'counting', 2, 1, 2, 2),
+        (2, util.MasterLock, 'exclusive', 1, 2, 1, 1),
+        (2, util.WorkerLock, 'exclusive', 1, 2, 1, 1),
+        (2, util.MasterLock, 'exclusive', 2, 1, 1, 1),
+        (2, util.WorkerLock, 'exclusive', 2, 1, 1, 1),
     ])
     @defer.inlineCallbacks
     def test_changing_max_lock_count_does_not_break_builder_locks(
             self, builder_count, lock_cls, mode, max_count_before,
             max_count_after, allowed_builds_before, allowed_builds_after):
-        # TODO: the test currently demonstrates broken behavior
         '''
         Check that Buildbot does not allow extra claims on a claimed lock after
         a reconfig that changed the maxCount of that lock. Some Buildbot
@@ -360,25 +359,23 @@ class TestReconfig(RunFakeMasterTestCase):
             yield flushEventualQueue()
 
         builds = yield master.data.get(("builds",))
-        self.assertEqual(len(builds), allowed_builds_after)
-        for b in builds:
+        for b in builds[allowed_builds_after:]:
             self.assertEqual(b['results'], SUCCESS)
 
     @parameterized.expand([
-        (3, util.MasterLock, 'counting', 1, 2, 1, 3),
-        (3, util.WorkerLock, 'counting', 1, 2, 1, 3),
-        (3, util.MasterLock, 'counting', 2, 1, 2, 3),
-        (3, util.WorkerLock, 'counting', 2, 1, 2, 3),
-        (2, util.MasterLock, 'exclusive', 1, 2, 1, 2),
-        (2, util.WorkerLock, 'exclusive', 1, 2, 1, 2),
-        (2, util.MasterLock, 'exclusive', 2, 1, 1, 2),
-        (2, util.WorkerLock, 'exclusive', 2, 1, 1, 2),
+        (3, util.MasterLock, 'counting', 1, 2, 1, 2),
+        (3, util.WorkerLock, 'counting', 1, 2, 1, 2),
+        (3, util.MasterLock, 'counting', 2, 1, 2, 2),
+        (3, util.WorkerLock, 'counting', 2, 1, 2, 2),
+        (2, util.MasterLock, 'exclusive', 1, 2, 1, 1),
+        (2, util.WorkerLock, 'exclusive', 1, 2, 1, 1),
+        (2, util.MasterLock, 'exclusive', 2, 1, 1, 1),
+        (2, util.WorkerLock, 'exclusive', 2, 1, 1, 1),
     ])
     @defer.inlineCallbacks
     def test_changing_max_lock_count_does_not_break_step_locks(
             self, builder_count, lock_cls, mode, max_count_before,
             max_count_after, allowed_steps_before, allowed_steps_after):
-        # TODO: the test currently demonstrates broken behavior
         '''
         Check that Buildbot does not allow extra claims on a claimed lock after
         a reconfig that changed the maxCount of that lock. Some Buildbot

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1098,8 +1098,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
             return b
 
         def lock(name):
-            lock = mock.Mock(spec=locks.MasterLock)
-            lock.name = name
+            lock = locks.MasterLock(name)
             if bare_builder_lock:
                 return lock
             return locks.LockAccess(lock, "counting", _skipChecks=True)

--- a/master/buildbot/test/unit/test_locks.py
+++ b/master/buildbot/test/unit/test_locks.py
@@ -375,31 +375,28 @@ class BaseLockTests(unittest.TestCase):
 class RealLockTests(unittest.TestCase):
 
     def test_master_lock_init_from_lockid(self):
-        lockid = MasterLock('lock1', maxCount=3)
-        lock = RealMasterLock(lockid)
+        lock = RealMasterLock('lock1')
+        lock.updateFromLockId(MasterLock('lock1', maxCount=3), 0)
 
         self.assertEqual(lock.lockName, 'lock1')
         self.assertEqual(lock.maxCount, 3)
         self.assertEqual(lock.description, '<MasterLock(lock1, 3)>')
 
     def test_master_lock_update_from_lockid(self):
-        lockid = MasterLock('lock1', maxCount=3)
-        lock = RealMasterLock(lockid)
-
-        lockid = MasterLock('lock1', maxCount=4)
-        lock.updateFromLockId(lockid, 0)
+        lock = RealMasterLock('lock1')
+        lock.updateFromLockId(MasterLock('lock1', maxCount=3), 0)
+        lock.updateFromLockId(MasterLock('lock1', maxCount=4), 0)
 
         self.assertEqual(lock.lockName, 'lock1')
         self.assertEqual(lock.maxCount, 4)
         self.assertEqual(lock.description, '<MasterLock(lock1, 4)>')
 
         with self.assertRaises(AssertionError):
-            lockid = MasterLock('lock2', maxCount=4)
-            lock.updateFromLockId(lockid, 0)
+            lock.updateFromLockId(MasterLock('lock2', maxCount=4), 0)
 
     def test_worker_lock_init_from_lockid(self):
-        lockid = WorkerLock('lock1', maxCount=3)
-        lock = RealWorkerLock(lockid)
+        lock = RealWorkerLock('lock1')
+        lock.updateFromLockId(WorkerLock('lock1', maxCount=3), 0)
 
         self.assertEqual(lock.lockName, 'lock1')
         self.assertEqual(lock.maxCount, 3)
@@ -412,9 +409,9 @@ class RealLockTests(unittest.TestCase):
             '<WorkerLock(lock1, 3)[worker1]'))
 
     def test_worker_lock_init_from_lockid_count_for_worker(self):
-        lockid = WorkerLock('lock1', maxCount=3,
-                            maxCountForWorker={'worker2': 5})
-        lock = RealWorkerLock(lockid)
+        lock = RealWorkerLock('lock1')
+        lock.updateFromLockId(WorkerLock('lock1', maxCount=3,
+                                         maxCountForWorker={'worker2': 5}), 0)
 
         self.assertEqual(lock.lockName, 'lock1')
         self.assertEqual(lock.maxCount, 3)
@@ -425,14 +422,13 @@ class RealLockTests(unittest.TestCase):
         self.assertEqual(worker_lock.maxCount, 5)
 
     def test_worker_lock_update_from_lockid(self):
-        lockid = WorkerLock('lock1', maxCount=3)
-        lock = RealWorkerLock(lockid)
+        lock = RealWorkerLock('lock1')
+        lock.updateFromLockId(WorkerLock('lock1', maxCount=3), 0)
 
         worker_lock = lock.getLockForWorker('worker1')
         self.assertEqual(worker_lock.maxCount, 3)
 
-        lockid = WorkerLock('lock1', maxCount=5)
-        lock.updateFromLockId(lockid, 0)
+        lock.updateFromLockId(WorkerLock('lock1', maxCount=5), 0)
 
         self.assertEqual(lock.lockName, 'lock1')
         self.assertEqual(lock.maxCount, 5)
@@ -444,8 +440,7 @@ class RealLockTests(unittest.TestCase):
             '<WorkerLock(lock1, 5)[worker1]'))
 
         with self.assertRaises(AssertionError):
-            lockid = WorkerLock('lock2', maxCount=4)
-            lock.updateFromLockId(lockid, 0)
+            lock.updateFromLockId(WorkerLock('lock2', maxCount=4), 0)
 
     @parameterized.expand([
         (True, True, True),
@@ -467,9 +462,9 @@ class RealLockTests(unittest.TestCase):
         if worker_count_after:
             max_count_after = {'worker1': 7}
 
-        lockid = WorkerLock('lock1', maxCount=3,
-                            maxCountForWorker=max_count_before)
-        lock = RealWorkerLock(lockid)
+        lock = RealWorkerLock('lock1')
+        lock.updateFromLockId(WorkerLock('lock1', maxCount=3,
+                                         maxCountForWorker=max_count_before), 0)
 
         if acquire_before:
             worker_lock = lock.getLockForWorker('worker1')

--- a/master/buildbot/test/unit/test_locks.py
+++ b/master/buildbot/test/unit/test_locks.py
@@ -378,7 +378,7 @@ class RealLockTests(unittest.TestCase):
         lockid = MasterLock('lock1', maxCount=3)
         lock = RealMasterLock(lockid)
 
-        self.assertEqual(lock.name, 'lock1')
+        self.assertEqual(lock.lockName, 'lock1')
         self.assertEqual(lock.maxCount, 3)
         self.assertEqual(lock.description, '<MasterLock(lock1, 3)>')
 
@@ -389,7 +389,7 @@ class RealLockTests(unittest.TestCase):
         lockid = MasterLock('lock1', maxCount=4)
         lock.updateFromLockId(lockid, 0)
 
-        self.assertEqual(lock.name, 'lock1')
+        self.assertEqual(lock.lockName, 'lock1')
         self.assertEqual(lock.maxCount, 4)
         self.assertEqual(lock.description, '<MasterLock(lock1, 4)>')
 
@@ -401,12 +401,12 @@ class RealLockTests(unittest.TestCase):
         lockid = WorkerLock('lock1', maxCount=3)
         lock = RealWorkerLock(lockid)
 
-        self.assertEqual(lock.name, 'lock1')
+        self.assertEqual(lock.lockName, 'lock1')
         self.assertEqual(lock.maxCount, 3)
         self.assertEqual(lock.description, '<WorkerLock(lock1, 3, {})>')
 
         worker_lock = lock.getLockForWorker('worker1')
-        self.assertEqual(worker_lock.name, 'lock1')
+        self.assertEqual(worker_lock.lockName, 'lock1')
         self.assertEqual(worker_lock.maxCount, 3)
         self.assertTrue(worker_lock.description.startswith(
             '<WorkerLock(lock1, 3)[worker1]'))
@@ -416,7 +416,7 @@ class RealLockTests(unittest.TestCase):
                             maxCountForWorker={'worker2': 5})
         lock = RealWorkerLock(lockid)
 
-        self.assertEqual(lock.name, 'lock1')
+        self.assertEqual(lock.lockName, 'lock1')
         self.assertEqual(lock.maxCount, 3)
 
         worker_lock = lock.getLockForWorker('worker1')
@@ -434,11 +434,11 @@ class RealLockTests(unittest.TestCase):
         lockid = WorkerLock('lock1', maxCount=5)
         lock.updateFromLockId(lockid, 0)
 
-        self.assertEqual(lock.name, 'lock1')
+        self.assertEqual(lock.lockName, 'lock1')
         self.assertEqual(lock.maxCount, 5)
         self.assertEqual(lock.description, '<WorkerLock(lock1, 5, {})>')
 
-        self.assertEqual(worker_lock.name, 'lock1')
+        self.assertEqual(worker_lock.lockName, 'lock1')
         self.assertEqual(worker_lock.maxCount, 5)
         self.assertTrue(worker_lock.description.startswith(
             '<WorkerLock(lock1, 5)[worker1]'))

--- a/master/buildbot/test/unit/test_locks.py
+++ b/master/buildbot/test/unit/test_locks.py
@@ -387,7 +387,7 @@ class RealLockTests(unittest.TestCase):
         lock = RealMasterLock(lockid)
 
         lockid = MasterLock('lock1', maxCount=4)
-        lock.updateFromLockId(lockid)
+        lock.updateFromLockId(lockid, 0)
 
         self.assertEqual(lock.name, 'lock1')
         self.assertEqual(lock.maxCount, 4)
@@ -395,7 +395,7 @@ class RealLockTests(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             lockid = MasterLock('lock2', maxCount=4)
-            lock.updateFromLockId(lockid)
+            lock.updateFromLockId(lockid, 0)
 
     def test_worker_lock_init_from_lockid(self):
         lockid = WorkerLock('lock1', maxCount=3)
@@ -432,7 +432,7 @@ class RealLockTests(unittest.TestCase):
         self.assertEqual(worker_lock.maxCount, 3)
 
         lockid = WorkerLock('lock1', maxCount=5)
-        lock.updateFromLockId(lockid)
+        lock.updateFromLockId(lockid, 0)
 
         self.assertEqual(lock.name, 'lock1')
         self.assertEqual(lock.maxCount, 5)
@@ -445,7 +445,7 @@ class RealLockTests(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             lockid = WorkerLock('lock2', maxCount=4)
-            lock.updateFromLockId(lockid)
+            lock.updateFromLockId(lockid, 0)
 
     @parameterized.expand([
         (True, True, True),
@@ -478,7 +478,7 @@ class RealLockTests(unittest.TestCase):
 
         lockid = WorkerLock('lock1', maxCount=4,
                             maxCountForWorker=max_count_after)
-        lock.updateFromLockId(lockid)
+        lock.updateFromLockId(lockid, 0)
 
         if not acquire_before:
             worker_lock = lock.getLockForWorker('worker1')

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -111,6 +111,7 @@ class FakeBuilder:
         self.botmaster = master.botmaster
         self.builderid = 83
         self._builders = {}
+        self.config_version = 0
 
     def getBuilderId(self):
         return defer.succeed(self.builderid)
@@ -322,7 +323,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 
         lock = WorkerLock('lock')
         counting_access = lock.access('counting')
-        real_lock = b.builder.botmaster.getLockByID(lock)
+        real_lock = b.builder.botmaster.getLockByID(lock, 0)
 
         # no locks, so both these pass (call twice to verify there's no
         # state/memory)
@@ -392,7 +393,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         claimCount = [0]
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
-        real_lock = b.builder.botmaster.getLockByID(lock) \
+        real_lock = b.builder.botmaster.getLockByID(lock, 0) \
             .getLockForWorker(self.workerforbuilder.worker.workername)
 
         def claim(owner, access):
@@ -429,7 +430,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 
         lock = WorkerLock('lock', 2)
         claimLog = []
-        realLock = self.master.botmaster.getLockByID(lock) \
+        realLock = self.master.botmaster.getLockByID(lock, 0) \
             .getLockForWorker(self.worker.workername)
 
         def claim(owner, access):
@@ -470,7 +471,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         claimCount = [0]
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
-        real_lock = b.builder.botmaster.getLockByID(lock) \
+        real_lock = b.builder.botmaster.getLockByID(lock, 0) \
             .getLockForWorker(self.workerforbuilder.worker.workername)
 
         def claim(owner, access):
@@ -497,7 +498,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         lock = WorkerLock('lock')
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
-        real_lock = b.builder.botmaster.getLockByID(lock) \
+        real_lock = b.builder.botmaster.getLockByID(lock, 0) \
             .getLockForWorker(self.workerforbuilder.worker.workername)
         b.setLocks([lock_access])
 
@@ -524,7 +525,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         lock = WorkerLock('lock')
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
-        real_lock = b.builder.botmaster.getLockByID(lock) \
+        real_lock = b.builder.botmaster.getLockByID(lock, 0) \
             .getLockForWorker(self.workerforbuilder.worker.workername)
         b.setLocks([lock_access])
 
@@ -554,7 +555,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         lock = WorkerLock('lock')
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
-        real_lock = b.builder.botmaster.getLockByID(lock) \
+        real_lock = b.builder.botmaster.getLockByID(lock, 0) \
             .getLockForWorker(self.workerforbuilder.worker.workername)
 
         step = LoggingBuildStep(locks=[lock_access])

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -315,6 +315,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         self.assertIn('stop it', step1.interrupted)
         self.assertTrue(step2Started[0])
 
+    @defer.inlineCallbacks
     def testBuild_canAcquireLocks(self):
         b = self.build
 
@@ -323,7 +324,8 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 
         lock = WorkerLock('lock')
         counting_access = lock.access('counting')
-        real_lock = b.builder.botmaster.getLockByID(lock, 0)
+
+        real_lock = yield b.builder.botmaster.getLockByID(lock, 0)
 
         # no locks, so both these pass (call twice to verify there's no
         # state/memory)
@@ -386,6 +388,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
             [call('builddir', expected_path, 'Worker')],
             any_order=True)
 
+    @defer.inlineCallbacks
     def testBuildLocksAcquired(self):
         b = self.build
 
@@ -393,15 +396,16 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         claimCount = [0]
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
-        real_lock = b.builder.botmaster.getLockByID(lock, 0) \
-            .getLockForWorker(self.workerforbuilder.worker.workername)
+
+        real_workerlock = yield b.builder.botmaster.getLockByID(lock, 0)
+        real_lock = real_workerlock.getLockForWorker(self.workerforbuilder.worker.workername)
 
         def claim(owner, access):
             claimCount[0] += 1
             return real_lock.old_claim(owner, access)
         real_lock.old_claim = real_lock.claim
         real_lock.claim = claim
-        b.setLocks([lock_access])
+        yield b.setLocks([lock_access])
 
         step = FakeBuildStep()
         b.setStepFactories([FakeStepFactory(step)])
@@ -411,11 +415,11 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         self.assertEqual(b.results, SUCCESS)
         self.assertEqual(claimCount[0], 1)
 
+    @defer.inlineCallbacks
     def testBuildLocksOrder(self):
         """Test that locks are acquired in FIFO order; specifically that
         counting locks cannot jump ahead of exclusive locks"""
         eBuild = self.build
-
         cBuilder = FakeBuilder(self.master)
         cBuild = Build([self.request])
         cBuild.setBuilder(cBuilder)
@@ -430,8 +434,9 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 
         lock = WorkerLock('lock', 2)
         claimLog = []
-        realLock = self.master.botmaster.getLockByID(lock, 0) \
-            .getLockForWorker(self.worker.workername)
+
+        real_workerlock = yield self.master.botmaster.getLockByID(lock, 0)
+        realLock = real_workerlock.getLockForWorker(self.worker.workername)
 
         def claim(owner, access):
             claimLog.append(owner)
@@ -439,8 +444,8 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         realLock.oldClaim = realLock.claim
         realLock.claim = claim
 
-        eBuild.setLocks([lock.access('exclusive')])
-        cBuild.setLocks([lock.access('counting')])
+        yield eBuild.setLocks([lock.access('exclusive')])
+        yield cBuild.setLocks([lock.access('counting')])
 
         fakeBuild = Mock()
         fakeBuildAccess = lock.access('counting')
@@ -456,14 +461,12 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 
         realLock.release(fakeBuild, fakeBuildAccess)
 
-        def check(ign):
-            self.assertEqual(eBuild.results, SUCCESS)
-            self.assertEqual(cBuild.results, SUCCESS)
-            self.assertEqual(claimLog, [fakeBuild, eBuild, cBuild])
+        yield d
+        self.assertEqual(eBuild.results, SUCCESS)
+        self.assertEqual(cBuild.results, SUCCESS)
+        self.assertEqual(claimLog, [fakeBuild, eBuild, cBuild])
 
-        d.addCallback(check)
-        return d
-
+    @defer.inlineCallbacks
     def testBuildWaitingForLocks(self):
         b = self.build
 
@@ -471,15 +474,16 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         claimCount = [0]
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
-        real_lock = b.builder.botmaster.getLockByID(lock, 0) \
-            .getLockForWorker(self.workerforbuilder.worker.workername)
+
+        real_workerlock = yield b.builder.botmaster.getLockByID(lock, 0)
+        real_lock = real_workerlock.getLockForWorker(self.workerforbuilder.worker.workername)
 
         def claim(owner, access):
             claimCount[0] += 1
             return real_lock.old_claim(owner, access)
         real_lock.old_claim = real_lock.claim
         real_lock.claim = claim
-        b.setLocks([lock_access])
+        yield b.setLocks([lock_access])
 
         step = FakeBuildStep()
         b.setStepFactories([FakeStepFactory(step)])
@@ -492,15 +496,18 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         self.assertTrue(b.currentStep is None)
         self.assertTrue(b._acquiringLock is not None)
 
+    @defer.inlineCallbacks
     def testStopBuildWaitingForLocks(self):
         b = self.build
 
         lock = WorkerLock('lock')
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
-        real_lock = b.builder.botmaster.getLockByID(lock, 0) \
-            .getLockForWorker(self.workerforbuilder.worker.workername)
-        b.setLocks([lock_access])
+
+        real_workerlock = yield b.builder.botmaster.getLockByID(lock, 0)
+        real_lock = real_workerlock.getLockForWorker(self.workerforbuilder.worker.workername)
+
+        yield b.setLocks([lock_access])
 
         step = FakeBuildStep()
         step.alwaysRun = False
@@ -519,15 +526,18 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         self.assertTrue(b.currentStep is None)
         self.assertEqual(b.results, CANCELLED)
 
+    @defer.inlineCallbacks
     def testStopBuildWaitingForLocks_lostRemote(self):
         b = self.build
 
         lock = WorkerLock('lock')
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
-        real_lock = b.builder.botmaster.getLockByID(lock, 0) \
-            .getLockForWorker(self.workerforbuilder.worker.workername)
-        b.setLocks([lock_access])
+
+        real_workerlock = yield b.builder.botmaster.getLockByID(lock, 0)
+        real_lock = real_workerlock.getLockForWorker(self.workerforbuilder.worker.workername)
+
+        yield b.setLocks([lock_access])
 
         step = FakeBuildStep()
         step.alwaysRun = False
@@ -549,14 +559,16 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
             ["retry", "lost", "connection"])
         self.build.build_status.setResults.assert_called_with(RETRY)
 
+    @defer.inlineCallbacks
     def testStopBuildWaitingForStepLocks(self):
         b = self.build
 
         lock = WorkerLock('lock')
         lock_access = lock.access('counting')
         lock.access = lambda mode: lock_access
-        real_lock = b.builder.botmaster.getLockByID(lock, 0) \
-            .getLockForWorker(self.workerforbuilder.worker.workername)
+
+        real_workerlock = yield b.builder.botmaster.getLockByID(lock, 0)
+        real_lock = real_workerlock.getLockForWorker(self.workerforbuilder.worker.workername)
 
         step = LoggingBuildStep(locks=[lock_access])
         b.setStepFactories([FakeStepFactory(step)])

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -21,7 +21,6 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
-from buildbot import locks
 from buildbot.process import builder
 from buildbot.process import factory
 from buildbot.process.properties import Properties
@@ -279,8 +278,7 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
     def test_canStartBuild_cant_acquire_locks_but_no_locks(self):
         yield self.makeBuilder()
 
-        self.bldr.botmaster.getLockFromLockAccess = \
-            mock.Mock(return_value='dummy')
+        self.bldr.botmaster.getLockFromLockAccesses = mock.Mock(return_value=[])
 
         wfb = mock.Mock()
         wfb.worker = FakeWorker('worker')
@@ -295,12 +293,7 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
     def test_canStartBuild_with_locks(self):
         yield self.makeBuilder()
 
-        self.bldr.botmaster.getLockFromLockAccess = \
-            mock.Mock(return_value='dummy')
-
-        lock1 = mock.Mock(spec=locks.MasterLock)
-        lock1.name = "masterlock"
-        self.bldr.config.locks = [lock1]
+        self.bldr.botmaster.getLockFromLockAccesses = mock.Mock(return_value=[mock.Mock()])
 
         wfb = mock.Mock()
         wfb.worker = FakeWorker('worker')
@@ -315,26 +308,14 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
     def test_canStartBuild_with_renderable_locks(self):
         yield self.makeBuilder()
 
-        self.bldr.botmaster.getLockFromLockAccess = \
-            mock.Mock(return_value='dummy')
-
-        self.bldr.botmaster.getLockFromLockAccess = \
-            mock.Mock(return_value='dummy')
-
-        lock1 = mock.Mock(spec=locks.MasterLock)
-        lock1.name = "masterlock"
-
-        lock2 = mock.Mock(spec=locks.WorkerLock)
-        lock2.name = "workerlock"
+        self.bldr.botmaster.getLockFromLockAccesses = mock.Mock(return_value=[mock.Mock()])
 
         renderedLocks = [False]
 
         @renderer
         def rendered_locks(props):
             renderedLocks[0] = True
-            access1 = locks.LockAccess(lock1, 'counting')
-            access2 = locks.LockAccess(lock2, 'exclusive')
-            return [access1, access2]
+            return [mock.Mock()]
 
         self.bldr.config.locks = rendered_locks
 

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -157,11 +157,8 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     @defer.inlineCallbacks
     def test_renderableLocks(self):
-        lock1 = mock.Mock(spec=locks.MasterLock)
-        lock1.name = "masterlock"
-
-        lock2 = mock.Mock(spec=locks.WorkerLock)
-        lock2.name = "workerlock"
+        lock1 = locks.MasterLock("masterlock")
+        lock2 = locks.WorkerLock("workerlock")
 
         renderedLocks = [False]
 
@@ -195,11 +192,8 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
     @defer.inlineCallbacks
     def test_regularLocks(self):
-        lock1 = mock.Mock(spec=locks.MasterLock)
-        lock1.name = "masterlock"
-
-        lock2 = mock.Mock(spec=locks.WorkerLock)
-        lock2.name = "workerlock"
+        lock1 = locks.MasterLock("masterlock")
+        lock2 = locks.WorkerLock("workerlock")
 
         self.setupStep(self.FakeBuildStep(
             locks=[locks.LockAccess(lock1, 'counting'), locks.LockAccess(lock2, 'exclusive')]))
@@ -609,6 +603,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin,
         step = NewStyleStep()
         step.master = mock.Mock()
         step.build = mock.Mock()
+        step.build.builder.botmaster.getLockFromLockAccesses = mock.Mock(return_value=[])
         step.locks = []
         step.renderables = []
         step.build.render = defer.succeed

--- a/master/buildbot/test/unit/test_worker_base.py
+++ b/master/buildbot/test/unit/test_worker_base.py
@@ -118,15 +118,16 @@ class RealWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
         self.setUpTestReactor()
         self.wrk = ConcreteWorker('wrk', 'pa')
 
+    @defer.inlineCallbacks
     def callAttached(self):
         self.master = fakemaster.make_master(self, wantData=True)
-        self.master.workers.disownServiceParent()
+        yield self.master.workers.disownServiceParent()
         self.workers = bworkermanager.FakeWorkerManager()
-        self.workers.setServiceParent(self.master)
+        yield self.workers.setServiceParent(self.master)
         self.master.workers = self.workers
-        self.wrk.setServiceParent(self.master.workers)
+        yield self.wrk.setServiceParent(self.master.workers)
         self.conn = fakeprotocol.FakeConnection(self.master, self.wrk)
-        return self.wrk.attached(self.conn)
+        yield self.wrk.attached(self.conn)
 
 
 class FakeWorkerItfc(TestReactorMixin, unittest.TestCase,
@@ -144,14 +145,15 @@ class FakeWorkerItfc(TestReactorMixin, unittest.TestCase,
 
 class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.setUpLogging()
         self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
-        self.master.workers.disownServiceParent()
+        yield self.master.workers.disownServiceParent()
         self.workers = self.master.workers = bworkermanager.FakeWorkerManager()
-        self.workers.setServiceParent(self.master)
+        yield self.workers.setServiceParent(self.master)
 
     @defer.inlineCallbacks
     def createWorker(self, name='bot', password='pass', attached=False, configured=True, **kwargs):
@@ -438,7 +440,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         bsmanager = master.workers
         yield master.startService()
         bs = ConcreteWorker('bot', 'pass')
-        bs.setServiceParent(bsmanager)
+        yield bs.setServiceParent(bsmanager)
         self.assertEqual(bs.manager, bsmanager)
         self.assertEqual(bs.parent, bsmanager)
         self.assertEqual(bsmanager.master, master)
@@ -454,7 +456,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         yield master.startService()
         lock = locks.MasterLock('masterlock')
         bs = ConcreteWorker('bot', 'pass', locks=[lock.access("counting")])
-        bs.setServiceParent(bsmanager)
+        yield bs.setServiceParent(bsmanager)
 
     @defer.inlineCallbacks
     def test_setServiceParent_workerLocks(self):
@@ -466,7 +468,7 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         yield master.startService()
         lock = locks.WorkerLock('lock')
         bs = ConcreteWorker('bot', 'pass', locks=[lock.access("counting")])
-        bs.setServiceParent(bsmanager)
+        yield bs.setServiceParent(bsmanager)
 
     @defer.inlineCallbacks
     def test_startService_getWorkerInfo_empty(self):
@@ -648,31 +650,34 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
         self.assertEqual(worker._paused, False)
 
 
-class TestAbstractLatentWorker(TestReactorMixin, unittest.SynchronousTestCase):
+class TestAbstractLatentWorker(TestReactorMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
-        self.master.workers.disownServiceParent()
+        yield self.master.workers.disownServiceParent()
         self.workers = self.master.workers = bworkermanager.FakeWorkerManager()
-        self.workers.setServiceParent(self.master)
+        yield self.workers.setServiceParent(self.master)
 
+    @defer.inlineCallbacks
     def do_test_reconfigService(self, old, new, existingRegistration=True):
         old.parent = self.master
         if existingRegistration:
             old.registration = bworkermanager.FakeWorkerRegistration(old)
         old.missing_timer = mock.Mock(name='missing_timer')
-        self.successResultOf(old.startService())
+        yield old.startService()
 
-        self.successResultOf(old.reconfigServiceWithSibling(new))
+        yield old.reconfigServiceWithSibling(new)
 
+    @defer.inlineCallbacks
     def test_reconfigService(self):
         old = AbstractLatentWorker(
             "name", "password", build_wait_timeout=10)
         new = AbstractLatentWorker(
             "name", "password", build_wait_timeout=30)
 
-        self.do_test_reconfigService(old, new)
+        yield self.do_test_reconfigService(old, new)
 
         self.assertEqual(old.build_wait_timeout, 30)

--- a/master/buildbot/test/unit/test_worker_base.py
+++ b/master/buildbot/test/unit/test_worker_base.py
@@ -183,20 +183,22 @@ class TestAbstractWorker(logging.LoggingMixin, TestReactorMixin, unittest.TestCa
 
     @defer.inlineCallbacks
     def test_constructor_full(self):
-        lock1, lock2 = mock.Mock(name='lock1'), mock.Mock(name='lock2')
+        lock1, lock2 = locks.MasterLock('lock1'), locks.MasterLock('lock2')
+        access1, access2 = lock1.access('counting'), lock2.access('counting')
+
         bs = yield self.createWorker('bot', 'pass',
                             max_builds=2,
                             notify_on_missing=['me@me.com'],
                             missing_timeout=120,
                             properties={'a': 'b'},
-                            locks=[lock1, lock2])
+                            locks=[access1, access2])
         yield bs.startService()
 
         self.assertEqual(bs.max_builds, 2)
         self.assertEqual(bs.notify_on_missing, ['me@me.com'])
         self.assertEqual(bs.missing_timeout, 120)
         self.assertEqual(bs.properties.getProperty('a'), 'b')
-        self.assertEqual(bs.access, [lock1, lock2])
+        self.assertEqual(bs.access, [access1, access2])
 
     @defer.inlineCallbacks
     def test_constructor_notify_on_missing_not_list(self):

--- a/master/buildbot/test/unit/test_worker_libvirt.py
+++ b/master/buildbot/test/unit/test_worker_libvirt.py
@@ -179,7 +179,12 @@ class TestLibVirtWorker(unittest.TestCase):
     def setup_canStartBuild(self):
         bs = self.ConcreteWorker('b', 'p', self.conn, 'p', 'o')
         yield bs._find_existing_deferred
+
+        bs.parent = mock.Mock()
+        bs.config_version = 0
+        bs.parent.master.botmaster.getLockFromLockAccesses = mock.Mock(return_value=[])
         bs.updateLocks()
+
         return bs
 
     @defer.inlineCallbacks

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -162,7 +162,8 @@ class AbstractWorker(service.BuildbotService):
             s.unsubscribe()
 
         # convert locks into their real form
-        locks = [(self.botmaster.getLockFromLockAccess(a), a)
+        locks = [(self.botmaster.getLockFromLockAccess(a, self.config_version),
+                  a)
                  for a in self.access]
         self.locks = [(l.getLockForWorker(self.workername), la)
                       for l, la in locks]
@@ -236,6 +237,9 @@ class AbstractWorker(service.BuildbotService):
 
     @defer.inlineCallbacks
     def startService(self):
+        # tracks config version for locks
+        self.config_version = self.master.config_version
+
         self.updateLocks()
         self.workerid = yield self.master.data.updates.findWorkerId(
             self.name)
@@ -312,6 +316,8 @@ class AbstractWorker(service.BuildbotService):
             self.registration = yield self.master.workers.register(self)
         yield self.registration.update(self, self.master.config)
 
+        # tracks config version for locks
+        self.config_version = self.master.config_version
         self.updateLocks()
 
     @defer.inlineCallbacks

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -154,6 +154,7 @@ class AbstractWorker(service.BuildbotService):
             return None
         return self.master.botmaster
 
+    @defer.inlineCallbacks
     def updateLocks(self):
         """Convert the L{LockAccess} objects in C{self.locks} into real lock
         objects, while also maintaining the subscriptions to lock releases."""
@@ -162,9 +163,8 @@ class AbstractWorker(service.BuildbotService):
             s.unsubscribe()
 
         # convert locks into their real form
-        locks = [(self.botmaster.getLockFromLockAccess(a, self.config_version),
-                  a)
-                 for a in self.access]
+        locks = yield self.botmaster.getLockFromLockAccesses(self.access, self.config_version)
+
         self.locks = [(l.getLockForWorker(self.workername), la)
                       for l, la in locks]
         self.lock_subscriptions = [l.subscribeToReleases(self._lockReleased)


### PR DESCRIPTION
This PR fixes wrong behavior identified in #4634. Previously, it was possible to change `maxCount` parameter on a lock, reconfigure master and take two exclusive claims on the lock.

Also, locks are now tracked by name, this is a prerequisite for build request distributor improvements.

Finally, several worker tests have been fixed to wait on deferreds, as previously they didn't do that and any failures weren't being reported if tests were ran in multithreaded mode.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
