### PR TITLE
collection.service: bind context

### DIFF
--- a/www/data_module/src/services/data/collection/collection.service.js
+++ b/www/data_module/src/services/data/collection/collection.service.js
@@ -24,6 +24,10 @@ class Collection {
             constructorImpl(restPath, query, accessor) {
                 let className;
                 this.listener = this.listener.bind(this);
+                this.put = this.put.bind(this);
+                this.add = this.add.bind(this);
+                this.recomputeQuery = this.recomputeQuery.bind(this);
+                this.sendEvents = this.sendEvents.bind(this);
                 this.restPath = restPath;
                 if (query == null) { query = {}; }
                 this.query = query;


### PR DESCRIPTION
Functions `put, add, recomputeQuery, sendEvents` need to be in the context of `CollectionInstance`. Otherwise, when they are invoked, it leads to error. For example:
```
angular.js:15567 TypeError: this.put is not a function
    at Array.listener (collection.service.js:85)
    at stream.service.js:42
    at Array.map (<anonymous>)
    at StreamInstance.push (stream.service.js:42)
    at socket.service.js:55
    at l.$eval (angular.js:19393)
    at angular.js:19535
    at $ (angular.js:19793)
    at l.$eval (angular.js:19393)
    at l.$apply (angular.js:19492)
```

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
