### PR TITLE
DockerLatentWorker: Allow same volume twice

### DIFF
--- a/master/buildbot/newsfragments/better-docker-volumes.bugfix
+++ b/master/buildbot/newsfragments/better-docker-volumes.bugfix
@@ -1,0 +1,1 @@
+DockerLatentWorker: Allow to bind the same volume twice into a worker's container, Buildbot now requires 'docker-py' (nowadays 'docker') version 1.2.3+ from 2015.

--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -143,7 +143,7 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
         self.assertEqual(client.call_args_create_container[0]['volumes'],
                          ['/opt/webapp'])
         self.assertEqual(client.call_args_create_host_config[0]['binds'],
-                         {'/src/webapp': {'bind': '/opt/webapp', 'ro': False}})
+                         ["/src/webapp:/opt/webapp"])
 
     def test_volume_ro_rw(self):
         bs = self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker', ['bin/bash'],
@@ -156,8 +156,7 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
         self.assertEqual(client.call_args_create_container[0]['volumes'],
                          ['/opt/webapp', '/backup'])
         self.assertEqual(client.call_args_create_host_config[0]['binds'],
-                         {'/src/webapp': {'bind': '/opt/webapp', 'ro': True},
-                          '~': {'bind': '/backup', 'ro': False}})
+                         ['/src/webapp:/opt/webapp:ro', '~:/backup:rw'])
 
     def test_volume_bad_format(self):
         with self.assertRaises(config.ConfigErrors):

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -188,23 +188,19 @@ class DockerLatentWorker(DockerBaseWorker,
 
     def _thd_parse_volumes(self, volumes):
         volume_list = []
-        binds = {}
         for volume_string in (volumes or []):
             try:
-                bind, volume = volume_string.split(":", 1)
+                _, volume = volume_string.split(":", 1)
             except ValueError:
                 config.error("Invalid volume definition for docker "
                              "%s. Skipping..." % volume_string)
                 continue
 
-            ro = False
             if volume.endswith(':ro') or volume.endswith(':rw'):
-                ro = volume[-2:] == 'ro'
                 volume = volume[:-3]
 
             volume_list.append(volume)
-            binds[bind] = {'bind': volume, 'ro': ro}
-        return volume_list, binds
+        return volume_list, volumes
 
     def _getDockerClient(self):
         if docker.version[0] == '1':


### PR DESCRIPTION
Docker supports to mount the same named volume or host directory twice,
but the way that Buildbot implemented volumes that was not possible.

Previously buildbot would parse volume mounts (`<volume name/host path>:<container path>[:<rw/ro>]`) by itself and provide a dictionary with keys of `<volume name/host path>` to the docker-py API. Obviously a dictionary like that does not allow to contain the same volume name/host path twice so a volume could only be mounted once for a container.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
   * nothing to do here as far as I could see
