### PR TITLE
Support recursive matching MultipleFileUpload with `glob=True`

### DIFF
--- a/master/buildbot/newsfragments/support_recursive_glob_MultipleFileUpload.feature
+++ b/master/buildbot/newsfragments/support_recursive_glob_MultipleFileUpload.feature
@@ -1,0 +1,2 @@
+Support recursive matching ('**') in MultipleFileUpload when `glob=True`.
+This is only supported in python3.5+

--- a/worker/buildbot_worker/commands/fs.py
+++ b/worker/buildbot_worker/commands/fs.py
@@ -235,7 +235,11 @@ class GlobPath(base.Command):
         pathname = os.path.join(self.builder.basedir, self.args['path'])
 
         try:
-            files = glob.glob(pathname)
+            # recursive matching is only support in python3.5+
+            if sys.version_info[:2] >= (3, 5):
+                files = glob.glob(pathname, recursive=True)
+            else:
+                files = glob.glob(pathname)
             self.sendStatus({'files': files})
             self.sendStatus({'rc': 0})
         except OSError as e:

--- a/worker/buildbot_worker/test/unit/test_commands_fs.py
+++ b/worker/buildbot_worker/test/unit/test_commands_fs.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import os
 import shutil
+import sys
 
 from twisted.internet import defer
 from twisted.python import runtime
@@ -288,6 +289,27 @@ class TestGlobPath(CommandTestMixin, unittest.TestCase):
 
         self.assertEqual(
             self.get_updates()[0]['files'], [os.path.join(self.basedir, 'test-file')])
+        self.assertIn({'rc': 0},
+                      self.get_updates(),
+                      self.builder.show())
+
+    @defer.inlineCallbacks
+    def test_recursive(self):
+        self.make_command(fs.GlobPath, dict(
+            path='**/*.txt',
+        ), True)
+        os.makedirs(os.path.join(self.basedir, 'test/testdir'))
+        with open(os.path.join(self.basedir, 'test/testdir/test.txt'), 'w'):
+            pass
+
+        yield self.run_command()
+        if sys.version_info[:] >= (3, 5):
+            filename = 'test\\testdir\\test.txt' if sys.platform == 'win32' else 'test/testdir/test.txt'
+            self.assertEqual(
+                self.get_updates()[0]['files'], [os.path.join(self.basedir, filename)])
+        else:
+            self.assertEqual(
+                self.get_updates()[0]['files'], [])
         self.assertIn({'rc': 0},
                       self.get_updates(),
                       self.builder.show())


### PR DESCRIPTION
This will support `**` in python `glob.glob`.

By default `recursive` is set to `False`. Setting it to `True` wouldn't hurt anything.
The only disadvantage introduced by recursive matching is performance downgrade, which can be avoided by not using `**`.
