### PR TITLE
Get all builds corresponding to a change

### DIFF
--- a/master/buildbot/db/builds.py
+++ b/master/buildbot/db/builds.py
@@ -25,10 +25,6 @@ from buildbot.db import base
 from buildbot.util import epoch2datetime
 
 
-class BuildDict(dict):
-    pass
-
-
 class BuildsConnectorComponent(base.DBConnectorComponent):
     # Documentation is in developer/db.rst
 
@@ -124,20 +120,10 @@ class BuildsConnectorComponent(base.DBConnectorComponent):
             q = sa.select([builds_tbl]).select_from(
                 from_clause).where(changes_tbl.c.changeid == changeid)
             res = conn.execute(q)
-            return [self._rowToBuildsdict_thd(conn, row)
+            return [self._builddictFromRow(row)
                     for row in res.fetchall()]
 
         return self.db.pool.do(thd)
-
-    def _rowToBuildsdict_thd(self, conn, row):
-        buildid = row.id
-        builddict = BuildDict(buildid=buildid, number=row.number, builderid=row.builderid,
-                              buildrequestid=row.buildrequestid, workerid=row.workerid,
-                              masterid=row.masterid, started_at=row.started_at,
-                              complete_at=row.complete_at, state_string=row.state_string,
-                              results=row.results)
-
-        return builddict
 
     # returns a Deferred that returns a value
     def getBuilds(self, builderid=None, buildrequestid=None, workerid=None, complete=None, resultSpec=None):

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1956,6 +1956,9 @@ class FakeBuildsComponent(FakeDBComponent):
         self.builds[bid]['properties'][name] = (value, source)
         return defer.succeed(None)
 
+    def getBuildsForChange(self, changeid):
+        raise NotImplementedError(
+            "Please patch in tests to return appropriate results")
 
 class FakeStepsComponent(FakeDBComponent):
 

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1956,9 +1956,43 @@ class FakeBuildsComponent(FakeDBComponent):
         self.builds[bid]['properties'][name] = (value, source)
         return defer.succeed(None)
 
+    @defer.inlineCallbacks
     def getBuildsForChange(self, changeid):
-        raise NotImplementedError(
-            "Please patch in tests to return appropriate results")
+        change = yield self.db.changes.getChange(changeid)
+        bsets = yield self.db.buildsets.getBuildsets()
+        breqs = yield self.db.buildrequests.getBuildRequests()
+        builds = yield self.db.builds.getBuilds()
+
+        results = []
+        for bset in bsets:
+            for ssid in bset['sourcestamps']:
+                if change['sourcestampid'] == ssid:
+                    bset['changeid'] = changeid
+                    results.append({'buildsetid': bset['bsid']})
+
+        for breq in breqs:
+            for result in results:
+                if result['buildsetid'] == breq['buildsetid']:
+                    result['buildrequestid'] = breq['buildrequestid']
+
+        for build in builds:
+            for result in results:
+                if result['buildrequestid'] == build['buildrequestid']:
+                    result['buildid'] = build['id']
+                    result['number'] = build['number']
+                    result['builderid'] = build['builderid']
+                    result['workerid'] = build['workerid']
+                    result['masterid'] = build['masterid']
+                    result['started_at'] = 1304262222
+                    result['complete_at'] = build['complete_at']
+                    result['state_string'] = build['state_string']
+                    result['results'] = build['results']
+
+        for result in results:
+            del result['buildsetid']
+
+        return results
+
 
 class FakeStepsComponent(FakeDBComponent):
 

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -1978,12 +1978,12 @@ class FakeBuildsComponent(FakeDBComponent):
         for build in builds:
             for result in results:
                 if result['buildrequestid'] == build['buildrequestid']:
-                    result['buildid'] = build['id']
+                    result['id'] = build['id']
                     result['number'] = build['number']
                     result['builderid'] = build['builderid']
                     result['workerid'] = build['workerid']
                     result['masterid'] = build['masterid']
-                    result['started_at'] = 1304262222
+                    result['started_at'] = epoch2datetime(1304262222)
                     result['complete_at'] = build['complete_at']
                     result['state_string'] = build['state_string']
                     result['results'] = build['results']

--- a/master/buildbot/test/unit/test_db_builds.py
+++ b/master/buildbot/test/unit/test_db_builds.py
@@ -33,10 +33,6 @@ TIME4 = 1304262235
 CREATED_AT = 927845299
 
 
-def buildKey(build):
-    return (build['buildid'], build['state_string'])
-
-
 class Tests(interfaces.InterfaceTests):
 
     # common sample data
@@ -201,8 +197,7 @@ class Tests(interfaces.InterfaceTests):
 
         builds = yield self.db.builds.getBuildsForChange(changeid)
 
-        self.assertEqual(sorted(builds, key=buildKey),
-                         sorted(expected, key=buildKey))
+        self.assertEqual(sorted(builds), sorted(expected))
 
     def test_getBuildsForChange_OneCodebase(self):
         rows = [fakedb.Master(id=88, name="bar"),
@@ -222,13 +217,13 @@ class Tests(interfaces.InterfaceTests):
                              started_at=1304262222, results=1), ]
 
         expected = [{
-            'buildid': 50,
+            'id': 50,
             'number': 5,
             'builderid': 77,
             'buildrequestid': 19,
             'workerid': 13,
             'masterid': 88,
-            'started_at': 1304262222,
+            'started_at': epoch2datetime(1304262222),
             'complete_at': None,
             'state_string': 'test',
             'results': 1}]

--- a/master/buildbot/test/unit/test_db_builds.py
+++ b/master/buildbot/test/unit/test_db_builds.py
@@ -30,6 +30,11 @@ TIME1 = 1304262222
 TIME2 = 1304262223
 TIME3 = 1304262224
 TIME4 = 1304262235
+CREATED_AT = 927845299
+
+
+def buildKey(build):
+    return (build['buildid'], build['state_string'])
 
 
 class Tests(interfaces.InterfaceTests):
@@ -184,6 +189,51 @@ class Tests(interfaces.InterfaceTests):
             validation.verifyDbDict(self, 'dbbuilddict', bdict)
         self.assertEqual(sorted(bdicts, key=lambda bd: bd['id']),
                          [self.threeBdicts[50], self.threeBdicts[51]])
+
+    def test_signature_getBuildsForChange(self):
+        @self.assertArgSpecMatches(self.db.builds.getBuildsForChange)
+        def getBuildsForChange(self, changeid):
+            pass
+
+    @defer.inlineCallbacks
+    def do_test_getBuildsForChange(self, rows, changeid, expected):
+        yield self.insertTestData(rows)
+
+        builds = yield self.db.builds.getBuildsForChange(changeid)
+
+        self.assertEqual(sorted(builds, key=buildKey),
+                         sorted(expected, key=buildKey))
+
+    def test_getBuildsForChange_OneCodebase(self):
+        rows = [fakedb.Master(id=88, name="bar"),
+                fakedb.Worker(id=13, name='one'),
+                fakedb.Builder(id=77, name='A'),
+                fakedb.SourceStamp(id=234, created_at=CREATED_AT,
+                                   revision="aaa"),
+                fakedb.Change(changeid=14, codebase='A', sourcestampid=234),
+                fakedb.Buildset(id=30, reason='foo',
+                                submitted_at=1300305712, results=1),
+                fakedb.BuildsetSourceStamp(sourcestampid=234, buildsetid=30),
+                fakedb.BuildRequest(id=19, buildsetid=30, builderid=77,
+                                    priority=13, submitted_at=1300305712, results=1,
+                                    complete=0, complete_at=None),
+                fakedb.Build(id=50, buildrequestid=19, number=5, masterid=88,
+                             builderid=77, state_string="test", workerid=13,
+                             started_at=1304262222, results=1), ]
+
+        expected = [{
+            'buildid': 50,
+            'number': 5,
+            'builderid': 77,
+            'buildrequestid': 19,
+            'workerid': 13,
+            'masterid': 88,
+            'started_at': 1304262222,
+            'complete_at': None,
+            'state_string': 'test',
+            'results': 1}]
+
+        return self.do_test_getBuildsForChange(rows, 14, expected)
 
     @defer.inlineCallbacks
     def test_getBuilds_complete(self):
@@ -443,7 +493,8 @@ class TestRealDB(unittest.TestCase,
     def setUp(self):
         yield self.setUpConnectorComponent(
             table_names=['builds', 'builders', 'masters', 'buildrequests',
-                         'buildsets', 'workers', 'build_properties'])
+                         'buildsets', 'workers', 'build_properties', 'changes',
+                         'sourcestamps', 'buildset_sourcestamps', 'patches'])
 
         self.db.builds = builds.BuildsConnectorComponent(self.db)
 

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -915,6 +915,13 @@ changes
 
         Get the "blame" list of changes for a build.
 
+    .. py:method:: getBuildsForChange(changeid)
+
+        :param changeid: ID of the change
+        :returns: list of buildDict via Deferred
+
+        Get builds related to a change
+
     .. py:method:: getChangeFromSSid(sourcestampid)
 
         :param sourcestampid: ID of the sourcestampid

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -86,6 +86,7 @@ buildbot
 Buildbot
 buildCacheSize
 builddir
+buildDict
 builderid
 builderids
 buildername


### PR DESCRIPTION
Closes https://github.com/buildbot/buildbot/issues/3927
This will enable getting all builds corresponding to a change.

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
