### PR TITLE
www: Enable frontend unit tests on CI and fix them

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -22,7 +22,8 @@ env:
   - TWISTED=latest SQLALCHEMY=latest TESTS=coverage
 
   # add js tests in separate job. Start it early because it is quite long
-  - TWISTED=latest SQLALCHEMY=latest TESTS=js HYPER_SIZE=m1
+  - TWISTED=latest SQLALCHEMY=latest TESTS=js_build HYPER_SIZE=m1
+  - TWISTED=latest SQLALCHEMY=latest TESTS=js_unit HYPER_SIZE=m1
   - TWISTED=latest SQLALCHEMY=latest TESTS=smokes HYPER_SIZE=m2
 
   - TWISTED=17.9.0 SQLALCHEMY=latest TESTS=trial
@@ -125,13 +126,17 @@ before_script:
 # Tests running commands
 script:
   # make frontend_install_tests takes 17 min, so we only do it post submit
-  - title: frontend tests
-    condition: TESTS == "js" and TRAVIS_PULL_REQUEST
+  - title: frontend build tests
+    condition: TESTS == "js_build" and TRAVIS_PULL_REQUEST
     cmd: make frontend
 
   - title: full frontend tests
-    condition: TESTS == "js" and not TRAVIS_PULL_REQUEST
+    condition: TESTS == "js_build" and not TRAVIS_PULL_REQUEST
     cmd: make frontend_install_tests
+
+  - title: frontend unit tests
+    condition: TESTS == "js_unit" and not TRAVIS_PULL_REQUEST
+    cmd: make frontend_tests
 
   - title: master and worker tests
     condition: TESTS == "trial"

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ WWW_EX_PKGS := www/nestedexample www/codeparameter
 WWW_DEP_PKGS := www/guanlecoja-ui www/data_module
 ALL_PKGS := master worker pkg $(WWW_PKGS)
 
+WWW_PKGS_FOR_UNIT_TESTS := $(filter-out www/badges, $(WWW_DEP_PKGS) $(WWW_PKGS))
+
 ALL_PKGS_TARGETS := $(addsuffix _pkg,$(ALL_PKGS))
 .PHONY: $(ALL_PKGS_TARGETS)
 
@@ -47,7 +49,7 @@ frontend_deps: $(VENV_NAME)
 		do (cd $$i; yarn install --pure-lockfile; yarn run build); done
 
 frontend_tests: frontend_deps
-	for i in $(WWW_DEP_PKGS) $(WWW_PKGS); \
+	for i in $(WWW_PKGS_FOR_UNIT_TESTS); \
 		do (cd $$i; yarn run build-dev || exit 1; yarn run test || exit 1) || exit 1; done
 
 # rebuild front-end from source

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ frontend_deps: $(VENV_NAME)
 	for i in $(WWW_DEP_PKGS); \
 		do (cd $$i; yarn install --pure-lockfile; yarn run build); done
 
+frontend_tests: frontend_deps
+	for i in $(WWW_DEP_PKGS) $(WWW_PKGS); \
+		do (cd $$i; yarn run build-dev || exit 1; yarn run test || exit 1) || exit 1; done
+
 # rebuild front-end from source
 frontend: frontend_deps
 	for i in pkg $(WWW_PKGS); do $(PIP) install -e $$i || exit 1; done

--- a/master/docs/developer/quickstart.rst
+++ b/master/docs/developer/quickstart.rst
@@ -136,3 +136,13 @@ To run unit tests, do the following:
 .. code-block:: none
 
     yarn run test
+
+To run unit tests within all frontend packages within Buildbot, do the following at the root of the project:
+
+.. code-block:: none
+
+    make frontend_tests
+
+.. note::
+
+   You need to have Chrome-based browser installed in order to run unit tests in the default configuration.

--- a/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.js
+++ b/www/base/src/app/builders/buildrequest/buildrequest.controller.spec.js
@@ -49,6 +49,7 @@ describe('buildrequest controller', function() {
 
     it('should query for builds again if first query returns 0', function() {
         dataService.when('buildsets/1/properties', [{a: ['a','b']}]);
+        dataService.when('builders', [{builderid: 1}]);
         dataService.when('buildrequests/1', [{buildrequestid: 1, builderid: 1, buildsetid: 1}]);
         dataService.when('builders/1', [{builderid: 1}]);
         dataService.when('buildsets/1', [{buildsetid: 1}]);

--- a/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildrequestsummary/buildrequestsummary.directive.spec.js
@@ -35,9 +35,9 @@ describe('buildrequest summary controller', function() {
 
     it('should get the buildrequest', function() {
         const buildrequests = [{buildrequestid: 1, builderid: 2, buildsetid: 3}];
+        dataService.expect('builders', buildrequests);
         dataService.expect('buildrequests/1', buildrequests);
         dataService.expect('buildsets/3', buildrequests);
-        dataService.expect('builders/2', buildrequests);
         expect(dataService.get).not.toHaveBeenCalled();
         const controller = createController();
         $timeout.flush();
@@ -47,9 +47,9 @@ describe('buildrequest summary controller', function() {
 
     it('should query for builds again if first query returns 0', function() {
         const buildrequests = [{buildrequestid: 1, builderid: 2, buildsetid: 3}];
+        dataService.expect('builders', buildrequests);
         dataService.expect('buildrequests/1', buildrequests);
         dataService.expect('buildsets/3', buildrequests);
-        dataService.expect('builders/2', buildrequests);
         let builds = [];
 
         const controller = createController();

--- a/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsticker/buildsticker.directive.spec.js
@@ -19,7 +19,9 @@ describe('buildsticker controller', function() {
 
     it('directive should generate correct html', function() {
         const build = {buildid: 3, builderid: 2, number: 1};
+        dataService.when('builds', [build]);
         dataService.when('builds/3', [build]);
+        dataService.when('builders', [{builderid: 2}]);
         dataService.when('builders/2', [{builderid: 2}]);
         const data = dataService.open();
         data.getBuilds(build.buildid).onNew = build => scope.build = build;

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
@@ -1,18 +1,16 @@
 beforeEach(angular.mock.module('app'));
 
 describe('buildsummary controller', function() {
-    let $compile, $rootScope, $stateParams, baseurl, createController, results, scope;
-    let dataService = (scope = ($rootScope = ($compile = null)));
+    let $compile, $rootScope, $stateParams, baseurl, createController, results, $scope;
+    let dataService = ($scope = ($rootScope = ($compile = null)));
     let $timeout = (createController = ($stateParams = (results = (baseurl = null))));
-    let $controller = null;
-    const goneto  = null;
 
     const injected = function($injector) {
         results = $injector.get('RESULTS');
         $rootScope = $injector.get('$rootScope');
-        scope = $rootScope.$new();
-        scope.buildid = 1;
-        scope.condensed = 0;
+        $scope = $rootScope.$new();
+        $scope.buildid = 1;
+        $scope.condensed = 0;
 
         $timeout = $injector.get('$timeout');
         $stateParams = $injector.get('$stateParams');
@@ -32,8 +30,10 @@ describe('buildsummary controller', function() {
     beforeEach(inject(injected));
 
     it('should provide correct isStepDisplayed when condensed', function() {
-        scope.condensed = true;
-        const buildsummary = $controller('_buildsummaryController', {$scope: scope});
+        $scope.condensed = true;
+        const element = $compile("<buildsummary buildid='buildid' condensed='condensed'></buildsummary>")($scope);
+        $scope.$apply();
+        const { buildsummary } = element.isolateScope();
         expect(buildsummary.isStepDisplayed({results:results.SUCCESS})).toBe(false);
         expect(buildsummary.isStepDisplayed({results:results.WARNING})).toBe(false);
         expect(buildsummary.isStepDisplayed({results:results.FAILURE})).toBe(false);
@@ -52,8 +52,10 @@ describe('buildsummary controller', function() {
     });
 
     it('should provide correct isStepDisplayed when not condensed', function() {
-        scope.condensed = 0;
-        const buildsummary = $controller('_buildsummaryController', {$scope: scope});
+        $scope.condensed = 0;
+        const element = $compile("<buildsummary buildid='buildid' condensed='condensed'></buildsummary>")($scope);
+        $scope.$apply();
+        const { buildsummary } = element.isolateScope();
         expect(buildsummary.isStepDisplayed({results:results.SUCCESS})).toBe(true);
         expect(buildsummary.isStepDisplayed({results:results.WARNING})).toBe(true);
         expect(buildsummary.isStepDisplayed({results:results.FAILURE})).toBe(true);
@@ -69,13 +71,17 @@ describe('buildsummary controller', function() {
     });
 
     it('should provide correct getBuildRequestIDFromURL', function() {
-        const buildsummary = $controller('_buildsummaryController', {$scope: scope});
+        const element = $compile("<buildsummary buildid='buildid'></buildsummary>")($scope);
+        $scope.$apply();
+        const { buildsummary } = element.isolateScope();
         expect(buildsummary.getBuildRequestIDFromURL(`${baseurl}#buildrequests/123`))
         .toBe(123);
     });
 
     it('should provide correct isBuildRequestURL', function() {
-        const buildsummary = $controller('_buildsummaryController', {$scope: scope});
+        const element = $compile("<buildsummary buildid='buildid'></buildsummary>")($scope);
+        $scope.$apply();
+        const { buildsummary } = element.isolateScope();
         expect(buildsummary.isBuildRequestURL(`${baseurl}#buildrequests/123`))
         .toBe(true);
         expect(buildsummary.isBuildRequestURL("http://otherdomain:5000/#buildrequests/123"))
@@ -87,7 +93,9 @@ describe('buildsummary controller', function() {
     });
 
     it('should provide correct isBuildURL', function() {
-        const buildsummary = $controller('_buildsummaryController', {$scope: scope});
+        const element = $compile("<buildsummary buildid='buildid'></buildsummary>")($scope);
+        $scope.$apply();
+        const { buildsummary } = element.isolateScope();
         expect(buildsummary.isBuildURL(`${baseurl}#builders/123/builds/123`))
         .toBe(true);
         expect(buildsummary.isBuildURL(`${baseurl}#builders/sdf/builds/123`))

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
@@ -20,6 +20,7 @@ describe('buildsummary controller', function() {
 
         dataService = $injector.get('dataService');
         dataService.when('builds/1', [{buildid: 1, builderid: 1}]);
+        dataService.when('builders', [{builderid: 1}]);
         dataService.when('builders/1', [{builderid: 1}]);
         dataService.when('builds/1/steps', [{builderid: 1, stepid: 1, number: 1}]);
         dataService.when('steps/1/logs', [{stepid: 1, logid: 1}, {stepid: 1, logid: 2}]);

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
@@ -14,11 +14,9 @@ describe('buildsummary controller', function() {
 
         $timeout = $injector.get('$timeout');
         $stateParams = $injector.get('$stateParams');
-        $controller = $injector.get('$controller');
         const $q = $injector.get('$q');
         $compile = $injector.get('$compile');
-        const $location = $injector.get('$location');
-        baseurl = $location.absUrl().split("#")[0];
+        baseurl = $injector.get('config')['buildbotURL'];
 
         dataService = $injector.get('dataService');
         dataService.when('builds/1', [{buildid: 1, builderid: 1}]);

--- a/www/base/test/scripts/mocks/config.mock.js
+++ b/www/base/test/scripts/mocks/config.mock.js
@@ -1,1 +1,4 @@
-angular.module("buildbot_config", []).constant("config", {title:"foo"});
+angular.module("buildbot_config", []).constant("config", {
+    title: "foo",
+    buildbotURL: "test.example.com",
+});

--- a/www/data_module/package.json
+++ b/www/data_module/package.json
@@ -7,6 +7,7 @@
   "main": "dist/buildbot-data-js.js",
   "scripts": {
     "build": "rimraf dist && webpack --bail --progress --profile --env dev && webpack --bail --progress --profile --env prod",
+    "build-dev": "rimraf dist && webpack --bail --progress --profile --env dev",
     "test": "karma start",
     "test-watch": "karma start --auto-watch --no-single-run"
   },

--- a/www/guanlecoja-ui/package.json
+++ b/www/guanlecoja-ui/package.json
@@ -8,6 +8,7 @@
     "style": "dist/styles.css",
     "scripts": {
         "build": "rimraf dist && webpack --bail --progress --profile --env dev && webpack --bail --progress --profile --env prod",
+        "build-dev": "rimraf dist && webpack --bail --progress --profile --env dev",
         "test": "karma start",
         "test-watch": "karma start --auto-watch --no-single-run"
     },


### PR DESCRIPTION
Looks like that with the landing of Webpack rework we no longer run unit tests on the CI. I added a Makefile rule to run all frontend unit tests, fixed them and added a new rule to .bbtravis.