### PR TITLE
GitHubStatusPush: Gracefully handle null 'branch'

### DIFF
--- a/master/buildbot/newsfragments/fix-githubstatuspush-null-branch.bugfix
+++ b/master/buildbot/newsfragments/fix-githubstatuspush-null-branch.bugfix
@@ -1,0 +1,3 @@
+Fixed handling
+of null ``branch`` property
+in :py:class:`~buildbot.reporters.github.GitHubStatusPush`'s ``send()`` method.

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -129,12 +129,12 @@ class GitHubStatusPush(http.HttpStatusPushBase):
 
         project = sourcestamps[0]['project']
 
+        issue = None
         branch = props['branch']
-        m = re.search(r"refs/pull/([0-9]*)/merge", branch)
-        if m:
-            issue = m.group(1)
-        else:
-            issue = None
+        if branch:
+            m = re.search(r"refs/pull/([0-9]*)/merge", branch)
+            if m:
+                issue = m.group(1)
 
         if "/" in project:
             repoOwner, repoName = project.split('/')


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* ~~I have updated the appropriate documentation~~ No documentation update necessary.


This fixes an issue that we've had on buildbot.python.org, presumably with builders triggered by a daily scheduler rather than a push scheduler.  It seems to just leave an error message in the log, with no ill effects beyond not reporting the status.

I have not updated tests for this, as I'm not familiar enough with how the tests are set up (or how exactly GitHubStatusPush even works) to know what to update or how.  I'm happy to take suggestions, or the branch is open to you :)