### PR TITLE
Fix bug with git submodules

### DIFF
--- a/master/buildbot/newsfragments/git-submodules.bugfix
+++ b/master/buildbot/newsfragments/git-submodules.bugfix
@@ -1,2 +1,1 @@
-Fixed bug with git checkouting from branch with submodule to branch without
-that submodule in :py:class:`~buildbot.steps.source.git.Git`
+Fixed :py:class:~buildbot.steps.source.git.Git to clean the repository after the checkout when submodules are enabled. Previously this action could lead to untracked module directories after changing branches.

--- a/master/buildbot/newsfragments/git-submodules.bugfix
+++ b/master/buildbot/newsfragments/git-submodules.bugfix
@@ -1,0 +1,2 @@
+Fixed bug with git checkouting from branch with submodule to branch without
+that submodule in :py:class:`~buildbot.steps.source.git.Git`

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -187,8 +187,8 @@ class Git(Source, GitStepMixin):
 
     @defer.inlineCallbacks
     def clean(self):
-        command = ['clean', '-f', '-f', '-d']
-        rc = yield self._dovccmd(command)
+        clean_command = ['clean', '-f', '-f', '-d']
+        rc = yield self._dovccmd(clean_command)
         if rc != RC_SUCCESS:
             raise buildstep.BuildStepFailed
 
@@ -204,6 +204,11 @@ class Git(Source, GitStepMixin):
         rc = yield self._cleanSubmodule()
         if rc != RC_SUCCESS:
             raise buildstep.BuildStepFailed
+
+        if self.submodules:
+            rc = yield self._dovccmd(clean_command)
+            if rc != RC_SUCCESS:
+                raise buildstep.BuildStepFailed
         return RC_SUCCESS
 
     @defer.inlineCallbacks
@@ -215,7 +220,8 @@ class Git(Source, GitStepMixin):
 
     @defer.inlineCallbacks
     def fresh(self):
-        res = yield self._dovccmd(['clean', '-f', '-f', '-d', '-x'],
+        clean_command = ['clean', '-f', '-f', '-d', '-x']
+        res = yield self._dovccmd(clean_command,
                                   abandonOnFailure=False)
         if res == RC_SUCCESS:
             yield self._fetchOrFallback()
@@ -225,6 +231,8 @@ class Git(Source, GitStepMixin):
         yield self._syncSubmodule()
         yield self._updateSubmodule()
         yield self._cleanSubmodule()
+        if self.submodules:
+            yield self._dovccmd(clean_command)
 
     @defer.inlineCallbacks
     def copy(self):

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -1252,6 +1252,58 @@ class TestGit(sourcesteps.SourceStepMixin,
         self.expectOutcome(result=SUCCESS)
         return self.runStep()
 
+    def test_mode_full_clean_submodule(self):
+        self.setupStep(
+            self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
+                           mode='full', method='clean', submodules=True))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            Expect('stat', dict(file='wkdir/.buildbot-patched',
+                                logEnviron=True))
+            + 1,
+            Expect('listdir', {'dir': 'wkdir', 'logEnviron': True,
+                               'timeout': 1200})
+            + Expect.update('files', ['.git'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'fetch', '-t',
+                                 'http://github.com/buildbot/buildbot.git',
+                                 'HEAD'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'submodule', 'sync'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'submodule', 'update', '--init', '--recursive'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'submodule', 'foreach', '--recursive', 'git', 'clean',
+                                 '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'rev-parse', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        self.expectProperty(
+            'got_revision', 'f6ad368298bd941e934a41f3babc827b2aa95a1d', self.sourceName)
+        return self.runStep()
+
     def test_mode_full_clobber(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -1831,6 +1831,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                                  '-f', '-f', '-d', '-x'])
             + 0,
             ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d', '-x'])
+            + 0,
+            ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
@@ -1877,6 +1880,9 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='wkdir',
                         command=['git', 'submodule', 'foreach', '--recursive', 'git', 'clean',
                                  '-f', '-f', '-d', '-x'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d', '-x'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
@@ -1929,6 +1935,9 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='wkdir',
                         command=['git', 'submodule', 'foreach', '--recursive', 'git', 'clean',
                                  '-f', '-f', '-d', '-x'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'clean', '-f', '-f', '-d', '-x'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])


### PR DESCRIPTION
There are some caveats with git submodules, which are described in git-scm (https://git-scm.com/book/en/v2/Git-Tools-Submodules) book (see section "Issues with Submodules"). One of them is checkouting from branch with submodule to a branch without that submodule. After such action we still have the submodule directory as an untracked directory.

Source git step doesn't consider that and in "fresh" and "clean" methods we can get untracked directories. The solution, which I introduce in my commit, is pretty straightforward: execute "git clean -ddf" not only before checkout, but also after.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
