### PR TITLE
document more precisely www.port configuration

### DIFF
--- a/master/buildbot/newsfragments/improve-www.port.doc
+++ b/master/buildbot/newsfragments/improve-www.port.doc
@@ -1,0 +1,1 @@
+Link the documentation of www.port to the capabilities of twisted.application.strports.

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -12,6 +12,7 @@ This server is configured with the ``www`` configuration key, which specifies a 
 
 ``port``
     The TCP port on which to serve requests.
+    It might be an integer or any string accepted by `serverFromString <https://twistedmatrix.com/documents/current/api/twisted.internet.endpoints.html#serverFromString>`_ (ex: "tcp:8010:interface=127.0.0.1" to listen on another interface).
     Note that SSL is not supported.
     To host Buildbot with SSL, use an HTTP proxy such as lighttpd, nginx, or Apache.
     If this is ``None``, the default, then the master will not implement a web server.


### PR DESCRIPTION
linked to twisted documentation twisted.internet.endpoints.serverFromString

## Contributor Checklist:

* [ ] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
