### PR TITLE
fix python3 incompatibilities in KubeInClusterConfigLoader

### DIFF
--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -21,7 +21,7 @@ import copy
 import os
 import sys
 import textwrap
-from io import BytesIO
+from io import StringIO
 from unittest.case import SkipTest
 
 import yaml
@@ -51,11 +51,11 @@ class MockFileBase:
     def tearDown(self):
         self.patcher.stop()
 
-    def mock_open(self, filename, mode=None):
+    def mock_open(self, filename, mode=None, encoding='UTF-8'):
         filename_type = os.path.basename(filename)
         file_value = self.file_mock_config[filename_type]
         mock_open = mock.Mock(
-            __enter__=mock.Mock(return_value=BytesIO(file_value)),
+            __enter__=mock.Mock(return_value=StringIO(file_value)),
             __exit__=mock.Mock())
         return mock_open
 
@@ -64,8 +64,8 @@ class KubeClientServiceTestClusterConfig(
         MockFileBase, config.ConfigErrorsMixin, unittest.SynchronousTestCase):
 
     file_mock_config = {
-        'token': 'BASE64_TOKEN'.encode('utf-8'),
-        'namespace': 'buildbot_namespace'.encode('utf-8')
+        'token': 'BASE64_TOKEN',
+        'namespace': 'buildbot_namespace'
     }
 
     def setUp(self):

--- a/master/buildbot/util/kubeclientservice.py
+++ b/master/buildbot/util/kubeclientservice.py
@@ -190,14 +190,13 @@ class KubeInClusterConfigLoader(KubeConfigLoaderBase):
         self.config['master_url'] = os.environ['KUBERNETES_PORT'].replace(
             'tcp', 'https')
         self.config['verify'] = self.kube_cert_file
-        with open(self.kube_token_file) as token_content:
-            token = token_content.read().decode('utf-8').strip()
+        with open(self.kube_token_file, encoding="utf-8") as token_content:
+            token = token_content.read().strip()
             self.config['headers'] = {
                 'Authorization': 'Bearer {0}'.format(token)
             }
-        with open(self.kube_namespace_file) as namespace_content:
-            self.config['namespace'] = namespace_content.read().decode(
-                'utf-8').strip()
+        with open(self.kube_namespace_file, encoding="utf-8") as namespace_content:
+            self.config['namespace'] = namespace_content.read().strip()
 
     def getConfig(self):
         return self.config


### PR DESCRIPTION
* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
