### PR TITLE
mtrlogobserver: make parallel argument renderable

### DIFF
--- a/master/buildbot/steps/mtrlogobserver.py
+++ b/master/buildbot/steps/mtrlogobserver.py
@@ -278,7 +278,7 @@ class MTR(Test):
         dbpool is specified. The test_type string, if specified, will also
         appear on the waterfall page."""
 
-    renderables = ['mtr_subdir']
+    renderables = ['mtr_subdir', 'parallel']
 
     def __init__(self, dbpool=None, test_type=None, test_info="",
                  description=None, descriptionDone=None,


### PR DESCRIPTION
This way we can pass renderable parallel parameters to MTR step class instantiations.