### PR TITLE
Remove imports from __future__ as we're using python3 now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ release: virtualenv
 
 finishrelease:
 	rm -rf dist
-	python ./common/download_release.py
+	python3 ./common/download_release.py
 	rm -rf ./dist/v*
 	./common/smokedist.sh
 	twine upload --sign dist/*

--- a/common/download_release.py
+++ b/common/download_release.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import os
 

--- a/common/smokedist-download-compatible-chromedriver.py
+++ b/common/smokedist-download-compatible-chromedriver.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-from __future__ import absolute_import
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import argparse
 import re

--- a/master/buildbot/db/migrate/versions/052_cascading_set_null.py
+++ b/master/buildbot/db/migrate/versions/052_cascading_set_null.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import warnings
 
 import sqlalchemy as sa

--- a/master/buildbot/test/fake/kube.py
+++ b/master/buildbot/test/fake/kube.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import copy
 import time
 

--- a/master/buildbot/test/fake/private_tempdir.py
+++ b/master/buildbot/test/fake/private_tempdir.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 
 

--- a/master/buildbot/test/integration/test_worker_kubernetes.py
+++ b/master/buildbot/test/integration/test_worker_kubernetes.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 from unittest.case import SkipTest
 

--- a/master/buildbot/test/unit/test_db_migrate_versions_052_cascading_set_null.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_052_cascading_set_null.py
@@ -13,10 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import sqlalchemy as sa
 import sqlalchemy.exc as saexc
 

--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import base64
 import copy
 import os
@@ -99,7 +96,6 @@ class KubeClientServiceTestClusterConfig(
 
 
 KUBE_CTL_PROXY_FAKE = """
-from __future__ import print_function
 import time
 import sys
 
@@ -109,7 +105,6 @@ time.sleep(1000)
 """
 
 KUBE_CTL_PROXY_FAKE_ERROR = """
-from __future__ import print_function
 import time
 import sys
 

--- a/master/buildbot/test/unit/test_worker_kubernetes.py
+++ b/master/buildbot/test/unit/test_worker_kubernetes.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from twisted.internet import defer
 from twisted.trial import unittest
 

--- a/master/buildbot/util/kubeclientservice.py
+++ b/master/buildbot/util/kubeclientservice.py
@@ -13,10 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import abc
 import base64
 import os

--- a/master/buildbot/util/latent.py
+++ b/master/buildbot/util/latent.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import copy
 
 from twisted.internet import defer

--- a/master/buildbot/worker/kubernetes.py
+++ b/master/buildbot/worker/kubernetes.py
@@ -13,10 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from twisted.internet import defer
 
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate

--- a/pkg/buildbot_pkg.py
+++ b/pkg/buildbot_pkg.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 # Method to add build step taken from here
 # https://seasonofcode.com/posts/how-to-add-custom-build-steps-and-commands-to-setuppy.html
 import datetime

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -15,9 +15,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from setuptools import setup
 
 import buildbot_pkg

--- a/pkg/test_buildbot_pkg.py
+++ b/pkg/test_buildbot_pkg.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import shutil
 import sys

--- a/smokes/master.cfg
+++ b/smokes/master.cfg
@@ -1,9 +1,6 @@
 # -*- python -*-
 # ex: set filetype=python:
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from buildbot.plugins import *
 
 # This is a sample buildmaster config file. It must be installed as

--- a/smokes/mydashboard.py
+++ b/smokes/mydashboard.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 
 import os
 

--- a/www/badges/buildbot_badges/__init__.py
+++ b/www/badges/buildbot_badges/__init__.py
@@ -13,9 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 from xml.sax.saxutils import escape
 
 import jinja2

--- a/www/badges/setup.py
+++ b/www/badges/setup.py
@@ -15,10 +15,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 try:
     from buildbot_pkg import setup_www_plugin
 except ImportError:

--- a/www/base/setup.py
+++ b/www/base/setup.py
@@ -15,10 +15,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 try:
     from buildbot_pkg import setup_www_plugin
     import mock  # noqa

--- a/www/codeparameter/setup.py
+++ b/www/codeparameter/setup.py
@@ -15,10 +15,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 try:
     from buildbot_pkg import setup_www_plugin
 except ImportError:

--- a/www/console_view/setup.py
+++ b/www/console_view/setup.py
@@ -15,10 +15,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 try:
     from buildbot_pkg import setup_www_plugin
 except ImportError:

--- a/www/grid_view/setup.py
+++ b/www/grid_view/setup.py
@@ -15,10 +15,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 try:
     from buildbot_pkg import setup_www_plugin
 except ImportError:

--- a/www/nestedexample/buildbot_nestedexample/api.py
+++ b/www/nestedexample/buildbot_nestedexample/api.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 
 import json
 

--- a/www/nestedexample/setup.py
+++ b/www/nestedexample/setup.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 try:
     from buildbot_pkg import setup_www_plugin
 except ImportError:

--- a/www/waterfall_view/setup.py
+++ b/www/waterfall_view/setup.py
@@ -15,10 +15,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 try:
     from buildbot_pkg import setup_www_plugin
 except ImportError:

--- a/www/wsgi_dashboards/setup.py
+++ b/www/wsgi_dashboards/setup.py
@@ -15,10 +15,6 @@
 #
 # Copyright Buildbot Team Members
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 try:
     from buildbot_pkg import setup_www_plugin
 except ImportError:


### PR DESCRIPTION
There were several imports from __future__ left from the python2->3 migration. This PR removes them.