### PR TITLE
Fix statistics reconfigure

### DIFF
--- a/master/buildbot/newsfragments/statsservice-reconfig.bugfix
+++ b/master/buildbot/newsfragments/statsservice-reconfig.bugfix
@@ -1,0 +1,1 @@
+Fixed: On reconfig the StatsService would not correctly clear old consumers.

--- a/master/buildbot/statistics/stats_service.py
+++ b/master/buildbot/statistics/stats_service.py
@@ -26,6 +26,10 @@ class StatsService(service.BuildbotService):
     A middleware for passing on statistics data to all storage backends.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.consumers = []
+
     def checkConfig(self, storage_backends):
         for wfb in storage_backends:
             if not isinstance(wfb, StatsStorageBase):
@@ -43,12 +47,11 @@ class StatsService(service.BuildbotService):
         for svc in storage_backends:
             self.registeredStorageServices.append(svc)
 
-        self.consumers = []
+        self.removeConsumers()
         self.registerConsumers()
 
     @defer.inlineCallbacks
     def registerConsumers(self):
-        self.removeConsumers()  # remove existing consumers and add new ones
         self.consumers = []
 
         for svc in self.registeredStorageServices:

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -85,6 +85,15 @@ class TestStatsServicesConfiguration(TestStatsServicesBase):
         self.stats_service.reconfigService(new_storage_backends)
         self.checkEqual(new_storage_backends)
 
+    def test_reconfig_with_consumers(self):
+        backend = fakestats.FakeStatsStorageService(name='One')
+        backend.captures = [capture.CaptureProperty('test_builder', 'test')]
+        new_storage_backends = [backend]
+
+        self.stats_service.reconfigService(new_storage_backends)
+        self.stats_service.reconfigService(new_storage_backends)
+        self.assertEqual(len(self.master.mq.qrefs), 1)
+
     def test_bad_configuration(self):
         # Reconfigure with a bad configuration.
         new_storage_backends = [mock.Mock()]


### PR DESCRIPTION
Before, the consumers were not correctly unregistered, so each
reconfig would create new consumers *additional* to the old ones.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* ~[ ] I have updated the appropriate documentation~
