### PR TITLE
Flexible base dir in buildbot tac

### DIFF
--- a/master/docker/buildbot.tac
+++ b/master/docker/buildbot.tac
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from twisted.application import service
@@ -6,7 +7,8 @@ from twisted.python.log import ILogObserver
 
 from buildbot.master import BuildMaster
 
-basedir = '/var/lib/buildbot'
+basedir = os.environ.get("BUILDBOT_BASEDIR",
+    os.path.abspath(os.path.dirname(__file__)))
 configfile = 'master.cfg'
 
 # note: this line is matched against to check that this is a buildmaster

--- a/worker/docker/buildbot.tac
+++ b/worker/docker/buildbot.tac
@@ -9,7 +9,8 @@ from twisted.python.log import ILogObserver
 from buildbot_worker.bot import Worker
 
 # setup worker
-basedir = os.path.abspath(os.path.dirname(__file__))
+basedir = os.environ.get("BUILDBOT_BASEDIR",
+    os.path.abspath(os.path.dirname(__file__)))
 application = service.Application('buildbot-worker')
 
 


### PR DESCRIPTION
* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

This changes the docker's buildbot.tac to allow getting the base
dir from either the environment (BUILDBOT_BASEDIR), or to assume it is
the directory of the buildbot.tac file itself.
