### PR TITLE
Change git ssh data dir to be more unique

### DIFF
--- a/master/buildbot/newsfragments/git-ssh-data-path-fix.bugfix
+++ b/master/buildbot/newsfragments/git-ssh-data-path-fix.bugfix
@@ -1,1 +1,1 @@
-:py:class:`~buildbot.util.git.GitStepMixin`: Change ssh data path to be more unique for a given builder
+:py:class:`~buildbot.util.git.GitStepMixin`: Prevent builders from corrupting temporary ssh data path by using builder name as part of the path

--- a/master/buildbot/newsfragments/git-ssh-data-path-fix.bugfix
+++ b/master/buildbot/newsfragments/git-ssh-data-path-fix.bugfix
@@ -1,0 +1,1 @@
+:py:class:`~buildbot.util.git.GitStepMixin`: Change ssh data path to be more unique for a given builder

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -95,8 +95,8 @@ class TestGit(sourcesteps.SourceStepMixin,
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
 
@@ -154,8 +154,8 @@ class TestGit(sourcesteps.SourceStepMixin,
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
         ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
 
         self.expectCommands(
@@ -212,9 +212,9 @@ class TestGit(sourcesteps.SourceStepMixin,
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
-        ssh_wrapper_path = '/wrk/.wkdir.buildbot/ssh-wrapper.sh'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
+        ssh_wrapper_path = '/wrk/.Builder.wkdir.buildbot/ssh-wrapper.sh'
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',
@@ -281,9 +281,9 @@ class TestGit(sourcesteps.SourceStepMixin,
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='clean', sshPrivateKey='sshkey', **class_params))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
-        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
+        ssh_known_hosts_path = '/wrk/.Builder.wkdir.buildbot/ssh-known-hosts'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}" ' \
             '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
@@ -351,9 +351,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
-        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
+        ssh_known_hosts_path = '/wrk/.Builder.wkdir.buildbot/ssh-known-hosts'
         ssh_command = \
             'ssh -i "{0}" ' \
             '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
@@ -421,10 +421,10 @@ class TestGit(sourcesteps.SourceStepMixin,
                            mode='full', method='clean', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
-        ssh_wrapper_path = '/wrk/.wkdir.buildbot/ssh-wrapper.sh'
-        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
+        ssh_wrapper_path = '/wrk/.Builder.wkdir.buildbot/ssh-wrapper.sh'
+        ssh_known_hosts_path = '/wrk/.Builder.wkdir.buildbot/ssh-known-hosts'
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',
@@ -498,9 +498,9 @@ class TestGit(sourcesteps.SourceStepMixin,
         workdir = '/myworkdir/workdir'
         self.build.workdir = workdir
 
-        ssh_workdir = '/myworkdir/.workdir.buildbot'
-        ssh_key_path = '/myworkdir/.workdir.buildbot/ssh-key'
-        ssh_known_hosts_path = '/myworkdir/.workdir.buildbot/ssh-known-hosts'
+        ssh_workdir = '/myworkdir/.Builder.workdir.buildbot'
+        ssh_key_path = '/myworkdir/.Builder.workdir.buildbot/ssh-key'
+        ssh_known_hosts_path = '/myworkdir/.Builder.workdir.buildbot/ssh-known-hosts'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}" ' \
             '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
@@ -608,8 +608,8 @@ class TestGit(sourcesteps.SourceStepMixin,
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.changeWorkerSystem('win32')
 
-        ssh_workdir = '\\wrk\\.wkdir.buildbot'
-        ssh_key_path = '\\wrk\\.wkdir.buildbot\\ssh-key'
+        ssh_workdir = '\\wrk\\.Builder.wkdir.buildbot'
+        ssh_key_path = '\\wrk\\.Builder.wkdir.buildbot\\ssh-key'
         ssh_command_config = 'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
 
         self.expectCommands(
@@ -667,8 +667,8 @@ class TestGit(sourcesteps.SourceStepMixin,
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.changeWorkerSystem('win32')
 
-        ssh_workdir = '\\wrk\\.wkdir.buildbot'
-        ssh_key_path = '\\wrk\\.wkdir.buildbot\\ssh-key'
+        ssh_workdir = '\\wrk\\.Builder.wkdir.buildbot'
+        ssh_key_path = '\\wrk\\.Builder.wkdir.buildbot\\ssh-key'
         ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
 
         self.expectCommands(
@@ -726,9 +726,9 @@ class TestGit(sourcesteps.SourceStepMixin,
                            mode='full', method='clean', sshPrivateKey='sshkey'))
         self.changeWorkerSystem('win32')
 
-        ssh_workdir = '\\wrk\\.wkdir.buildbot'
-        ssh_key_path = '\\wrk\\.wkdir.buildbot\\ssh-key'
-        ssh_wrapper_path = '\\wrk\\.wkdir.buildbot\\ssh-wrapper.sh'
+        ssh_workdir = '\\wrk\\.Builder.wkdir.buildbot'
+        ssh_key_path = '\\wrk\\.Builder.wkdir.buildbot\\ssh-key'
+        ssh_wrapper_path = '\\wrk\\.Builder.wkdir.buildbot\\ssh-wrapper.sh'
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',
@@ -1634,8 +1634,8 @@ class TestGit(sourcesteps.SourceStepMixin,
                            mode='incremental', branch='test-branch',
                            sshPrivateKey='ssh-key'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
 
@@ -2338,8 +2338,8 @@ class TestGit(sourcesteps.SourceStepMixin,
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='full', method='copy', sshPrivateKey='sshkey'))
 
-        ssh_workdir = '/wrk/.source.buildbot'
-        ssh_key_path = '/wrk/.source.buildbot/ssh-key'
+        ssh_workdir = '/wrk/.Builder.source.buildbot'
+        ssh_key_path = '/wrk/.Builder.source.buildbot/ssh-key'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
 
@@ -3447,8 +3447,8 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}"'.format(ssh_key_path)
 
@@ -3487,8 +3487,8 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
         ssh_command = 'ssh -i "{0}"'.format(ssh_key_path)
 
         self.expectCommands(
@@ -3526,9 +3526,9 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
             self.stepClass(workdir='wkdir', repourl=url,
                            branch='testbranch', sshPrivateKey='sshKey'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
-        ssh_wrapper_path = '/wrk/.wkdir.buildbot/ssh-wrapper.sh'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
+        ssh_wrapper_path = '/wrk/.Builder.wkdir.buildbot/ssh-wrapper.sh'
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',
@@ -3573,9 +3573,9 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
-        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
+        ssh_known_hosts_path = '/wrk/.Builder.wkdir.buildbot/ssh-known-hosts'
         ssh_command_config = \
             'core.sshCommand=ssh -i "{0}" ' \
             '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
@@ -3623,9 +3623,9 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
-        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
+        ssh_known_hosts_path = '/wrk/.Builder.wkdir.buildbot/ssh-known-hosts'
         ssh_command = \
             'ssh -i "{0}" ' \
             '-o "UserKnownHostsFile={1}"'.format(ssh_key_path,
@@ -3673,10 +3673,10 @@ class TestGitPush(steps.BuildStepMixin, config.ConfigErrorsMixin,
                            branch='testbranch', sshPrivateKey='sshkey',
                            sshHostKey='sshhostkey'))
 
-        ssh_workdir = '/wrk/.wkdir.buildbot'
-        ssh_key_path = '/wrk/.wkdir.buildbot/ssh-key'
-        ssh_wrapper_path = '/wrk/.wkdir.buildbot/ssh-wrapper.sh'
-        ssh_known_hosts_path = '/wrk/.wkdir.buildbot/ssh-known-hosts'
+        ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
+        ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
+        ssh_wrapper_path = '/wrk/.Builder.wkdir.buildbot/ssh-wrapper.sh'
+        ssh_known_hosts_path = '/wrk/.Builder.wkdir.buildbot/ssh-known-hosts'
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -151,24 +151,22 @@ class GitStepMixin(GitMixin):
         # temporary directory for that data to ensure the confidentiality of it.
         # So instead of
         # '{path}/{to}/{workdir}/.buildbot-ssh-key' we put the key at
-        # '{path}/{to}/.{workdir}.buildbot/ssh-key'.
+        # '{path}/{to}/.{builder_name}.{workdir}.buildbot/ssh-key'.
 
         # basename and dirname interpret the last element being empty for paths
         # ending with a slash
         path_module = self.build.path_module
 
-        if self.build.hasProperty("builddir"):
-            base_path = self.build.getProperty("builddir").rstrip("/\\")
-        else:
-            base_path = self._getSshDataWorkDir().rstrip("/\\")
+        workdir = self._getSshDataWorkDir().rstrip("/\\")
 
-        if path_module.isabs(base_path):
-            parent_path = path_module.dirname(base_path)
+        if path_module.isabs(workdir):
+            parent_path = path_module.dirname(workdir)
         else:
             parent_path = path_module.join(self.worker.worker_basedir,
-                                           path_module.dirname(base_path))
+                                           path_module.dirname(workdir))
 
-        basename = '.{0}.buildbot'.format(path_module.basename(base_path))
+        basename = '.{0}.{1}.buildbot'.format(self.build.builder.name,
+                                              path_module.basename(workdir))
         return path_module.join(parent_path, basename)
 
     def _getSshPrivateKeyPath(self, ssh_data_path):

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -157,7 +157,7 @@ class GitStepMixin(GitMixin):
         # ending with a slash
         path_module = self.build.path_module
 
-        workdir = self._getSshDataWorkDir().rstrip("/\\")
+        workdir = self._getSshDataWorkDir().rstrip('/\\')
 
         if path_module.isabs(workdir):
             parent_path = path_module.dirname(workdir)

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -157,14 +157,18 @@ class GitStepMixin(GitMixin):
         # ending with a slash
         path_module = self.build.path_module
 
-        workdir = self._getSshDataWorkDir().rstrip('/\\')
-        if path_module.isabs(workdir):
-            parent_path = path_module.dirname(workdir)
+        if self.build.hasProperty("builddir"):
+            base_path = self.build.getProperty("builddir").rstrip("/\\")
+        else:
+            base_path = self._getSshDataWorkDir().rstrip("/\\")
+
+        if path_module.isabs(base_path):
+            parent_path = path_module.dirname(base_path)
         else:
             parent_path = path_module.join(self.worker.worker_basedir,
-                                           path_module.dirname(workdir))
+                                           path_module.dirname(base_path))
 
-        basename = '.{0}.buildbot'.format(path_module.basename(workdir))
+        basename = '.{0}.buildbot'.format(path_module.basename(base_path))
         return path_module.join(parent_path, basename)
 
     def _getSshPrivateKeyPath(self, ssh_data_path):


### PR DESCRIPTION
Currently if you have multiple builders running on the same worker
with the same workdir, the ssh keys are trying to be downloaded to the
same path, which obviously causes problems with parallel builds on the same worker.

This change tries to use the builddir parameter to make the path more unique
for each builder so they won't interfere with each other.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
