### PR TITLE
www: Fix useless returns created by decaffeinate

### DIFF
--- a/www/base/src/app/about/about.controller.js
+++ b/www/base/src/app/about/about.controller.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 class About {
     constructor($scope, config, restService) {
 

--- a/www/base/src/app/app.run.js
+++ b/www/base/src/app/app.run.js
@@ -47,7 +47,7 @@ class ReconnectingListener {
                             // send event to connectionstatus directive
                             $rootScope.$broadcast("mq.lost_connection")
                         );
-                        return reloadWhenReady();
+                        reloadWhenReady();
                     };
                 }
             }

--- a/www/base/src/app/app.run.js
+++ b/www/base/src/app/app.run.js
@@ -36,7 +36,7 @@ class ReconnectingListener {
                     $interval.cancel(interval);
                     interval = null;
                     hasBeenConnected = true;
-                    return socketService.socket.onclose = function(evt) {
+                    socketService.socket.onclose = function(evt) {
                         // ignore if we are navigating away from buildbot
                         // see https://github.com/buildbot/buildbot/issues/3306
                         if (evt.code <= 1001) {  // CLOSE_GOING_AWAY or CLOSE_NORMAL

--- a/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.js
+++ b/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.js
@@ -14,7 +14,6 @@ describe('buildrequest controller', function() {
     beforeEach(angular.mock.module(function($provide) {
         $provide.value("$state", {go(...args) { return goneto = args; }});
         $provide.value("$stateParams", {buildrequest: 1});
-        return null;  // those module callbacks need to return null!
     })
     );
 

--- a/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.js
+++ b/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.js
@@ -25,7 +25,7 @@ describe('buildrequest controller', function() {
         const $controller = $injector.get('$controller');
         const $q = $injector.get('$q');
         dataService = $injector.get('dataService');
-        return createController = () =>
+        createController = () =>
             $controller('buildrequestController',
                 {$scope})
         ;

--- a/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.js
+++ b/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.js
@@ -45,7 +45,7 @@ describe('buildrequest controller', function() {
             [{buildid: 1, buildrequestid: 1}, {buildid: 2, buildrequestid: 1}]);
         $scope.$apply(() => $scope.buildrequest.claimed = true);
         $timeout.flush();
-        return expect($scope.builds[0]).toBeDefined();
+        expect($scope.builds[0]).toBeDefined();
     });
 
     it('should query for builds again if first query returns 0', function() {
@@ -62,7 +62,7 @@ describe('buildrequest controller', function() {
         // simulate new builds from event stream
         $scope.builds.from([{buildid: 1, buildrequestid: 1}, {buildid: 2, buildrequestid: 1}]);
         $timeout.flush();
-        return expect($scope.builds.length).toBe(2);
+        expect($scope.builds.length).toBe(2);
     });
 
     return it('should go to build page if build started', function() {
@@ -76,6 +76,6 @@ describe('buildrequest controller', function() {
         dataService.when('builds', {buildrequestid: 1}, [{buildid: 1, builderid: 3, number: 1, buildrequestid: 1}]);
         $scope.$apply(() => $scope.buildrequest.claimed = true);
         $timeout.flush();
-        return expect(goneto).toEqual(['build', { builder : 3, build : 1 }]);
+        expect(goneto).toEqual(['build', { builder : 3, build : 1 }]);
     });
 });

--- a/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.js
+++ b/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.js
@@ -65,7 +65,7 @@ describe('buildrequest controller', function() {
         expect($scope.builds.length).toBe(2);
     });
 
-    return it('should go to build page if build started', function() {
+    it('should go to build page if build started', function() {
         dataService.when('buildsets/1/properties', [{a: ['a','b']}]);
         dataService.when('buildrequests/1', [{buildrequestid: 1, builderid: 3, buildsetid: 1}]);
         dataService.when('builders/3', [{builderid: 3}]);

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.controller.js
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.controller.js
@@ -13,39 +13,32 @@ class forceDialog {
             const all_fields_by_name = {};
 
             // prepare default values
-            var prepareFields = fields =>
-                (() => {
-                    const result = [];
-                    for (let field of Array.from(fields)) {
-                        all_fields_by_name[field.fullName] = field;
-                        // give a reference of other fields to easily implement
-                        // autopopulate
-                        field.all_fields_by_name = all_fields_by_name;
-                        field.errors = '';
-                        field.haserrors = false;
-                        if (field.fields != null) {
-                            result.push(prepareFields(field.fields));
-                        } else {
-                            field.value = field.default;
-                            // if field type is username, then we just hide the field
-                            // the backend will fill the value automatically
-                            if (field.type === 'username') {
+            var prepareFields = fields => {
+                for (let field of Array.from(fields)) {
+                    all_fields_by_name[field.fullName] = field;
+                    // give a reference of other fields to easily implement
+                    // autopopulate
+                    field.all_fields_by_name = all_fields_by_name;
+                    field.errors = '';
+                    field.haserrors = false;
+                    if (field.fields != null) {
+                        prepareFields(field.fields);
+                    } else {
+                        field.value = field.default;
+                        // if field type is username, then we just hide the field
+                        // the backend will fill the value automatically
+                        if (field.type === 'username') {
+                            field.type = "text";
+                            const { user } = config;
+                            if (user.email != null) {
                                 field.type = "text";
-                                const { user } = config;
-                                if (user.email != null) {
-                                    field.type = "text";
-                                    result.push(field.hide = true);
-                                } else {
-                                    result.push(undefined);
-                                }
-                            } else {
-                                result.push(undefined);
+                                field.hide = true;
                             }
                         }
                     }
-                    return result;
-                })()
-            ;
+                }
+            };
+
             prepareFields(scheduler.all_fields);
             return angular.extend($scope, {
                 rootfield: {
@@ -70,15 +63,12 @@ class forceDialog {
                             return;
                         }
                         if (err.error.code === -32602) {
-                            return (() => {
-                                const result = [];
-                                for (let k in err.error.message) {
-                                    const v = err.error.message[k];
-                                    all_fields_by_name[k].errors = v;
-                                    result.push(all_fields_by_name[k].haserrors = true);
-                                }
-                                return result;
-                            })();
+                            for (let k in err.error.message) {
+                                const v = err.error.message[k];
+                                all_fields_by_name[k].errors = v;
+                                all_fields_by_name[k].haserrors = true;
+                            }
+                            return null;
                         } else {
                             return $scope.error = err.error.message;
                         }

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.spec.js
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.spec.js
@@ -35,7 +35,7 @@ describe('buildrequest controller', function() {
     it('should query for forcecheduler', function() {
         dataService.when('forceschedulers/forcesched', [{all_fields:[{'foo': 'int'}]}]);
         const controller = createController();
-        return $rootScope.$apply();
+        $rootScope.$apply();
     });
 
     it('should call forcecheduler control api when ok', function() {
@@ -44,6 +44,6 @@ describe('buildrequest controller', function() {
         $timeout.flush();
         $httpBackend.when('POST', 'api/v2/forceschedulers/forcesched') .respond("{}");
         $scope.ok();
-        return $rootScope.$apply();
+        $rootScope.$apply();
     });
 });

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.spec.js
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.spec.js
@@ -20,7 +20,7 @@ describe('buildrequest controller', function() {
         $httpBackend = $injector.get('$httpBackend');
 
         modal = {};
-        return createController = () =>
+        createController = () =>
             $controller('forceDialogController', {
                 $scope,
                 builderid: 1,

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.spec.js
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.spec.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 beforeEach(angular.mock.module('app'));
 
 describe('buildrequest controller', function() {

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.spec.js
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.spec.js
@@ -38,7 +38,7 @@ describe('buildrequest controller', function() {
         return $rootScope.$apply();
     });
 
-    return it('should call forcecheduler control api when ok', function() {
+    it('should call forcecheduler control api when ok', function() {
         dataService.when('forceschedulers/forcesched', [{name: "forcesched", all_fields:[{'foo': 'int'}]}]);
         const controller = createController();
         $timeout.flush();

--- a/www/base/src/app/builders/log/logviewer/scrollviewport.spec.js
+++ b/www/base/src/app/builders/log/logviewer/scrollviewport.spec.js
@@ -200,7 +200,7 @@ describe('page with sidebar', function() {
         scrollTo(10000, 9950);
 
         expect(queries).toEqual([[0,10], [990, 10]]);
-        return assertDOM([
+        assertDOM([
             elements(0,9),   // 100
             padding(9800),   // 9900
             elements(990, 999) // 10000

--- a/www/base/src/app/builders/log/logviewer/scrollviewport.spec.js
+++ b/www/base/src/app/builders/log/logviewer/scrollviewport.spec.js
@@ -66,7 +66,7 @@ describe('page with sidebar', function() {
 
         timeout.flush();
         // make sure it did not changed
-        return expect(elmBody.scrollTop()).toBe(verifyPos);
+        expect(elmBody.scrollTop()).toBe(verifyPos);
     };
 
     beforeEach(inject(function($rootScope, $compile, glMenuService, $timeout, $q, $document) {
@@ -107,7 +107,7 @@ describe('page with sidebar', function() {
             elements(0,9),
             padding(9900)
         ]);
-        return expect(elmBody[0].scrollHeight).toEqual(1000 * 10);
+        expect(elmBody[0].scrollHeight).toEqual(1000 * 10);
     })
     );
 
@@ -124,7 +124,7 @@ describe('page with sidebar', function() {
             elements(55,69), // 700
             padding(10000 - 700)
         ]);
-        return expect(elmBody[0].scrollHeight).toEqual(1000 * 10);
+        expect(elmBody[0].scrollHeight).toEqual(1000 * 10);
     })
     );
 
@@ -190,7 +190,7 @@ describe('page with sidebar', function() {
             elements(0,69), // 700
             padding(10000 - 700)
         ]);
-        return expect(elmBody[0].scrollHeight).toEqual(1000 * 10);
+        expect(elmBody[0].scrollHeight).toEqual(1000 * 10);
     })
     );
 

--- a/www/base/src/app/builders/log/logviewer/scrollviewport.spec.js
+++ b/www/base/src/app/builders/log/logviewer/scrollviewport.spec.js
@@ -194,7 +194,7 @@ describe('page with sidebar', function() {
     })
     );
 
-    return it('Scroll to the end', inject(function($timeout) {
+    it('Scroll to the end', inject(function($timeout) {
         // initial load
         $timeout.flush();
         scrollTo(10000, 9950);

--- a/www/base/src/app/builders/log/logviewer/scrollviewport.spec.js
+++ b/www/base/src/app/builders/log/logviewer/scrollviewport.spec.js
@@ -18,31 +18,22 @@ describe('page with sidebar', function() {
     const assertDOM = function(l) {
         const childs = [];
         $("div", elmContent).each((i, c) => childs.push(c));
-        return (() => {
-            const result = [];
-            for (var item of Array.from(l)) {
-                var c;
-                if (item.type === "padding") {
+
+        for (var item of Array.from(l)) {
+            var c;
+            if (item.type === "padding") {
+                c = childs.shift();
+                expect($(c).hasClass("padding")).toBe(true, c.outerHTML);
+                expect($(c).height()).toEqual(item.height, c.outerHTML);
+            }
+            if (item.type === "elements") {
+                for (let i = item.start, { end } = item, asc = item.start <= end; asc ? i <= end : i >= end; asc ? i++ : i--) {
                     c = childs.shift();
-                    expect($(c).hasClass("padding")).toBe(true, c.outerHTML);
-                    expect($(c).height()).toEqual(item.height, c.outerHTML);
-                }
-                if (item.type === "elements") {
-                    result.push((() => {
-                        const result1 = [];
-                        for (let i = item.start, { end } = item, asc = item.start <= end; asc ? i <= end : i >= end; asc ? i++ : i--) {
-                            c = childs.shift();
-                            expect($(c).hasClass("padding")).toBe(false, c.outerHTML);
-                            result1.push(expect(c.innerText).toEqual(i.toString() + "a" + i.toString(), c.outerHTML));
-                        }
-                        return result1;
-                    })());
-                } else {
-                    result.push(undefined);
+                    expect($(c).hasClass("padding")).toBe(false, c.outerHTML);
+                    expect(c.innerText).toEqual(i.toString() + "a" + i.toString(), c.outerHTML);
                 }
             }
-            return result;
-        })();
+        }
     };
     const printDOM = () =>
         $("div", elmContent).each(function() {

--- a/www/base/src/app/builders/log/logviewer/scrollviewport.spec.js
+++ b/www/base/src/app/builders/log/logviewer/scrollviewport.spec.js
@@ -97,7 +97,7 @@ describe('page with sidebar', function() {
 
         // we need to append to body, so that the element is styled properly, and gets a height
         elmBody.appendTo("body");
-        return elmContent = $("div", elmBody)[0];}));
+        elmContent = $("div", elmBody)[0];}));
 
     // ViewPort height is 50, and item height is 10, so a screen should contain 5 item
     it('should initially load 2 screens', inject(function($timeout) {

--- a/www/base/src/app/changes/changes.controller.js
+++ b/www/base/src/app/changes/changes.controller.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 class Changes {
     constructor($log, $scope, dataService, bbSettingsService) {
         $scope.settings = bbSettingsService.getSettingsGroup("Changes");

--- a/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.spec.js
@@ -14,7 +14,6 @@ describe('buildrequest summary controller', function() {
     beforeEach(angular.mock.module(function($provide) {
         $provide.value("$state",
                         {go(...args) { return goneto = args; }});
-        return null;  // those module callbacks need to return null!
     })
     );
 

--- a/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.spec.js
@@ -46,7 +46,7 @@ describe('buildrequest summary controller', function() {
         expect($scope.buildrequest.buildrequestid).toBe(1);
     });
 
-    return it('should query for builds again if first query returns 0', function() {
+    it('should query for builds again if first query returns 0', function() {
         const buildrequests = [{buildrequestid: 1, builderid: 2, buildsetid: 3}];
         dataService.expect('buildrequests/1', buildrequests);
         dataService.expect('buildsets/3', buildrequests);

--- a/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.spec.js
@@ -26,7 +26,7 @@ describe('buildrequest summary controller', function() {
         $q = $injector.get('$q');
         dataService = $injector.get('dataService');
         // stub out the actual backend of mqservice
-        return createController = () =>
+        createController = () =>
             $controller('_buildrequestsummaryController',
                 {$scope})
         ;

--- a/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.spec.js
@@ -43,7 +43,7 @@ describe('buildrequest summary controller', function() {
         const controller = createController();
         $timeout.flush();
         dataService.verifyNoOutstandingExpectation();
-        return expect($scope.buildrequest.buildrequestid).toBe(1);
+        expect($scope.buildrequest.buildrequestid).toBe(1);
     });
 
     return it('should query for builds again if first query returns 0', function() {
@@ -70,6 +70,6 @@ describe('buildrequest summary controller', function() {
 
         $timeout.flush();
         dataService.verifyNoOutstandingExpectation();
-        return expect($scope.builds.length).toBe(builds.length);
+        expect($scope.builds.length).toBe(builds.length);
     });
 });

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.js
@@ -17,7 +17,7 @@ describe('buildsticker controller', function() {
         const $q = $injector.get('$q');
         $timeout = $injector.get('$timeout');
         results = $injector.get('RESULTS');
-        return dataService = $injector.get('dataService');
+        dataService = $injector.get('dataService');
     };
 
     beforeEach(inject(injected));

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.js
@@ -22,7 +22,7 @@ describe('buildsticker controller', function() {
 
     beforeEach(inject(injected));
 
-    return it('directive should generate correct html', function() {
+    it('directive should generate correct html', function() {
         const build = {buildid: 3, builderid: 2, number: 1};
         dataService.when('builds/3', [build]);
         dataService.when('builders/2', [{builderid: 2}]);

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 beforeEach(angular.mock.module('app'));
 
 describe('buildsticker controller', function() {

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.js
@@ -82,6 +82,6 @@ describe('buildsticker controller', function() {
         expect(durationSpan.hasClass('ng-hide')).toBe(false);
         expect(startedSpan.hasClass('ng-hide')).toBe(true);
         expect(durationSpan.text()).toBe('1 s');
-        return expect(stateSpan.text()).toBe('failed');
+        expect(stateSpan.text()).toBe('failed');
     });
 });

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
@@ -36,7 +36,7 @@ class _buildsummary {
         // to get an update of the current builds every seconds, we need to update self.now
         // but we want to stop counting when the scope destroys!
         const stop = $interval(() => {
-            return this.now = moment().unix();
+            this.now = moment().unix();
         }
         , 1000);
         $scope.$on("$destroy", () => $interval.cancel(stop));

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
@@ -73,7 +73,7 @@ describe('buildsummary controller', function() {
         expect(buildsummary.isStepDisplayed({results:results.SUCCESS})).toBe(false);
         expect(buildsummary.isStepDisplayed({results:results.WARNING})).toBe(true);
         expect(buildsummary.isStepDisplayed({results:results.FAILURE})).toBe(true);
-        return buildsummary.toggleDetails();
+        buildsummary.toggleDetails();
     });
 
     it('should provide correct getBuildRequestIDFromURL', function() {

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
@@ -98,7 +98,7 @@ describe('buildsummary controller', function() {
         .toBe(false);
     });
 
-    return it('should provide correct isBuildURL', function() {
+    it('should provide correct isBuildURL', function() {
         const element = $compile("<buildsummary buildid='buildid'></buildsummary>")(scope);
         scope.$apply();
         const { buildsummary } = element.isolateScope();

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
@@ -54,7 +54,7 @@ describe('buildsummary controller', function() {
         buildsummary.toggleDetails();
         expect(buildsummary.isStepDisplayed({results:results.SUCCESS})).toBe(false);
         expect(buildsummary.isStepDisplayed({results:results.WARNING})).toBe(false);
-        return expect(buildsummary.isStepDisplayed({results:results.FAILURE})).toBe(false);
+        expect(buildsummary.isStepDisplayed({results:results.FAILURE})).toBe(false);
     });
 
     it('should provide correct isStepDisplayed when not condensed', function() {
@@ -80,7 +80,7 @@ describe('buildsummary controller', function() {
         const element = $compile("<buildsummary buildid='buildid'></buildsummary>")(scope);
         scope.$apply();
         const { buildsummary } = element.isolateScope();
-        return expect(buildsummary.getBuildRequestIDFromURL(`${baseurl}#buildrequests/123`))
+        expect(buildsummary.getBuildRequestIDFromURL(`${baseurl}#buildrequests/123`))
         .toBe(123);
     });
 
@@ -94,7 +94,7 @@ describe('buildsummary controller', function() {
         .toBe(false);
         expect(buildsummary.isBuildRequestURL(`${baseurl}#builds/123`))
         .toBe(false);
-        return expect(buildsummary.isBuildRequestURL(`${baseurl}#buildrequests/bla`))
+        expect(buildsummary.isBuildRequestURL(`${baseurl}#buildrequests/bla`))
         .toBe(false);
     });
 
@@ -104,7 +104,7 @@ describe('buildsummary controller', function() {
         const { buildsummary } = element.isolateScope();
         expect(buildsummary.isBuildURL(`${baseurl}#builders/123/builds/123`))
         .toBe(true);
-        return expect(buildsummary.isBuildURL(`${baseurl}#builders/sdf/builds/123`))
+        expect(buildsummary.isBuildURL(`${baseurl}#builders/sdf/builds/123`))
         .toBe(false);
     });
 });

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
@@ -30,7 +30,7 @@ describe('buildsummary controller', function() {
         dataService.when('builds/1', [{buildid: 1, builderid: 1}]);
         dataService.when('builders/1', [{builderid: 1}]);
         dataService.when('builds/1/steps', [{builderid: 1, stepid: 1, number: 1}]);
-        return dataService.when('steps/1/logs', [{stepid: 1, logid: 1}, {stepid: 1, logid: 2}]);
+        dataService.when('steps/1/logs', [{stepid: 1, logid: 1}, {stepid: 1, logid: 2}]);
     };
 
     beforeEach(inject(injected));

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 beforeEach(angular.mock.module('app'));
 
 describe('buildsummary controller', function() {

--- a/www/base/src/app/common/directives/changelist/changelist.directive.js
+++ b/www/base/src/app/common/directives/changelist/changelist.directive.js
@@ -1,7 +1,6 @@
 /*
  * decaffeinate suggestions:
  * DS101: Remove unnecessary use of Array.from
- * DS102: Remove unnecessary code created because of implicit returns
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
 class Changelist {

--- a/www/base/src/app/common/directives/loginbar/loginbar.directive.js
+++ b/www/base/src/app/common/directives/loginbar/loginbar.directive.js
@@ -1,6 +1,5 @@
 /*
  * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */

--- a/www/base/src/app/common/services/ansicodes/ansicodes.service.spec.js
+++ b/www/base/src/app/common/services/ansicodes/ansicodes.service.spec.js
@@ -14,7 +14,7 @@ describe('ansicode service', function() {
 
     const runTest = function(string, ...expected) {
         const ret = ansicodesService.parseAnsiSgr(string);
-        return expect(ret).toEqual(expected);
+        expect(ret).toEqual(expected);
     };
 
     it("test_ansi0m", () => runTest("mfoo", "foo", []));
@@ -34,14 +34,14 @@ describe('ansicode service', function() {
 
     it('should provide correct split_ansi_line', function() {
         const ret = ansicodesService.splitAnsiLine("\x1b[36mDEBUG [plugin]: \x1b[39mLoading plugin karma-jasmine.");
-        return expect(ret).toEqual([
+        expect(ret).toEqual([
             {class: 'ansi36', text: 'DEBUG [plugin]: '},
             {class: '', text: 'Loading plugin karma-jasmine.'}]);
 });
 
     it('should provide correct split_ansi_line for nested codes', function() {
         const ret = ansicodesService.splitAnsiLine("\x1b[1m\x1b[36mDEBUG [plugin]: \x1b[39mLoading plugin karma-jasmine.");
-        return expect(ret).toEqual([
+        expect(ret).toEqual([
             {class: 'ansi1 ansi36', text: 'DEBUG [plugin]: '},
             {class: '', text: 'Loading plugin karma-jasmine.'}]);
 });
@@ -49,7 +49,7 @@ describe('ansicode service', function() {
     it('should provide correct split_ansi_line for reset codes', function() {
         // code sequence from protractor
         const ret = ansicodesService.splitAnsiLine("\x1b[32m.\x1b[0m\x1b[31mF\x1b[0m\x1b[32m.\x1b[39m\x1b[32m.\x1b[0m");
-        return expect(ret).toEqual([
+        expect(ret).toEqual([
             {class: "ansi32", text: "."},
             {class: "ansi31", text: "F"},
             {class: "ansi32", text: "."},
@@ -59,7 +59,7 @@ describe('ansicode service', function() {
 
     it('should provide correct split_ansi_line for 256 colors', function() {
         const ret = ansicodesService.splitAnsiLine("\x1b[48;5;71mDEBUG \x1b[38;5;72m[plugin]: \x1b[39mLoading plugin karma-jasmine.");
-        return expect(ret).toEqual([
+        expect(ret).toEqual([
             {class: 'ansibg-71', text: 'DEBUG '},
             {class: 'ansifg-72', text: '[plugin]: '},
             {class: '', text: 'Loading plugin karma-jasmine.'}]);
@@ -67,7 +67,7 @@ describe('ansicode service', function() {
 
     it('should provide correct split_ansi_line for joint codes', function() {
         const ret = ansicodesService.splitAnsiLine("\x1b[1;36mDEBUG [plugin]: \x1b[39mLoading plugin karma-jasmine.");
-        return expect(ret).toEqual([
+        expect(ret).toEqual([
             {class: 'ansi1 ansi36', text: 'DEBUG [plugin]: '},
             {class: '', text: 'Loading plugin karma-jasmine.'}]);
 });
@@ -75,20 +75,20 @@ describe('ansicode service', function() {
     it('should provide correct split_ansi_line for unsupported modes', function() {
         const val = "\x1b[1A\x1b[2KPhantomJS 1.9.8 (Linux 0.0.0)";
         const ret = ansicodesService.splitAnsiLine(val);
-        return expect(ret).toEqual([
+        expect(ret).toEqual([
             { class: '', text: 'PhantomJS 1.9.8 (Linux 0.0.0)'}]);
 });
 
     it('should provide correct ansi2html', function() {
         const ret = ansicodesService.ansi2html("\x1b[36mDEBUG [plugin]: \x1b[39mLoading plugin karma-jasmine.");
-        return expect(ret).toEqual("<span class='ansi36'>DEBUG [plugin]: </span><span class=''>Loading plugin karma-jasmine.</span>");
+        expect(ret).toEqual("<span class='ansi36'>DEBUG [plugin]: </span><span class=''>Loading plugin karma-jasmine.</span>");
     });
 
     it('should provide correct color cube generator', function() {
         const ret = ansicodesService.generateStyle();
         expect(ret).toContain('pre.log .ansibg-232 { background-color: #090909; }');
         expect(ret).toContain('pre.log .ansibg-241 { background-color: #626262; }');
-        return expect(ret).toContain('pre.log .ansifg-209 { color: #f96; }');
+        expect(ret).toContain('pre.log .ansifg-209 { color: #f96; }');
     });
 
 
@@ -99,6 +99,6 @@ describe('ansicode service', function() {
         ansicodesService.injectStyle();
         const after2 = document.getElementsByTagName("style").length;
         expect(after1).toEqual(before + 1);
-        return expect(after2).toEqual(before + 1);
+        expect(after2).toEqual(before + 1);
     });
 });

--- a/www/base/src/app/common/services/ansicodes/ansicodes.service.spec.js
+++ b/www/base/src/app/common/services/ansicodes/ansicodes.service.spec.js
@@ -92,7 +92,7 @@ describe('ansicode service', function() {
     });
 
 
-    return it('should inject generated style only once', function() {
+    it('should inject generated style only once', function() {
         const before = document.getElementsByTagName("style").length;
         ansicodesService.injectStyle();
         const after1 = document.getElementsByTagName("style").length;

--- a/www/base/src/app/common/services/ansicodes/ansicodes.service.spec.js
+++ b/www/base/src/app/common/services/ansicodes/ansicodes.service.spec.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 beforeEach(angular.mock.module('app'));
 
 describe('ansicode service', function() {

--- a/www/base/src/app/common/services/results/results.service.spec.js
+++ b/www/base/src/app/common/services/results/results.service.spec.js
@@ -37,7 +37,7 @@ describe('results service', function() {
         )).toBe("results_PENDING pulse");
     });
 
-    return it('should provide correct results2Text', function() {
+    it('should provide correct results2Text', function() {
         const { results } = resultsService;
         const results2text = r => resultsService.results2text({results: r});
 

--- a/www/base/src/app/common/services/results/results.service.spec.js
+++ b/www/base/src/app/common/services/results/results.service.spec.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 beforeEach(angular.mock.module('app'));
 
 describe('results service', function() {

--- a/www/base/src/app/common/services/results/results.service.spec.js
+++ b/www/base/src/app/common/services/results/results.service.spec.js
@@ -28,7 +28,7 @@ describe('results service', function() {
             started_at:undefined
         })).toBe("results_UNKNOWN");
 
-        return expect(resultsService.results2class({
+        expect(resultsService.results2class({
             results:undefined,
             complete:false,
             started_at:10
@@ -53,7 +53,7 @@ describe('results service', function() {
             started_at:undefined
         })).toBe("...");
 
-        return expect(resultsService.results2text({
+        expect(resultsService.results2text({
             results:undefined,
             complete:false,
             started_at:10

--- a/www/base/src/app/common/services/settings/settings.service.spec.js
+++ b/www/base/src/app/common/services/settings/settings.service.spec.js
@@ -355,7 +355,7 @@ describe('settingsService', function() {
     })
     );
 
-    return it('should be overriden by master.cfg', inject(function(bbSettingsService) {
+    it('should be overriden by master.cfg', inject(function(bbSettingsService) {
         let to_override = bbSettingsService.getSetting('User.config_overriden');
         expect(to_override.value).toEqual(100);
         to_override.value = 200;

--- a/www/base/src/app/common/services/settings/settings.service.spec.js
+++ b/www/base/src/app/common/services/settings/settings.service.spec.js
@@ -97,7 +97,7 @@ describe('settingsService', function() {
             ]
         };
         const group_result = bbSettingsServiceProviderRef._mergeNewGroup(old_group, new_group);
-        return expect(group_result).toEqual({
+        expect(group_result).toEqual({
             name:'Auth',
             caption: 'Auth related settings',
             items:[{
@@ -133,7 +133,7 @@ describe('settingsService', function() {
             items:[]
         };
         const group_result = bbSettingsServiceProviderRef._mergeNewGroup(old_group, new_group);
-        return expect(group_result).toEqual({
+        expect(group_result).toEqual({
             name:'Auth',
             caption: 'Auth related settings',
             items:[]});}));
@@ -161,7 +161,7 @@ describe('settingsService', function() {
             ]
         };
         const group_result = bbSettingsServiceProviderRef._mergeNewGroup(old_group, new_group);
-        return expect(group_result).toEqual({
+        expect(group_result).toEqual({
             name:'System',
             caption: 'System related settings',
             items:[{
@@ -196,7 +196,7 @@ describe('settingsService', function() {
             ]
         };
         const group_result = bbSettingsServiceProviderRef._mergeNewGroup(old_group, undefined);
-        return expect(group_result).toBeUndefined();
+        expect(group_result).toBeUndefined();
     })
     );
 
@@ -218,7 +218,7 @@ describe('settingsService', function() {
             ]
         };
         const group_result = bbSettingsServiceProviderRef._mergeNewGroup(undefined, new_group);
-        return expect(group_result).toEqual({
+        expect(group_result).toEqual({
             name:'Auth',
             caption: 'Auth related settings',
             items:[{
@@ -255,7 +255,7 @@ describe('settingsService', function() {
             let group_result;
             return group_result = bbSettingsServiceProviderRef.addSettingsGroup(group);
         };
-        return expect(exceptionRun).toThrow();
+        expect(exceptionRun).toThrow();
     })
     );
 
@@ -282,7 +282,7 @@ describe('settingsService', function() {
             ]
         };
         const group_result = bbSettingsServiceProviderRef._mergeNewGroup(old_group, new_group);
-        return expect(group_result).toEqual({
+        expect(group_result).toEqual({
             name:'System',
             caption: 'System related settings',
             items:[{
@@ -301,7 +301,7 @@ describe('settingsService', function() {
 
     it('should generate correct settings', inject(function(bbSettingsService) {
         const groups = bbSettingsService.getSettingsGroups();
-        return expect(groups['Release']).toEqual({
+        expect(groups['Release']).toEqual({
             name:'Release',
             caption: 'Release related settings',
             items:[{
@@ -340,7 +340,7 @@ describe('settingsService', function() {
         const userSetting3 = bbSettingsService.getSetting('UserAA.User_checkbox1');
         expect(userSetting1).toBeDefined();
         expect(userSetting2).toBeUndefined();
-        return expect(userSetting3).toBeUndefined();
+        expect(userSetting3).toBeUndefined();
     })
     );
 
@@ -351,7 +351,7 @@ describe('settingsService', function() {
         bbSettingsService.save();
         const storageGroups = angular.fromJson(localStorage.getItem('settings'));
         const storageCheckbox = storageGroups['User'].items[0].value;
-        return expect(storageCheckbox).toBeTruthy();
+        expect(storageCheckbox).toBeTruthy();
     })
     );
 
@@ -362,7 +362,7 @@ describe('settingsService', function() {
         bbSettingsService.save();
         const storageGroups = angular.fromJson(localStorage.getItem('settings'));
         to_override = storageGroups['User'].items[1].value;
-        return expect(to_override).toEqual(200);
+        expect(to_override).toEqual(200);
     })
     );
 });

--- a/www/base/src/app/common/services/settings/settings.service.spec.js
+++ b/www/base/src/app/common/services/settings/settings.service.spec.js
@@ -64,7 +64,6 @@ describe('settingsService', function() {
                 ]
             }
             ]});
-        return null;
     })
     );
 

--- a/www/codeparameter/guanlecoja/config.js
+++ b/www/codeparameter/guanlecoja/config.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 /* *///###########################################################################################
 //
 //   This module contains all configuration for the build process

--- a/www/codeparameter/test/main.js
+++ b/www/codeparameter/test/main.js
@@ -30,6 +30,6 @@ describe('minimalistic test', function() {
         expect(elmBody).toBeDefined();
         // if we can find a div with class ace_layer, then ace has loaded
         const elm = elmBody.find('.ace_layer');
-        return expect(elm.length).toBeGreaterThan(0);
+        expect(elm.length).toBeGreaterThan(0);
     });
 });

--- a/www/codeparameter/test/main.js
+++ b/www/codeparameter/test/main.js
@@ -26,7 +26,7 @@ describe('minimalistic test', function() {
 
     beforeEach((inject(injected)));
 
-    return it('should load ace ui ', function() {
+    it('should load ace ui ', function() {
         expect(elmBody).toBeDefined();
         // if we can find a div with class ace_layer, then ace has loaded
         const elm = elmBody.find('.ace_layer');

--- a/www/console_view/src/module/main.module.js
+++ b/www/console_view/src/module/main.module.js
@@ -139,28 +139,19 @@ class Console {
         }
 
         this.filtered_changes = [];
-        return (() => {
-            const result = [];
-            for (let ssid in this.changesBySSID) {
-                change = this.changesBySSID[ssid];
-                if (change.comments) {
-                    change.subject = change.comments.split("\n")[0];
-                }
-                result.push((() => {
-                    const result1 = [];
-                    for (let builder of Array.from(change.builders)) {
-                        if (builder.builds.length > 0) {
-                            this.filtered_changes.push(change);
-                            break;
-                        } else {
-                            result1.push(undefined);
-                        }
-                    }
-                    return result1;
-                })());
+
+        for (let ssid in this.changesBySSID) {
+            change = this.changesBySSID[ssid];
+            if (change.comments) {
+                change.subject = change.comments.split("\n")[0];
             }
-            return result;
-        })();
+            for (let builder of Array.from(change.builders)) {
+                if (builder.builds.length > 0) {
+                    this.filtered_changes.push(change);
+                    break;
+                }
+            }
+        }
     }
     /*
      * Sort builders by tags
@@ -325,15 +316,11 @@ class Console {
     populateChange(change) {
         change.builders = [];
         change.buildersById = {};
-        return (() => {
-            const result = [];
-            for (let builder of Array.from(this.builders)) {
-                builder = {builderid: builder.builderid, name: builder.name, builds: []};
-                change.builders.push(builder);
-                result.push(change.buildersById[builder.builderid] = builder);
-            }
-            return result;
-        })();
+        for (let builder of Array.from(this.builders)) {
+            builder = {builderid: builder.builderid, name: builder.name, builds: []};
+            change.builders.push(builder);
+            change.buildersById[builder.builderid] = builder;
+        }
     }
     /*
      * Match builds with a change

--- a/www/console_view/src/module/main.module.spec.js
+++ b/www/console_view/src/module/main.module.spec.js
@@ -168,7 +168,7 @@ describe('Console view controller', function() {
 
         // Create new controller using controller as syntax
         const $controller = $injector.get('$controller');
-        return createController = () =>
+        createController = () =>
             $controller('consoleController as c', {
                 // Inject controller dependencies
                 $q,

--- a/www/console_view/src/module/main.module.spec.js
+++ b/www/console_view/src/module/main.module.spec.js
@@ -8,11 +8,9 @@
 beforeEach(function() {
     module(function($provide) {
         $provide.service('$uibModal', function() { return {open() {}}; });
-        return null;
     });
     module(function($provide) {
         $provide.service('resultsService', function() { return {results2class() {}}; });
-        return null;
     });
 
     // Mock bbSettingsProvider
@@ -42,7 +40,6 @@ beforeEach(function() {
             return Cls;
         })()
         );
-        return null;
     });
     return module('console_view');
 });

--- a/www/console_view/src/module/main.module.spec.js
+++ b/www/console_view/src/module/main.module.spec.js
@@ -52,7 +52,7 @@ describe('Console view', function() {
     beforeEach(inject($injector => $state = $injector.get('$state'))
     );
 
-    return it('should register a new state with the correct configuration', function() {
+    it('should register a new state with the correct configuration', function() {
         const name = 'console';
         const state = $state.get().pop();
         const { data } = state;

--- a/www/console_view/src/module/main.module.spec.js
+++ b/www/console_view/src/module/main.module.spec.js
@@ -59,7 +59,7 @@ describe('Console view', function() {
         expect(state.controller).toBe(`${name}Controller`);
         expect(state.controllerAs).toBe('c');
         expect(state.templateUrl).toBe(`console_view/views/${name}.html`);
-        return expect(state.url).toBe(`/${name}`);
+        expect(state.url).toBe(`/${name}`);
     });
 });
 
@@ -186,7 +186,7 @@ describe('Console view controller', function() {
 
     it('should be defined', function() {
         createController();
-        return expect(scope.c).toBeDefined();
+        expect(scope.c).toBeDefined();
     });
 
     it('should bind the builds, builders, changes, buildrequests and buildsets to scope', function() {
@@ -202,7 +202,7 @@ describe('Console view controller', function() {
         expect(scope.c.buildrequests).toBeDefined();
         expect(scope.c.buildrequests.length).toBe(buildrequests.length);
         expect(scope.c.buildsets).toBeDefined();
-        return expect(scope.c.buildsets.length).toBe(buildsets.length);
+        expect(scope.c.buildsets.length).toBe(buildsets.length);
     });
 
     it('should match the builds with the change', function() {
@@ -216,7 +216,7 @@ describe('Console view controller', function() {
         expect(builders[0].builds[0].buildid).toBe(1);
         expect(builders[1].builds[0].buildid).toBe(2);
         expect(builders[2].builds[0].buildid).toBe(4);
-        return expect(builders[3].builds[0].buildid).toBe(3);
+        expect(builders[3].builds[0].buildid).toBe(3);
     });
 
     return xit('should match sort the builders by tag groups', function() {
@@ -227,6 +227,6 @@ describe('Console view controller', function() {
         }
         scope.c.sortBuildersByTags(_builders);
         expect(_builders.length).toBe(scope.c.builders.length);
-        return expect(scope.c.tag_lines.length).toEqual(5);
+        expect(scope.c.tag_lines.length).toEqual(5);
     });
 });

--- a/www/console_view/src/module/main.module.spec.js
+++ b/www/console_view/src/module/main.module.spec.js
@@ -216,7 +216,7 @@ describe('Console view controller', function() {
         expect(builders[3].builds[0].buildid).toBe(3);
     });
 
-    return xit('should match sort the builders by tag groups', function() {
+    xit('should match sort the builders by tag groups', function() {
         createController();
         const _builders = FIXTURES['builders.fixture.json'].builders;
         for (let builder of Array.from(_builders)) {

--- a/www/data_module/src/classes/base.service.spec.js
+++ b/www/data_module/src/classes/base.service.spec.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 describe('Base class', function() {
     let $q, dataService, socketService;
     beforeEach(angular.mock.module('bbData'));

--- a/www/data_module/src/classes/base.service.spec.js
+++ b/www/data_module/src/classes/base.service.spec.js
@@ -26,7 +26,7 @@ describe('Base class', function() {
         expect(base.b).toEqual(object.b);
     });
 
-    return it('should have loadXxx function for child endpoints', function() {
+    it('should have loadXxx function for child endpoints', function() {
         const children = ['a', 'bcd', 'ccc'];
         const base = new Base({}, 'ab', children);
         expect(angular.isFunction(base.loadA)).toBeTruthy();

--- a/www/data_module/src/classes/base.service.spec.js
+++ b/www/data_module/src/classes/base.service.spec.js
@@ -23,7 +23,7 @@ describe('Base class', function() {
         const object = {a: 1, b: 2};
         const base = new Base(object, 'ab');
         expect(base.a).toEqual(object.a);
-        return expect(base.b).toEqual(object.b);
+        expect(base.b).toEqual(object.b);
     });
 
     return it('should have loadXxx function for child endpoints', function() {
@@ -31,6 +31,6 @@ describe('Base class', function() {
         const base = new Base({}, 'ab', children);
         expect(angular.isFunction(base.loadA)).toBeTruthy();
         expect(angular.isFunction(base.loadBcd)).toBeTruthy();
-        return expect(angular.isFunction(base.loadCcc)).toBeTruthy();
+        expect(angular.isFunction(base.loadCcc)).toBeTruthy();
     });
 });

--- a/www/data_module/src/classes/base.service.spec.js
+++ b/www/data_module/src/classes/base.service.spec.js
@@ -12,7 +12,7 @@ describe('Base class', function() {
         Base = $injector.get('Base');
         dataService = $injector.get('dataService');
         socketService = $injector.get('socketService');
-        return $q = $injector.get('$q');
+        $q = $injector.get('$q');
     };
 
     beforeEach(inject(injected));

--- a/www/data_module/src/classes/changes.spec.js
+++ b/www/data_module/src/classes/changes.spec.js
@@ -6,7 +6,7 @@
 describe('change class', function() {
     beforeEach(angular.mock.module('bbData'));
 
-    return it('should calculate authors emails', inject(function(Change) {
+    it('should calculate authors emails', inject(function(Change) {
         const changes = [
             new Change({author: "foo <bar@foo.com>"}, "changes")
         ,

--- a/www/data_module/src/classes/changes.spec.js
+++ b/www/data_module/src/classes/changes.spec.js
@@ -19,7 +19,7 @@ describe('change class', function() {
         expect(changes[2].author_email).toBeUndefined();
         expect(changes[0].author_name).toBe("foo");
         expect(changes[1].author_name).toBe("foo");
-        return expect(changes[2].author_name).toBe("foo");
+        expect(changes[2].author_name).toBe("foo");
     })
     );
 });

--- a/www/data_module/src/classes/changes.spec.js
+++ b/www/data_module/src/classes/changes.spec.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 describe('change class', function() {
     beforeEach(angular.mock.module('bbData'));
 

--- a/www/data_module/src/services/data/collection/collection.service.js
+++ b/www/data_module/src/services/data/collection/collection.service.js
@@ -148,13 +148,9 @@ class Collection {
             }
 
             clear() {
-                return (() => {
-                    const result = [];
-                    while (this.length > 0) {
-                        result.push(this.pop());
-                    }
-                    return result;
-                })();
+                while (this.length > 0) {
+                    this.pop();
+                }
             }
 
             delete(element) {

--- a/www/data_module/src/services/data/collection/collection.service.spec.js
+++ b/www/data_module/src/services/data/collection/collection.service.spec.js
@@ -63,7 +63,7 @@ describe('Collection', function() {
             expect(c.length).toEqual(2);
         });
 
-        return it("should order the updates correctly", function() {
+        it("should order the updates correctly", function() {
             c.listener({k: "builds/1/update", m: {buildid: 1, value:1}});
             c.initial([{
                 buildid: 1,
@@ -100,7 +100,7 @@ describe('Collection', function() {
             expect(c[1].buildid).toEqual(4);
         });
 
-        return it('should call the event handlers', function() {
+        it('should call the event handlers', function() {
             spyOn(c, 'onNew');
             spyOn(c, 'onChange');
             spyOn(c, 'onUpdate');
@@ -136,7 +136,7 @@ describe('Collection', function() {
     describe("singleid collection", function() {
         beforeEach(function() { c = new Collection('builds/1'); } );
 
-        return it("should manage the updates correctly", function() {
+        it("should manage the updates correctly", function() {
             c.listener({k: "builds/1/update", m: {buildid: 1, value:1}});
             c.listener({k: "builds/2/update", m: {buildid: 2, value:2}});
             c.initial([{

--- a/www/data_module/src/services/data/collection/collection.service.spec.js
+++ b/www/data_module/src/services/data/collection/collection.service.spec.js
@@ -13,7 +13,7 @@ describe('Collection', function() {
         $rootScope = $injector.get('$rootScope');
         Collection = $injector.get('Collection');
         $timeout = $injector.get('$timeout');
-        return $filter = $injector.get('$filter');
+        $filter = $injector.get('$filter');
     };
 
     beforeEach(inject(injected));

--- a/www/data_module/src/services/data/collection/collection.service.spec.js
+++ b/www/data_module/src/services/data/collection/collection.service.spec.js
@@ -23,7 +23,7 @@ describe('Collection', function() {
 
         it('should be defined', function() {
             expect(Collection).toBeDefined();
-            return expect(c).toBeDefined();
+            expect(c).toBeDefined();
         });
 
         it('should be like an array', () => expect(angular.isArray(c)).toBeTruthy());
@@ -35,12 +35,12 @@ describe('Collection', function() {
                 {buildid: 2}
             ]);
             const filtered = $filter('filter')(c, {buildid:1});
-            return expect(filtered.length).toBe(1);
+            expect(filtered.length).toBe(1);
         });
 
         it('empty collection should be filterable with angular.filter', function() {
             const filtered = $filter('filter')(c, {buildid:1});
-            return expect(filtered.length).toBe(0);
+            expect(filtered.length).toBe(0);
         });
 
         it('should have a put function, which does not add twice for the same id', function() {
@@ -49,7 +49,7 @@ describe('Collection', function() {
             c.put({buildid: 1});
             expect(c.length).toEqual(1);
             c.put({buildid: 2});
-            return expect(c.length).toEqual(2);
+            expect(c.length).toEqual(2);
         });
 
         it('should have a from function, which iteratively inserts data', function() {
@@ -60,7 +60,7 @@ describe('Collection', function() {
             ,
                 {buildid: 2}
             ]);
-            return expect(c.length).toEqual(2);
+            expect(c.length).toEqual(2);
         });
 
         return it("should order the updates correctly", function() {
@@ -72,7 +72,7 @@ describe('Collection', function() {
             ]);
             expect(c[0].value).toEqual(1);
             c.listener({k: "builds/1/update", m: {buildid: 1, value:2}});
-            return expect(c[0].value).toEqual(2);
+            expect(c[0].value).toEqual(2);
         });
     });
 
@@ -97,7 +97,7 @@ describe('Collection', function() {
             ]);
             expect(c.length).toEqual(2);
             expect(c[0].buildid).toEqual(5);
-            return expect(c[1].buildid).toEqual(4);
+            expect(c[1].buildid).toEqual(4);
         });
 
         return it('should call the event handlers', function() {
@@ -128,7 +128,7 @@ describe('Collection', function() {
             $timeout.flush();
             expect(c.onNew.calls.count()).toEqual(2);
             expect(c.onUpdate.calls.count()).toEqual(0);
-            return expect(c.onChange.calls.count()).toEqual(1);
+            expect(c.onChange.calls.count()).toEqual(1);
         });
     });
 
@@ -147,7 +147,7 @@ describe('Collection', function() {
             expect(c.length).toEqual(1);
             expect(c[0].value).toEqual(1);
             c.listener({k: "builds/1/update", m: {buildid: 1, value:2}});
-            return expect(c[0].value).toEqual(2);
+            expect(c[0].value).toEqual(2);
         });
     });
 });

--- a/www/data_module/src/services/data/collection/collection.service.spec.js
+++ b/www/data_module/src/services/data/collection/collection.service.spec.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 describe('Collection', function() {
     let $filter, $q, $rootScope, $timeout, c, indexedDBService, tabexService;
     beforeEach(angular.mock.module('bbData'));

--- a/www/data_module/src/services/data/collection/dataquery.service.js
+++ b/www/data_module/src/services/data/collection/dataquery.service.js
@@ -115,13 +115,9 @@ class DataQuery {
             }
 
             limit(array, limit) {
-                return (() => {
-                    const result = [];
-                    while (array.length > limit) {
-                        result.push(array.pop());
-                    }
-                    return result;
-                })();
+                while (array.length > limit) {
+                    array.pop();
+                }
             }
         });
     }

--- a/www/data_module/src/services/data/collection/dataquery.service.spec.js
+++ b/www/data_module/src/services/data/collection/dataquery.service.spec.js
@@ -68,64 +68,64 @@ describe('dataquery service', function() {
         it('should filter the array (one filter)', function() {
             const result = wrappedDataQuery.filter(testArray, {complete: false});
             expect(result.length).toBe(1);
-            return expect(result).toContain(testArray[0]);
+            expect(result).toContain(testArray[0]);
         });
 
         it('should filter the array (more than one filters)', function() {
             const result = wrappedDataQuery.filter(testArray, {complete: true, buildrequestid: 1});
             expect(result.length).toBe(2);
             expect(result).toContain(testArray[1]);
-            return expect(result).toContain(testArray[2]);
+            expect(result).toContain(testArray[2]);
         });
 
         it('should filter the array (eq - equal)', function() {
             const result = wrappedDataQuery.filter(testArray, {'complete__eq': true});
             expect(result.length).toBe(2);
             expect(result).toContain(testArray[1]);
-            return expect(result).toContain(testArray[2]);
+            expect(result).toContain(testArray[2]);
         });
 
         it('should filter the array (two eq)', function() {
             const result = wrappedDataQuery.filter(testArray, {'buildid__eq': [1, 2]});
             expect(result.length).toBe(2);
             expect(result).toContain(testArray[1]);
-            return expect(result).toContain(testArray[2]);
+            expect(result).toContain(testArray[2]);
         });
 
         it('should treat empty eq criteria as no restriction', function() {
             const result = wrappedDataQuery.filter(testArray, {'buildid__eq': []});
-            return expect(result.length).toBe(3);
+            expect(result.length).toBe(3);
         });
 
         it('should filter the array (ne - not equal)', function() {
             const result = wrappedDataQuery.filter(testArray, {'complete__ne': true});
             expect(result.length).toBe(1);
-            return expect(result).toContain(testArray[0]);
+            expect(result).toContain(testArray[0]);
         });
 
         it('should filter the array (lt - less than)', function() {
             const result = wrappedDataQuery.filter(testArray, {'buildid__lt': 3});
             expect(result.length).toBe(2);
             expect(result).toContain(testArray[1]);
-            return expect(result).toContain(testArray[2]);
+            expect(result).toContain(testArray[2]);
         });
 
         it('should filter the array (le - less than or equal to)', function() {
             const result = wrappedDataQuery.filter(testArray, {'buildid__le': 3});
-            return expect(result.length).toBe(3);
+            expect(result.length).toBe(3);
         });
 
         it('should filter the array (gt - greater than)', function() {
             const result = wrappedDataQuery.filter(testArray, {'started_at__gt': 1417803025});
             expect(result.length).toBe(1);
-            return expect(result).toContain(testArray[1]);
+            expect(result).toContain(testArray[1]);
         });
 
         it('should filter the array (ge - greater than or equal to)', function() {
             const result = wrappedDataQuery.filter(testArray, {'started_at__ge': 1417803025});
             expect(result.length).toBe(2);
             expect(result).toContain(testArray[1]);
-            return expect(result).toContain(testArray[2]);
+            expect(result).toContain(testArray[2]);
         });
 
         return it('should convert on/off, true/false, yes/no to boolean', function() {
@@ -144,7 +144,7 @@ describe('dataquery service', function() {
             result = wrappedDataQuery.filter(testArray, {complete: 'false'});
             expect(result).toEqual(resultFalse);
             result = wrappedDataQuery.filter(testArray, {complete: 'no'});
-            return expect(result).toEqual(resultFalse);
+            expect(result).toEqual(resultFalse);
         });
     });
 
@@ -154,21 +154,21 @@ describe('dataquery service', function() {
             const result = wrappedDataQuery.sort(testArray, 'buildid');
             expect(result[0]).toEqual(testArray[1]);
             expect(result[1]).toEqual(testArray[2]);
-            return expect(result[2]).toEqual(testArray[0]);
+            expect(result[2]).toEqual(testArray[0]);
         });
 
         it('should sort the array (one parameter, - reverse)', function() {
             const result = wrappedDataQuery.sort(testArray, '-buildid');
             expect(result[0]).toEqual(testArray[0]);
             expect(result[1]).toEqual(testArray[2]);
-            return expect(result[2]).toEqual(testArray[1]);
+            expect(result[2]).toEqual(testArray[1]);
         });
 
         return it('should sort the array (more parameter)', function() {
             const result = wrappedDataQuery.sort(testArray, ['builderid', '-buildid']);
             expect(result[0]).toEqual(testArray[0]);
             expect(result[1]).toEqual(testArray[2]);
-            return expect(result[2]).toEqual(testArray[1]);
+            expect(result[2]).toEqual(testArray[1]);
         });
     });
 
@@ -177,13 +177,13 @@ describe('dataquery service', function() {
         it('should slice the array', function() {
             const result = wrappedDataQuery.limit(testArray, 1);
             expect(result.length).toBe(1);
-            return expect(result[0]).toEqual(testArray[0]);
+            expect(result[0]).toEqual(testArray[0]);
         });
 
         return it('should return the array when the limit >= array.length', function() {
             const result = wrappedDataQuery.limit(testArray, 3);
             expect(result.length).toBe(3);
-            return expect(result[2]).toEqual(testArray[2]);
+            expect(result[2]).toEqual(testArray[2]);
         });
     });
 });

--- a/www/data_module/src/services/data/collection/dataquery.service.spec.js
+++ b/www/data_module/src/services/data/collection/dataquery.service.spec.js
@@ -172,7 +172,7 @@ describe('dataquery service', function() {
         });
     });
 
-    return describe('limit(array, limit)', function() {
+    describe('limit(array, limit)', function() {
 
         it('should slice the array', function() {
             const result = wrappedDataQuery.limit(testArray, 1);

--- a/www/data_module/src/services/data/collection/dataquery.service.spec.js
+++ b/www/data_module/src/services/data/collection/dataquery.service.spec.js
@@ -57,7 +57,7 @@ describe('dataquery service', function() {
                 return array;
             }
         }
-        return wrappedDataQuery = new WrappedDataQuery();
+        wrappedDataQuery = new WrappedDataQuery();
     };
     beforeEach(inject(injected));
 

--- a/www/data_module/src/services/data/collection/dataquery.service.spec.js
+++ b/www/data_module/src/services/data/collection/dataquery.service.spec.js
@@ -128,7 +128,7 @@ describe('dataquery service', function() {
             expect(result).toContain(testArray[2]);
         });
 
-        return it('should convert on/off, true/false, yes/no to boolean', function() {
+        it('should convert on/off, true/false, yes/no to boolean', function() {
             const resultTrue = wrappedDataQuery.filter(testArray, {complete: true});
             const resultFalse = wrappedDataQuery.filter(testArray, {complete: false});
 
@@ -164,7 +164,7 @@ describe('dataquery service', function() {
             expect(result[2]).toEqual(testArray[1]);
         });
 
-        return it('should sort the array (more parameter)', function() {
+        it('should sort the array (more parameter)', function() {
             const result = wrappedDataQuery.sort(testArray, ['builderid', '-buildid']);
             expect(result[0]).toEqual(testArray[0]);
             expect(result[1]).toEqual(testArray[2]);
@@ -180,7 +180,7 @@ describe('dataquery service', function() {
             expect(result[0]).toEqual(testArray[0]);
         });
 
-        return it('should return the array when the limit >= array.length', function() {
+        it('should return the array when the limit >= array.length', function() {
             const result = wrappedDataQuery.limit(testArray, 3);
             expect(result.length).toBe(3);
             expect(result[2]).toEqual(testArray[2]);

--- a/www/data_module/src/services/data/data.service.spec.js
+++ b/www/data_module/src/services/data/data.service.spec.js
@@ -40,7 +40,7 @@ describe('Data service', function() {
     describe('get()', function() {
         it('should return a collection', function() {
             const ret = dataService.getBuilds();
-            return expect(ret.length).toBeDefined();
+            expect(ret.length).toBeDefined();
         });
 
         it('should call get for the rest api endpoint', function() {
@@ -49,7 +49,7 @@ describe('Data service', function() {
             expect(restService.get).not.toHaveBeenCalled();
             $rootScope.$apply(() => dataService.get('asd', {subscribe: false}));
             // the query should not contain the subscribe field
-            return expect(restService.get).toHaveBeenCalledWith('asd', {});
+            expect(restService.get).toHaveBeenCalledWith('asd', {});
         });
 
         it('should send startConsuming with the socket path', function() {
@@ -81,7 +81,7 @@ describe('Data service', function() {
                 cmd: 'stopConsuming',
                 path: 'builds/*/*'
             });
-            return expect(socketService.send).toHaveBeenCalledWith({
+            expect(socketService.send).toHaveBeenCalledWith({
                 cmd: 'stopConsuming',
                 path: 'builds/1/*'
             });
@@ -94,7 +94,7 @@ describe('Data service', function() {
             spyOn(socketService, 'send').and.returnValue(d.promise);
             expect(socketService.send).not.toHaveBeenCalled();
             $rootScope.$apply(() => dataService.getBuilds({subscribe: false}));
-            return expect(socketService.send).not.toHaveBeenCalled();
+            expect(socketService.send).not.toHaveBeenCalled();
         });
 
         return it('should add the new instance on /new WebSocket message', function() {
@@ -106,7 +106,7 @@ describe('Data service', function() {
                 m: { asd: 111
             }
             });
-            return expect(builds.pop().asd).toBe(111);
+            expect(builds.pop().asd).toBe(111);
         });
     });
 
@@ -118,7 +118,7 @@ describe('Data service', function() {
             const method = 'force';
             const params = {a: 1};
             dataService.control("a", 1, method, params);
-            return expect(restService.post).toHaveBeenCalledWith("a/1", {
+            expect(restService.post).toHaveBeenCalledWith("a/1", {
                 id: 1,
                 jsonrpc: '2.0',
                 method,
@@ -155,7 +155,7 @@ describe('Data service', function() {
             expect(builds.length).toBe(3);
             spyOn(builds, 'close');
             opened.close();
-            return expect(builds.close).toHaveBeenCalled();
+            expect(builds.close).toHaveBeenCalled();
         });
 
         it('should call close when the $scope is destroyed', function() {
@@ -164,7 +164,7 @@ describe('Data service', function() {
             opened.closeOnDestroy(scope);
             expect(opened.close).not.toHaveBeenCalled();
             scope.$destroy();
-            return expect(opened.close).toHaveBeenCalled();
+            expect(opened.close).toHaveBeenCalled();
         });
 
         return it('should work with mock calls as well', function() {

--- a/www/data_module/src/services/data/data.service.spec.js
+++ b/www/data_module/src/services/data/data.service.spec.js
@@ -174,7 +174,7 @@ describe('Data service', function() {
         });
     });
 
-    return describe('when()', () =>
+    describe('when()', () =>
         it('should autopopulate ids', function(done) {
             dataService.when('builds', [{}, {}, {}]);
             dataService.getBuilds().onChange = function(builds) {

--- a/www/data_module/src/services/data/data.service.spec.js
+++ b/www/data_module/src/services/data/data.service.spec.js
@@ -18,7 +18,7 @@ describe('Data service', function() {
         ENDPOINTS = $injector.get('ENDPOINTS');
         $rootScope = $injector.get('$rootScope');
         $q = $injector.get('$q');
-        return $httpBackend = $injector.get('$httpBackend');
+        $httpBackend = $injector.get('$httpBackend');
     };
 
     beforeEach(inject(injected));

--- a/www/data_module/src/services/data/data.service.spec.js
+++ b/www/data_module/src/services/data/data.service.spec.js
@@ -33,7 +33,7 @@ describe('Data service', function() {
                 expect(dataService[`get${E}`]).toBeDefined();
                 result.push(expect(angular.isFunction(dataService[`get${E}`])).toBeTruthy());
             }
-            return result;
+            result;
         })()
     );
 
@@ -143,7 +143,7 @@ describe('Data service', function() {
                     expect(opened[`get${E}`]).toBeDefined();
                     result.push(expect(angular.isFunction(opened[`get${E}`])).toBeTruthy());
                 }
-                return result;
+                result;
             })()
         );
 
@@ -181,9 +181,9 @@ describe('Data service', function() {
                 expect(builds.length).toBe(3);
                 expect(builds[1].buildid).toBe(2);
                 expect(builds[2].buildid).toBe(3);
-                return done();
+                done();
             };
-            return $timeout.flush();
+            $timeout.flush();
         })
     );
 });

--- a/www/data_module/src/services/data/data.service.spec.js
+++ b/www/data_module/src/services/data/data.service.spec.js
@@ -97,7 +97,7 @@ describe('Data service', function() {
             expect(socketService.send).not.toHaveBeenCalled();
         });
 
-        return it('should add the new instance on /new WebSocket message', function() {
+        it('should add the new instance on /new WebSocket message', function() {
             spyOn(restService, 'get').and.returnValue($q.resolve({builds: []}));
             let builds = null;
             $rootScope.$apply(() => builds = dataService.getBuilds({subscribe: false}));
@@ -167,7 +167,7 @@ describe('Data service', function() {
             expect(opened.close).toHaveBeenCalled();
         });
 
-        return it('should work with mock calls as well', function() {
+        it('should work with mock calls as well', function() {
             let builds;
             dataService.when('builds/1', [{buildid: 1, builderid: 1}]);
             builds = opened.getBuilds(1, {subscribe: false});

--- a/www/data_module/src/services/dataUtils/dataUtils.service.spec.js
+++ b/www/data_module/src/services/dataUtils/dataUtils.service.spec.js
@@ -158,7 +158,7 @@ describe('Data utils service', function() {
         });
     });
 
-    return describe('emailInString(string)', () =>
+    describe('emailInString(string)', () =>
 
         it('should return an email from a string', function() {
             let email = dataUtilsService.emailInString('foo <bar@foo.com>');

--- a/www/data_module/src/services/dataUtils/dataUtils.service.spec.js
+++ b/www/data_module/src/services/dataUtils/dataUtils.service.spec.js
@@ -103,7 +103,7 @@ describe('Data utils service', function() {
             expect(result).toEqual(array);
         });
 
-        return it('should split a string', function() {
+        it('should split a string', function() {
             const string = 'asd/123/bnm';
             const result = dataUtilsService.copyOrSplit(string);
             expect(result).toEqual(['asd', '123', 'bnm']);
@@ -152,7 +152,7 @@ describe('Data utils service', function() {
             expect(result).toBe(12);
         });
 
-        return it('should return the string if it is not a number', function() {
+        it('should return the string if it is not a number', function() {
             const result = dataUtilsService.numberOrString('w3as');
             expect(result).toBe('w3as');
         });

--- a/www/data_module/src/services/dataUtils/dataUtils.service.spec.js
+++ b/www/data_module/src/services/dataUtils/dataUtils.service.spec.js
@@ -20,7 +20,7 @@ describe('Data utils service', function() {
             expect(result).toBe('Test');
 
             result = dataUtilsService.capitalize('t');
-            return expect(result).toBe('T');
+            expect(result).toBe('T');
         })
     );
 
@@ -31,7 +31,7 @@ describe('Data utils service', function() {
             expect(result).toBe('asd');
 
             result = dataUtilsService.type('asd/1/bnm');
-            return expect(result).toBe('bnm');
+            expect(result).toBe('bnm');
         })
     );
 
@@ -42,7 +42,7 @@ describe('Data utils service', function() {
             expect(result).toBe('test');
 
             result = dataUtilsService.singularType('tests');
-            return expect(result).toBe('test');
+            expect(result).toBe('test');
         })
     );
 
@@ -53,7 +53,7 @@ describe('Data utils service', function() {
             expect(result).toBe('asd/1/bnm/*/*');
 
             result = dataUtilsService.socketPath('asd/1');
-            return expect(result).toBe('asd/1/*');
+            expect(result).toBe('asd/1/*');
         })
     );
 
@@ -67,7 +67,7 @@ describe('Data utils service', function() {
             expect(result).toBe('^asd\\/1\\/bnm\\/[^\\/]+\\/[^\\/]+$');
 
             result = dataUtilsService.socketPathRE('asd/1/*').source;
-            return expect(result).toBe('^asd\\/1\\/[^\\/]+$');
+            expect(result).toBe('^asd\\/1\\/[^\\/]+$');
         })
     );
 
@@ -79,7 +79,7 @@ describe('Data utils service', function() {
             expect(result).toBe('asd/1/bnm');
 
             result = dataUtilsService.restPath('asd/1/*');
-            return expect(result).toBe('asd/1');
+            expect(result).toBe('asd/1');
         })
     );
 
@@ -90,7 +90,7 @@ describe('Data utils service', function() {
             expect(result).toBe('asd/1/bnm');
 
             result = dataUtilsService.endpointPath('asd/1/*');
-            return expect(result).toBe('asd');
+            expect(result).toBe('asd');
         })
     );
 
@@ -100,13 +100,13 @@ describe('Data utils service', function() {
             const array = [1, 2, 3];
             const result = dataUtilsService.copyOrSplit(array);
             expect(result).not.toBe(array);
-            return expect(result).toEqual(array);
+            expect(result).toEqual(array);
         });
 
         return it('should split a string', function() {
             const string = 'asd/123/bnm';
             const result = dataUtilsService.copyOrSplit(string);
-            return expect(result).toEqual(['asd', '123', 'bnm']);
+            expect(result).toEqual(['asd', '123', 'bnm']);
         });
     });
 
@@ -121,7 +121,7 @@ describe('Data utils service', function() {
             expect(result).toBe(data.asd);
 
             result = dataUtilsService.unWrap(data, 'bnm/1/asd/2');
-            return expect(result).toBe(data.asd);
+            expect(result).toBe(data.asd);
         })
     );
 
@@ -141,7 +141,7 @@ describe('Data utils service', function() {
 
             const parsed = dataUtilsService.parse(test);
 
-            return expect(parsed).toEqual(test);
+            expect(parsed).toEqual(test);
         })
     );
 
@@ -149,12 +149,12 @@ describe('Data utils service', function() {
 
         it('should convert a string to a number if possible', function() {
             const result = dataUtilsService.numberOrString('12');
-            return expect(result).toBe(12);
+            expect(result).toBe(12);
         });
 
         return it('should return the string if it is not a number', function() {
             const result = dataUtilsService.numberOrString('w3as');
-            return expect(result).toBe('w3as');
+            expect(result).toBe('w3as');
         });
     });
 
@@ -164,7 +164,7 @@ describe('Data utils service', function() {
             let email = dataUtilsService.emailInString('foo <bar@foo.com>');
             expect(email).toBe('bar@foo.com');
             email = dataUtilsService.emailInString('bar@foo.com');
-            return expect(email).toBe('bar@foo.com');
+            expect(email).toBe('bar@foo.com');
         })
     );
 });

--- a/www/data_module/src/services/rest/rest.service.spec.js
+++ b/www/data_module/src/services/rest/rest.service.spec.js
@@ -34,7 +34,7 @@ describe('Rest service', function() {
         expect(gotResponse).toBeNull();
 
         $httpBackend.flush();
-        return expect(gotResponse).toEqual(response);
+        expect(gotResponse).toEqual(response);
     });
 
     it('should make an ajax GET call to /api/endpoint with parameters', function() {
@@ -54,7 +54,7 @@ describe('Rest service', function() {
         , reason => gotResponse = reason);
 
         $httpBackend.flush();
-        return expect(gotResponse).toBe(error);
+        expect(gotResponse).toBe(error);
     });
 
     it('should make an ajax POST call to /api/endpoint', function() {
@@ -66,7 +66,7 @@ describe('Rest service', function() {
         restService.post('endpoint', data).then(r => gotResponse = r);
 
         $httpBackend.flush();
-        return expect(gotResponse).toEqual(response);
+        expect(gotResponse).toEqual(response);
     });
 
     it('should reject the promise when the response is not valid JSON', function() {
@@ -81,7 +81,7 @@ describe('Rest service', function() {
 
         $httpBackend.flush();
         expect(gotResponse).not.toBeNull();
-        return expect(gotResponse).not.toEqual(response);
+        expect(gotResponse).not.toEqual(response);
     });
 
     return it('should reject the promise when cancelled', inject(function($rootScope) {
@@ -96,7 +96,7 @@ describe('Rest service', function() {
         request.cancel();
         $rootScope.$apply();
         expect(gotResponse).toBeNull();
-        return expect(rejected).toBe(true);
+        expect(rejected).toBe(true);
     })
     );
 });

--- a/www/data_module/src/services/rest/rest.service.spec.js
+++ b/www/data_module/src/services/rest/rest.service.spec.js
@@ -13,7 +13,7 @@ describe('Rest service', function() {
     let restService = ($httpBackend = undefined);
     const injected = function($injector) {
         restService = $injector.get('restService');
-        return $httpBackend = $injector.get('$httpBackend');
+        $httpBackend = $injector.get('$httpBackend');
     };
 
     beforeEach(inject(injected));
@@ -42,7 +42,7 @@ describe('Rest service', function() {
         $httpBackend.whenGET('/api/endpoint?key=value').respond(200);
 
         restService.get('endpoint', params);
-        return $httpBackend.flush();
+        $httpBackend.flush();
     });
 
     it('should reject the promise on error', function() {

--- a/www/data_module/src/services/rest/rest.service.spec.js
+++ b/www/data_module/src/services/rest/rest.service.spec.js
@@ -84,7 +84,7 @@ describe('Rest service', function() {
         expect(gotResponse).not.toEqual(response);
     });
 
-    return it('should reject the promise when cancelled', inject(function($rootScope) {
+    it('should reject the promise when cancelled', inject(function($rootScope) {
         $httpBackend.expectGET('/api/endpoint').respond({});
 
         let gotResponse = null;

--- a/www/data_module/src/services/rest/rest.service.spec.js
+++ b/www/data_module/src/services/rest/rest.service.spec.js
@@ -20,7 +20,7 @@ describe('Rest service', function() {
 
     afterEach(function() {
         $httpBackend.verifyNoOutstandingExpectation();
-        return $httpBackend.verifyNoOutstandingRequest();
+        $httpBackend.verifyNoOutstandingRequest();
     });
 
     it('should be defined', () => expect(restService).toBeDefined());

--- a/www/data_module/src/services/rest/rest.service.spec.js
+++ b/www/data_module/src/services/rest/rest.service.spec.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 describe('Rest service', function() {
     let $httpBackend;
     beforeEach(angular.mock.module('bbData'));

--- a/www/data_module/src/services/socket/socket.service.js
+++ b/www/data_module/src/services/socket/socket.service.js
@@ -86,14 +86,10 @@ class Socket {
 
                 flush() {
                     // send all the data waiting in the queue
-                    return (() => {
-                        let data;
-                        const result = [];
-                        while ((data = this.queue.pop())) {
-                            result.push(this.socket.send(data));
-                        }
-                        return result;
-                    })();
+                    let data;
+                    while ((data = this.queue.pop())) {
+                        this.socket.send(data);
+                    }
                 }
 
                 nextId() {

--- a/www/data_module/src/services/socket/socket.service.spec.js
+++ b/www/data_module/src/services/socket/socket.service.spec.js
@@ -96,7 +96,7 @@ describe('Socket service', function() {
         expect(socket.send).toHaveBeenCalled();
         expect(webSocketBackend.receiveQueue).toContain(angular.toJson(msg1));
         expect(webSocketBackend.receiveQueue).toContain(angular.toJson(msg2));
-        return expect(webSocketBackend.receiveQueue).not.toContain(angular.toJson(msg3));
+        expect(webSocketBackend.receiveQueue).not.toContain(angular.toJson(msg3));
     });
 
     it('should add an _id to each message', function() {
@@ -105,7 +105,7 @@ describe('Socket service', function() {
         socketService.send({});
         expect(socket.send).toHaveBeenCalledWith(jasmine.any(String));
         const argument = socket.send.calls.argsFor(0)[0];
-        return expect(angular.fromJson(argument)._id).toBeDefined();
+        expect(angular.fromJson(argument)._id).toBeDefined();
     });
 
     it('should resolve the promise when a response message is received with code 200', function() {
@@ -127,7 +127,7 @@ describe('Socket service', function() {
         webSocketBackend.send(response);
         $rootScope.$apply(() => webSocketBackend.flush());
         // the promise should be resolved
-        return expect(handler).toHaveBeenCalled();
+        expect(handler).toHaveBeenCalled();
     });
 
     it('should reject the promise when a response message is received, but the code is not 200', function() {
@@ -152,7 +152,7 @@ describe('Socket service', function() {
         $rootScope.$apply(() => webSocketBackend.flush());
         // the promise should be rejected
         expect(handler).not.toHaveBeenCalled();
-        return expect(errorHandler).toHaveBeenCalled();
+        expect(errorHandler).toHaveBeenCalled();
     });
 
 
@@ -166,7 +166,7 @@ describe('Socket service', function() {
             spyOn(socketService, 'getRootPath').and.returnValue('/');
 
             const url = socketService.getUrl();
-            return expect(url).toBe('ws://localhost:8080/ws');
+            expect(url).toBe('ws://localhost:8080/ws');
         });
 
         it('should return the WebSocket url based on the host and port', function() {
@@ -177,7 +177,7 @@ describe('Socket service', function() {
             spyOn(socketService, 'getRootPath').and.returnValue('/');
 
             const url = socketService.getUrl();
-            return expect(url).toBe('ws://buildbot.test/ws');
+            expect(url).toBe('ws://buildbot.test/ws');
         });
 
         it('should return the WebSocket url based on the host and port and protocol', function() {
@@ -190,7 +190,7 @@ describe('Socket service', function() {
             spyOn(socketService, 'getRootPath').and.returnValue('/');
 
             const url = socketService.getUrl();
-            return expect(url).toBe('wss://buildbot.test/ws');
+            expect(url).toBe('wss://buildbot.test/ws');
         });
 
         return it('should return the WebSocket url based on the host and port and protocol and basedir', function() {
@@ -204,7 +204,7 @@ describe('Socket service', function() {
             spyOn(socketService, 'getRootPath').and.returnValue(path);
 
             const url = socketService.getUrl();
-            return expect(url).toBe('wss://buildbot.test/travis/ws');
+            expect(url).toBe('wss://buildbot.test/travis/ws');
         });
     });
 });

--- a/www/data_module/src/services/socket/socket.service.spec.js
+++ b/www/data_module/src/services/socket/socket.service.spec.js
@@ -74,7 +74,7 @@ describe('Socket service', function() {
         socketService = $injector.get('socketService');
         ({ socket } = socketService);
         spyOn(socket, 'send').and.callThrough();
-        return spyOn(socket, 'onmessage').and.callThrough();
+        spyOn(socket, 'onmessage').and.callThrough();
     };
 
     beforeEach(inject(injected));

--- a/www/data_module/src/services/socket/socket.service.spec.js
+++ b/www/data_module/src/services/socket/socket.service.spec.js
@@ -43,14 +43,10 @@ describe('Socket service', function() {
             }
 
             flush() {
-                return (() => {
-                    let message;
-                    const result = [];
-                    while ((message = this.sendQueue.shift())) {
-                        result.push(this.webSocket.onmessage(message));
-                    }
-                    return result;
-                })();
+                let message;
+                while ((message = this.sendQueue.shift())) {
+                    this.webSocket.onmessage(message);
+                }
             }
 
             getWebSocket() {

--- a/www/data_module/src/services/socket/socket.service.spec.js
+++ b/www/data_module/src/services/socket/socket.service.spec.js
@@ -156,7 +156,7 @@ describe('Socket service', function() {
     });
 
 
-    return describe('getUrl()', function() {
+    describe('getUrl()', function() {
 
         it('should return the WebSocket url based on the host and port (localhost)', function() {
             const host = 'localhost';

--- a/www/data_module/src/services/socket/socket.service.spec.js
+++ b/www/data_module/src/services/socket/socket.service.spec.js
@@ -193,7 +193,7 @@ describe('Socket service', function() {
             expect(url).toBe('wss://buildbot.test/ws');
         });
 
-        return it('should return the WebSocket url based on the host and port and protocol and basedir', function() {
+        it('should return the WebSocket url based on the host and port and protocol and basedir', function() {
             const host = 'buildbot.test';
             const port = 443;
             const protocol = 'https';

--- a/www/data_module/src/services/socket/webSocketBackend.service.js
+++ b/www/data_module/src/services/socket/webSocketBackend.service.js
@@ -40,14 +40,10 @@ var WebSocketBackend = (function() {
         }
 
         flush() {
-            return (() => {
-                let message;
-                const result = [];
-                while ((message = this.sendQueue.shift())) {
-                    result.push(this.webSocket.onmessage(message));
-                }
-                return result;
-            })();
+            let message;
+            while ((message = this.sendQueue.shift())) {
+                this.webSocket.onmessage(message);
+            }
         }
 
         getWebSocket() {

--- a/www/data_module/src/services/socket/websocket.service.js
+++ b/www/data_module/src/services/socket/websocket.service.js
@@ -1,6 +1,5 @@
 /*
  * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */

--- a/www/data_module/src/services/stream/stream.service.js
+++ b/www/data_module/src/services/stream/stream.service.js
@@ -44,13 +44,9 @@ class Stream {
 
                 destroy() {
                     // @listeners = [], but keep the reference
-                    return (() => {
-                        const result = [];
-                        while (this.listeners.length > 0) {
-                            result.push(this.listeners.pop());
-                        }
-                        return result;
-                    })();
+                    while (this.listeners.length > 0) {
+                        this.listeners.pop();
+                    }
                 }
 
                 generateId() {

--- a/www/data_module/src/services/stream/stream.service.spec.js
+++ b/www/data_module/src/services/stream/stream.service.spec.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 describe('Stream service', function() {
     let stream;
     beforeEach(angular.mock.module('bbData'));

--- a/www/data_module/src/services/stream/stream.service.spec.js
+++ b/www/data_module/src/services/stream/stream.service.spec.js
@@ -90,7 +90,7 @@ describe('Stream service', function() {
         expect(listeners.length).toBe(0);
     });
 
-    return it('should call the unsubscribe listener on unsubscribe call', function() {
+    it('should call the unsubscribe listener on unsubscribe call', function() {
         spyOn(stream, 'onUnsubscribe');
 
         const listener = function() {};

--- a/www/data_module/src/services/stream/stream.service.spec.js
+++ b/www/data_module/src/services/stream/stream.service.spec.js
@@ -10,7 +10,7 @@ describe('Stream service', function() {
     let Stream = (stream = null);
     const injected = function($injector) {
         Stream = $injector.get('Stream');
-        return stream = new Stream();
+        stream = new Stream();
     };
 
     beforeEach(inject(injected));

--- a/www/data_module/src/services/stream/stream.service.spec.js
+++ b/www/data_module/src/services/stream/stream.service.spec.js
@@ -17,7 +17,7 @@ describe('Stream service', function() {
 
     it('should be defined', function() {
         expect(Stream).toBeDefined();
-        return expect(stream).toBeDefined();
+        expect(stream).toBeDefined();
     });
 
     it('should add the listener to listeners on subscribe call', function() {
@@ -25,7 +25,7 @@ describe('Stream service', function() {
         expect(listeners.length).toBe(0);
 
         stream.subscribe(function() {});
-        return expect(listeners.length).toBe(1);
+        expect(listeners.length).toBe(1);
     });
 
     it('should add a unique id to each listener passed in to subscribe', function() {
@@ -39,7 +39,7 @@ describe('Stream service', function() {
 
         expect(listener1.id).toBeDefined();
         expect(listener2.id).toBeDefined();
-        return expect(listener1.id).not.toBe(listener2.id);
+        expect(listener1.id).not.toBe(listener2.id);
     });
 
     it('should return the unsubscribe function on subscribe call', function() {
@@ -53,14 +53,14 @@ describe('Stream service', function() {
 
         unsubscribe();
         expect(listeners).not.toContain(listener);
-        return expect(listeners).toContain(otherListener);
+        expect(listeners).toContain(otherListener);
     });
 
     it('should call all listeners on push call', function() {
         const data = {a: 'A', b: 'B'};
         const listeners = {
-            first(data) { return expect(data).toEqual({a: 'A', b: 'B'}); },
-            second(data) { return expect(data).toEqual({a: 'A', b: 'B'}); }
+            first(data) { expect(data).toEqual({a: 'A', b: 'B'}); },
+            second(data) { expect(data).toEqual({a: 'A', b: 'B'}); }
         };
 
         spyOn(listeners, 'first').and.callThrough();
@@ -75,7 +75,7 @@ describe('Stream service', function() {
         stream.push(data);
 
         expect(listeners.first).toHaveBeenCalled();
-        return expect(listeners.second).toHaveBeenCalled();
+        expect(listeners.second).toHaveBeenCalled();
     });
 
     it('should remove all listeners on destroy call', function() {
@@ -87,7 +87,7 @@ describe('Stream service', function() {
         expect(listeners.length).not.toBe(0);
 
         stream.destroy();
-        return expect(listeners.length).toBe(0);
+        expect(listeners.length).toBe(0);
     });
 
     return it('should call the unsubscribe listener on unsubscribe call', function() {
@@ -98,6 +98,6 @@ describe('Stream service', function() {
 
         expect(stream.onUnsubscribe).not.toHaveBeenCalled();
         unsubscribe();
-        return expect(stream.onUnsubscribe).toHaveBeenCalledWith(listener);
+        expect(stream.onUnsubscribe).toHaveBeenCalledWith(listener);
     });
 });

--- a/www/grid_view/src/module/main.module.spec.js
+++ b/www/grid_view/src/module/main.module.spec.js
@@ -259,7 +259,7 @@ describe('Grid view controller', function() {
         expect(scope.builders.length).toBe(3);
     });
 
-    return it('should only list builders with the selected tags', function() {
+    it('should only list builders with the selected tags', function() {
         createController();
         $rootScope.$digest();
         scope.C.tags = ['b'];

--- a/www/grid_view/src/module/main.module.spec.js
+++ b/www/grid_view/src/module/main.module.spec.js
@@ -202,7 +202,7 @@ describe('Grid view controller', function() {
 
         // Create new controller using controller as syntax
         const $controller = $injector.get('$controller');
-        return createController = () =>
+        createController = () =>
             $controller('gridController as C',
                 // Inject controller dependencies
                 {$scope: scope})

--- a/www/grid_view/src/module/main.module.spec.js
+++ b/www/grid_view/src/module/main.module.spec.js
@@ -7,7 +7,6 @@
 beforeEach(function() {
     module(function($provide) {
         $provide.service('resultsService', function() { return {results2class() {}}; });
-        return null;
     });
 
     // Mock bbSettingsProvider
@@ -37,7 +36,6 @@ beforeEach(function() {
             return Cls;
         })()
         );
-        return null;
     });
     return module('grid_view');
 });

--- a/www/grid_view/src/module/main.module.spec.js
+++ b/www/grid_view/src/module/main.module.spec.js
@@ -215,7 +215,7 @@ describe('Grid view controller', function() {
 
     it('should be defined', function() {
         createController();
-        return expect(scope.C).toBeDefined();
+        expect(scope.C).toBeDefined();
     });
 
     it('should bind the builds, builders, changes, buildrequests and buildsets to scope', function() {
@@ -230,7 +230,7 @@ describe('Grid view controller', function() {
         expect(scope.C.buildrequests).toBeDefined();
         expect(scope.C.buildrequests.length).toBe(buildrequests.length);
         expect(scope.C.buildsets).toBeDefined();
-        return expect(scope.C.buildsets.length).toBe(buildsets.length);
+        expect(scope.C.buildsets.length).toBe(buildsets.length);
     });
 
     it('should list branches', function() {
@@ -238,7 +238,7 @@ describe('Grid view controller', function() {
         $rootScope.$digest();
         scope.C.onChange();
         expect(scope.branches).toBeDefined();
-        return expect(scope.branches).toEqual(['refs/pull/3333/merge', 'master']);
+        expect(scope.branches).toEqual(['refs/pull/3333/merge', 'master']);
     });
 
     it('should only list changes of the selected branch', function() {
@@ -247,7 +247,7 @@ describe('Grid view controller', function() {
         scope.C.branch = 'master';
         scope.C.onChange();
         expect(scope.changes).toBeDefined();
-        return expect(scope.changes.length).toBe(2);
+        expect(scope.changes.length).toBe(2);
     });
 
     it('should only list builders with builds of the selected branch', function() {
@@ -256,7 +256,7 @@ describe('Grid view controller', function() {
         scope.C.branch = 'refs/pull/3333/merge';
         scope.C.onChange();
         expect(scope.builders).toBeDefined();
-        return expect(scope.builders.length).toBe(3);
+        expect(scope.builders.length).toBe(3);
     });
 
     return it('should only list builders with the selected tags', function() {
@@ -265,6 +265,6 @@ describe('Grid view controller', function() {
         scope.C.tags = ['b'];
         scope.C.onChange();
         expect(scope.builders).toBeDefined();
-        return expect(scope.builders.length).toBe(2);
+        expect(scope.builders.length).toBe(2);
     });
 });

--- a/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.js
+++ b/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.js
@@ -56,20 +56,16 @@ class DataProcessor {
 
     // Add the most recent build result to the builder
     addStatus(builders) {
-        return (() => {
-            const result = [];
-            for (let builder of Array.from(builders)) {
-                let latest = null;
-                for (let build of Array.from(builder.builds)) {
-                    latest = build;
-                    if (build.number > latest.number) { latest = build; }
-                }
-                builder.started_at = latest != null ? latest.started_at : undefined;
-                builder.complete = (latest != null ? latest.complete : undefined) || false;
-                result.push(builder.results = latest != null ? latest.results : undefined);
+        for (let builder of Array.from(builders)) {
+            let latest = null;
+            for (let build of Array.from(builder.builds)) {
+                latest = build;
+                if (build.number > latest.number) { latest = build; }
             }
-            return result;
-        })();
+            builder.started_at = latest != null ? latest.started_at : undefined;
+            builder.complete = (latest != null ? latest.complete : undefined) || false;
+            builder.results = latest != null ? latest.results : undefined;
+        }
     }
 
     filterBuilders(builders) {

--- a/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.js
+++ b/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.js
@@ -1,7 +1,6 @@
 /*
  * decaffeinate suggestions:
  * DS101: Remove unnecessary use of Array.from
- * DS102: Remove unnecessary code created because of implicit returns
  * DS205: Consider reworking code to avoid use of IIFEs
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md

--- a/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
+++ b/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
@@ -75,7 +75,7 @@ describe('Data Processor service', function() {
         }
         ];
         builds = new Collection("builds", {});
-        return builds.from(_builds);
+        builds.from(_builds);
     };
 
     beforeEach(inject(injected));

--- a/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
+++ b/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
@@ -130,7 +130,7 @@ describe('Data Processor service', function() {
         expect(buildsInGroups).toEqual(builds.length);
 
         // If the time between two builds is less than the threshold, they should be in different groups
-        return Array.from(builds).map((build1, i) =>
+        Array.from(builds).map((build1, i) =>
             (() => {
                 const result = [];
                 for (let build2 of Array.from(builds.slice(i + 1))) {
@@ -151,7 +151,7 @@ describe('Data Processor service', function() {
     it('should add complete_at to unfinished builds', function() {
         const unfinishedBuilds = builds.filter(build => !build.complete);
         dataProcessorService.getGroups(builders, unfinishedBuilds, 0);
-        return (() => {
+        (() => {
             const result = [];
             for (let build of Array.from(unfinishedBuilds)) {
                 expect(build.complete_at).toBeDefined();
@@ -166,7 +166,7 @@ describe('Data Processor service', function() {
         // Add builds to builders first
         dataProcessorService.getGroups(builders, builds, 0);
         dataProcessorService.addStatus(builders);
-        return Array.from(builders).map((builder) =>
+        Array.from(builders).map((builder) =>
             builder.complete ? expect(builder.results).toBeDefined()
             : expect(builder.results).not.toBeDefined());
     });

--- a/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
+++ b/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
@@ -162,7 +162,7 @@ describe('Data Processor service', function() {
         })();
     });
 
-    return it('should add status to builders', function() {
+    it('should add status to builders', function() {
         // Add builds to builders first
         dataProcessorService.getGroups(builders, builds, 0);
         dataProcessorService.addStatus(builders);

--- a/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
+++ b/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
@@ -87,7 +87,7 @@ describe('Data Processor service', function() {
         expect(typeof dataProcessorService.getGroups).toBe('function');
         // addStatus is a function
         expect(dataProcessorService.addStatus).toBeDefined();
-        return expect(typeof dataProcessorService.addStatus).toBe('function');
+        expect(typeof dataProcessorService.addStatus).toBe('function');
     });
 
     it('should add builds to builders', function() {
@@ -102,7 +102,7 @@ describe('Data Processor service', function() {
         for (let builder of Array.from(builders)) {
             buildsInBuilders += builder.builds.length;
         }
-        return expect(buildsInBuilders).toEqual(builds.length);
+        expect(buildsInBuilders).toEqual(builds.length);
     });
 
     it('should create groups', function() {

--- a/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
+++ b/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
@@ -130,36 +130,28 @@ describe('Data Processor service', function() {
         expect(buildsInGroups).toEqual(builds.length);
 
         // If the time between two builds is less than the threshold, they should be in different groups
-        Array.from(builds).map((build1, i) =>
-            (() => {
-                const result = [];
-                for (let build2 of Array.from(builds.slice(i + 1))) {
-                // If build2 starts earlier than build1, swap them
-                    if (build2.buildid < build1.buildid) {
-                        [build1, build2] = Array.from([build2, build1]);
-                    }
-                    if ((build2.started_at - build1.complete_at) > threshold) {
-                        result.push(expect(build1.groupid).not.toBe(build2.groupid));
-                    } else {
-                        result.push(undefined);
-                    }
+        Array.from(builds).map((build1, i) => {
+            for (let build2 of Array.from(builds.slice(i + 1))) {
+            // If build2 starts earlier than build1, swap them
+                if (build2.buildid < build1.buildid) {
+                    [build1, build2] = Array.from([build2, build1]);
                 }
-                return result;
-            })());
+                if ((build2.started_at - build1.complete_at) > threshold) {
+                    expect(build1.groupid).not.toBe(build2.groupid);
+                }
+            }
+        });
     });
 
     it('should add complete_at to unfinished builds', function() {
         const unfinishedBuilds = builds.filter(build => !build.complete);
         dataProcessorService.getGroups(builders, unfinishedBuilds, 0);
-        (() => {
-            const result = [];
-            for (let build of Array.from(unfinishedBuilds)) {
-                expect(build.complete_at).toBeDefined();
-                // It should be a correct timestamp
-                result.push(expect(build.complete_at.toString().length).toBe(10));
-            }
-            return result;
-        })();
+
+        for (let build of Array.from(unfinishedBuilds)) {
+            expect(build.complete_at).toBeDefined();
+            // It should be a correct timestamp
+            expect(build.complete_at.toString().length).toBe(10);
+        }
     });
 
     it('should add status to builders', function() {

--- a/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
+++ b/www/waterfall_view/src/module/dataProcessor/dataProcessor.service.spec.js
@@ -1,7 +1,6 @@
 /*
  * decaffeinate suggestions:
  * DS101: Remove unnecessary use of Array.from
- * DS102: Remove unnecessary code created because of implicit returns
  * DS205: Consider reworking code to avoid use of IIFEs
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md

--- a/www/waterfall_view/src/module/main.module.js
+++ b/www/waterfall_view/src/module/main.module.js
@@ -452,20 +452,14 @@ var WaterfallController = (function() {
                 const words = e.text().split('^');
                 e.text('');
 
-                return (() => {
-                    const result = [];
-                    for (i = 0; i < words.length; i++) {
-                        const word = words[i];
-                        const text = e.append('tspan').text(word);
-                        if (i !== 0) {
-                            const x = e.attr('x');
-                            result.push(text.attr('x', x).attr('dy', i * 10));
-                        } else {
-                            result.push(undefined);
-                        }
+                for (i = 0; i < words.length; i++) {
+                    const word = words[i];
+                    const text = e.append('tspan').text(word);
+                    if (i !== 0) {
+                        const x = e.attr('x');
+                        text.attr('x', x).attr('dy', i * 10);
                     }
-                    return result;
-                })();
+                }
             };
             yAxis.selectAll('text').each(lineBreak);
 

--- a/www/waterfall_view/src/module/main.module.spec.js
+++ b/www/waterfall_view/src/module/main.module.spec.js
@@ -227,7 +227,7 @@ describe('Waterfall view controller', function() {
         expect(newSetting).toBe(oldSetting * 1.5);
     });
 
-    return it('should have string representations of result codes', function() {
+    it('should have string representations of result codes', function() {
         const testBuild = {
             complete: false,
             started_at: 0

--- a/www/waterfall_view/src/module/main.module.spec.js
+++ b/www/waterfall_view/src/module/main.module.spec.js
@@ -166,7 +166,7 @@ describe('Waterfall view controller', function() {
     afterEach(function() {
         expect($document.find('svg').length).toEqual(2);
         elem.remove();
-        return expect($document.find('svg').length).toEqual(0);
+        expect($document.find('svg').length).toEqual(0);
     });
 
     it('should be defined', () => expect(w).toBeDefined());
@@ -177,19 +177,19 @@ describe('Waterfall view controller', function() {
         expect(w.builds).toBeDefined();
         expect(w.builds.length).toBe(limit);
         expect(w.builders).toBeDefined();
-        return expect(w.builders.length).not.toBe(0);
+        expect(w.builders.length).not.toBe(0);
     });
 
     it('should create svg elements', function() {
         expect(elem.find('svg').length).toBeGreaterThan(1);
-        return expect(elem.find('g').length).toBeGreaterThan(1);
+        expect(elem.find('g').length).toBeGreaterThan(1);
     });
 
     it('should rerender the waterfall on resize', function() {
         spyOn(w, 'render').and.callThrough();
         expect(w.render).not.toHaveBeenCalled();
         angular.element($window).triggerHandler('resize');
-        return expect(w.render).toHaveBeenCalled();
+        expect(w.render).toHaveBeenCalled();
     });
 
     it('should rerender the waterfall on data change', function() {
@@ -200,7 +200,7 @@ describe('Waterfall view controller', function() {
         w.buildLimit = 0;
         w.loadMore();
         $timeout.flush();
-        return expect(w.render).toHaveBeenCalled();
+        expect(w.render).toHaveBeenCalled();
     });
 
     it('should lazy load data on scroll', function() {
@@ -212,7 +212,7 @@ describe('Waterfall view controller', function() {
         expect(callCount).toBe(0);
         angular.element(n).triggerHandler('scroll');
         callCount = w.loadMore.calls.count();
-        return expect(callCount).toBe(1);
+        expect(callCount).toBe(1);
     });
 
     it('height should be scalable', function() {
@@ -224,7 +224,7 @@ describe('Waterfall view controller', function() {
         const newHeight = w.getInnerHeight();
         expect(newHeight).toBe(height * 1.5);
         const newSetting = group.scaling_waterfall.value;
-        return expect(newSetting).toBe(oldSetting * 1.5);
+        expect(newSetting).toBe(oldSetting * 1.5);
     });
 
     return it('should have string representations of result codes', function() {

--- a/www/waterfall_view/src/module/main.module.spec.js
+++ b/www/waterfall_view/src/module/main.module.spec.js
@@ -155,7 +155,7 @@ describe('Waterfall view controller', function() {
         spyOn(w, 'click').and.callThrough();
         spyOn(w, 'loadMore').and.callThrough();
         // Data is loaded
-        return $timeout.flush();
+        $timeout.flush();
     };
 
     beforeEach(inject(injected));

--- a/www/waterfall_view/src/module/main.module.spec.js
+++ b/www/waterfall_view/src/module/main.module.spec.js
@@ -241,13 +241,10 @@ describe('Waterfall view controller', function() {
             4: 'exception',
             5: 'cancelled'
         };
-        (() => {
-            const result = [];
-            for (let i = 0; i <= 5; i++) {
-                testBuild.results = i;
-                result.push(expect(w.getResultClassFromThing(testBuild)).toBe(results[i]));
-            }
-            return result;
-        })();
+
+        for (let i = 0; i <= 5; i++) {
+            testBuild.results = i;
+            expect(w.getResultClassFromThing(testBuild)).toBe(results[i]);
+        }
     });
 });

--- a/www/waterfall_view/src/module/main.module.spec.js
+++ b/www/waterfall_view/src/module/main.module.spec.js
@@ -241,7 +241,7 @@ describe('Waterfall view controller', function() {
             4: 'exception',
             5: 'cancelled'
         };
-        return (() => {
+        (() => {
             const result = [];
             for (let i = 0; i <= 5; i++) {
                 testBuild.results = i;

--- a/www/waterfall_view/src/module/main.module.spec.js
+++ b/www/waterfall_view/src/module/main.module.spec.js
@@ -8,7 +8,6 @@
 beforeEach(function() {
     module(function($provide) {
         $provide.service('$uibModal', function() { return {open() {}}; });
-        return null;
     });
 
     // Mock bbSettingsProvider
@@ -38,7 +37,6 @@ beforeEach(function() {
             return Cls;
         })()
         );
-        return null;
     });
 
     return module('waterfall_view');

--- a/www/waterfall_view/src/module/modal/modal.controller.spec.js
+++ b/www/waterfall_view/src/module/modal/modal.controller.spec.js
@@ -48,7 +48,7 @@ describe('Waterfall modal controller', function() {
         expect(m.close).toHaveBeenCalled();
     });
 
-    return it('should call $uibModalInstance.close on close()', function() {
+    it('should call $uibModalInstance.close on close()', function() {
         createController();
         const { m } = scope;
         spyOn($uibModalInstance, 'close');

--- a/www/waterfall_view/src/module/modal/modal.controller.spec.js
+++ b/www/waterfall_view/src/module/modal/modal.controller.spec.js
@@ -37,7 +37,7 @@ describe('Waterfall modal controller', function() {
         expect(m).toBeDefined();
         // close function should be to defined
         expect(m.close).toBeDefined();
-        return expect(typeof m.close).toBe('function');
+        expect(typeof m.close).toBe('function');
     });
 
     it('should call close() on stateChangeStart event', function() {
@@ -45,7 +45,7 @@ describe('Waterfall modal controller', function() {
         const { m } = scope;
         spyOn(m, 'close');
         $rootScope.$broadcast('$stateChangeStart');
-        return expect(m.close).toHaveBeenCalled();
+        expect(m.close).toHaveBeenCalled();
     });
 
     return it('should call $uibModalInstance.close on close()', function() {
@@ -54,6 +54,6 @@ describe('Waterfall modal controller', function() {
         spyOn($uibModalInstance, 'close');
         expect($uibModalInstance.close).not.toHaveBeenCalled();
         m.close();
-        return expect($uibModalInstance.close).toHaveBeenCalled();
+        expect($uibModalInstance.close).toHaveBeenCalled();
     });
 });

--- a/www/waterfall_view/src/module/modal/modal.controller.spec.js
+++ b/www/waterfall_view/src/module/modal/modal.controller.spec.js
@@ -20,7 +20,7 @@ describe('Waterfall modal controller', function() {
         $uibModalInstance = $injector.get('$uibModalInstance');
         scope = $rootScope.$new();
 
-        return createController = () =>
+        createController = () =>
             $controller('waterfallModalController as m', {
                 $scope: scope,
                 selectedBuild: {}

--- a/www/waterfall_view/src/module/modal/modal.controller.spec.js
+++ b/www/waterfall_view/src/module/modal/modal.controller.spec.js
@@ -7,7 +7,6 @@ beforeEach(() =>
     // Mock modalService
     module(function($provide) {
         $provide.service('$uibModalInstance', function() { return {close() {}}; });
-        return null;
     })
 );
 

--- a/www/waterfall_view/src/module/scale/scale.service.spec.js
+++ b/www/waterfall_view/src/module/scale/scale.service.spec.js
@@ -60,7 +60,7 @@ describe('Scale service', function() {
         expect(typeof scale.getY).toBe('function');
         // getBuilderName is a function
         expect(scale.getBuilderName).toBeDefined();
-        return expect(typeof scale.getBuilderName).toBe('function');
+        expect(typeof scale.getBuilderName).toBe('function');
     });
 
     it('should return a builderid to X scale', function() {
@@ -74,7 +74,7 @@ describe('Scale service', function() {
             expect(a).toBeLessThan(b);
         }
         // Out of domain
-        return expect(idToX(8)).toBeUndefined();
+        expect(idToX(8)).toBeUndefined();
     });
 
     it('should return a build length to height scale', function() {
@@ -97,7 +97,7 @@ describe('Scale service', function() {
         expect(idToY.getCoord(date)).toBeGreaterThan(idToY.getCoord(date + 10000));
         // Out of domain
         expect(idToY.getCoord(1359731101)).toBeUndefined();
-        return expect(idToY.invert(120)).toBeUndefined();
+        expect(idToY.invert(120)).toBeUndefined();
     });
 
     return it('should return a builderid to name scale', function() {

--- a/www/waterfall_view/src/module/scale/scale.service.spec.js
+++ b/www/waterfall_view/src/module/scale/scale.service.spec.js
@@ -43,7 +43,7 @@ describe('Scale service', function() {
             name: 'builder4'
         }
         ];
-        return $rootScope.$digest();
+        $rootScope.$digest();
     };
 
 
@@ -104,7 +104,7 @@ describe('Scale service', function() {
         // Get new scale
         const idToName = scale.getBuilderName(builders);
         // The return value should be the name of the builder
-        return Array.from(builders).map((builder) =>
+        Array.from(builders).map((builder) =>
             expect(idToName(builder.builderid)).toEqual(builder.name));
     });
 });

--- a/www/waterfall_view/src/module/scale/scale.service.spec.js
+++ b/www/waterfall_view/src/module/scale/scale.service.spec.js
@@ -100,7 +100,7 @@ describe('Scale service', function() {
         expect(idToY.invert(120)).toBeUndefined();
     });
 
-    return it('should return a builderid to name scale', function() {
+    it('should return a builderid to name scale', function() {
         // Get new scale
         const idToName = scale.getBuilderName(builders);
         // The return value should be the name of the builder

--- a/www/waterfall_view/src/module/scale/scale.service.spec.js
+++ b/www/waterfall_view/src/module/scale/scale.service.spec.js
@@ -1,7 +1,6 @@
 /*
  * decaffeinate suggestions:
  * DS101: Remove unnecessary use of Array.from
- * DS102: Remove unnecessary code created because of implicit returns
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
 describe('Scale service', function() {

--- a/www/waterfall_view/src/module/waterfall.route.spec.js
+++ b/www/waterfall_view/src/module/waterfall.route.spec.js
@@ -13,6 +13,6 @@ describe('Waterfall view', function() {
     return it('should register a new state with the correct configuration', function() {
         const name = 'waterfall';
         const states = $state.get().map(state => state.name);
-        return expect(states).toContain(name);
+        expect(states).toContain(name);
     });
 });

--- a/www/waterfall_view/src/module/waterfall.route.spec.js
+++ b/www/waterfall_view/src/module/waterfall.route.spec.js
@@ -10,7 +10,7 @@ describe('Waterfall view', function() {
 
     beforeEach(inject(injected));
 
-    return it('should register a new state with the correct configuration', function() {
+    it('should register a new state with the correct configuration', function() {
         const name = 'waterfall';
         const states = $state.get().map(state => state.name);
         expect(states).toContain(name);

--- a/www/waterfall_view/src/module/waterfall.route.spec.js
+++ b/www/waterfall_view/src/module/waterfall.route.spec.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 describe('Waterfall view', function() {
     let $state = null;
 

--- a/www/wsgi_dashboards/src/module/main.module.spec.js
+++ b/www/wsgi_dashboards/src/module/main.module.spec.js
@@ -1,6 +1,1 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 describe('WSGIDashboards', () => it('should have one test', function() {}));


### PR DESCRIPTION
Clean up some obvious cases where returns were not necessary, but decaffeinate did not know better as returns are implicit in CoffeeScript.