### PR TITLE
gitpoller: fix pushes with no commits, not a branch tip (#4809)

### DIFF
--- a/master/buildbot/newsfragments/gitpoller-pushes-no-commits-not-tip.bugfix
+++ b/master/buildbot/newsfragments/gitpoller-pushes-no-commits-not-tip.bugfix
@@ -1,0 +1,1 @@
+:py:class:`~buildbot.changes.gitpoller.GitPoller`: Trigger on pushes with no commits when the new revision is not the tip of another branch.


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
