### PR TITLE
De-duplicate gerrit change events between the Stream and Poller

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -233,6 +233,7 @@ callwhenrunning
 cancelcleanshutdown
 cancelled
 cancelling
+canonicalize
 canstartbuild
 canstartwithworkerforbuilder
 cb

--- a/master/buildbot/newsfragments/gerritevent-dedup.feature
+++ b/master/buildbot/newsfragments/gerritevent-dedup.feature
@@ -1,0 +1,1 @@
+:py:class:`GerritEventLogPoller` and :py:class:`GerritChangeSource` coordinate so as not to generate duplicate changes, resolves :issue:`4786`

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1173,6 +1173,17 @@ class FakeSourceStampsComponent(FakeDBComponent):
                           patch_body=None, patch_level=None,
                           patch_author=None, patch_comment=None,
                           patch_subdir=None):
+        d = self.findOrCreateId(
+            branch, revision, repository, project, codebase, patch_body,
+            patch_level, patch_author, patch_comment, patch_subdir)
+        d.addCallback(lambda pair: pair[0])
+        return d
+
+    def findOrCreateId(self, branch=None, revision=None, repository=None,
+                       project=None, codebase=None,
+                       patch_body=None, patch_level=None,
+                       patch_author=None, patch_comment=None,
+                       patch_subdir=None):
         if patch_body:
             patchid = len(self.patches) + 1
             while patchid in self.patches:
@@ -1194,13 +1205,13 @@ class FakeSourceStampsComponent(FakeDBComponent):
             keys = ['branch', 'revision', 'repository',
                     'codebase', 'project', 'patchid']
             if [ssdict[k] for k in keys] == [new_ssdict[k] for k in keys]:
-                return defer.succeed(id)
+                return defer.succeed((id, True))
 
         id = len(self.sourcestamps) + 100
         while id in self.sourcestamps:
             id += 1
         self.sourcestamps[id] = new_ssdict
-        return defer.succeed(id)
+        return defer.succeed((id, False))
 
     def getSourceStamp(self, key, no_cache=False):
         return defer.succeed(self._getSourceStamp_sync(key))

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -1352,7 +1352,7 @@ Note that the decision of whether to use :bb:chsrc:`GerritEventLogPoller` and :b
 1. :bb:chsrc:`GerritChangeSource` is low-overhead and reacts instantaneously to events, but a broken connection to Gerrit will lead to missed changes
 2. :bb:chsrc:`GerritEventLogPoller` is subject to polling overhead and reacts only at it's polling rate, but is robust to a broken connection to Gerrit and missed changes will be discovered when a connection is restored.
 
-However, you probably do not want use both at the same time as they do not coordinate and changes will be duplicated in this case.
+You can use both at the same time to get the advantages of each. They will coordinate through the database to avoid duplicate changes generated for buildbot.
 
 .. note::
 


### PR DESCRIPTION
This change adds a new database table storing a message digest of the normalized Gerrit event JSON for both `GerritEventLogPoller` and `GerritChangeSource`. If either source encounters an event which has already been logged, it will discard the event. 

In addition, if the `GerritEventLogPoller` has no recorded "last successful timestamp" it performs the next query using a lookback period (rather than "now") such that queued events are actually picked up. 

Closes: #4786 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
