### PR TITLE
fix missing declaration for SecretInPass in setup.py

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -251,6 +251,7 @@ setup_args = {
         ]),
         ('buildbot.secrets', [
             ('buildbot.secrets.providers.file', ['SecretInAFile']),
+            ('buildbot.secrets.providers.passwordstore', ['SecretInPass']),
             ('buildbot.secrets.providers.vault', ['HashiCorpVaultSecretProvider'])
         ]),
         ('buildbot.worker', [


### PR DESCRIPTION
this would result in missing attribute error when used in the "master.cfg" configuration as shown in the documentation

(contributor checklist is not concerned as this is just complementing a missing declaration in setup.py that should have been there. The code is in place in last version and submitted by someone else)
