### PR TITLE
Allow dots in worker names

### DIFF
--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -98,7 +98,9 @@ class IdentifierValidator(Validator):
     name = 'identifier'
     hasArgs = True
 
-    ident_re = re.compile('^[a-zA-Z\u00a0-\U0010ffff_-][a-zA-Z0-9\u00a0-\U0010ffff_-]*$', flags=re.UNICODE)
+    # Not sure about this one, but I added a dot for consistency
+    # I'm also not yet sure why this is not using the expression defined in util/identifiers.py
+    ident_re = re.compile('^[a-zA-Z\u00a0-\U0010ffff._-][a-zA-Z0-9\u00a0-\U0010ffff._-]*$', flags=re.UNICODE)
 
     def __init__(self, len):
         self.len = len

--- a/master/buildbot/util/identifiers.py
+++ b/master/buildbot/util/identifiers.py
@@ -17,7 +17,8 @@ import re
 
 from buildbot import util
 
-ident_re = re.compile('^[a-zA-Z\u00a0-\U0010ffff_-][a-zA-Z0-9\u00a0-\U0010ffff_-]*$', flags=re.UNICODE)
+# this line is needed to allow the dot in worker name
+ident_re = re.compile('^[a-zA-Z\u00a0-\U0010ffff._-][a-zA-Z0-9\u00a0-\U0010ffff._-]*$', flags=re.UNICODE)
 initial_re = re.compile('^[^a-zA-Z_-]')
 subsequent_re = re.compile('[^a-zA-Z0-9_-]')
 trailing_digits_re = re.compile('_([0-9]+)$')


### PR DESCRIPTION
I would like to be able to use dots in worker names.

I'm opening a draft pull request just to get some basic feedback, but I still need to set up my environment and figure out the process of running and modifying the unit tests (I'll do that next), as well as write the newsframents of course.

The inline comments would of course be removed.

There are a lot of different regular expressions. I was pointed at the one in `buildbot/data/types.py`, but that one is not used for checking worker names. I did not yet fully investigate where it is used. I had to change `buildbot/util/identifiers.py` for the change to have the desired effect.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation