### PR TITLE
www: buildsummary: Show arrow for step with buildrequests

### DIFF
--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -42,7 +42,7 @@
             span.badge-status(ng-class="results2class(step, 'pulse')")
               | {{step.number}}
             | #{' '}
-            i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':step.fulldisplay}", ng-if="step.logs.length")
+            i.fa.fa-chevron-circle-right.rotate(ng-class="{'fa-rotate-90':step.fulldisplay}", ng-if="step.logs.length || step.buildrequests.length")
             | #{' '} {{step.name}}
             span(ng-if="step.buildrequests.length") #{' '} {{step.builds.length}} builds, {{step.buildrequests.length - step.builds.length}} pending builds
 


### PR DESCRIPTION
If child builds in step can be hidden, we should have the arrow icon to indicate this fact. Same as when we have logs in step.
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
