### PR TITLE
MasterShellCommand should not print master's environment variables by default

### DIFF
--- a/master/buildbot/newsfragments/mastershellcommand_logenviron.bugfix
+++ b/master/buildbot/newsfragments/mastershellcommand_logenviron.bugfix
@@ -1,0 +1,1 @@
+MasterShellCommand should not print master's environment variables by default (:issue:`4770`)

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -47,7 +47,7 @@ class MasterShellCommand(BuildStep):
         self.env = kwargs.pop('env', None)
         self.usePTY = kwargs.pop('usePTY', 0)
         self.interruptSignal = kwargs.pop('interruptSignal', 'KILL')
-        self.logEnviron = kwargs.pop('logEnviron', True)
+        self.logEnviron = kwargs.pop('logEnviron', False)
 
         super().__init__(**kwargs)
 


### PR DESCRIPTION
Fixed https://github.com/buildbot/buildbot/issues/4770