### PR TITLE
github: Fix error handling in case of bad interpolaters

### DIFF
--- a/master/buildbot/newsfragments/github_reporter_erroring.bugfix
+++ b/master/buildbot/newsfragments/github_reporter_erroring.bugfix
@@ -1,0 +1,1 @@
+Fix Github error reporting to handle exceptions that happen before the http request is sent

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -149,6 +149,7 @@ class GitHubStatusPush(http.HttpStatusPushBase):
 
         for sourcestamp in sourcestamps:
             sha = sourcestamp['revision']
+            response = None
             try:
                 repo_user = repoOwner
                 repo_name = repoName
@@ -174,7 +175,11 @@ class GitHubStatusPush(http.HttpStatusPushBase):
                             state=state, repoOwner=repoOwner, repoName=repoName,
                             sha=sha, issue=issue, context=context))
             except Exception as e:
-                content = yield response.content()
+                if response:
+                    content = yield response.content()
+                    code = response.code
+                else:
+                    content = code = "n/a"
                 log.err(
                     e,
                     'Failed to update "{state}" for {repoOwner}/{repoName} '
@@ -182,7 +187,7 @@ class GitHubStatusPush(http.HttpStatusPushBase):
                     'http {code}, {content}'.format(
                         state=state, repoOwner=repoOwner, repoName=repoName,
                         sha=sha, issue=issue, context=context,
-                        code=response.code, content=content))
+                        code=code, content=content))
 
 
 class GitHubCommentPush(GitHubStatusPush):


### PR DESCRIPTION
Fix: #4898 

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
