### PR TITLE
Update plugin list link in documentation to github wiki.

### DIFF
--- a/master/buildbot/newsfragments/update-plugin-list-link.doc
+++ b/master/buildbot/newsfragments/update-plugin-list-link.doc
@@ -1,0 +1,1 @@
+Changed PluginList link from trac wiki directly to the GitHub wiki.

--- a/master/docs/manual/plugins.rst
+++ b/master/docs/manual/plugins.rst
@@ -55,13 +55,13 @@ Web interface plugins are not used directly: as described in :doc:`web server co
 Finding Plugins
 ===============
 
-Buildbot maintains a list of plugins at http://trac.buildbot.net/wiki/Plugins.
+Buildbot maintains a list of plugins at https://github.com/buildbot/buildbot/wiki/PluginList.
 
 Developing Plugins
 ==================
 
 :ref:`Plugin-Module` contains all necessary information for you to develop new plugins.
-Please edit http://trac.buildbot.net/wiki/Plugins to add a link to your plugin!
+Please edit https://github.com/buildbot/buildbot/wiki/PluginList to add a link to your plugin!
 
 Plugins of note
 ===============


### PR DESCRIPTION
As the http://trac.buildbot.net/wiki/Plugins site suggests, this is now located in the GitHub wiki, so I've updated the link in the documentation.
(And I've updated the github wiki with the plugins I created.)


## Contributor Checklist:

* [ ] I have updated the unit tests - Not needed
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
