### PR TITLE
smokes: Cleanup the configuration file

### DIFF
--- a/smokes/master.cfg
+++ b/smokes/master.cfg
@@ -6,41 +6,25 @@ from __future__ import print_function
 
 from buildbot.plugins import *
 
-# This is a sample buildmaster config file. It must be installed as
-# 'master.cfg' in your buildmaster's base directory.
-
 NUM_BUILDERS = 2
 
-# This is the dictionary that the buildmaster pays attention to. We also use
-# a shorter alias to save typing.
 c = BuildmasterConfig = {}
 
 ####### WORKERS
-# The 'workers' list defines the set of recognized workers. Each element is
-# a Worker object, specifying a unique worker name and password.  The same
-# worker name and password must be configured on the worker.
-c['workers'] = [worker.Worker("example-worker", "pass")]
 
-# 'protocols' contains information about protocols which master will use for
-# communicating with workers. You must define at least 'port' option that workers
-# could connect to your master with this protocol.
-# 'port' must match the value configured into the workers (with their
-# --master option)
+c['workers'] = [worker.Worker("example-worker", "pass")]
 c['protocols'] = {'pb': {'port': 9989}}
 
 
 ####### CHANGESOURCES
-# the 'change_source' setting tells the buildmaster how it should find out
-# about source code changes.  Here we point to the buildbot clone of pyflakes.
+
 c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
-        'https://github.com/buildbot/hello-world.git',
+        'https://github.com/buildbot/hello-world.git',  # the buildbot clone of pyflakes
         workdir='gitpoller-workdir', branch='master',
         pollinterval=300))
 
 ####### SCHEDULERS
-# Configure the Schedulers, which decide how to react to incoming changes.  In this
-# case, just kick off a 'runtests' build
 
 c['schedulers'] = []
 c['schedulers'].append(schedulers.SingleBranchScheduler(
@@ -80,57 +64,44 @@ c['schedulers'].append(schedulers.ForceScheduler(
             default="")]))
 
 ####### BUILDERS
-# The 'builders' list defines the Builders, which tell Buildbot how to perform a build:
-# what steps, and which workers can execute them.  Note that any particular build will
-# only take place on one worker.
 
 factory = util.BuildFactory()
-# check out the source
-factory.addStep(steps.Git(repourl='https://github.com/buildbot/hello-world.git', mode='incremental'))
+factory.addStep(steps.Git(repourl='https://github.com/buildbot/hello-world.git',
+                          mode='incremental'))
 factory.addStep(steps.ShellCommand(command=["trial", "hello"],
                                    env={"PYTHONPATH": "."}))
 
 slowfactory = util.BuildFactory()
-#check out the source
-slowfactory.addStep(steps.Git(repourl='https://github.com/buildbot/hello-world.git', mode='incremental'))
+slowfactory.addStep(steps.Git(repourl='https://github.com/buildbot/hello-world.git',
+                              mode='incremental'))
 slowfactory.addStep(steps.ShellCommand(command=["trial", "hello"],
                                        env={"PYTHONPATH": "."}))
 slowfactory.addStep(steps.ShellCommand(command=["sleep", "10"]))
 
 
-
 c['builders'] = []
 c['builders'].append(
     util.BuilderConfig(name="runtests",
-      workernames=["example-worker"],
-      factory=factory))
+                       workernames=["example-worker"],
+                       factory=factory))
 c['builders'].append(
     util.BuilderConfig(name="slowruntests",
-      workernames=["example-worker"],
-      factory=slowfactory))
+                       workernames=["example-worker"],
+                       factory=slowfactory))
 
 for i in range(NUM_BUILDERS):
     c['builders'].append(
         util.BuilderConfig(name="runtests" + str(i),
-          workernames=["example-worker"],
-          factory=factory))
+                           workernames=["example-worker"],
+                           factory=factory))
 
 
 ####### PROJECT IDENTITY
-# the 'title' string will appear at the top of this buildbot installation's
-# home pages (linked to the 'titleURL').
 
 c['title'] = "Pyflakes"
 c['titleURL'] = "https://launchpad.net/pyflakes"
-
-# the 'buildbotURL' string should point to the location where the buildbot's
-# internal web server is visible. This typically uses the port number set in
-# the 'www' entry below, but with an externally-visible host name which the
-# buildbot cannot figure out without some help.
-
 c['buildbotURL'] = "http://localhost:8011/"
 
-# minimalistic config to activate new web UI
 # we're not using the default port so that it would not accidentally conflict
 # with any development instances of buildbot on developer machines
 c['www'] = dict(port=8011,
@@ -139,10 +110,10 @@ c['www'] = dict(port=8011,
                 ui_default_config={'Builders.buildFetchLimit': 201})
 
 c['buildbotNetUsageData'] = None
+
 ####### DB URL
+
 c['db'] = {
-    # This specifies what database buildbot uses to store its state.  You can leave
-    # this at its default for all but the largest installations.
     'db_url': "sqlite:///state.sqlite",
 }
 


### PR DESCRIPTION
This is a simple PR to clean up extra comments from the smokes/master.cfg file. Most of the comments are only useful for beginner users of BuildBot, but that file is read only by the Buildbot developers. The result is that these comments are harmless because it's harder to find actually useful information dispersed within them.