### PR TITLE
worker: test for invalid utf-8 in log file and fix the LogFileWatcher

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1456,6 +1456,7 @@ txrequests
 txt
 tz
 ubuntu
+ufffd
 ui
 uid
 umask

--- a/worker/buildbot_worker/invalid_utf8.bugfix
+++ b/worker/buildbot_worker/invalid_utf8.bugfix
@@ -1,0 +1,2 @@
+- Fixed escaping of invalid UTF-8 sequences in log files that are
+  being watched by the worker (:issue:`4744`).

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -857,3 +857,20 @@ class TestLogFileWatcher(BasedirMixin, unittest.TestCase):
         self.assertEqual(
             st and st[2], 2, "statfile.log exists and size is correct")
         os.remove('statfile.log')
+
+    def test_invalid_utf8(self):
+        # create the log file watcher first
+        rp = self.makeRP()
+        lf = runprocess.LogFileWatcher(rp, 'test', 'invalid_utf8.log',
+                                       follow=False, poll=False)
+        # now write to the log file
+        INVALID_UTF8 = b'\xff'
+        with open('invalid_utf8.log', 'wb') as f:
+            f.write(INVALID_UTF8)
+        # the watcher picks up the changed log
+        lf.poll()
+        # flush she buffer
+        rp._sendBuffers()
+        # cleanup
+        lf.stop()
+        os.remove('invalid_utf8.log')


### PR DESCRIPTION
The log file watcher does not utf-8 decode the file content, so
* RunProcessPP.outReceived safely decodes (ignoring errors) before calling RunProcess.addStdout
* LogFileWatcher.poll does not decode before calling RunProcess.addLogfile
So if the log file contains invalid utf-8, once the buffered logs are flushed, we trigger a UnicodeDecodeError

The added unit case fails with UnicodeDecodeError without the change to LogFileWatcher