### PR TITLE
Added P4CONFIG to P4Poller

### DIFF
--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -102,7 +102,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
                      "server_tz")
 
     env_vars = ["P4CLIENT", "P4PORT", "P4PASSWD", "P4USER",
-                "P4CHARSET", "PATH"]
+                "P4CHARSET", "PATH", "P4CONFIG"]
 
     changes_line_re = re.compile(
         r"Change (?P<num>\d+) on \S+ by \S+@\S+ '.*'$")

--- a/master/buildbot/newsfragments/P4Source.feature
+++ b/master/buildbot/newsfragments/P4Source.feature
@@ -1,0 +1,1 @@
+Added support for environment variable P4CONFIG to class ``P4Source``


### PR DESCRIPTION
On some configurations, all P4USER, P4PASS and other variables are locally stored in a P4CONFIG file that's exposed by the use of the P4CONFIG environment variable. This patch adds P4CONFIG to the allowed environment variables to expose it to Twisted.

Tested locally on my build environment and found to fix my issue where P4CONFIG wasn't being exposed.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
