### PR TITLE
www: Prevent accidental start of multiple force builds

### DIFF
--- a/master/buildbot/newsfragments/www-accidental-force-builds.bugfix
+++ b/master/buildbot/newsfragments/www-accidental-force-builds.bugfix
@@ -1,0 +1,1 @@
+Prevent accidental start of multiple force builds. (:issue:`4823`)

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.controller.js
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.controller.js
@@ -48,7 +48,13 @@ class forceDialog {
                     columns: 1
                 },
                 sch: scheduler,
+                startDisabled: false,
                 ok() {
+                    if ($scope.startDisabled == true) {
+                        // prevent multiple executions of scheduler
+                        return null;
+                    };
+                    $scope.startDisabled = true;
                     const params =
                         {builderid};
                     for (let name in all_fields_by_name) {
@@ -59,6 +65,7 @@ class forceDialog {
                     return scheduler.control('force', params)
                     .then(res => modal.modal.close(res.result)
                     ,   function(err) {
+                        $scope.startDisabled = false;
                         if (err === null) {
                             return;
                         }

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.tpl.jade
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.tpl.jade
@@ -9,4 +9,4 @@
             forcefield(field="rootfield" ng-if="rootfield")
     .modal-footer
       button.btn.btn-default(ng-click="cancel()") Cancel
-      button.btn.btn-primary(ng-click="ok()", ng-disabled="!sch.enabled") Start Build
+      button.btn.btn-primary(ng-click="ok()", ng-disabled="!sch.enabled || startDisabled") Start Build


### PR DESCRIPTION
Multiple force builds can be started if client is slow or if force
scheduler takes too long to execute. We disable the start button after it is
pressed to prevent this behavior.

Issue #4823

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
