### PR TITLE
Add webpage to display all builds for a revision

### DIFF
--- a/www/base/src/app/app.module.js
+++ b/www/base/src/app/app.module.js
@@ -50,6 +50,8 @@ require('./builders/step/step.controller.js');
 require('./builders/step/step.route.js');
 require('./buildrequests/pendingbuildrequests.controller.js');
 require('./buildrequests/pendingbuildrequests.route.js');
+require('./changes/changebuilds/changebuilds.controller.js');
+require('./changes/changebuilds/changebuilds.route.js');
 require('./changes/changes.controller.js');
 require('./changes/changes.route.js');
 require('./common/common.constant.js');

--- a/www/base/src/app/changes/changebuilds/changebuilds.controller.js
+++ b/www/base/src/app/changes/changebuilds/changebuilds.controller.js
@@ -1,0 +1,40 @@
+class ChangeBuildsController {
+    constructor($scope, dataService, bbSettingsService, $stateParams, resultsService, $interval, restService) {
+
+        _.mixin($scope, resultsService);
+        $scope.settings = bbSettingsService.getSettingsGroup('ChangeBuilds');
+        $scope.$watch('settings', () => bbSettingsService.save()
+        , true);
+        const buildsFetchLimit = $scope.settings.buildsFetchLimit.value;
+
+        const dataAccessor = dataService.open().closeOnDestroy($scope);
+        $scope.builders = dataAccessor.getBuilders();
+
+        const changeId = $scope.changeId = $stateParams.changeid;
+
+        dataAccessor.getChanges(changeId).onNew = function(change) {
+            $scope.change = change;
+        }
+
+        const getBuildsData = function() {
+            let requestUrl = `changes/${changeId}/builds`;
+            if (!buildsFetchLimit == '') {
+                requestUrl = `changes/${changeId}/builds?limit=${buildsFetchLimit}`;
+            }
+            restService.get(requestUrl).then((data) => {
+                $scope.builds = data.builds;
+            });
+        }
+
+        getBuildsData();
+
+        const stop = $interval(() => {
+            getBuildsData();
+        }, 5000);
+
+        $scope.$on('$destroy', () => $interval.cancel(stop));
+    }
+}
+
+angular.module('app')
+.controller('changebuildsController', ['$scope', 'dataService', 'bbSettingsService', '$stateParams', 'resultsService', '$interval', 'restService', ChangeBuildsController]);

--- a/www/base/src/app/changes/changebuilds/changebuilds.route.js
+++ b/www/base/src/app/changes/changebuilds/changebuilds.route.js
@@ -1,0 +1,35 @@
+class ChangeBuildsState {
+    constructor($stateProvider, bbSettingsServiceProvider) {
+        // Name of the state
+        const name = 'changebuilds';
+
+        // Configuration
+        const cfg = {}
+
+        // Register new state
+        const state = {
+            controller: `${name}Controller`,
+            template: require('./changebuilds.tpl.jade'),
+            name,
+            url: '/changes/:changeid',
+            data: cfg,
+            reloadOnSearch: false
+        }
+
+        $stateProvider.state(state);
+
+        bbSettingsServiceProvider.addSettingsGroup({
+            name:'ChangeBuilds',
+            caption: 'ChangeBuilds page related settings',
+            items:[{
+                type:'integer',
+                name:'buildsFetchLimit',
+                caption:'Maximum number of builds to fetch for the selected change',
+                default_value: ''
+            }]
+        });
+    }
+}
+
+angular.module('app')
+.config(['$stateProvider', 'bbSettingsServiceProvider', ChangeBuildsState]);

--- a/www/base/src/app/changes/changebuilds/changebuilds.tpl.jade
+++ b/www/base/src/app/changes/changebuilds/changebuilds.tpl.jade
@@ -1,0 +1,5 @@
+.container
+  .row
+    changedetails(change="change")
+    div(ng-if="builds")
+        builds-table(builds="builds", builders="builders", ng-if="builds")

--- a/www/base/src/app/changes/changes.controller.js
+++ b/www/base/src/app/changes/changes.controller.js
@@ -1,5 +1,6 @@
 class Changes {
-    constructor($log, $scope, dataService, bbSettingsService) {
+    constructor($log, $scope, dataService, bbSettingsService,
+        $location, $rootScope) {
         $scope.settings = bbSettingsService.getSettingsGroup("Changes");
         $scope.$watch('settings', () => bbSettingsService.save()
         , true);
@@ -13,4 +14,4 @@ class Changes {
 
 
 angular.module('app')
-.controller('changesController', ['$log', '$scope', 'dataService', 'bbSettingsService', Changes]);
+.controller('changesController', ['$log', '$scope', 'dataService', 'bbSettingsService', '$location', '$rootScope', Changes]);

--- a/www/base/src/app/changes/changes.route.js
+++ b/www/base/src/app/changes/changes.route.js
@@ -15,8 +15,9 @@ class ChangesState {
             controller: `${name}Controller`,
             template: require('./changes.tpl.jade'),
             name,
-            url: '/changes',
-            data: cfg
+            url: '/changes?id',
+            data: cfg,
+            reloadOnSearch: false
         };
 
         $stateProvider.state(state);
@@ -29,8 +30,7 @@ class ChangesState {
                 name:'changesFetchLimit',
                 caption:'Maximum number of changes to fetch',
                 default_value: 50
-            }
-            ]});
+            }]});
     }
 }
 

--- a/www/base/src/app/common/directives/changelist/changelist.tpl.jade
+++ b/www/base/src/app/common/directives/changelist/changelist.tpl.jade
@@ -15,4 +15,6 @@
     .row
         ul.list-group
             li.list-group-item(ng-repeat="change in changes")
+                a(ui-sref="changebuilds({changeid: change.changeid})")
+                    | See builds
                 changedetails(change="change")


### PR DESCRIPTION
Closes https://github.com/buildbot/buildbot/issues/3926

- [x] Allow bookmarking individual changes
Use $location to bookmark changes url.
- [x] Display builds for each change

* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
