### PR TITLE
GitCommit: allow to define behavior when there's nothing to be committed

### DIFF
--- a/master/buildbot/newsfragments/gitcommit-empty.feature
+++ b/master/buildbot/newsfragments/gitcommit-empty.feature
@@ -1,0 +1,1 @@
+Allow to define behavior for GitCommit when there is nothing to commit.

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -689,7 +689,7 @@ class GitCommit(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
     renderables = ['paths', 'messages']
 
     def __init__(self, workdir=None, paths=None, messages=None, env=None,
-                 timeout=20 * 60, logEnviron=True,
+                 timeout=20 * 60, logEnviron=True, emptyCommits='disallow',
                  config=None, **kwargs):
 
         self.workdir = workdir
@@ -699,6 +699,7 @@ class GitCommit(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
         self.timeout = timeout
         self.logEnviron = logEnviron
         self.config = config
+        self.emptyCommits = emptyCommits
         # The repourl, sshPrivateKey and sshHostKey attributes are required by
         # GitStepMixin, but aren't needed by git add and commit operations
         self.repourl = " "
@@ -721,6 +722,10 @@ class GitCommit(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
 
         if not isinstance(self.paths, list):
             bbconfig.error('GitCommit: paths must be a list')
+
+        if self.emptyCommits not in ('disallow', 'create-empty-commit', 'ignore'):
+            bbconfig.error('GitCommit: emptyCommits must be one of "disallow", '
+                           '"create-empty-commit" and "ignore"')
 
     @defer.inlineCallbacks
     def run(self):
@@ -746,11 +751,29 @@ class GitCommit(buildstep.BuildStep, GitStepMixin, CompositeStepMixin):
             raise buildstep.BuildStepFailed
 
     @defer.inlineCallbacks
+    def _checkHasSomethingToCommit(self):
+        cmd = ['status', '--porcelain=v1']
+        stdout = yield self._dovccmd(cmd, collectStdout=True)
+
+        for line in stdout.splitlines(False):
+            if line[0] in 'MADRCU':
+                return True
+        return False
+
+    @defer.inlineCallbacks
     def _doCommit(self):
+        if self.emptyCommits == 'ignore':
+            has_commit = yield self._checkHasSomethingToCommit()
+            if not has_commit:
+                return 0
+
         cmd = ['commit']
 
         for message in self.messages:
             cmd.extend(['-m', message])
+
+        if self.emptyCommits == 'create-empty-commit':
+            cmd.extend(['--allow-empty'])
 
         ret = yield self._dovccmd(cmd)
         return ret

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -3916,6 +3916,138 @@ class TestGitCommit(steps.BuildStepMixin, config.ConfigErrorsMixin,
         self.expectOutcome(result=SUCCESS)
         return self.runStep()
 
+    def test_commit_empty_disallow(self):
+        self.setupStep(
+            self.stepClass(workdir='wkdir', paths=self.path_list, messages=self.message_list,
+                           emptyCommits='disallow'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'symbolic-ref', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='refs/head/myBranch')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'add', 'file1.txt', 'file2.txt'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'commit', '-m', 'my commit', '-m', '42'])
+            + 1,
+        )
+        self.expectOutcome(result=FAILURE)
+        return self.runStep()
+
+    def test_commit_empty_allow(self):
+        self.setupStep(
+            self.stepClass(workdir='wkdir', paths=self.path_list, messages=self.message_list,
+                           emptyCommits='create-empty-commit'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'symbolic-ref', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='refs/head/myBranch')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'add', 'file1.txt', 'file2.txt'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'commit', '-m', 'my commit', '-m', '42', '--allow-empty'])
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
+    def test_commit_empty_ignore_withcommit(self):
+        self.setupStep(
+            self.stepClass(workdir='wkdir', paths=self.path_list, messages=self.message_list,
+                           emptyCommits='ignore'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'symbolic-ref', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='refs/head/myBranch')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'add', 'file1.txt', 'file2.txt'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'status', '--porcelain=v1'])
+            + ExpectShell.log('stdio',
+                              stdout='MM file2.txt\n?? file3.txt')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'commit', '-m', 'my commit', '-m', '42'])
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
+    def test_commit_empty_ignore_withoutcommit(self):
+        self.setupStep(
+            self.stepClass(workdir='wkdir', paths=self.path_list, messages=self.message_list,
+                           emptyCommits='ignore'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'symbolic-ref', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='refs/head/myBranch')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'add', 'file1.txt', 'file2.txt'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'status', '--porcelain=v1'])
+            + ExpectShell.log('stdio',
+                              stdout='?? file3.txt')
+            + 0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        return self.runStep()
+
+    def test_commit_empty_ignore_witherror(self):
+        self.setupStep(
+            self.stepClass(workdir='wkdir', paths=self.path_list, messages=self.message_list,
+                           emptyCommits='ignore'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir',
+                        command=['git', '--version'])
+            + ExpectShell.log('stdio',
+                              stdout='git version 1.7.5')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'symbolic-ref', 'HEAD'])
+            + ExpectShell.log('stdio',
+                              stdout='refs/head/myBranch')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'add', 'file1.txt', 'file2.txt'])
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'status', '--porcelain=v1'])
+            + 1,
+        )
+        self.expectOutcome(result=FAILURE)
+        return self.runStep()
+
     def test_detached_head(self):
         self.setupStep(
             self.stepClass(workdir='wkdir', paths=self.path_list, messages=self.message_list))

--- a/master/docs/manual/configuration/buildsteps.rst
+++ b/master/docs/manual/configuration/buildsteps.rst
@@ -1146,6 +1146,12 @@ The GitCommit step takes the following arguments:
 ``config``
     (optional) A dict of git configuration settings to pass to the remote git commands.
 
+``emptyCommits``
+    (optional) One of the values ``disallow`` (default), ``create-empty-commit``, and ``ignore``. Decides the behavior when there is nothing to be committed.
+    The value ``disallow`` will make the buildstep fail.
+    The value ``create-empty-commit`` will create an empty commit.
+    The value ``ignore`` will create no commit.
+
 .. bb:step:: GitPush
 
 GitPush


### PR DESCRIPTION
This adds a new option `emptyCommits` to the `GitCommit` build step, which allows to determine the behavior when there's nothing to commit. Default behavior is `disallow`, which fails (current behavior). One can also specify `create-empty-commit` to create empty commits, and `ignore` to not create a commit.

I've also tested both `disallow` and `ignore` in a real environment, both worked as expected (both with and without commits).

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
