### PR TITLE
Fix secrets leak when non-interpolated secret was passed to a step

### DIFF
--- a/master/buildbot/newsfragments/non-interpolated-secret-leak.bugfix
+++ b/master/buildbot/newsfragments/non-interpolated-secret-leak.bugfix
@@ -1,0 +1,1 @@
+Fix secret leak when non-interpolated secret was passed to a step (:issue:`4007`)

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -478,25 +478,7 @@ class _SecretRenderer:
 class Secret(_SecretRenderer):
 
     def __repr__(self):
-        return "Secret({0})".format(self.secretKey)
-
-    def __init__(self, secretKey):
-        self.secretKey = secretKey
-
-    @defer.inlineCallbacks
-    def getRenderingFor(self, props):
-        secretsSrv = props.master.namedServices.get("secrets")
-        if not secretsSrv:
-            error_message = "secrets service not started, need to configure" \
-                            " SecretManager in c['services'] to use 'secrets'" \
-                            "in Interpolate"
-            raise KeyError(error_message)
-        credsservice = props.master.namedServices['secrets']
-        secret_detail = yield credsservice.get(self.secretKey)
-        if secret_detail is None:
-            raise KeyError("secret key %s is not found in any provider" % self.secretKey)
-        props.useSecret(secret_detail.value, self.secretKey)
-        return secret_detail.value
+        return "Secret({0})".format(self.secret_name)
 
 
 class _SecretIndexer:

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -495,6 +495,7 @@ class Secret(_SecretRenderer):
         secret_detail = yield credsservice.get(self.secretKey)
         if secret_detail is None:
             raise KeyError("secret key %s is not found in any provider" % self.secretKey)
+        props.useSecret(secret_detail.value, self.secretKey)
         return secret_detail.value
 
 

--- a/master/buildbot/test/integration/interop/test_integration_secrets.py
+++ b/master/buildbot/test/integration/interop/test_integration_secrets.py
@@ -15,6 +15,8 @@
 
 import os
 
+from parameterized import parameterized
+
 from twisted.internet import defer
 
 from buildbot.process.properties import Interpolate
@@ -31,24 +33,40 @@ class FakeSecretReporter(HttpStatusPush):
 
 class SecretsConfig(RunMasterBase):
 
+    @parameterized.expand([
+        ('with_interpolation', True),
+        ('plain_command', False),
+    ])
     @defer.inlineCallbacks
-    def test_secret(self):
-        c = masterConfig()
+    def test_secret(self, name, use_interpolation):
+        c = masterConfig(use_interpolation)
         yield self.setupConfig(c)
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['buildid'], 1)
+
+        # check the command line
         res = yield self.checkBuildStepLogExist(build, "echo <foo>")
-        if os.name == "posix":
+
+        # also check the secrets are replaced in argv
+        yield self.checkBuildStepLogExist(build, "argv:.*echo.*<foo>", regex=True)
+
+        # also check that the correct value goes to the command
+        if os.name == "posix" and use_interpolation:
             res &= yield self.checkBuildStepLogExist(build, "The password was there")
+
         self.assertTrue(res)
         # at this point, build contains all the log and steps info that is in the db
         # we check that our secret is not in there!
         self.assertNotIn("bar", repr(build))
         self.assertTrue(c['services'][0].reported)
 
+    @parameterized.expand([
+        ('with_interpolation', True),
+        ('plain_command', False),
+    ])
     @defer.inlineCallbacks
-    def test_secretReconfig(self):
-        c = masterConfig()
+    def test_secretReconfig(self, name, use_interpolation):
+        c = masterConfig(use_interpolation)
         yield self.setupConfig(c)
         c['secretsProviders'] = [FakeSecretStorage(
             secretdict={"foo": "different_value", "something": "more"})]
@@ -67,11 +85,11 @@ class SecretsConfigPB(SecretsConfig):
 
 
 # master configuration
-def masterConfig():
+def masterConfig(use_interpolation):
     c = {}
     from buildbot.config import BuilderConfig
     from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import schedulers, steps
+    from buildbot.plugins import schedulers, steps, util
 
     c['services'] = [FakeSecretReporter('http://example.com/hook',
                                         auth=('user', Interpolate('%(secret:httppasswd)s')))]
@@ -83,12 +101,18 @@ def masterConfig():
     c['secretsProviders'] = [FakeSecretStorage(
         secretdict={"foo": "bar", "something": "more", 'httppasswd': 'myhttppasswd'})]
     f = BuildFactory()
-    if os.name == "posix":
-        f.addStep(steps.ShellCommand(command=Interpolate(
-            'echo %(secret:foo)s | sed "s/bar/The password was there/"')))
+
+    if use_interpolation:
+        if os.name == "posix":
+            # on posix we can also check whether the password was passed to the command
+            command = Interpolate('echo %(secret:foo)s | sed "s/bar/The password was there/"')
+        else:
+            command = Interpolate('echo %(secret:foo)s')
     else:
-        f.addStep(steps.ShellCommand(command=Interpolate(
-            'echo %(secret:foo)s')))
+        command = ['echo', util.Secret('foo')]
+
+    f.addStep(steps.ShellCommand(command=command))
+
     c['builders'] = [
         BuilderConfig(name="testy",
                       workernames=["local1"],

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import os
+import re
 import sys
 from io import StringIO
 
@@ -291,15 +292,19 @@ class RunMasterBase(unittest.TestCase):
                     self.printLog(log, out)
 
     @defer.inlineCallbacks
-    def checkBuildStepLogExist(self, build, expectedLog, onlyStdout=False):
+    def checkBuildStepLogExist(self, build, expectedLog, onlyStdout=False, regex=False):
         yield self.enrichBuild(build, wantSteps=True, wantProperties=True, wantLogs=True)
         for step in build['steps']:
             for log in step['logs']:
                 for line in log['contents']['content'].splitlines():
                     if onlyStdout and line[0] != 'o':
                         continue
-                    if expectedLog in line:
-                        return True
+                    if regex:
+                        if re.search(expectedLog, line):
+                            return True
+                    else:
+                        if expectedLog in line:
+                            return True
         return False
 
     def printLog(self, log, out):


### PR DESCRIPTION
Fixes #4007. There was some non-identical code duplication, see b389b48fe8 for the actual fix.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
