### PR TITLE
set committer as nullable

### DIFF
--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -370,7 +370,7 @@ class Model(base.DBConnectorComponent):
         sa.Column('author', sa.String(255), nullable=False),
 
         # committer's name
-        sa.Column('committer', sa.String(255), nullable=False),
+        sa.Column('committer', sa.String(255), nullable=True),
 
         # commit comment
         sa.Column('comments', sa.Text, nullable=False),

--- a/master/buildbot/newsfragments/committer_nullable.bugfix
+++ b/master/buildbot/newsfragments/committer_nullable.bugfix
@@ -1,0 +1,1 @@
+allow committer of a change to be null for new setups (:issue:`4987`)


### PR DESCRIPTION
Fix #4987

The migration table already has is nullable.
so #4987 is only about new setups

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
