### PR TITLE
Fix running tests from an installed copy

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -217,6 +217,8 @@ setup_args = {
         include("buildbot/spec/types", "*.raml"),
         include("buildbot/test/unit/test_templates_dir", "*.html"),
         include("buildbot/test/unit/test_templates_dir/plugin", "*.*"),
+        include("buildbot/test/integration/pki", "*.*"),
+        include("buildbot/test/integration/pki/ca", "*.*"),
     ] + include_statics("buildbot/www/static"),
     'cmdclass': {'install_data': install_data_twisted,
                  'sdist': our_sdist},


### PR DESCRIPTION
TLS certificates added in #4609 do not exist in an installed copy,
breaking some tests. Add missing entries to setup.py to fix them.
```
[ERROR]
Traceback (most recent call last):
  File "/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/test/integration/test_worker_comm.py", line 325, in test_tls_connect_disconnect
    yield self.addWorker()
  File "/usr/lib/python3.7/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/test/integration/test_worker_comm.py", line 242, in addWorker
    self.port = self.buildworker.registration.getPBPort()
  File "/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/worker/manager.py", line 54, in getPBPort
    return self.pbReg.getPort()
  File "/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/pbmanager.py", line 111, in getPort
    return disp.port.getHost().port
builtins.AttributeError: 'NoneType' object has no attribute 'getHost'

buildbot.test.integration.test_worker_comm.TestWorkerComm.test_tls_connect_disconnect
===============================================================================
[ERROR]
Traceback (most recent call last):
  File "/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/test/integration/test_worker_comm.py", line 215, in tearDown
    if self.buildworker and self.buildworker.detach_d:
builtins.AttributeError: 'MyWorker' object has no attribute 'detach_d'

buildbot.test.integration.test_worker_comm.TestWorkerComm.test_tls_connect_disconnect
===============================================================================
[ERROR]
Traceback (most recent call last):
  File "/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/util/service.py", line 102, in stopService
    yield defer.gatherResults(dl, consumeErrors=True)
twisted.internet.defer.FirstError: FirstError[#0, [Failure instance: Traceback: <class 'AssertionError'>:
/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/util/service.py:99:stopService
/usr/lib/python3.7/site-packages/twisted/internet/defer.py:151:maybeDeferred
/usr/lib/python3.7/site-packages/twisted/internet/defer.py:1613:unwindGenerator
/usr/lib/python3.7/site-packages/twisted/internet/defer.py:1529:_cancellableInlineCallbacks
--- <exception caught here> ---
/usr/lib/python3.7/site-packages/twisted/internet/defer.py:1418:_inlineCallbacks
/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/pbmanager.py:143:stopService
]]

buildbot.test.integration.test_worker_latent.Tests.test_build_stop_with_cancelled_during_substantiation
===============================================================================
[ERROR]
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
    result = g.send(result)
  File "/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/util/service.py", line 62, in setServiceParent
    yield self.parent.addService(self)
  File "/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/util/service.py", line 117, in addService
    return service.startService()
  File "/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/pbmanager.py", line 137, in startService
    self.port = strports.listen(self.portstr, self.serverFactory)
  File "/usr/lib/python3.7/site-packages/twisted/application/strports.py", line 65, in listen
    name, args, kw = endpoints._parseServer(description, factory)
  File "/usr/lib/python3.7/site-packages/twisted/internet/endpoints.py", line 1645, in _parseServer
    return (endpointType.upper(),) + parser(factory, *args[1:], **kw)
  File "/usr/lib/python3.7/site-packages/twisted/internet/endpoints.py", line 1376, in _parseSSL
    certPEM = FilePath(certKey).getContent()
  File "/usr/lib/python3.7/site-packages/twisted/python/filepath.py", line 294, in getContent
    with self.open() as fp:
  File "/usr/lib/python3.7/site-packages/twisted/python/filepath.py", line 1012, in open
    return open(self.path, mode + 'b')
builtins.FileNotFoundError: [Errno 2] No such file or directory: '/build/buildbot/src/tmp_install/usr/lib/python3.7/site-packages/buildbot/test/integration/pki/127.0.0.1.crt'

buildbot.test.integration.test_worker_latent.Tests.test_build_stop_with_cancelled_during_substantiation
```
## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
