### PR TITLE
Support Ubuntu Chromium

### DIFF
--- a/master/buildbot/newsfragments/chromium-supported.bugfix
+++ b/master/buildbot/newsfragments/chromium-supported.bugfix
@@ -1,0 +1,1 @@
+Updates supported browser list so that Ubuntu Chromium will not always be flagged as out of date.

--- a/www/base/src/app/app.browserwarning.notranspile.js
+++ b/www/base/src/app/app.browserwarning.notranspile.js
@@ -4,6 +4,8 @@
 outdatedBrowserRework({
     browserSupport: {
         'Chrome': 56, // Includes Chrome for mobile devices
+        'Chromium': 56, // same as Chrome, but needs to be listed explicitly
+                        // (https://github.com/mikemaccana/outdated-browser-rework/issues/49)
         'Edge': 13,
         'Safari': 10,
         'Mobile Safari': 10,


### PR DESCRIPTION
Currently, when using Ubuntu's Chromium (latest version) to visit a Buildbot instance, one gets a big fat "YOUR BROWSER IS OUT-OF-DATE!" warning. According to mikemaccana/outdated-browser-rework#49 this is caused by Ubuntu tweaking the User-Agent string, and so the detected browser name is "Chromium" and not "Chrome". Adding "Chromium" to the supported browser list with the same version as for Chrome should fix this problem.