### PR TITLE
www: build: Make URLs in steps always visible

### DIFF
--- a/www/base/src/app/builders/builds/build.route.js
+++ b/www/base/src/app/builders/builds/build.route.js
@@ -39,13 +39,19 @@ class BuildState {
             }
             ]});
         bbSettingsServiceProvider.addSettingsGroup({
-            name:'TriggerStep',
-            caption: 'Builds per page',
+            name:'Build',
+            caption: 'Build page related settings',
             items:[{
                 type:'integer',
-                name:'page_size',
+                name:'trigger_step_page_size',
                 caption:'Number of builds to show per page in trigger step',
                 default_value: 20
+            },
+            {
+                type:'bool',
+                name:'show_urls',
+                caption:'Always show URLs in step',
+                default_value: true
             }
             ]});
     }

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
@@ -99,7 +99,8 @@ class _buildsummary {
             }, 1000);
             $scope.$on("$destroy", () => $interval.cancel(stop));
             $scope.settings = bbSettingsService.getSettingsGroup("LogPreview");
-            $scope.page_size = bbSettingsService.getSettingsGroup("TriggerStep").page_size.value;
+            $scope.trigger_step_page_size = bbSettingsService.getSettingsGroup("Build").trigger_step_page_size.value;
+            $scope.show_urls = bbSettingsService.getSettingsGroup("Build").show_urls.value;
 
             const NONE = 0;
             const ONLY_NOT_SUCCESS = 1;

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -42,19 +42,22 @@
             span.badge-status(ng-class="results2class(step, 'pulse')")
               | {{step.number}}
             | #{' '}
-            i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':step.fulldisplay}", ng-if="step.logs.length || step.buildrequests.length")
+            i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':step.fulldisplay}", ng-if="step.logs.length || step.buildrequests.length || (step.other_urls.length && !show_urls)")
             | #{' '} {{step.name}}
             span(ng-if="step.buildrequests.length") #{' '} {{step.builds.length}} builds, {{step.buildrequests.length - step.builds.length}} pending builds
+        ul(ng-if="show_urls")
+          li(ng-repeat="url in step.other_urls")
+            a(ng-href="{{url.url}}", target="_blank") {{url.name}}
 
         div.anim-stepdetails(ng-if="step.fulldisplay")
-          ul
+          ul(ng-if="!show_urls")
             li(ng-repeat="url in step.other_urls")
               a(ng-href="{{url.url}}", target="_blank") {{url.name}}
-          ul(ng-if="step.buildrequests.length>page_size",uib-pagination,total-items="step.buildrequests.length",
+          ul(ng-if="step.buildrequests.length>trigger_step_page_size",uib-pagination,total-items="step.buildrequests.length",
             ng-model="step.buildrequestsCurrentPage",class="pagination-sm" boundary-link-numbers="true",
-            max-size=10, items-per-page="page_size", style="margin-left:30px;margin-bottom:0px")
+            max-size=10, items-per-page="trigger_step_page_size", style="margin-left:30px;margin-bottom:0px")
           ul.list-unstyled
-            li(ng-repeat="br in step.buildrequests | limitTo: page_size :(step.buildrequestsCurrentPage-1)*page_size")
+            li(ng-repeat="br in step.buildrequests | limitTo: trigger_step_page_size :(step.buildrequestsCurrentPage-1)*trigger_step_page_size")
               buildrequestsummary(style="margin-left:30px;margin-top:8px",buildrequestid='br.buildrequestid')
           logpreview(ng-repeat="log in buildsummary.getLogs(step)", log="log",
                      fulldisplay="step.logs.length == 1 || buildsummary.expandByName(log)",


### PR DESCRIPTION
I think the following change started to hide (other) URLs by mistake.
https://github.com/buildbot/buildbot/commit/056301f21b67c700c2cf501eb849d3809700f1e6#diff-2d366bdd85ca12602b61b8a11ab99251R47-R58

In any case, would you consider using this fix, so (other) URLs are always visible?

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
