### PR TITLE
Fix tilde in git repo url on py3.7 GH#4639

### DIFF
--- a/master/buildbot/changes/gitpoller.py
+++ b/master/buildbot/changes/gitpoller.py
@@ -181,8 +181,9 @@ class GitPoller(base.PollingChangeSource, StateMixin, GitMixin):
         return branch
 
     def _trackerBranch(self, branch):
-        return "refs/buildbot/{}/{}".format(urlquote(self.repourl, ''),
-                                        self._removeHeads(branch))
+        # manually quote tilde for Python 3.7
+        url = urlquote(self.repourl, '').replace('~', '%7E')
+        return "refs/buildbot/{}/{}".format(url, self._removeHeads(branch))
 
     @defer.inlineCallbacks
     def poll(self):

--- a/master/buildbot/newsfragments/git-repo-tilde-python-3.7.bugfix
+++ b/master/buildbot/newsfragments/git-repo-tilde-python-3.7.bugfix
@@ -1,0 +1,1 @@
+Fixed bug with tilde in git repo url on Python 3.7 (:issue:`4639`).

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -40,7 +40,7 @@ class GitOutputParsing(gpo.GetProcessOutputMixin, unittest.TestCase):
     """Test GitPoller methods for parsing git output"""
 
     def setUp(self):
-        self.poller = gitpoller.GitPoller('git@example.com:foo/baz.git')
+        self.poller = gitpoller.GitPoller('git@example.com:~foo/baz.git')
         self.setUpGetProcessOutput()
 
     dummyRevStr = '12345abcde'
@@ -174,8 +174,8 @@ class TestGitPollerBase(gpo.GetProcessOutputMixin,
                         TestReactorMixin,
                         unittest.TestCase):
 
-    REPOURL = 'git@example.com:foo/baz.git'
-    REPOURL_QUOTED = 'git%40example.com%3Afoo%2Fbaz.git'
+    REPOURL = 'git@example.com:~foo/baz.git'
+    REPOURL_QUOTED = 'git%40example.com%3A%7Efoo%2Fbaz.git'
 
     def createPoller(self):
         # this is overridden in TestGitPollerWithSshPrivateKey
@@ -544,7 +544,7 @@ class TestGitPoller(TestGitPollerBase):
                 'files': ['/etc/442'],
                 'project': '',
                 'properties': {},
-                'repository': 'git@example.com:foo/baz.git',
+                'repository': 'git@example.com:~foo/baz.git',
                 'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
                 'revlink': '',
                 'src': 'git',
@@ -559,7 +559,7 @@ class TestGitPoller(TestGitPollerBase):
                 'files': ['/etc/64a'],
                 'project': '',
                 'properties': {},
-                'repository': 'git@example.com:foo/baz.git',
+                'repository': 'git@example.com:~foo/baz.git',
                 'revision': '64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
                 'revlink': '',
                 'src': 'git',
@@ -574,7 +574,7 @@ class TestGitPoller(TestGitPollerBase):
                 'files': ['/etc/911'],
                 'project': '',
                 'properties': {},
-                'repository': 'git@example.com:foo/baz.git',
+                'repository': 'git@example.com:~foo/baz.git',
                 'revision': '9118f4ab71963d23d02d4bdc54876ac8bf05acf2',
                 'revlink': '',
                 'src': 'git',
@@ -692,7 +692,7 @@ class TestGitPoller(TestGitPollerBase):
              'files': ['/etc/442'],
              'project': '',
              'properties': {},
-             'repository': 'git@example.com:foo/baz.git',
+             'repository': 'git@example.com:~foo/baz.git',
              'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
              'revlink': '',
              'src': 'git',
@@ -769,7 +769,7 @@ class TestGitPoller(TestGitPollerBase):
              'files': ['/etc/442'],
              'project': '',
              'properties': {},
-             'repository': 'git@example.com:foo/baz.git',
+             'repository': 'git@example.com:~foo/baz.git',
              'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
              'revlink': '',
              'src': 'git',
@@ -1233,7 +1233,7 @@ class TestGitPoller(TestGitPollerBase):
             'files': ['/etc/442'],
             'project': '',
             'properties': {},
-            'repository': 'git@example.com:foo/baz.git',
+            'repository': 'git@example.com:~foo/baz.git',
             'revision': '4423cdbcbb89c14e50dd5f4152415afd686c5241',
             'revlink': '',
             'src': 'git',
@@ -1247,7 +1247,7 @@ class TestGitPoller(TestGitPollerBase):
             'files': ['/etc/64a'],
             'project': '',
             'properties': {},
-            'repository': 'git@example.com:foo/baz.git',
+            'repository': 'git@example.com:~foo/baz.git',
             'revision': '64a5dc2a4bd4f558b5dd193d47c83c7d7abc9a1a',
             'revlink': '',
             'src': 'git',


### PR DESCRIPTION
Fixes bug with tilde in git repo url on Python 3.7 (#4639).

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
