### PR TITLE
tests: Fix flakyness of buildbot.test.integration.test_worker_workerside.TestWorkerConnection.test_pb_keepalive 

### DIFF
--- a/master/buildbot/test/integration/test_worker_workerside.py
+++ b/master/buildbot/test/integration/test_worker_workerside.py
@@ -72,8 +72,9 @@ class MasterSideWorker(worker.Worker):
         self.detach_d = defer.Deferred()
         return super().attached(conn)
 
+    @defer.inlineCallbacks
     def detached(self):
-        super().detached()
+        yield super().detached()
         self.detach_d, d = None, self.detach_d
         d.callback(None)
 
@@ -218,9 +219,9 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
     def workerSideDisconnect(self, worker):
         """Disconnect from the worker side
 
-        This seems a good way to simulate a broken connection
+        This seems a good way to simulate a broken connection. Returns a Deferred
         """
-        worker.bf.disconnect()
+        return worker.bf.disconnect()
 
     def addWorker(self, connection_string_tpl=r"tcp:host=127.0.0.1:port={port}",
                   password="pw", name="testworker", keepalive=None):
@@ -232,7 +233,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def test_connect_disconnect(self):
-        self.addMasterSideWorker()
+        yield self.addMasterSideWorker()
 
         def could_not_connect():
             self.fail("Worker never got connected to master")
@@ -249,7 +250,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
 
     @defer.inlineCallbacks
     def test_reconnect_network(self):
-        self.addMasterSideWorker()
+        yield self.addMasterSideWorker()
 
         def could_not_connect():
             self.fail("Worker did not reconnect in time to master")
@@ -261,7 +262,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
         self.assertTrue('bldr' in worker.bot.builders)
 
         timeout = reactor.callLater(10, could_not_connect)
-        self.workerSideDisconnect(worker)
+        yield self.workerSideDisconnect(worker)
         yield worker.tests_connected
 
         timeout.cancel()
@@ -275,7 +276,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
         The worker starts with a password that the master does not accept
         at first, and then the master gets reconfigured to accept it.
         """
-        self.addMasterSideWorker()
+        yield self.addMasterSideWorker()
         worker = self.addWorker(password="pw2")
         yield worker.startService()
         why, broker = yield worker.tests_login_failed
@@ -297,6 +298,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
 
         timeout.cancel()
         self.assertTrue('bldr' in worker.bot.builders)
+
         yield worker.stopService()
         yield worker.tests_disconnected
 
@@ -316,7 +318,7 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
         from buildbot.worker.protocols.pb import Connection
         self.patch(Connection, 'perspective_keepalive', perspective_keepalive)
 
-        self.addMasterSideWorker()
+        yield self.addMasterSideWorker()
         # short keepalive to make the test bearable to run
         worker = self.addWorker(keepalive=0.1)
         waiter = worker.keepalive_waiter = defer.Deferred()

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -669,8 +669,9 @@ class AbstractWorker(service.BuildbotService):
 
 class Worker(AbstractWorker):
 
+    @defer.inlineCallbacks
     def detached(self):
-        super().detached()
+        yield super().detached()
         self.botmaster.workerLost(self)
         self.startMissingTimer()
 


### PR DESCRIPTION
Fixes #4969. The instability was caused by us not handling duplicate keepalives in appropriate way. In the tests the keepalive interval is short and on a shared CI environment it's possible that the time it takes to handle a keepalive is longer than the keepalive interval, which results in a second keepalive, which is not expected by the tests and results in different failures depending on when the keepalive arrived. This PR fixes this by making sure we don't create parallel keepalive requests on worker side and also that adding handling of more than one keepalive in a row on the tests side.