### PR TITLE
steps.http: Add option to hide HTTP header values from log.

### DIFF
--- a/master/buildbot/newsfragments/hide-http-headers.feature
+++ b/master/buildbot/newsfragments/hide-http-headers.feature
@@ -1,0 +1,1 @@
+:py:class:`~buildbot.steps.http.HTTPStep`: Add the option to hide sensitive HTTP header values from the log.

--- a/master/docs/manual/configuration/buildsteps.rst
+++ b/master/docs/manual/configuration/buildsteps.rst
@@ -3071,6 +3071,14 @@ The parameters are the following:
 ``headers``
     Dictionary of headers to send.
 
+``hide_request_headers``
+   Iterable of request headers to be hidden from the log.
+   The header will be listed in the log but the value will be shown as ``<HIDDEN>``.
+
+``hide_response_headers``
+   Iterable of response headers to be hidden from the log.
+   The header will be listed in the log but the value will be shown as ``<HIDDEN>``.
+
 ``other params``
     Any other keywords supported by the ``requests``
     `api <http://docs.python-requests.org/en/master/api/#main-interface>`_


### PR DESCRIPTION
This PR adds two options to the HTTPStep: `hide_request_headers` and `hide_response_headers`. These can be used to remove sensitive information from the logs.

The headers will still appear in the log, but with a value of `<HIDDEN>`, rather than the actual value. This can't be distinguished from a header with the actual value `<HIDDEN>`. However, I think that's not really a problem in practice. It can be important to know the header is present, even if the value shouldn't be logged.