### PR TITLE
latent: Implement "generic" latent machines

### DIFF
--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -191,6 +191,14 @@ class IMachine(Interface):
     pass
 
 
+class IMachineAction(Interface):
+    def perform(self, manager):
+        """ Perform an action on the machine managed by manager. Returns a
+            deferred evaluating to True if it was possible to execute the
+            action.
+        """
+
+
 class ILatentMachine(IMachine):
     """ A machine that is not always running, but can be started when requested.
     """

--- a/master/buildbot/machine/generic.py
+++ b/master/buildbot/machine/generic.py
@@ -13,9 +13,20 @@
 #
 # Copyright Buildbot Team Members
 
+import os
+import stat
 
+from twisted.internet import defer
+from twisted.internet import utils
+from zope.interface import implementer
+
+from buildbot import config
 from buildbot.interfaces import IMachineAction
 from buildbot.machine.latent import AbstractLatentMachine
+from buildbot.util import misc
+from buildbot.util import private_tempdir
+from buildbot.util.git import getSshArgsForKeys
+from buildbot.util.git import getSshKnownHostsContents
 
 
 class GenericLatentMachine(AbstractLatentMachine):
@@ -40,3 +51,112 @@ class GenericLatentMachine(AbstractLatentMachine):
 
     def stop_machine(self):
         return self.stop_action.perform(self)
+
+
+class _LocalMachineActionMixin:
+    def setupLocal(self, command):
+        if not isinstance(command, list):
+            config.error('command parameter must be a list')
+        self._command = command
+
+    @defer.inlineCallbacks
+    def perform(self, manager):
+        args = yield manager.renderSecrets(self._command)
+        _, _, code = yield utils.getProcessOutputAndValue(args[0], args[1:])
+        return code == 0
+
+
+class _SshActionMixin:
+    def setupSsh(self, sshBin, host, remoteCommand, sshKey=None,
+                 sshHostKey=None):
+        if not isinstance(sshBin, str):
+            config.error('sshBin parameter must be a string')
+        if not isinstance(host, str):
+            config.error('host parameter must be a string')
+        if not isinstance(remoteCommand, list):
+            config.error('remoteCommand parameter must be a list')
+
+        self._sshBin = sshBin
+        self._host = host
+        self._remoteCommand = remoteCommand
+        self._sshKey = sshKey
+        self._sshHostKey = sshHostKey
+
+    @defer.inlineCallbacks
+    def _performImpl(self, manager, key_path, known_hosts_path):
+        args = getSshArgsForKeys(key_path, known_hosts_path)
+        args.append((yield manager.renderSecrets(self._host)))
+        args.extend((yield manager.renderSecrets(self._remoteCommand)))
+        _, _, code = yield utils.getProcessOutputAndValue(self._sshBin, args)
+        return code == 0)
+
+    @defer.inlineCallbacks
+    def _prepareSshKeys(self, manager, temp_dir_path):
+        key_path = None
+        if self._sshKey is not None:
+            ssh_key_data = yield manager.renderSecrets(self._sshKey)
+
+            key_path = os.path.join(temp_dir_path, 'ssh-key')
+            misc.writeLocalFile(key_path, ssh_key_data,
+                                mode=stat.S_IRUSR)
+
+        known_hosts_path = None
+        if self._sshHostKey is not None:
+            ssh_host_key_data = yield manager.renderSecrets(self._sshHostKey)
+            ssh_host_key_data = getSshKnownHostsContents(ssh_host_key_data)
+
+            known_hosts_path = os.path.join(temp_dir_path, 'ssh-known-hosts')
+            misc.writeLocalFile(known_hosts_path, ssh_host_key_data)
+
+        defer.returnValue((key_path, known_hosts_path))
+
+    @defer.inlineCallbacks
+    def perform(self, manager):
+        if self._sshKey is not None or self._sshHostKey is not None:
+            with private_tempdir.PrivateTemporaryDirectory(
+                    prefix='ssh-', dir=manager.master.basedir) as temp_dir:
+
+                key_path, hosts_path = yield self._prepareSshKeys(manager,
+                                                                  temp_dir)
+
+                ret = yield self._performImpl(manager, key_path, hosts_path)
+        else:
+            ret = yield self._performImpl(manager, None, None)
+        defer.returnValue(ret)
+
+
+@implementer(IMachineAction)
+class LocalWakeAction(_LocalMachineActionMixin):
+    def __init__(self, command):
+        self.setupLocal(command)
+
+
+class LocalWOLAction(LocalWakeAction):
+    def __init__(self, wakeMac, wolBin='wakeonlan'):
+        LocalWakeAction.__init__(self, [wolBin, wakeMac])
+
+
+@implementer(IMachineAction)
+class RemoteSshWakeAction(_SshActionMixin):
+    def __init__(self, host, remoteCommand, sshBin='ssh',
+                 sshKey=None, sshHostKey=None):
+        self.setupSsh(sshBin, host, remoteCommand,
+                      sshKey=sshKey, sshHostKey=sshHostKey)
+
+
+class RemoteSshWOLAction(RemoteSshWakeAction):
+    def __init__(self, host, wakeMac, wolBin='wakeonlan', sshBin='ssh',
+                 sshKey=None, sshHostKey=None):
+        RemoteSshWakeAction.__init__(self, host, [wolBin, wakeMac],
+                                     sshBin=sshBin,
+                                     sshKey=sshKey, sshHostKey=sshHostKey)
+
+
+@implementer(IMachineAction)
+class RemoteSshSuspendAction(_SshActionMixin):
+    def __init__(self, host, remoteCommand=None, sshBin='ssh',
+                 sshKey=None, sshHostKey=None):
+        if remoteCommand is None:
+            remoteCommand = ['systemctl', 'suspend']
+        self.setupSsh(sshBin, host, remoteCommand,
+                      sshKey=sshKey, sshHostKey=sshHostKey)

--- a/master/buildbot/machine/generic.py
+++ b/master/buildbot/machine/generic.py
@@ -1,0 +1,42 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from buildbot.interfaces import IMachineAction
+from buildbot.machine.latent import AbstractLatentMachine
+
+
+class GenericLatentMachine(AbstractLatentMachine):
+
+    def checkConfig(self, name, start_action, stop_action, **kwargs):
+        super().checkConfig(name, **kwargs)
+
+        for action, arg_name in [(start_action, 'start_action'),
+                                 (stop_action, 'stop_action')]:
+            if not IMachineAction.providedBy(action):
+                msg = "{} of {} does not implement required " \
+                      "interface".format(arg_name, self.name)
+                raise Exception(msg)
+
+    def reconfigService(self, name, start_action, stop_action, **kwargs):
+        super().reconfigService(name, **kwargs)
+        self.start_action = start_action
+        self.stop_action = stop_action
+
+    def start_machine(self):
+        return self.start_action.perform(self)
+
+    def stop_machine(self):
+        return self.stop_action.perform(self)

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -51,11 +51,16 @@ class LatentController(SeverWorkerConnectionMixin):
     stop_instance() is executed.
     """
 
-    def __init__(self, case, name, kind=None, build_wait_timeout=600, **kwargs):
+    def __init__(self, case, name, kind=None, build_wait_timeout=600,
+                 starts_without_substantiate=None, **kwargs):
         self.case = case
         self.build_wait_timeout = build_wait_timeout
         self.worker = ControllableLatentWorker(name, self, **kwargs)
         self.remote_worker = None
+
+        if starts_without_substantiate is not None:
+            self.worker.starts_without_substantiate = \
+                starts_without_substantiate
 
         self.state = States.STOPPED
         self.auto_stop_flag = False

--- a/master/buildbot/test/unit/test_machine_generic.py
+++ b/master/buildbot/test/unit/test_machine_generic.py
@@ -1,0 +1,203 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import os
+from unittest import mock
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.machine.generic import LocalWakeAction
+from buildbot.machine.generic import LocalWOLAction
+from buildbot.machine.generic import RemoteSshSuspendAction
+from buildbot.machine.generic import RemoteSshWakeAction
+from buildbot.machine.generic import RemoteSshWOLAction
+from buildbot.test.fake.private_tempdir import MockPrivateTemporaryDirectory
+from buildbot.test.util import config
+from buildbot.test.util import gpo
+
+
+class FakeManager:
+
+    def __init__(self, basedir=None):
+        self.master = mock.Mock()
+        self.master.basedir = basedir
+
+    def renderSecrets(self, args):
+        return defer.succeed(args)
+
+
+class TestActions(unittest.TestCase, gpo.GetProcessOutputMixin,
+                  config.ConfigErrorsMixin):
+    def setUp(self):
+        self.setUpGetProcessOutput()
+
+    def tearDown(self):
+        pass
+
+    @defer.inlineCallbacks
+    def test_local_wake_action(self):
+        self.expectCommands(
+            gpo.Expect('cmd', 'arg1', 'arg2')
+            .exit(1),
+            gpo.Expect('cmd', 'arg1', 'arg2')
+            .exit(0),
+        )
+
+        manager = FakeManager()
+        action = LocalWakeAction(['cmd', 'arg1', 'arg2'])
+        self.assertFalse((yield action.perform(manager)))
+        self.assertTrue((yield action.perform(manager)))
+        self.assertAllCommandsRan()
+
+    def test_local_wake_action_command_not_list(self):
+        with self.assertRaisesConfigError('command parameter must be a list'):
+            LocalWakeAction('not-list')
+
+    @defer.inlineCallbacks
+    def test_local_wol_action(self):
+        self.expectCommands(
+            gpo.Expect('wol', '00:11:22:33:44:55')
+            .exit(1),
+            gpo.Expect('wakeonlan', '00:11:22:33:44:55')
+            .exit(0),
+        )
+
+        manager = FakeManager()
+        action = LocalWOLAction('00:11:22:33:44:55', wolBin='wol')
+        self.assertFalse((yield action.perform(manager)))
+
+        action = LocalWOLAction('00:11:22:33:44:55')
+        self.assertTrue((yield action.perform(manager)))
+        self.assertAllCommandsRan()
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch('buildbot.util.misc.writeLocalFile')
+    @defer.inlineCallbacks
+    def test_remote_ssh_wake_action_no_keys(self, write_local_file_mock,
+                                            temp_dir_mock):
+        self.expectCommands(
+            gpo.Expect('ssh', 'remote_host', 'remotebin', 'arg1')
+            .exit(1),
+            gpo.Expect('ssh', 'remote_host', 'remotebin', 'arg1')
+            .exit(0),
+        )
+
+        manager = FakeManager()
+        action = RemoteSshWakeAction('remote_host', ['remotebin', 'arg1'])
+        self.assertFalse((yield action.perform(manager)))
+        self.assertTrue((yield action.perform(manager)))
+        self.assertAllCommandsRan()
+
+        self.assertEqual(temp_dir_mock.dirs, [])
+        write_local_file_mock.assert_not_called()
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch('buildbot.util.misc.writeLocalFile')
+    @defer.inlineCallbacks
+    def test_remote_ssh_wake_action_with_keys(self, write_local_file_mock,
+                                              temp_dir_mock):
+        temp_dir_path = os.path.join('path-to-master', 'ssh-@@@')
+        ssh_key_path = os.path.join(temp_dir_path, 'ssh-key')
+        ssh_known_hosts_path = os.path.join(temp_dir_path, 'ssh-known-hosts')
+
+        self.expectCommands(
+            gpo.Expect('ssh', '-i', ssh_key_path,
+                       '-o', 'UserKnownHostsFile={0}'.format(ssh_known_hosts_path),
+                       'remote_host', 'remotebin', 'arg1')
+            .exit(0),
+        )
+
+        manager = FakeManager('path-to-master')
+        action = RemoteSshWakeAction('remote_host', ['remotebin', 'arg1'],
+                                     sshKey='ssh_key',
+                                     sshHostKey='ssh_host_key')
+        self.assertTrue((yield action.perform(manager)))
+
+        self.assertAllCommandsRan()
+
+        self.assertEqual(temp_dir_mock.dirs,
+                         [(temp_dir_path, 0o700)])
+
+        self.assertSequenceEqual(write_local_file_mock.call_args_list, [
+            mock.call(ssh_key_path, 'ssh_key', mode=0o400),
+            mock.call(ssh_known_hosts_path, '* ssh_host_key'),
+        ])
+
+    def test_remote_ssh_wake_action_sshBin_not_str(self):
+        with self.assertRaisesConfigError('sshBin parameter must be a string'):
+            RemoteSshWakeAction('host', ['cmd'], sshBin=123)
+
+    def test_remote_ssh_wake_action_host_not_str(self):
+        with self.assertRaisesConfigError('host parameter must be a string'):
+            RemoteSshWakeAction(123, ['cmd'])
+
+    def test_remote_ssh_wake_action_command_not_list(self):
+        with self.assertRaisesConfigError(
+                'remoteCommand parameter must be a list'):
+            RemoteSshWakeAction('host', 'cmd')
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch('buildbot.util.misc.writeLocalFile')
+    @defer.inlineCallbacks
+    def test_remote_ssh_wol_action_no_keys(self, write_local_file_mock,
+                                           temp_dir_mock):
+        self.expectCommands(
+            gpo.Expect('ssh', 'remote_host', 'wakeonlan', '00:11:22:33:44:55')
+            .exit(0),
+            gpo.Expect('ssh', 'remote_host', 'wolbin', '00:11:22:33:44:55')
+            .exit(0),
+        )
+
+        manager = FakeManager()
+        action = RemoteSshWOLAction('remote_host', '00:11:22:33:44:55')
+        self.assertTrue((yield action.perform(manager)))
+
+        action = RemoteSshWOLAction('remote_host', '00:11:22:33:44:55',
+                                    wolBin='wolbin')
+        self.assertTrue((yield action.perform(manager)))
+        self.assertAllCommandsRan()
+
+        self.assertEqual(temp_dir_mock.dirs, [])
+        write_local_file_mock.assert_not_called()
+
+    @mock.patch('buildbot.util.private_tempdir.PrivateTemporaryDirectory',
+                new_callable=MockPrivateTemporaryDirectory)
+    @mock.patch('buildbot.util.misc.writeLocalFile')
+    @defer.inlineCallbacks
+    def test_remote_ssh_suspend_action_no_keys(self, write_local_file_mock,
+                                               temp_dir_mock):
+        self.expectCommands(
+            gpo.Expect('ssh', 'remote_host', 'systemctl', 'suspend')
+            .exit(0),
+            gpo.Expect('ssh', 'remote_host', 'dosuspend', 'arg1')
+            .exit(0),
+        )
+
+        manager = FakeManager()
+        action = RemoteSshSuspendAction('remote_host')
+        self.assertTrue((yield action.perform(manager)))
+
+        action = RemoteSshSuspendAction('remote_host',
+                                        remoteCommand=['dosuspend', 'arg1'])
+        self.assertTrue((yield action.perform(manager)))
+        self.assertAllCommandsRan()
+
+        self.assertEqual(temp_dir_mock.dirs, [])
+        write_local_file_mock.assert_not_called()

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -81,6 +81,11 @@ class AbstractLatentWorker(AbstractWorker):
     build_wait_timer = None
     start_missing_on_startup = False
 
+    # override if the latent worker may connect without substantiate. Most
+    # often this will be used in workers whose lifetime is managed by
+    # latent machines.
+    starts_without_substantiate = False
+
     # Caveats: The handling of latent workers is much more complex than it
     # might seem. The code must handle at least the following conditions:
     #
@@ -507,3 +512,19 @@ class AbstractLatentWorker(AbstractWorker):
             if b.name not in self.workerforbuilders:
                 b.addLatentWorker(self)
         return super().updateWorker()
+
+
+class LocalLatentWorker(AbstractLatentWorker):
+    """
+    A worker that can be suspended by shutting down or suspending the hardware
+    it runs on. It is intended to be used with LatentMachines.
+    """
+    starts_without_substantiate = True
+
+    def checkConfig(self, name, password, **kwargs):
+        super.checkConfig(self, name, password, build_wait_timeout=-1,
+                          **kwargs)
+
+    def reconfigService(self, name, password, **kwargs):
+        return super().reconfigService(name, password, build_wait_timeout=-1,
+                                       **kwargs)


### PR DESCRIPTION
This PR implements a type of latent machine that can do any action for wake and shutdown. Several actions geared towards management of physical hosts via ssh are implemented. This functionality is unlikely to be used in any commercial build farm as there are more convenient tools to manage large number of machines. However it's still valuable as a toy implementation of the concept and also for small build farms where reduction of noise and/or power use is relatively more important.

The API is currently not intended to be used by the end users, therefore there are no API documentation nor release notes yet. My plan is to verify that the APIs are relatively future-proof by implementing and testing `EC2LatentMachine` in a subsequent PR. Documentation and release notes will be written after that.