### PR TITLE
add a warning inside configuration about not using sqlite in production

### DIFF
--- a/master/buildbot/scripts/sample.cfg
+++ b/master/buildbot/scripts/sample.cfg
@@ -100,8 +100,8 @@ c['www'] = dict(port=8010,
 
 c['db'] = {
     # This specifies what database buildbot uses to store its state.
-    # sqlite is easy to start, but it is recommended to
-    # switch to dedicated database (postgres or mysql) in scaled production environment.
+    # It's easy to start with sqlite, but it's recommended to switch to a dedicated
+    # database, such as PostgreSQL or MySQL, for use in production environments.
     # http://docs.buildbot.net/current/manual/configuration/global.html#database-specification
     'db_url' : "sqlite:///state.sqlite",
 }

--- a/master/buildbot/scripts/sample.cfg
+++ b/master/buildbot/scripts/sample.cfg
@@ -99,7 +99,9 @@ c['www'] = dict(port=8010,
 ####### DB URL
 
 c['db'] = {
-    # This specifies what database buildbot uses to store its state.  You can leave
-    # this at its default for all but the largest installations.
+    # This specifies what database buildbot uses to store its state.
+    # sqlite is easy to start, but it is recommended to
+    # switch to dedicated database (postgres or mysql) in scaled production environment.
+    # http://docs.buildbot.net/current/manual/configuration/global.html#database-specification
     'db_url' : "sqlite:///state.sqlite",
 }


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
