### PR TITLE
requirements: Prevent pyup from upgrading sphinx

### DIFF
--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -1,4 +1,4 @@
-Sphinx==2.0.1
+Sphinx==2.0.1 # pyup: ignore
 sphinx-jinja==1.1.0
 sphinxcontrib-blockdiag==1.5.5
 sphinxcontrib-spelling==4.2.1


### PR DESCRIPTION
We can't upgrade sphinx to 2.1.0 or newer due to bug either in Sphinx or in our code. See https://github.com/sphinx-doc/sphinx/issues/6474.