### PR TITLE
Remove dot from console_view package description

### DIFF
--- a/www/console_view/setup.py
+++ b/www/console_view/setup.py
@@ -26,7 +26,7 @@ except ImportError:
 
 setup_www_plugin(
     name='buildbot-console-view',
-    description='Buildbot Console View plugin.',
+    description='Buildbot Console View plugin',
     author=u'Pierre Tardy',
     author_email=u'tardyp@gmail.com',
     url='http://buildbot.net/',


### PR DESCRIPTION
Keep consistency in package descriptions. Others don't have the trailing dot.

(And sorry for the way-too-trivial PR.)

## Contributor Checklist:

(None applies.)

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
