### PR TITLE
Docs: remove invisible unicode characters

### DIFF
--- a/master/docs/developer/pull-request.rst
+++ b/master/docs/developer/pull-request.rst
@@ -3,7 +3,7 @@ Submitting Pull Requests
 
 As Buildbot is used by software developers, it tends to receive a significant number of patches.
 The most effective way to make sure your patch gets noticed and merged is to submit it via GitHub.
-This assumes some familiarity with git, but not too much. Note that GitHub has some great `​Git guides <http://github.com/guides>`_ to get you started.
+This assumes some familiarity with git, but not too much. Note that GitHub has some great `Git guides <http://github.com/guides>`_ to get you started.
 
 Guidelines
 ----------
@@ -61,9 +61,9 @@ How to create a pull request
 
    See `this github guide <https://help.github.com/en/articles/fork-a-repo>`_ which offers a more generic description of this process.
 
-* Sign up for a free account at ​http://github.com, if you don't already have one.
+* Sign up for a free account at http://github.com, if you don't already have one.
 
-* Go to ​http://github.com/buildbot/buildbot and click “fork”.
+* Go to http://github.com/buildbot/buildbot and click “fork”.
   This will create your own public copy of the latest Buildbot source.
 
 * Clone your forked repository on your local machine, so you can do your changes.

--- a/master/docs/developer/pull-request.rst
+++ b/master/docs/developer/pull-request.rst
@@ -59,7 +59,7 @@ How to create a pull request
 
 .. note::
 
-   See ​`this github guide <https://help.github.com/en/articles/fork-a-repo>`_ which offers a more generic description of this process.
+   See `this github guide <https://help.github.com/en/articles/fork-a-repo>`_ which offers a more generic description of this process.
 
 * Sign up for a free account at ​http://github.com, if you don't already have one.
 


### PR DESCRIPTION
I noticed that in the first "Note" in https://docs.buildbot.net/latest/developer/pull-request.html#how-to-create-a-pull-request, the link is broken. When trying to fix it, I noticed that this is caused by some invisible Unicode character before the first backtick. I removed it, and then found some more of these and removed them as well. (I also checked the other buildbot and worker docs, but couldn't find it anywhere else.)