### PR TITLE
Git step: pass the git submodule foreach subcommand as single argument

### DIFF
--- a/master/buildbot/newsfragments/gitstep-clean-submodules.bugfix
+++ b/master/buildbot/newsfragments/gitstep-clean-submodules.bugfix
@@ -1,0 +1,1 @@
+:py:class:`~buildbot.steps.source.git.Git`: Fix the invocation of `git submodule foreach` on cleaning

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -482,10 +482,10 @@ class Git(Source, GitStepMixin):
     def _cleanSubmodule(self, _=None):
         rc = RC_SUCCESS
         if self.submodules:
-            command = ['submodule', 'foreach', '--recursive',
-                       'git', 'clean', '-f', '-f', '-d']
+            subcommand = 'git clean -f -f -d'
             if self.mode == 'full' and self.method == 'fresh':
-                command.append('-x')
+                subcommand += ' -x'
+            command = ['submodule', 'foreach', '--recursive', subcommand]
             rc = yield self._dovccmd(command)
         return rc
 

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -1287,8 +1287,8 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'submodule', 'update', '--init', '--recursive'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'submodule', 'foreach', '--recursive', 'git', 'clean',
-                                 '-f', '-f', '-d'])
+                        command=['git', 'submodule', 'foreach', '--recursive',
+                                 'git clean -f -f -d'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d'])
@@ -1879,8 +1879,8 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'submodule', 'update', '--init', '--recursive'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'submodule', 'foreach', '--recursive', 'git', 'clean',
-                                 '-f', '-f', '-d', '-x'])
+                        command=['git', 'submodule', 'foreach', '--recursive',
+                                 'git clean -f -f -d -x'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
@@ -1930,8 +1930,8 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'submodule', 'update', '--init', '--recursive', '--force'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'submodule', 'foreach', '--recursive', 'git', 'clean',
-                                 '-f', '-f', '-d', '-x'])
+                        command=['git', 'submodule', 'foreach', '--recursive',
+                                 'git clean -f -f -d -x'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
@@ -1985,8 +1985,8 @@ class TestGit(sourcesteps.SourceStepMixin,
                                  '--force', '--checkout'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'submodule', 'foreach', '--recursive', 'git', 'clean',
-                                 '-f', '-f', '-d', '-x'])
+                        command=['git', 'submodule', 'foreach', '--recursive',
+                                 'git clean -f -f -d -x'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])


### PR DESCRIPTION
to prevent options aimed at the subcommand to be interpreted as options
for the "git submodule foreach" command.

This fixes the following error in git steps (using Git 2.21):

    $ git submodule foreach --recursive git clean -f -f -d
    error: unknown switch `f'
    usage: git submodule--helper foreach [--quiet] [--recursive] <command>

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation (not applicable)
