### PR TITLE
Remove future from setup.py

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -13,9 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
-from future.utils import raise_with_traceback
-
 import re
+import sys
 
 from twisted.internet import defer
 from twisted.internet import error
@@ -406,7 +405,8 @@ class BuildStep(results.ResultComputingConfigMixin,
                     # python thinks it is actually workdir that is not existing.
                     # python will then swallow the attribute error and call
                     # __getattr__ from worker_transition
-                    raise raise_with_traceback(CallableAttributeError(e))
+                    _, _, traceback = sys.exc_info()
+                    raise CallableAttributeError(e).with_traceback(traceback)
                     # we re-raise the original exception by changing its type,
                     # but keeping its stacktrace
             else:

--- a/master/setup.py
+++ b/master/setup.py
@@ -465,8 +465,6 @@ setup_args['install_requires'] = [
     'Jinja2 >= 2.1',
     # required for tests, but Twisted requires this anyway
     'zope.interface >= 4.1.1',
-    # python-future required for py2/3 compatibility
-    'future',
     'sqlalchemy>=1.1.0',
     'sqlalchemy-migrate>=0.9',
     'python-dateutil>=1.5',


### PR DESCRIPTION
Remove unnecessary use of future.utils.raise_with_traceback.
Remove future from setup.py. 
