### PR TITLE
PULL_REQUEST_TEMPLATE: add a note about usage of infinitive instead of past sense

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,13 @@ http://docs.buildbot.net/latest/developer/quickstart.html
 And especially:
 http://docs.buildbot.net/latest/developer/pull-request.html
 
-
 ## Contributor Checklist:
+
+*Important*: please use infinitive when describing changes- not "Added" but "Add": you are submitting a request to change, you have not change anything yet (in your branch, yes, in the target branch, no).
+
+Related to review comments:
+
+* `nitpick` means that it _might_ be a nice change, but it's up to the submitter.
 
 * [ ] I have updated the unit tests
 * [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests -- *no need*
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory) -- *no need*
* [x] I have updated the appropriate documentation -- *no need*
