### PR TITLE
fix Exception thrown when there is no log to delete

### DIFF
--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -368,16 +368,20 @@ class LogsConnectorComponent(base.DBConnectorComponent):
                 .order_by(model.steps.c.id.desc())
                 .limit(1)
             )
-            stepid_max = res.fetchone()[0]
+            res_list = res.fetchone()
+            stepid_max = None
+            if res_list:
+                stepid_max = res_list[0]
             res.close()
 
             # UPDATE logs SET logs.type = 'd' WHERE logs.stepid <= stepid_max;
-            res = conn.execute(
-                model.logs.update()
-                .where(model.logs.c.stepid <= stepid_max)
-                .values(type='d')
-            )
-            res.close()
+            if stepid_max:
+                res = conn.execute(
+                    model.logs.update()
+                    .where(model.logs.c.stepid <= stepid_max)
+                    .values(type='d')
+                )
+                res.close()
 
             # query all logs with type 'd' and delete their chunks.
             q = sa.select([model.logs.c.id])

--- a/master/buildbot/newsfragments/fix_janitor.bugfix
+++ b/master/buildbot/newsfragments/fix_janitor.bugfix
@@ -1,0 +1,1 @@
++Fix janitor Exception when there is no logchunk to delete.

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -563,6 +563,8 @@ class RealTests(Tests):
         deleted_chunks = yield self.db.logs.deleteOldLogChunks(
             self.TIMESTAMP_STEP102 + self.TIMESTAMP_STEP101)
         self.assertEqual(deleted_chunks, 0)
+        deleted_chunks = yield self.db.logs.deleteOldLogChunks(0)
+        self.assertEqual(deleted_chunks, 0)
         for logid in logids:
             logdict = yield self.db.logs.getLog(logid)
             self.assertEqual(logdict['type'], 'd')


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
