### PR TITLE
Convert the buildbot.www.auth module into a package

### DIFF
--- a/master/buildbot/newsfragments/buildbot-master-www-auth-package.misc
+++ b/master/buildbot/newsfragments/buildbot-master-www-auth-package.misc
@@ -1,0 +1,1 @@
+The :py:class:`~buildbot.www.auth` module was converted into a package. 

--- a/master/buildbot/www/auth/__init__.py
+++ b/master/buildbot/www/auth/__init__.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from buildbot.www.auth.base import (
+    AuthRootResource, AuthBase, UserInfoProviderBase, LoginResource,
+    AuthRealm, PreAuthenticatedLoginResource, LogoutResource
+)
+from buildbot.www.auth.userpasswd import (
+    TwistedICredAuthBase, HTPasswdAuth, UserPasswordAuth
+)
+from buildbot.www.auth.customauth import CustomAuth
+from buildbot.www.auth.remoteuser import RemoteUserAuth
+
+
+class NoAuth(AuthBase):
+    pass

--- a/master/buildbot/www/auth/customauth.py
+++ b/master/buildbot/www/auth/customauth.py
@@ -1,0 +1,46 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from abc import ABCMeta
+from abc import abstractmethod
+
+from twisted.cred.checkers import ICredentialsChecker
+from twisted.cred.credentials import IUsernamePassword
+from twisted.cred.error import UnauthorizedLogin
+from twisted.internet import defer
+from twisted.web.guard import BasicCredentialFactory
+from zope.interface import implementer
+
+from buildbot.www.auth.userpasswd import TwistedICredAuthBase
+
+
+@implementer(ICredentialsChecker)
+class CustomAuth(TwistedICredAuthBase):
+    __metaclass__ = ABCMeta
+    credentialInterfaces = [IUsernamePassword]
+
+    def __init__(self, **kwargs):
+        super().__init__([BasicCredentialFactory(b"buildbot")],
+            [self],
+            **kwargs)
+
+    def requestAvatarId(self, cred):
+        if self.check_credentials(cred.username, cred.password):
+            return defer.succeed(cred.username)
+        return defer.fail(UnauthorizedLogin())
+
+    @abstractmethod
+    def check_credentials(username, password):
+        return False

--- a/master/buildbot/www/auth/remoteuser.py
+++ b/master/buildbot/www/auth/remoteuser.py
@@ -1,0 +1,53 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import re
+
+from twisted.internet import defer
+from twisted.web.error import Error
+
+from buildbot.util import bytes2unicode
+from buildbot.util import unicode2bytes
+from buildbot.www.auth.base import AuthBase
+from buildbot.www.auth.base import UserInfoProviderBase
+
+
+class RemoteUserAuth(AuthBase):
+    header = b"REMOTE_USER"
+    headerRegex = re.compile(br"(?P<username>[^ @]+)@(?P<realm>[^ @]+)")
+
+    def __init__(self, header=None, headerRegex=None, **kwargs):
+        super().__init__(**kwargs)
+        if self.userInfoProvider is None:
+            self.userInfoProvider = UserInfoProviderBase()
+        if header is not None:
+            self.header = unicode2bytes(header)
+        if headerRegex is not None:
+            self.headerRegex = re.compile(unicode2bytes(headerRegex))
+
+    @defer.inlineCallbacks
+    def maybeAutoLogin(self, request):
+        header = request.getHeader(self.header)
+        if header is None:
+            raise Error(403, b"missing http header " + self.header + b". Check your reverse proxy config!")
+        res = self.headerRegex.match(header)
+        if res is None:
+            raise Error(
+                403, b'http header does not match regex! "' + header + b'" not matching ' + self.headerRegex.pattern)
+        session = request.getSession()
+        user_info = {k: bytes2unicode(v) for k, v in res.groupdict().items()}
+        if session.user_info != user_info:
+            session.user_info = user_info
+            yield self.updateUserInfo(request)

--- a/master/buildbot/www/auth/userpasswd.py
+++ b/master/buildbot/www/auth/userpasswd.py
@@ -1,0 +1,63 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.cred.checkers import FilePasswordDB
+from twisted.cred.checkers import InMemoryUsernamePasswordDatabaseDontUse
+from twisted.cred.portal import Portal
+from twisted.web.guard import BasicCredentialFactory
+from twisted.web.guard import DigestCredentialFactory
+from twisted.web.guard import HTTPAuthSessionWrapper
+
+from buildbot.util import unicode2bytes
+from buildbot.www.auth.base import AuthBase
+from buildbot.www.auth.base import AuthRealm
+from buildbot.www.auth.base import UserInfoProviderBase
+
+
+class TwistedICredAuthBase(AuthBase):
+
+    def __init__(self, credentialFactories, checkers, **kwargs):
+        super().__init__(**kwargs)
+        if self.userInfoProvider is None:
+            self.userInfoProvider = UserInfoProviderBase()
+        self.credentialFactories = credentialFactories
+        self.checkers = checkers
+
+    def getLoginResource(self):
+        return HTTPAuthSessionWrapper(
+            Portal(AuthRealm(self.master, self), self.checkers),
+            self.credentialFactories)
+
+
+class HTPasswdAuth(TwistedICredAuthBase):
+
+    def __init__(self, passwdFile, **kwargs):
+        super().__init__([DigestCredentialFactory(b"md5", b"buildbot"),
+             BasicCredentialFactory(b"buildbot")],
+            [FilePasswordDB(passwdFile)],
+            **kwargs)
+
+
+class UserPasswordAuth(TwistedICredAuthBase):
+
+    def __init__(self, users, **kwargs):
+        if isinstance(users, dict):
+            users = {user: unicode2bytes(pw) for user, pw in users.items()}
+        elif isinstance(users, list):
+            users = [(user, unicode2bytes(pw)) for user, pw in users]
+        super().__init__([DigestCredentialFactory(b"md5", b"buildbot"),
+             BasicCredentialFactory(b"buildbot")],
+            [InMemoryUsernamePasswordDatabaseDontUse(**dict(users))],
+            **kwargs)

--- a/master/setup.py
+++ b/master/setup.py
@@ -192,6 +192,7 @@ setup_args = {
         "buildbot.wamp",
         "buildbot.www",
         "buildbot.www.hooks",
+        "buildbot.www.auth",
         "buildbot.www.authz",
     ] + ([] if BUILDING_WHEEL else [  # skip tests for wheels (save 50% of the archive)
         "buildbot.test",
@@ -392,8 +393,10 @@ setup_args = {
             ('buildbot.steps.shellsequence', ['ShellArg']),
             ('buildbot.util.kubeclientservice', ['KubeHardcodedConfig', 'KubeCtlProxyConfigLoader', 'KubeInClusterConfigLoader']),
             ('buildbot.www.avatar', ['AvatarGravatar']),
-            ('buildbot.www.auth', [
-                'UserPasswordAuth', 'HTPasswdAuth', 'RemoteUserAuth', 'CustomAuth']),
+            ('buildbot.www.auth', ['NoAuth']),
+            ('buildbot.www.auth.userpasswd', ['UserPasswordAuth', 'HTPasswdAuth']),
+            ('buildbot.www.auth.remoteuser', ['RemoteUserAuth']),
+            ('buildbot.www.auth.customauth', ['CustomAuth']),
             ('buildbot.www.ldapuserinfo', ['LdapUserInfo']),
             ('buildbot.www.oauth2', [
                 'GoogleAuth', 'GitHubAuth', 'GitLabAuth', 'BitbucketAuth']),


### PR DESCRIPTION
I've began work on an `LdapAuth` authentication provider. It's based on [ldapauth.py](https://github.com/nextgis/buildbot/blob/master/ldapauth.py), but makes use of the already existing `LdapUserInfo`. This feature can be implemented more cleanly if the `buildbot.www.auth` module was split into a package (similar to how `authz` is structured). 

The change moves a lot of code around, so I'd like to know if it's a go/no-go before I continue working on the authentication provider.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
