### PR TITLE
bitbucket server push event handler

### DIFF
--- a/master/buildbot/newsfragments/bitbucketserver-refs-changed.bugfix
+++ b/master/buildbot/newsfragments/bitbucketserver-refs-changed.bugfix
@@ -1,0 +1,1 @@
+Fix handling of the regs_changed event in the BitBucket Server web hook.

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
@@ -686,10 +686,24 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
             '793d4754230023d85532f9a38dba3290f959beb4')
 
     @defer.inlineCallbacks
-    def testHookWithChangeOnPushEvent(self):
+    def testHookWithChangeOnRefsChangedEvent(self):
 
         request = _prepare_request(
             pushJsonPayload, headers={_HEADER_EVENT: 'repo:refs_changed'})
+
+        yield request.test_render(self.change_hook)
+
+        self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
+        change = self.change_hook.master.data.updates.changesAdded[0]
+        self._checkPush(change)
+        self.assertEqual(change['branch'], 'refs/heads/branch_1496411680')
+        self.assertEqual(change['category'], 'push')
+
+    @defer.inlineCallbacks
+    def testHookWithChangeOnPushEvent(self):
+
+        request = _prepare_request(
+            pushJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
 
         yield request.test_render(self.change_hook)
 

--- a/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_www_hooks_bitbucketserver.py
@@ -689,7 +689,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
     def testHookWithChangeOnPushEvent(self):
 
         request = _prepare_request(
-            pushJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
+            pushJsonPayload, headers={_HEADER_EVENT: 'repo:refs_changed'})
 
         yield request.test_render(self.change_hook)
 
@@ -782,7 +782,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
     @defer.inlineCallbacks
     def _checkCodebase(self, event_type, expected_codebase):
         payloads = {
-            'repo:push': pushJsonPayload,
+            'repo:refs_changed': pushJsonPayload,
             'pullrequest:updated': pullRequestUpdatedJsonPayload}
         request = _prepare_request(
             payloads[event_type], headers={_HEADER_EVENT: event_type})
@@ -795,7 +795,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
     def testHookWithCodebaseValueOnPushEvent(self):
         self.change_hook.dialects = {
             'bitbucketserver': {'codebase': 'super-codebase'}}
-        yield self._checkCodebase('repo:push', 'super-codebase')
+        yield self._checkCodebase('repo:refs_changed', 'super-codebase')
 
     @defer.inlineCallbacks
     def testHookWithCodebaseFunctionOnPushEvent(self):
@@ -803,7 +803,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
             'bitbucketserver': {
                 'codebase':
                     lambda payload: payload['repository']['project']['key']}}
-        yield self._checkCodebase('repo:push', 'CI')
+        yield self._checkCodebase('repo:refs_changed', 'CI')
 
     @defer.inlineCallbacks
     def testHookWithCodebaseValueOnPullEvent(self):
@@ -830,7 +830,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
     @defer.inlineCallbacks
     def testHookWithChangeOnCreateTag(self):
         request = _prepare_request(
-            newTagJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
+            newTagJsonPayload, headers={_HEADER_EVENT: 'repo:refs_changed'})
         yield request.test_render(self.change_hook)
         self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
         change = self.change_hook.master.data.updates.changesAdded[0]
@@ -841,7 +841,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
     @defer.inlineCallbacks
     def testHookWithChangeOnDeleteTag(self):
         request = _prepare_request(
-            deleteTagJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
+            deleteTagJsonPayload, headers={_HEADER_EVENT: 'repo:refs_changed'})
         yield request.test_render(self.change_hook)
         self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
         change = self.change_hook.master.data.updates.changesAdded[0]
@@ -852,7 +852,8 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
     @defer.inlineCallbacks
     def testHookWithChangeOnDeleteBranch(self):
         request = _prepare_request(
-            deleteBranchJsonPayload, headers={_HEADER_EVENT: 'repo:push'})
+            deleteBranchJsonPayload,
+            headers={_HEADER_EVENT: 'repo:refs_changed'})
         yield request.test_render(self.change_hook)
         self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 1)
         change = self.change_hook.master.data.updates.changesAdded[0]
@@ -863,7 +864,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
     @defer.inlineCallbacks
     def testHookWithInvalidContentType(self):
         request = _prepare_request(
-            pushJsonPayload, headers={_HEADER_EVENT: b'repo:push'})
+            pushJsonPayload, headers={_HEADER_EVENT: b'repo:refs_changed'})
         request.received_headers[b'Content-Type'] = b'invalid/content'
         yield request.test_render(self.change_hook)
         self.assertEqual(len(self.change_hook.master.data.updates.changesAdded), 0)

--- a/master/buildbot/www/hooks/bitbucketserver.py
+++ b/master/buildbot/www/hooks/bitbucketserver.py
@@ -68,7 +68,7 @@ class BitbucketServerEventHandler:
 
         return payload
 
-    def handle_repo_push(self, payload):
+    def handle_repo_refs_changed(self, payload):
         changes = []
         project = payload['repository']['project']['name']
         repo_url = payload['repository']['links']['self'][0]['href']

--- a/master/buildbot/www/hooks/bitbucketserver.py
+++ b/master/buildbot/www/hooks/bitbucketserver.py
@@ -69,6 +69,15 @@ class BitbucketServerEventHandler:
         return payload
 
     def handle_repo_refs_changed(self, payload):
+        return self._handle_repo_refs_changed_common(payload)
+
+    def handle_repo_push(self, payload):
+        # repo:push works exactly like repo:refs_changed, but is no longer documented (not even
+        # in the historical documentation of old versions of Bitbucket Server). The old code path
+        # has been preserved for backwards compatibility.
+        return self._handle_repo_refs_changed_common(payload)
+
+    def _handle_repo_refs_changed_common(self, payload):
         changes = []
         project = payload['repository']['project']['name']
         repo_url = payload['repository']['links']['self'][0]['href']


### PR DESCRIPTION
This is for issue https://github.com/buildbot/buildbot/issues/4945



The Bitbucket server push event handler
uses the x-event-key value 'repo:refs_changed' to signify
push events.

bitbucket server: update header event

replace header event repo:push with repo:refs_changed

https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html

