### PR TITLE
docs - fix typo in nine-upgrade

### DIFF
--- a/master/docs/manual/upgrading/nine-upgrade.rst
+++ b/master/docs/manual/upgrading/nine-upgrade.rst
@@ -89,7 +89,7 @@ Common uses of the status API are:
 
  * ``getBuild`` in a custom renderable
  * ``MailNotifier`` message formatters (see below for upgrade hints)
- * ``doIf`` functions on steps
+ * ``doStepIf`` functions on steps
 
 Import paths for several classes under the ``buildbot.status`` package but which remain useful have changed.
 Most of these are now available as plugins (see above), but for the remainder, consult the source code.


### PR DESCRIPTION

## Contributor Checklist:

* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
Do you want a fragment for this small typo ?

* [x] I have updated the appropriate documentation
