### PR TITLE
Don't interpret zero epoch differently in DB layer

### DIFF
--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -235,12 +235,9 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
             claimed = True
             claimed_by_masterid = row.masterid
 
-        def mkdt(epoch):
-            if epoch:
-                return epoch2datetime(epoch)
-        submitted_at = mkdt(row.submitted_at)
-        complete_at = mkdt(row.complete_at)
-        claimed_at = mkdt(claimed_at)
+        submitted_at = epoch2datetime(row.submitted_at)
+        complete_at = epoch2datetime(row.complete_at)
+        claimed_at = epoch2datetime(claimed_at)
 
         return BrDict(buildrequestid=row.id, buildsetid=row.buildsetid,
                       builderid=row.builderid, buildername=row.buildername,

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -214,10 +214,6 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
         yield self.db.pool.do(thd)
 
     def _builddictFromRow(self, row):
-        def mkdt(epoch):
-            if epoch:
-                return epoch2datetime(epoch)
-
         return dict(
             id=row.id,
             number=row.number,
@@ -225,7 +221,7 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
             buildrequestid=row.buildrequestid,
             workerid=row.workerid,
             masterid=row.masterid,
-            started_at=mkdt(row.started_at),
-            complete_at=mkdt(row.complete_at),
+            started_at=epoch2datetime(row.started_at),
+            complete_at=epoch2datetime(row.complete_at),
             state_string=row.state_string,
             results=row.results)

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -238,13 +238,12 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
                         conn.execute(sa.select([tbl.c.sourcestampid],
                                                (tbl.c.buildsetid == row.id))).fetchall()]
 
-        def mkdt(epoch):
-            if epoch:
-                return epoch2datetime(epoch)
         return BsDict(external_idstring=row.external_idstring,
-                      reason=row.reason, submitted_at=mkdt(row.submitted_at),
+                      reason=row.reason,
+                      submitted_at=epoch2datetime(row.submitted_at),
                       complete=bool(row.complete),
-                      complete_at=mkdt(row.complete_at), results=row.results,
+                      complete_at=epoch2datetime(row.complete_at),
+                      results=row.results,
                       bsid=row.id, sourcestamps=sourcestamps,
                       parent_buildid=row.parent_buildid,
                       parent_relationship=row.parent_relationship)

--- a/master/buildbot/db/steps.py
+++ b/master/buildbot/db/steps.py
@@ -176,17 +176,13 @@ class StepsConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thd)
 
     def _stepdictFromRow(self, row):
-        def mkdt(epoch):
-            if epoch:
-                return epoch2datetime(epoch)
-
         return dict(
             id=row.id,
             number=row.number,
             name=row.name,
             buildid=row.buildid,
-            started_at=mkdt(row.started_at),
-            complete_at=mkdt(row.complete_at),
+            started_at=epoch2datetime(row.started_at),
+            complete_at=epoch2datetime(row.complete_at),
             state_string=row.state_string,
             results=row.results,
             urls=json.loads(row.urls_json),

--- a/master/buildbot/test/unit/test_data_masters.py
+++ b/master/buildbot/test/unit/test_data_masters.py
@@ -249,7 +249,8 @@ class Master(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
         yield self.rtype.expireMasters(_reactor=clock)
         master = yield self.master.db.masters.getMaster(14)
         self.assertEqual(master, dict(id=14, name='other',
-                                      active=False, last_active=None))
+                                      active=False,
+                                      last_active=epoch2datetime(0)))
         self.rtype._masterDeactivated. \
             assert_called_with(14, 'other')
 

--- a/master/buildbot/test/unit/test_data_schedulers.py
+++ b/master/buildbot/test/unit/test_data_schedulers.py
@@ -25,6 +25,7 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
 from buildbot.test.util.misc import TestReactorMixin
+from buildbot.util import epoch2datetime
 
 
 class SchedulerEndpoint(endpoint.EndpointMixin, unittest.TestCase):
@@ -168,7 +169,7 @@ class Scheduler(TestReactorMixin, interfaces.InterfaceTests,
             [(('schedulers', '13', 'updated'),
               {'enabled': False,
                'master': {'active': False,
-                          'last_active': fakedb._mkdt(SOMETIME),
+                          'last_active': epoch2datetime(SOMETIME),
                           'masterid': 22,
                           'name': 'some:master'},
                'name': 'some:scheduler',
@@ -178,7 +179,7 @@ class Scheduler(TestReactorMixin, interfaces.InterfaceTests,
             [(('schedulers', '13', 'updated'),
               {'enabled': True,
                'master': {'active': False,
-                          'last_active': fakedb._mkdt(SOMETIME),
+                          'last_active': epoch2datetime(SOMETIME),
                           'masterid': 22,
                           'name': 'some:master'},
                'name': 'some:scheduler',

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -176,7 +176,8 @@ class Tests(interfaces.InterfaceTests):
                                       reason='rsn', sourcestamps=[234],
                                       submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
                                                                      tzinfo=UTC),
-                                      complete=False, complete_at=None, results=-1,
+                                      complete=False,
+                                      complete_at=epoch2datetime(0), results=-1,
                                       bsid=91,
                                       parent_buildid=None, parent_relationship=None))
 

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -143,25 +143,6 @@ class Tests(interfaces.InterfaceTests):
         return self.do_test_getBuildsetProperties(91, [], dict())
 
     @defer.inlineCallbacks
-    def test_getBuildset_incomplete_None(self):
-        yield self.insertTestData([
-            fakedb.Buildset(id=91, complete=0,
-                            complete_at=None, results=-1, submitted_at=266761875,
-                            external_idstring='extid', reason='rsn'),
-            fakedb.BuildsetSourceStamp(buildsetid=91, sourcestampid=234),
-        ])
-        bsdict = yield self.db.buildsets.getBuildset(91)
-
-        validation.verifyDbDict(self, 'bsdict', bsdict)
-        self.assertEqual(bsdict, dict(external_idstring='extid',
-                                      reason='rsn', sourcestamps=[234],
-                                      submitted_at=datetime.datetime(1978, 6, 15, 12, 31, 15,
-                                                                     tzinfo=UTC),
-                                      complete=False, complete_at=None, results=-1,
-                                      bsid=91,
-                                      parent_buildid=None, parent_relationship=None))
-
-    @defer.inlineCallbacks
     def test_getBuildset_incomplete_zero(self):
         yield self.insertTestData([
             fakedb.Buildset(id=91, complete=0,

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -260,12 +260,14 @@ def epoch2datetime(epoch):
     """Convert a UNIX epoch time to a datetime object, in the UTC timezone"""
     if epoch is not None:
         return datetime.datetime.fromtimestamp(epoch, tz=UTC)
+    return None
 
 
 def datetime2epoch(dt):
     """Convert a non-naive datetime object to a UNIX epoch timestamp"""
     if dt is not None:
         return calendar.timegm(dt.utctimetuple())
+    return None
 
 
 # TODO: maybe "merge" with formatInterval?

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -65,6 +65,7 @@ Several small utilities are available at the top-level :mod:`buildbot.util` pack
 
     Convert a UNIX epoch timestamp to a Python datetime object, in the UTC timezone.
     Note that timestamps specify UTC time (modulo leap seconds and a few other minor details).
+    If the argument is None, returns None.
 
 .. py:function:: datetime2epoch(datetime)
 
@@ -72,6 +73,7 @@ Several small utilities are available at the top-level :mod:`buildbot.util` pack
     :returns: equivalent epoch time (integer)
 
     Convert an arbitrary Python datetime object into a UNIX epoch timestamp.
+    If the argument is None, returns None.
 
 .. py:data:: UTC
 


### PR DESCRIPTION
Currently we don't convert dates that evaluate to zero between epoch and datetime. This leads to inconsistent data as APIs expecting datetime now must handle None, int==0 and datetime objects correctly. This PR always compares epoch to None, so the downstream code only needs to handle None and datetime. In addition to that, we can use fake reactors freely in test code without having to advance them out of the initial zero time.

This change is safe, because there's no way to actually send zero epoch to the database currently if it means something like None, i.e. not set epoch. Any 0 epochs in old databases will be converted to 1970-01-01 00:00 datetime, but I believe this is completely insignificant issue.