### PR TITLE
Use fake reactor in tests (part 4)

### DIFF
--- a/master/buildbot/scripts/dataspec.py
+++ b/master/buildbot/scripts/dataspec.py
@@ -28,7 +28,7 @@ from buildbot.util import in_reactor
 @in_reactor
 @defer.inlineCallbacks
 def dataspec(config):
-    master = yield fakemaster.make_master()
+    master = yield fakemaster.make_master(None, wantRealReactor=True)
     data = connector.DataConnector()
     data.setServiceParent(master)
     if config['out'] != '--':

--- a/master/buildbot/scripts/processwwwindex.py
+++ b/master/buildbot/scripts/processwwwindex.py
@@ -31,7 +31,7 @@ from buildbot.www.service import WWWService
 @in_reactor
 @defer.inlineCallbacks
 def processwwwindex(config):
-    master = yield fakemaster.make_master()
+    master = yield fakemaster.make_master(None, wantRealReactor=True)
     master_service = WWWService()
     master_service.setServiceParent(master)
     if not config.get('index-file'):

--- a/master/buildbot/secrets/providers/passwordstore.py
+++ b/master/buildbot/secrets/providers/passwordstore.py
@@ -19,9 +19,11 @@ password store based provider
 import os
 from pathlib import Path
 
+from twisted.internet import defer
+from twisted.internet import utils
+
 from buildbot import config
 from buildbot.secrets.providers.base import SecretProviderBase
-from twisted.internet import defer, utils
 
 
 class SecretInPass(SecretProviderBase):

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -206,8 +206,15 @@ class FakeMaster(service.MasterService):
 # Leave this alias, in case we want to add more behavior later
 
 
-def make_master(_reactor=reactor, wantMq=False, wantDb=False, wantData=False,
-                testcase=None, url=None, **kwargs):
+def make_master(testcase, wantMq=False, wantDb=False, wantData=False,
+                wantRealReactor=False, url=None, **kwargs):
+    if wantRealReactor:
+        _reactor = reactor
+    else:
+        assert testcase is not None, "need testcase for fake reactor"
+        # The test case must inherit from TestReactorMixin and setup it.
+        _reactor = testcase.reactor
+
     master = FakeMaster(_reactor, **kwargs)
     if url:
         master.buildbotURL = url

--- a/master/buildbot/test/fake/web.py
+++ b/master/buildbot/test/fake/web.py
@@ -27,8 +27,7 @@ def fakeMasterForHooks(testcase):
     # testcase must derive from TestReactorMixin and setUpTestReactor()
     # must be called before calling this function.
 
-    master = fakemaster.make_master(testcase.reactor, wantData=True,
-                                    testcase=testcase)
+    master = fakemaster.make_master(testcase, wantData=True)
     master.www = Mock()
     return master
 

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -157,8 +157,8 @@ class RunSteps(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantMq=True, wantDb=True)
+        self.master = fakemaster.make_master(self, wantData=True,
+                                             wantMq=True, wantDb=True)
         self.master.db.insertTestData([
             fakedb.Builder(id=80, name='test'), ])
 

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -89,7 +89,7 @@ class UpgradeTestMixin(db.RealDatabaseMixin, TestReactorMixin):
                 os.makedirs("basedir")
             self.basedir = os.path.abspath("basedir")
 
-        self.master = master = fakemaster.make_master(self.reactor)
+        self.master = master = fakemaster.make_master(self)
         master.config.db['db_url'] = self.db_url
         self.db = connector.DBConnector(self.basedir)
         self.db.setServiceParent(master)

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -165,9 +165,8 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             testcase=self, wantMq=True,
-                                             wantData=True, wantDb=True)
+        self.master = fakemaster.make_master(self, wantMq=True, wantData=True,
+                                             wantDb=True)
 
         # set the worker port to a loopback address with unspecified
         # port

--- a/master/buildbot/test/integration/test_worker_workerside.py
+++ b/master/buildbot/test/integration/test_worker_workerside.py
@@ -134,9 +134,8 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             testcase=self, wantMq=True,
-                                             wantData=True, wantDb=True)
+        self.master = fakemaster.make_master(self, wantMq=True, wantData=True,
+                                             wantDb=True)
         # set the worker port to a loopback address with unspecified
         # port
         self.pbmanager = self.master.pbmanager = pbmanager.PBManager()

--- a/master/buildbot/test/unit/test_changes_changes.py
+++ b/master/buildbot/test/unit/test_changes_changes.py
@@ -46,8 +46,7 @@ class Change(unittest.TestCase, TestReactorMixin):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             testcase=self, wantDb=True)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.change23 = changes.Change(**dict(  # using **dict(..) forces kwargs
             category='devel',
             repository='git://warner',

--- a/master/buildbot/test/unit/test_changes_manager.py
+++ b/master/buildbot/test/unit/test_changes_manager.py
@@ -29,8 +29,7 @@ class TestChangeManager(unittest.TestCase, TestReactorMixin):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             testcase=self, wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
         self.cm = manager.ChangeManager()
         self.master.startService()
         self.cm.setServiceParent(self.master)

--- a/master/buildbot/test/unit/test_changes_pb.py
+++ b/master/buildbot/test/unit/test_changes_pb.py
@@ -215,8 +215,7 @@ class TestChangePerspective(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantDb=True, wantData=True)
+        self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
 
     @defer.inlineCallbacks
     def test_addChange_noprefix(self):

--- a/master/buildbot/test/unit/test_data_base.py
+++ b/master/buildbot/test/unit/test_data_base.py
@@ -59,8 +59,7 @@ class ResourceType(TestReactorMixin, unittest.TestCase):
         cls = self.makeResourceTypeSubclass(
             name='singular',
             eventPathPatterns="/foo/:fooid/bar/:barid")
-        master = fakemaster.make_master(self.reactor, testcase=self,
-                                        wantMq=True)
+        master = fakemaster.make_master(self, wantMq=True)
         master.mq.verifyMessages = False  # since this is a pretend message
         inst = cls(master)
         inst.produceEvent(dict(fooid=10, barid='20'),  # note integer vs. string
@@ -75,8 +74,7 @@ class ResourceType(TestReactorMixin, unittest.TestCase):
                 /builder/:builderid/build/:number
                 /build/:buildid
             """
-        master = fakemaster.make_master(self.reactor, testcase=self,
-                                        wantMq=True)
+        master = fakemaster.make_master(self, wantMq=True)
         master.mq.verifyMessages = False  # since this is a pretend message
         inst = MyResourceType(master)
         self.assertEqual(

--- a/master/buildbot/test/unit/test_data_builders.py
+++ b/master/buildbot/test/unit/test_data_builders.py
@@ -169,8 +169,7 @@ class Builder(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = builders.Builder(self.master)
         return self.master.db.insertTestData([

--- a/master/buildbot/test/unit/test_data_buildrequests.py
+++ b/master/buildbot/test/unit/test_data_buildrequests.py
@@ -258,8 +258,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = buildrequests.BuildRequest(self.master)
 

--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -267,8 +267,7 @@ class Build(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = builds.Build(self.master)
 

--- a/master/buildbot/test/unit/test_data_buildsets.py
+++ b/master/buildbot/test/unit/test_data_buildsets.py
@@ -130,8 +130,8 @@ class Buildset(TestReactorMixin, util_interfaces.InterfaceTests,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True, wantDb=True, wantData=True)
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
+                                             wantData=True)
         self.rtype = buildsets.Buildset(self.master)
         return self.master.db.insertTestData([
             fakedb.SourceStamp(id=234, branch='br', codebase='cb',

--- a/master/buildbot/test/unit/test_data_changes.py
+++ b/master/buildbot/test/unit/test_data_changes.py
@@ -150,9 +150,8 @@ class Change(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             wantMq=True, wantDb=True,
-                                             wantData=True, testcase=self)
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
+                                             wantData=True)
         self.rtype = changes.Change(self.master)
 
     def test_signature_addChange(self):

--- a/master/buildbot/test/unit/test_data_changesources.py
+++ b/master/buildbot/test/unit/test_data_changesources.py
@@ -148,9 +148,8 @@ class ChangeSource(TestReactorMixin, interfaces.InterfaceTests,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             wantMq=True, wantDb=True,
-                                             wantData=True, testcase=self)
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
+                                             wantData=True)
         self.rtype = changesources.ChangeSource(self.master)
 
     def test_signature_findChangeSourceId(self):

--- a/master/buildbot/test/unit/test_data_connector.py
+++ b/master/buildbot/test/unit/test_data_connector.py
@@ -92,8 +92,7 @@ class TestFakeData(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True, wantData=True,
+        self.master = fakemaster.make_master(self, wantMq=True, wantData=True,
                                              wantDb=True)
         self.data = self.master.data
 
@@ -102,8 +101,7 @@ class TestDataConnector(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True)
+        self.master = fakemaster.make_master(self, wantMq=True)
         self.data = connector.DataConnector()
         self.data.setServiceParent(self.master)
 
@@ -112,7 +110,7 @@ class DataConnector(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         # don't load by default
         self.patch(connector.DataConnector, 'submodules', [])
         self.data = connector.DataConnector()

--- a/master/buildbot/test/unit/test_data_logs.py
+++ b/master/buildbot/test/unit/test_data_logs.py
@@ -191,8 +191,7 @@ class Log(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = logs.Log(self.master)
 

--- a/master/buildbot/test/unit/test_data_masters.py
+++ b/master/buildbot/test/unit/test_data_masters.py
@@ -134,9 +134,8 @@ class Master(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             wantMq=True, wantDb=True,
-                                             wantData=True, testcase=self)
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
+                                             wantData=True)
         self.rtype = masters.Master(self.master)
 
     def test_signature_masterActive(self):

--- a/master/buildbot/test/unit/test_data_patches.py
+++ b/master/buildbot/test/unit/test_data_patches.py
@@ -24,9 +24,8 @@ class Patch(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             wantMq=True, wantDb=True,
-                                             wantData=True, testcase=self)
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
+                                             wantData=True)
         self.rtype = patches.Patch(self.master)
 
     # no update methods -> nothing to test

--- a/master/buildbot/test/unit/test_data_properties.py
+++ b/master/buildbot/test/unit/test_data_properties.py
@@ -92,8 +92,7 @@ class Properties(interfaces.InterfaceTests, TestReactorMixin,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=False, wantDb=True,
+        self.master = fakemaster.make_master(self, wantMq=False, wantDb=True,
                                              wantData=True)
         self.rtype = properties.Properties(self.master)
 

--- a/master/buildbot/test/unit/test_data_schedulers.py
+++ b/master/buildbot/test/unit/test_data_schedulers.py
@@ -144,9 +144,8 @@ class Scheduler(TestReactorMixin, interfaces.InterfaceTests,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             wantMq=True, wantDb=True,
-                                             wantData=True, testcase=self)
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
+                                             wantData=True)
         self.rtype = schedulers.Scheduler(self.master)
 
     def test_signature_schedulerEnable(self):

--- a/master/buildbot/test/unit/test_data_steps.py
+++ b/master/buildbot/test/unit/test_data_steps.py
@@ -170,8 +170,7 @@ class Step(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = steps.Step(self.master)
 

--- a/master/buildbot/test/unit/test_data_workers.py
+++ b/master/buildbot/test/unit/test_data_workers.py
@@ -258,8 +258,7 @@ class Worker(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
                                              wantData=True)
         self.rtype = workers.Worker(self.master)
         return self.master.db.insertTestData([

--- a/master/buildbot/test/unit/test_db_builders.py
+++ b/master/buildbot/test/unit/test_db_builders.py
@@ -252,8 +252,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData

--- a/master/buildbot/test/unit/test_db_buildrequests.py
+++ b/master/buildbot/test/unit/test_db_buildrequests.py
@@ -647,8 +647,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData

--- a/master/buildbot/test/unit/test_db_builds.py
+++ b/master/buildbot/test/unit/test_db_builds.py
@@ -431,8 +431,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -511,8 +511,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData

--- a/master/buildbot/test/unit/test_db_changes.py
+++ b/master/buildbot/test/unit/test_db_changes.py
@@ -751,8 +751,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData

--- a/master/buildbot/test/unit/test_db_changesources.py
+++ b/master/buildbot/test/unit/test_db_changesources.py
@@ -280,8 +280,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantDb=True)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData

--- a/master/buildbot/test/unit/test_db_connector.py
+++ b/master/buildbot/test/unit/test_db_connector.py
@@ -44,7 +44,7 @@ class TestDBConnector(TestReactorMixin, db.RealDatabaseMixin,
             'sourcestampsets', 'builds', 'builders', 'masters',
             'buildrequests', 'workers'])
 
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.master.config = config.MasterConfig()
         self.db = connector.DBConnector(os.path.abspath('basedir'))
         self.db.setServiceParent(self.master)

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -576,8 +576,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData

--- a/master/buildbot/test/unit/test_db_masters.py
+++ b/master/buildbot/test/unit/test_db_masters.py
@@ -209,8 +209,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
     def setUp(self):
         self.setUpTestReactor()
         self.reactor.advance(SOMETIME)
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData

--- a/master/buildbot/test/unit/test_db_schedulers.py
+++ b/master/buildbot/test/unit/test_db_schedulers.py
@@ -395,8 +395,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantDb=True)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData

--- a/master/buildbot/test/unit/test_db_sourcestamps.py
+++ b/master/buildbot/test/unit/test_db_sourcestamps.py
@@ -372,8 +372,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData

--- a/master/buildbot/test/unit/test_db_steps.py
+++ b/master/buildbot/test/unit/test_db_steps.py
@@ -349,8 +349,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData

--- a/master/buildbot/test/unit/test_db_workers.py
+++ b/master/buildbot/test/unit/test_db_workers.py
@@ -657,7 +657,7 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.db = fakedb.FakeDBConnector(self)
         self.db.setServiceParent(self.master)
         self.db.checkForeignKeys = True

--- a/master/buildbot/test/unit/test_fake_secrets_manager.py
+++ b/master/buildbot/test/unit/test_fake_secrets_manager.py
@@ -13,7 +13,7 @@ class TestSecretsManager(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.master.config.secretsProviders = [FakeSecretStorage(secretdict={"foo": "bar",
                                                                              "other": "value"})]
 

--- a/master/buildbot/test/unit/test_interpolate_secrets.py
+++ b/master/buildbot/test/unit/test_interpolate_secrets.py
@@ -24,7 +24,7 @@ class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage()
         fakeStorageService.reconfigService(secretdict={"foo": "bar",
                                                        "other": "value"})
@@ -53,7 +53,7 @@ class TestInterpolateSecretsNoService(TestReactorMixin, unittest.TestCase,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.build = FakeBuildWithMaster(self.master)
 
     @defer.inlineCallbacks
@@ -69,7 +69,7 @@ class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage()
         fakeStorageService.reconfigService(secretdict={"foo": "bar",
                                                        "other": "value"})

--- a/master/buildbot/test/unit/test_mq.py
+++ b/master/buildbot/test/unit/test_mq.py
@@ -137,8 +137,7 @@ class TestFakeMQ(TestReactorMixin, unittest.TestCase, Tests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True)
+        self.master = fakemaster.make_master(self, wantMq=True)
         self.mq = self.master.mq
         self.mq.verifyMessages = False
 
@@ -147,6 +146,6 @@ class TestSimpleMQ(TestReactorMixin, unittest.TestCase, RealTests):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.mq = simple.SimpleMQ()
         self.mq.setServiceParent(self.master)

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -44,7 +44,7 @@ class MQConnector(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.mqconfig = self.master.config.mq = {}
         self.conn = connector.MQConnector()
         self.conn.setServiceParent(self.master)

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -107,7 +107,7 @@ class WampMQ(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.master.wamp = FakeWampConnector()
         self.mq = wamp.WampMQ()
         self.mq.setServiceParent(self.master)
@@ -177,7 +177,7 @@ class WampMQReal(TestReactorMixin, unittest.TestCase):
         self.setUpTestReactor()
         if "WAMP_ROUTER_URL" not in os.environ:
             raise unittest.SkipTest(self.HOW_TO_RUN)
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.mq = wamp.WampMQ()
         yield self.mq.setServiceParent(self.master)
         self.connector = self.master.wamp = connector.WampConnector()

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -31,8 +31,7 @@ class TestCleanShutdown(unittest.TestCase):
 
     def setUp(self):
         self.reactor = mock.Mock()
-        self.master = fakemaster.make_master(testcase=self,
-                                             wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
         self.botmaster = BotMaster()
         self.botmaster.setServiceParent(self.master)
         self.botmaster.startService()
@@ -150,8 +149,7 @@ class TestBotMaster(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True, wantData=True)
+        self.master = fakemaster.make_master(self, wantMq=True, wantData=True)
         self.master.mq = self.master.mq
         self.master.botmaster.disownServiceParent()
         self.botmaster = BotMaster()

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -185,8 +185,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
         r.sources[0].revision = "12345"
 
         self.request = r
-        self.master = fakemaster.make_master(self.reactor, wantData=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantData=True)
 
         self.worker = worker.FakeWorker(self.master)
         self.worker.attached(None)
@@ -990,8 +989,7 @@ class TestSetupProperties_MultipleSources(TestReactorMixin, unittest.TestCase):
         r.sources[1].revision = "34567"
         self.build = Build([r])
         self.build.setStepFactories([])
-        self.builder = FakeBuilder(
-            fakemaster.make_master(self.reactor, wantData=True, testcase=self))
+        self.builder = FakeBuilder(fakemaster.make_master(self, wantData=True))
         self.build.setBuilder(self.builder)
         self.build.build_status = FakeBuildStatus()
         # record properties that will be set
@@ -1033,8 +1031,7 @@ class TestSetupProperties_SingleSource(TestReactorMixin, unittest.TestCase):
         r.sources[0].revision = "12345"
         self.build = Build([r])
         self.build.setStepFactories([])
-        self.builder = FakeBuilder(
-            fakemaster.make_master(self.reactor, wantData=True, testcase=self))
+        self.builder = FakeBuilder(fakemaster.make_master(self, wantData=True))
         self.build.setBuilder(self.builder)
         self.build.build_status = FakeBuildStatus()
         # record properties that will be set
@@ -1095,16 +1092,14 @@ class TestBuildProperties(TestReactorMixin, unittest.TestCase):
         r.sources = [FakeSource()]
         r.sources[0].changes = [FakeChange()]
         r.sources[0].revision = "12345"
-        self.master = fakemaster.make_master(self.reactor, wantData=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantData=True)
         self.worker = worker.FakeWorker(self.master)
         self.worker.attached(None)
         self.workerforbuilder = Mock(name='workerforbuilder')
         self.workerforbuilder.worker = self.worker
         self.build = Build([r])
         self.build.setStepFactories([])
-        self.builder = FakeBuilder(
-            fakemaster.make_master(self.reactor, wantData=True, testcase=self))
+        self.builder = FakeBuilder(fakemaster.make_master(self, wantData=True))
         self.build.setBuilder(self.builder)
         self.properties = self.build.properties = FakeProperties()
         self.build_status = FakeBuildStatus()

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -38,8 +38,7 @@ class BuilderMixin:
 
     def setUpBuilderMixin(self):
         self.factory = factory.BuildFactory()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
         self.mq = self.master.mq
         self.db = self.master.db
 
@@ -418,8 +417,7 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_getBuilderId(self):
         self.factory = factory.BuildFactory()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
         # only include the necessary required config, plus user-requested
         self.bldr = builder.Builder('bldr')
         self.bldr.master = self.master

--- a/master/buildbot/test/unit/test_process_buildrequest.py
+++ b/master/buildbot/test/unit/test_process_buildrequest.py
@@ -30,9 +30,7 @@ class TestBuildRequestCollapser(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True,
-                                             wantDb=True)
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True)
         self.master.botmaster = mock.Mock(name='botmaster')
         self.master.botmaster.builders = {}
         self.builders = {}
@@ -294,8 +292,7 @@ class TestBuildRequest(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_fromBrdict(self):
-        master = fakemaster.make_master(self.reactor, testcase=self,
-                                        wantData=True, wantDb=True)
+        master = fakemaster.make_master(self, wantData=True, wantDb=True)
         master.db.insertTestData([
             fakedb.Builder(id=77, name='bldr'),
             fakedb.SourceStamp(id=234, branch='trunk',
@@ -333,8 +330,7 @@ class TestBuildRequest(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_fromBrdict_submittedAt_NULL(self):
-        master = fakemaster.make_master(self.reactor, testcase=self,
-                                        wantData=True, wantDb=True)
+        master = fakemaster.make_master(self, wantData=True, wantDb=True)
         master.db.insertTestData([
             fakedb.Builder(id=77, name='bldr'),
             fakedb.SourceStamp(id=234, branch='trunk',
@@ -354,8 +350,7 @@ class TestBuildRequest(TestReactorMixin, unittest.TestCase):
         self.assertEqual(br.submittedAt, None)
 
     def test_fromBrdict_no_sourcestamps(self):
-        master = fakemaster.make_master(self.reactor, testcase=self,
-                                        wantData=True, wantDb=True)
+        master = fakemaster.make_master(self, wantData=True, wantDb=True)
         master.db.insertTestData([
             fakedb.Builder(id=78, name='not important'),
             fakedb.Buildset(id=539, reason='triggered'),
@@ -372,8 +367,7 @@ class TestBuildRequest(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_fromBrdict_multiple_sourcestamps(self):
-        master = fakemaster.make_master(self.reactor, testcase=self,
-                                        wantData=True, wantDb=True)
+        master = fakemaster.make_master(self, wantData=True, wantDb=True)
         master.db.insertTestData([
             fakedb.Builder(id=77, name='bldr'),
             fakedb.SourceStamp(id=234, branch='trunk',
@@ -429,8 +423,7 @@ class TestBuildRequest(TestReactorMixin, unittest.TestCase):
             Source2 has rev 9201 and contains changes 14 and 16 from repository svn://b
         """
         brs = []  # list of buildrequests
-        master = fakemaster.make_master(self.reactor, testcase=self,
-                                        wantData=True, wantDb=True)
+        master = fakemaster.make_master(self, wantData=True, wantDb=True)
         master.db.insertTestData([
             fakedb.Builder(id=77, name='bldr'),
             fakedb.SourceStamp(id=234, branch='trunk',
@@ -507,8 +500,7 @@ class TestBuildRequest(TestReactorMixin, unittest.TestCase):
               Merging requests requires both requests to have the same codebases
         """
         brDicts = []  # list of buildrequests dictionary
-        master = fakemaster.make_master(self.reactor, testcase=self,
-                                        wantData=True, wantDb=True)
+        master = fakemaster.make_master(self, wantData=True, wantDb=True)
         master.db.insertTestData([
             fakedb.Builder(id=77, name='bldr'),
             fakedb.SourceStamp(id=238, branch='trunk',

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -54,8 +54,7 @@ class TestBRDBase(TestReactorMixin, unittest.TestCase):
             # simple sort-by-name by default
             return sorted(builders, key=lambda b1: b1.name)
         self.master = self.botmaster.master = \
-            fakemaster.make_master(self.reactor, testcase=self,
-                                   wantData=True, wantDb=True)
+            fakemaster.make_master(self, wantData=True, wantDb=True)
         self.master.caches = fakemaster.FakeCaches()
         self.master.config.prioritizeBuilders = prioritizeBuilders
         self.brd = buildrequestdistributor.BuildRequestDistributor(

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -408,8 +408,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin,
         self.patch(NewStyleStep, 'getResultSummary',
                    lambda self: defer.succeed({'step': 'CS', 'build': 'CB'}))
         step = NewStyleStep()
-        step.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True)
+        step.master = fakemaster.make_master(self, wantData=True, wantDb=True)
         step.stepid = 13
         step.step_status = mock.Mock()
         step.build = fakebuild.FakeBuild()

--- a/master/buildbot/test/unit/test_process_debug.py
+++ b/master/buildbot/test/unit/test_process_debug.py
@@ -39,7 +39,7 @@ class TestDebugServices(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_reconfigService_manhole(self):
-        master = fakemaster.make_master(self.reactor)
+        master = fakemaster.make_master(self)
         ds = debug.DebugServices()
         ds.setServiceParent(master)
         yield master.startService()

--- a/master/buildbot/test/unit/test_process_log.py
+++ b/master/buildbot/test/unit/test_process_log.py
@@ -30,8 +30,7 @@ class Tests(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks
     def makeLog(self, type, logEncoding='utf-8'):

--- a/master/buildbot/test/unit/test_process_logobserver.py
+++ b/master/buildbot/test/unit/test_process_logobserver.py
@@ -47,8 +47,7 @@ class TestLogObserver(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks
     def test_sequence(self):
@@ -97,8 +96,7 @@ class TestLineConsumerLogObesrver(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks
     def do_test_sequence(self, consumer):
@@ -163,8 +161,7 @@ class TestLogLineObserver(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks
     def test_sequence(self):
@@ -201,8 +198,7 @@ class TestOutputProgressObserver(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks
     def test_sequence(self):
@@ -222,8 +218,7 @@ class TestBufferObserver(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
 
     @defer.inlineCallbacks
     def do_test_sequence(self, lo):

--- a/master/buildbot/test/unit/test_process_metrics.py
+++ b/master/buildbot/test/unit/test_process_metrics.py
@@ -29,8 +29,7 @@ class TestMetricBase(TestReactorMixin, unittest.TestCase):
     def setUp(self):
         self.setUpTestReactor()
         self.observer = metrics.MetricLogObserver()
-        self.observer.parent = self.master = \
-            fakemaster.make_master(self.reactor)
+        self.observer.parent = self.master = fakemaster.make_master(self)
         self.master.config.metrics = dict(log_interval=0, periodic_interval=0)
         self.observer._reactor = self.reactor
         self.observer.startService()

--- a/master/buildbot/test/unit/test_process_users_manual.py
+++ b/master/buildbot/test/unit/test_process_users_manual.py
@@ -34,8 +34,7 @@ class ManualUsersMixin:
     """
 
     def setUpManualUsers(self):
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantDb=True)
+        self.master = fakemaster.make_master(self, wantDb=True)
 
 
 class TestUsersBase(unittest.TestCase):

--- a/master/buildbot/test/unit/test_process_users_users.py
+++ b/master/buildbot/test/unit/test_process_users_users.py
@@ -26,8 +26,7 @@ class UsersTests(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantDb=True)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.test_sha = users.encrypt("cancer")
 

--- a/master/buildbot/test/unit/test_reporter_bitbucket.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucket.py
@@ -42,8 +42,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
 
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(

--- a/master/buildbot/test/unit/test_reporter_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucketserver.py
@@ -44,8 +44,7 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
         self.setUpTestReactor()
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
@@ -189,8 +188,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
         self.setUpTestReactor()
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
         yield self.master.startService()
 

--- a/master/buildbot/test/unit/test_reporter_gerrit.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit.py
@@ -142,8 +142,8 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True, wantMq=True)
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
 
     @defer.inlineCallbacks
     def setupGerritStatusPushSimple(self, *args, **kwargs):

--- a/master/buildbot/test/unit/test_reporter_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/test_reporter_gerrit_verify_status.py
@@ -48,8 +48,7 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
         self.setUpTestReactor()
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
         yield self.master.startService()

--- a/master/buildbot/test/unit/test_reporter_github.py
+++ b/master/buildbot/test/unit/test_reporter_github.py
@@ -41,8 +41,8 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
         self.setUpTestReactor()
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True, wantMq=True)
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
 
         yield self.master.startService()
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
@@ -128,8 +128,7 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
 
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
         yield self.master.startService()

--- a/master/buildbot/test/unit/test_reporter_gitlab.py
+++ b/master/buildbot/test/unit/test_reporter_gitlab.py
@@ -41,8 +41,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
         self.setUpTestReactor()
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
         yield self.master.startService()

--- a/master/buildbot/test/unit/test_reporter_http.py
+++ b/master/buildbot/test/unit/test_reporter_http.py
@@ -65,8 +65,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
         self.setUpTestReactor()
         # ignore config error if txrequests is not installed
         config._errors = Mock()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
         yield self.master.startService()
 

--- a/master/buildbot/test/unit/test_reporters_hipchat.py
+++ b/master/buildbot/test/unit/test_reporters_hipchat.py
@@ -37,8 +37,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
         self.setUpTestReactor()
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True,
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -50,8 +50,8 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True, wantMq=True)
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
 
     @defer.inlineCallbacks
     def setupMailNotifier(self, *args, **kwargs):

--- a/master/buildbot/test/unit/test_reporters_message.py
+++ b/master/buildbot/test/unit/test_reporters_message.py
@@ -31,8 +31,8 @@ class TestMessage(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True, wantMq=True)
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
 
         self.message = message.MessageFormatter()
         self.messageMissing = message.MessageFormatterMissingWorker()

--- a/master/buildbot/test/unit/test_reporters_notifier.py
+++ b/master/buildbot/test/unit/test_reporters_notifier.py
@@ -44,8 +44,8 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True, wantMq=True)
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
 
     @defer.inlineCallbacks
     def setupNotifier(self, *args, **kwargs):

--- a/master/buildbot/test/unit/test_reporters_pushjet.py
+++ b/master/buildbot/test/unit/test_reporters_pushjet.py
@@ -34,8 +34,8 @@ class TestPushjetNotifier(ConfigErrorsMixin, TestReactorMixin,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True, wantMq=True)
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
 
     def setupFakeHttp(self, base_url='https://api.pushjet.io'):
         return self.successResultOf(fakehttpclientservice.HTTPClientService.getFakeService(

--- a/master/buildbot/test/unit/test_reporters_pushover.py
+++ b/master/buildbot/test/unit/test_reporters_pushover.py
@@ -34,8 +34,8 @@ class TestPushoverNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCas
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True, wantMq=True)
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
 
     def setupFakeHttp(self):
         return self.successResultOf(fakehttpclientservice.HTTPClientService.getFakeService(

--- a/master/buildbot/test/unit/test_reporters_utils.py
+++ b/master/buildbot/test/unit/test_reporters_utils.py
@@ -36,8 +36,8 @@ class TestDataUtils(TestReactorMixin, unittest.TestCase, logging.LoggingMixin):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True, wantDb=True, wantMq=True)
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
 
     def setupDb(self):
         self.db = self.master.db
@@ -182,7 +182,7 @@ class TestURLUtils(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self)
+        self.master = fakemaster.make_master(self)
 
     def test_UrlForBuild(self):
         self.assertEqual(utils.getURLForBuild(self.master, 1, 3),

--- a/master/buildbot/test/unit/test_reporters_words.py
+++ b/master/buildbot/test/unit/test_reporters_words.py
@@ -37,9 +37,8 @@ class TestContactChannel(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             testcase=self, wantMq=True,
-                                             wantData=True, wantDb=True)
+        self.master = fakemaster.make_master(self, wantMq=True, wantData=True,
+                                             wantDb=True)
 
         for builderid, name in zip(self.BUILDER_IDS, self.BUILDER_NAMES):
             self.master.db.builders.addTestBuilder(

--- a/master/buildbot/test/unit/test_scripts_cleanupdb.py
+++ b/master/buildbot/test/unit/test_scripts_cleanupdb.py
@@ -132,7 +132,7 @@ class TestCleanupDb(misc.StdoutAssertionsMixin, dirs.DirsMixin,
         yield self.setUpRealDatabase(table_names=['logs', 'logchunks', 'steps', 'builds', 'builders',
                                                   'masters', 'buildrequests', 'buildsets',
                                                   'workers'])
-        master = fakemaster.make_master(self.reactor)
+        master = fakemaster.make_master(self)
         master.config.db['db_url'] = self.db_url
         self.db = DBConnector(self.basedir)
         self.db.setServiceParent(master)

--- a/master/buildbot/test/unit/test_secret_in_passwordstore.py
+++ b/master/buildbot/test/unit/test_secret_in_passwordstore.py
@@ -16,7 +16,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from twisted.internet import defer, utils
+from twisted.internet import defer
+from twisted.internet import utils
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 

--- a/master/buildbot/test/unit/test_secret_in_vault.py
+++ b/master/buildbot/test/unit/test_secret_in_vault.py
@@ -31,8 +31,7 @@ class TestSecretInVaultHttpFakeBase(ConfigErrorsMixin, TestReactorMixin,
         self.srvcVault = HashiCorpVaultSecretProvider(vaultServer="http://vaultServer",
                                                       vaultToken="someToken",
                                                       apiVersion=version)
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
         self._http = self.successResultOf(
             fakehttpclientservice.HTTPClientService.getFakeService(
                 self.master, self, 'http://vaultServer', headers={'X-Vault-Token': "someToken"}))

--- a/master/buildbot/test/unit/test_secret_rendered_service.py
+++ b/master/buildbot/test/unit/test_secret_rendered_service.py
@@ -30,7 +30,7 @@ class TestRenderSecrets(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage(secretdict={"foo": "bar",
                                                        "other": "value"})
         self.secretsrv = SecretManager()

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -41,9 +41,8 @@ class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             testcase=self, wantMq=True,
-                                             wantData=True, wantDb=True)
+        self.master = fakemaster.make_master(self, wantMq=True, wantData=True,
+                                             wantDb=True)
 
         for builderid, name in zip(self.BUILDER_IDS, self.BUILDER_NAMES):
             self.master.db.builders.addTestBuilder(

--- a/master/buildbot/test/unit/test_util_codebase.py
+++ b/master/buildbot/test/unit/test_util_codebase.py
@@ -41,8 +41,7 @@ class TestAbsoluteSourceStampsMixin(unittest.TestCase,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             wantData=True, testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
         self.db = self.master.db
         self.object = FakeObject(self.master, self.codebases)
 

--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -272,7 +272,7 @@ class RealKubeClientServiceTest(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self)
+        self.master = fakemaster.make_master(self)
         self.createKube()
         self.kube.setServiceParent(self.master)
         return self.master.startService()

--- a/master/buildbot/test/unit/test_util_state.py
+++ b/master/buildbot/test/unit/test_util_state.py
@@ -34,8 +34,7 @@ class TestStateMixin(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True)
         self.object = FakeObject(self.master)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_wamp_connector.py
+++ b/master/buildbot/test/unit/test_wamp_connector.py
@@ -57,7 +57,7 @@ class WampConnector(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
-        master = fakemaster.make_master(self.reactor)
+        master = fakemaster.make_master(self)
         self.connector = TestedWampConnector()
         yield self.connector.setServiceParent(master)
         yield master.startService()

--- a/master/buildbot/test/unit/test_worker_base.py
+++ b/master/buildbot/test/unit/test_worker_base.py
@@ -115,8 +115,7 @@ class RealWorkerItfc(TestReactorMixin, unittest.TestCase, WorkerInterfaceTests):
         self.wrk = ConcreteWorker('wrk', 'pa')
 
     def callAttached(self):
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantData=True)
+        self.master = fakemaster.make_master(self, wantData=True)
         self.master.workers.disownServiceParent()
         self.workers = bworkermanager.FakeWorkerManager()
         self.workers.setServiceParent(self.master)
@@ -131,7 +130,7 @@ class FakeWorkerItfc(TestReactorMixin, unittest.TestCase,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self)
+        self.master = fakemaster.make_master(self)
         self.wrk = worker.FakeWorker(self.master)
 
     def callAttached(self):
@@ -143,9 +142,7 @@ class TestAbstractWorker(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, wantDb=True,
-                                             wantData=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
         self.master.workers.disownServiceParent()
         self.workers = self.master.workers = bworkermanager.FakeWorkerManager()
@@ -563,9 +560,7 @@ class TestAbstractLatentWorker(TestReactorMixin, unittest.SynchronousTestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             wantDb=True, wantData=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
         self.master.workers.disownServiceParent()
         self.workers = self.master.workers = bworkermanager.FakeWorkerManager()

--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -32,8 +32,7 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
     def setupWorker(self, *args, **kwargs):
         self.patch(dockerworker, 'docker', docker)
         worker = dockerworker.DockerLatentWorker(*args, **kwargs)
-        master = fakemaster.make_master(self.reactor, testcase=self,
-                                        wantData=True)
+        master = fakemaster.make_master(self, wantData=True)
         fakemaster.master = master
         worker.setServiceParent(master)
         self.successResultOf(master.startService())

--- a/master/buildbot/test/unit/test_worker_kubernetes.py
+++ b/master/buildbot/test/unit/test_worker_kubernetes.py
@@ -59,8 +59,7 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
         config = KubeHardcodedConfig(master_url="https://kube.example.com")
         self.worker = worker = kubernetes.KubeLatentWorker(
             *args, kube_config=config, **kwargs)
-        master = fakemaster.make_master(self.reactor, testcase=self,
-                                        wantData=True)
+        master = fakemaster.make_master(self, wantData=True)
         self._kube = self.successResultOf(
             KubeClientService.getFakeService(master, self, kube_config=config))
         worker.setServiceParent(master)

--- a/master/buildbot/test/unit/test_worker_local.py
+++ b/master/buildbot/test/unit/test_worker_local.py
@@ -34,9 +34,7 @@ class TestLocalWorker(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             wantDb=True, wantData=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
         self.botmaster = self.master.botmaster
         self.workers = self.master.workers
 

--- a/master/buildbot/test/unit/test_worker_manager.py
+++ b/master/buildbot/test/unit/test_worker_manager.py
@@ -49,8 +49,7 @@ class TestWorkerManager(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor, testcase=self,
-                                             wantMq=True, wantData=True)
+        self.master = fakemaster.make_master(self, wantMq=True, wantData=True)
         self.master.mq = self.master.mq
         self.workers = workermanager.WorkerManager(self.master)
         self.workers.setServiceParent(self.master)

--- a/master/buildbot/test/unit/test_worker_marathon.py
+++ b/master/buildbot/test/unit/test_worker_marathon.py
@@ -64,8 +64,7 @@ class TestMarathonLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
         kwargs.setdefault('image', 'debian:wheezy')
         worker = MarathonLatentWorker('bot', 'tcp://marathon.local', **kwargs)
         self.worker = worker
-        master = fakemaster.make_master(self.reactor,
-                                        testcase=self, wantData=True)
+        master = fakemaster.make_master(self, wantData=True)
         self._http = self.successResultOf(
             fakehttpclientservice.HTTPClientService.getFakeService(
                 master, self, 'tcp://marathon.local', auth=kwargs.get(

--- a/master/buildbot/test/unit/test_worker_protocols_base.py
+++ b/master/buildbot/test/unit/test_worker_protocols_base.py
@@ -28,7 +28,7 @@ class TestListener(TestReactorMixin, unittest.TestCase):
 
     def test_constructor(self):
         self.setUpTestReactor()
-        master = fakemaster.make_master(self.reactor)
+        master = fakemaster.make_master(self)
         listener = base.Listener()
         listener.setServiceParent(master)
         self.assertEqual(listener.master, master)
@@ -39,7 +39,7 @@ class TestFakeConnection(protocols.ConnectionInterfaceTest,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.worker = mock.Mock()
         self.conn = fakeprotocol.FakeConnection(self.master, self.worker)
 
@@ -49,7 +49,7 @@ class TestConnection(protocols.ConnectionInterfaceTest,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.worker = mock.Mock()
         self.conn = base.Connection(self.master, self.worker)
 

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -30,7 +30,7 @@ class TestListener(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
 
     def makeListener(self):
         listener = pb.Listener()
@@ -91,7 +91,7 @@ class TestConnectionApi(util_protocols.ConnectionInterfaceTest,
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.conn = pb.Connection(self.master, mock.Mock(), mock.Mock())
 
 
@@ -99,7 +99,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor)
+        self.master = fakemaster.make_master(self)
         self.mind = mock.Mock()
         self.worker = mock.Mock()
 

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -24,8 +24,8 @@ from twisted.trial import unittest
 
 from buildbot.plugins import util
 from buildbot.secrets.manager import SecretManager
-from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
 from buildbot.test.util.misc import TestReactorMixin

--- a/master/buildbot/test/unit/test_www_hooks_poller.py
+++ b/master/buildbot/test/unit/test_www_hooks_poller.py
@@ -45,7 +45,7 @@ class TestPollingChangeHook(TestReactorMixin, unittest.TestCase):
         self.request.method = b"GET"
         www = self.request.site.master.www
         self.master = master = self.request.site.master = \
-            fakemaster.make_master(self.reactor, testcase=self, wantData=True)
+            fakemaster.make_master(self, wantData=True)
         master.www = www
         yield self.master.startService()
         self.changeHook = change_hook.ChangeHookResource(

--- a/master/buildbot/test/util/changesource.py
+++ b/master/buildbot/test/util/changesource.py
@@ -38,9 +38,7 @@ class ChangeSourceMixin:
 
     def setUpChangeSource(self):
         "Set up the mixin - returns a deferred."
-        self.master = fakemaster.make_master(self.reactor,
-                                             wantDb=True, wantData=True,
-                                             testcase=self)
+        self.master = fakemaster.make_master(self, wantDb=True, wantData=True)
         assert not hasattr(self.master, 'addChange')  # just checking..
         return defer.succeed(None)
 

--- a/master/buildbot/test/util/connector_component.py
+++ b/master/buildbot/test/util/connector_component.py
@@ -51,7 +51,7 @@ class ConnectorComponentMixin(TestReactorMixin, db.RealDatabaseMixin):
 
         self.db = FakeDBConnector()
         self.db.pool = self.db_pool
-        self.db.master = fakemaster.make_master(self.reactor)
+        self.db.master = fakemaster.make_master(self)
         self.db.model = model.Model(self.db)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/util/endpoint.py
+++ b/master/buildbot/test/util/endpoint.py
@@ -37,9 +37,8 @@ class EndpointMixin(TestReactorMixin, interfaces.InterfaceTests):
 
     def setUpEndpoint(self):
         self.setUpTestReactor()
-        self.master = fakemaster.make_master(self.reactor,
-                                             wantMq=True, wantDb=True,
-                                             wantData=True, testcase=self)
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True,
+                                             wantData=True)
         self.db = self.master.db
         self.mq = self.master.mq
         self.data = self.master.data

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -48,7 +48,7 @@ class MigrateTestMixin(TestReactorMixin, db.RealDatabaseMixin, dirs.DirsMixin):
 
         yield self.setUpRealDatabase()
 
-        master = fakemaster.make_master(self.reactor)
+        master = fakemaster.make_master(self)
         self.db = connector.DBConnector(self.basedir)
         self.db.setServiceParent(master)
         self.db.pool = self.db_pool

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -43,9 +43,7 @@ class SchedulerMixin(interfaces.InterfaceTests):
     OTHER_MASTER_ID = 93
 
     def setUpScheduler(self):
-        self.master = fakemaster.make_master(self.reactor,
-                                             testcase=self,
-                                             wantDb=True, wantMq=True,
+        self.master = fakemaster.make_master(self, wantDb=True, wantMq=True,
                                              wantData=True)
 
     def tearDownScheduler(self):

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -169,9 +169,8 @@ class BuildStepMixin:
         factory = interfaces.IBuildStepFactory(step)
 
         step = self.step = factory.buildStep()
-        self.master = fakemaster.make_master(self.reactor,
-                                             wantData=wantData, wantDb=wantDb,
-                                             wantMq=wantMq, testcase=self)
+        self.master = fakemaster.make_master(self, wantData=wantData,
+                                             wantDb=wantDb, wantMq=wantMq)
 
         # mock out the reactor for updateSummary's debouncing
         self.debounceClock = task.Clock()

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -134,8 +134,7 @@ class WwwTestMixin(RequiresWwwMixin):
     UUID = str(uuid1())
 
     def make_master(self, url=None, **kwargs):
-        master = fakemaster.make_master(self.reactor, wantData=True,
-                                        testcase=self)
+        master = fakemaster.make_master(self, wantData=True)
         self.master = master
         master.www = mock.Mock()  # to handle the resourceNeedsReconfigs call
         master.www.getUserInfos = lambda _: getattr(

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -26,11 +26,11 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot.changes.github import PullRequestMixin
+from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
 from buildbot.util import unicode2bytes
 from buildbot.www.hooks.base import BaseHookHandler
-from buildbot.process.properties import Properties
 
 _HEADER_EVENT = b'X-GitHub-Event'
 _HEADER_SIGNATURE = b'X-Hub-Signature'


### PR DESCRIPTION
This PR makes fake reactor as default in `fakemaster.make_master()`. Most of the tests already pass fake reactor to it, so it simplifies the interface and reduces the amount of code slightly.