### PR TITLE
worker: add test for invalid utf-8 output

### DIFF
--- a/worker/tox.ini
+++ b/worker/tox.ini
@@ -4,7 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py24, py25, py26, py27
+envlist = py24, py25, py26, py27, py35, py36, py37
 
 [testenv]
+deps = setuptools_trial
 commands = python setup.py test


### PR DESCRIPTION
Add a unit test for worker receiving invalid utf-8 output, and update tox