### PR TITLE
Remove extraneous `import os` in buildbot_tac.tmpl.

### DIFF
--- a/master/buildbot/scripts/buildbot_tac.tmpl
+++ b/master/buildbot/scripts/buildbot_tac.tmpl
@@ -19,7 +19,6 @@ umask = None
 
 # if this is a relocatable tac file, get the directory containing the TAC
 if basedir == '.':
-    import os
     basedir = os.path.abspath(os.path.dirname(__file__))
 
 # note: this line is matched against to check that this is a buildmaster
@@ -39,4 +38,3 @@ m.setServiceParent(application)
 m.log_rotation.rotateLength = rotateLength
 m.log_rotation.maxRotatedFiles = maxRotatedFiles
 {%- endif %}
-


### PR DESCRIPTION
This is a very small change of removing an extraneous import in `Buildbot_tac.tmpl`.

The detail provided in this description are very minimal because there isn't much that happened here, but please do let me know if there is anything additional I should do.