### PR TITLE
Feature: add more git buildstep (git add and git commit)

### DIFF
--- a/master/buildbot/newsfragments/gitcommit.feature
+++ b/master/buildbot/newsfragments/gitcommit.feature
@@ -1,0 +1,1 @@
+Added new :bb:step:`GitCommit` step to perform git commit operation

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -67,7 +67,6 @@ git_describe_flags = [
 
 class Git(Source, GitStepMixin):
 
-    """ Class for Git with all the smarts """
     name = 'git'
     renderables = ["repourl", "reference", "branch",
                    "codebase", "mode", "method", "origin"]
@@ -76,65 +75,7 @@ class Git(Source, GitStepMixin):
                  reference=None, submodules=False, shallow=False, progress=False, retryFetch=False,
                  clobberOnFailure=False, getDescription=False, config=None,
                  origin=None, sshPrivateKey=None, sshHostKey=None, **kwargs):
-        """
-        @type  repourl: string
-        @param repourl: the URL which points at the git repository
 
-        @type  branch: string
-        @param branch: The branch or tag to check out by default. If
-                       a build specifies a different branch, it will
-                       be used instead of this.
-
-        @type  submodules: boolean
-        @param submodules: Whether or not to update (and initialize)
-                       git submodules.
-
-        @type  mode: string
-        @param mode: Type of checkout. Described in docs.
-
-        @type  method: string
-        @param method: Full builds can be done is different ways. This parameter
-                       specifies which method to use.
-
-        @type reference: string
-        @param reference: If available use a reference repo.
-                          Uses `--reference` in git command. Refer `git clone --help`
-        @type  progress: boolean
-        @param progress: Pass the --progress option when fetching. This
-                         can solve long fetches getting killed due to
-                         lack of output, but requires Git 1.7.2+.
-
-        @type  shallow: boolean or integer
-        @param shallow: Use a shallow or clone, if possible
-
-        @type  retryFetch: boolean
-        @param retryFetch: Retry fetching before failing source checkout.
-
-        @type  getDescription: boolean or dict
-        @param getDescription: Use 'git describe' to describe the fetched revision
-
-        @type origin: string
-        @param origin: The name to give the remote when cloning (default None)
-
-        @type  sshPrivateKey: Secret or string
-        @param sshPrivateKey: The private key to use when running git for fetch
-                              operations. The ssh utility must be in the system
-                              path in order to use this option. On Windows only
-                              git distribution that embeds MINGW has been
-                              tested (as of July 2017 the official distribution
-                              is MINGW-based).
-
-        @type  sshHostKey: Secret or string
-        @param sshHostKey: Specifies public host key to match when
-                           authenticating with SSH public key authentication.
-                           `sshPrivateKey` must be specified in order to use
-                           this option. The host key must be in the form of
-                           `<key type> <base64-encoded string>`,
-                           e.g. `ssh-rsa AAAAB3N<...>FAaQ==`.
-
-        @type  config: dict
-        @param config: Git configuration options to enable when running git
-        """
         if not getDescription and not isinstance(getDescription, dict):
             getDescription = False
 
@@ -590,8 +531,6 @@ class GitPush(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
     descriptionDone = None
     descriptionSuffix = None
 
-    ''' Class to perform Git push commands '''
-
     name = 'gitpush'
     renderables = ['repourl', 'branch']
 
@@ -599,54 +538,6 @@ class GitPush(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
                  env=None, timeout=20 * 60, logEnviron=True,
                  sshPrivateKey=None, sshHostKey=None,
                  config=None, **kwargs):
-        """
-        @type  workdir: string
-        @param workdir: local directory (relative to the Builder's root)
-                        where the tree should be placed
-
-        @type  repourl: string
-        @param repourl: the URL which points at the git repository
-
-        @type  branch: string
-        @param branch: The branch to push. The branch should already exist on
-                       the local repository.
-
-        @type force: boolean
-        @param force: If True, forces overwrite of refs on the remote
-                      repository. Corresponds to the '--force' flag.
-
-        @type env: dict
-        @param env: Specifies custom environment variables to set
-
-        @type logEnviron: boolean
-        @param logEnviron: If this option is true (the default), then the
-                           step's logfile will describe the environment
-                           variables on the worker. In situations where the
-                           environment is not relevant and is long, it may
-                           be easier to set logEnviron=False.
-
-        @type timeout
-        @param timeout: Specifies the timeout for individual git operations
-
-        @type  sshPrivateKey: Secret or string
-        @param sshPrivateKey: The private key to use when running git for push
-                              operations. The ssh utility must be in the system
-                              path in order to use this option. On Windows only
-                              git distribution that embeds MINGW has been
-                              tested (as of July 2017 the official distribution
-                              is MINGW-based).
-
-        @type  sshHostKey: Secret or string
-        @param sshHostKey: Specifies public host key to match when
-                           authenticating with SSH public key authentication.
-                           `sshPrivateKey` must be specified in order to use
-                           this option. The host key must be in the form of
-                           `<key type> <base64-encoded string>`,
-                           e.g. `ssh-rsa AAAAB3N<...>FAaQ==`.
-
-        @type  config: dict
-        @param config: Git configuration options to enable when running git
-        """
 
         self.workdir = workdir
         self.repourl = repourl

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -3293,6 +3293,7 @@ class TestGit(sourcesteps.SourceStepMixin,
         return self._test_WorkerTooOldError(_dovccmd, step, msg)
 
 
+
 class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                   TestReactorMixin,
                   unittest.TestCase):
@@ -3658,6 +3659,10 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
         self.expectOutcome(result=EXCEPTION)
         self.runStep()
         self.flushLoggedErrors(WorkerTooOldError)
+
+    def test_config_fail_no_branch(self):
+        with self.assertRaisesConfigError("GitPush: must provide branch"):
+            self.stepClass(workdir='wkdir', repourl="url")
 
 
 class TestGitTag(steps.BuildStepMixin, config.ConfigErrorsMixin,

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -3292,6 +3292,15 @@ class TestGit(sourcesteps.SourceStepMixin,
         msg = 'git is not installed on worker'
         return self._test_WorkerTooOldError(_dovccmd, step, msg)
 
+    def test_config_get_description_not_dict_or_boolean(self):
+        with self.assertRaisesConfigError("Git: getDescription must be a boolean or a dict."):
+            self.stepClass(repourl="http://github.com/buildbot/buildbot.git",
+                           getDescription=["list"])
+
+    def test_config_invalid_method_with_full(self):
+        with self.assertRaisesConfigError("Git: invalid method for mode 'full'."):
+            self.stepClass(repourl="http://github.com/buildbot/buildbot.git",
+                           mode='full', method='unknown')
 
 
 class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,

--- a/master/docs/manual/configuration/buildsteps.rst
+++ b/master/docs/manual/configuration/buildsteps.rst
@@ -1075,7 +1075,43 @@ Monotone step takes the following arguments:
 Other Source operations
 -----------------------
 
-Currently the only non-checkout steps that are related to version control are ``GitPush`` and ``GitTag``.
+Currently the only non-checkout steps that are related to version control are ``GitCommit``, ``GitPush`` and ``GitTag``.
+
+.. bb:step:: GitCommit
+
+GitCommit
++++++++++
+
+.. py:class:: buildbot.steps.source.git.GitCommit
+
+The :bb:step:`GitCommit` build step add files and commit modifications in your local `Git <http://git.or.cz/>`_ repository.
+
+The GitCommit step takes the following arguments:
+
+``workdir``
+    (required) The path to the local repository to push commits from.
+
+``messages``
+    (required) List of message that will be created with the commit.
+    Correspond to the ``-m`` flag of the ``git commit`` command.
+
+``paths``
+    (required) List of path that will be added to the commit.
+
+``logEnviron``
+    (optional) If this option is true (the default), then the step's logfile will describe the environment variables on the worker.
+    In situations where the environment is not relevant and is long, it may be easier to set ``logEnviron=False``.
+
+``env``
+    (optional) A dictionary of environment strings which will be added to the child command's environment.
+    The usual property interpolations can be used in environment variable names and values - see :ref:`Properties`.
+
+``timeout``
+    (optional) Specifies the timeout for worker-side operations, in seconds.
+    If your repositories are particularly large, then you may need to increase this  value from its default of 1200 (20 minutes).
+
+``config``
+    (optional) A dict of git configuration settings to pass to the remote git commands.
 
 .. bb:step:: GitPush
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -296,7 +296,7 @@ setup_args = {
             ('buildbot.steps.source.cvs', ['CVS']),
             ('buildbot.steps.source.darcs', ['Darcs']),
             ('buildbot.steps.source.gerrit', ['Gerrit']),
-            ('buildbot.steps.source.git', ['Git', 'GitTag']),
+            ('buildbot.steps.source.git', ['Git', 'GitCommit', 'GitTag']),
             ('buildbot.steps.source.github', ['GitHub']),
             ('buildbot.steps.source.gitlab', ['GitLab']),
             ('buildbot.steps.source.mercurial', ['Mercurial']),


### PR DESCRIPTION
This PR add two buildsteps:
- GitAdd to add some files in the staging area
- GitCommit to commit the files in the staging area

I have removed old styles docs from the source (like describe in the docs) and add some trivial test cases in other git related steps.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
