### PR TITLE
www: Reinstante support for proxy for frontend development.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,10 +39,12 @@ _build
 *.egg
 .eggs/
 master/setuptools_trial*
-master/buildbot/www/static/js/default/
 sandbox
 sandbox.*
 .idea/
 /.venv/
+
+# www
 */node_modules/
 node_modules
+www/base/buildbot_www_proxy

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ $(ALL_PKGS_TARGETS): cleanup_for_tarballs frontend_deps
 	. $(VENV_NAME)/bin/activate && ./common/maketarball.sh $(patsubst %_pkg,%,$@)
 
 cleanup_for_tarballs:
-	find . -name VERSION -exec rm {} \;
+	find master pkg worker www -name VERSION -exec rm {} \;
 	rm -rf dist
 	mkdir dist
 .PHONY: cleanup_for_tarballs

--- a/master/buildbot/newsfragments/www-fontend-proxy.bugfix
+++ b/master/buildbot/newsfragments/www-fontend-proxy.bugfix
@@ -1,0 +1,2 @@
+The support for proxying BuildBot frontend to another BuildBot instance during development has been fixed.
+This feature has been broken since v2.3.0.

--- a/master/buildbot/scripts/processwwwindex.py
+++ b/master/buildbot/scripts/processwwwindex.py
@@ -29,6 +29,13 @@ from buildbot.www.config import IndexResource
 from buildbot.www.service import WWWService
 
 
+def get_www_plugins_config(master):
+    all_apps = [(name, master.apps.get(name)) for name in master.apps.names]
+    all_apps = [(name, app) for name, app in all_apps if name != "base"]
+    all_apps = [(name, app) for name, app in all_apps if app.ui]
+    return {name: {} for name, _ in all_apps}
+
+
 @in_reactor
 @defer.inlineCallbacks
 def processwwwindex(config):
@@ -67,15 +74,13 @@ def processwwwindex(config):
             except OSError:
                 print('Could not link static dir of plugin {}'.format(name))
 
-    plugins = dict((k, {}) for k in master_service.apps.names if k != "base")
-
     fakeconfig = {"user": {"anonymous": True}}
     fakeconfig['buildbotURL'] = master.config.buildbotURL
     fakeconfig['title'] = master.config.title
     fakeconfig['titleURL'] = master.config.titleURL
     fakeconfig['multiMaster'] = master.config.multiMaster
     fakeconfig['versions'] = IndexResource.getEnvironmentVersions()
-    fakeconfig['plugins'] = plugins
+    fakeconfig['plugins'] = get_www_plugins_config(master_service)
     fakeconfig['auth'] = auth.NoAuth().getConfigDict()
 
     indexfile_path = os.path.join(dst_dir, 'index.html')

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -656,13 +656,14 @@ class DataSpecOption(base.BasedirMixin, base.SubcommandOptions):
 
 class ProcessWWWIndexOption(base.BasedirMixin, base.SubcommandOptions):
 
-    """This command is used with the front end's proxy task. It enables to run the front end
-    without the backend server running in the background"""
+    """This command is used with the front end's development proxy task. It enables to run the
+    front end with a third-party buildbot instance without the backend server running in the
+    background"""
 
     subcommandFunction = "buildbot.scripts.processwwwindex.processwwwindex"
     optParameters = [
-        ['index-file', 'i', None,
-            "Path to the index.html file to be processed"],
+        ['src-dir', None, None, "Path to the build directory of the base app"],
+        ['dst-dir', None, None, "Path to the directory to create the proxy data files in"],
     ]
 
 
@@ -727,8 +728,8 @@ class Options(usage.Options):
         ['dataspec', None, DataSpecOption,
          "Output data api spec"],
         ['processwwwindex', None, ProcessWWWIndexOption,
-         "Process the index.html to enable the front end package working without backend. "
-         "This is a command to work with the frontend's proxy task."
+         "Create a directory structure for the development proxy that allows using the frontend "
+         "with another buildbot instance."
          ],
         ['cleanupdb', None, CleanupDBOptions,
          "cleanup the database"

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -19,6 +19,7 @@ import itertools
 import json
 import locale
 import re
+import sys
 import textwrap
 import time
 from builtins import bytes
@@ -317,7 +318,7 @@ def in_reactor(f):
 
             @d.addErrback
             def eb(f):
-                f.printTraceback()
+                f.printTraceback(file=sys.stderr)
 
             @d.addBoth
             def do_stop(r):

--- a/master/docs/developer/www-base-app.rst
+++ b/master/docs/developer/www-base-app.rst
@@ -166,7 +166,6 @@ The Python glue implements the interface described below, with some care taken t
 
 See :ref:`JSDevQuickStart` for a more extensive explanation and tutorial.
 
-
 Testing Setup
 -------------
 
@@ -184,3 +183,30 @@ Debug with karma
 ``console.log`` is available via karma.
 In order to debug the unit tests, you can also use the global variable ``dump``, which dumps any object for inspection in the console.
 This can be handy to be sure that you don't let debug logs in your code to always use ``dump``
+
+Testing with real data
+~~~~~~~~~~~~~~~~~~~~~~
+
+It is possible to run only the frontend and proxy the requests to another BuildBot instance.
+This allows skipping the setup of a BuildBot installation of appropriate complexity and just using already existing one.
+
+This is implemented as the ``www/base/frontend_proxy.js`` nodejs script.
+To run it, setup and enable a virtualenv like described in :ref:`PythonDevQuickStart`.
+Then execute the script as follows:
+
+.. code-block:: bash
+
+    cd www/base
+    nodejs fontend_proxy.js --host <buildbot_host> --port <localhost_port>
+
+You can then just point your browser to `localhost:<localhost_port>`, and you will access `http://<buildbot_host>` with your own version of the JavaScript UI.
+
+If your buildbot instance is served over HTTPS, use the ``--secure`` argument to access the host via ``https://`` and ``wss://``, respectively.
+The argument ``--ignoresslerrors`` may be helpful if the server uses a self-signed certificate.
+Note that the ``--host`` parameter can specify port and URL path, in case buildbot is served on a non-standard port or not from the root path ``/``.
+
+.. code-block:: none
+
+    nodejs fontend_proxy.js --host ssl-protected.ci.example.com --secure
+    nodejs fontend_proxy.js --host self-signed-ssl.ci.example.com/buildbot \
+        --secure --ignoresslerrors

--- a/master/docs/developer/www-base-app.rst
+++ b/master/docs/developer/www-base-app.rst
@@ -35,11 +35,11 @@ On top of Angular we use nodeJS tools to ease development
 
 Additionally the following npm modules are loaded by webpack and available to plugins:
 
-* `@uirouter/angularjs <https://www.npmjs.com/package/@uirouter/angularjs>`
-* `angular-animate <https://www.npmjs.com/package/angular-animate>`
-* `angular-ui-boostrap <https://www.npmjs.com/package/angular-ui-bootstrap>`
-* `d3 <https://www.npmjs.com/package/d3>`
-* `jQuery <https://www.npmjs.com/package/jquery>`
+* `@uirouter/angularjs <https://www.npmjs.com/package/@uirouter/angularjs>`_
+* `angular-animate <https://www.npmjs.com/package/angular-animate>`_
+* `angular-ui-boostrap <https://www.npmjs.com/package/angular-ui-bootstrap>`_
+* `d3 <https://www.npmjs.com/package/d3>`_
+* `jQuery <https://www.npmjs.com/package/jquery>`_
 
 For exact versions of these dependencies available, check ``www/base/package.json``.
 
@@ -54,33 +54,50 @@ You can also completely replace the default application by another application m
 Some Web plugins are maintained inside buildbot's git repository, but this is not required in order for a plugin to work.
 Unofficial plugins are possible and encouraged.
 
-Please look at official plugins for working samples.
-
 Typical plugin source code layout is:
 
-.. code-block:: bash
+``setup.py``
+    Standard setup script.
+    Most plugins should use the same boilerplate, which implements building the BuildBot plugin app as part of the package setup.
+    Minimal adaptation is needed.
 
-    setup.py                     # standard setup script. Most plugins should use the same boilerplate, which helps building guanlecoja app as part of the setup. Minimal adaptation is needed
-    <pluginname>/__init__.py     # python entrypoint. Must contain an "ep" variable of type buildbot.www.plugin.Application. Minimal adaptation is needed
-    webpack.config.js            # Configuration for webpack. Few changes are usually needed here. Please see webpack docs for details.
-    src/..                       # source code for the angularjs application.
-    package.json                 # declares npm dependencies.
-    MANIFEST.in                  # needed by setup.py for sdist generation. You need to adapt this file to match the name of your plugin
+``<pluginname>/__init__.py``
+    The python entrypoint.
+    Must contain an "ep" variable of type buildbot.www.plugin.Application.
+    Minimal adaptation is needed
+
+``webpack.config.js``
+    Configuration for Webpack.
+    Few changes are usually needed here.
+    Please see webpack docs for details.
+
+``src/...``
+    Source code for the angularjs application.
+
+``package.json``
+    Declares npm dependencies and development scripts.
+
+``MANIFEST.in``
+    Needed by setup.py for sdist generation.
+    You need to adapt this file to match the name of your plugin.
+
 
 Plugins are packaged as python entry-points for the ``buildbot.www`` namespace.
 The python part is defined in the ``buildbot.www.plugin`` module.
 The entrypoint must contain a ``twisted.web`` Resource, that is populated in the web server in ``/<pluginname>/``.
 
-The front-end part of the plugin system automatically loads ``/<pluginname>/scripts.js`` and ``/<pluginname>/styles.css`` into the angular.js application.
-The scripts.js files can register itself as a dependency to the main "app" module, register some new states to ``$stateProvider``, or new menu items via glMenuProvider.
+The plugin may only add a http endpoint, or it could add a full JavaScript UI.
+This is controlled by the ``ui`` argument of the ``Application`` endpoint object.
+If ``ui==True``, then will automatically load ``/<pluginname>/scripts.js`` and ``/<pluginname>/styles.css`` into the angular.js application.
+Additionally, an angular.js module with the name ``<pluginname>`` will be registered as a dependency of the main ``app`` module.
+The ``scripts.js`` file may register some new states to ``$stateProvider`` or add new menu items via ``glMenuProvider`` for example.
 
-The entrypoint containing a Resource, nothing forbids plugin writers to add more REST apis in ``/<pluginname>/api``.
+The plugin writers may add more REST apis to ``/<pluginname>/api``.
 For that, a reference to the master singleton is provided in ``master`` attribute of the Application entrypoint.
-You are even not restricted to twisted, and could even `load a wsgi application using flask, django, etc <https://twistedmatrix.com/documents/current/web/howto/web-in-60/wsgi.html>`_.
+The plugins are not restricted to Twisted, and could even `load a wsgi application using flask, django, or some other framework <https://twistedmatrix.com/documents/current/web/howto/web-in-60/wsgi.html>`_.
 
-It is also possible to make a web plugin which only adds http endpoint, and has no javascript UI.
-For that the ``Application`` endpoint object should have ``ui=False`` argument.
-You can look at the :src:`www/badges` plugin for an example of a ui-less plugin.
+Please look into the official BuildBot www plugins for examples.
+The :src:`www/grid_view` and :src:`www/badges` are good examples of plugins with and without a JavaScript UI respectively.
 
 .. _Routing:
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -279,6 +279,7 @@ Encodings
 endsWith
 entityType
 entrypoint
+ep
 eq
 errback
 errbacks
@@ -609,6 +610,7 @@ procmail
 prois
 propertiesDict
 propKey
+proxying
 psycopg
 Psycopg
 pubDate
@@ -693,6 +695,7 @@ schedulerName
 schedulerNames
 schemas
 scp
+sdist
 searchable
 sed
 selectable

--- a/www/base/frontend_proxy.js
+++ b/www/base/frontend_proxy.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+'use strict';
+
+const argv = require('minimist')(process.argv);
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const httpProxy = require('http-proxy');
+const child_process = require('child_process');
+
+const baseAppBuildDir = 'buildbot_www/static';
+const proxyBuildDir = 'buildbot_www_proxy';
+
+// this is a task for developing, it proxy api request to http://nine.buildbot.net
+if (argv.host == null) {
+    console.log('Host not set, using nine.buildbot.net as the default');
+    argv.host = 'nine.buildbot.net';
+}
+if (argv.port == null) {
+    console.log('Port not set, using 8080 as the default');
+    argv.port = 8080;
+}
+if (argv.secure == null) {
+    argv.secure = false;
+}
+if (argv.ignoresslerrors == null) {
+    argv.ignoresslerrors = false;
+}
+
+console.log('Creating file tree for the proxy');
+console.log(`buildbot processwwwindex --src-dir "${baseAppBuildDir}" ` +
+            `--dst-dir "${proxyBuildDir}"`);
+child_process.execSync(`buildbot processwwwindex --src-dir "${baseAppBuildDir}" ` +
+                       `--dst-dir "${proxyBuildDir}"`, {stdio: 'inherit', stderr: 'inherit'});
+console.log('... Done');
+
+const proxy = httpProxy.createProxyServer({
+    secure: !argv.ignoresslerrors,
+});
+
+proxy.on('proxyReq', function(proxyReq, req, res, options) {
+    delete proxyReq.removeHeader('Origin');
+    delete proxyReq.removeHeader('Referer');
+});
+
+proxy.on('proxyRes', function(proxyRes, req, res) {
+    proxyRes.headers['Access-Control-Allow-Origin'] = '*';
+    console.log(`[Proxy] ${req.method} ${req.url}`);
+});
+
+const server = http.createServer(function(req, res) {
+    if (req.url.match(/^\/(api|sse|avatar)/)) {
+        return proxy.web(req, res, {target: `http${argv.secure ? 's' : ''}://${argv.host}`});
+    } else {
+        let filepath = proxyBuildDir + req.url.split('?')[0];
+        if (fs.existsSync(filepath) && fs.lstatSync(filepath).isDirectory()) {
+            filepath = path.join(filepath, 'index.html');
+        }
+        return fs.readFile(filepath, function(err, data) {
+            if (err) {
+                res.writeHead(404);
+                return res.end(JSON.stringify(err));
+            } else {
+                res.writeHead(200);
+                return res.end(data);
+            }
+        });
+    }
+});
+
+server.on('upgrade', (req, socket, head) => {
+    return proxy.ws(req, socket, {target: `ws${argv.secure ? 's' : ''}://${argv.host}`});
+});
+
+server.listen(parseInt(argv.port));
+console.log(`[Proxy] server listening on port ${argv.port}, ` +
+            `target {http${argv.secure ? 's' : ''},ws${argv.secure ? 's' : ''}}` +
+            `://${argv.host}/{api,sse,avatar}`);
+


### PR DESCRIPTION
This PR brings back support for proxy for frontend development that has been removed in v2.3.0.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
