### PR TITLE
Add release notes for releases that have branched off master

### DIFF
--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -10,6 +10,16 @@ Release Notes
 
 .. towncrier release notes start
 
+Buildbot ``2.3.1`` ( ``2019-05-22`` )
+=====================================
+
+Bug fixes
+---------
+
+- Fix vulnerability in OAuth where user-submitted authorization token was used for authentication
+  (https://github.com/buildbot/buildbot/wiki/OAuth-vulnerability-in-using-submitted-authorization-token-for-authentication)
+  Thanks to Phillip Kuhrt for reporting it.
+
 Buildbot ``2.3.0`` ( ``2019-05-06`` )
 =====================================
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -155,6 +155,16 @@ Features
 - Identifiers can now contain UTF-8 characters which are not ASCII. This
   includes worker names, builder names, and step names.
 
+Buildbot ``1.8.2`` ( ``2019-05-22`` )
+=====================================
+
+Bug fixes
+---------
+
+- Fix vulnerability in OAuth where user-submitted authorization token was used for authentication
+  (https://github.com/buildbot/buildbot/wiki/OAuth-vulnerability-in-using-submitted-authorization-token-for-authentication)
+  Thanks to Phillip Kuhrt for reporting it.
+
 Buildbot ``1.8.1`` ( ``2019-02-02`` )
 =====================================
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -155,6 +155,14 @@ Features
 - Identifiers can now contain UTF-8 characters which are not ASCII. This
   includes worker names, builder names, and step names.
 
+Buildbot ``1.8.1`` ( ``2019-02-02`` )
+=====================================
+
+Bug fixes
+---------
+
+- Fix CRLF injection vulnerability with validating user provided redirect parameters (https://github.com/buildbot/buildbot/wiki/CRLF-injection-in-Buildbot-login-and-logout-redirect-code)
+  Thanks to ``mik317`` and ``mariadb`` for reporting it.
 
 Buildbot ``1.8.0`` ( ``2019-01-20`` )
 =====================================

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -429,6 +429,7 @@ KiB
 kibibytes
 kube
 kubernetes
+Kuhrt
 kv
 kwargs
 latin


### PR DESCRIPTION
Currently the release notes of releases that have branched off master (e.g. v1.8.1) are hard to find - you need to go directly to the documentation for that specific version. Including these release notes into the list of the release notes for master improves this situation.