### PR TITLE
www: Add release note for CoffeeScript removal

### DIFF
--- a/master/buildbot/newsfragments/www-coffeescript-removal.misc
+++ b/master/buildbot/newsfragments/www-coffeescript-removal.misc
@@ -1,0 +1,4 @@
+The implementation language of the Buildbot web frontend has been changed from CoffeeScript to JavaScript.
+The documentation has not been updated yet, as we plan to transition to TypeScript.
+In the transitory period support for some browsers, notably IE 11 has been dropped.
+We hope to bring support for older browsers back once the transitory period is over.


### PR DESCRIPTION
This PR adds a release note for CoffeeScript removal, which is not entirely internal matter, as some browsers have been dropped temporarily.