### PR TITLE
Add support for grouping workers to machines

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1099,6 +1099,7 @@ reconfiguring
 reconnection
 recurse
 redhat
+reentrant
 refactor
 refcount
 refetch

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -187,6 +187,10 @@ class ILatentWorker(IWorker):
         """
 
 
+class IMachine(Interface):
+    pass
+
+
 class IRenderable(Interface):
 
     """An object that can be interpolated with properties from a build.

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -191,6 +191,11 @@ class IMachine(Interface):
     pass
 
 
+class ILatentMachine(IMachine):
+    """ A machine that is not always running, but can be started when requested.
+    """
+
+
 class IRenderable(Interface):
 
     """An object that can be interpolated with properties from a build.

--- a/master/buildbot/machine/__init__.py
+++ b/master/buildbot/machine/__init__.py
@@ -1,0 +1,14 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members

--- a/master/buildbot/machine/base.py
+++ b/master/buildbot/machine/base.py
@@ -1,0 +1,34 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Portions Copyright Buildbot Team Members
+
+from zope.interface import implementer
+
+from buildbot import interfaces
+from buildbot.util import service
+
+
+@implementer(interfaces.IMachine)
+class Machine(service.BuildbotService):
+
+    def checkConfig(self, name, **kwargs):
+        super().checkConfig(**kwargs)
+        self.name = name
+
+    def reconfigService(self, name, **kwargs):
+        super().reconfigService(**kwargs)
+        assert self.name == name
+
+    def __repr__(self):
+        return "<Machine '{}' at {}>".format(self.name, id(self))

--- a/master/buildbot/machine/latent.py
+++ b/master/buildbot/machine/latent.py
@@ -1,0 +1,170 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import enum
+
+from twisted.internet import defer
+from twisted.python import log
+from zope.interface import implementer
+
+from buildbot import interfaces
+from buildbot.machine.base import Machine
+from buildbot.util import Notifier
+
+
+class States(enum.Enum):
+    # Represents the state of LatentMachine
+    STOPPED = 0
+    STARTING = 1
+    STARTED = 2
+    STOPPING = 3
+
+
+@implementer(interfaces.ILatentMachine)
+class AbstractLatentMachine(Machine):
+
+    DEFAULT_MISSING_TIMEOUT = 20 * 60
+
+    def checkConfig(self, name,
+                    build_wait_timeout=0,
+                    missing_timeout=DEFAULT_MISSING_TIMEOUT, **kwargs):
+        super().checkConfig(name, **kwargs)
+        self.state = States.STOPPED
+        self.latent_workers = []
+
+    def reconfigService(self, name,
+                        build_wait_timeout=0,
+                        missing_timeout=DEFAULT_MISSING_TIMEOUT, **kwargs):
+        super().reconfigService(name, **kwargs)
+        self.build_wait_timeout = build_wait_timeout
+        self.missing_timeout = missing_timeout
+
+        for worker in self.workers:
+            if not interfaces.ILatentWorker.providedBy(worker):
+                raise Exception('Worker is not latent {}'.format(
+                    worker.name))
+
+        self.state = States.STOPPED
+        self._start_notifier = Notifier()
+        self._stop_notifier = Notifier()
+        self._build_wait_timer = None
+        self._missing_timer = None
+
+    def start_machine(self):
+        # Responsible for starting the machine. The function should return a
+        # deferred which should result in True if the startup has been
+        # successful, or False otherwise.
+        raise NotImplementedError
+
+    def stop_machine(self):
+        # Responsible for shutting down the machine
+        raise NotImplementedError
+
+    @defer.inlineCallbacks
+    def substantiate(self, starting_worker):
+        if self.state == States.STOPPING:
+            # wait until stop action finishes
+            yield self._stop_notifier.wait()
+
+        if self.state == States.STARTED:
+            # may happen if we waited for stop to complete and in the mean
+            # time the machine was successfully woken.
+            return True
+
+        # wait for already proceeding startup to finish, if any
+        if self.state == States.STARTING:
+            return (yield self._start_notifier.wait())
+
+        self.state = States.STARTING
+
+        # Start the machine. start_machine may substantiate additional workers
+        # depending on the implementation.
+        try:
+            ret = yield self.start_machine()
+        except Exception as e:
+            log.err(e, 'while starting latent machine {0}'.format(self.name))
+            ret = False
+
+        if not ret:
+            yield defer.DeferredList([worker.insubstantiate()
+                                      for worker in self.workers],
+                                     consumeErrors=True)
+        else:
+            self._setMissingTimer()
+
+        self.state = States.STARTED if ret else States.STOPPED
+        self._start_notifier.notify(ret)
+
+        return ret
+
+    @defer.inlineCallbacks
+    def _stop(self):
+        if any(worker.building for worker in self.workers) or \
+                self.state == States.STARTING:
+            return None
+
+        if self.state == States.STOPPING:
+            yield self._stop_notifier.wait()
+            return None
+
+        self.state = States.STOPPING
+
+        # wait until workers insubstantiate, then stop
+        yield defer.DeferredList([worker.insubstantiate()
+                                  for worker in self.workers],
+                                 consumeErrors=True)
+        try:
+            yield self.stop_machine()
+        except Exception as e:
+            log.err(e, 'while stopping latent machine {0}'.format(
+                self.name))
+
+        self.state = States.STOPPED
+        self._stop_notifier.notify(None)
+
+    def notifyBuildStarted(self):
+        self._clearMissingTimer()
+
+    def notifyBuildFinished(self):
+        if any(worker.building for worker in self.workers):
+            self._clearBuildWaitTimer()
+        else:
+            self._setBuildWaitTimer()
+
+    def _clearMissingTimer(self):
+        if self._missing_timer is not None:
+            if self._missing_timer.active():
+                self._missing_timer.cancel()
+            self._missing_timer = None
+
+    def _setMissingTimer(self):
+        self._clearMissingTimer()
+        self._missing_timer = self.master.reactor.callLater(
+            self.missing_timeout, self._stop)
+
+    def _clearBuildWaitTimer(self):
+        if self._build_wait_timer is not None:
+            if self._build_wait_timer.active():
+                self._build_wait_timer.cancel()
+            self._build_wait_timer = None
+
+    def _setBuildWaitTimer(self):
+        self._clearBuildWaitTimer()
+        self._build_wait_timer = self.master.reactor.callLater(
+            self.build_wait_timeout, self._stop)
+
+    def __repr__(self):
+        return "<AbstractLatentMachine '{}' at {}>".format(self.name, id(self))

--- a/master/buildbot/machine/manager.py
+++ b/master/buildbot/machine/manager.py
@@ -27,3 +27,8 @@ class MachineManager(service.BuildbotServiceManager):
     @property
     def machines(self):
         return self.namedServices
+
+    def getMachineByName(self, name):
+        if name in self.machines:
+            return self.machines[name]
+        return None

--- a/master/buildbot/machine/manager.py
+++ b/master/buildbot/machine/manager.py
@@ -13,31 +13,17 @@
 #
 # Portions Copyright Buildbot Team Members
 
-from zope.interface import implementer
 
-from buildbot import interfaces
 from buildbot.util import service
+from buildbot.worker.manager import WorkerManager
 
 
-@implementer(interfaces.IMachine)
-class Machine(service.BuildbotService):
+class MachineManager(service.BuildbotServiceManager):
+    reconfig_priority = WorkerManager.reconfig_priority + 1
+    name = 'MachineManager'
+    managed_services_name = 'machines'
+    config_attr = 'machines'
 
-    def checkConfig(self, name, **kwargs):
-        super().checkConfig(**kwargs)
-        self.name = name
-        self.workers = []
-
-    def reconfigService(self, name, **kwargs):
-        super().reconfigService(**kwargs)
-        assert self.name == name
-
-    def registerWorker(self, worker):
-        assert worker.machine_name == self.name
-        self.workers.append(worker)
-
-    def unregisterWorker(self, worker):
-        assert worker in self.workers
-        self.workers.remove(worker)
-
-    def __repr__(self):
-        return "<Machine '{}' at {}>".format(self.name, id(self))
+    @property
+    def machines(self):
+        return self.namedServices

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -34,6 +34,7 @@ from buildbot.changes.manager import ChangeManager
 from buildbot.data import connector as dataconnector
 from buildbot.db import connector as dbconnector
 from buildbot.db import exceptions
+from buildbot.machine.manager import MachineManager
 from buildbot.mq import connector as mqconnector
 from buildbot.process import cache
 from buildbot.process import debug
@@ -150,6 +151,9 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
         self.botmaster = BotMaster()
         self.botmaster.setServiceParent(self)
+
+        self.machine_manager = MachineManager()
+        self.machine_manager.setServiceParent(self)
 
         self.scheduler_manager = SchedulerManager()
         self.scheduler_manager.setServiceParent(self)

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -32,6 +32,7 @@ from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemq
 from buildbot.test.fake import pbmanager
 from buildbot.test.fake.botmaster import FakeBotMaster
+from buildbot.test.fake.machine import FakeMachineManager
 from buildbot.util import service
 
 
@@ -183,6 +184,8 @@ class FakeMaster(service.MasterService):
         self.masterid = master_id
         self.workers = bworkermanager.FakeWorkerManager()
         self.workers.setServiceParent(self)
+        self.machine_manager = FakeMachineManager()
+        self.machine_manager.setServiceParent(self)
         self.log_rotation = FakeLogRotation()
         self.db = mock.Mock()
         self.next_objectid = 0

--- a/master/buildbot/test/fake/machine.py
+++ b/master/buildbot/test/fake/machine.py
@@ -1,0 +1,25 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from buildbot.util import service
+
+
+class FakeMachineManager(service.AsyncMultiService):
+    name = 'MachineManager'
+
+    @property
+    def machines(self):
+        return self.namedServices

--- a/master/buildbot/test/fake/machine.py
+++ b/master/buildbot/test/fake/machine.py
@@ -27,6 +27,11 @@ class FakeMachineManager(service.AsyncMultiService):
     def machines(self):
         return self.namedServices
 
+    def getMachineByName(self, name):
+        if name in self.machines:
+            return self.machines[name]
+        return None
+
 
 class LatentMachineController:
     """ A controller for ``ControllableLatentMachine``

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -19,6 +19,7 @@ from zope.interface import implementer
 
 from buildbot.config import BuilderConfig
 from buildbot.interfaces import IBuildStepFactory
+from buildbot.machine.base import Machine
 from buildbot.process.buildstep import BuildStep
 from buildbot.process.factory import BuildFactory
 from buildbot.process.results import CANCELLED
@@ -162,6 +163,28 @@ class Tests(RunFakeMasterTestCase):
         )
 
         self.assertEqual(len(started_builds), 1)
+
+    @defer.inlineCallbacks
+    def test_worker_registered_to_machine(self):
+        worker = self.createLocalWorker('worker1', machine_name='machine1')
+        machine = Machine('machine1')
+
+        config_dict = {
+            'builders': [
+                BuilderConfig(name="builder1",
+                              workernames=["worker1"],
+                              factory=BuildFactory(),
+                              ),
+            ],
+            'workers': [worker],
+            'machines': [machine],
+            'protocols': {'null': {}},
+            'multiMaster': True,
+        }
+
+        yield self.getMaster(config_dict)
+
+        self.assertIs(worker.machine, machine)
 
     if RemoteWorker is None:
         skip = "buildbot-worker package is not installed"

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -298,9 +298,8 @@ class AbstractWorker(service.BuildbotService):
 
         self.machine_name = machine_name
         if self.machine is None and self.machine_name is not None:
-            machines = self.master.machine_manager.machines
-            if self.machine_name in machines:
-                self.machine = machines[self.machine_name]
+            self.machine = self.master.machine_manager.getMachineByName(self.machine_name)
+            if self.machine is not None:
                 self.machine.registerWorker(self)
                 self.properties.setProperty("machine_name", self.machine_name,
                                             "Worker")

--- a/master/setup.py
+++ b/master/setup.py
@@ -170,6 +170,7 @@ setup_args = {
         "buildbot.db",
         "buildbot.db.migrate.versions",
         "buildbot.db.types",
+        "buildbot.machine",
         "buildbot.monkeypatches",
         "buildbot.mq",
         "buildbot.plugins",
@@ -261,6 +262,9 @@ setup_args = {
             ('buildbot.worker.docker', ['DockerLatentWorker']),
             ('buildbot.worker.kubernetes', ['KubeLatentWorker']),
             ('buildbot.worker.local', ['LocalWorker']),
+        ]),
+        ('buildbot.machine', [
+            ('buildbot.machine.base', ['Machine']),
         ]),
         ('buildbot.steps', [
             ('buildbot.process.buildstep', ['BuildStep']),


### PR DESCRIPTION
This PR implements a way to associate workers with entities called "machines". A machine groups one or more workers sharing physical resources. Exposing this allows the following possibilities:

 - latent machines (implemented in this PR). Currently there's no way to shutdown resources that are shared by multiple latent workers. For example, ideally a physical machine or an EC2 instance would be shut down when there are no builds and woken up on new builds.

 - per-machine locks. Often more than one worker runs on the same host and this makes `WorkerLock` useless to prevent excessive usage of resources. In the future we could have `MachineLock` which would prevent e.g. excessive usage of memory.

This PR supersedes #4616 which implemented latent machines in a much more limited way.
 
The PR currently adds neither the newsfragment nor updates the documentation. I think that there's possibility the API may need slight changes once various types of machines are actually implemented. Once we have support for e.g. EC2 machine then it's a good time to expose the functionality to the end users.

Questions:
Is "machine" a good naming? It does not necessarily need to correspond to a physical machine, so the current naming is potentially a bit confusing.