### PR TITLE
Fix LibVirtWorker disconnect error

### DIFF
--- a/master/buildbot/newsfragments/fix-libvirt-disconnect.bugfix
+++ b/master/buildbot/newsfragments/fix-libvirt-disconnect.bugfix
@@ -1,0 +1,1 @@
+:issue:`4844`: Fix errors when disconnecting a libvirt worker.


### PR DESCRIPTION
When insubstantiating a libvirt worker the disconnection will raise an
excepcion complaining that:

  builtins.TypeError: super(type, obj): obj must be an instance or subtype
  of type

This is because super() cannot find the right method to call.

This patch replaces super().disconnect() with self.disconnect() which
will call the right disconnect method, the one in the
AbstractLatentWorker.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [-] I have updated the appropriate documentation