### PR TITLE
Fix the date format for GerritEventLogPoller

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -374,7 +374,7 @@ class GerritEventLogPoller(GerritChangeSourceBase):
             last_event = self.now()
         else:
             last_event = datetime.datetime.utcfromtimestamp(last_event_ts)
-        last_event_formatted = last_event.strftime("%Y-%d-%m %H:%M:%S")
+        last_event_formatted = last_event.strftime("%Y-%m-%d %H:%M:%S")
         res = yield self._http.get("/plugins/events-log/events/", params=dict(t1=last_event_formatted))
         lines = yield res.content()
         for line in lines.splitlines():

--- a/master/buildbot/newsfragments/fix_gerriteventlogpoller_datefmt.bugfix
+++ b/master/buildbot/newsfragments/fix_gerriteventlogpoller_datefmt.bugfix
@@ -1,0 +1,1 @@
++Fix GerritEventLogPoller was using the wrong date format.

--- a/master/buildbot/test/unit/test_changes_gerritchangesource.py
+++ b/master/buildbot/test/unit/test_changes_gerritchangesource.py
@@ -235,8 +235,8 @@ class TestGerritEventLogPoller(changesource.ChangeSourceMixin,
                                unittest.TestCase):
     NOW_TIMESTAMP = 1479302598
     EVENT_TIMESTAMP = 1479302599
-    NOW_FORMATTED = '2016-16-11 13:23:18'
-    EVENT_FORMATTED = '2016-16-11 13:23:19'
+    NOW_FORMATTED = '2016-11-16 13:23:18'
+    EVENT_FORMATTED = '2016-11-16 13:23:19'
     OBJECTID = 1234
 
     @defer.inlineCallbacks

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -1338,10 +1338,12 @@ GerritEventLogPoller
 
 The :bb:chsrc:`GerritEventLogPoller` class is similar to :bb:chsrc:`GerritChangeSource` but connects to the Gerrit server by its HTTP interface and uses the events-log_ plugin.
 
-It is possible to use both :bb:chsrc:`GerritEventLogPoller` and :bb:chsrc:`GerritChangeSource` together which is advantageous because:
+Note that the decision of whether to use :bb:chsrc:`GerritEventLogPoller` and :bb:chsrc:`GerritChangeSource` will depend on your needs. The trade off is:
 
 1. :bb:chsrc:`GerritChangeSource` is low-overhead and reacts instantaneously to events, but a broken connection to Gerrit will lead to missed changes
 2. :bb:chsrc:`GerritEventLogPoller` is subject to polling overhead and reacts only at it's polling rate, but is robust to a broken connection to Gerrit and missed changes will be discovered when a connection is restored.
+
+However, you probably do not want use both at the same time as they do not coordinate and changes will be duplicated in this case.
 
 .. note::
 
@@ -1560,4 +1562,3 @@ Change Properties
 
 A Change may have one or more properties attached to it, usually specified through the Force Build form or :bb:cmdline:`sendchange`.
 Properties are discussed in detail in the :ref:`Build-Properties` section.
-


### PR DESCRIPTION
The [date format expected][1] by the events-log plugin for gerrit version 2.16 is:

```
  private static final DateTimeFormatter DATE_TIME_FORMAT =
      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
  private static final DateTimeFormatter DATE_ONLY_FORMAT =
      DateTimeFormatter.ofPattern("yyyy-MM-dd");
```

This seems to be the case for version [2.15][2], [2.14][3], [2.13][4] as well.
In fact, I'm wondering how this ever worked? 

This change also adds a few additional documentation notes on the usage of 
`GerritEventLogPoller` and `GerritChangeSource`.

[1]: https://gerrit.googlesource.com/plugins/events-log/+/refs/heads/stable-2.16/src/main/java/com/ericsson/gerrit/plugins/eventslog/sql/SQLQueryMaker.java#37
[2]: https://gerrit.googlesource.com/plugins/events-log/+/refs/heads/stable-2.15/src/main/java/com/ericsson/gerrit/plugins/eventslog/sql/SQLQueryMaker.java#37
[3]: https://gerrit.googlesource.com/plugins/events-log/+/refs/heads/stable-2.14/src/main/java/com/ericsson/gerrit/plugins/eventslog/sql/SQLQueryMaker.java#37
[4]: https://gerrit.googlesource.com/plugins/events-log/+/refs/heads/stable-2.13/src/main/java/com/ericsson/gerrit/plugins/eventslog/sql/SQLQueryMaker.java#37

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
