### PR TITLE
Trigger ui optimization for large scale triggers

### DIFF
--- a/master/buildbot/newsfragments/trigger_step_ui.feature
+++ b/master/buildbot/newsfragments/trigger_step_ui.feature
@@ -1,0 +1,1 @@
+UI now shows a paginated view for trigger step sub builds

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -396,7 +396,7 @@ class TestMaybeStartBuilds(TestBRDBase):
         self.assertBuildsStarted(exp_builds)
 
     @defer.inlineCallbacks
-    def test_no_buildreqests(self):
+    def test_no_buildrequests(self):
         self.addWorkers({'test-worker11': 1})
         yield self.do_test_maybeStartBuildsOnBuilder(exp_claims=[], exp_builds=[])
 

--- a/www/base/src/app/builders/builds/build.route.js
+++ b/www/base/src/app/builders/builds/build.route.js
@@ -38,6 +38,16 @@ class BuildState {
                 default_value: 'summary'
             }
             ]});
+        bbSettingsServiceProvider.addSettingsGroup({
+            name:'TriggerStep',
+            caption: 'Builds per page',
+            items:[{
+                type:'integer',
+                name:'page_size',
+                caption:'Number of builds to show per page in trigger step',
+                default_value: 20
+            }
+            ]});
     }
 }
 

--- a/www/base/src/app/buildrequests/pendingbuildrequests.route.js
+++ b/www/base/src/app/buildrequests/pendingbuildrequests.route.js
@@ -23,7 +23,7 @@ class PendingBuildRequestsState {
 
         bbSettingsServiceProvider.addSettingsGroup({
             name:'BuildRequests',
-            caption: 'Buildreqests page related settings',
+            caption: 'Buildrequests page related settings',
             items:[{
                 type:'integer',
                 name:'buildrequestFetchLimit',

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
@@ -19,6 +19,8 @@ class Buildsummary {
             replace: true,
             restrict: 'E',
             scope: {
+                builderid: '=?',
+                buildnumber: '=?',
                 buildid: '=?',
                 build: '=?',
                 condensed: '=?',
@@ -47,7 +49,7 @@ class _buildsummary {
             buildrequestURLMatchers.push($urlMatcherFactory.compile(
                 `${baseurl}#buildrequests/{buildrequestid:[0-9]+}`))
             buildURLMatchers.push($urlMatcherFactory.compile(
-                `${baseurl}#builders/{builderid:[0-9]+}/builds/{buildid:[0-9]+}`));
+                `${baseurl}#builders/{builderid:[0-9]+}/builds/{buildnumber:[0-9]+}`));
         }
 
         function execMatchers(matchers, url) {
@@ -58,6 +60,33 @@ class _buildsummary {
                 }
             }
             return null
+        }
+        this.stepUpdated = function(step) {
+            step.fulldisplay = (step.complete === false) || (step.results > 0);
+            if (step.complete) {
+                step.duration = step.complete_at - step.started_at;
+            }
+            step.other_urls = []
+            step.buildrequests = []
+            step.builds = []
+            for (let url of step.urls) {
+                let brRes = execMatchers(buildrequestURLMatchers, url.url)
+                if (brRes !== null) {
+                    step.buildrequests.push({
+                        buildrequestid: brRes.buildrequestid
+                    })
+                    continue
+                }
+                let buildRes = execMatchers(buildURLMatchers, url.url)
+                if (buildRes !== null) {
+                    step.builds.push({
+                        builderid: buildRes.builderid,
+                        buildnumber: buildRes.buildnumber
+                    })
+                    continue
+                }
+                step.other_urls.push(url)
+            }
         }
         this.$onInit = function () {
 
@@ -99,10 +128,6 @@ class _buildsummary {
                 }
             };
 
-            this.getBuildRequestIDFromURL = memoize(url => parseInt(execMatchers(buildrequestURLMatchers, url).buildrequestid, 10));
-
-            this.isBuildRequestURL = memoize(url => execMatchers(buildrequestURLMatchers, url) !== null);
-            this.isBuildURL = memoize(url => execMatchers(buildURLMatchers, url) !== null);
 
             this.getBuildProperty = function (property) {
                 const hasProperty = self.properties && self.properties.hasOwnProperty(property);
@@ -159,7 +184,7 @@ class _buildsummary {
                     return self.reason = self.getBuildProperty('reason');
                 };
 
-                return $scope.$watch((() => details), function (details) {
+                $scope.$watch((() => details), function (details) {
                     if ((details !== NONE) && (self.steps == null)) {
                         self.steps = build.getSteps();
 
@@ -169,13 +194,7 @@ class _buildsummary {
                             // but we need to update our additional needed attributes
                             return self.steps.onUpdate(step);
                         };
-
-                        return self.steps.onUpdate = function (step) {
-                            step.fulldisplay = (step.complete === false) || (step.results > 0);
-                            if (step.complete) {
-                                return step.duration = step.complete_at - step.started_at;
-                            }
-                        };
+                        self.steps.onUpdate = self.stepUpdated
                     }
                 });
             });

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
@@ -19,8 +19,6 @@ class Buildsummary {
             replace: true,
             restrict: 'E',
             scope: {
-                builderid: '=?',
-                buildnumber: '=?',
                 buildid: '=?',
                 build: '=?',
                 condensed: '=?',
@@ -97,6 +95,7 @@ class _buildsummary {
             }, 1000);
             $scope.$on("$destroy", () => $interval.cancel(stop));
             $scope.settings = bbSettingsService.getSettingsGroup("LogPreview");
+            $scope.page_size = bbSettingsService.getSettingsGroup("TriggerStep").page_size.value;
 
             const NONE = 0;
             const ONLY_NOT_SUCCESS = 1;

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -45,11 +45,11 @@
             i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':step.fulldisplay}", ng-if="step.logs.length")
             | #{' '} {{step.name}}
         ul
-          li(ng-if='!(buildsummary.isBuildRequestURL(url.url) || buildsummary.isBuildURL(url.url))', ng-repeat="url in step.urls")
+          li(ng-repeat="url in step.other_urls")
             a(ng-href="{{url.url}}", target="_blank") {{url.name}}
         ul.list-unstyled
-          li(ng-if='buildsummary.isBuildRequestURL(url.url)', ng-repeat="url in step.urls")
-            buildrequestsummary(style="margin-left:30px;margin-top:8px",buildrequestid='buildsummary.getBuildRequestIDFromURL(url.url)')
+          li(ng-repeat="br in step.builds")
+            buildsummary(style="margin-left:30px;margin-top:8px", builderid="build.builderid", buildnumber="build.buildnumber", condensed="true")
         div.anim-stepdetails(ng-if="step.fulldisplay")
           logpreview(ng-repeat="log in buildsummary.getLogs(step)", log="log",
                      fulldisplay="step.logs.length == 1 || buildsummary.expandByName(log)",

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -44,13 +44,18 @@
             | #{' '}
             i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':step.fulldisplay}", ng-if="step.logs.length")
             | #{' '} {{step.name}}
-        ul
-          li(ng-repeat="url in step.other_urls")
-            a(ng-href="{{url.url}}", target="_blank") {{url.name}}
-        ul.list-unstyled
-          li(ng-repeat="br in step.builds")
-            buildsummary(style="margin-left:30px;margin-top:8px", builderid="build.builderid", buildnumber="build.buildnumber", condensed="true")
+            span(ng-if="step.buildrequests.length") #{' '} {{step.builds.length}} builds, {{step.buildrequests.length - step.builds.length}} pending builds
+
         div.anim-stepdetails(ng-if="step.fulldisplay")
+          ul
+            li(ng-repeat="url in step.other_urls")
+              a(ng-href="{{url.url}}", target="_blank") {{url.name}}
+          ul(ng-if="step.buildrequests.length>page_size",uib-pagination,total-items="step.buildrequests.length",
+            ng-model="step.buildrequestsCurrentPage",class="pagination-sm" boundary-link-numbers="true",
+            max-size=10, items-per-page="page_size")
+          ul.list-unstyled
+            li(ng-repeat="br in step.buildrequests | limitTo: page_size :(step.buildrequestsCurrentPage-1)*page_size")
+              buildrequestsummary(style="margin-left:30px;margin-top:8px",buildrequestid='br.buildrequestid')
           logpreview(ng-repeat="log in buildsummary.getLogs(step)", log="log",
                      fulldisplay="step.logs.length == 1 || buildsummary.expandByName(log)",
                      builderid="buildsummary.build.builderid", buildnumber="buildsummary.build.number",


### PR DESCRIPTION
A couple of optimizations for trigger UI

- avoid parsing URLs over and over (only parse them when they change)
- add paging to the trigger UI

Remaining:
* [ ] don't go through buildrequest to display a build
At the moment, there is no support in data module to directly get a build via (builderid, buildnumber)
We need to add some metadata in the urls so that all of that is efficient at scale.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
