### PR TITLE
Enable an incorrectly skipped test

### DIFF
--- a/master/buildbot/process/metrics.py
+++ b/master/buildbot/process/metrics.py
@@ -326,7 +326,7 @@ class AttachedWorkersWatcher:
 
 
 def _get_rss():
-    if sys.platform == 'linux2':
+    if sys.platform == 'linux':
         try:
             with open("/proc/%i/statm" % os.getpid()) as f:
                 return int(f.read().split()[1])

--- a/master/buildbot/test/unit/test_process_metrics.py
+++ b/master/buildbot/test/unit/test_process_metrics.py
@@ -169,8 +169,8 @@ class TestPeriodicChecks(TestMetricBase):
 
     def testGetRSS(self):
         self.assertTrue(metrics._get_rss() > 0)
-    if sys.platform != 'linux2':
-        testGetRSS.skip = "only available on linux2 platforms"
+    if sys.platform != 'linux':
+        testGetRSS.skip = "only available on linux platforms"
 
 
 class TestReconfig(TestMetricBase):


### PR DESCRIPTION
Since Python 3.3, sys.platform is 'linux' on Linux [1], so
TestPeriodicChecks.testGetRSS is skipped even on Linux.

[1] https://docs.python.org/3/library/sys.html#sys.platform

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
