### PR TITLE
Miscelaneous latent worker fixes

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1465,6 +1465,7 @@ unclaim
 unclaimedbrdicts
 unclosed
 unconfigure
+unconfigured
 underpowered
 unencrypted
 unexpectedsuccesses

--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1140,6 +1140,7 @@ requestcancelled
 requestjson
 requestsubmitted
 requeue
+requeued
 requiredargs
 reschedulenextbuild
 resetmocks

--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1483,6 +1483,7 @@ unlink
 unlinked
 unparsable
 unparseable
+unpatch
 unregister
 unregisters
 unserialized

--- a/master/buildbot/newsfragments/latent-negative-build-timeout-stop-during-master-shutdown.bugfix
+++ b/master/buildbot/newsfragments/latent-negative-build-timeout-stop-during-master-shutdown.bugfix
@@ -1,0 +1,1 @@
+Latent workers with negative build_wait_timeout will be shutdown on master shutdown.

--- a/master/buildbot/newsfragments/latent-worker-always-wait-start-stop-instance-finish.bugfix
+++ b/master/buildbot/newsfragments/latent-worker-always-wait-start-stop-instance-finish.bugfix
@@ -1,0 +1,1 @@
+Latent worker will now wait until start_instance() before starting stop_instance() or vice-versa. Master will wait for these functions to finish during shutdown.

--- a/master/buildbot/newsfragments/latent-worker-synchronous-exception-stop-instance.bugfix
+++ b/master/buildbot/newsfragments/latent-worker-synchronous-exception-stop-instance.bugfix
@@ -1,0 +1,1 @@
+Latent worker will now correctly handle synchronous exception from the backend worker driver.

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -205,7 +205,7 @@ class ControllableLatentWorker(AbstractLatentWorker):
         return self._controller._start_deferred
 
     @defer.inlineCallbacks
-    def stop_instance(self, build):
+    def stop_instance(self, fast):
         assert self._controller.state == States.STARTED
         self._controller.state = States.STOPPING
 

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -206,12 +206,7 @@ class ControllableLatentWorker(AbstractLatentWorker):
 
     @defer.inlineCallbacks
     def stop_instance(self, build):
-        assert self._controller.state in [States.STARTED, States.STARTING]
-        # if we did not succeed starting, at least call back the failure result
-        if self._controller.state == States.STARTING:
-            self._controller.state = States.STOPPED
-            d, self._controller._start_deferred = self._controller._start_deferred, None
-            d.callback(False)
+        assert self._controller.state == States.STARTED
         self._controller.state = States.STOPPING
 
         if self._controller.auto_stop_flag:

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -1093,8 +1093,9 @@ class Tests(TimeoutableTestCase, RunFakeMasterTestCase):
         controller.start_instance(True)
         self.assertTrue(controller.started)
 
-        controller.worker.insubstantiate()
+        d = controller.worker.insubstantiate()
         controller.stop_instance(True)
+        yield d
 
     @defer.inlineCallbacks
     def test_supports_no_build_for_substantiation_accepts_build_later(self):

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -295,6 +295,9 @@ class Tests(TimeoutableTestCase, RunFakeMasterTestCase):
         master.reactor.advance(controller.worker.quarantine_initial_timeout)
         self.assertEqual(controller.starting, True)
 
+        controller.auto_start(True)
+        controller.auto_stop(True)
+
     @defer.inlineCallbacks
     def test_worker_multiple_substantiations_succeed(self):
         """
@@ -448,6 +451,7 @@ class Tests(TimeoutableTestCase, RunFakeMasterTestCase):
         # after the latent workers completes start-stop cycle.
         yield self.createBuildrequest(master, [builder_id])
         d = controller.worker.insubstantiate()
+        controller.start_instance(False)
         controller.stop_instance(True)
         yield d
 
@@ -509,6 +513,7 @@ class Tests(TimeoutableTestCase, RunFakeMasterTestCase):
             set(brids),
             {req['buildrequestid'] for req in unclaimed_build_requests}
         )
+        yield controller.start_instance(False)
         yield controller.auto_stop(True)
 
     @defer.inlineCallbacks
@@ -672,8 +677,7 @@ class Tests(TimeoutableTestCase, RunFakeMasterTestCase):
         yield controller.disconnect_worker()
         yield self.assertBuildResults(1, RETRY)
 
-        # Request one build.
-        yield self.createBuildrequest(master, [builder_id])
+        # Now check that the build requeued and finished with success
         controller.start_instance(True)
 
         yield self.assertBuildResults(2, None)

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -188,6 +188,8 @@ class Tests(TimeoutableTestCase, RunFakeMasterTestCase):
             set(brids),
             {req['buildrequestid'] for req in unclaimed_build_requests}
         )
+
+        yield self.assertBuildResults(1, RETRY)
         yield controller.auto_stop(True)
         self.flushLoggedErrors(LatentWorkerFailedToSubstantiate)
 
@@ -219,6 +221,7 @@ class Tests(TimeoutableTestCase, RunFakeMasterTestCase):
             set(brids),
             {req['buildrequestid'] for req in unclaimed_build_requests}
         )
+        yield self.assertBuildResults(1, RETRY)
         yield controller.auto_stop(True)
 
     @defer.inlineCallbacks
@@ -282,6 +285,8 @@ class Tests(TimeoutableTestCase, RunFakeMasterTestCase):
             Failure(TestException("substantiation failed")))
         # Flush the errors logged by the failure.
         self.flushLoggedErrors(TestException)
+
+        yield self.assertBuildResults(1, RETRY)
 
         # advance the time to the point where we should not retry
         master.reactor.advance(controller.worker.quarantine_initial_timeout)

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -386,9 +386,8 @@ class AbstractLatentWorker(AbstractWorker):
         else:
             self.state = States.INSUBSTANTIATING
         self._clearBuildWaitTimer()
-        d = self.stop_instance(fast)
         try:
-            yield d
+            yield self.stop_instance(fast)
         except Exception as e:
             # The case of failure for insubstantiation is bad as we have a
             # left-over costing resource There is not much thing to do here

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -373,7 +373,8 @@ class AbstractLatentWorker(AbstractWorker):
         assert self.state in [States.INSUBSTANTIATING,
                               States.INSUBSTANTIATING_SUBSTANTIATING]
 
-        if notify_cancel:
+        if notify_cancel and self._substantiation_notifier:
+            # if worker already tried to attach() then _substantiation_notifier is already notified
             self._fireSubstantiationNotifier(
                 failure.Failure(LatentWorkerSubstantiatiationCancelled()))
 

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -410,7 +410,6 @@ class AbstractLatentWorker(AbstractWorker):
             log.msg("Weird: Got request to stop before started. Allowing "
                     "worker to start cleanly to avoid inconsistent state")
             yield self._substantiation_notifier.wait()
-            self.substantiation_build = None
             log.msg("Substantiation complete, immediately terminating.")
 
         yield defer.DeferredList([

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -187,7 +187,7 @@ class AbstractLatentWorker(AbstractWorker):
         if self.state == States.SUBSTANTIATED and self.conn is None:
             # connection dropped while we were substantiated.
             # insubstantiate to clean up and then substantiate normally.
-            d_ins = self.insubstantiate(_force_substantiation=True)
+            d_ins = self.insubstantiate(force_substantiation=True)
             d_ins.addErrback(log.err, 'while insubstantiating')
             return d
 
@@ -334,9 +334,9 @@ class AbstractLatentWorker(AbstractWorker):
             self.build_wait_timeout, self._soft_disconnect)
 
     @defer.inlineCallbacks
-    def insubstantiate(self, fast=False, _force_substantiation=False):
-        # _force_substantiation=True means we'll try to substantiate a build
-        # with stored substantiation_build at the end of substantiation
+    def insubstantiate(self, fast=False, force_substantiation=False):
+        # force_substantiation=True means we'll try to substantiate a build with stored
+        # substantiation_build at the end of substantiation
 
         log.msg("insubstantiating worker {}".format(self))
         if self.state == States.NOT_SUBSTANTIATED:
@@ -355,7 +355,7 @@ class AbstractLatentWorker(AbstractWorker):
 
         notify_cancel = self.state == States.SUBSTANTIATING
 
-        if _force_substantiation:
+        if force_substantiation:
             self.state = States.INSUBSTANTIATING_SUBSTANTIATING
         else:
             self.state = States.INSUBSTANTIATING

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -431,14 +431,6 @@ class AbstractLatentWorker(AbstractWorker):
 
         self.stopMissingTimer()
 
-        # if master is stopping, we will never achieve consistent state, as workermanager
-        # won't accept new connection
-        if self._substantiation_notifier and self.master.running:
-            log.msg("Weird: Got request to stop before started. Allowing "
-                    "worker to start cleanly to avoid inconsistent state")
-            yield self._substantiation_notifier.wait()
-            log.msg("Substantiation complete, immediately terminating.")
-
         yield defer.DeferredList([
             super().disconnect(),
             self.insubstantiate(fast)

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -429,9 +429,12 @@ class AbstractLatentWorker(AbstractWorker):
     @defer.inlineCallbacks
     def _soft_disconnect(self, fast=False, stopping_service=False):
         if self.building:
-            # wait until build finished
-            # TODO: remove this behavior as AbstractWorker disconnects forcibly
+            # If there are builds running or about to start on this worker, don't disconnect.
+            # soft_disconnect happens during master reconfiguration or shutdown. It's not a good
+            # reason to kill these builds. We effectively slow down reconfig until all workers
+            # that have been unconfigured finish their builds.
             return
+
         # a negative build_wait_timeout means the worker should never be shut
         # down, so just disconnect.
         if not stopping_service and self.build_wait_timeout < 0:

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -99,27 +99,37 @@ class AbstractLatentWorker(AbstractWorker):
 
     state = States.NOT_SUBSTANTIATED
 
-    # state transitions:
-    #
-    # substantiate(): either of
-    # NOT_SUBSTANTIATED -> SUBSTANTIATING
-    # INSUBSTANTIATING -> INSUBSTANTIATING_SUBSTANTIATING
-    #
-    # attached():
-    # SUBSTANTIATING -> SUBSTANTIATED
-    # self.conn -> not None
-    #
-    # detached():
-    # self.conn -> None
-    #
-    # errors in any of above will call insubstantiate()
-    #
-    # insubstantiate():
-    # SUBSTANTIATED -> INSUBSTANTIATING
-    # INSUBSTANTIATING_SUBSTANTIATING -> INSUBSTANTIATING (cancels substantiation request)
-    # < other state transitions may happen during this time >
-    # INSUBSTANTIATING_SUBSTANTIATING -> SUBSTANTIATING
-    # INSUBSTANTIATING -> NOT_SUBSTANTIATED
+    '''
+    state transitions:
+
+    substantiate(): either of
+        NOT_SUBSTANTIATED -> SUBSTANTIATING
+        INSUBSTANTIATING -> INSUBSTANTIATING_SUBSTANTIATING
+
+    attached():
+        SUBSTANTIATING -> SUBSTANTIATED
+        then:
+        self.conn -> not None
+
+    detached():
+        self.conn -> None
+
+    errors in any of above will call insubstantiate()
+
+    insubstantiate():
+        either of:
+            SUBSTANTIATED -> INSUBSTANTIATING
+            INSUBSTANTIATING_SUBSTANTIATING -> INSUBSTANTIATING (cancels substantiation request)
+            SUBSTANTIATING -> INSUBSTANTIATING
+            SUBSTANTIATING -> INSUBSTANTIATING_SUBSTANTIATING
+
+        then:
+            < other state transitions may happen during this time >
+
+        then either of:
+            INSUBSTANTIATING_SUBSTANTIATING -> SUBSTANTIATING
+            INSUBSTANTIATING -> NOT_SUBSTANTIATED
+    '''
 
     def checkConfig(self, name, password,
                     build_wait_timeout=60 * 10,

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -391,14 +391,14 @@ class AbstractLatentWorker(AbstractWorker):
         self.botmaster.maybeStartBuildsForWorker(self.name)
 
     @defer.inlineCallbacks
-    def _soft_disconnect(self, fast=False):
+    def _soft_disconnect(self, fast=False, stopping_service=False):
         if self.building:
             # wait until build finished
             # TODO: remove this behavior as AbstractWorker disconnects forcibly
             return
         # a negative build_wait_timeout means the worker should never be shut
         # down, so just disconnect.
-        if self.build_wait_timeout < 0:
+        if not stopping_service and self.build_wait_timeout < 0:
             yield super().disconnect()
             return
 
@@ -433,7 +433,7 @@ class AbstractLatentWorker(AbstractWorker):
 
         if self.conn is not None or self.state in [States.SUBSTANTIATING,
                                                    States.SUBSTANTIATED]:
-            yield self._soft_disconnect()
+            yield self._soft_disconnect(stopping_service=True)
         self._clearBuildWaitTimer()
         res = yield super().stopService()
         return res

--- a/master/docs/manual/configuration/workers.rst
+++ b/master/docs/manual/configuration/workers.rst
@@ -222,7 +222,7 @@ The following options are available for all latent workers.
     This option allows you to specify how long a latent worker should wait after a build for another build before it shuts down.
     It defaults to 10 minutes.
     If this is set to 0 then the worker will be shut down immediately.
-    If it is less than 0 it will never automatically shutdown.
+    If it is less than 0 it will be shut down only when shutting down master.
 
 .. _Supported-Latent-Workers:
 

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -573,7 +573,7 @@ Overriding these members ensures that builds aren't ran on incompatible workers 
         If ``fast`` is ``True`` then the function should call back as soon as it is safe to do so, as, for example, the master may be shutting down.
         The value returned by the callback is ignored.
         Buildbot will ensure that a single worker will never have its ``stop_instance`` called before any previous calls to ``stop_instance`` finish.
-        ``stop_instance`` may be called before ``start_instance`` finishes only if ``start_instance`` takes a long time and the worker times out.
+        During master shutdown any pending calls to ``start_instance`` or ``stop_instance`` will be waited upon finish.
 
     .. py:attribute:: builds_may_be_incompatible
 


### PR DESCRIPTION
This PR fixes several bugs in latent worker:
 - Latent workers with negative build_wait_timeout will be shutdown on master shutdown. Previously potentially costly resource would have been left running. Some people possibly don't shutdown latent workers due to long startup time, but it's not acceptable to leave them running when master itself is shutdown.

 - Master will now wait until `start_instance` or `stop_instance` finish during master shutdown and also before other `start_instance` or `stop_instance` call on the same worker is started. This makes proper lifetime management in latent workers backends easier, because calls to `start_instance` or `stop_instance` will never overlap.

 - Latent worker will now correctly handle synchronous exception from `stop_instance()`.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
