### PR TITLE
Fix db migration errors on sqlite (and potentially others)

### DIFF
--- a/master/buildbot/newsfragments/migration-integrity-errors.bugfix
+++ b/master/buildbot/newsfragments/migration-integrity-errors.bugfix
@@ -1,0 +1,1 @@
+Fixed a potential error during database migration when upgrading to versions >=2.0 (:issue:`4711`).

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -789,6 +789,8 @@ class BuildStep(results.ResultComputingConfigMixin,
         return self.build.getWorkerName()
 
     def addLog(self, name, type='s', logEncoding=None):
+        if self.stepid is None:
+            raise BuildStepCancelled
         d = self.master.data.updates.addLog(self.stepid,
                                             util.bytes2unicode(name),
                                             str(type))
@@ -819,6 +821,8 @@ class BuildStep(results.ResultComputingConfigMixin,
     @_maybeUnhandled
     @defer.inlineCallbacks
     def addCompleteLog(self, name, text):
+        if self.stepid is None:
+            raise BuildStepCancelled
         logid = yield self.master.data.updates.addLog(self.stepid,
                                                       util.bytes2unicode(name), 't')
         _log = self._newLog(name, 't', logid)
@@ -828,6 +832,8 @@ class BuildStep(results.ResultComputingConfigMixin,
     @_maybeUnhandled
     @defer.inlineCallbacks
     def addHTMLLog(self, name, html):
+        if self.stepid is None:
+            raise BuildStepCancelled
         logid = yield self.master.data.updates.addLog(self.stepid,
                                                       util.bytes2unicode(name), 'h')
         _log = self._newLog(name, 'h', logid)


### PR DESCRIPTION
When a build is cancelled while a step is starting up. The stepid has not been initialized yet. Before #4539, there was no integrity constraints on the stepid column which may have caused "invalid" rows to be created.

This may cause migration number 52 to fail since the constraint is violated.

In case such offending rows are found during the migration, issue a warning and delete them since they are indeed invalid.

Fixes: #4711 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)