### PR TITLE
ci: Bump the version of python used for interop tests

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -29,7 +29,7 @@ env:
   - TWISTED=17.9.0 SQLALCHEMY=latest TESTS=trial
 
   - TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.6
-  - TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.4
+  - TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.5
 
   # Configuration when SQLite database is persistent between running tests
   # (by default in other tests in-memory SQLite database is used which is


### PR DESCRIPTION
The `TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.4` tests fail because Twisted complains that it no longer supports that version of Python. This PR bumps the python version as it's also no longer supported by pip.
