### PR TITLE
Fix HgPoller committer constraint violation

### DIFF
--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -282,7 +282,7 @@ class HgPoller(base.PollingChangeSource, StateMixin):
                 node)
             yield self.master.data.updates.addChange(
                 author=author,
-                committer=None,
+                committer=author,
                 revision=str(node),
                 files=files,
                 comments=comments,


### PR DESCRIPTION
Fixes (part of?) #4987. I haven't created a newsfragment because I think once all of this is fixed, it should warrant a single newsfragment, but not only for this PR.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation