### PR TITLE
Enable autoescape in jinja2

### DIFF
--- a/master/buildbot/scripts/create_master.py
+++ b/master/buildbot/scripts/create_master.py
@@ -39,7 +39,7 @@ def makeBasedir(config):
 def makeTAC(config):
     # render buildbot_tac.tmpl using the config
     loader = jinja2.FileSystemLoader(os.path.dirname(__file__))
-    env = jinja2.Environment(loader=loader, undefined=jinja2.StrictUndefined)
+    env = jinja2.Environment(loader=loader, undefined=jinja2.StrictUndefined, autoescape=True)
     env.filters['repr'] = repr
     tpl = env.get_template('buildbot_tac.tmpl')
     cxt = dict((k.replace('-', '_'), v) for k, v in config.items())

--- a/master/buildbot/scripts/devproxy.py
+++ b/master/buildbot/scripts/devproxy.py
@@ -61,7 +61,7 @@ class DevProxy:
                 app.router.add_static('/' + plugin, staticdir)
         staticdir = self.staticdir = self.apps.get('base').static_dir
         loader = jinja2.FileSystemLoader(staticdir)
-        self.jinja = jinja2.Environment(
+        self.jinja = jinja2.Environment(autoescape=True,
             loader=loader, undefined=jinja2.StrictUndefined)
         app.router.add_static('/', staticdir)
         conn = aiohttp.TCPConnector(

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -390,7 +390,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
                     print(
                         "You may update the test with (copied to clipboard):\n" + formatted)
                     xerox.copy(formatted)
-                    input()
+                    input() # nosec
                 except ImportError:
                     print("Note: for quick fix, pip install xerox")
             self.assertEqual(gotSpec, expectSpec)

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -390,7 +390,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
                     print(
                         "You may update the test with (copied to clipboard):\n" + formatted)
                     xerox.copy(formatted)
-                    input() # nosec
+                    input()  # nosec
                 except ImportError:
                     print("Note: for quick fix, pip install xerox")
             self.assertEqual(gotSpec, expectSpec)

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -36,7 +36,7 @@ class IndexResource(resource.Resource):
     def __init__(self, master, staticdir):
         super().__init__(master)
         loader = jinja2.FileSystemLoader(staticdir)
-        self.jinja = jinja2.Environment(
+        self.jinja = jinja2.Environment(autoescape=True,
             loader=loader, undefined=jinja2.StrictUndefined)
 
     def reconfigResource(self, new_config):

--- a/worker/buildbot_worker/test/unit/test_commands_utils.py
+++ b/worker/buildbot_worker/test/unit/test_commands_utils.py
@@ -142,7 +142,7 @@ class RmdirRecursive(unittest.TestCase):
         finally:
             # even Twisted can't clean this up very well, so try hard to
             # clean it up ourselves..
-            os.chmod("noperms/x", 0o777)
+            os.chmod("noperms/x", 0o777) # nosec
             os.unlink("noperms/x")
             os.rmdir("noperms")
 

--- a/worker/buildbot_worker/test/unit/test_commands_utils.py
+++ b/worker/buildbot_worker/test/unit/test_commands_utils.py
@@ -142,7 +142,7 @@ class RmdirRecursive(unittest.TestCase):
         finally:
             # even Twisted can't clean this up very well, so try hard to
             # clean it up ourselves..
-            os.chmod("noperms/x", 0o777) # nosec
+            os.chmod("noperms/x", 0o777)  # nosec
             os.unlink("noperms/x")
             os.rmdir("noperms")
 


### PR DESCRIPTION
Per [Bandit
findings](https://bandit.readthedocs.io/en/latest/plugins/b701_jinja2_autoescape_false.html).
By default `jinja2` disables autoescaping which enables a number of XSS
vectors.

Also marked several other findings in test scripts as false positives
(`# nosec`).

## Remove this paragraph

If you don't remove this paragraph from the pull request description, this means you didn't read our contributor documentation, and your patch will need more back and forth before it can be accepted!

Please have a look at our developer documentation before submitting your Pull Request.

http://docs.buildbot.net/latest/developer/quickstart.html

And especially:
http://docs.buildbot.net/latest/developer/pull-request.html


## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
