### PR TITLE
Fixed try client by replaceing str functions with decode

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -460,9 +460,9 @@ def createJobfile(jobid, branch, baserev, patch_level, patch_body, repository,
     if version < 5:
         job += ns(jobid)
         job += ns(branch)
-        job += ns(str(baserev))
+        job += ns(baserev.decode())
         job += ns("{}".format(patch_level))
-        job += ns(patch_body or "")
+        job += ns(patch_body.decode() or "")
         job += ns(repository)
         job += ns(project)
         if (version >= 3):
@@ -474,8 +474,8 @@ def createJobfile(jobid, branch, baserev, patch_level, patch_body, repository,
     else:
         job += ns(
             json.dumps({
-                'jobid': jobid, 'branch': branch, 'baserev': str(baserev),
-                'patch_level': patch_level, 'patch_body': patch_body,
+                'jobid': jobid, 'branch': branch, 'baserev': baserev.decode(),
+                'patch_level': "{}".format(patch_level), 'patch_body': patch_body.decode(),
                 'repository': repository, 'project': project, 'who': who,
                 'comment': comment, 'builderNames': builderNames,
                 'properties': properties,
@@ -509,7 +509,7 @@ class RemoteTryPP(protocol.ProcessProtocol):
         self.d = defer.Deferred()
 
     def connectionMade(self):
-        self.transport.write(self.job)
+        self.transport.write(self.job.encode('utf-8'))
         self.transport.closeStdin()
 
     def outReceived(self, data):


### PR DESCRIPTION
Fixes errors that were occuring with the try scheduler on Python 3
with git vc that was caused by invalid conversions from bytes to
strings.

I am not sure if this is the ideal solution. I tried to run the test scripts but many of them failed even on master. The patch seems to work on my machine&trade; but the tests seem to be failing. I am not very familiar with python so please let me know if something can be improved. This address the errors in #4746 

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
