### PR TITLE
hgpoller: Add support for revlink

### DIFF
--- a/master/buildbot/newsfragments/hgpoller_revlink.feature
+++ b/master/buildbot/newsfragments/hgpoller_revlink.feature
@@ -1,0 +1,1 @@
+Add support for revision links to Mercurial poller

--- a/master/buildbot/test/unit/test_changes_hgpoller.py
+++ b/master/buildbot/test/unit/test_changes_hgpoller.py
@@ -46,6 +46,7 @@ class TestHgPollerBase(gpo.GetProcessOutputMixin,
         self.setUpGetProcessOutput()
         yield self.setUpChangeSource()
         self.remote_repo = 'ssh://example.com/foo/baz'
+        self.remote_hgweb = 'http://example.com/foo/baz/rev/{}'
         self.repo_ready = True
 
         def _isRepositoryReady():
@@ -55,7 +56,9 @@ class TestHgPollerBase(gpo.GetProcessOutputMixin,
                                         usetimestamps=self.usetimestamps,
                                         workdir='/some/dir',
                                         branches=self.branches,
-                                        bookmarks=self.bookmarks)
+                                        bookmarks=self.bookmarks,
+                                        revlink=lambda branch, revision:
+                                            self.remote_hgweb.format(revision))
         self.poller.setServiceParent(self.master)
         self.poller._isRepositoryReady = _isRepositoryReady
 
@@ -137,6 +140,7 @@ class TestHgPollerBranches(TestHgPollerBase):
         self.assertEqual(len(self.master.data.updates.changesAdded), 1)
         change = self.master.data.updates.changesAdded[0]
         self.assertEqual(change['revision'], '784bd')
+        self.assertEqual(change['revlink'], 'http://example.com/foo/baz/rev/784bd')
         self.assertEqual(change['comments'], 'Comment')
 
 

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -1002,6 +1002,11 @@ The :bb:chsrc:`HgPoller` accepts the following arguments:
     Set encoding will be used to parse author's name and commit message.
     Default encoding is ``'utf-8'``.
 
+``revlink``
+    A function that maps branch and revision to a valid url (e.g. hgweb), stored along with the change.
+    This function must be a callable which takes two arguments, the branch and the revision.
+    Defaults to lambda branch, revision: (u'')
+
 A configuration for the Mercurial poller might look like this:
 
 .. code-block:: python

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -359,6 +359,7 @@ hardcodes
 hardcoding
 hasn
 Hassler
+hgweb
 highlevel
 hipchat
 Hipchat


### PR DESCRIPTION
This makes it possibly to have clickable links to some web interface when using  the`hgpoller` change source.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
