### PR TITLE
tests: Ignore new warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ docker-buildbot-master:
 	$(DOCKERBUILD) -t buildbot/buildbot-master:master master
 
 $(VENV_NAME):
-	virtualenv -p $(VENV_PY_VERSION) $(VENV_NAME)
+	virtualenv -p $(VENV_PY_VERSION) --no-site-packages $(VENV_NAME)
 	$(PIP) install -U pip setuptools
 
 # helper for virtualenv creation

--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -80,6 +80,7 @@ atm
 atomicity
 attachscheduler
 attr
+attrs
 attributeerror
 aug
 auth

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -119,3 +119,13 @@ warnings.filterwarnings('ignore', ".*the imp module is deprecated in favour of i
 
 # sqlalchemy-migrate uses deprecated api from sqlalchemy https://review.openstack.org/#/c/648072/
 warnings.filterwarnings('ignore', ".*Engine.contextual_connect.*", DeprecationWarning)
+
+# ignore an attrs API warning for APIs used in dependencies
+warnings.filterwarnings('ignore', ".*The usage of `cmp` is deprecated and will be removed "
+                                  "on or after.*", DeprecationWarning)
+
+# ignore a warning emitted by pkg_resources when importing certain namespace packages
+warnings.filterwarnings('ignore', ".*Not importing directory .*/zope: missing __init__",
+                        category=ImportWarning)
+warnings.filterwarnings('ignore', ".*Not importing directory .*/sphinxcontrib: missing __init__",
+                        category=ImportWarning)


### PR DESCRIPTION
In one of my environments the test run produces a bunch of warnings no matter what. This PR disables them as they come from our dependencies, not buildbot code.