### PR TITLE
Use fake reactor in the tests more

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1492,6 +1492,7 @@ unsubscription
 unsubsribed
 unsubstantiated
 untarring
+untracked
 upcall
 updatable
 updatebuilderlist

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -164,7 +164,8 @@ class FakeMaster(service.MasterService):
     - Non-caching implementation for C{self.caches}
     """
 
-    def __init__(self, master_id=fakedb.FakeBuildRequestsComponent.MASTER_ID):
+    def __init__(self, reactor,
+                 master_id=fakedb.FakeBuildRequestsComponent.MASTER_ID):
         super().__init__()
         self._master_id = master_id
         self.reactor = reactor
@@ -205,9 +206,9 @@ class FakeMaster(service.MasterService):
 # Leave this alias, in case we want to add more behavior later
 
 
-def make_master(wantMq=False, wantDb=False, wantData=False,
+def make_master(_reactor=reactor, wantMq=False, wantDb=False, wantData=False,
                 testcase=None, url=None, **kwargs):
-    master = FakeMaster(**kwargs)
+    master = FakeMaster(_reactor, **kwargs)
     if url:
         master.buildbotURL = url
     if wantData:

--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -24,7 +24,11 @@ from buildbot.test.fake import fakemaster
 
 
 def fakeMasterForHooks(testcase):
-    master = fakemaster.make_master(wantData=True, testcase=testcase)
+    # testcase must derive from TestReactorMixin and setUpTestReactor()
+    # must be called before calling this function.
+
+    master = fakemaster.make_master(testcase.reactor, wantData=True,
+                                    testcase=testcase)
     master.www = Mock()
     return master
 

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -33,6 +33,7 @@ from buildbot.steps import shell
 from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import fakeprotocol
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.worker.base import Worker
 
 
@@ -151,11 +152,12 @@ class OldPerlModuleTest(shell.Test):
         return results.SUCCESS
 
 
-class RunSteps(unittest.TestCase):
+class RunSteps(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.master = fakemaster.make_master(testcase=self,
+        self.setUpTestReactor()
+        self.master = fakemaster.make_master(self.reactor, testcase=self,
                                              wantData=True, wantMq=True, wantDb=True)
         self.master.db.insertTestData([
             fakedb.Builder(id=80, name='test'), ])

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -69,7 +69,7 @@ class Www(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase):
         yield self.setUpRealDatabase(table_names=['masters', 'objects', 'object_state'],
                                      sqlite_memory=False)
 
-        master = fakemaster.FakeMaster()
+        master = fakemaster.FakeMaster(reactor)
 
         master.config.db = dict(db_url=self.db_url)
         master.db = dbconnector.DBConnector('basedir')

--- a/master/buildbot/test/unit/test_download_secret_to_worker.py
+++ b/master/buildbot/test/unit/test_download_secret_to_worker.py
@@ -28,11 +28,15 @@ from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestDownloadFileSecretToWorkerCommand(steps.BuildStepMixin, unittest.TestCase):
+class TestDownloadFileSecretToWorkerCommand(steps.BuildStepMixin,
+                                            TestReactorMixin,
+                                            unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
@@ -74,9 +78,12 @@ class TestDownloadFileSecretToWorkerCommand(steps.BuildStepMixin, unittest.TestC
         return d
 
 
-class TestRemoveWorkerFileSecretCommand30(steps.BuildStepMixin, unittest.TestCase):
+class TestRemoveWorkerFileSecretCommand30(steps.BuildStepMixin,
+                                          TestReactorMixin,
+                                          unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path
@@ -113,10 +120,13 @@ class TestRemoveWorkerFileSecretCommand30(steps.BuildStepMixin, unittest.TestCas
         return d
 
 
-class TestRemoveFileSecretToWorkerCommand(steps.BuildStepMixin, unittest.TestCase,
-                                          configmixin.ConfigErrorsMixin):
+class TestRemoveFileSecretToWorkerCommand(steps.BuildStepMixin,
+                                          configmixin.ConfigErrorsMixin,
+                                          TestReactorMixin,
+                                          unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         tempdir = FilePath(self.mktemp())
         tempdir.createDirectory()
         self.temp_path = tempdir.path

--- a/master/buildbot/test/unit/test_janitor_configurator.py
+++ b/master/buildbot/test/unit/test_janitor_configurator.py
@@ -32,6 +32,7 @@ from buildbot.schedulers.timed import Nightly
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import configurators
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import datetime2epoch
 from buildbot.worker.local import LocalWorker
 
@@ -53,10 +54,14 @@ class JanitorConfiguratorTests(configurators.ConfiguratorMixin, unittest.Synchro
         self.expectNoConfigError()
 
 
-class LogChunksJanitorTests(steps.BuildStepMixin, unittest.TestCase, configmixin.ConfigErrorsMixin):
+class LogChunksJanitorTests(steps.BuildStepMixin,
+                            configmixin.ConfigErrorsMixin,
+                            TestReactorMixin,
+                            unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
+        self.setUpTestReactor()
         yield self.setUpBuildStep()
         self.patch(janitor, "now", lambda: datetime.datetime(year=2017, month=1, day=1))
 

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -44,6 +44,7 @@ from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import config
 from buildbot.test.util import interfaces
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util.eventual import eventually
 
 
@@ -59,7 +60,9 @@ class NewStyleStep(buildstep.BuildStep):
         pass
 
 
-class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.TestCase):
+class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin,
+                    TestReactorMixin,
+                    unittest.TestCase):
 
     class FakeBuildStep(buildstep.BuildStep):
 
@@ -72,6 +75,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.Tes
             return SKIPPED
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -786,9 +790,11 @@ class InterfaceTests(interfaces.InterfaceTests):
 
 
 class TestFakeItfc(unittest.TestCase,
-                   steps.BuildStepMixin, InterfaceTests):
+                   steps.BuildStepMixin, TestReactorMixin,
+                   InterfaceTests):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setupStep(buildstep.BuildStep())
 
 
@@ -808,10 +814,12 @@ class CommandMixinExample(buildstep.CommandMixin, buildstep.BuildStep):
         return SUCCESS
 
 
-class TestCommandMixin(steps.BuildStepMixin, unittest.TestCase):
+class TestCommandMixin(steps.BuildStepMixin, TestReactorMixin,
+                       unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
+        self.setUpTestReactor()
         yield self.setUpBuildStep()
         self.step = CommandMixinExample()
         self.setupStep(self.step)
@@ -966,10 +974,12 @@ class SimpleShellCommand(buildstep.ShellMixin, buildstep.BuildStep):
 
 class TestShellMixin(steps.BuildStepMixin,
                      config.ConfigErrorsMixin,
+                     TestReactorMixin,
                      unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
+        self.setUpTestReactor()
         yield self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -25,15 +25,18 @@ from buildbot.process import properties
 from buildbot.schedulers import base
 from buildbot.test.fake import fakedb
 from buildbot.test.util import scheduler
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class BaseScheduler(scheduler.SchedulerMixin, unittest.TestCase):
+class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin,
+                    unittest.TestCase):
 
     OBJECTID = 19
     SCHEDULERID = 9
     exp_bsid_brids = (123, {'b': 456})
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_schedulers_basic.py
+++ b/master/buildbot/test/unit/test_schedulers_basic.py
@@ -23,6 +23,7 @@ from buildbot import config
 from buildbot.schedulers import basic
 from buildbot.test.fake import fakedb
 from buildbot.test.util import scheduler
+from buildbot.test.util.misc import TestReactorMixin
 
 
 class CommonStuffMixin:
@@ -69,7 +70,9 @@ class CommonStuffMixin:
 
 
 class BaseBasicScheduler(CommonStuffMixin,
-                         scheduler.SchedulerMixin, unittest.TestCase):
+                         scheduler.SchedulerMixin,
+                         TestReactorMixin,
+                         unittest.TestCase):
 
     OBJECTID = 244
     SCHEDULERID = 4
@@ -92,6 +95,7 @@ class BaseBasicScheduler(CommonStuffMixin,
             return self.master.db.schedulers.getChangeClassifications(schedulerid)
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def tearDown(self):
@@ -305,7 +309,9 @@ class BaseBasicScheduler(CommonStuffMixin,
 
 
 class SingleBranchScheduler(CommonStuffMixin,
-                            scheduler.SchedulerMixin, unittest.TestCase):
+                            scheduler.SchedulerMixin,
+                            TestReactorMixin,
+                            unittest.TestCase):
 
     SCHEDULERID = 245
     OBJECTID = 224455
@@ -350,6 +356,7 @@ class SingleBranchScheduler(CommonStuffMixin,
         return ch
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def tearDown(self):
@@ -471,12 +478,15 @@ class SingleBranchScheduler(CommonStuffMixin,
 
 
 class AnyBranchScheduler(CommonStuffMixin,
-                         scheduler.SchedulerMixin, unittest.TestCase):
+                         scheduler.SchedulerMixin,
+                         TestReactorMixin,
+                         unittest.TestCase):
 
     SCHEDULERID = 6
     OBJECTID = 246
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_schedulers_dependent.py
+++ b/master/buildbot/test/unit/test_schedulers_dependent.py
@@ -25,6 +25,7 @@ from buildbot.schedulers import base
 from buildbot.schedulers import dependent
 from buildbot.test.fake import fakedb
 from buildbot.test.util import scheduler
+from buildbot.test.util.misc import TestReactorMixin
 
 SUBMITTED_AT_TIME = 111111111
 COMPLETE_AT_TIME = 222222222
@@ -33,9 +34,10 @@ SCHEDULERID = 133
 UPSTREAM_NAME = 'uppy'
 
 
-class Dependent(scheduler.SchedulerMixin, unittest.TestCase):
+class Dependent(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -36,15 +36,18 @@ from buildbot.schedulers.forcesched import UserNameParameter
 from buildbot.schedulers.forcesched import oneCodebase
 from buildbot.test.util import scheduler
 from buildbot.test.util.config import ConfigErrorsMixin
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.TestCase):
+class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
+                         TestReactorMixin, unittest.TestCase):
 
     OBJECTID = 19
     SCHEDULERID = 9
     maxDiff = None
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_schedulers_timed_NightlyBase.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_NightlyBase.py
@@ -20,6 +20,7 @@ from twisted.trial import unittest
 
 from buildbot.schedulers import timed
 from buildbot.test.util import scheduler
+from buildbot.test.util.misc import TestReactorMixin
 
 try:
     from multiprocessing import Process
@@ -28,7 +29,8 @@ except ImportError:
     Process = None
 
 
-class NightlyBase(scheduler.SchedulerMixin, unittest.TestCase):
+class NightlyBase(scheduler.SchedulerMixin, TestReactorMixin,
+                  unittest.TestCase):
 
     """detailed getNextBuildTime tests"""
 
@@ -36,6 +38,7 @@ class NightlyBase(scheduler.SchedulerMixin, unittest.TestCase):
     SCHEDULERID = 33
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def makeScheduler(self, firstBuildDuration=0, **kwargs):

--- a/master/buildbot/test/unit/test_schedulers_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_NightlyTriggerable.py
@@ -22,9 +22,11 @@ from buildbot.process import properties
 from buildbot.schedulers import timed
 from buildbot.test.fake import fakedb
 from buildbot.test.util import scheduler
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
+class NightlyTriggerable(scheduler.SchedulerMixin, TestReactorMixin,
+                         unittest.TestCase):
 
     try:
         datetime.datetime.fromtimestamp(1)
@@ -47,6 +49,7 @@ class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
         return sched
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_schedulers_timed_Timed.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Timed.py
@@ -19,13 +19,15 @@ from twisted.trial import unittest
 
 from buildbot.schedulers import timed
 from buildbot.test.util import scheduler
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class Timed(scheduler.SchedulerMixin, unittest.TestCase):
+class Timed(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     OBJECTID = 928754
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -29,13 +29,15 @@ from twisted.trial import unittest
 from buildbot.schedulers import trysched
 from buildbot.test.util import dirs
 from buildbot.test.util import scheduler
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TryBase(scheduler.SchedulerMixin, unittest.TestCase):
+class TryBase(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
     OBJECTID = 26
     SCHEDULERID = 6
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def tearDown(self):
@@ -127,12 +129,13 @@ class JobdirService(dirs.DirsMixin, unittest.TestCase):
         svc.messageReceived('jobdata')
 
 
-class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
+class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     OBJECTID = 23
     SCHEDULERID = 3
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
         self.jobdir = None
 
@@ -678,12 +681,14 @@ class Try_Jobdir(scheduler.SchedulerMixin, unittest.TestCase):
         return self.assertFailure(d, AttributeError)
 
 
-class Try_Userpass_Perspective(scheduler.SchedulerMixin, unittest.TestCase):
+class Try_Userpass_Perspective(scheduler.SchedulerMixin, TestReactorMixin,
+                               unittest.TestCase):
 
     OBJECTID = 26
     SCHEDULERID = 6
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def tearDown(self):
@@ -790,12 +795,14 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, unittest.TestCase):
         self.assertEqual(buildernames, ['a', 'b'])
 
 
-class Try_Userpass(scheduler.SchedulerMixin, unittest.TestCase):
+class Try_Userpass(scheduler.SchedulerMixin, TestReactorMixin,
+                   unittest.TestCase):
 
     OBJECTID = 25
     SCHEDULERID = 5
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpScheduler()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_scripts_create_master.py
+++ b/master/buildbot/test/unit/test_scripts_create_master.py
@@ -26,6 +26,7 @@ from buildbot.scripts import create_master
 from buildbot.test.util import dirs
 from buildbot.test.util import misc
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 
 
 def mkconfig(**kwargs):
@@ -83,9 +84,11 @@ class TestCreateMaster(misc.StdoutAssertionsMixin, unittest.TestCase):
 
 
 class TestCreateMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
-                                misc.StdoutAssertionsMixin, unittest.TestCase):
+                                misc.StdoutAssertionsMixin, TestReactorMixin,
+                                unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpDirs('test')
         self.basedir = os.path.abspath(os.path.join('test', 'basedir'))
         self.setUpStdoutAssertions()

--- a/master/buildbot/test/unit/test_scripts_upgrade_master.py
+++ b/master/buildbot/test/unit/test_scripts_upgrade_master.py
@@ -31,6 +31,7 @@ from buildbot.scripts import upgrade_master
 from buildbot.test.util import dirs
 from buildbot.test.util import misc
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 
 
 def mkconfig(**kwargs):
@@ -106,9 +107,12 @@ class TestUpgradeMaster(dirs.DirsMixin, misc.StdoutAssertionsMixin,
 
 
 class TestUpgradeMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
-                                 misc.StdoutAssertionsMixin, unittest.TestCase):
+                                 misc.StdoutAssertionsMixin,
+                                 TestReactorMixin,
+                                 unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpDirs('test')
         self.basedir = os.path.abspath(os.path.join('test', 'basedir'))
         self.setUpStdoutAssertions()

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -31,15 +31,18 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake import fakestats
 from buildbot.test.util import logging
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestStatsServicesBase(unittest.TestCase):
+class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
 
     BUILDER_NAMES = ['builder1', 'builder2']
     BUILDER_IDS = [1, 2]
 
     def setUp(self):
-        self.master = fakemaster.make_master(testcase=self, wantMq=True,
+        self.setUpTestReactor()
+        self.master = fakemaster.make_master(self.reactor,
+                                             testcase=self, wantMq=True,
                                              wantData=True, wantDb=True)
 
         for builderid, name in zip(self.BUILDER_IDS, self.BUILDER_NAMES):

--- a/master/buildbot/test/unit/test_steps_cmake.py
+++ b/master/buildbot/test/unit/test_steps_cmake.py
@@ -13,19 +13,21 @@
 #
 # Copyright Buildbot Team Members
 
-from twisted.trial.unittest import TestCase
+from twisted.trial import unittest
 
 from buildbot.config import ConfigErrors
 from buildbot.process.properties import Property
 from buildbot.process.results import SUCCESS
 from buildbot.steps.cmake import CMake
 from buildbot.test.fake.remotecommand import ExpectShell
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.steps import BuildStepMixin
 
 
-class TestCMake(BuildStepMixin, TestCase):
+class TestCMake(BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_cppcheck.py
+++ b/master/buildbot/test/unit/test_steps_cppcheck.py
@@ -22,11 +22,13 @@ from buildbot.process.results import WARNINGS
 from buildbot.steps import cppcheck
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class Cppcheck(steps.BuildStepMixin, unittest.TestCase):
+class Cppcheck(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_http.py
+++ b/master/buildbot/test/unit/test_steps_http.py
@@ -24,6 +24,7 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.steps import http
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 try:
     import txrequests
@@ -49,11 +50,12 @@ class TestPage(Resource):
         return b"OK"
 
 
-class TestHTTPStep(steps.BuildStepMixin, unittest.TestCase):
+class TestHTTPStep(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     timeout = 3  # those tests should not run long
 
     def setUp(self):
+        self.setUpTestReactor()
         if txrequests is None:
             raise unittest.SkipTest(
                 "Need to install txrequests to test http steps")

--- a/master/buildbot/test/unit/test_steps_master.py
+++ b/master/buildbot/test/unit/test_steps_master.py
@@ -32,13 +32,16 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.steps import master
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 _COMSPEC_ENV = 'COMSPEC'
 
 
-class TestMasterShellCommand(steps.BuildStepMixin, unittest.TestCase):
+class TestMasterShellCommand(steps.BuildStepMixin, TestReactorMixin,
+                             unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         if runtime.platformType == 'win32':
             self.comspec = os.environ.get(_COMSPEC_ENV)
             os.environ[_COMSPEC_ENV] = r'C:\WINDOWS\system32\cmd.exe'
@@ -207,9 +210,11 @@ class TestMasterShellCommand(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestSetProperty(steps.BuildStepMixin, unittest.TestCase):
+class TestSetProperty(steps.BuildStepMixin, TestReactorMixin,
+                      unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -228,9 +233,11 @@ class TestSetProperty(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestLogRenderable(steps.BuildStepMixin, unittest.TestCase):
+class TestLogRenderable(steps.BuildStepMixin, TestReactorMixin,
+                        unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -249,9 +256,11 @@ class TestLogRenderable(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestsSetProperties(steps.BuildStepMixin, unittest.TestCase):
+class TestsSetProperties(steps.BuildStepMixin, TestReactorMixin,
+                         unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -280,9 +289,11 @@ class TestsSetProperties(steps.BuildStepMixin, unittest.TestCase):
         return self.doOneTest(properties=manipulate)
 
 
-class TestAssert(steps.BuildStepMixin, unittest.TestCase):
+class TestAssert(steps.BuildStepMixin, TestReactorMixin,
+                 unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_maxq.py
+++ b/master/buildbot/test/unit/test_steps_maxq.py
@@ -21,11 +21,14 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps import maxq
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase):
+class TestShellCommandExecution(steps.BuildStepMixin, TestReactorMixin,
+                                unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_mswin.py
+++ b/master/buildbot/test/unit/test_steps_mswin.py
@@ -25,15 +25,18 @@ from buildbot.process.results import Results
 from buildbot.steps import mswin
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestRobocopySimple(steps.BuildStepMixin, unittest.TestCase):
+class TestRobocopySimple(steps.BuildStepMixin, TestReactorMixin,
+                         unittest.TestCase):
 
     """
     Test L{Robocopy} command building.
     """
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_package_deb_lintian.py
+++ b/master/buildbot/test/unit/test_steps_package_deb_lintian.py
@@ -20,11 +20,14 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps.package.deb import lintian
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestDebLintian(steps.BuildStepMixin, unittest.TestCase):
+class TestDebLintian(steps.BuildStepMixin, TestReactorMixin,
+                     unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_package_deb_pbuilder.py
+++ b/master/buildbot/test/unit/test_steps_package_deb_pbuilder.py
@@ -25,11 +25,14 @@ from buildbot.steps.package.deb import pbuilder
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestDebPbuilder(steps.BuildStepMixin, unittest.TestCase):
+class TestDebPbuilder(steps.BuildStepMixin, TestReactorMixin,
+                      unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -244,9 +247,11 @@ class TestDebPbuilder(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestDebCowbuilder(steps.BuildStepMixin, unittest.TestCase):
+class TestDebCowbuilder(steps.BuildStepMixin, TestReactorMixin,
+                        unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -344,9 +349,11 @@ class TestDebCowbuilder(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestUbuPbuilder(steps.BuildStepMixin, unittest.TestCase):
+class TestUbuPbuilder(steps.BuildStepMixin, TestReactorMixin,
+                      unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -378,9 +385,11 @@ class TestUbuPbuilder(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestUbuCowbuilder(steps.BuildStepMixin, unittest.TestCase):
+class TestUbuCowbuilder(steps.BuildStepMixin, TestReactorMixin,
+                        unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_package_rpm_mock.py
+++ b/master/buildbot/test/unit/test_steps_package_rpm_mock.py
@@ -22,11 +22,13 @@ from buildbot.steps.package.rpm import mock
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestMock(steps.BuildStepMixin, unittest.TestCase):
+class TestMock(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -92,9 +94,11 @@ class TestMock(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestMockBuildSRPM(steps.BuildStepMixin, unittest.TestCase):
+class TestMockBuildSRPM(steps.BuildStepMixin, TestReactorMixin,
+                        unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -122,9 +126,11 @@ class TestMockBuildSRPM(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestMockRebuild(steps.BuildStepMixin, unittest.TestCase):
+class TestMockRebuild(steps.BuildStepMixin, TestReactorMixin,
+                      unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_package_rpm_rpmbuild.py
+++ b/master/buildbot/test/unit/test_steps_package_rpm_rpmbuild.py
@@ -24,11 +24,13 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps.package.rpm import rpmbuild
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class RpmBuild(steps.BuildStepMixin, unittest.TestCase):
+class RpmBuild(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_package_rpm_rpmlint.py
+++ b/master/buildbot/test/unit/test_steps_package_rpm_rpmlint.py
@@ -19,11 +19,13 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps.package.rpm import rpmlint
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestRpmLint(steps.BuildStepMixin, unittest.TestCase):
+class TestRpmLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_python.py
+++ b/master/buildbot/test/unit/test_steps_python.py
@@ -23,6 +23,7 @@ from buildbot.process.results import WARNINGS
 from buildbot.steps import python
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 log_output_success = '''\
 Making output directory...
@@ -110,9 +111,10 @@ Warning: Unable to extract the base list for
 '''
 
 
-class BuildEPYDoc(steps.BuildStepMixin, unittest.TestCase):
+class BuildEPYDoc(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -131,9 +133,10 @@ class BuildEPYDoc(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class PyLint(steps.BuildStepMixin, unittest.TestCase):
+class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -344,9 +347,10 @@ class PyLint(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class PyFlakes(steps.BuildStepMixin, unittest.TestCase):
+class PyFlakes(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -443,9 +447,10 @@ class PyFlakes(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestSphinx(steps.BuildStepMixin, unittest.TestCase):
+class TestSphinx(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_python_twisted.py
+++ b/master/buildbot/test/unit/test_steps_python_twisted.py
@@ -24,6 +24,7 @@ from buildbot.process.results import WARNINGS
 from buildbot.steps import python_twisted
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 failureLog = '''\
 buildbot.test.unit.test_steps_python_twisted.Trial.testProperties ... [FAILURE]
@@ -89,9 +90,10 @@ FAILED (failures=8)
 '''  # noqa: max-line-length
 
 
-class Trial(steps.BuildStepMixin, unittest.TestCase):
+class Trial(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -275,9 +277,10 @@ class Trial(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class HLint(steps.BuildStepMixin, unittest.TestCase):
+class HLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_renderable.py
+++ b/master/buildbot/test/unit/test_steps_renderable.py
@@ -19,6 +19,7 @@ from buildbot.process.buildstep import BuildStep
 from buildbot.process.properties import Interpolate
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestBuildStep(BuildStep):
@@ -27,9 +28,12 @@ class TestBuildStep(BuildStep):
         return 0
 
 
-class TestBuildStepNameIsRenderable(steps.BuildStepMixin, unittest.TestCase, configmixin.ConfigErrorsMixin):
+class TestBuildStepNameIsRenderable(steps.BuildStepMixin, unittest.TestCase,
+                                    TestReactorMixin,
+                                    configmixin.ConfigErrorsMixin):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -33,11 +33,16 @@ from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase, configmixin.ConfigErrorsMixin):
+class TestShellCommandExecution(steps.BuildStepMixin,
+                                configmixin.ConfigErrorsMixin,
+                                TestReactorMixin,
+                                unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -319,9 +324,10 @@ class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase, configm
             shell.ShellCommand()
 
 
-class TreeSize(steps.BuildStepMixin, unittest.TestCase):
+class TreeSize(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -365,9 +371,11 @@ class TreeSize(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class SetPropertyFromCommand(steps.BuildStepMixin, unittest.TestCase):
+class SetPropertyFromCommand(steps.BuildStepMixin, TestReactorMixin,
+                             unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -527,9 +535,10 @@ class SetPropertyFromCommand(steps.BuildStepMixin, unittest.TestCase):
             shell.SetPropertyFromCommand(command=["echo", "value"])
 
 
-class PerlModuleTest(steps.BuildStepMixin, unittest.TestCase):
+class PerlModuleTest(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -661,10 +670,13 @@ class Configure(unittest.TestCase):
         self.assertEqual(step.command, ['./configure'])
 
 
-class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase,
-                                  configmixin.ConfigErrorsMixin):
+class WarningCountingShellCommand(steps.BuildStepMixin,
+                                  configmixin.ConfigErrorsMixin,
+                                  TestReactorMixin,
+                                  unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -1008,9 +1020,10 @@ class WarningCountingShellCommand(steps.BuildStepMixin, unittest.TestCase,
             shell.WarningCountingShellCommand()
 
 
-class Compile(steps.BuildStepMixin, unittest.TestCase):
+class Compile(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -1028,9 +1041,12 @@ class Compile(steps.BuildStepMixin, unittest.TestCase):
         self.assertEqual(step.command, ["make", "all"])
 
 
-class Test(steps.BuildStepMixin, unittest.TestCase):
+class Test(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
+           TestReactorMixin,
+           unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_shellsequence.py
+++ b/master/buildbot/test/unit/test_steps_shellsequence.py
@@ -25,6 +25,7 @@ from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
 class DynamicRun(shellsequence.ShellSequence):
@@ -33,9 +34,11 @@ class DynamicRun(shellsequence.ShellSequence):
         return self.runShellSequence(self.dynamicCommands)
 
 
-class TestOneShellCommand(steps.BuildStepMixin, unittest.TestCase, configmixin.ConfigErrorsMixin):
+class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
+                          TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_source_base_Source.py
+++ b/master/buildbot/test/unit/test_steps_source_base_Source.py
@@ -20,11 +20,14 @@ from twisted.trial import unittest
 from buildbot.steps.source import Source
 from buildbot.test.util import sourcesteps
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestSource(sourcesteps.SourceStepMixin, unittest.SynchronousTestCase):
+class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin,
+                 unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -119,9 +122,11 @@ class TestSource(sourcesteps.SourceStepMixin, unittest.SynchronousTestCase):
         self.assertEqual(step.describe(True), ['update', 'suffix'])
 
 
-class TestSourceDescription(steps.BuildStepMixin, unittest.TestCase):
+class TestSourceDescription(steps.BuildStepMixin, TestReactorMixin,
+                            unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -154,9 +159,11 @@ class AttrGroup(Source):
         pass
 
 
-class TestSourceAttrGroup(sourcesteps.SourceStepMixin, unittest.TestCase):
+class TestSourceAttrGroup(sourcesteps.SourceStepMixin, TestReactorMixin,
+                          unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_source_bzr.py
+++ b/master/buildbot/test/unit/test_steps_source_bzr.py
@@ -29,11 +29,14 @@ from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import sourcesteps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestBzr(sourcesteps.SourceStepMixin, unittest.TestCase):
+class TestBzr(sourcesteps.SourceStepMixin, TestReactorMixin,
+              unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_source_cvs.py
+++ b/master/buildbot/test/unit/test_steps_source_cvs.py
@@ -27,6 +27,7 @@ from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import sourcesteps
+from buildbot.test.util.misc import TestReactorMixin
 
 
 def uploadString(cvsroot):
@@ -37,9 +38,11 @@ def uploadString(cvsroot):
     return behavior
 
 
-class TestCVS(sourcesteps.SourceStepMixin, unittest.TestCase):
+class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
+              unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_source_darcs.py
+++ b/master/buildbot/test/unit/test_steps_source_darcs.py
@@ -25,11 +25,14 @@ from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import sourcesteps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestDarcs(sourcesteps.SourceStepMixin, unittest.TestCase):
+class TestDarcs(sourcesteps.SourceStepMixin, TestReactorMixin,
+                unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_source_gerrit.py
+++ b/master/buildbot/test/unit/test_steps_source_gerrit.py
@@ -21,11 +21,14 @@ from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import config
 from buildbot.test.util import sourcesteps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.TestCase):
+class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
+                 TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -31,12 +31,18 @@ from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import config
 from buildbot.test.util import sourcesteps
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.TestCase):
+class TestGit(sourcesteps.SourceStepMixin,
+              config.ConfigErrorsMixin,
+              TestReactorMixin,
+              unittest.TestCase):
+
     stepClass = git.Git
 
     def setUp(self):
+        self.setUpTestReactor()
         self.sourceName = self.stepClass.__name__
         return self.setUpSourceStep()
 
@@ -3288,10 +3294,12 @@ class TestGit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.Te
 
 
 class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
+                  TestReactorMixin,
                   unittest.TestCase):
     stepClass = git.GitPush
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -3653,10 +3661,11 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
 
 
 class TestGitTag(steps.BuildStepMixin, config.ConfigErrorsMixin,
-                 unittest.TestCase):
+                 TestReactorMixin, unittest.TestCase):
     stepClass = git.GitTag
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_source_gitlab.py
+++ b/master/buildbot/test/unit/test_steps_source_gitlab.py
@@ -21,12 +21,16 @@ from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import config
 from buildbot.test.util import sourcesteps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestGitLab(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin, unittest.TestCase):
+class TestGitLab(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
+                 TestReactorMixin,
+                 unittest.TestCase):
     stepClass = gitlab.GitLab
 
     def setUp(self):
+        self.setUpTestReactor()
         self.sourceName = self.stepClass.__name__
         return self.setUpSourceStep()
 

--- a/master/buildbot/test/unit/test_steps_source_mercurial.py
+++ b/master/buildbot/test/unit/test_steps_source_mercurial.py
@@ -27,11 +27,14 @@ from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import sourcesteps
+from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestMercurial(sourcesteps.SourceStepMixin, unittest.TestCase):
+class TestMercurial(sourcesteps.SourceStepMixin, TestReactorMixin,
+                    unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_source_mtn.py
+++ b/master/buildbot/test/unit/test_steps_source_mtn.py
@@ -27,9 +27,11 @@ from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import config
 from buildbot.test.util import sourcesteps
+from buildbot.test.util.misc import TestReactorMixin
 
 
 class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
+                   TestReactorMixin,
                    unittest.TestCase):
 
     # Just some random revision id to test.
@@ -37,6 +39,7 @@ class TestMonotone(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
     MTN_VER = 'monotone 1.0 (base revision: UNKNOWN_REV)'
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_source_p4.py
+++ b/master/buildbot/test/unit/test_steps_source_p4.py
@@ -28,14 +28,16 @@ from buildbot.steps.source.p4 import P4
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import sourcesteps
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.properties import ConstantRenderable
 
 _is_windows = (platform.system() == 'Windows')
 
 
-class TestP4(sourcesteps.SourceStepMixin, unittest.TestCase):
+class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_source_repo.py
+++ b/master/buildbot/test/unit/test_steps_source_repo.py
@@ -23,6 +23,7 @@ from buildbot.steps.source import repo
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import sourcesteps
+from buildbot.test.util.misc import TestReactorMixin
 
 from .test_changes_gerritchangesource import TestGerritChangeSource
 
@@ -55,9 +56,11 @@ class RepoURL(unittest.TestCase):
             {'a': "repo download test/bla 564/12"}, ["test/bla 564/12"])
 
 
-class TestRepo(sourcesteps.SourceStepMixin, unittest.TestCase):
+class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
+               unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.shouldRetry = False
         self.logEnviron = True
         return self.setUpSourceStep()

--- a/master/buildbot/test/unit/test_steps_source_svn.py
+++ b/master/buildbot/test/unit/test_steps_source_svn.py
@@ -30,10 +30,11 @@ from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import sourcesteps
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.properties import ConstantRenderable
 
 
-class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
+class TestSVN(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
 
     svn_st_xml = """<?xml version="1.0"?>
         <status>
@@ -117,6 +118,7 @@ class TestSVN(sourcesteps.SourceStepMixin, unittest.TestCase):
                             </info>"""
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpSourceStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_subunit.py
+++ b/master/buildbot/test/unit/test_steps_subunit.py
@@ -25,6 +25,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.steps import subunit
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
 @implementer(interfaces.ILogObserver)
@@ -32,9 +33,11 @@ class StubLogObserver(mock.Mock):
     pass
 
 
-class TestSetPropertiesFromEnv(steps.BuildStepMixin, unittest.TestCase):
+class TestSetPropertiesFromEnv(steps.BuildStepMixin, TestReactorMixin,
+                               unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.logobserver = StubLogObserver()
         self.logobserver.failures = []
         self.logobserver.errors = []

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -37,6 +37,7 @@ from buildbot.steps import transfer
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 
@@ -90,9 +91,10 @@ class UploadError:
         raise RuntimeError('uh oh')
 
 
-class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
+class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         fd, self.destfile = tempfile.mkstemp()
         os.close(fd)
         os.unlink(self.destfile)
@@ -300,9 +302,11 @@ class TestFileUpload(steps.BuildStepMixin, unittest.TestCase):
             transfer.FileUpload('src')
 
 
-class TestDirectoryUpload(steps.BuildStepMixin, unittest.TestCase):
+class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
+                          unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.destdir = os.path.abspath('destdir')
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
@@ -408,9 +412,11 @@ class TestDirectoryUpload(steps.BuildStepMixin, unittest.TestCase):
             transfer.DirectoryUpload('src')
 
 
-class TestMultipleFileUpload(steps.BuildStepMixin, unittest.TestCase):
+class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
+                             unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.destdir = os.path.abspath('destdir')
         if os.path.exists(self.destdir):
             shutil.rmtree(self.destdir)
@@ -748,9 +754,11 @@ class TestMultipleFileUpload(steps.BuildStepMixin, unittest.TestCase):
             transfer.MultipleFileUpload(['srcfile'])
 
 
-class TestFileDownload(steps.BuildStepMixin, unittest.TestCase):
+class TestFileDownload(steps.BuildStepMixin, TestReactorMixin,
+                       unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         fd, self.destfile = tempfile.mkstemp()
         os.close(fd)
         os.unlink(self.destfile)
@@ -841,9 +849,11 @@ class TestFileDownload(steps.BuildStepMixin, unittest.TestCase):
             self.assertEqual(b''.join(read), contents)
 
 
-class TestStringDownload(steps.BuildStepMixin, unittest.TestCase):
+class TestStringDownload(steps.BuildStepMixin, TestReactorMixin,
+                         unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -939,9 +949,11 @@ class TestStringDownload(steps.BuildStepMixin, unittest.TestCase):
             transfer.StringDownload('srcfile')
 
 
-class TestJSONStringDownload(steps.BuildStepMixin, unittest.TestCase):
+class TestJSONStringDownload(steps.BuildStepMixin, TestReactorMixin,
+                             unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -33,6 +33,7 @@ from buildbot.steps import trigger
 from buildbot.test.fake import fakedb
 from buildbot.test.util import steps
 from buildbot.test.util.interfaces import InterfaceTests
+from buildbot.test.util.misc import TestReactorMixin
 
 
 @implementer(interfaces.ITriggerableScheduler)
@@ -96,9 +97,10 @@ def BRID_TO_BUILD_NUMBER(brid):
     return brid + 4000
 
 
-class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
+class TestTrigger(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_vstudio.py
+++ b/master/buildbot/test/unit/test_steps_vstudio.py
@@ -25,6 +25,7 @@ from buildbot.process.results import WARNINGS
 from buildbot.steps import vstudio
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 real_log = r"""
 1>------ Build started: Project: lib1, Configuration: debug Win32 ------
@@ -197,13 +198,14 @@ class VCx(vstudio.VisualStudio):
         return super().start()
 
 
-class VisualStudio(steps.BuildStepMixin, unittest.TestCase):
+class VisualStudio(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     """
     Test L{VisualStudio} with a simple subclass, L{VCx}.
     """
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -334,9 +336,10 @@ class VisualStudio(steps.BuildStepMixin, unittest.TestCase):
                 ['aa', 'bb', 'cc'])
 
 
-class TestVC6(steps.BuildStepMixin, unittest.TestCase):
+class TestVC6(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -434,9 +437,10 @@ class TestVC6(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestVC7(steps.BuildStepMixin, unittest.TestCase):
+class TestVC7(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -576,9 +580,11 @@ class VC8ExpectedEnvMixin:
         )
 
 
-class TestVC8(VC8ExpectedEnvMixin, steps.BuildStepMixin, unittest.TestCase):
+class TestVC8(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
+              unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -651,9 +657,11 @@ class TestVC8(VC8ExpectedEnvMixin, steps.BuildStepMixin, unittest.TestCase):
 
 
 class TestVCExpress9(VC8ExpectedEnvMixin, steps.BuildStepMixin,
+                     TestReactorMixin,
                      unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -708,9 +716,11 @@ class TestVCExpress9(VC8ExpectedEnvMixin, steps.BuildStepMixin,
         return self.runStep()
 
 
-class TestVC9(VC8ExpectedEnvMixin, steps.BuildStepMixin, unittest.TestCase):
+class TestVC9(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
+              unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -732,9 +742,11 @@ class TestVC9(VC8ExpectedEnvMixin, steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestVC10(VC8ExpectedEnvMixin, steps.BuildStepMixin, unittest.TestCase):
+class TestVC10(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
+               unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -756,9 +768,11 @@ class TestVC10(VC8ExpectedEnvMixin, steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestVC11(VC8ExpectedEnvMixin, steps.BuildStepMixin, unittest.TestCase):
+class TestVC11(VC8ExpectedEnvMixin, steps.BuildStepMixin, TestReactorMixin,
+               unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -780,9 +794,10 @@ class TestVC11(VC8ExpectedEnvMixin, steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestMsBuild(steps.BuildStepMixin, unittest.TestCase):
+class TestMsBuild(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_steps_worker.py
+++ b/master/buildbot/test/unit/test_steps_worker.py
@@ -29,6 +29,7 @@ from buildbot.steps import worker
 from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
 
 
 def uploadString(string):
@@ -39,9 +40,11 @@ def uploadString(string):
     return behavior
 
 
-class TestSetPropertiesFromEnv(steps.BuildStepMixin, unittest.TestCase):
+class TestSetPropertiesFromEnv(steps.BuildStepMixin, TestReactorMixin,
+                               unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -82,9 +85,11 @@ class TestSetPropertiesFromEnv(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestFileExists(steps.BuildStepMixin, unittest.TestCase):
+class TestFileExists(steps.BuildStepMixin, TestReactorMixin,
+                     unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -142,9 +147,11 @@ class TestFileExists(steps.BuildStepMixin, unittest.TestCase):
         self.flushLoggedErrors(WorkerTooOldError)
 
 
-class TestCopyDirectory(steps.BuildStepMixin, unittest.TestCase):
+class TestCopyDirectory(steps.BuildStepMixin, TestReactorMixin,
+                        unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -200,9 +207,11 @@ class TestCopyDirectory(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestRemoveDirectory(steps.BuildStepMixin, unittest.TestCase):
+class TestRemoveDirectory(steps.BuildStepMixin, TestReactorMixin,
+                          unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -240,9 +249,11 @@ class TestRemoveDirectory(steps.BuildStepMixin, unittest.TestCase):
         return self.runStep()
 
 
-class TestMakeDirectory(steps.BuildStepMixin, unittest.TestCase):
+class TestMakeDirectory(steps.BuildStepMixin, TestReactorMixin,
+                        unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):
@@ -297,9 +308,11 @@ class CompositeUser(buildstep.LoggingBuildStep, worker.CompositeStepMixin):
         self.finished(FAILURE if res else SUCCESS)
 
 
-class TestCompositeStepMixin(steps.BuildStepMixin, unittest.TestCase):
+class TestCompositeStepMixin(steps.BuildStepMixin, TestReactorMixin,
+                             unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         return self.setUpBuildStep()
 
     def tearDown(self):

--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 
 
-from twisted.internet import threads
 from twisted.trial import unittest
 
 from buildbot import config
@@ -42,11 +41,6 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
 
     def setUp(self):
         self.setUpTestReactor()
-
-        def deferToThread(f, *args, **kwargs):
-            return threads.deferToThreadPool(self.reactor, self.reactor.getThreadPool(),
-                                             f, *args, **kwargs)
-        self.patch(threads, 'deferToThread', deferToThread)
 
         self.build = Properties(
             image='busybox:latest', builder='docker_worker', distro='wheezy')

--- a/master/buildbot/test/unit/test_www_auth.py
+++ b/master/buildbot/test/unit/test_www_auth.py
@@ -26,6 +26,7 @@ from twisted.web.guard import HTTPAuthSessionWrapper
 from twisted.web.resource import IResource
 
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import auth
 
 
@@ -38,9 +39,11 @@ class AuthResourceMixin:
         self.auth.master = self.master
 
 
-class AuthRootResource(www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
+class AuthRootResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin,
+                       unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpAuthResource()
         self.rsrc = auth.AuthRootResource(self.master)
 
@@ -57,9 +60,10 @@ class AuthRootResource(www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
         self.assertIdentical(child, glr())
 
 
-class AuthBase(www.WwwTestMixin, unittest.TestCase):
+class AuthBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.auth = auth.AuthBase()
         self.master = self.make_master(url='h:/a/b/')
         self.auth.master = self.master
@@ -102,9 +106,10 @@ class NoAuth(unittest.TestCase):
         assert auth.NoAuth
 
 
-class RemoteUserAuth(www.WwwTestMixin, unittest.TestCase):
+class RemoteUserAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.auth = auth.RemoteUserAuth(header=b'HDR')
         self.make_master()
         self.request = self.make_request(b'/')
@@ -138,9 +143,10 @@ class RemoteUserAuth(www.WwwTestMixin, unittest.TestCase):
             self.fail("403 expected")
 
 
-class AuthRealm(www.WwwTestMixin, unittest.TestCase):
+class AuthRealm(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.auth = auth.RemoteUserAuth(header=b'HDR')
         self.auth = auth.NoAuth()
         self.make_master()
@@ -152,7 +158,11 @@ class AuthRealm(www.WwwTestMixin, unittest.TestCase):
         self.assertIsInstance(rsrc, auth.PreAuthenticatedLoginResource)
 
 
-class TwistedICredAuthBase(www.WwwTestMixin, unittest.TestCase):
+class TwistedICredAuthBase(TestReactorMixin, www.WwwTestMixin,
+                           unittest.TestCase):
+
+    def setUp(self):
+        self.setUpTestReactor()
 
     # twisted.web makes it difficult to simulate the authentication process, so
     # this only tests the mechanics of the getLoginResource method.
@@ -184,11 +194,14 @@ class UserPasswordAuth(www.WwwTestMixin, unittest.TestCase):
         self.assertEqual(self.auth.checkers[0].users, correct_login)
 
 
-class CustomAuth(www.WwwTestMixin, unittest.TestCase):
+class CustomAuth(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     class MockCustomAuth(auth.CustomAuth):
         def check_credentials(self, us, ps):
             return us == 'fellow' and ps == 'correct'
+
+    def setUp(self):
+        self.setUpTestReactor()
 
     @defer.inlineCallbacks
     def test_callable(self):
@@ -201,11 +214,15 @@ class CustomAuth(www.WwwTestMixin, unittest.TestCase):
         yield self.assertFailure(defer_bad, UnauthorizedLogin)
 
 
-class LoginResource(www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
+class LoginResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin,
+                    unittest.TestCase):
+
+    def setUp(self):
+        self.setUpTestReactor()
+        self.setUpAuthResource()
 
     @defer.inlineCallbacks
     def test_render(self):
-        self.setUpAuthResource()
         self.rsrc = auth.LoginResource(self.master)
         self.rsrc.renderLogin = mock.Mock(
             spec=self.rsrc.renderLogin, return_value=defer.succeed(b'hi'))
@@ -214,10 +231,11 @@ class LoginResource(www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
         self.rsrc.renderLogin.assert_called_with(mock.ANY)
 
 
-class PreAuthenticatedLoginResource(www.WwwTestMixin, AuthResourceMixin,
-                                    unittest.TestCase):
+class PreAuthenticatedLoginResource(TestReactorMixin, www.WwwTestMixin,
+                                    AuthResourceMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpAuthResource()
         self.rsrc = auth.PreAuthenticatedLoginResource(self.master, 'him')
 
@@ -240,9 +258,11 @@ class PreAuthenticatedLoginResource(www.WwwTestMixin, AuthResourceMixin,
                          {'email': 'him@org', 'username': 'him'})
 
 
-class LogoutResource(www.WwwTestMixin, AuthResourceMixin, unittest.TestCase):
+class LogoutResource(TestReactorMixin, www.WwwTestMixin, AuthResourceMixin,
+                     unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.setUpAuthResource()
         self.rsrc = auth.LogoutResource(self.master)
 

--- a/master/buildbot/test/unit/test_www_authz.py
+++ b/master/buildbot/test/unit/test_www_authz.py
@@ -18,6 +18,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake import fakedb
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import authz
 from buildbot.www.authz.endpointmatchers import AnyEndpointMatcher
 from buildbot.www.authz.endpointmatchers import BranchEndpointMatcher
@@ -31,9 +32,10 @@ from buildbot.www.authz.roles import RolesFromGroups
 from buildbot.www.authz.roles import RolesFromOwner
 
 
-class Authz(www.WwwTestMixin, unittest.TestCase):
+class Authz(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         authzcfg = authz.Authz(
             # simple matcher with '*' glob character
             stringsMatcher=authz.fnmatchStrMatcher,

--- a/master/buildbot/test/unit/test_www_avatar.py
+++ b/master/buildbot/test/unit/test_www_avatar.py
@@ -17,11 +17,15 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import auth
 from buildbot.www import avatar
 
 
-class AvatarResource(www.WwwTestMixin, unittest.TestCase):
+class AvatarResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.setUpTestReactor()
 
     @defer.inlineCallbacks
     def test_default(self):

--- a/master/buildbot/test/unit/test_www_config.py
+++ b/master/buildbot/test/unit/test_www_config.py
@@ -23,12 +23,16 @@ from twisted.python import util
 from twisted.trial import unittest
 
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.www import auth
 from buildbot.www import config
 
 
-class IndexResource(www.WwwTestMixin, unittest.TestCase):
+class IndexResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.setUpTestReactor()
 
     @defer.inlineCallbacks
     def test_render(self):

--- a/master/buildbot/test/unit/test_www_endpointmatchers.py
+++ b/master/buildbot/test/unit/test_www_endpointmatchers.py
@@ -20,12 +20,14 @@ from twisted.trial import unittest
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.test.fake import fakedb
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www.authz import endpointmatchers
 
 
-class EndpointBase(www.WwwTestMixin, unittest.TestCase):
+class EndpointBase(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.master = self.make_master(url='h:/a/b/')
         self.db = self.master.db
         self.matcher = self.makeMatcher()

--- a/master/buildbot/test/unit/test_www_hooks_base.py
+++ b/master/buildbot/test/unit/test_www_hooks_base.py
@@ -5,6 +5,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.www.change_hook import ChangeHookResource
 from buildbot.www.hooks.base import BaseHookHandler
@@ -37,8 +38,9 @@ def _prepare_request(payload, headers=None):
     return request
 
 
-class TestChangeHookConfiguredWithBase(unittest.TestCase):
+class TestChangeHookConfiguredWithBase(unittest.TestCase, TestReactorMixin):
     def setUp(self):
+        self.setUpTestReactor()
         self.changeHook = _prepare_base_change_hook(self)
 
     @defer.inlineCallbacks
@@ -96,8 +98,11 @@ class TestChangeHookConfiguredWithBase(unittest.TestCase):
         })
 
 
-class TestChangeHookConfiguredWithCustomBase(unittest.TestCase):
+class TestChangeHookConfiguredWithCustomBase(unittest.TestCase,
+                                             TestReactorMixin):
     def setUp(self):
+        self.setUpTestReactor()
+
         class CustomBase(BaseHookHandler):
             def getChanges(self, request):
                 args = request.args

--- a/master/buildbot/test/unit/test_www_hooks_bitbucket.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucket.py
@@ -19,6 +19,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import change_hook
 from buildbot.www.hooks.bitbucket import _HEADER_EVENT
 
@@ -133,12 +134,14 @@ mercurialJsonNoCommitsPayload = b"""{
 }"""
 
 
-class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase):
+class TestChangeHookConfiguredWithBitbucketChange(unittest.TestCase,
+                                                  TestReactorMixin):
 
     """Unit tests for BitBucket Change Hook
     """
 
     def setUp(self):
+        self.setUpTestReactor()
         self.change_hook = change_hook.ChangeHookResource(
             dialects={'bitbucket': True}, master=fakeMasterForHooks(self))
 

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketcloud.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketcloud.py
@@ -21,6 +21,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import unicode2bytes
 from buildbot.www import change_hook
 from buildbot.www.hooks.bitbucketcloud import _HEADER_EVENT
@@ -640,9 +641,11 @@ def _prepare_request(payload, headers=None, change_dict=None):
     return request
 
 
-class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
+class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
+                                            TestReactorMixin):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.change_hook = change_hook.ChangeHookResource(
             dialects={'bitbucketcloud': {}}, master=fakeMasterForHooks(self))
 

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
@@ -21,6 +21,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import unicode2bytes
 from buildbot.www import change_hook
 from buildbot.www.hooks.bitbucketserver import _HEADER_EVENT
@@ -660,9 +661,11 @@ def _prepare_request(payload, headers=None, change_dict=None):
     return request
 
 
-class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
+class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
+                                            TestReactorMixin):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.change_hook = change_hook.ChangeHookResource(
             dialects={'bitbucketserver': {}}, master=fakeMasterForHooks(self))
 

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -25,6 +25,7 @@ from twisted.trial import unittest
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import unicode2bytes
 from buildbot.www.change_hook import ChangeHookResource
 from buildbot.www.hooks.github import _HEADER_EVENT
@@ -561,10 +562,12 @@ def _prepare_request(event, payload, _secret=None, headers=None):
     return request
 
 
-class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
+class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
+                                            TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
+        self.setUpTestReactor()
         self.changeHook = _prepare_github_change_hook(
             self, strict=False, github_property_whitelist=["github.*"])
         self.master = self.changeHook.master
@@ -853,10 +856,12 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
                 gitJsonPayloadPullRequest)
 
 
-class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(unittest.TestCase):
+class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(
+        unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
+        self.setUpTestReactor()
         self.changeHook = _prepare_github_change_hook(
             self, strict=False, github_property_whitelist=["github.*"],
             pullrequest_ref="head")
@@ -883,10 +888,12 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(unittest.TestCas
         self.assertEqual(change["branch"], "refs/pull/50/head")
 
 
-class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase):
+class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase,
+                                              TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
+        self.setUpTestReactor()
         self.changeHook = _prepare_github_change_hook(
             self, strict=False, skips=[r'\[ *bb *skip *\]'])
         self.master = self.changeHook.master
@@ -962,10 +969,12 @@ class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase):
         self._check_pull_request_no_skip(gitJsonPayloadPullRequest)
 
 
-class TestChangeHookConfiguredWithAuth(unittest.TestCase):
+class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
+        self.setUpTestReactor()
+
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = _prepare_github_change_hook(
             self, strict=False, token=_token)
@@ -994,10 +1003,12 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase):
         self._check_pull_request(gitJsonPayloadPullRequest)
 
 
-class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase):
+class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase,
+                                                TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
+        self.setUpTestReactor()
         self.changeHook = _prepare_github_change_hook(
             self, strict=False, github_api_endpoint='https://black.magic.io')
         self.master = self.changeHook.master
@@ -1024,10 +1035,13 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase):
         self._check_pull_request(gitJsonPayloadPullRequest)
 
 
-class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase):
+class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase,
+                                                        TestReactorMixin):
 
     @defer.inlineCallbacks
     def setUp(self):
+        self.setUpTestReactor()
+
         _token = '7e076f41-b73a-4045-a817'
         self.changeHook = _prepare_github_change_hook(
             self, strict=False, github_api_endpoint='https://black.magic.io',
@@ -1057,11 +1071,12 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase):
         self._check_pull_request(gitJsonPayloadPullRequest)
 
 
-class TestChangeHookConfiguredWithStrict(unittest.TestCase):
+class TestChangeHookConfiguredWithStrict(unittest.TestCase, TestReactorMixin):
 
     _SECRET = 'somethingreallysecret'
 
     def setUp(self):
+        self.setUpTestReactor()
         self.changeHook = _prepare_github_change_hook(self, strict=True,
                                                       secret=self._SECRET)
 
@@ -1159,9 +1174,11 @@ class TestChangeHookConfiguredWithStrict(unittest.TestCase):
         self.assertEqual(self.request.written, expected)
 
 
-class TestChangeHookConfiguredWithCodebaseValue(unittest.TestCase):
+class TestChangeHookConfiguredWithCodebaseValue(unittest.TestCase,
+                                                TestReactorMixin):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.changeHook = _prepare_github_change_hook(self, codebase='foobar')
 
     @defer.inlineCallbacks
@@ -1183,9 +1200,11 @@ def _codebase_function(payload):
     return 'foobar-' + payload['repository']['name']
 
 
-class TestChangeHookConfiguredWithCodebaseFunction(unittest.TestCase):
+class TestChangeHookConfiguredWithCodebaseFunction(unittest.TestCase,
+                                                   TestReactorMixin):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.changeHook = _prepare_github_change_hook(
             self, codebase=_codebase_function)
 
@@ -1204,9 +1223,12 @@ class TestChangeHookConfiguredWithCodebaseFunction(unittest.TestCase):
         return self._check_git_with_change(gitJsonPayload)
 
 
-class TestChangeHookConfiguredWithCustomEventHandler(unittest.TestCase):
+class TestChangeHookConfiguredWithCustomEventHandler(unittest.TestCase,
+                                                     TestReactorMixin):
 
     def setUp(self):
+        self.setUpTestReactor()
+
         class CustomGitHubEventHandler(GitHubEventHandler):
             def handle_ping(self, _, __):
                 self.master.hook_called = True

--- a/master/buildbot/test/unit/test_www_hooks_gitlab.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitlab.py
@@ -23,6 +23,7 @@ from buildbot.secrets.manager import SecretManager
 from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import change_hook
 from buildbot.www.hooks.gitlab import _HEADER_EVENT
 from buildbot.www.hooks.gitlab import _HEADER_GITLAB_TOKEN
@@ -805,9 +806,11 @@ def FakeRequestMR(content):
     return request
 
 
-class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
+class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
+                                            TestReactorMixin):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.changeHook = change_hook.ChangeHookResource(
             dialects={'gitlab': True}, master=fakeMasterForHooks(self))
 
@@ -996,12 +999,12 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
         self.assertEqual(change["category"], "merge_request")
 
 
-class TestChangeHookConfiguredWithSecret(unittest.TestCase):
+class TestChangeHookConfiguredWithSecret(unittest.TestCase, TestReactorMixin):
 
     _SECRET = 'thesecret'
 
     def setUp(self):
-
+        self.setUpTestReactor()
         self.master = fakeMasterForHooks(self)
 
         fakeStorageService = FakeSecretStorage()

--- a/master/buildbot/test/unit/test_www_hooks_gitorious.py
+++ b/master/buildbot/test/unit/test_www_hooks_gitorious.py
@@ -19,6 +19,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import change_hook
 
 # Sample Gitorious commit payload
@@ -60,9 +61,11 @@ gitJsonPayload = b"""
 """
 
 
-class TestChangeHookConfiguredWithGitChange(unittest.TestCase):
+class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
+                                            TestReactorMixin):
 
     def setUp(self):
+        self.setUpTestReactor()
         dialects = {'gitorious': True}
         self.changeHook = change_hook.ChangeHookResource(
             dialects=dialects, master=fakeMasterForHooks(self))

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -32,6 +32,7 @@ from buildbot.secrets.manager import SecretManager
 from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.test.util import www
 from buildbot.test.util.config import ConfigErrorsMixin
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 
 try:
@@ -54,9 +55,11 @@ class FakeResponse:
         pass
 
 
-class OAuth2Auth(www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
+class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin,
+                 unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         if requests is None:
             raise unittest.SkipTest("Need to install requests to test oauth2")
 
@@ -501,13 +504,16 @@ class OAuth2Auth(www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
 #  }
 
 
-class OAuth2AuthGitHubE2E(www.WwwTestMixin, unittest.TestCase):
+class OAuth2AuthGitHubE2E(TestReactorMixin, www.WwwTestMixin,
+                          unittest.TestCase):
     authClass = "GitHubAuth"
 
     def _instantiateAuth(self, cls, config):
         return cls(config["CLIENTID"], config["CLIENTSECRET"])
 
     def setUp(self):
+        self.setUpTestReactor()
+
         if requests is None:
             raise unittest.SkipTest("Need to install requests to test oauth2")
 

--- a/master/buildbot/test/unit/test_www_resource.py
+++ b/master/buildbot/test/unit/test_www_resource.py
@@ -17,6 +17,7 @@
 from twisted.trial import unittest
 
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import resource
 
 
@@ -25,7 +26,10 @@ class ResourceSubclass(resource.Resource):
     needsReconfig = True
 
 
-class Resource(www.WwwTestMixin, unittest.TestCase):
+class Resource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.setUpTestReactor()
 
     def test_base_url(self):
         master = self.make_master(url=b'h:/a/b/')
@@ -38,7 +42,10 @@ class Resource(www.WwwTestMixin, unittest.TestCase):
         master.www.resourceNeedsReconfigs.assert_called_with(rsrc)
 
 
-class RedirectResource(www.WwwTestMixin, unittest.TestCase):
+class RedirectResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.setUpTestReactor()
 
     def test_redirect(self):
         master = self.make_master(url=b'h:/a/b/')

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -23,6 +23,7 @@ from twisted.trial import unittest
 
 from buildbot.test.fake import endpoint
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.www import authz
@@ -31,9 +32,12 @@ from buildbot.www.rest import JSONRPC_CODES
 from buildbot.www.rest import BadRequest
 
 
-class RestRootResource(www.WwwTestMixin, unittest.TestCase):
+class RestRootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     maxVersion = 2
+
+    def setUp(self):
+        self.setUpTestReactor()
 
     @defer.inlineCallbacks
     def test_render(self):
@@ -63,9 +67,10 @@ class RestRootResource(www.WwwTestMixin, unittest.TestCase):
         self.assertEqual(sorted(rsrc.listNames()), sorted(versions))
 
 
-class V2RootResource(www.WwwTestMixin, unittest.TestCase):
+class V2RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.master = self.make_master(url='http://server/path/')
         self.master.data._scanModule(endpoint)
         self.rsrc = rest.V2RootResource(self.master)
@@ -135,9 +140,11 @@ class V2RootResource(www.WwwTestMixin, unittest.TestCase):
         )
 
 
-class V2RootResource_CORS(www.WwwTestMixin, unittest.TestCase):
+class V2RootResource_CORS(TestReactorMixin, www.WwwTestMixin,
+                          unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.master = self.make_master(url='h:/')
         self.master.data._scanModule(endpoint)
         self.rsrc = rest.V2RootResource(self.master)
@@ -234,9 +241,11 @@ class V2RootResource_CORS(www.WwwTestMixin, unittest.TestCase):
         self.assertNotOk(message='invalid origin')
 
 
-class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
+class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin,
+                          unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.master = self.make_master(url='h:/')
         self.master.config.www['debug'] = True
         self.master.data._scanModule(endpoint)
@@ -679,9 +688,11 @@ class V2RootResource_REST(www.WwwTestMixin, unittest.TestCase):
         self.assertEqual(got, exp)
 
 
-class V2RootResource_JSONRPC2(www.WwwTestMixin, unittest.TestCase):
+class V2RootResource_JSONRPC2(TestReactorMixin, www.WwwTestMixin,
+                              unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.master = self.make_master(url='h:/')
 
         def allow(*args, **kw):

--- a/master/buildbot/test/unit/test_www_service.py
+++ b/master/buildbot/test/unit/test_www_service.py
@@ -29,6 +29,7 @@ from twisted.web.server import Request
 
 from buildbot.test.unit import test_www_hooks_base
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import auth
 from buildbot.www import change_hook
 from buildbot.www import resource
@@ -45,9 +46,10 @@ class NeedsReconfigResource(resource.Resource):
         NeedsReconfigResource.reconfigs += 1
 
 
-class Test(www.WwwTestMixin, unittest.TestCase):
+class Test(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.master = self.make_master(url='h:/a/b/')
         self.svc = self.master.www = service.WWWService()
         self.svc.setServiceParent(self.master)

--- a/master/buildbot/test/unit/test_www_sse.py
+++ b/master/buildbot/test/unit/test_www_sse.py
@@ -21,15 +21,17 @@ from twisted.trial import unittest
 
 from buildbot.test.unit import test_data_changes
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.util import datetime2epoch
 from buildbot.util import unicode2bytes
 from buildbot.www import sse
 
 
-class EventResource(www.WwwTestMixin, unittest.TestCase):
+class EventResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.master = master = self.make_master(url=b'h:/a/b/')
         self.sse = sse.EventResource(master)
 

--- a/master/buildbot/test/unit/test_www_ws.py
+++ b/master/buildbot/test/unit/test_www_ws.py
@@ -20,13 +20,15 @@ from mock import Mock
 from twisted.trial import unittest
 
 from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.www import ws
 
 
-class WsResource(www.WwwTestMixin, unittest.TestCase):
+class WsResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
+        self.setUpTestReactor()
         self.master = master = self.make_master(url='h:/a/b/')
         self.ws = ws.WsResource(master)
         self.proto = self.ws._factory.buildProtocol("me")

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -16,6 +16,7 @@
 import os
 import sys
 
+from twisted.internet import threads
 from twisted.python import log
 from twisted.python import threadpool
 from twisted.python.compat import NativeStringIO
@@ -76,6 +77,12 @@ class TestReactorMixin:
         self.patch(threadpool, 'ThreadPool', NonThreadPool)
         self.reactor = TestReactor()
         _setReactor(self.reactor)
+
+        def deferToThread(f, *args, **kwargs):
+            return threads.deferToThreadPool(self.reactor, self.reactor.getThreadPool(),
+                                             f, *args, **kwargs)
+        self.patch(threads, 'deferToThread', deferToThread)
+
         # During shutdown sequence we must first stop the reactor and only then
         # set unset the reactor used for eventually() because any callbacks
         # that are run during reactor.stop() may use eventually() themselves.

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -43,8 +43,10 @@ class SchedulerMixin(interfaces.InterfaceTests):
     OTHER_MASTER_ID = 93
 
     def setUpScheduler(self):
-        self.master = fakemaster.make_master(testcase=self,
-                                             wantDb=True, wantMq=True, wantData=True)
+        self.master = fakemaster.make_master(self.reactor,
+                                             testcase=self,
+                                             wantDb=True, wantMq=True,
+                                             wantData=True)
 
     def tearDownScheduler(self):
         pass

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -169,7 +169,8 @@ class BuildStepMixin:
         factory = interfaces.IBuildStepFactory(step)
 
         step = self.step = factory.buildStep()
-        self.master = fakemaster.make_master(wantData=wantData, wantDb=wantDb,
+        self.master = fakemaster.make_master(self.reactor,
+                                             wantData=wantData, wantDb=wantDb,
                                              wantMq=wantMq, testcase=self)
 
         # mock out the reactor for updateSummary's debouncing

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -134,7 +134,8 @@ class WwwTestMixin(RequiresWwwMixin):
     UUID = str(uuid1())
 
     def make_master(self, url=None, **kwargs):
-        master = fakemaster.make_master(wantData=True, testcase=self)
+        master = fakemaster.make_master(self.reactor, wantData=True,
+                                        testcase=self)
         self.master = master
         master.www = mock.Mock()  # to handle the resourceNeedsReconfigs call
         master.www.getUserInfos = lambda _: getattr(


### PR DESCRIPTION
Long term we should be able to retire using real reactor in most of the unit tests altogether. This PR goes in that direction a little bit: we can now specify fake reactor to `fakemaster.make_master` which then sets `master.reactor` which various components should use as their reactor instead of importing `twisted.internet.reactor`. This PR then fixes a number of tests.