### PR TITLE
GitTag: Fix tagName arguments not in renderable list

### DIFF
--- a/master/buildbot/newsfragments/gitTag-tagName-not-renderable.bugfix
+++ b/master/buildbot/newsfragments/gitTag-tagName-not-renderable.bugfix
@@ -1,0 +1,1 @@
+:py:class:`~buildbot.util.git.GitTag`: Allow ``tagName`` to be a renderable

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -605,7 +605,7 @@ class GitTag(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
     descriptionSuffix = None
 
     name = 'gittag'
-    renderables = ['repourl', 'name', 'messages']
+    renderables = ['repourl', 'tagName', 'messages']
 
     def __init__(self, workdir=None, tagName=None,
                  annotated=False, messages=None, force=False, env=None,


### PR DESCRIPTION
The parameter tagName of the GitTag step is not in the renderable list.

I don't know if I should create a unit test for testing that all parameters are renderables ? I looked in the other git buildstep unit test and I don't found any.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
