### PR TITLE
www: fix data_module tests with Chromium 77.0.3865

### DIFF
--- a/www/data_module/src/services/dataUtils/dataUtils.service.spec.js
+++ b/www/data_module/src/services/dataUtils/dataUtils.service.spec.js
@@ -64,10 +64,16 @@ describe('Data utils service', function() {
             expect(result.test("asd/1/new")).toBeTruthy();
 
             result = dataUtilsService.socketPathRE('asd/1/bnm/*/*').source;
-            expect(result).toBe('^asd\\/1\\/bnm\\/[^\\/]+\\/[^\\/]+$');
+            expect([
+                '^asd\\/1\\/bnm\\/[^\\/]+\\/[^\\/]+$',
+                '^asd\\/1\\/bnm\\/[^/]+\\/[^/]+$'
+            ]).toContain(result);
 
             result = dataUtilsService.socketPathRE('asd/1/*').source;
-            expect(result).toBe('^asd\\/1\\/[^\\/]+$');
+            expect([
+                '^asd\\/1\\/[^\\/]+$',
+                '^asd\\/1\\/[^/]+$'
+            ]).toContain(result);
         })
     );
 


### PR DESCRIPTION
Accept patterns before and after 52e7fb4.
Apparently Chromium has changed back how Regexp is handled.

Inspired by https://stackoverflow.com/a/42317843/3786245

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
