### PR TITLE
grid-view: fix branch/status filtering error

### DIFF
--- a/www/grid_view/src/module/grid.controller.js
+++ b/www/grid_view/src/module/grid.controller.js
@@ -255,18 +255,10 @@ class Grid {
     }
 
     refresh() {
-        this.$stateParams.branch = this.branch;
-        if (this.tags.length === 0) {
-            this.$stateParams.tag = undefined;
-        } else {
-            this.$stateParams.tag = this.tags;
-        }
-        this.$stateParams.result = this.result;
-
         const params = {
-            branch: this.$stateParams.branch,
-            tag: this.$stateParams.tag,
-            result: this.$stateParams.result
+            branch: this.branch,
+            tag: this.tags.length === 0 ? undefined : this.tags,
+            result: this.result
         };
 
         // change URL without reloading page


### PR DESCRIPTION
Fix the following error when filtering by branch/results and/or builder tags:

```
angular.js:15567 TypeError: Cannot assign to read only property 'branch' of object '#<Object>'
    at Grid.refresh (grid.controller.js:258)
    at Grid.changeResult (grid.controller.js:239)
    at fn (eval at compile (angular.js:16418), <anonymous>:4:255)
    at l.$eval (angular.js:19393)
    at angular.js:27827
    at Object.<anonymous> (angular.js:30812)
    at k (angular.js:387)
    at Object.$$writeModelToScope (angular.js:30810)
    at o (angular.js:30803)
    at angular.js:30797
```

There is no need to modify the `$stateParams` object anyway. Affect the values in the local `params` object directly.

Fixes: #4801
Fixes: f098bdd5d7fb ("www: add grid_view plugin")