### PR TITLE
Handle exception in BuildsEndpoint

### DIFF
--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -170,12 +170,15 @@ class BuildsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
         for b in builds:
             data = yield self.db2data(b)
             # Avoid to request DB for Build's properties if not specified
-            if filters:  # pragma: no cover
-                props = yield self.master.db.builds.getBuildProperties(b['id'])
-                filtered_properties = self._generate_filtered_properties(
-                    props, filters)
-                if filtered_properties:
-                    data['properties'] = filtered_properties
+            try:
+                if filters:  # pragma: no cover
+                    props = yield self.master.db.builds.getBuildProperties(b['id'])
+                    filtered_properties = self._generate_filtered_properties(
+                        props, filters)
+                    if filtered_properties:
+                        data['properties'] = filtered_properties
+            except NameError:
+                pass
             buildscol.append(data)
         return buildscol
 

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -164,21 +164,21 @@ class BuildsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
                 workerid=kwargs.get('workerid'),
                 complete=complete,
                 resultSpec=resultSpec)
-            # returns properties' list
-            filters = resultSpec.popProperties()
+
+        # returns properties' list
+        filters = resultSpec.popProperties()
+
         buildscol = []
         for b in builds:
             data = yield self.db2data(b)
             # Avoid to request DB for Build's properties if not specified
-            try:
-                if filters:  # pragma: no cover
-                    props = yield self.master.db.builds.getBuildProperties(b['id'])
-                    filtered_properties = self._generate_filtered_properties(
-                        props, filters)
-                    if filtered_properties:
-                        data['properties'] = filtered_properties
-            except NameError:
-                pass
+            if filters:  # pragma: no cover
+                props = yield self.master.db.builds.getBuildProperties(b['id'])
+                filtered_properties = self._generate_filtered_properties(
+                    props, filters)
+                if filtered_properties:
+                    data['properties'] = filtered_properties
+
             buildscol.append(data)
         return buildscol
 


### PR DESCRIPTION
Check whether `filters` variable is defined.

Fixes https://github.com/buildbot/buildbot/issues/4903