### PR TITLE
Fix #4873 per latest Bitbucket API documentation

### DIFF
--- a/master/buildbot/newsfragments/fix_bitbucketcloud_hook.bugfix
+++ b/master/buildbot/newsfragments/fix_bitbucketcloud_hook.bugfix
@@ -1,0 +1,1 @@
+:issue:`4873`: Fix Bitbucket Cloud hook crash due to changes in their API.

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketcloud.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketcloud.py
@@ -31,7 +31,7 @@ _CT_JSON = b'application/json'
 pushJsonPayload = """
 {
     "actor": {
-        "username": "John",
+        "nickname": "John",
         "display_name": "John Smith"
     },
     "repository": {
@@ -52,7 +52,7 @@ pushJsonPayload = """
         "public": false,
         "ownerName": "CI",
         "owner": {
-            "username": "CI",
+            "nickname": "CI",
             "display_name": "CI"
         },
         "fullName": "CI/py-repo"
@@ -87,7 +87,7 @@ pushJsonPayload = """
 pullRequestCreatedJsonPayload = """
 {
     "actor": {
-        "username": "John",
+        "nickname": "John",
         "display_name": "John Smith"
     },
     "pullrequest": {
@@ -111,7 +111,7 @@ pullRequestCreatedJsonPayload = """
                 "public": false,
                 "ownerName": "CI",
                 "owner": {
-                    "username": "CI",
+                    "nickname": "CI",
                     "display_name": "CI"
                 },
                 "fullName": "CI/py-repo"
@@ -143,7 +143,7 @@ pullRequestCreatedJsonPayload = """
                 "public": false,
                 "ownerName": "CI",
                 "owner": {
-                    "username": "CI",
+                    "nickname": "CI",
                     "display_name": "CI"
                 },
                 "fullName": "CI/py-repo"
@@ -175,7 +175,7 @@ pullRequestCreatedJsonPayload = """
         "public": false,
         "ownerName": "CI",
         "owner": {
-            "username": "CI",
+            "nickname": "CI",
             "display_name": "CI"
         },
         "fullName": "CI/py-repo"
@@ -186,7 +186,7 @@ pullRequestCreatedJsonPayload = """
 pullRequestUpdatedJsonPayload = """
 {
     "actor": {
-        "username": "John",
+        "nickname": "John",
         "display_name": "John Smith"
     },
     "pullrequest": {
@@ -210,7 +210,7 @@ pullRequestUpdatedJsonPayload = """
                 "public": false,
                 "ownerName": "CI",
                 "owner": {
-                    "username": "CI",
+                    "nickname": "CI",
                     "display_name": "CI"
                 },
                 "fullName": "CI/py-repo"
@@ -242,7 +242,7 @@ pullRequestUpdatedJsonPayload = """
                 "public": false,
                 "ownerName": "CI",
                 "owner": {
-                    "username": "CI",
+                    "nickname": "CI",
                     "display_name": "CI"
                 },
                 "fullName": "CI/py-repo"
@@ -274,7 +274,7 @@ pullRequestUpdatedJsonPayload = """
         "public": false,
         "ownerName": "CI",
         "owner": {
-            "username": "CI",
+            "nickname": "CI",
             "display_name": "CI"
         },
         "fullName": "CI/py-repo"
@@ -285,7 +285,7 @@ pullRequestUpdatedJsonPayload = """
 pullRequestRejectedJsonPayload = """
 {
     "actor": {
-        "username": "John",
+        "nickname": "John",
         "display_name": "John Smith"
     },
     "pullrequest": {
@@ -309,7 +309,7 @@ pullRequestRejectedJsonPayload = """
                 "public": false,
                 "ownerName": "CI",
                 "owner": {
-                    "username": "CI",
+                    "nickname": "CI",
                     "display_name": "CI"
                 },
                 "fullName": "CI/py-repo"
@@ -341,7 +341,7 @@ pullRequestRejectedJsonPayload = """
                 "public": false,
                 "ownerName": "CI",
                 "owner": {
-                    "username": "CI",
+                    "nickname": "CI",
                     "display_name": "CI"
                 },
                 "fullName": "CI/py-repo"
@@ -373,7 +373,7 @@ pullRequestRejectedJsonPayload = """
         "public": false,
         "ownerName": "CI",
         "owner": {
-            "username": "CI",
+            "nickname": "CI",
             "display_name": "CI"
         },
         "fullName": "CI/py-repo"
@@ -384,7 +384,7 @@ pullRequestRejectedJsonPayload = """
 pullRequestFulfilledJsonPayload = """
 {
     "actor": {
-        "username": "John",
+        "nickname": "John",
         "display_name": "John Smith"
     },
     "pullrequest": {
@@ -408,7 +408,7 @@ pullRequestFulfilledJsonPayload = """
                 "public": false,
                 "ownerName": "CI",
                 "owner": {
-                    "username": "CI",
+                    "nickname": "CI",
                     "display_name": "CI"
                 },
                 "fullName": "CI/py-repo"
@@ -440,7 +440,7 @@ pullRequestFulfilledJsonPayload = """
                 "public": false,
                 "ownerName": "CI",
                 "owner": {
-                    "username": "CI",
+                    "nickname": "CI",
                     "display_name": "CI"
                 },
                 "fullName": "CI/py-repo"
@@ -472,7 +472,7 @@ pullRequestFulfilledJsonPayload = """
         "public": false,
         "ownerName": "CI",
         "owner": {
-            "username": "CI",
+            "nickname": "CI",
             "display_name": "CI"
         },
         "fullName": "CI/py-repo"
@@ -483,7 +483,7 @@ pullRequestFulfilledJsonPayload = """
 deleteTagJsonPayload = """
 {
     "actor": {
-        "username": "John",
+        "nickname": "John",
         "display_name": "John Smith"
     },
     "repository": {
@@ -504,7 +504,7 @@ deleteTagJsonPayload = """
         "ownerName": "BUIL",
         "public": false,
         "owner": {
-            "username": "CI",
+            "nickname": "CI",
             "display_name": "CI"
         },
         "fullName": "CI/py-repo"
@@ -532,7 +532,7 @@ deleteTagJsonPayload = """
 deleteBranchJsonPayload = """
 {
     "actor": {
-        "username": "John",
+        "nickname": "John",
         "display_name": "John Smith"
     },
     "repository": {
@@ -553,7 +553,7 @@ deleteBranchJsonPayload = """
         "ownerName": "CI",
         "public": false,
         "owner": {
-            "username": "CI",
+            "nickname": "CI",
             "display_name": "CI"
         },
         "fullName": "CI/py-repo"
@@ -581,7 +581,7 @@ deleteBranchJsonPayload = """
 newTagJsonPayload = """
 {
     "actor": {
-        "username": "John",
+        "nickname": "John",
         "display_name": "John Smith"
     },
     "repository": {
@@ -602,7 +602,7 @@ newTagJsonPayload = """
         "public": false,
         "ownerName": "CI",
         "owner": {
-            "username": "CI",
+            "nickname": "CI",
             "display_name": "CI"
         },
         "fullName": "CI/py-repo"

--- a/master/buildbot/www/hooks/bitbucketcloud.py
+++ b/master/buildbot/www/hooks/bitbucketcloud.py
@@ -145,7 +145,7 @@ class BitbucketCloudEventHandler:
             'revlink': payload['pullrequest']['link'],
             'repository': repo_url,
             'author': '{} <{}>'.format(payload['actor']['display_name'],
-                                       payload['actor']['username']),
+                                       payload['actor']['nickname']),
             'comments': 'Bitbucket Cloud Pull Request #{}'.format(pr_number),
             'branch': refname,
             'project': project,

--- a/master/buildbot/www/hooks/bitbucketcloud.py
+++ b/master/buildbot/www/hooks/bitbucketcloud.py
@@ -70,7 +70,10 @@ class BitbucketCloudEventHandler:
 
     def handle_repo_push(self, payload):
         changes = []
+        if payload['repository'].get('project'):
         project = payload['repository']['project']['name']
+        else:
+            project = 'none'
         repo_url = payload['repository']['links']['self']['href']
         web_url = payload['repository']['links']['html']['href']
 
@@ -94,7 +97,7 @@ class BitbucketCloudEventHandler:
                 'revlink': '{}/commits/{}'.format(web_url, commit_hash),
                 'repository': repo_url,
                 'author': '{} <{}>'.format(payload['actor']['display_name'],
-                                           payload['actor']['username']),
+                                           payload['actor']['nickname']),
                 'comments': 'Bitbucket Cloud commit {}'.format(commit_hash),
                 'branch': branch,
                 'project': project,
@@ -139,6 +142,10 @@ class BitbucketCloudEventHandler:
     def handle_pullrequest(self, payload, refname, category):
         pr_number = int(payload['pullrequest']['id'])
         repo_url = payload['repository']['links']['self']['href']
+        if payload['repository'].get('project'):
+            project = payload['repository']['project']['name']
+        else:
+            project = 'none'
         change = {
             'revision': payload['pullrequest']['fromRef']['commit']['hash'],
             'revlink': payload['pullrequest']['link'],
@@ -147,7 +154,7 @@ class BitbucketCloudEventHandler:
                                        payload['actor']['username']),
             'comments': 'Bitbucket Cloud Pull Request #{}'.format(pr_number),
             'branch': refname,
-            'project': payload['repository']['project']['name'],
+            'project': project,
             'category': category,
             'properties': {'pullrequesturl': payload['pullrequest']['link']}
         }

--- a/master/buildbot/www/hooks/bitbucketcloud.py
+++ b/master/buildbot/www/hooks/bitbucketcloud.py
@@ -70,10 +70,7 @@ class BitbucketCloudEventHandler:
 
     def handle_repo_push(self, payload):
         changes = []
-        if payload['repository'].get('project'):
-        project = payload['repository']['project']['name']
-        else:
-            project = 'none'
+        project = payload['repository'].get('project', {'name': 'none'})['name']
         repo_url = payload['repository']['links']['self']['href']
         web_url = payload['repository']['links']['html']['href']
 
@@ -142,10 +139,7 @@ class BitbucketCloudEventHandler:
     def handle_pullrequest(self, payload, refname, category):
         pr_number = int(payload['pullrequest']['id'])
         repo_url = payload['repository']['links']['self']['href']
-        if payload['repository'].get('project'):
-            project = payload['repository']['project']['name']
-        else:
-            project = 'none'
+        project = payload['repository'].get('project', {'name': 'none'})['name']
         change = {
             'revision': payload['pullrequest']['fromRef']['commit']['hash'],
             'revlink': payload['pullrequest']['link'],


### PR DESCRIPTION
* replace the username property with nickname (per the privacy changes in API)
  https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-entity_user

* per Bitbucket documentation the project property in repository is not guaranteed to be always present which was also crashing my Buildbot
  https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-entity_repositoryRepository

## Remove this paragraph

If you don't remove this paragraph from the pull request description, this means you didn't read our contributor documentation, and your patch will need more back and forth before it can be accepted!

Please have a look at our developer documentation before submitting your Pull Request.

http://docs.buildbot.net/latest/developer/quickstart.html

And especially:
http://docs.buildbot.net/latest/developer/pull-request.html


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
