### PR TITLE
Set progress=True for supported Git versions.

### DIFF
--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -74,10 +74,15 @@ class Git(Source, GitStepMixin):
     def __init__(self, repourl=None, branch='HEAD', mode='incremental', method=None,
                  reference=None, submodules=False, shallow=False, progress=False, retryFetch=False,
                  clobberOnFailure=False, getDescription=False, config=None,
-                 origin=None, sshPrivateKey=None, sshHostKey=None, sshKnownHosts=None, **kwargs):
+                 origin=None, sshPrivateKey=None, sshHostKey=None, sshKnownHosts=None, supportsProgress=None, **kwargs):
 
         if not getDescription and not isinstance(getDescription, dict):
             getDescription = False
+
+        self.supportsProgress = supportsProgress
+
+        if supportsProgress:
+            progress = True
 
         self.branch = branch
         self.method = method

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -1225,7 +1225,7 @@ class TestGit(sourcesteps.SourceStepMixin,
     def test_mode_full_clean_no_existing_repo_with_origin(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
-                           mode='full', method='clean', origin='foo'))
+                           mode='full', method='clean', origin='foo', progress=True))
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -1241,7 +1241,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone', '--origin', 'foo',
-                                 'http://github.com/buildbot/buildbot.git', '.'])
+                                 'http://github.com/buildbot/buildbot.git', '.', '--progress'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
@@ -1255,7 +1255,7 @@ class TestGit(sourcesteps.SourceStepMixin,
     def test_mode_full_clean_submodule(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
-                           mode='full', method='clean', submodules=True))
+                           mode='full', method='clean', submodules=True, progress=True))
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -1275,7 +1275,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
-                                 'HEAD'])
+                                 'HEAD', '--progress'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -1404,7 +1404,7 @@ class TestGit(sourcesteps.SourceStepMixin,
     def test_mode_full_clobber_no_branch_support(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
-                           mode='full', method='clobber', progress=True, branch='test-branch'))
+                           mode='full', method='clobber', branch='test-branch'))
 
         self.expectCommands(
             ExpectShell(workdir='wkdir',
@@ -1422,7 +1422,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='wkdir',
                         command=['git', 'clone',
                                  'http://github.com/buildbot/buildbot.git',
-                                 '.', '--progress'])
+                                 '.'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'rev-parse', 'HEAD'])
@@ -1438,7 +1438,7 @@ class TestGit(sourcesteps.SourceStepMixin,
     def test_mode_incremental_oldworker(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
-                           mode='incremental'))
+                           mode='incremental', progress=True))
         self.step.build.getWorkerCommandVersion = lambda cmd, oldversion: "2.15"
         self.expectCommands(
             ExpectShell(workdir='wkdir',
@@ -1455,7 +1455,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
-                                 'HEAD'])
+                                 'HEAD', '--progress'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -1475,7 +1475,7 @@ class TestGit(sourcesteps.SourceStepMixin,
     def test_mode_incremental(self):
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
-                           mode='incremental'))
+                           mode='incremental', progress=True))
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['git', '--version'])
@@ -1492,7 +1492,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             ExpectShell(workdir='wkdir',
                         command=['git', 'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
-                                 'HEAD'])
+                                 'HEAD', '--progress'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
@@ -1632,7 +1632,7 @@ class TestGit(sourcesteps.SourceStepMixin,
         self.setupStep(
             self.stepClass(repourl='http://github.com/buildbot/buildbot.git',
                            mode='incremental', branch='test-branch',
-                           sshPrivateKey='ssh-key'))
+                           sshPrivateKey='ssh-key', progress=True))
 
         ssh_workdir = '/wrk/.Builder.wkdir.buildbot'
         ssh_key_path = '/wrk/.Builder.wkdir.buildbot/ssh-key'
@@ -1666,7 +1666,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', '-c', ssh_command_config,
                                  'fetch', '-t',
                                  'http://github.com/buildbot/buildbot.git',
-                                 'test-branch'])
+                                 'test-branch', '--progress'])
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])

--- a/master/buildbot/util/git.py
+++ b/master/buildbot/util/git.py
@@ -68,6 +68,7 @@ class GitMixin:
 
         self.gitInstalled = False
         self.supportsBranch = False
+        self.supportsProgress = False
         self.supportsSubmoduleForce = False
         self.supportsSubmoduleCheckout = False
         self.supportsSshPrivateKeyAsEnvOption = False
@@ -86,6 +87,8 @@ class GitMixin:
         self.gitInstalled = True
         if LooseVersion(version) >= LooseVersion("1.6.5"):
             self.supportsBranch = True
+        if LooseVersion(version) >= LooseVersion("1.7.2"):
+            self.supportsProgress = True
         if LooseVersion(version) >= LooseVersion("1.7.6"):
             self.supportsSubmoduleForce = True
         if LooseVersion(version) >= LooseVersion("1.7.8"):

--- a/master/docs/manual/configuration/buildsteps.rst
+++ b/master/docs/manual/configuration/buildsteps.rst
@@ -385,6 +385,7 @@ The Git step takes the following arguments:
 ``progress`` (optional)
    Passes the (``--progress``) flag to (:command:`git fetch`).
    This solves issues of long fetches being killed due to lack of output, but requires Git 1.7.2 or later.
+   Its value is True on Git 1.7.2 or later.
 
 ``retryFetch`` (optional, default: ``False``)
    If true, if the ``git fetch`` fails then Buildbot retries to fetch again instead of failing the entire source checkout.


### PR DESCRIPTION
For Buildsteps, use --progress flag on Git 1.7.2 or later.

Fixes https://github.com/buildbot/buildbot/issues/4745

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
