### PR TITLE
www: Remove yarn-update-local command

### DIFF
--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -208,7 +208,6 @@ class BuildJsCommand(distutils.cmd.Command):
 
             commands = []
 
-            commands.append(['yarn', 'run', 'yarn-update-local'])
             commands.append(['yarn', 'install', '--pure-lockfile'])
 
             if os.path.exists("gulpfile.js"):


### PR DESCRIPTION
Ensure buildbot_pkg is still able to build guanlecoja based plugins.

Fixes https://github.com/buildbot/buildbot/issues/4778

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
