### PR TITLE
hgpoller: make default name dependent on branches or bookmarks

### DIFF
--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -265,6 +265,16 @@ class HgPoller(base.PollingChangeSource, StateMixin):
             yield self._processBranchChanges(rev, branch)
 
     @defer.inlineCallbacks
+    def _getRevNodeList(self, revset):
+        revListArgs = ['log', '-r', revset, r'--template={rev}:{node}\n']
+        results = yield utils.getProcessOutput(self.hgbin, revListArgs,
+                                               path=self._absWorkdir(), env=os.environ, errortoo=False)
+        results = results.decode(self.encoding)
+
+        revNodeList = [rn.split(':', 1) for rn in results.strip().split()]
+        defer.returnValue(revNodeList)
+
+    @defer.inlineCallbacks
     def _processBranchChanges(self, new_rev, branch):
         prev_rev = yield self._getCurrentRev(branch)
         if new_rev == prev_rev:
@@ -276,18 +286,16 @@ class HgPoller(base.PollingChangeSource, StateMixin):
             return
 
         # two passes for hg log makes parsing simpler (comments is multi-lines)
-        revset = '{}::{}'.format(prev_rev, new_rev)
-        revListArgs = ['log', '-r', revset, r'--template={rev}:{node}\n']
-        results = yield utils.getProcessOutput(self.hgbin, revListArgs,
-                                               path=self._absWorkdir(), env=os.environ, errortoo=False)
-        results = results.decode(self.encoding)
+        revNodeList = yield self._getRevNodeList('{}::{}'.format(prev_rev, new_rev))
 
-        revNodeList = [rn.split(':', 1) for rn in results.strip().split()]
         # revsets are inclusive. Strip the already-known "current" changeset.
-        if revNodeList:
+        if not revNodeList:
+            # empty revNodeList probably means the branch has changed head (strip of force push?)
+            # in that case, we should still produce a change for that new rev (but we can't know how many parents were pushed)
+            revNodeList = yield self._getRevNodeList(new_rev)
+        else:
             del revNodeList[0]
-        # empty revNodeList probably means the branch has changed head (strip of force push?)
-        # @TODO in that case, we should produce a change for that new rev
+
         log.msg('hgpoller: processing %d changes in branch %r: %r in %r'
                 % (len(revNodeList), branch, revNodeList, self._absWorkdir()))
         for rev, node in revNodeList:

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -50,9 +50,6 @@ class HgPoller(base.PollingChangeSource, StateMixin):
         if pollinterval != -2:
             pollInterval = pollinterval
 
-        if name is None:
-            name = repourl
-
         self.repourl = repourl
 
         if branch and branches:
@@ -63,6 +60,13 @@ class HgPoller(base.PollingChangeSource, StateMixin):
             self.branches = branches or []
 
         self.bookmarks = bookmarks or []
+
+        if name is None:
+            name = repourl
+            if self.bookmarks:
+                name += "_" + "_".join(self.bookmarks)
+            if self.branches:
+                name += "_" + "_".join(self.branches)
 
         if not self.branches and not self.bookmarks:
             self.branches = ['default']

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -284,8 +284,10 @@ class HgPoller(base.PollingChangeSource, StateMixin):
 
         revNodeList = [rn.split(':', 1) for rn in results.strip().split()]
         # revsets are inclusive. Strip the already-known "current" changeset.
-        del revNodeList[0]
-
+        if revNodeList:
+            del revNodeList[0]
+        # empty revNodeList probably means the branch has changed head (strip of force push?)
+        # @TODO in that case, we should produce a change for that new rev
         log.msg('hgpoller: processing %d changes in branch %r: %r in %r'
                 % (len(revNodeList), branch, revNodeList, self._absWorkdir()))
         for rev, node in revNodeList:

--- a/master/buildbot/newsfragments/hgpoller.bugfix
+++ b/master/buildbot/newsfragments/hgpoller.bugfix
@@ -1,0 +1,1 @@
+Prepare unique hgpoller name when using multiple hgpoller for multiple branches (:issue:`5004`)

--- a/master/buildbot/newsfragments/hgpoller_force_push.bugfix
+++ b/master/buildbot/newsfragments/hgpoller_force_push.bugfix
@@ -1,0 +1,1 @@
+Fix hgpoller crash when force pushing a branch (:issue:`4876`)

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -360,6 +360,7 @@ hardcodes
 hardcoding
 hasn
 Hassler
+hgpoller
 hgweb
 highlevel
 hipchat


### PR DESCRIPTION
fixes #5004 

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
