### PR TITLE
Custom templates: loading fixed #5035

### DIFF
--- a/master/buildbot/test/unit/test_www_config.py
+++ b/master/buildbot/test/unit/test_www_config.py
@@ -78,14 +78,14 @@ class IndexResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         self.assertEqual(res, exp)
 
     def test_parseCustomTemplateDir(self):
-        exp = {'views/builds.html': json.dumps('<div>\n</div>')}
+        exp = {'views/builds.html': '<div>\n</div>'}
         try:
             # we make the test work if pyjade is present or note
             # It is better than just skip if pyjade is not there
             import pyjade
             [pyjade]
             exp.update({'plugin/views/plugin.html':
-                        json.dumps('<div class="myclass"><pre>this is customized</pre></div>')})
+                        '<div class="myclass"><pre>this is customized</pre></div>'})
         except ImportError:
             log.msg("Only testing html based template override")
         template_dir = util.sibpath(__file__, "test_templates_dir")

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -91,7 +91,7 @@ class IndexResource(resource.Resource):
                         compiler = pyjade.ext.html.Compiler(
                             block, pretty=False)
                         html = compiler.compile()
-                res[template_name % (basename,)] = json.dumps(html)
+                res[template_name % (basename,)] = html
 
         return res
 

--- a/www/base/package.json
+++ b/www/base/package.json
@@ -1,5 +1,6 @@
 {
     "name": "buildbot-www",
+    "plugin_name": "buildbot-www",
     "private": true,
     "main": "buildbot_www/static/scripts.js",
     "style": "buildbot_www/static/styles.css",

--- a/www/build_common/src/ng-template-loader.js
+++ b/www/build_common/src/ng-template-loader.js
@@ -11,10 +11,10 @@ module.exports = function() {
   var fileName = this.resourcePath;
   var code = pug.compileFile(fileName);
   var content = code();
-	var pluginName = loaderUtils.getOptions(this).pluginName;
+  var pluginName = loaderUtils.getOptions(this).pluginName;
 
   // compute template name (as defined by ancient gulp based build system)
-  var tplName = path.parse(fileName).name.replace(/.tpl$/,'') + ".html";
+  var tplName = "views/" + path.parse(fileName).name.replace(/.tpl$/,'') + ".html";
   if (pluginName != "buildbot-www") {
     tplName = pluginName + "/" + tplName;
   }


### PR DESCRIPTION
- master/buildbot/www/config.py:parseCustomTemplateDir
    Returns pure HTML. Conversion to JSON is done in
    www/base/src/app/layout.jade
- www/base/package.json
    Missing plugin_name fixed
- www/build_common/src/ng-template-loader.js
    Fixed missing "views/" part of template name

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
