### PR TITLE
Revert "master: Accept GitHub `access_token` directly from user"

### DIFF
--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -194,30 +194,7 @@ class OAuth2Auth(www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
                           'full_name': 'foo bar'}, res)
 
     @defer.inlineCallbacks
-    def test_GithubAcceptToken(self):
-        requests.get.side_effect = []
-        requests.post.side_effect = [
-            FakeResponse(dict(access_token="TOK3N"))]
-        self.githubAuth.get = mock.Mock(side_effect=[
-            dict(  # /user
-                login="bar",
-                name="foo bar",
-                email="buzz@bar"),
-            [  # /user/emails
-                {'email': 'buzz@bar', 'verified': True, 'primary': False},
-                {'email': 'bar@foo', 'verified': True, 'primary': True}],
-            [  # /user/orgs
-                dict(login="hello"),
-                dict(login="grp"),
-            ]])
-        res = yield self.githubAuth.acceptToken("TOK3N")
-        self.assertEqual({'email': 'bar@foo',
-                          'username': 'bar',
-                          'groups': ["hello", "grp"],
-                          'full_name': 'foo bar'}, res)
-
-    @defer.inlineCallbacks
-    def test_GithubAcceptToken_v4(self):
+    def test_GithubVerifyCode_v4(self):
         requests.get.side_effect = []
         requests.post.side_effect = [
             FakeResponse(dict(access_token="TOK3N"))]
@@ -246,14 +223,14 @@ class OAuth2Auth(www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
                 }
             }
         ])
-        res = yield self.githubAuth_v4.acceptToken("TOK3N")
+        res = yield self.githubAuth_v4.verifyCode("code!")
         self.assertEqual({'email': 'bar@foo',
                           'username': 'bar',
                           'groups': ["hello", "grp"],
                           'full_name': 'foo bar'}, res)
 
     @defer.inlineCallbacks
-    def test_GithubAcceptToken_v4_teams(self):
+    def test_GithubVerifyCode_v4_teams(self):
         requests.get.side_effect = []
         requests.post.side_effect = [
             FakeResponse(dict(access_token="TOK3N"))]
@@ -334,7 +311,7 @@ class OAuth2Auth(www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
                 }
             }
         ])
-        res = yield self.githubAuth_v4_teams.acceptToken("TOK3N")
+        res = yield self.githubAuth_v4_teams.verifyCode("code!")
         self.assertEqual({'email': 'bar@foo',
                           'username': 'bar',
                           'groups': [
@@ -437,11 +414,9 @@ class OAuth2Auth(www.WwwTestMixin, ConfigErrorsMixin, unittest.TestCase):
         rsrc.auth.verifyCode.assert_called_once_with(b"code!")
         self.assertEqual(self.master.session.user_info, {'username': 'bar'})
         self.assertEqual(res, {'redirected': b'://me'})
+        # token not supported anymore
         res = yield self.render_resource(rsrc, b'/?token=token!')
-        rsrc.auth.getLoginURL.assert_not_called()
-        rsrc.auth.acceptToken.assert_called_once_with(b"token!")
-        self.assertEqual(self.master.session.user_info, {'username': 'bar'})
-        self.assertEqual(res, {'redirected': b'://me'})
+        rsrc.auth.getLoginURL.assert_called_once()
 
     def test_getConfig(self):
         self.assertEqual(self.githubAuth.getConfigDict(), {'fa_icon': 'fa-github', 'autologin': False,

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -53,16 +53,12 @@ class OAuth2LoginResource(auth.LoginResource):
     @defer.inlineCallbacks
     def renderLogin(self, request):
         code = request.args.get(b"code", [b""])[0]
-        token = request.args.get(b"token", [b""])[0]
-        if not token and not code:
+        if not code:
             url = request.args.get(b"redirect", [None])[0]
             url = yield self.auth.getLoginURL(url)
             raise resource.Redirect(url)
         else:
-            if not token:
-                details = yield self.auth.verifyCode(code)
-            else:
-                details = yield self.auth.acceptToken(token)
+            details = yield self.auth.verifyCode(code)
             if self.auth.userInfoProvider is not None:
                 infos = yield self.auth.userInfoProvider.getUserInfo(details['username'])
                 details.update(infos)
@@ -131,14 +127,6 @@ class OAuth2Auth(auth.AuthBase):
     def get(self, session, path):
         ret = session.get(self.resourceEndpoint + path)
         return ret.json()
-
-    # If the user wants to authenticate directly with an access token they
-    # already have, go ahead and just directly accept an access_token from them.
-    def acceptToken(self, token):
-        def thd():
-            session = self.createSessionFromToken({'access_token': token})
-            return self.getUserInfoFromOAuthClient(session)
-        return threads.deferToThread(thd)
 
     # based on https://github.com/maraujop/requests-oauth
     # from Miguel Araujo, augmented to support header based clientSecret


### PR DESCRIPTION
Backport of https://github.com/buildbot/buildbot/pull/4763 to 1.8.x.

Test failures are not caused by this PR and will be fixed in another PR.