### PR TITLE
Changed files support for GerritChangeSource and GerritEventLogPoller

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -431,6 +431,14 @@ class GerritEventLogPoller(GerritChangeSourceBase):
             yield self.master.db.state.setState(self._oid, 'last_event_ts', event['eventCreatedOn'])
         return res
 
+    @defer.inlineCallbacks
+    def getFiles(self, change, patchset):
+        res = yield self._http.get("/changes/%s/revisions/%s/files/" % (change, patchset))
+        res = yield res.content()
+
+        res = res.splitlines()[1].decode('utf8')  # the first line of every response is `)]}'`
+        return list(json.loads(res))
+
     # FIXME this copy the code from PollingChangeSource
     # but as PollingChangeSource and its subclasses need to be ported to reconfigurability
     # we can't use it right now

--- a/master/buildbot/newsfragments/gerrit_get_files.feature
+++ b/master/buildbot/newsfragments/gerrit_get_files.feature
@@ -1,0 +1,1 @@
+The :py:class:`~buildbot.changes.gerritchangesource.GerritChangeFilter` and :py:class:`~buildbot.changes.gerritchangesource.GerritEventLogPoller` now populate the `files` attribute of emitted changes when the `get_files` argument is true. Enabling this feature triggers an additional HTTP request or SSH command to the Gerrit server for every emitted change.

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -1191,6 +1191,10 @@ The :bb:chsrc:`GerritChangeSource` accepts the following arguments:
     event to be handled (optional).
     By default processes `patchset-created` and `ref-updated`
 
+``get_files``
+    Populate the `files` attribute of emitted changes (default `False`).
+    Buildbot will run an extra query command for each handled event to determine the changed files.
+
 ``debug``
     Print Gerrit event in the log (default `False`).
     This allows to debug event content, but will eventually fill your logs with useless Gerrit event logs.

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -1378,6 +1378,10 @@ The :bb:chsrc:`GerritEventLogPoller` accepts the following arguments:
 ``gitBaseURL``
     The git URL where Gerrit is accessible via git+ssh protocol
 
+``get_files``
+    Populate the `files` attribute of emitted changes (default `False`).
+    Buildbot will run an extra query command for each handled event to determine the changed files.
+
 ``debug``
     Print Gerrit event in the log (default `False`).
     This allows to debug event content, but will eventually fill your logs with useless Gerrit event logs.


### PR DESCRIPTION
Set the `files` property for changes emitted by the Gerrit change sources. It's disabled by default as the extra traffic to the Gerrit server may come as an unpleasant surprise to some. The feature can be enabled by setting `get_files` to true.

Fixes #3996.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation


**Side-note:**
I last contributed (mostly subversion features and fixes) to buildbot 9 years ago - it's great to see how far the project has come since then! I also can't believe the project is still using some of the [figures](4339e66d11f6f547d9711e14600c86938f1b988d) I made for the documentation back then :)  
