### PR TITLE
buider.attached returns Deferred and causes assert failure

### DIFF
--- a/master/buildbot/newsfragments/assert-reconfig-workers.bugfix
+++ b/master/buildbot/newsfragments/assert-reconfig-workers.bugfix
@@ -1,0 +1,1 @@
+Fix crash when reconfiguring changed workers that have new builders assigned to them (:issue:`4757`, :issue:`5027`).

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -222,7 +222,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
                 #
                 # Therefore, when we see that we're already attached, we can
                 # just ignore it.
-                return defer.succeed(self)
+                return self
 
         wfb = workerforbuilder.WorkerForBuilder()
         wfb.setBuilder(self)

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -186,5 +186,33 @@ class Tests(RunFakeMasterTestCase):
 
         self.assertIs(worker.machine, machine)
 
+    @defer.inlineCallbacks
+    def test_worker_reconfigure_with_new_builder(self):
+        """
+        Checks if we can successfully reconfigure if we add new builders to worker.
+        """
+        config_dict = {
+            'builders': [
+                BuilderConfig(name="builder1",
+                              workernames=['local1'],
+                              factory=BuildFactory()),
+            ],
+            'workers': [self.createLocalWorker('local1', max_builds=1)],
+            'protocols': {'null': {}},
+            # Disable checks about missing scheduler.
+            'multiMaster': True,
+        }
+        yield self.getMaster(config_dict)
+
+        config_dict['builders'] += [
+            BuilderConfig(name="builder2",
+                          workernames=['local1'],
+                          factory=BuildFactory()),
+        ]
+        config_dict['workers'] = [self.createLocalWorker('local1', max_builds=2)]
+
+        # reconfig should succeed
+        yield self.reconfigMaster(config_dict)
+
     if RemoteWorker is None:
         skip = "buildbot-worker package is not installed"

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -94,8 +94,13 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin,
 
     @defer.inlineCallbacks
     def getMaster(self, config_dict):
-        self.master = master = yield getMaster(self, self.reactor, config_dict)
-        defer.returnValue(master)
+        self.master = yield getMaster(self, self.reactor, config_dict)
+        return self.master
+
+    @defer.inlineCallbacks
+    def reconfigMaster(self, config_dict):
+        self.master.config_loader.config_dict = config_dict
+        yield self.master.doReconfig()
 
     def createLocalWorker(self, name, **kwargs):
         workdir = FilePath(self.mktemp())


### PR DESCRIPTION
Functions decorated with inlineCallbacks cause a failed assert when they
return Deferred: "assert not isinstance(result,Deferred)".