### PR TITLE
waterfall_view: Add show_builders_without_builds option

### DIFF
--- a/www/waterfall_view/src/module/main.module.js
+++ b/www/waterfall_view/src/module/main.module.js
@@ -110,7 +110,7 @@ var WaterfallController = (function() {
 
             // Load data (builds and builders)
             this.all_builders = this.dataAccessor.getBuilders({order: 'name'});
-            this.$scope.builders = (this.builders = []);
+            this.$scope.builders = (this.builders = this.all_builders);
             this.buildLimit = this.c.limit;
             this.$scope.builds = (this.builds = this.dataAccessor.getBuilds({limit: this.buildLimit, order: '-started_at'}));
 
@@ -122,7 +122,11 @@ var WaterfallController = (function() {
 
                 // Create groups and add builds to builders
                 this.groups = this.dataProcessorService.getGroups(this.all_builders, this.builds, this.c.threshold);
-                this.$scope.builders = (this.builders = this.dataProcessorService.filterBuilders(this.all_builders));
+                if (this.s.show_builders_without_builds.value) {
+                    this.$scope.builders = this.all_builders;
+                } else {
+                    this.$scope.builders = (this.builders = this.dataProcessorService.filterBuilders(this.all_builders));
+                }
                 // Add builder status to builders
                 this.dataProcessorService.addStatus(this.builders);
 
@@ -633,7 +637,11 @@ var WaterfallController = (function() {
 
         renderNewData() {
             this.groups = this.dataProcessorService.getGroups(this.all_builders, this.builds, this.c.threshold);
-            this.$scope.builders = (this.builders = this.dataProcessorService.filterBuilders(this.all_builders));
+            if (this.s.show_builders_without_builds.value) {
+                this.$scope.builders = this.all_builders;
+            } else {
+                this.$scope.builders = (this.builders = this.dataProcessorService.filterBuilders(this.all_builders));
+            }
             this.dataProcessorService.addStatus(this.builders);
             this.render();
             return this.loadingMore = false;

--- a/www/waterfall_view/src/module/waterfall.config.js
+++ b/www/waterfall_view/src/module/waterfall.config.js
@@ -34,6 +34,12 @@ class Waterfall {
                 caption: 'Build number background',
                 default_value: false
             }
+            , {
+                type: 'bool',
+                name: 'show_builders_without_builds',
+                caption: 'Show builders without builds',
+                default_value: false
+            }
             ]});
     }
 }


### PR DESCRIPTION
Allow builders with no builds to be displayed in Waterfall view.

Closes https://github.com/buildbot/buildbot/issues/4760

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
