### PR TITLE
Use fake reactor in tests (part 6)

### DIFF
--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 
 from twisted.internet import defer
-from twisted.internet import reactor
 
 from buildbot.data import base
 from buildbot.data import types
@@ -224,12 +223,11 @@ class BuildRequest(base.ResourceType):
         return True
 
     @base.updateMethod
-    def claimBuildRequests(self, brids, claimed_at=None, _reactor=reactor):
+    def claimBuildRequests(self, brids, claimed_at=None):
         return self.callDbBuildRequests(brids,
                                         self.master.db.buildrequests.claimBuildRequests,
                                         event="claimed",
-                                        claimed_at=claimed_at,
-                                        _reactor=_reactor)
+                                        claimed_at=claimed_at)
 
     @base.updateMethod
     @defer.inlineCallbacks
@@ -240,8 +238,7 @@ class BuildRequest(base.ResourceType):
 
     @base.updateMethod
     @defer.inlineCallbacks
-    def completeBuildRequests(self, brids, results, complete_at=None,
-                              _reactor=reactor):
+    def completeBuildRequests(self, brids, results, complete_at=None):
         assert results != RETRY, "a buildrequest cannot be completed with a retry status!"
         if not brids:
             # empty buildrequest list. No need to call db API
@@ -250,8 +247,7 @@ class BuildRequest(base.ResourceType):
             yield self.master.db.buildrequests.completeBuildRequests(
                 brids,
                 results,
-                complete_at=complete_at,
-                _reactor=_reactor)
+                complete_at=complete_at)
         except NotClaimedError:
             # the db layer returned a NotClaimedError exception, usually
             # because one of the buildrequests has been claimed by another

--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -16,7 +16,6 @@
 import copy
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.python import log
 
 from buildbot.data import base
@@ -124,7 +123,7 @@ class Change(base.ResourceType):
     def addChange(self, files=None, comments=None, author=None, revision=None,
                   when_timestamp=None, branch=None, category=None, revlink='',
                   properties=None, repository='', codebase=None, project='',
-                  src=None, _reactor=reactor):
+                  src=None):
         metrics.MetricCountEvent.log("added_changes", 1)
 
         if properties is None:
@@ -191,8 +190,7 @@ class Change(base.ResourceType):
             repository=repository,
             codebase=codebase,
             project=project,
-            uid=uid,
-            _reactor=_reactor)
+            uid=uid)
 
         # get the change and munge the result for the notification
         change = yield self.master.data.get(('changes', str(changeid)))

--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -19,7 +19,6 @@ import itertools
 import sqlalchemy as sa
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.python import log
 
 from buildbot.db import NULL
@@ -134,11 +133,11 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
         return res
 
     @defer.inlineCallbacks
-    def claimBuildRequests(self, brids, claimed_at=None, _reactor=reactor):
+    def claimBuildRequests(self, brids, claimed_at=None):
         if claimed_at is not None:
             claimed_at = datetime2epoch(claimed_at)
         else:
-            claimed_at = _reactor.seconds()
+            claimed_at = int(self.master.reactor.seconds())
 
         def thd(conn):
             transaction = conn.begin()
@@ -186,13 +185,12 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thd)
 
     @defer.inlineCallbacks
-    def completeBuildRequests(self, brids, results, complete_at=None,
-                              _reactor=reactor):
+    def completeBuildRequests(self, brids, results, complete_at=None):
         assert results != RETRY, "a buildrequest cannot be completed with a retry status!"
         if complete_at is not None:
             complete_at = datetime2epoch(complete_at)
         else:
-            complete_at = _reactor.seconds()
+            complete_at = int(self.master.reactor.seconds())
 
         def thd(conn):
             transaction = conn.begin()

--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -19,7 +19,6 @@ import json
 import sqlalchemy as sa
 
 from twisted.internet import defer
-from twisted.internet import reactor
 
 from buildbot.db import NULL
 from buildbot.db import base
@@ -125,8 +124,8 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
 
     # returns a Deferred that returns a value
     def addBuild(self, builderid, buildrequestid, workerid, masterid,
-                 state_string, _reactor=reactor, _race_hook=None):
-        started_at = _reactor.seconds()
+                 state_string, _race_hook=None):
+        started_at = int(self.master.reactor.seconds())
 
         def thd(conn):
             tbl = self.db.model.builds
@@ -166,12 +165,12 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thd)
 
     # returns a Deferred that returns None
-    def finishBuild(self, buildid, results, _reactor=reactor):
+    def finishBuild(self, buildid, results):
         def thd(conn):
             tbl = self.db.model.builds
             q = tbl.update(whereclause=(tbl.c.id == buildid))
             conn.execute(q,
-                         complete_at=_reactor.seconds(),
+                         complete_at=self.master.reactor.seconds(),
                          results=results)
         return self.db.pool.do(thd)
 

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -21,7 +21,6 @@ import json
 import sqlalchemy as sa
 
 from twisted.internet import defer
-from twisted.internet import reactor
 
 from buildbot.db import NULL
 from buildbot.db import base
@@ -47,12 +46,11 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
     @defer.inlineCallbacks
     def addBuildset(self, sourcestamps, reason, properties, builderids,
                     waited_for, external_idstring=None, submitted_at=None,
-                    parent_buildid=None, parent_relationship=None,
-                    _reactor=reactor):
-        if submitted_at:
+                    parent_buildid=None, parent_relationship=None):
+        if submitted_at is not None:
             submitted_at = datetime2epoch(submitted_at)
         else:
-            submitted_at = _reactor.seconds()
+            submitted_at = int(self.master.reactor.seconds())
 
         # convert to sourcestamp IDs first, as necessary
         def toSsid(sourcestamp):
@@ -130,12 +128,11 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
         return (bsid, brids)
 
     @defer.inlineCallbacks
-    def completeBuildset(self, bsid, results, complete_at=None,
-                         _reactor=reactor):
+    def completeBuildset(self, bsid, results, complete_at=None):
         if complete_at is not None:
             complete_at = datetime2epoch(complete_at)
         else:
-            complete_at = _reactor.seconds()
+            complete_at = int(self.master.reactor.seconds())
 
         def thd(conn):
             tbl = self.db.model.buildsets

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -22,7 +22,6 @@ import json
 import sqlalchemy as sa
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.python import log
 
 from buildbot.db import base
@@ -57,7 +56,7 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
     def addChange(self, author=None, files=None, comments=None, is_dir=None,
                   revision=None, when_timestamp=None, branch=None,
                   category=None, revlink='', properties=None, repository='', codebase='',
-                  project='', uid=None, _reactor=reactor):
+                  project='', uid=None):
         assert project is not None, "project must be a string, not None"
         assert repository is not None, "repository must be a string, not None"
 
@@ -65,7 +64,7 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
             log.msg("WARNING: change source is providing deprecated "
                     "value is_dir (ignored)")
         if when_timestamp is None:
-            when_timestamp = epoch2datetime(_reactor.seconds())
+            when_timestamp = epoch2datetime(self.master.reactor.seconds())
 
         if properties is None:
             properties = {}
@@ -88,7 +87,7 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
         # calculate the sourcestamp first, before adding it
         ssid = yield self.db.sourcestamps.findSourceStampId(
             revision=revision, branch=branch, repository=repository,
-            codebase=codebase, project=project, _reactor=_reactor)
+            codebase=codebase, project=project)
 
         parent_changeids = yield self.getParentChangeIds(branch, repository, project, codebase)
         # Someday, changes will have multiple parents.

--- a/master/buildbot/db/masters.py
+++ b/master/buildbot/db/masters.py
@@ -16,8 +16,6 @@
 
 import sqlalchemy as sa
 
-from twisted.internet import reactor
-
 from buildbot.db import base
 from buildbot.util import epoch2datetime
 
@@ -29,7 +27,7 @@ class MasterDict(dict):
 class MastersConnectorComponent(base.DBConnectorComponent):
     data2db = {"masterid": "id", "link": "id"}
 
-    def findMasterId(self, name, _reactor=reactor):
+    def findMasterId(self, name):
         tbl = self.db.model.masters
         return self.findSomethingId(
             tbl=tbl,
@@ -38,11 +36,11 @@ class MastersConnectorComponent(base.DBConnectorComponent):
                 name=name,
                 name_hash=self.hashColumns(name),
                 active=0,  # initially inactive
-                last_active=_reactor.seconds()
+                last_active=self.master.reactor.seconds()
             ))
 
     # returns a Deferred that returns a value
-    def setMasterState(self, masterid, active, _reactor=reactor):
+    def setMasterState(self, masterid, active):
         def thd(conn):
             tbl = self.db.model.masters
             whereclause = (tbl.c.id == masterid)
@@ -68,7 +66,7 @@ class MastersConnectorComponent(base.DBConnectorComponent):
             q = tbl.update(whereclause=whereclause)
             q = q.values(active=1 if active else 0)
             if active:
-                q = q.values(last_active=_reactor.seconds())
+                q = q.values(last_active=self.master.reactor.seconds())
             conn.execute(q)
 
             # return True if there was a change in state
@@ -100,7 +98,7 @@ class MastersConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thd)
 
     # returns a Deferred that returns None
-    def setAllMastersActiveLongTimeAgo(self, _reactor=reactor):
+    def setAllMastersActiveLongTimeAgo(self):
         def thd(conn):
             tbl = self.db.model.masters
             q = tbl.update().values(active=1, last_active=0)

--- a/master/buildbot/db/sourcestamps.py
+++ b/master/buildbot/db/sourcestamps.py
@@ -19,7 +19,6 @@ import base64
 import sqlalchemy as sa
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.python import log
 
 from buildbot.db import base
@@ -43,8 +42,7 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
     def findSourceStampId(self, branch=None, revision=None, repository=None,
                           project=None, codebase=None, patch_body=None,
                           patch_level=None, patch_author=None,
-                          patch_comment=None, patch_subdir=None,
-                          _reactor=reactor):
+                          patch_comment=None, patch_subdir=None):
         tbl = self.db.model.sourcestamps
 
         assert codebase is not None, "codebase cannot be None"
@@ -85,7 +83,7 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
                 'project': project,
                 'patchid': patchid,
                 'ss_hash': ss_hash,
-                'created_at': _reactor.seconds(),
+                'created_at': self.master.reactor.seconds(),
             })
         return sourcestampid
 

--- a/master/buildbot/db/steps.py
+++ b/master/buildbot/db/steps.py
@@ -19,7 +19,6 @@ import json
 import sqlalchemy as sa
 
 from twisted.internet import defer
-from twisted.internet import reactor
 
 from buildbot.db import base
 from buildbot.util import epoch2datetime
@@ -114,8 +113,8 @@ class StepsConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thd)
 
     @defer.inlineCallbacks
-    def startStep(self, stepid, _reactor=reactor):
-        started_at = _reactor.seconds()
+    def startStep(self, stepid):
+        started_at = int(self.master.reactor.seconds())
 
         def thd(conn):
             tbl = self.db.model.steps
@@ -165,12 +164,12 @@ class StepsConnectorComponent(base.DBConnectorComponent):
         return self.url_lock.run(lambda: self.db.pool.do(thd))
 
     # returns a Deferred that returns None
-    def finishStep(self, stepid, results, hidden, _reactor=reactor):
+    def finishStep(self, stepid, results, hidden):
         def thd(conn):
             tbl = self.db.model.steps
             q = tbl.update(whereclause=(tbl.c.id == stepid))
             conn.execute(q,
-                         complete_at=_reactor.seconds(),
+                         complete_at=self.master.reactor.seconds(),
                          results=results,
                          hidden=1 if hidden else 0)
         return self.db.pool.do(thd)

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -121,38 +121,6 @@ class ForceOptions(usage.Options):
             self['reason'] = " ".join(args)
 
 
-class BuildRequest:
-    hasStarted = False
-    timer = None
-
-    def __init__(self, parent, useRevisions=False, useColors=True):
-        self.parent = parent
-        self.useRevisions = useRevisions
-        self.useColors = useColors
-        self.timer = reactor.callLater(5, self.soon)
-
-    def soon(self):
-        del self.timer
-        if not self.hasStarted:
-            self.parent.send("The build has been queued, I'll give a shout"
-                             " when it starts")
-
-    def started(self, s):
-        self.hasStarted = True
-        if self.timer:
-            self.timer.cancel()
-            del self.timer
-        if self.useRevisions:
-            response = "build containing revision(s) [%s] forced" % s.getRevisions(
-            )
-        else:
-            response = "build #%d forced" % s.getNumber()
-        self.parent.send(response)
-        self.parent.send("I'll give a shout when the build finishes")
-        d = s.waitUntilFinished()
-        d.addCallback(self.parent.watchedBuildFinished)
-
-
 class Contact(service.AsyncService):
 
     """I hold the state for a single user's interaction with the buildbot.

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -162,7 +162,7 @@ class Contact(service.AsyncService):
     'broadcast contact' (chat rooms, IRC channels as a whole).
     """
 
-    def __init__(self, bot, user=None, channel=None):
+    def __init__(self, bot, user=None, channel=None, _reactor=reactor):
         """
         :param StatusBot bot: StatusBot this Contact belongs to
         :param user: User ID representing this contact
@@ -190,6 +190,8 @@ class Contact(service.AsyncService):
         self.channel = channel
         self._next_HELLO = 'yes?'
 
+        self.reactor = _reactor
+
     # silliness
 
     silly = {
@@ -213,7 +215,7 @@ class Contact(service.AsyncService):
         response = self.silly[message]
         when = 0.5
         for r in response:
-            reactor.callLater(when, self.send, r)
+            self.reactor.callLater(when, self.send, r)
             when += 2.5
 
     def builderMatchesAnyTag(self, builder_tags):
@@ -776,7 +778,8 @@ class Contact(service.AsyncService):
                     complete_at = lastBuild['complete_at']
                     if complete_at:
                         complete_at = util.datetime2epoch(complete_at)
-                        ago = self.convertTime(int(util.now() - complete_at))
+                        ago = self.convertTime(int(self.reactor.seconds() -
+                                                   complete_at))
                     else:
                         ago = "??"
                     status = lastBuild['state_string']
@@ -821,7 +824,8 @@ class Contact(service.AsyncService):
                 complete_at = lastBuild['complete_at']
                 if complete_at:
                     complete_at = util.datetime2epoch(complete_at)
-                    ago = self.convertTime(int(util.now() - complete_at))
+                    ago = self.convertTime(int(self.reactor.seconds() -
+                                               complete_at))
                 else:
                     ago = "??"
                 status = lastBuild['state_string']
@@ -905,11 +909,11 @@ class Contact(service.AsyncService):
             self.act("readies phasers")
 
     def command_DANCE(self, args):
-        reactor.callLater(1.0, self.send, "<(^.^<)")
-        reactor.callLater(2.0, self.send, "<(^.^)>")
-        reactor.callLater(3.0, self.send, "(>^.^)>")
-        reactor.callLater(3.5, self.send, "(7^.^)7")
-        reactor.callLater(5.0, self.send, "(>^.^<)")
+        self.reactor.callLater(1.0, self.send, "<(^.^<)")
+        self.reactor.callLater(2.0, self.send, "<(^.^)>")
+        self.reactor.callLater(3.0, self.send, "(>^.^)>")
+        self.reactor.callLater(3.5, self.send, "(7^.^)7")
+        self.reactor.callLater(5.0, self.send, "(>^.^<)")
 
     def command_HUSTLE(self, args):
         self.act("does the hustle")
@@ -945,7 +949,7 @@ class Contact(service.AsyncService):
                 botmaster.cancelCleanShutdown()
         elif args == 'now':
             self.send("Stopping buildbot")
-            reactor.stop()
+            self.reactor.stop()
     command_SHUTDOWN.usage = {
         None: "shutdown check|start|stop|now - shutdown the buildbot master",
         "check": "shutdown check - check if the buildbot master is running or shutting down",

--- a/master/buildbot/spec/types/buildrequest.raml
+++ b/master/buildbot/spec/types/buildrequest.raml
@@ -11,11 +11,10 @@ description: |
 
     .. py:class:: buildbot.data.buildrequests.BuildRequest
 
-        .. py:method:: claimBuildRequests(brids, claimed_at=None, _reactor=twisted.internet.reactor)
+        .. py:method:: claimBuildRequests(brids, claimed_at=None)
 
             :param list(integer) brids: list of buildrequest id to claim
             :param datetime claimed_at: date and time when the buildrequest is claimed
-            :param twisted.internet.interfaces.IReactorTime _reactor: reactor used to get current time if ``claimed_at`` is None
             :returns: (boolean) whether claim succeeded or not
 
             Claim a list of buildrequests
@@ -26,12 +25,11 @@ description: |
 
             Unclaim a list of buildrequests
 
-        .. py:method:: completeBuildRequests(brids, results, complete_at=None, _reactor=twisted.internet.reactor)
+        .. py:method:: completeBuildRequests(brids, results, complete_at=None)
 
             :param list(integer) brids: list of buildrequest id to complete
             :param integer results: the results of the buildrequest (see :ref:`Build-Result-Codes`)
             :param datetime complete_at: date and time when the buildrequest is completed
-            :param twisted.internet.interfaces.IReactorTime _reactor: reactor used to get current time, if ``complete_at`` is None
 
             Complete a list of buildrequest with the ``results`` status
 

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -16,7 +16,6 @@
 import json
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.python import failure
 
 from buildbot.data import connector
@@ -174,7 +173,7 @@ class FakeUpdates(service.AsyncService):
         return defer.succeed(None)
 
     @defer.inlineCallbacks
-    def claimBuildRequests(self, brids, claimed_at=None, _reactor=reactor):
+    def claimBuildRequests(self, brids, claimed_at=None):
         validation.verifyType(self.testcase, 'brids', brids,
                               validation.ListValidator(validation.IntValidator()))
         validation.verifyType(self.testcase, 'claimed_at', claimed_at,
@@ -183,7 +182,7 @@ class FakeUpdates(service.AsyncService):
             return True
         try:
             yield self.master.db.buildrequests.claimBuildRequests(
-                brids=brids, claimed_at=claimed_at, _reactor=_reactor)
+                brids=brids, claimed_at=claimed_at)
         except AlreadyClaimedError:
             return False
         self.claimedBuildRequests.update(set(brids))
@@ -197,7 +196,7 @@ class FakeUpdates(service.AsyncService):
         if brids:
             yield self.master.db.buildrequests.unclaimBuildRequests(brids)
 
-    def completeBuildRequests(self, brids, results, complete_at=None, _reactor=reactor):
+    def completeBuildRequests(self, brids, results, complete_at=None):
         validation.verifyType(self.testcase, 'brids', brids,
                               validation.ListValidator(validation.IntValidator()))
         validation.verifyType(self.testcase, 'results', results,

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -25,7 +25,6 @@ import hashlib
 import json
 
 from twisted.internet import defer
-from twisted.internet import reactor
 
 from buildbot.data import resultspec
 from buildbot.db import buildrequests
@@ -683,6 +682,7 @@ class FakeDBComponent:
     def __init__(self, db, testcase):
         self.db = db
         self.t = testcase
+        self.reactor = testcase.reactor
         self.setUp()
 
     def mapFilter(self, f, fieldMapping):
@@ -834,7 +834,7 @@ class FakeChangesComponent(FakeDBComponent):
     def addChange(self, author=None, files=None, comments=None, is_dir=None,
                   revision=None, when_timestamp=None, branch=None,
                   category=None, revlink='', properties=None, repository='',
-                  codebase='', project='', uid=None, _reactor=reactor):
+                  codebase='', project='', uid=None):
         if properties is None:
             properties = {}
 
@@ -845,7 +845,7 @@ class FakeChangesComponent(FakeDBComponent):
 
         ssid = yield self.db.sourcestamps.findSourceStampId(
             revision=revision, branch=branch, repository=repository,
-            codebase=codebase, project=project, _reactor=_reactor)
+            codebase=codebase, project=project)
 
         parent_changeids = yield self.getParentChangeIds(branch, repository, project, codebase)
 
@@ -1169,8 +1169,8 @@ class FakeSourceStampsComponent(FakeDBComponent):
     def findSourceStampId(self, branch=None, revision=None, repository=None,
                           project=None, codebase=None,
                           patch_body=None, patch_level=None,
-                          patch_author=None, patch_comment=None, patch_subdir=None,
-                          _reactor=reactor):
+                          patch_author=None, patch_comment=None,
+                          patch_subdir=None):
         if patch_body:
             patchid = len(self.patches) + 1
             while patchid in self.patches:
@@ -1187,7 +1187,7 @@ class FakeSourceStampsComponent(FakeDBComponent):
 
         new_ssdict = dict(branch=branch, revision=revision, codebase=codebase,
                           patchid=patchid, repository=repository, project=project,
-                          created_at=epoch2datetime(_reactor.seconds()))
+                          created_at=epoch2datetime(self.reactor.seconds()))
         for id, ssdict in self.sourcestamps.items():
             keys = ['branch', 'revision', 'repository',
                     'codebase', 'project', 'patchid']
@@ -1276,17 +1276,16 @@ class FakeBuildsetsComponent(FakeDBComponent):
     @defer.inlineCallbacks
     def addBuildset(self, sourcestamps, reason, properties, builderids, waited_for,
                     external_idstring=None, submitted_at=None,
-                    parent_buildid=None, parent_relationship=None,
-                    _reactor=reactor):
+                    parent_buildid=None, parent_relationship=None):
         # We've gotten this wrong a couple times.
         assert isinstance(
             waited_for, bool), 'waited_for should be boolean: %r' % waited_for
 
         # calculate submitted at
-        if submitted_at:
+        if submitted_at is not None:
             submitted_at = datetime2epoch(submitted_at)
         else:
-            submitted_at = _reactor.seconds()
+            submitted_at = int(self.reactor.seconds())
 
         bsid = self._newBsid()
         br_rows = []
@@ -1294,6 +1293,7 @@ class FakeBuildsetsComponent(FakeDBComponent):
             br_rows.append(
                 BuildRequest(buildsetid=bsid, builderid=builderid, waited_for=waited_for,
                              submitted_at=submitted_at))
+
         self.db.buildrequests.insertTestData(br_rows)
 
         # make up a row and keep its dictionary, with the properties tacked on
@@ -1301,6 +1301,7 @@ class FakeBuildsetsComponent(FakeDBComponent):
                          external_idstring=external_idstring,
                          submitted_at=submitted_at,
                          parent_buildid=parent_buildid, parent_relationship=parent_relationship)
+
         self.buildsets[bsid] = bsrow.values.copy()
         self.buildsets[bsid]['properties'] = properties
 
@@ -1314,14 +1315,18 @@ class FakeBuildsetsComponent(FakeDBComponent):
 
         return (bsid, {br.builderid: br.id for br in br_rows})
 
-    def completeBuildset(self, bsid, results, complete_at=None,
-                         _reactor=reactor):
+    def completeBuildset(self, bsid, results, complete_at=None):
         if bsid not in self.buildsets or self.buildsets[bsid]['complete']:
             raise buildsets.AlreadyCompleteError()
+
+        if complete_at is not None:
+            complete_at = datetime2epoch(complete_at)
+        else:
+            complete_at = int(self.reactor.seconds())
+
         self.buildsets[bsid]['results'] = results
         self.buildsets[bsid]['complete'] = 1
-        self.buildsets[bsid]['complete_at'] = \
-            datetime2epoch(complete_at) if complete_at else _reactor.seconds()
+        self.buildsets[bsid]['complete_at'] = complete_at
         return defer.succeed(None)
 
     def getBuildset(self, bsid):
@@ -1451,7 +1456,7 @@ class FakeWorkersComponent(FakeDBComponent):
                     masterid=row.masterid,
                     workerid=row.workerid)
 
-    def findWorkerId(self, name, _reactor=reactor):
+    def findWorkerId(self, name):
         validation.verifyType(self.t, 'name', name,
                               validation.IdentifierValidator(50))
         for m in self.workers.values():
@@ -1695,9 +1700,6 @@ class FakeBuildRequestsComponent(FakeDBComponent):
     # for use in determining "my" requests
     MASTER_ID = 824
 
-    # override this to set reactor.seconds
-    _reactor = reactor
-
     def setUp(self):
         self.reqs = {}
         self.claims = {}
@@ -1781,19 +1783,21 @@ class FakeBuildRequestsComponent(FakeDBComponent):
             rv = self.applyResultSpec(rv, resultSpec)
         return rv
 
-    def claimBuildRequests(self, brids, claimed_at=None, _reactor=reactor):
+    def claimBuildRequests(self, brids, claimed_at=None):
         for brid in brids:
             if brid not in self.reqs or brid in self.claims:
                 raise buildrequests.AlreadyClaimedError
 
-        claimed_at = datetime2epoch(claimed_at)
-        if not claimed_at:
-            claimed_at = _reactor.seconds()
+        if claimed_at is not None:
+            claimed_at = datetime2epoch(claimed_at)
+        else:
+            claimed_at = int(self.reactor.seconds())
 
         # now that we've thrown any necessary exceptions, get started
         for brid in brids:
             self.claims[brid] = BuildRequestClaim(brid=brid,
-                                                  masterid=self.MASTER_ID, claimed_at=claimed_at)
+                                                  masterid=self.MASTER_ID,
+                                                  claimed_at=claimed_at)
         return defer.succeed(None)
 
     def unclaimBuildRequests(self, brids):
@@ -1801,12 +1805,11 @@ class FakeBuildRequestsComponent(FakeDBComponent):
             if brid in self.claims and self.claims[brid].masterid == self.db.master.masterid:
                 self.claims.pop(brid)
 
-    def completeBuildRequests(self, brids, results, complete_at=None,
-                              _reactor=reactor):
+    def completeBuildRequests(self, brids, results, complete_at=None):
         if complete_at is not None:
             complete_at = datetime2epoch(complete_at)
         else:
-            complete_at = _reactor.seconds()
+            complete_at = int(self.reactor.seconds())
 
         for brid in brids:
             if brid not in self.reqs or self.reqs[brid].complete == 1:
@@ -1827,7 +1830,8 @@ class FakeBuildRequestsComponent(FakeDBComponent):
         if masterid is None:
             masterid = self.MASTER_ID
         self.claims[brid] = BuildRequestClaim(brid=brid,
-                                              masterid=masterid, claimed_at=self._reactor.seconds())
+                                              masterid=masterid,
+                                              claimed_at=self.reactor.seconds())
 
     def fakeUnclaimBuildRequest(self, brid):
         del self.claims[brid]
@@ -1909,7 +1913,7 @@ class FakeBuildsComponent(FakeDBComponent):
         return defer.succeed(ret)
 
     def addBuild(self, builderid, buildrequestid, workerid, masterid,
-                 state_string, _reactor=reactor):
+                 state_string):
         validation.verifyType(self.t, 'state_string', state_string,
                               validation.StringValidator())
         id = self._newId()
@@ -1919,7 +1923,8 @@ class FakeBuildsComponent(FakeDBComponent):
                                buildrequestid=buildrequestid, builderid=builderid,
                                workerid=workerid, masterid=masterid,
                                state_string=state_string,
-                               started_at=_reactor.seconds(), complete_at=None,
+                               started_at=self.reactor.seconds(),
+                               complete_at=None,
                                results=None)
         return defer.succeed((id, number))
 
@@ -1931,8 +1936,8 @@ class FakeBuildsComponent(FakeDBComponent):
             b['state_string'] = state_string
         return defer.succeed(None)
 
-    def finishBuild(self, buildid, results, _reactor=reactor):
-        now = _reactor.seconds()
+    def finishBuild(self, buildid, results):
+        now = self.reactor.seconds()
         b = self.builds.get(buildid)
         if b:
             b['complete_at'] = now
@@ -2011,7 +2016,7 @@ class FakeStepsComponent(FakeDBComponent):
         ret.sort(key=lambda r: r['number'])
         return defer.succeed(ret)
 
-    def addStep(self, buildid, name, state_string, _reactor=reactor):
+    def addStep(self, buildid, name, state_string):
         validation.verifyType(self.t, 'state_string', state_string,
                               validation.StringValidator())
         validation.verifyType(self.t, 'name', name,
@@ -2045,10 +2050,10 @@ class FakeStepsComponent(FakeDBComponent):
 
         return defer.succeed((id, number, name))
 
-    def startStep(self, stepid, _reactor=reactor):
+    def startStep(self, stepid):
         b = self.steps.get(stepid)
         if b:
-            b['started_at'] = _reactor.seconds()
+            b['started_at'] = self.reactor.seconds()
         return defer.succeed(None)
 
     def setStepStateString(self, stepid, state_string):
@@ -2075,8 +2080,8 @@ class FakeStepsComponent(FakeDBComponent):
             b['urls_json'] = json.dumps(urls)
         return defer.succeed(None)
 
-    def finishStep(self, stepid, results, hidden, _reactor=reactor):
-        now = _reactor.seconds()
+    def finishStep(self, stepid, results, hidden):
+        now = self.reactor.seconds()
         b = self.steps.get(stepid)
         if b:
             b['complete_at'] = now
@@ -2315,7 +2320,7 @@ class FakeMastersComponent(FakeDBComponent):
                     active=bool(row.active),
                     last_active=epoch2datetime(row.last_active))
 
-    def findMasterId(self, name, _reactor=reactor):
+    def findMasterId(self, name):
         for m in self.masters.values():
             if m['name'] == name:
                 return defer.succeed(m['id'])
@@ -2324,16 +2329,16 @@ class FakeMastersComponent(FakeDBComponent):
             id=id,
             name=name,
             active=False,
-            last_active=epoch2datetime(_reactor.seconds()))
+            last_active=epoch2datetime(self.reactor.seconds()))
         return defer.succeed(id)
 
-    def setMasterState(self, masterid, active, _reactor=reactor):
+    def setMasterState(self, masterid, active):
         if masterid in self.masters:
             was_active = self.masters[masterid]['active']
             self.masters[masterid]['active'] = active
             if active:
                 self.masters[masterid]['last_active'] = \
-                    epoch2datetime(_reactor.seconds())
+                    epoch2datetime(self.reactor.seconds())
             return defer.succeed(bool(was_active) != bool(active))
         else:
             return defer.succeed(False)
@@ -2377,7 +2382,7 @@ class FakeBuildersComponent(FakeDBComponent):
                 self.builders_tags.setdefault(row.builderid,
                                               []).append(row.tagid)
 
-    def findBuilderId(self, name, autoCreate=True, _reactor=reactor):
+    def findBuilderId(self, name, autoCreate=True):
         for m in self.builders.values():
             if m['name'] == name:
                 return defer.succeed(m['id'])
@@ -2467,7 +2472,7 @@ class FakeTagsComponent(FakeDBComponent):
                     id=row.id,
                     name=row.name)
 
-    def findTagId(self, name, _reactor=reactor):
+    def findTagId(self, name):
         for m in self.tags.values():
             if m['name'] == name:
                 return defer.succeed(m['id'])

--- a/master/buildbot/test/unit/test_data_buildrequests.py
+++ b/master/buildbot/test/unit/test_data_buildrequests.py
@@ -19,7 +19,6 @@ import datetime
 import mock
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.trial import unittest
 
 from buildbot.data import buildrequests
@@ -30,6 +29,7 @@ from buildbot.test.util import endpoint
 from buildbot.test.util import interfaces
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import UTC
+from buildbot.util import epoch2datetime
 
 
 class TestBuildRequestEndpoint(endpoint.EndpointMixin, unittest.TestCase):
@@ -289,7 +289,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
         @self.assertArgSpecMatches(
             self.master.data.updates.claimBuildRequests,  # fake
             self.rtype.claimBuildRequests)  # real
-        def claimBuildRequests(self, brids, claimed_at=None, _reactor=reactor):
+        def claimBuildRequests(self, brids, claimed_at=None):
             pass
 
     @defer.inlineCallbacks
@@ -300,8 +300,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
         ])
         res = yield self.master.data.updates.claimBuildRequests(
             [44, 55],
-            claimed_at=self.CLAIMED_AT,
-            _reactor=reactor)
+            claimed_at=self.CLAIMED_AT)
         self.assertTrue(res)
 
     @defer.inlineCallbacks
@@ -320,8 +319,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
         yield self.doTestCallthrough('claimBuildRequests', claimBuildRequestsMock,
                                      self.rtype.claimBuildRequests,
                                      methodargs=[[44]],
-                                     methodkwargs=dict(claimed_at=self.CLAIMED_AT,
-                                                       _reactor=reactor),
+                                     methodkwargs=dict(claimed_at=self.CLAIMED_AT),
                                      expectedRes=True,
                                      expectedException=None)
         msg = {
@@ -365,8 +363,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
         yield self.doTestCallthrough('claimBuildRequests', claimBuildRequestsMock,
                                      self.rtype.claimBuildRequests,
                                      methodargs=[[44]],
-                                     methodkwargs=dict(claimed_at=self.CLAIMED_AT,
-                                                       _reactor=reactor),
+                                     methodkwargs=dict(claimed_at=self.CLAIMED_AT),
                                      expectedRes=False,
                                      expectedException=None)
         self.assertEqual(self.master.mq.productions, [])
@@ -378,8 +375,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
         yield self.doTestCallthrough('claimBuildRequests', claimBuildRequestsMock,
                                      self.rtype.claimBuildRequests,
                                      methodargs=[[44]],
-                                     methodkwargs=dict(claimed_at=self.CLAIMED_AT,
-                                                       _reactor=reactor),
+                                     methodkwargs=dict(claimed_at=self.CLAIMED_AT),
                                      expectedRes=None,
                                      expectedException=self.dBLayerException)
         self.assertEqual(self.master.mq.productions, [])
@@ -453,8 +449,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
         @self.assertArgSpecMatches(
             self.master.data.updates.completeBuildRequests,  # fake
             self.rtype.completeBuildRequests)  # real
-        def completeBuildRequests(self, brids, results, complete_at=None,
-                                  _reactor=reactor):
+        def completeBuildRequests(self, brids, results, complete_at=None):
             pass
 
     @defer.inlineCallbacks
@@ -462,8 +457,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
         res = yield self.master.data.updates.completeBuildRequests(
             [44, 55],
             12,
-            complete_at=self.COMPLETE_AT,
-            _reactor=reactor)
+            complete_at=self.COMPLETE_AT)
         self.assertTrue(res)
 
     @defer.inlineCallbacks
@@ -478,8 +472,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
                                      completeBuildRequestsMock,
                                      self.rtype.completeBuildRequests,
                                      methodargs=[[46], 12],
-                                     methodkwargs=dict(complete_at=self.COMPLETE_AT,
-                                                       _reactor=reactor),
+                                     methodkwargs=dict(complete_at=self.COMPLETE_AT),
                                      expectedRes=True,
                                      expectedException=None)
 
@@ -503,8 +496,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
                                      completeBuildRequestsMock,
                                      self.rtype.completeBuildRequests,
                                      methodargs=[[46], 12],
-                                     methodkwargs=dict(complete_at=self.COMPLETE_AT,
-                                                       _reactor=reactor),
+                                     methodkwargs=dict(complete_at=self.COMPLETE_AT),
                                      expectedRes=False,
                                      expectedException=None)
 
@@ -516,8 +508,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
                                      completeBuildRequestsMock,
                                      self.rtype.completeBuildRequests,
                                      methodargs=[[46], 12],
-                                     methodkwargs=dict(complete_at=self.COMPLETE_AT,
-                                                       _reactor=reactor),
+                                     methodkwargs=dict(complete_at=self.COMPLETE_AT),
                                      expectedRes=None,
                                      expectedException=self.dBLayerException)
 
@@ -542,11 +533,10 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
         self.assertEqual(list(brid_dict.keys()), [77])
         buildrequest = yield self.master.data.get(('buildrequests', brid_dict[77]))
         # submitted_at is the time of the test, so better not depend on it
-        self.assertTrue(buildrequest['submitted_at'] is not None)
-        buildrequest['submitted_at'] = None
         self.assertEqual(buildrequest, {'buildrequestid': 1001, 'complete': False, 'waited_for': False,
                                         'claimed_at': None, 'results': -1, 'claimed': False,
-                                        'buildsetid': 200, 'complete_at': None, 'submitted_at': None,
+                                        'buildsetid': 200, 'complete_at': None,
+                                        'submitted_at': epoch2datetime(0),
                                         'builderid': 77, 'claimed_by_masterid': None, 'priority': 0,
                                         'properties': None})
         buildset = yield self.master.data.get(('buildsets', new_bsid))
@@ -555,9 +545,7 @@ class TestBuildRequest(interfaces.InterfaceTests, TestReactorMixin,
         # assert same sourcestamp
         self.assertEqual(buildset['sourcestamps'], oldbuildset['sourcestamps'])
         buildset['sourcestamps'] = None
-        self.assertTrue(buildset['submitted_at'] is not None)
-        buildset['submitted_at'] = None
-        self.assertEqual(buildset, {'bsid': 200, 'complete_at': None, 'submitted_at': None,
+        self.assertEqual(buildset, {'bsid': 200, 'complete_at': None, 'submitted_at': 0,
                                     'sourcestamps': None, 'parent_buildid': None,
                                     'results': -1, 'parent_relationship': None,
                                     'reason': 'rebuild',

--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -17,7 +17,6 @@
 import mock
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.trial import unittest
 
 from buildbot.data import builds
@@ -284,9 +283,9 @@ class Build(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def do_test_event(self, method, exp_events=None,
                       *args, **kwargs):
+        self.reactor.advance(1)
         if exp_events is None:
             exp_events = []
-        self.patch(reactor, "seconds", lambda: 1)
         yield method(*args, **kwargs)
         self.master.mq.assertProductions(exp_events)
 

--- a/master/buildbot/test/unit/test_data_buildsets.py
+++ b/master/buildbot/test/unit/test_data_buildsets.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 
 from twisted.internet import defer
-from twisted.internet import task
 from twisted.trial import unittest
 from zope.interface import implementer
 
@@ -168,11 +167,9 @@ class Buildset(TestReactorMixin, util_interfaces.InterfaceTests,
         Note that addBuildset does not add sourcestamps, so this method assumes
         there are none in the db.
         """
-        clock = task.Clock()
-        clock.advance(A_TIMESTAMP)
-        xxx_todo_changeme = yield self.rtype.addBuildset(_reactor=clock, **kwargs)
+        self.reactor.advance(A_TIMESTAMP)
 
-        (bsid, brids) = xxx_todo_changeme
+        (bsid, brids) = yield self.rtype.addBuildset(**kwargs)
         self.assertEqual((bsid, brids), expectedReturn)
         # check the correct message was received
         self.master.mq.assertProductions(
@@ -324,8 +321,7 @@ class Buildset(TestReactorMixin, util_interfaces.InterfaceTests,
         if buildRequestResults is None:
             buildRequestResults = {}
 
-        clock = task.Clock()
-        clock.advance(A_TIMESTAMP)
+        self.reactor.advance(A_TIMESTAMP)
 
         def mkbr(brid, bsid=72):
             return fakedb.BuildRequest(id=brid, buildsetid=bsid, builderid=42,
@@ -346,7 +342,7 @@ class Buildset(TestReactorMixin, util_interfaces.InterfaceTests,
             fakedb.BuildsetSourceStamp(buildsetid=73, sourcestampid=234),
         ])
 
-        yield self.rtype.maybeBuildsetComplete(72, _reactor=clock)
+        yield self.rtype.maybeBuildsetComplete(72)
 
         self.master.db.buildsets.assertBuildsetCompletion(72, expectComplete)
         if expectMessage:

--- a/master/buildbot/test/unit/test_data_changes.py
+++ b/master/buildbot/test/unit/test_data_changes.py
@@ -17,7 +17,6 @@
 import mock
 
 from twisted.internet import defer
-from twisted.internet import task
 from twisted.trial import unittest
 
 from buildbot.data import changes
@@ -170,9 +169,8 @@ class Change(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
                           expectedChangeUsers=None):
         if expectedChangeUsers is None:
             expectedChangeUsers = []
-        clock = task.Clock()
-        clock.advance(10000000)
-        changeid = yield self.rtype.addChange(_reactor=clock, **kwargs)
+        self.reactor.advance(10000000)
+        changeid = yield self.rtype.addChange(**kwargs)
 
         self.assertEqual(changeid, 500)
         # check the correct message was received

--- a/master/buildbot/test/unit/test_data_steps.py
+++ b/master/buildbot/test/unit/test_data_steps.py
@@ -15,7 +15,6 @@
 
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.trial import unittest
 
 from buildbot.data import steps
@@ -232,7 +231,7 @@ class Step(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_startStep(self):
-        self.patch(reactor, 'seconds', lambda: TIME1)
+        self.reactor.advance(TIME1)
         yield self.master.db.steps.addStep(buildid=10, name='ten',
                                            state_string='pending')
         yield self.rtype.startStep(stepid=100)
@@ -323,9 +322,9 @@ class Step(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
     def test_finishStep(self):
         yield self.master.db.steps.addStep(buildid=10, name='ten',
                                            state_string='pending')
-        self.patch(reactor, 'seconds', lambda: TIME1)
+        self.reactor.advance(TIME1)
         yield self.rtype.startStep(stepid=100)
-        self.patch(reactor, 'seconds', lambda: TIME2)
+        self.reactor.advance(TIME2 - TIME1)
         self.master.mq.clearProductions()
         yield self.rtype.finishStep(stepid=100, results=9, hidden=False)
 

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -20,7 +20,6 @@ import json
 import mock
 
 from twisted.internet import defer
-from twisted.internet import task
 from twisted.trial import unittest
 
 from buildbot.db import buildsets
@@ -40,8 +39,7 @@ class Tests(interfaces.InterfaceTests):
 
     def setUpTests(self):
         self.now = 9272359
-        self.clock = task.Clock()
-        self.clock.advance(self.now)
+        self.reactor.advance(self.now)
 
         # set up a sourcestamp with id 234 for use below
         return self.insertTestData([
@@ -85,9 +83,10 @@ class Tests(interfaces.InterfaceTests):
 
     @defer.inlineCallbacks
     def test_addBuildset_getBuildset(self):
-        bsid, brids = yield self.db.buildsets.addBuildset(sourcestamps=[234],
-                                                          reason='because', properties={}, builderids=[1],
-                                                          external_idstring='extid', _reactor=self.clock, waited_for=False)
+        bsid, brids = yield self.db.buildsets.addBuildset(
+                sourcestamps=[234], reason='because', properties={},
+                builderids=[1], external_idstring='extid', waited_for=False)
+
         # TODO: verify buildrequests too
         bsdict = yield self.db.buildsets.getBuildset(bsid)
         validation.verifyDbDict(self, 'bsdict', bsdict)
@@ -104,7 +103,7 @@ class Tests(interfaces.InterfaceTests):
         bsid_brids = yield self.db.buildsets.addBuildset(
                 sourcestamps=[234], reason='because', properties={},
                 builderids=[1], external_idstring='extid',
-                submitted_at=epoch2datetime(8888888), _reactor=self.clock,
+                submitted_at=epoch2datetime(8888888),
                 waited_for=False)
         bsdict = yield self.db.buildsets.getBuildset(bsid_brids[0])
 
@@ -272,22 +271,19 @@ class Tests(interfaces.InterfaceTests):
     def test_completeBuildset_already_completed(self):
         d = self.insert_test_getBuildsets_data()
         d.addCallback(lambda _:
-                      self.db.buildsets.completeBuildset(bsid=92, results=6,
-                                                         _reactor=self.clock))
+                      self.db.buildsets.completeBuildset(bsid=92, results=6))
         return self.assertFailure(d, buildsets.AlreadyCompleteError)
 
     def test_completeBuildset_missing(self):
         d = self.insert_test_getBuildsets_data()
         d.addCallback(lambda _:
-                      self.db.buildsets.completeBuildset(bsid=93, results=6,
-                                                         _reactor=self.clock))
+                      self.db.buildsets.completeBuildset(bsid=93, results=6))
         return self.assertFailure(d, buildsets.AlreadyCompleteError)
 
     @defer.inlineCallbacks
     def test_completeBuildset(self):
         yield self.insert_test_getBuildsets_data()
-        yield self.db.buildsets.completeBuildset(bsid=91, results=6,
-                                                 _reactor=self.clock)
+        yield self.db.buildsets.completeBuildset(bsid=91, results=6)
         bsdicts = yield self.db.buildsets.getBuildsets()
 
         bsdicts = [(bsdict['bsid'], bsdict['complete'],
@@ -406,11 +402,8 @@ class RealTests(Tests):
     @defer.inlineCallbacks
     def test_addBuildset_simple(self):
         (bsid, brids) = yield self.db.buildsets.addBuildset(
-                                            sourcestamps=[234], reason='because',
-                                            properties={}, builderids=[2],
-                                            external_idstring='extid',
-                                            waited_for=True,
-                                            _reactor=self.clock)
+                sourcestamps=[234], reason='because', properties={},
+                builderids=[2], external_idstring='extid', waited_for=True)
 
         def thd(conn):
             # we should only have one brid
@@ -503,8 +496,9 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
     def test_addBuildset_bad_waited_for(self):
         # only the fake db asserts on the type of waited_for
         d = self.db.buildsets.addBuildset(sourcestamps=[234], reason='because',
-                                          properties={}, builderids=[1], external_idstring='extid',
-                                          waited_for='wat', _reactor=self.clock)
+                                          properties={}, builderids=[1],
+                                          external_idstring='extid',
+                                          waited_for='wat')
         yield self.assertFailure(d, AssertionError)
 
 

--- a/master/buildbot/test/unit/test_db_changes.py
+++ b/master/buildbot/test/unit/test_db_changes.py
@@ -16,7 +16,6 @@
 import sqlalchemy as sa
 
 from twisted.internet import defer
-from twisted.internet import task
 from twisted.trial import unittest
 
 from buildbot.db import builds
@@ -98,8 +97,7 @@ class Tests(interfaces.InterfaceTests):
 
     @defer.inlineCallbacks
     def test_addChange_getChange(self):
-        clock = task.Clock()
-        clock.advance(SOMETIME)
+        self.reactor.advance(SOMETIME)
         changeid = yield self.db.changes.addChange(
             author='dustin',
             files=[],
@@ -112,8 +110,7 @@ class Tests(interfaces.InterfaceTests):
             properties={},
             repository='repo://',
             codebase='cb',
-            project='proj',
-            _reactor=clock)
+            project='proj')
         chdict = yield self.db.changes.getChange(changeid)
         validation.verifyDbDict(self, 'chdict', chdict)
         chdict = chdict.copy()
@@ -155,8 +152,7 @@ class Tests(interfaces.InterfaceTests):
     def test_addChange_withParent(self):
         yield self.insertTestData(self.change14_rows)
 
-        clock = task.Clock()
-        clock.advance(SOMETIME)
+        self.reactor.advance(SOMETIME)
         changeid = yield self.db.changes.addChange(
             author='delanne',
             files=[],
@@ -169,8 +165,7 @@ class Tests(interfaces.InterfaceTests):
             properties={},
             repository='git://warner',
             codebase='mainapp',
-            project='Buildbot',
-            _reactor=clock)
+            project='Buildbot')
         chdict = yield self.db.changes.getChange(changeid)
         validation.verifyDbDict(self, 'chdict', chdict)
         chdict = chdict.copy()
@@ -378,8 +373,7 @@ class RealTests(Tests):
 
     @defer.inlineCallbacks
     def test_addChange(self):
-        clock = task.Clock()
-        clock.advance(SOMETIME)
+        self.reactor.advance(SOMETIME)
         changeid = yield self.db.changes.addChange(
             author='dustin',
             files=['master/LICENSING.txt', 'worker/LICENSING.txt'],
@@ -392,8 +386,7 @@ class RealTests(Tests):
             properties={'platform': ('linux', 'Change')},
             repository='',
             codebase='cb',
-            project='',
-            _reactor=clock)
+            project='')
         # check all of the columns of the four relevant tables
 
         def thd_change(conn):
@@ -461,8 +454,7 @@ class RealTests(Tests):
 
     @defer.inlineCallbacks
     def test_addChange_when_timestamp_None(self):
-        clock = task.Clock()
-        clock.advance(OTHERTIME)
+        self.reactor.advance(OTHERTIME)
         changeid = yield self.db.changes.addChange(
             author='dustin',
             files=[],
@@ -475,8 +467,7 @@ class RealTests(Tests):
             properties={},
             repository='',
             codebase='',
-            project='',
-            _reactor=clock)
+            project='')
         # check all of the columns of the four relevant tables
 
         def thd(conn):

--- a/master/buildbot/test/unit/test_db_masters.py
+++ b/master/buildbot/test/unit/test_db_masters.py
@@ -64,8 +64,7 @@ class Tests(interfaces.InterfaceTests):
 
     @defer.inlineCallbacks
     def test_findMasterId_new(self):
-        id = yield self.db.masters.findMasterId('some:master',
-                                                _reactor=self.reactor)
+        id = yield self.db.masters.findMasterId('some:master')
         masterdict = yield self.db.masters.getMaster(id)
         self.assertEqual(masterdict,
                          dict(id=id, name='some:master', active=False,
@@ -92,7 +91,7 @@ class Tests(interfaces.InterfaceTests):
                           active=1, last_active=OTHERTIME),
         ])
         activated = yield self.db.masters.setMasterState(
-            masterid=7, active=True, _reactor=self.reactor)
+            masterid=7, active=True)
         self.assertFalse(activated)  # it was already active
         masterdict = yield self.db.masters.getMaster(7)
         self.assertEqual(masterdict,
@@ -106,7 +105,7 @@ class Tests(interfaces.InterfaceTests):
                           active=0, last_active=OTHERTIME),
         ])
         activated = yield self.db.masters.setMasterState(
-            masterid=7, active=True, _reactor=self.reactor)
+            masterid=7, active=True)
         self.assertTrue(activated)
         masterdict = yield self.db.masters.getMaster(7)
         self.assertEqual(masterdict,
@@ -120,7 +119,7 @@ class Tests(interfaces.InterfaceTests):
                           active=1, last_active=OTHERTIME),
         ])
         deactivated = yield self.db.masters.setMasterState(
-            masterid=7, active=False, _reactor=self.reactor)
+            masterid=7, active=False)
         self.assertTrue(deactivated)
         masterdict = yield self.db.masters.getMaster(7)
         self.assertEqual(masterdict,
@@ -134,7 +133,7 @@ class Tests(interfaces.InterfaceTests):
                           active=0, last_active=OTHERTIME),
         ])
         deactivated = yield self.db.masters.setMasterState(
-            masterid=7, active=False, _reactor=self.reactor)
+            masterid=7, active=False)
         self.assertFalse(deactivated)
         masterdict = yield self.db.masters.getMaster(7)
         self.assertEqual(masterdict,
@@ -194,7 +193,7 @@ class RealTests(Tests):
             fakedb.SchedulerMaster(schedulerid=21, masterid=7),
         ])
         deactivated = yield self.db.masters.setMasterState(
-            masterid=7, active=False, _reactor=self.reactor)
+            masterid=7, active=False)
         self.assertTrue(deactivated)
 
         # check that the scheduler_masters row was deleted

--- a/master/buildbot/test/unit/test_db_sourcestamps.py
+++ b/master/buildbot/test/unit/test_db_sourcestamps.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 
 from twisted.internet import defer
-from twisted.internet import task
 from twisted.trial import unittest
 
 from buildbot.db import sourcestamps
@@ -56,12 +55,10 @@ class Tests(interfaces.InterfaceTests):
 
     @defer.inlineCallbacks
     def test_findSourceStampId_simple(self):
-        clock = task.Clock()
-        clock.advance(CREATED_AT)
+        self.reactor.advance(CREATED_AT)
         ssid = yield self.db.sourcestamps.findSourceStampId(
             branch='production', revision='abdef',
-            repository='test://repo', codebase='cb', project='stamper',
-            _reactor=clock)
+            repository='test://repo', codebase='cb', project='stamper')
         ssdict = yield self.db.sourcestamps.getSourceStamp(ssid)
         validation.verifyDbDict(self, 'ssdict', ssdict)
         self.assertEqual(ssdict, {
@@ -111,13 +108,12 @@ class Tests(interfaces.InterfaceTests):
 
     @defer.inlineCallbacks
     def test_findSourceStampId_patch(self):
-        clock = task.Clock()
-        clock.advance(CREATED_AT)
+        self.reactor.advance(CREATED_AT)
         ssid = yield self.db.sourcestamps.findSourceStampId(
             branch='production', revision='abdef',
             repository='test://repo', codebase='cb', project='stamper',
             patch_body=b'my patch', patch_level=3, patch_subdir='master/',
-            patch_author='me', patch_comment="comment", _reactor=clock)
+            patch_author='me', patch_comment="comment")
         ssdict = yield self.db.sourcestamps.getSourceStamp(ssid)
         validation.verifyDbDict(self, 'ssdict', ssdict)
         self.assertEqual(ssdict, {

--- a/master/buildbot/test/unit/test_db_steps.py
+++ b/master/buildbot/test/unit/test_db_steps.py
@@ -17,7 +17,6 @@
 import time
 
 from twisted.internet import defer
-from twisted.internet import task
 from twisted.trial import unittest
 
 from buildbot.db import steps
@@ -35,7 +34,7 @@ TIME3 = 1304262224
 TIME4 = 1304262235
 
 
-class Tests(interfaces.InterfaceTests):
+class Tests(TestReactorMixin, interfaces.InterfaceTests):
 
     # common sample data
 
@@ -86,6 +85,9 @@ class Tests(interfaces.InterfaceTests):
          'urls': [],
          'hidden': False},
     ]
+
+    def setUp(self):
+        self.setUpTestReactor()
 
     # signature tests
 
@@ -181,12 +183,12 @@ class Tests(interfaces.InterfaceTests):
 
     @defer.inlineCallbacks
     def test_addStep_getStep(self):
-        clock = task.Clock()
-        clock.advance(TIME1)
+        self.reactor.advance(TIME1)
         yield self.insertTestData(self.backgroundData)
         stepid, number, name = yield self.db.steps.addStep(buildid=30,
-                                                           name='new', state_string='new')
-        yield self.db.steps.startStep(stepid=stepid, _reactor=clock)
+                                                           name='new',
+                                                           state_string='new')
+        yield self.db.steps.startStep(stepid=stepid)
         self.assertEqual((number, name), (0, 'new'))
         stepdict = yield self.db.steps.getStep(stepid=stepid)
         validation.verifyDbDict(self, 'stepdict', stepdict)
@@ -204,12 +206,11 @@ class Tests(interfaces.InterfaceTests):
 
     @defer.inlineCallbacks
     def test_addStep_getStep_existing_step(self):
-        clock = task.Clock()
-        clock.advance(TIME1)
+        self.reactor.advance(TIME1)
         yield self.insertTestData(self.backgroundData + [self.stepRows[0]])
         stepid, number, name = yield self.db.steps.addStep(
             buildid=30, name='new', state_string='new')
-        yield self.db.steps.startStep(stepid=stepid, _reactor=clock)
+        yield self.db.steps.startStep(stepid=stepid)
         self.assertEqual((number, name), (1, 'new'))
         stepdict = yield self.db.steps.getStep(stepid=stepid)
         validation.verifyDbDict(self, 'stepdict', stepdict)
@@ -218,8 +219,7 @@ class Tests(interfaces.InterfaceTests):
 
     @defer.inlineCallbacks
     def test_addStep_getStep_name_collisions(self):
-        clock = task.Clock()
-        clock.advance(TIME1)
+        self.reactor.advance(TIME1)
         yield self.insertTestData(self.backgroundData + [
             fakedb.Step(id=73, number=0, name='new', buildid=30),
             fakedb.Step(id=74, number=1, name='new_1', buildid=30),
@@ -228,7 +228,7 @@ class Tests(interfaces.InterfaceTests):
         ])
         stepid, number, name = yield self.db.steps.addStep(
             buildid=30, name='new', state_string='new')
-        yield self.db.steps.startStep(stepid=stepid, _reactor=clock)
+        yield self.db.steps.startStep(stepid=stepid)
         self.assertEqual((number, name), (4, 'new_3'))
         stepdict = yield self.db.steps.getStep(stepid=stepid)
         validation.verifyDbDict(self, 'stepdict', stepdict)
@@ -285,11 +285,9 @@ class Tests(interfaces.InterfaceTests):
 
     @defer.inlineCallbacks
     def test_finishStep(self):
-        clock = task.Clock()
-        clock.advance(TIME2)
+        self.reactor.advance(TIME2)
         yield self.insertTestData(self.backgroundData + [self.stepRows[2]])
-        yield self.db.steps.finishStep(stepid=72, results=11, hidden=False,
-                                       _reactor=clock)
+        yield self.db.steps.finishStep(stepid=72, results=11, hidden=False)
         stepdict = yield self.db.steps.getStep(stepid=72)
         self.assertEqual(stepdict['results'], 11)
         self.assertEqual(stepdict['complete_at'], epoch2datetime(TIME2))
@@ -306,18 +304,16 @@ class Tests(interfaces.InterfaceTests):
 class RealTests(Tests):
 
     # the fake connector doesn't deal with this edge case
-
     @defer.inlineCallbacks
     def test_addStep_getStep_name_collisions_too_long(self):
-        clock = task.Clock()
-        clock.advance(TIME1)
+        self.reactor.advance(TIME1)
         yield self.insertTestData(self.backgroundData + [
             fakedb.Step(id=73, number=0, name='a' * 49, buildid=30),
             fakedb.Step(id=74, number=1, name='a' * 48 + '_1', buildid=30),
         ])
         stepid, number, name = yield self.db.steps.addStep(
             buildid=30, name='a' * 49, state_string='new')
-        yield self.db.steps.startStep(stepid=stepid, _reactor=clock)
+        yield self.db.steps.startStep(stepid=stepid)
         self.assertEqual((number, name), (2, 'a' * 48 + '_2'))
         stepdict = yield self.db.steps.getStep(stepid=stepid)
         validation.verifyDbDict(self, 'stepdict', stepdict)
@@ -326,8 +322,7 @@ class RealTests(Tests):
 
     @defer.inlineCallbacks
     def test_addStep_getStep_name_collisions_too_long_extra_digits(self):
-        clock = task.Clock()
-        clock.advance(TIME1)
+        self.reactor.advance(TIME1)
         yield self.insertTestData(self.backgroundData + [
             fakedb.Step(id=73, number=0, name='a' * 50, buildid=30),
         ] + [fakedb.Step(id=73 + i, number=i, name='a' * 48 + ('_%d' % i), buildid=30)
@@ -337,7 +332,7 @@ class RealTests(Tests):
                   ])
         stepid, number, name = yield self.db.steps.addStep(
             buildid=30, name='a' * 50, state_string='new')
-        yield self.db.steps.startStep(stepid=stepid, _reactor=clock)
+        yield self.db.steps.startStep(stepid=stepid)
         self.assertEqual((number, name), (100, 'a' * 46 + '_100'))
         stepdict = yield self.db.steps.getStep(stepid=stepid)
         validation.verifyDbDict(self, 'stepdict', stepdict)
@@ -345,10 +340,10 @@ class RealTests(Tests):
         self.assertEqual(stepdict['name'], name)
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(Tests, unittest.TestCase):
 
     def setUp(self):
-        self.setUpTestReactor()
+        super().setUp()
         self.master = fakemaster.make_master(self, wantDb=True)
         self.db = self.master.db
         self.db.checkForeignKeys = True

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -27,20 +27,20 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestCleanShutdown(unittest.TestCase):
+class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
-        self.reactor = mock.Mock()
+        self.setUpTestReactor()
         self.master = fakemaster.make_master(self, wantData=True)
         self.botmaster = BotMaster()
         self.botmaster.setServiceParent(self.master)
         self.botmaster.startService()
 
     def assertReactorStopped(self, _=None):
-        self.assertTrue(self.reactor.stop.called)
+        self.assertTrue(self.reactor.stop_called)
 
     def assertReactorNotStopped(self, _=None):
-        self.assertFalse(self.reactor.stop.called)
+        self.assertFalse(self.reactor.stop_called)
 
     def makeFakeBuild(self, waitedFor=False):
         self.fake_builder = builder = mock.Mock()

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -703,7 +703,7 @@ class TestMaybeStartBuilds(TestBRDBase):
         # fake a race condition on the buildrequests table
         old_claimBuildRequests = self.master.db.buildrequests.claimBuildRequests
 
-        def claimBuildRequests(brids, claimed_at=None, _reactor=None):
+        def claimBuildRequests(brids, claimed_at=None):
             # first, ensure this only happens the first time
             self.master.db.buildrequests.claimBuildRequests = old_claimBuildRequests
             # claim brid 10 for some other master

--- a/master/buildbot/test/unit/test_schedulers_triggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_triggerable.py
@@ -13,8 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-import mock
-
 from twisted.internet import defer
 from twisted.python import log
 from twisted.trial import unittest
@@ -44,16 +42,11 @@ class Triggerable(scheduler.SchedulerMixin, TestReactorMixin,
         # Necessary to get an assertable submitted_at time.
         self.reactor.advance(946684799)
 
-        self.reactor_patch = mock.patch(
-            'buildbot.test.fake.fakedb.reactor.seconds', self.reactor.seconds)
-        self.reactor_patch.start()
-
         self.setUpScheduler()
         self.subscription = None
 
     def tearDown(self):
         self.tearDownScheduler()
-        self.reactor_patch.stop()
 
     def makeScheduler(self, overrideBuildsetMethods=False, **kwargs):
         self.master.db.insertTestData([fakedb.Builder(id=77, name='b')])


### PR DESCRIPTION
This PR uses fake reactor in even more tests. The DB and data API implementations now use reactor from master which can be modified in tests. This way there's no need to pass an additional `_reactor` argument.

There's interesting fact that the tests became around 2.5% faster after moving to fake reactor.