### PR TITLE
Add regex support in buildstep DirectoryUpload

### DIFF
--- a/master/buildbot/newsfragments/add_regex_step_DirectoryUpload.feature
+++ b/master/buildbot/newsfragments/add_regex_step_DirectoryUpload.feature
@@ -1,0 +1,1 @@
+Add support for regex in buildstep DirectoryUpload

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -97,7 +97,7 @@ class FileUpload(_TransferBuildStep):
 
     def __init__(self, workersrc=None, masterdest=None,
                  workdir=None, maxsize=None, blocksize=256 * 1024, mode=None,
-                 keepstamp=False, url=None, urlText=None,
+                 keepstamp=False, url=None, urlText=None, regex=None,
                  **buildstep_kwargs):
         # Emulate that first two arguments are positional.
         if workersrc is None or masterdest is None:
@@ -264,7 +264,7 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
 
     def __init__(self, workersrcs=None, masterdest=None,
                  workdir=None, maxsize=None, blocksize=16 * 1024, glob=False,
-                 mode=None, compress=None, keepstamp=False, url=None,
+                 mode=None, compress=None, keepstamp=False, url=None, regex=None,
                  **buildstep_kwargs):
 
         # Emulate that first two arguments are positional.

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -198,7 +198,7 @@ class DirectoryUpload(_TransferBuildStep):
         super().__init__(workdir=workdir, **buildstep_kwargs)
 
         self.workersrc = workersrc
-        self.regex= regex
+        self.regex = regex
         self.masterdest = masterdest
         self.maxsize = maxsize
         self.blocksize = blocksize

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -188,7 +188,7 @@ class DirectoryUpload(_TransferBuildStep):
 
     def __init__(self, workersrc=None, masterdest=None,
                  workdir=None, maxsize=None, blocksize=16 * 1024,
-                 compress=None, url=None, urlText=None,
+                 compress=None, url=None, urlText=None, regex=None,
                  **buildstep_kwargs
                  ):
         # Emulate that first two arguments are positional.
@@ -198,6 +198,7 @@ class DirectoryUpload(_TransferBuildStep):
         super().__init__(workdir=workdir, **buildstep_kwargs)
 
         self.workersrc = workersrc
+        self.regex= regex
         self.masterdest = masterdest
         self.maxsize = maxsize
         self.blocksize = blocksize
@@ -240,7 +241,8 @@ class DirectoryUpload(_TransferBuildStep):
             'writer': dirWriter,
             'maxsize': self.maxsize,
             'blocksize': self.blocksize,
-            'compress': self.compress
+            'compress': self.compress,
+            'regex': self.regex
         }
 
         if self.workerVersionIsOlderThan('uploadDirectory', '3.0'):

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -116,6 +116,7 @@ class FileUpload(_TransferBuildStep):
         self.keepstamp = keepstamp
         self.url = url
         self.urlText = urlText
+        self.regex = regex
 
     def finished(self, results):
         log.msg("File '{}' upload finished with results {}".format(
@@ -168,6 +169,7 @@ class FileUpload(_TransferBuildStep):
             'maxsize': self.maxsize,
             'blocksize': self.blocksize,
             'keepstamp': self.keepstamp,
+            'regex': self.regex,
         }
 
         if self.workerVersionIsOlderThan('uploadFile', '3.0'):
@@ -288,6 +290,7 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
         self.glob = glob
         self.keepstamp = keepstamp
         self.url = url
+        self.regex = regex
 
     def uploadFile(self, source, masterdest):
         fileWriter = remotetransfer.FileWriter(
@@ -299,6 +302,7 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
             'maxsize': self.maxsize,
             'blocksize': self.blocksize,
             'keepstamp': self.keepstamp,
+            'regex': self.regex,
         }
 
         if self.workerVersionIsOlderThan('uploadFile', '3.0'):
@@ -318,7 +322,8 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
             'writer': dirWriter,
             'maxsize': self.maxsize,
             'blocksize': self.blocksize,
-            'compress': self.compress
+            'compress': self.compress,
+            'regex': self.regex
         }
 
         if self.workerVersionIsOlderThan('uploadDirectory', '3.0'):

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -601,7 +601,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -116,7 +116,7 @@ class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=262144, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -134,7 +134,7 @@ class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 slavesrc="srcfile", workdir='wkdir',
-                blocksize=262144, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -155,7 +155,7 @@ class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc=__file__, workdir='wkdir',
-                blocksize=262144, maxsize=None, keepstamp=True,
+                blocksize=262144, maxsize=None, keepstamp=True, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString('test', timestamp=timestamp))
             + 0)
@@ -185,7 +185,7 @@ class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc=__file__, workdir='wkdir',
-                blocksize=262144, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -207,7 +207,7 @@ class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc=__file__, workdir='wkdir',
-                blocksize=262144, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -231,7 +231,7 @@ class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc=__file__, workdir='wkdir',
-                blocksize=262144, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -252,7 +252,7 @@ class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=262144, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + 1)
 
@@ -272,7 +272,7 @@ class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expectCommands(
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=262144, maxsize=None, keepstamp=False,
+                blocksize=262144, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(behavior))
 
@@ -326,7 +326,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -345,7 +345,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -362,7 +362,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + 1)
 
@@ -381,7 +381,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(behavior))
 
@@ -450,7 +450,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=16384, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -490,7 +490,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=16384, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0,
@@ -500,7 +500,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -520,7 +520,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=16384, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -543,7 +543,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=16384, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0,
@@ -579,7 +579,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadFile', dict(
                 slavesrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=16384, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0)
@@ -623,7 +623,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadFile', dict(
                 slavesrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=16384, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0,
@@ -633,7 +633,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -654,7 +654,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=16384, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + 1)
 
@@ -677,7 +677,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=16384, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(behavior))
 
@@ -706,7 +706,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadFile', dict(
                 workersrc="srcfile", workdir='wkdir',
-                blocksize=16384, maxsize=None, keepstamp=False,
+                blocksize=16384, maxsize=None, keepstamp=False, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.FileWriter)))
             + Expect.behavior(uploadString("Hello world!"))
             + 0,
@@ -716,7 +716,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -326,7 +326,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -345,7 +345,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -362,7 +362,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + 1)
 
@@ -470,7 +470,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -500,7 +500,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -601,7 +601,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -633,7 +633,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -716,7 +716,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -326,7 +326,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -345,7 +345,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -362,7 +362,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + 1)
 
@@ -381,7 +381,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(behavior))
 
@@ -470,7 +470,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -500,7 +500,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,  regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -601,7 +601,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -633,7 +633,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -716,7 +716,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -470,7 +470,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -362,7 +362,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + 1)
 
@@ -381,7 +381,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(behavior))
 
@@ -470,7 +470,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -500,7 +500,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -601,7 +601,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -633,7 +633,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -716,7 +716,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -470,7 +470,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None, regex=None,
+                blocksize=16384, compress=None, maxsize=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -362,7 +362,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + 1)
 
@@ -381,7 +381,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(behavior))
 
@@ -470,7 +470,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -500,7 +500,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None,  regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -601,7 +601,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -633,7 +633,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 slavesrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)
@@ -716,7 +716,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             + 0,
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(uploadTarFile('fake.tar', test="Hello world!"))
             + 0)

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -381,7 +381,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
         self.expectCommands(
             Expect('uploadDirectory', dict(
                 workersrc="srcdir", workdir='wkdir',
-                blocksize=16384, compress=None, maxsize=None,
+                blocksize=16384, compress=None, maxsize=None, regex=None,
                 writer=ExpectRemoteRef(remotetransfer.DirectoryWriter)))
             + Expect.behavior(behavior))
 

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -402,7 +402,7 @@ class BuildStepMixin:
             if exp_tup != got:
                 text = _describe_cmd_difference(exp, command)
                 raise AssertionError(
-                    "Command contents different from expected; " + text)
+                    f"Command contents different from expected; expected: {exp.args}, cmd: {exp.remote_command}" + text)
 
         if exp.shouldRunBehaviors():
             # let the Expect object show any behaviors that are required

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -402,7 +402,7 @@ class BuildStepMixin:
             if exp_tup != got:
                 text = _describe_cmd_difference(exp, command)
                 raise AssertionError(
-                    f"Command contents different from expected; expected: {exp.args}, cmd: {exp.remote_command}" + text)
+                    "Command contents different from expected; " + text)
 
         if exp.shouldRunBehaviors():
             # let the Expect object show any behaviors that are required

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -402,7 +402,7 @@ class BuildStepMixin:
             if exp_tup != got:
                 text = _describe_cmd_difference(exp, command)
                 raise AssertionError(
-                    "Command contents different from expected; " + text)
+                    "Command contents different from expected; " + text + str(exp.args) + ":" + str(exp.remote_command))
 
         if exp.shouldRunBehaviors():
             # let the Expect object show any behaviors that are required

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -17,9 +17,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
+import re
 import tarfile
 import tempfile
-import re
 
 from twisted.internet import defer
 from twisted.python import log

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -349,7 +349,8 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
             writer=FakeRemote(self.fakemaster),
             maxsize=None,
             blocksize=512,
-            compress=None
+            compress=None,
+            regex=None
         ))
 
         yield self.assertFailure(self.run_command(), RuntimeError)

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -306,6 +306,7 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
             maxsize=None,
             blocksize=512,
             compress=compress,
+            regex=None
         ))
 
         yield self.run_command()


### PR DESCRIPTION
It's quite useful to copy files selectively from a directory instead of the whole directory.
For example, `gradle` would generate build results in lots of `.xml` files which need to be copied to the master for anlalysis.

All subdirectories will still be uploaded, but for files, only paths that match the regex will be uploaded