### PR TITLE
docker: add txrequests to extra requirements

### DIFF
--- a/master/requirements-docker-extras.txt
+++ b/master/requirements-docker-extras.txt
@@ -1,2 +1,3 @@
 requests==2.22.0
 psycopg2==2.8.3
+txrequests==0.9.6


### PR DESCRIPTION
It is necessary for buildbot.plugins.reporters.GitHubStatusPush, which I consider to be quite useful in the docker image.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
