### PR TITLE
Replace deprecated contextual_connect() with connect()

### DIFF
--- a/master/buildbot/db/pool.py
+++ b/master/buildbot/db/pool.py
@@ -176,7 +176,7 @@ class DBThreadPool:
             if with_engine:
                 arg = self.engine
             else:
-                arg = self.engine.contextual_connect()
+                arg = self.engine.connect()
             try:
                 try:
                     rv = callable(arg, *args, **kwargs)


### PR DESCRIPTION
See:
https://docs.sqlalchemy.org/en/latest/core/connections.html#sqlalchemy.engine.Connectable.contextual_connect

This method is emitting DeprecationWarnings in the unit tests.