### PR TITLE
GitPush: Add missing entrypoint in setup.py

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -296,7 +296,7 @@ setup_args = {
             ('buildbot.steps.source.cvs', ['CVS']),
             ('buildbot.steps.source.darcs', ['Darcs']),
             ('buildbot.steps.source.gerrit', ['Gerrit']),
-            ('buildbot.steps.source.git', ['Git', 'GitCommit', 'GitTag']),
+            ('buildbot.steps.source.git', ['Git', 'GitCommit', 'GitPush', 'GitTag']),
             ('buildbot.steps.source.github', ['GitHub']),
             ('buildbot.steps.source.gitlab', ['GitLab']),
             ('buildbot.steps.source.mercurial', ['Mercurial']),


### PR DESCRIPTION
Add GitPush in the entrypoint list.

I don't know if this patch need a newsfragment or not.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
