### PR TITLE
steps: Add GitTag buildstep

### DIFF
--- a/master/buildbot/newsfragments/gittag.feature
+++ b/master/buildbot/newsfragments/gittag.feature
@@ -1,0 +1,1 @@
+Added new :bb:step:`GitTag` step to perform git tag operation

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -17,8 +17,10 @@ from twisted.internet import defer
 from twisted.internet import error
 from twisted.trial import unittest
 
+from buildbot import config as bbconfig
 from buildbot.interfaces import WorkerTooOldError
 from buildbot.process import remotetransfer
+from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import RETRY
 from buildbot.process.results import SUCCESS
@@ -3634,3 +3636,118 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
         )
         self.expectOutcome(result=SUCCESS)
         return self.runStep()
+
+
+class TestGitTag(steps.BuildStepMixin, config.ConfigErrorsMixin,
+                 unittest.TestCase):
+    stepClass = git.GitTag
+
+    def setUp(self):
+        return self.setUpBuildStep()
+
+    def tearDown(self):
+        return self.tearDownBuildStep()
+
+    def test_tag_annotated(self):
+        messages = ['msg1', 'msg2']
+
+        self.setupStep(
+            self.stepClass(workdir='wkdir', tagName='myTag', annotated=True, messages=messages))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'tag', '-a', 'myTag', '-m', 'msg1', '-m', 'msg2'])
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
+    def test_tag_simple(self):
+        self.setupStep(
+            self.stepClass(workdir='wkdir',
+                           tagName='myTag'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'tag', 'myTag'])
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
+    def test_tag_force(self):
+        self.setupStep(
+            self.stepClass(workdir='wkdir',
+                           tagName='myTag', force=True))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'tag', 'myTag', '--force'])
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
+    def test_tag_fail_already_exist(self):
+        self.setupStep(
+            self.stepClass(workdir='wkdir',
+                           tagName='myTag'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'tag', 'myTag'])
+            + ExpectShell.log('stdio',
+                              stderr="fatal: tag \'%s\' already exist\n")
+            + 1
+        )
+        self.expectOutcome(result=FAILURE)
+        return self.runStep()
+
+    def test_config_annotated_no_messages(self):
+        with self.assertRaises(bbconfig.ConfigErrors):
+            self.setupStep(
+                self.stepClass(workdir='wkdir', tagName='myTag', annotated=True))
+
+    def test_config_no_tag_name(self):
+        with self.assertRaises(bbconfig.ConfigErrors):
+            self.setupStep(
+                self.stepClass(workdir='wkdir'))
+
+    def test_config_not_annotated_but_meessages(self):
+        with self.assertRaises(bbconfig.ConfigErrors):
+            self.setupStep(
+                self.stepClass(workdir='wkdir', tagName='myTag', messages=['msg']))
+
+    def test_config_annotated_message_not_list(self):
+        with self.assertRaises(bbconfig.ConfigErrors):
+            self.setupStep(
+                self.stepClass(workdir='wkdir', tagName='myTag', annotated=True, messages="msg"))
+
+    def test_raise_no_git(self):
+        @defer.inlineCallbacks
+        def _checkFeatureSupport(self):
+            yield
+            return False
+
+        step = self.stepClass(workdir='wdir', tagName='myTag')
+        self.patch(self.stepClass, "checkFeatureSupport", _checkFeatureSupport)
+        self.setupStep(step)
+        self.expectOutcome(result=EXCEPTION)
+        self.runStep()
+        self.flushLoggedErrors(WorkerTooOldError)

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -3637,6 +3637,20 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
         self.expectOutcome(result=SUCCESS)
         return self.runStep()
 
+    def test_raise_no_git(self):
+        @defer.inlineCallbacks
+        def _checkFeatureSupport(self):
+            yield
+            return False
+
+        url = 'ssh://github.com/test/test.git'
+        step = self.stepClass(workdir='wkdir', repourl=url, branch='testbranch')
+        self.patch(self.stepClass, "checkFeatureSupport", _checkFeatureSupport)
+        self.setupStep(step)
+        self.expectOutcome(result=EXCEPTION)
+        self.runStep()
+        self.flushLoggedErrors(WorkerTooOldError)
+
 
 class TestGitTag(steps.BuildStepMixin, config.ConfigErrorsMixin,
                  unittest.TestCase):

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -238,7 +238,7 @@ class GitStepMixin(GitMixin):
         return cmd.rc
 
     @defer.inlineCallbacks
-    def checkBranchSupport(self):
+    def checkFeatureSupport(self):
         stdout = yield self._dovccmd(['--version'], collectStdout=True)
 
         self.parseGitFeatures(stdout)

--- a/master/docs/manual/configuration/buildsteps.rst
+++ b/master/docs/manual/configuration/buildsteps.rst
@@ -1075,7 +1075,7 @@ Monotone step takes the following arguments:
 Other Source operations
 -----------------------
 
-Currently the only non-checkout step that is related to version control is ``GitPush``.
+Currently the only non-checkout steps that are related to version control are ``GitPush`` and ``GitTag``.
 
 .. bb:step:: GitPush
 
@@ -1131,6 +1131,50 @@ The GitPush step takes the following arguments:
     This may be either a :ref:`Secret` or just a string.
     ``sshPrivateKey`` must be specified in order to use this option.
     The host key must be in the form of ``<key type> <base64-encoded string>``, e.g. ``ssh-rsa AAAAB3N<...>FAaQ==``.
+
+.. bb:step:: GitTag
+
+GitTag
+++++++
+
+.. py:class:: buildbot.steps.source.git.GitTag
+
+The :bb:step:`GitTag` build step create a tag in your local `Git <http://git.or.cz/>`_ repository.
+
+The GitTag step takes the following arguments:
+
+``workdir``
+    (required) The path to the local repository to push commits from.
+
+``tagName``
+    (required) The name of the tag.
+
+``annotated``
+    (optional) If ``True``, create an annotated tag.
+
+``messages``
+    (optional) List of message that will be created with the annotated tag.
+    Must be set only if annotated parameter is ``True``.
+    Correspond to the ``-m`` flag of the ``git tag`` command.
+
+``force``
+    (optional) If ``True``, forces overwrite of tags on the local repository.
+    Corresponds to the ``--force`` flag of the ``git tag`` command.
+
+``logEnviron``
+    (optional) If this option is true (the default), then the step's logfile will describe the environment variables on the worker.
+    In situations where the environment is not relevant and is long, it may be easier to set ``logEnviron=False``.
+
+``env``
+    (optional) A dictionary of environment strings which will be added to the child command's environment.
+    The usual property interpolations can be used in environment variable names and values - see :ref:`Properties`.
+
+``timeout``
+    (optional) Specifies the timeout for worker-side operations, in seconds.
+    If your repositories are particularly large, then you may need to increase this  value from its default of 1200 (20 minutes).
+
+``config``
+    (optional) A dict of git configuration settings to pass to the remote git commands.
 
 .. bb:step:: ShellCommand
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -294,7 +294,7 @@ setup_args = {
             ('buildbot.steps.source.cvs', ['CVS']),
             ('buildbot.steps.source.darcs', ['Darcs']),
             ('buildbot.steps.source.gerrit', ['Gerrit']),
-            ('buildbot.steps.source.git', ['Git']),
+            ('buildbot.steps.source.git', ['Git', 'GitTag']),
             ('buildbot.steps.source.github', ['GitHub']),
             ('buildbot.steps.source.gitlab', ['GitLab']),
             ('buildbot.steps.source.mercurial', ['Mercurial']),


### PR DESCRIPTION
Add a buildstep to be able to tag a local Git repository.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
