### PR TITLE
Remove used of bytes2unicode in buildbot master

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -25,7 +25,6 @@ from buildbot import config
 from buildbot import util
 from buildbot.changes import base
 from buildbot.changes.filter import ChangeFilter
-from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
 
 
@@ -89,7 +88,9 @@ class GerritChangeSourceBase(base.ChangeSource):
 
     def lineReceived(self, line):
         try:
-            event = json.loads(bytes2unicode(line))
+            if isinstance(line, bytes):
+                line = line.decode()
+            event = json.loads(line)
         except ValueError:
             msg = "bad json line: %s"
             log.msg(msg % line)
@@ -160,7 +161,7 @@ class GerritChangeSourceBase(base.ChangeSource):
             event_change = event["change"]
             return self.addChange({
                 'author': _gerrit_user_to_author(event_change["owner"]),
-                'project': util.bytes2unicode(event_change["project"]),
+                'project': event_change["project"],
                 'repository': "{}/{}".format(
                     self.gitBaseURL, event_change["project"]),
                 'branch': self.getGroupingPolicyFromEvent(event),

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -22,7 +22,6 @@ from twisted.python import log
 
 from buildbot import config
 from buildbot.changes import base
-from buildbot.util import bytes2unicode
 from buildbot.util import deferredLocked
 from buildbot.util.state import StateMixin
 
@@ -72,8 +71,9 @@ class HgPoller(base.PollingChangeSource, StateMixin):
         self.hgbin = hgbin
         self.workdir = workdir
         self.usetimestamps = usetimestamps
-        self.category = category if callable(
-            category) else bytes2unicode(category)
+        self.category = category
+        if isinstance(category, bytes):
+            category = category.decode()
         self.project = project
         self.initLock = defer.DeferredLock()
         self.lastRev = {}
@@ -286,10 +286,10 @@ class HgPoller(base.PollingChangeSource, StateMixin):
                 files=files,
                 comments=comments,
                 when_timestamp=int(timestamp) if timestamp else None,
-                branch=bytes2unicode(branch),
-                category=bytes2unicode(self.category),
-                project=bytes2unicode(self.project),
-                repository=bytes2unicode(self.repourl),
+                branch=branch,
+                category=self.category,
+                project=self.project,
+                repository=self.repourl,
                 src='hg')
             # writing after addChange so that a rev is never missed,
             # but at once to avoid impact from later errors

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -109,7 +109,8 @@ class CVSMaildirSource(MaildirSource):
             author = addr  # might still be useful
         else:
             author = addr[:at]
-        author = util.bytes2unicode(author, encoding="ascii")
+        if isinstance(author, bytes):
+            author = author.decode(encoding="ascii")
 
         # CVS accepts RFC822 dates. buildbot-cvs-mail adds the date as
         # part of the mail header, so use that.

--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -32,7 +32,6 @@ from twisted.python import log
 from buildbot import config
 from buildbot import util
 from buildbot.changes import base
-from buildbot.util import bytes2unicode
 
 debug_logging = False
 
@@ -156,7 +155,9 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
         self.p4bin = p4bin
         self.split_file = split_file
         self.encoding = encoding
-        self.project = util.bytes2unicode(project)
+        self.project = project
+        if isinstance(self.project, bytes):
+            self.project = self.project.decode()
         self.use_tickets = use_tickets
         self.ticket_login_interval = ticket_login_interval
         self.revlink_callable = revlink
@@ -245,11 +246,11 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
         result = yield self._get_process_output(args)
         # decode the result from its designated encoding
         try:
-            result = bytes2unicode(result, self.encoding)
+            result = result.decode(encoding=self.encoding)
         except UnicodeError as ex:
             log.msg("{}: cannot fully decode {} in {}".format(
                     ex, repr(result), self.encoding))
-            result = bytes2unicode(result, encoding=self.encoding, errors="replace")
+            result = result.decode(encoding=self.encoding, errors="replace")
 
         last_change = self.last_change
         changelists = []
@@ -285,7 +286,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
 
             # decode the result from its designated encoding
             try:
-                result = bytes2unicode(result, self.encoding)
+                result = result.decode(encoding=self.encoding)
             except UnicodeError as ex:
                 log.msg(
                     "P4Poller: couldn't decode changelist description: %s" % ex.encoding)

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -33,7 +33,6 @@ from buildbot import util
 from buildbot.interfaces import IRenderable
 from buildbot.revlinks import default_revlink_matcher
 from buildbot.util import ComparableMixin
-from buildbot.util import bytes2unicode
 from buildbot.util import config as util_config
 from buildbot.util import identifiers as util_identifiers
 from buildbot.util import safeTranslate
@@ -911,9 +910,12 @@ class BuilderConfig(util_config.ConfiguredMixin):
             error(
                 "builder names must not start with an underscore: '%s'" % name)
         try:
-            self.name = util.bytes2unicode(name, encoding="ascii")
-        except UnicodeDecodeError:
-            error("builder names must be unicode or ASCII")
+            if isinstance(name, bytes):
+                name = name.decode()
+        except UnicodeDecodeError as e:
+            error("builder names must be unicode or UTF-8: {}".format(e))
+
+        self.name = name
 
         # factory is required
         if factory is None:
@@ -949,7 +951,6 @@ class BuilderConfig(util_config.ConfiguredMixin):
         # builddir defaults to name
         if builddir is None:
             builddir = safeTranslate(name)
-            builddir = bytes2unicode(builddir)
         self.builddir = builddir
 
         # workerbuilddir defaults to builddir

--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -19,7 +19,6 @@ import json
 import re
 
 from buildbot import util
-from buildbot.util import bytes2unicode
 
 
 class Type:
@@ -129,7 +128,9 @@ class String(Instance):
     ramlType = "string"
 
     def valueFromString(self, arg):
-        val = util.bytes2unicode(arg)
+        val = arg
+        if isinstance(val, bytes):
+            val = val.decode()
         return val
 
 
@@ -164,7 +165,9 @@ class Identifier(Type):
         self.len = len
 
     def valueFromString(self, arg):
-        val = util.bytes2unicode(arg)
+        val = arg
+        if isinstance(val, bytes):
+            val = val.decode()
         if not self.identRe.match(val) or len(val) > self.len or not val:
             raise TypeError
         return val
@@ -246,7 +249,9 @@ class SourcedProperties(Type):
             if not isinstance(propsrc, str):
                 yield "%s[%s] source %r is not unicode" % (name, k, propsrc)
             try:
-                json.loads(bytes2unicode(propval))
+                if isinstance(propval, bytes):
+                    propval = propval.decode()
+                json.loads(propval)
             except ValueError:
                 yield "%s[%r] value is not JSON-able" % (name, k)
 

--- a/master/buildbot/db/sourcestamps.py
+++ b/master/buildbot/db/sourcestamps.py
@@ -22,7 +22,6 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot.db import base
-from buildbot.util import bytes2unicode
 from buildbot.util import epoch2datetime
 from buildbot.util import unicode2bytes
 
@@ -62,7 +61,7 @@ class SourceStampsConnectorComponent(base.DBConnectorComponent):
                 ins = self.db.model.patches.insert()
                 r = conn.execute(ins, dict(
                     patchlevel=patch_level,
-                    patch_base64=bytes2unicode(patch_base64_bytes),
+                    patch_base64=patch_base64_bytes.decode(),
                     patch_author=patch_author,
                     patch_comment=patch_comment,
                     subdir=patch_subdir))

--- a/master/buildbot/pbmanager.py
+++ b/master/buildbot/pbmanager.py
@@ -25,7 +25,6 @@ from twisted.spread import pb
 from zope.interface import implementer
 
 from buildbot.process.properties import Properties
-from buildbot.util import bytes2unicode
 from buildbot.util import service
 from buildbot.util import unicode2bytes
 from buildbot.util.eventual import eventually
@@ -164,7 +163,8 @@ class Dispatcher(service.AsyncService):
 
     def requestAvatar(self, username, mind, interface):
         assert interface == pb.IPerspective
-        username = bytes2unicode(username)
+        if isinstance(username, bytes):
+            username = username.decode()
         if username not in self.users:
             d = defer.succeed(None)  # no perspective
         else:
@@ -198,7 +198,9 @@ class Dispatcher(service.AsyncService):
     def requestAvatarId(self, creds):
         p = Properties()
         p.master = self.master
-        username = bytes2unicode(creds.username)
+        username = creds.username
+        if isinstance(username, bytes):
+            username = username.decode()
         try:
             yield self.master.initLock.acquire()
             if username in self.users:

--- a/master/buildbot/pbutil.py
+++ b/master/buildbot/pbutil.py
@@ -22,8 +22,6 @@ from twisted.python import log
 from twisted.spread import pb
 from twisted.spread.pb import PBClientFactory
 
-from buildbot.util import bytes2unicode
-
 
 class NewCredPerspective(pb.Avatar):
 
@@ -162,7 +160,7 @@ def decode(data, encoding='utf-8', errors='strict'):
     data_type = type(data)
 
     if data_type == bytes:
-        return bytes2unicode(data, encoding, errors)
+        return data.decode(encoding, errors)
     if data_type in (dict, list, tuple):
         if data_type == dict:
             data = data.items()

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -240,7 +240,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
         yield self.master.data.updates.updateBuilderList(
             self.master.masterid,
-            [util.bytes2unicode(n) for n in self.builderNames])
+            [n.decode() if isinstance(n, bytes) else n for n in self.builderNames])
 
         metrics.MetricCountEvent.log("num_builders",
                                      len(self.builders), absolute=True)

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -29,7 +29,6 @@ from buildbot.process import workerforbuilder
 from buildbot.process.build import Build
 from buildbot.process.properties import Properties
 from buildbot.process.results import RETRY
-from buildbot.util import bytes2unicode
 from buildbot.util import epoch2datetime
 from buildbot.util import service as util_service
 
@@ -123,7 +122,8 @@ class Builder(util_service.ReconfigurableServiceMixin,
     def getBuilderIdForName(self, name):
         # buildbot.config should ensure this is already unicode, but it doesn't
         # hurt to check again
-        name = bytes2unicode(name)
+        if isinstance(name, bytes):
+            name = name.decode()
         return self.master.data.updates.findBuilderId(name)
 
     def getBuilderId(self):

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -183,9 +183,11 @@ class Properties(util.ComparableMixin):
     has_key = hasProperty
 
     def setProperty(self, name, value, source, runtime=False):
-        name = util.bytes2unicode(name)
+        if isinstance(name, bytes):
+            name = name.decode()
         json.dumps(value)  # Let the exception propagate ...
-        source = util.bytes2unicode(source)
+        if isinstance(source, bytes):
+            source = source.decode()
 
         self.properties[name] = (value, source)
         if runtime:

--- a/master/buildbot/process/remotetransfer.py
+++ b/master/buildbot/process/remotetransfer.py
@@ -19,7 +19,6 @@ import tarfile
 import tempfile
 from io import BytesIO
 
-from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.worker.protocols import base
 
@@ -180,7 +179,9 @@ class StringFileWriter(base.FileWriterImpl):
         self.buffer = ""
 
     def remote_write(self, data):
-        self.buffer += bytes2unicode(data)
+        if isinstance(data, bytes):
+            data = data.decode()
+        self.buffer += data
 
     def remote_close(self):
         pass

--- a/master/buildbot/process/users/users.py
+++ b/master/buildbot/process/users/users.py
@@ -21,7 +21,6 @@ from hashlib import sha1
 from twisted.internet import defer
 from twisted.python import log
 
-from buildbot.util import bytes2unicode
 from buildbot.util import flatten
 from buildbot.util import unicode2bytes
 
@@ -165,7 +164,7 @@ def encrypt(passwd):
     m = sha1()
     salt = hexlify(os.urandom(salt_len))
     m.update(unicode2bytes(passwd) + salt)
-    crypted = bytes2unicode(salt) + m.hexdigest()
+    crypted = salt.decode() + m.hexdigest()
     return crypted
 
 
@@ -180,8 +179,10 @@ def check_passwd(guess, passwd):
     @returns: boolean
     """
     m = sha1()
+    if isinstance(passwd, bytes):
+        passwd = passwd.decode()
     salt = passwd[:salt_len * 2]  # salt_len * 2 due to encode('hex_codec')
     m.update(unicode2bytes(guess) + unicode2bytes(salt))
-    crypted_guess = bytes2unicode(salt) + m.hexdigest()
+    crypted_guess = salt + m.hexdigest()
 
-    return (crypted_guess == bytes2unicode(passwd))
+    return (crypted_guess == passwd)

--- a/master/buildbot/reporters/bitbucketserver.py
+++ b/master/buildbot/reporters/bitbucketserver.py
@@ -23,9 +23,7 @@ from buildbot.process.properties import Properties
 from buildbot.process.results import SUCCESS
 from buildbot.reporters import http
 from buildbot.reporters import notifier
-from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
-from buildbot.util import unicode2bytes
 
 # Magic words understood by Bitbucket Server REST API
 INPROGRESS = 'INPROGRESS'
@@ -160,10 +158,12 @@ class BitbucketServerPRCommentPush(notifier.NotifierBase):
         pass
 
     def sendComment(self, pr_url, text):
-        path = urlparse(unicode2bytes(pr_url)).path
+        path = urlparse(pr_url).path
+        if isinstance(path, bytes):
+            path = path.decode()
         payload = {'text': text}
         return self._http.post(COMMENT_API_URL.format(
-            path=bytes2unicode(path)), json=payload)
+            path=path), json=payload)
 
     @defer.inlineCallbacks
     def sendMessage(self, body, subject=None, type=None, builderName=None,

--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -32,7 +32,6 @@ from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.process.results import Results
 from buildbot.reporters import utils
-from buildbot.util import bytes2unicode
 from buildbot.util import service
 
 # Cache the version that the gerrit server is running for this many seconds
@@ -209,7 +208,7 @@ class GerritStatusPush(service.BuildbotService):
                 return
             vers = data[len(vstr):].strip()
             log.msg(b"gerrit version: " + vers)
-            self.gerrit_version = LooseVersion(bytes2unicode(vers))
+            self.gerrit_version = LooseVersion(vers.decode())
 
         def errReceived(self, data):
             log.msg(b"gerriterr: " + data)

--- a/master/buildbot/schedulers/basic.py
+++ b/master/buildbot/schedulers/basic.py
@@ -77,9 +77,9 @@ class BaseBasicScheduler(base.BaseScheduler):
         self._stable_timers = defaultdict(lambda: None)
         self._stable_timers_lock = defer.DeferredLock()
 
-        self.reason = util.bytes2unicode(reason % {
+        self.reason = reason % {
             'name': name, 'classname': self.__class__.__name__
-        })
+        }
 
     def getChangeFilter(self, branch, branches, change_filter, categories):
         raise NotImplementedError

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -60,7 +60,9 @@ class Timed(AbsoluteSourceStampsMixin, base.BaseScheduler):
         self.actuateAt = None
         self.actuateAtTimer = None
 
-        self.reason = util.bytes2unicode(reason % {'name': name})
+        self.reason = reason % {'name': name}
+        if isinstance(self.reason, bytes):
+            self.reason = self.reason.decode()
         self.branch = branch
         self.change_filter = ChangeFilter.fromSchedulerConstructorArgs(
             change_filter=change_filter)

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -27,7 +27,6 @@ from buildbot.status import builder
 from buildbot.status import buildrequest
 from buildbot.status import buildset
 from buildbot.util import bbcollections
-from buildbot.util import bytes2unicode
 from buildbot.util import service
 from buildbot.util.eventual import eventually
 
@@ -342,8 +341,9 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
         builder_status.setTags(tags)
         builder_status.description = description
         builder_status.master = self.master
-        builder_status.basedir = os.path.join(bytes2unicode(self.basedir),
-                                              bytes2unicode(basedir))
+        if isinstance(basedir, bytes):
+            basedir = basedir.decode()
+        builder_status.basedir = os.path.join(self.basedir, basedir)
         builder_status.name = name  # it might have been updated
         builder_status.status = self
 

--- a/master/buildbot/status/worker.py
+++ b/master/buildbot/status/worker.py
@@ -19,7 +19,6 @@ import time
 from zope.interface import implementer
 
 from buildbot import interfaces
-from buildbot.util import bytes2unicode
 from buildbot.util.eventual import eventually
 
 
@@ -74,10 +73,14 @@ class WorkerStatus:
         return len([t for t in self.connect_times if t > then])
 
     def setAdmin(self, admin):
-        self.admin = bytes2unicode(admin)
+        self.admin = admin
+        if isinstance(self.admin, bytes):
+            self.admin = self.admin.decode()
 
     def setHost(self, host):
-        self.host = bytes2unicode(host)
+        self.host = host
+        if isinstance(self.host, bytes):
+            self.host = self.host.decode()
 
     def setAccessURI(self, access_uri):
         self.access_uri = access_uri

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -23,7 +23,6 @@ from buildbot.process.buildstep import LoggingBuildStep
 from buildbot.status.builder import FAILURE
 from buildbot.status.builder import SKIPPED
 from buildbot.steps.worker import CompositeStepMixin
-from buildbot.util import bytes2unicode
 
 
 class Source(LoggingBuildStep, CompositeStepMixin):
@@ -282,7 +281,10 @@ class Source(LoggingBuildStep, CompositeStepMixin):
                 # root is optional.
                 patch = s.patch
                 if patch:
-                    self.addCompleteLog("patch", bytes2unicode(patch[1]))
+                    patch_1 = patch[1]
+                    if isinstance(patch_1, bytes):
+                        patch_1 = patch_1.decode()
+                    self.addCompleteLog("patch", patch_1)
             else:
                 log.msg(
                     "No sourcestamp found in build for codebase '%s'" % self.codebase)

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -22,7 +22,6 @@ from buildbot.process import remotecommand
 from buildbot.process import remotetransfer
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
-from buildbot.util import bytes2unicode
 
 
 class WorkerBuildStep(buildstep.BuildStep):
@@ -152,8 +151,12 @@ class CopyDirectory(WorkerBuildStep):
 
     # TODO: BuildStep subclasses don't have a describe()....
     def getResultSummary(self):
-        src = bytes2unicode(self.src, errors='replace')
-        dest = bytes2unicode(self.dest, errors='replace')
+        src = self.src
+        if isinstance(src, bytes):
+            src = src.decode(errors='replace')
+        dest = self.dest
+        if isinstance(dest, bytes):
+            dest = dest.decode(errors='replace')
         copy = "{} to {}".format(src, dest)
         if self.results == SUCCESS:
             rv = 'Copied ' + copy

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -32,7 +32,6 @@ from buildbot.db import buildsets
 from buildbot.db import changesources
 from buildbot.db import schedulers
 from buildbot.test.util import validation
-from buildbot.util import bytes2unicode
 from buildbot.util import datetime2epoch
 from buildbot.util import epoch2datetime
 from buildbot.util import service
@@ -1661,7 +1660,9 @@ class FakeStateComponent(FakeDBComponent):
 
     def atomicCreateState(self, objectid, name, thd_create_callback):
         value = thd_create_callback()
-        self.states[objectid][name] = json.dumps(bytes2unicode(value))
+        if isinstance(value, bytes):
+            value = value.decode()
+        self.states[objectid][name] = json.dumps(value)
         return defer.succeed(value)
 
     # fake methods

--- a/master/buildbot/test/integration/test_notifier.py
+++ b/master/buildbot/test/integration/test_notifier.py
@@ -24,7 +24,6 @@ from buildbot.reporters.message import MessageFormatter
 from buildbot.reporters.message import MessageFormatterMissingWorker
 from buildbot.reporters.pushover import PushoverNotifier
 from buildbot.test.util.integration import RunMasterBase
-from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 
 
@@ -80,7 +79,7 @@ class NotifierMaster(RunMasterBase):
             self.assertIn(text, mail)
         else:  # b64encode and remove '=' padding (hence [:-1])
             encodedBytes = base64.b64encode(unicode2bytes(text)).rstrip(b"=")
-            encodedText = bytes2unicode(encodedBytes)
+            encodedText = encodedBytes.decode()
             self.assertIn(encodedText, mail)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -31,7 +31,6 @@ from buildbot.test.fake import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import db
 from buildbot.test.util import www
-from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.www import auth
 from buildbot.www import authz
@@ -140,7 +139,9 @@ class Www(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase):
         if expect200 and pg.code != 200:
             self.fail("did not get 200 response for '%s'" % (url,))
 
-        return json.loads(bytes2unicode(body))
+        if isinstance(body, bytes):
+            body = body.decode()
+        return json.loads(body)
 
     def link(self, suffix):
         return self.url + b'api/v2/' + suffix

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -28,7 +28,6 @@ from buildbot.test.util import config
 from buildbot.test.util import gpo
 from buildbot.test.util import logging
 from buildbot.test.util.misc import TestReactorMixin
-from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 
 # Test that environment variables get propagated to subprocesses (See #2116)
@@ -147,7 +146,7 @@ class GitOutputParsing(gpo.GetProcessOutputMixin, unittest.TestCase):
 
     def test_get_commit_files_with_space_in_changed_files(self):
         filesBytes = b'normal_directory/file1\ndirectory with space/file2'
-        filesStr = bytes2unicode(filesBytes)
+        filesStr = filesBytes.decode()
         return self._perform_git_output_test(
             self.poller._get_commit_files,
             ['log', '--name-only', '--no-walk',
@@ -159,7 +158,7 @@ class GitOutputParsing(gpo.GetProcessOutputMixin, unittest.TestCase):
 
     def test_get_commit_timestamp(self):
         stampBytes = b'1273258009'
-        stampStr = bytes2unicode(stampBytes)
+        stampStr = stampBytes.decode()
         return self._perform_git_output_test(self.poller._get_commit_timestamp,
                                              ['log', '--no-walk', '--format=%ct',
                                                  self.dummyRevStr, '--'],
@@ -200,8 +199,8 @@ class TestGitPoller(TestGitPollerBase):
         self.assertSubstring("GitPoller", self.poller.describe())
 
     def test_name(self):
-        self.assertEqual(bytes2unicode(self.REPOURL),
-                         bytes2unicode(self.poller.name))
+        self.assertEqual(self.REPOURL,
+                         self.poller.name)
 
         # and one with explicit name...
         other = gitpoller.GitPoller(self.REPOURL, name="MyName")
@@ -257,7 +256,7 @@ class TestGitPoller(TestGitPollerBase):
             'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
         })
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
+            name=self.REPOURL, class_name='GitPoller',
             lastRev={
                 'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
             })
@@ -417,7 +416,7 @@ class TestGitPoller(TestGitPollerBase):
 
         self.assertAllCommandsRan()
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
+            name=self.REPOURL, class_name='GitPoller',
             lastRev={
                 'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
             })
@@ -1256,7 +1255,7 @@ class TestGitPoller(TestGitPollerBase):
         self.assertAllCommandsRan()
 
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
+            name=self.REPOURL, class_name='GitPoller',
             lastRev={
                 'master': '4423cdbcbb89c14e50dd5f4152415afd686c5241'
             })
@@ -1356,7 +1355,7 @@ class TestGitPoller(TestGitPollerBase):
     @defer.inlineCallbacks
     def test_startService_loadLastRev(self):
         self.master.db.state.fakeState(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
+            name=self.REPOURL, class_name='GitPoller',
             lastRev={"master": "fa3ae8ed68e664d4db24798611b352e3c6509930"},
         )
 
@@ -1424,7 +1423,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
             'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
         })
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
+            name=self.REPOURL, class_name='GitPoller',
             lastRev={
                 'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
             })
@@ -1467,7 +1466,7 @@ class TestGitPollerWithSshPrivateKey(TestGitPollerBase):
             'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
         })
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
+            name=self.REPOURL, class_name='GitPoller',
             lastRev={
                 'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
             })
@@ -1562,7 +1561,7 @@ class TestGitPollerWithSshHostKey(TestGitPollerBase):
             'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
         })
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
+            name=self.REPOURL, class_name='GitPoller',
             lastRev={
                 'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
             })
@@ -1630,7 +1629,7 @@ class TestGitPollerWithSshKnownHosts(TestGitPollerBase):
             'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
         })
         self.master.db.state.assertStateByClass(
-            name=bytes2unicode(self.REPOURL), class_name='GitPoller',
+            name=self.REPOURL, class_name='GitPoller',
             lastRev={
                 'master': 'bf0b01df6d00ae8d1ffa0b2e2acbe642a6cd35d5'
             })

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1261,12 +1261,6 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
             config.BuilderConfig(name='_a', factory=self.factory,
                                  workernames=['a'])
 
-    def test_utf8_name(self):
-        with self.assertRaisesConfigError(
-                "builder names must be unicode or ASCII"):
-            config.BuilderConfig(name="\N{SNOWMAN}".encode('utf-8'),
-                                 factory=self.factory, workernames=['a'])
-
     def test_no_factory(self):
         with self.assertRaisesConfigError("builder 'a' has no factory"):
             config.BuilderConfig(name='a', workernames=['a'])

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -29,7 +29,6 @@ from buildbot.test.util import connector_component
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
 from buildbot.test.util.misc import TestReactorMixin
-from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 
 
@@ -228,11 +227,13 @@ class Tests(interfaces.InterfaceTests):
         content = self.bug3101Content
         yield self.insertTestData(self.backgroundData + self.bug3101Rows)
         # overall content is the same, with '\n' padding at the end
-        expected = bytes2unicode(self.bug3101Content + b'\n')
+        expected = self.bug3101Content + b'\n'
+        expected = expected.decode()
         self.assertEqual((yield self.db.logs.getLogLines(1470, 0, 99)),
                          expected)
         # try to fetch just one line
-        expected = bytes2unicode(content.split(b'\n')[0] + b'\n')
+        expected = content.split(b'\n')[0] + b'\n'
+        expected = expected.decode()
         self.assertEqual((yield self.db.logs.getLogLines(1470, 0, 0)),
                          expected)
 

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -34,7 +34,6 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.notifier import NotifierTestMixin
-from buildbot.util import bytes2unicode
 from buildbot.util import ssl
 
 py_27 = sys.version_info[0] > 2 or (sys.version_info[0] == 2
@@ -174,7 +173,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
             if "base64" not in s:
                 self.assertIn("Unicode log", s)
             else:  # b64encode and remove '=' padding (hence [:-1])
-                logStr = bytes2unicode(base64.b64encode(b"Unicode log")[:-1])
+                logStr = base64.b64encode(b"Unicode log")[:-1].decode()
                 self.assertIn(logStr, s)
 
             self.assertIn(
@@ -345,8 +344,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
         mn, builds = yield self.do_test_sendMessage()
 
         self.assertEqual(1, len(fakereactor.method_calls))
-        self.assertIn(('connectTCP', ('localhost', 25, None), {}),
-                      fakereactor.method_calls)
+        self.assertIn(('connectTCP', ('localhost', 25, None), {}), fakereactor.method_calls)
 
     @defer.inlineCallbacks
     def test_sendMessageWithInterpolatedConfig(self):
@@ -363,8 +361,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
         self.assertEqual(mn.smtpUser, "u$er")
         self.assertEqual(mn.smtpPassword, "pa$$word")
         self.assertEqual(1, len(fakereactor.method_calls))
-        self.assertIn(('connectTCP', ('localhost', 25, None), {}),
-                      fakereactor.method_calls)
+        self.assertIn(('connectTCP', ('localhost', 25, None), {}), fakereactor.method_calls)
 
     @ssl.skipUnless
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -38,7 +38,6 @@ from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot.test.util import steps
 from buildbot.test.util.misc import TestReactorMixin
-from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 
 
@@ -1043,8 +1042,7 @@ class TestJSONPropertiesDownload(unittest.TestCase):
                 self.assertEqual(kwargs['workerdest'], 'props.json')
                 reader = kwargs['reader']
                 data = reader.remote_read(100)
-                data = bytes2unicode(data)
-                actualJson = json.loads(data)
+                actualJson = json.loads(data.decode())
                 expectedJson = dict(sourcestamps=[ss.asDict()], properties={'key1': 'value1'})
                 self.assertEqual(actualJson, expectedJson)
                 break
@@ -1075,8 +1073,7 @@ class TestJSONPropertiesDownload(unittest.TestCase):
                 self.assertEqual(kwargs['slavedest'], 'props.json')
                 reader = kwargs['reader']
                 data = reader.remote_read(100)
-                data = bytes2unicode(data)
-                actualJson = json.loads(data)
+                actualJson = json.loads(data.decode())
                 expectedJson = dict(sourcestamps=[ss.asDict()], properties={'key1': 'value1'})
                 self.assertEqual(actualJson, expectedJson)
                 break

--- a/master/buildbot/test/unit/test_util.py
+++ b/master/buildbot/test/unit/test_util.py
@@ -105,27 +105,27 @@ class TestHumanReadableDelta(unittest.TestCase):
 class safeTranslate(unittest.TestCase):
 
     def test_str_good(self):
-        self.assertEqual(util.safeTranslate(str("full")), b"full")
+        self.assertEqual(util.safeTranslate(str("full")), "full")
 
     def test_str_bad(self):
         self.assertEqual(util.safeTranslate(str("speed=slow;quality=high")),
-                         b"speed_slow_quality_high")
+                         "speed_slow_quality_high")
 
     def test_str_pathological(self):
         # if you needed proof this wasn't for use with sensitive data
         self.assertEqual(util.safeTranslate(str("p\ath\x01ogy")),
-                         b"p\ath\x01ogy")  # bad chars still here!
+                         "p\ath\x01ogy")  # bad chars still here!
 
     def test_unicode_good(self):
-        self.assertEqual(util.safeTranslate("full"), b"full")
+        self.assertEqual(util.safeTranslate("full"), "full")
 
     def test_unicode_bad(self):
         self.assertEqual(util.safeTranslate(str("speed=slow;quality=high")),
-                         b"speed_slow_quality_high")
+                         "speed_slow_quality_high")
 
     def test_unicode_pathological(self):
         self.assertEqual(util.safeTranslate("\u0109"),
-                         b"\xc4\x89")  # yuck!
+                         "\u0109")  # yuck!
 
 
 class naturalSort(unittest.TestCase):

--- a/master/buildbot/test/unit/test_util_httpclientservice.py
+++ b/master/buildbot/test/unit/test_util_httpclientservice.py
@@ -29,7 +29,6 @@ from twisted.web import server
 
 from buildbot import interfaces
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
-from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
 from buildbot.util import service
 from buildbot.util import unicode2bytes
@@ -206,9 +205,9 @@ class MyResource(resource.Resource):
     def render_GET(self, request):
         def decode(x):
             if isinstance(x, bytes):
-                return bytes2unicode(x)
+                return x.decode()
             elif isinstance(x, (list, tuple)):
-                return [bytes2unicode(y) for y in x]
+                return [y.decode() if isinstance(y, bytes) else y for y in x]
             elif isinstance(x, dict):
                 newArgs = {}
                 for a, b in x.items():
@@ -219,8 +218,7 @@ class MyResource(resource.Resource):
         args = decode(request.args)
         content_type = request.getHeader(b'content-type')
         if content_type == b"application/json":
-            jsonBytes = request.content.read()
-            jsonStr = bytes2unicode(jsonBytes)
+            jsonStr = request.content.read().decode()
             args['json_received'] = json.loads(jsonStr)
 
         data = json.dumps(args)
@@ -300,7 +298,7 @@ class HTTPClientServiceTestTxRequestE2E(unittest.TestCase):
                     content_json=exp_content_json)
         res = yield self._http.post('/', json=dict(a='b'))
         content = yield res.content()
-        content = bytes2unicode(content)
+        content = content.decode()
         content = json.loads(content)
         self.assertEqual(content, exp_content_json)
 
@@ -312,7 +310,7 @@ class HTTPClientServiceTestTxRequestE2E(unittest.TestCase):
                     content_json=exp_content_json)
         res = yield self._http.post('/', json=dict(a='b', ts=dt))
         content = yield res.content()
-        content = bytes2unicode(content)
+        content = content.decode()
         content = json.loads(content)
         self.assertEqual(content, exp_content_json)
 

--- a/master/buildbot/test/unit/test_www_config.py
+++ b/master/buildbot/test/unit/test_www_config.py
@@ -24,7 +24,6 @@ from twisted.trial import unittest
 
 from buildbot.test.util import www
 from buildbot.test.util.misc import TestReactorMixin
-from buildbot.util import bytes2unicode
 from buildbot.www import auth
 from buildbot.www import config
 
@@ -55,7 +54,8 @@ class IndexResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
                  for v in rsrc.getEnvironmentVersions()] + custom_versions
 
         res = yield self.render_resource(rsrc, b'/')
-        res = json.loads(bytes2unicode(res))
+        res = res.decode()
+        res = json.loads(res)
         _auth.maybeAutoLogin.assert_called_with(mock.ANY)
         exp = {"authz": {}, "titleURL": "http://buildbot.net", "versions": vjson, "title": "Buildbot", "auth": {
             "name": "NoAuth"}, "user": {"anonymous": True}, "buildbotURL": "h:/a/b/", "multiMaster": False, "port": None}
@@ -63,7 +63,8 @@ class IndexResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
         master.session.user_info = dict(name="me", email="me@me.org")
         res = yield self.render_resource(rsrc, b'/')
-        res = json.loads(bytes2unicode(res))
+        res = res.decode()
+        res = json.loads(res)
         exp = {"authz": {}, "titleURL": "http://buildbot.net", "versions": vjson, "title": "Buildbot", "auth": {"name": "NoAuth"},
                "user": {"email": "me@me.org", "name": "me"}, "buildbotURL": "h:/a/b/", "multiMaster": False, "port": None}
         self.assertEqual(res, exp)
@@ -72,7 +73,8 @@ class IndexResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             url='h:/a/c/', auth=_auth, versions=custom_versions)
         rsrc.reconfigResource(master.config)
         res = yield self.render_resource(rsrc, b'/')
-        res = json.loads(bytes2unicode(res))
+        res = res.decode()
+        res = json.loads(res)
         exp = {"authz": {}, "titleURL": "http://buildbot.net", "versions": vjson, "title": "Buildbot", "auth": {
             "name": "NoAuth"}, "user": {"anonymous": True}, "buildbotURL": "h:/a/b/", "multiMaster": False, "port": None}
         self.assertEqual(res, exp)

--- a/master/buildbot/test/unit/test_www_hooks_base.py
+++ b/master/buildbot/test/unit/test_www_hooks_base.py
@@ -6,7 +6,6 @@ from twisted.trial import unittest
 from buildbot.test.fake.web import FakeRequest
 from buildbot.test.fake.web import fakeMasterForHooks
 from buildbot.test.util.misc import TestReactorMixin
-from buildbot.util import bytes2unicode
 from buildbot.www.change_hook import ChangeHookResource
 from buildbot.www.hooks.base import BaseHookHandler
 
@@ -53,7 +52,9 @@ class TestChangeHookConfiguredWithBase(unittest.TestCase, TestReactorMixin):
         def _first_or_nothing(val):
             if isinstance(val, type([])):
                 val = val[0]
-            return bytes2unicode(val)
+            if isinstance(val, bytes):
+                val = val.decode()
+            return val
 
         if payload.get(b'files'):
             files = json.loads(_first_or_nothing(payload.get(b'files')))

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -33,7 +33,6 @@ from buildbot.test.fake.secrets import FakeSecretStorage
 from buildbot.test.util import www
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.misc import TestReactorMixin
-from buildbot.util import bytes2unicode
 
 try:
     import requests
@@ -573,7 +572,7 @@ class OAuth2AuthGitHubE2E(TestReactorMixin, www.WwwTestMixin,
 
         def thd():
             res = requests.get('http://localhost:5000/auth/login')
-            content = bytes2unicode(res.content)
+            content = res.content.decode()
             webbrowser.open(content)
         threads.deferToThread(thd)
         res = yield d

--- a/master/buildbot/test/unit/test_www_rest.py
+++ b/master/buildbot/test/unit/test_www_rest.py
@@ -24,7 +24,6 @@ from twisted.trial import unittest
 from buildbot.test.fake import endpoint
 from buildbot.test.util import www
 from buildbot.test.util.misc import TestReactorMixin
-from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.www import authz
 from buildbot.www import rest
@@ -265,7 +264,7 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin,
                              total=None, contentType=None, orderSignificant=False):
         self.assertFalse(isinstance(self.request.written, str))
         got = {}
-        got['content'] = json.loads(bytes2unicode(self.request.written))
+        got['content'] = json.loads(self.request.written.decode())
         got['contentType'] = self.request.headers[b'content-type']
         got['responseCode'] = self.request.responseCode
 
@@ -292,7 +291,7 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin,
     def assertRestDetails(self, typeName, item,
                           contentType=None):
         got = {}
-        got['content'] = json.loads(bytes2unicode(self.request.written))
+        got['content'] = json.loads(self.request.written.decode())
         got['contentType'] = self.request.headers[b'content-type']
         got['responseCode'] = self.request.responseCode
 
@@ -307,7 +306,7 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin,
         self.assertEqual(got, exp)
 
     def assertRestError(self, responseCode, message):
-        content = json.loads(bytes2unicode(self.request.written))
+        content = json.loads(self.request.written.decode())
         gotResponseCode = self.request.responseCode
         self.assertEqual(list(content.keys()), ['error'])
         self.assertRegex(content['error'], message)
@@ -666,7 +665,7 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin,
         got = {}
         got['contentType'] = self.request.headers[b'content-type']
         got['responseCode'] = self.request.responseCode
-        content = json.loads(bytes2unicode(self.request.written))
+        content = json.loads(self.request.written.decode())
 
         if 'error' not in content:
             self.fail("response does not have proper error form: %r"
@@ -707,7 +706,7 @@ class V2RootResource_JSONRPC2(TestReactorMixin, www.WwwTestMixin,
         got = {}
         got['contentType'] = self.request.headers[b'content-type']
         got['responseCode'] = self.request.responseCode
-        content = json.loads(bytes2unicode(self.request.written))
+        content = json.loads(self.request.written.decode())
         if ('error' not in content
                 or sorted(content['error'].keys()) != ['code', 'message']):
             self.fail("response does not have proper error form: %r"

--- a/master/buildbot/test/unit/test_www_sse.py
+++ b/master/buildbot/test/unit/test_www_sse.py
@@ -22,7 +22,6 @@ from twisted.trial import unittest
 from buildbot.test.unit import test_data_changes
 from buildbot.test.util import www
 from buildbot.test.util.misc import TestReactorMixin
-from buildbot.util import bytes2unicode
 from buildbot.util import datetime2epoch
 from buildbot.util import unicode2bytes
 from buildbot.www import sse
@@ -118,7 +117,7 @@ class EventResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
             ("changes", "500", "new"), test_data_changes.Change.changeEvent)
         kw = self.readEvent(request)
         self.assertEqual(kw[b"event"], b"event")
-        msg = json.loads(bytes2unicode(kw[b"data"]))
+        msg = json.loads(kw[b"data"].decode())
         self.assertEqual(msg["key"], ['changes', '500', 'new'])
         self.assertEqual(msg["message"], json.loads(
             json.dumps(test_data_changes.Change.changeEvent, default=self._toJson)))

--- a/master/buildbot/test/unit/test_www_ws.py
+++ b/master/buildbot/test/unit/test_www_ws.py
@@ -21,7 +21,6 @@ from twisted.trial import unittest
 
 from buildbot.test.util import www
 from buildbot.test.util.misc import TestReactorMixin
-from buildbot.util import bytes2unicode
 from buildbot.www import ws
 
 
@@ -37,7 +36,8 @@ class WsResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def assert_called_with_json(self, obj, expected_json):
         jsonArg = obj.call_args[0][0]
-        jsonArg = bytes2unicode(jsonArg)
+        if isinstance(jsonArg, bytes):
+            jsonArg = jsonArg.decode()
         actual_json = json.loads(jsonArg)
         self.assertEqual(actual_json, expected_json)
 

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -29,7 +29,6 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake import logfile
 from buildbot.test.fake import remotecommand
 from buildbot.test.fake import worker
-from buildbot.util import bytes2unicode
 
 
 def _dict_diff(d1, d2):
@@ -219,7 +218,8 @@ class BuildStepMixin:
 
         def addHTMLLog(name, html):
             _log = logfile.FakeLogFile(name, step)
-            html = bytes2unicode(html)
+            if isinstance(html, bytes):
+                html = html.decode()
             _log.addStdout(html)
             return defer.succeed(None)
         step.addHTMLLog = addHTMLLog

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -20,7 +20,6 @@ import json
 import re
 
 from buildbot.util import UTC
-from buildbot.util import bytes2unicode
 
 # Base class
 
@@ -263,7 +262,7 @@ class MessageValidator(Validator):
     routingKeyValidator = TupleValidator(StrValidator())
 
     def __init__(self, events, messageValidator):
-        self.events = [bytes2unicode(e) for e in set(events)]
+        self.events = [e.decode() if isinstance(e, bytes) else e for e in set(events)]
         self.messageValidator = messageValidator
 
     def validate(self, name, routingKey_message):
@@ -661,7 +660,10 @@ def verifyMessage(testcase, routingKey, message_):
     # the "type" of the message is identified by last path name
     # -1 being the event, and -2 the id.
 
-    validator = message[bytes2unicode(routingKey[-3])]
+    if isinstance(routingKey[-3], bytes):
+        validator = message[routingKey[-3].decode()]
+    else:
+        validator = message[routingKey[-3]]
     _verify(testcase, validator, '',
             (routingKey, (routingKey, message_)))
 

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -27,7 +27,6 @@ from twisted.python.compat import NativeStringIO
 from twisted.web import server
 
 from buildbot.test.fake import fakemaster
-from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.www import auth
 from buildbot.www import authz
@@ -67,7 +66,7 @@ class FakeRequest:
         self.uri = self.path
         self.postpath = []
         for p in path[1:].split(b'/'):
-            path = urlunquote(bytes2unicode(p))
+            path = urlunquote(p.decode())
             self.postpath.append(unicode2bytes(path))
 
         self.deferred = defer.Deferred()
@@ -194,7 +193,7 @@ class WwwTestMixin(RequiresWwwMixin):
         if rv == server.NOT_DONE_YET:
             rv = yield request.deferred
 
-        res = json.loads(bytes2unicode(rv))
+        res = json.loads(rv.decode())
         self.assertIn("jsonrpc", res)
         self.assertEqual(res["jsonrpc"], "2.0")
         if not requestJson:
@@ -212,7 +211,7 @@ class WwwTestMixin(RequiresWwwMixin):
             exp['content'] = content
         if contentJson is not None:
             got['contentJson'] = json.loads(
-                bytes2unicode(self.request.written))
+                self.request.written.decode())
             exp['contentJson'] = contentJson
         if contentType is not None:
             got['contentType'] = self.request.headers[b'content-type']

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -201,7 +201,7 @@ badchars_map = bytes.maketrans(b"\t !#$%&'()*+,./:;<=>?@[\\]^{|}~",
 def safeTranslate(s):
     if isinstance(s, str):
         s = s.encode('utf8')
-    return s.translate(badchars_map)
+    return s.translate(badchars_map).decode()
 
 
 def none_or_str(x):

--- a/master/buildbot/util/identifiers.py
+++ b/master/buildbot/util/identifiers.py
@@ -15,8 +15,6 @@
 
 import re
 
-from buildbot import util
-
 ident_re = re.compile('^[a-zA-Z\u00a0-\U0010ffff_-][a-zA-Z0-9\u00a0-\U0010ffff_-]*$', flags=re.UNICODE)
 initial_re = re.compile('^[^a-zA-Z_-]')
 subsequent_re = re.compile('[^a-zA-Z0-9_-]')
@@ -37,8 +35,8 @@ def forceIdentifier(maxLength, s):
     if not isinstance(s, str):
         raise TypeError("%r cannot be coerced to an identifier" % (str,))
 
-    # usually bytes2unicode can handle it
-    s = util.bytes2unicode(s)
+    if isinstance(s, bytes):
+        s = s.decode()
     if isIdentifier(maxLength, s):
         return s
 

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -23,7 +23,6 @@ from twisted.python import reflect
 from twisted.python.reflect import accumulateClassList
 
 from buildbot import util
-from buildbot.util import bytes2unicode
 from buildbot.util import config
 from buildbot.util import unicode2bytes
 
@@ -175,8 +174,10 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
 
     def __init__(self, *args, **kwargs):
         name = kwargs.pop("name", None)
+        if isinstance(name, bytes):
+            name = name.decode()
         if name is not None:
-            self.name = bytes2unicode(name)
+            self.name = name
         self.checkConfig(*args, **kwargs)
         if self.name is None:
             raise ValueError(

--- a/master/buildbot/wamp/connector.py
+++ b/master/buildbot/wamp/connector.py
@@ -22,7 +22,6 @@ from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log
 
-from buildbot.util import bytes2unicode
 from buildbot.util import service
 
 
@@ -140,10 +139,13 @@ class WampConnector(service.ReconfigurableServiceMixin, service.AsyncMultiServic
         if router_url is None:
             return
         self.router_url = router_url
+        realm = wamp.get('realm', 'buildbot')
+        if isinstance(realm, bytes):
+            realm = realm.decode()
         self.app = self.serviceClass(
             url=self.router_url,
             extra=dict(master=self.master, parent=self),
-            realm=bytes2unicode(wamp.get('realm', 'buildbot')),
+            realm=realm,
             make=make
         )
         wamp_debug_level = wamp.get('wamp_debug_level', 'error')

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -26,7 +26,6 @@ from buildbot.interfaces import IWorker
 from buildbot.process import metrics
 from buildbot.process.properties import Properties
 from buildbot.status.worker import WorkerStatus
-from buildbot.util import bytes2unicode
 from buildbot.util import service
 from buildbot.util.eventual import eventually
 
@@ -80,7 +79,9 @@ class AbstractWorker(service.BuildbotService):
                       can be used
         @type locks: dictionary
         """
-        self.name = name = bytes2unicode(name)
+        if isinstance(name, bytes):
+            name = name.decode()
+        self.name = name
 
         self.password = password
 

--- a/master/buildbot/www/authz/endpointmatchers.py
+++ b/master/buildbot/www/authz/endpointmatchers.py
@@ -18,7 +18,6 @@ import inspect
 from twisted.internet import defer
 
 from buildbot.data.exceptions import InvalidPathError
-from buildbot.util import bytes2unicode
 
 
 class EndpointMatcherBase:
@@ -101,7 +100,9 @@ class AnyEndpointMatcher(EndpointMatcherBase):
 class AnyControlEndpointMatcher(EndpointMatcherBase):
 
     def match(self, ep, action="", options=None):
-        if bytes2unicode(action).lower() != "get":
+        if isinstance(action, bytes):
+            action = action.decode()
+        if action.lower() != "get":
             return defer.succeed(Match(self.master))
         return defer.succeed(None)
 

--- a/master/buildbot/www/hooks/base.py
+++ b/master/buildbot/www/hooks/base.py
@@ -21,8 +21,6 @@
 
 import json
 
-from buildbot.util import bytes2unicode
-
 
 class BaseHookHandler:
     def __init__(self, master, options):
@@ -47,7 +45,9 @@ class BaseHookHandler:
             """
             if (isinstance(value, type([]))):
                 value = value[0]
-            return bytes2unicode(value)
+            if isinstance(value, bytes):
+                value = value.decode()
+            return value
 
         args = request.args
         # first, convert files, links and properties

--- a/master/buildbot/www/hooks/bitbucket.py
+++ b/master/buildbot/www/hooks/bitbucket.py
@@ -21,7 +21,6 @@ from dateutil.parser import parse as dateparse
 
 from twisted.python import log
 
-from buildbot.util import bytes2unicode
 from buildbot.www.hooks.base import BaseHookHandler
 
 _HEADER_EVENT = b'X-Event-Key'
@@ -40,12 +39,12 @@ class BitBucketHandler(BaseHookHandler):
         """
 
         event_type = request.getHeader(_HEADER_EVENT)
-        event_type = bytes2unicode(event_type)
-        payload = json.loads(bytes2unicode(request.args[b'payload'][0]))
+        if isinstance(event_type, bytes):
+            event_type = event_type.decode()
+        payload = json.loads(request.args[b'payload'][0].decode())
         repo_url = '{}{}'.format(
             payload['canon_url'], payload['repository']['absolute_url'])
-        project = request.args.get(b'project', [b''])[0]
-        project = bytes2unicode(project)
+        project = request.args.get(b'project', [b''])[0].decode()
 
         changes = []
         for commit in payload['commits']:

--- a/master/buildbot/www/hooks/bitbucketcloud.py
+++ b/master/buildbot/www/hooks/bitbucketcloud.py
@@ -19,8 +19,6 @@ import json
 
 from twisted.python import log
 
-from buildbot.util import bytes2unicode
-
 GIT_BRANCH_REF = "refs/heads/{}"
 GIT_MERGE_REF = "refs/pull-requests/{}/merge"
 GIT_TAG_REF = "refs/tags/{}"
@@ -42,7 +40,8 @@ class BitbucketCloudEventHandler:
     def process(self, request):
         payload = self._get_payload(request)
         event_type = request.getHeader(_HEADER_EVENT)
-        event_type = bytes2unicode(event_type)
+        if isinstance(event_type, bytes):
+            event_type = event_type.decode()
         log.msg("Processing event {header}: {event}"
                 .format(header=_HEADER_EVENT, event=event_type))
         event_type = event_type.replace(":", "_")
@@ -54,10 +53,8 @@ class BitbucketCloudEventHandler:
         return handler(payload)
 
     def _get_payload(self, request):
-        content = request.content.read()
-        content = bytes2unicode(content)
-        content_type = request.getHeader(b'Content-Type')
-        content_type = bytes2unicode(content_type)
+        content = request.content.read().decode()
+        content_type = request.getHeader(b'Content-Type').decode()
         if content_type.startswith('application/json'):
             payload = json.loads(content)
         else:

--- a/master/buildbot/www/hooks/bitbucketserver.py
+++ b/master/buildbot/www/hooks/bitbucketserver.py
@@ -19,8 +19,6 @@ import json
 
 from twisted.python import log
 
-from buildbot.util import bytes2unicode
-
 GIT_BRANCH_REF = "refs/heads/{}"
 GIT_MERGE_REF = "refs/pull-requests/{}/merge"
 GIT_TAG_REF = "refs/tags/{}"
@@ -42,7 +40,8 @@ class BitbucketServerEventHandler:
     def process(self, request):
         payload = self._get_payload(request)
         event_type = request.getHeader(_HEADER_EVENT)
-        event_type = bytes2unicode(event_type)
+        if isinstance(event_type, bytes):
+            event_type = event_type.decode()
         log.msg("Processing event {header}: {event}"
                 .format(header=_HEADER_EVENT, event=event_type))
         event_type = event_type.replace(":", "_")
@@ -54,10 +53,8 @@ class BitbucketServerEventHandler:
         return handler(payload)
 
     def _get_payload(self, request):
-        content = request.content.read()
-        content = bytes2unicode(content)
-        content_type = request.getHeader(b'Content-Type')
-        content_type = bytes2unicode(content_type)
+        content = request.content.read().decode()
+        content_type = request.getHeader(b'Content-Type').decode()
         if content_type.startswith('application/json'):
             payload = json.loads(content)
         else:

--- a/master/buildbot/www/hooks/gitorious.py
+++ b/master/buildbot/www/hooks/gitorious.py
@@ -23,14 +23,13 @@ from dateutil.parser import parse as dateparse
 
 from twisted.python import log
 
-from buildbot.util import bytes2unicode
 from buildbot.www.hooks.base import BaseHookHandler
 
 
 class GitoriousHandler(BaseHookHandler):
 
     def getChanges(self, request):
-        payload = json.loads(bytes2unicode(request.args[b'payload'][0]))
+        payload = json.loads(request.args[b'payload'][0].decode())
         user = payload['repository']['owner']['name']
         repo = payload['repository']['name']
         repo_url = payload['repository']['url']

--- a/master/buildbot/www/hooks/poller.py
+++ b/master/buildbot/www/hooks/poller.py
@@ -18,7 +18,6 @@
 
 
 from buildbot.changes.base import PollingChangeSource
-from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.www.hooks.base import BaseHookHandler
 
@@ -54,7 +53,7 @@ class PollingHandler(BaseHookHandler):
                       set(unicode2bytes(s.name) for s in pollers))
             if missing:
                 raise ValueError("Could not find pollers: {}".format(
-                    bytes2unicode(b",".join(missing))))
+                    b",".join(missing).decode()))
 
         for p in pollers:
             p.force()

--- a/master/buildbot/www/ldapuserinfo.py
+++ b/master/buildbot/www/ldapuserinfo.py
@@ -30,7 +30,6 @@ import ldap3
 
 from twisted.internet import threads
 
-from buildbot.util import bytes2unicode
 from buildbot.util import flatten
 from buildbot.www import auth
 from buildbot.www import avatar
@@ -96,7 +95,8 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
         return c.response
 
     def getUserInfo(self, username):
-        username = bytes2unicode(username)
+        if isinstance(username, bytes):
+            username = username.decode()
 
         def thd():
             c = self.connectLdap()
@@ -148,7 +148,8 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
         return None
 
     def getUserAvatar(self, user_email, size, defaultAvatarUrl):
-        user_email = bytes2unicode(user_email)
+        if isinstance(user_email, bytes):
+            user_email = user_email.decode()
 
         def thd():
             c = self.connectLdap()

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -28,7 +28,6 @@ from twisted.internet import threads
 
 from buildbot import config
 from buildbot.process.properties import Properties
-from buildbot.util import bytes2unicode
 from buildbot.util.logger import Logger
 from buildbot.www import auth
 from buildbot.www import resource
@@ -161,7 +160,9 @@ class OAuth2Auth(auth.AuthBase):
             response = requests.post(
                 url, data=data, auth=auth, verify=self.sslVerify)
             response.raise_for_status()
-            responseContent = bytes2unicode(response.content)
+            responseContent = response.content
+            if isinstance(responseContent, bytes):
+                responseContent = responseContent.decode()
             try:
                 content = json.loads(responseContent)
             except ValueError:

--- a/master/buildbot/www/plugin.py
+++ b/master/buildbot/www/plugin.py
@@ -18,8 +18,6 @@ import pkg_resources
 
 from twisted.web import static
 
-from buildbot.util import bytes2unicode
-
 
 class Application:
 
@@ -27,7 +25,8 @@ class Application:
         self.description = description
         self.version = pkg_resources.resource_string(
             modulename, "VERSION").strip()
-        self.version = bytes2unicode(self.version)
+        if isinstance(self.version, bytes):
+            self.version = self.version.decode()
         self.static_dir = pkg_resources.resource_filename(
             modulename, "static")
         self.resource = static.File(self.static_dir)

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -33,7 +33,6 @@ from twisted.web import server
 from zope.interface import implementer
 
 from buildbot.plugins.db import get_plugins
-from buildbot.util import bytes2unicode
 from buildbot.util import service
 from buildbot.util import unicode2bytes
 from buildbot.www import auth
@@ -358,7 +357,7 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             # and other runs of this master
 
             # we encode that in hex for db storage convenience
-            return bytes2unicode(hexlify(os.urandom(int(SESSION_SECRET_LENGTH / 8))))
+            return hexlify(os.urandom(int(SESSION_SECRET_LENGTH / 8))).decode()
 
         session_secret = yield state.atomicCreateState(objectid, "session_secret", create_session_secret)
         self.site.setSessionSecret(session_secret)

--- a/master/buildbot/www/sse.py
+++ b/master/buildbot/www/sse.py
@@ -21,7 +21,6 @@ from twisted.web import resource
 from twisted.web import server
 
 from buildbot.data.exceptions import InvalidPathError
-from buildbot.util import bytes2unicode
 from buildbot.util import toJson
 from buildbot.util import unicode2bytes
 
@@ -42,7 +41,7 @@ class Consumer:
 
     def onMessage(self, event, data):
         request = self.request
-        key = [bytes2unicode(e) for e in event]
+        key = [e.decode() if isinstance(e, bytes) else e for e in event]
         msg = dict(key=key, message=data)
         request.write(b"event: " + b"event" + b"\n")
         request.write(
@@ -110,7 +109,7 @@ class EventResource(resource.Resource):
             try:
                 d = self.master.mq.startConsuming(
                     consumer.onMessage,
-                    tuple([bytes2unicode(p) for p in path]))
+                    tuple([p.decode() if isinstance(p, bytes) else p for p in path]))
 
                 @d.addCallback
                 def register(qref):

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -21,7 +21,6 @@ from autobahn.twisted.websocket import WebSocketServerProtocol
 from twisted.internet import defer
 from twisted.python import log
 
-from buildbot.util import bytes2unicode
 from buildbot.util import toJson
 from buildbot.util import unicode2bytes
 
@@ -38,11 +37,13 @@ class WsProtocol(WebSocketServerProtocol):
         return self.sendMessage(unicode2bytes(json.dumps(msg, default=toJson, separators=(',', ':'))))
 
     def onMessage(self, frame, isBinary):
+        if isinstance(frame, bytes):
+            frame = frame.decode()
         if self.debug:
             log.msg("FRAME %s" % frame)
         # parse the incoming request
 
-        frame = json.loads(bytes2unicode(frame))
+        frame = json.loads(frame)
         _id = frame.get("_id")
         if _id is None:
             return self.sendJsonMessage(error="no '_id' in websocket frame", code=400, _id=None)

--- a/www/badges/buildbot_badges/__init__.py
+++ b/www/badges/buildbot_badges/__init__.py
@@ -26,7 +26,6 @@ from twisted.internet import defer
 import cairocffi as cairo
 import cairosvg
 from buildbot.process.results import Results
-from buildbot.util import bytes2unicode
 from buildbot.www.plugin import Application
 
 
@@ -70,8 +69,12 @@ class Api:
                 config[k] = v
 
         for k, v in request.args.items():
-            k = bytes2unicode(k)
-            config[k] = escape(bytes2unicode(v[0]))
+            if isinstance(k, bytes):
+                k = k.decode()
+            v0 = v[0]
+            if isinstance(v0, bytes):
+                v0 = v0.decode()
+            config[k] = escape(v0)
         return config
 
     @app.route("/<string:builder>.png", methods=['GET'])


### PR DESCRIPTION
Now that buildbot master is only supported on Python 3.5+,
we can get rid of the internal usage of `bytes2unicode()`.

The semantics of `bytes.decode()` on Python 3 are well understood and consistent, so we should just use that:
https://docs.python.org/3.5/library/stdtypes.html#bytes.decode

## Contributor Checklist:

* [X] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
