### PR TITLE
schedulers: More robust Timed scheduler

### DIFF
--- a/master/buildbot/newsfragments/timescheduler.bugfix
+++ b/master/buildbot/newsfragments/timescheduler.bugfix
@@ -1,0 +1,1 @@
+Improve reliability of timed scheduler.

--- a/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
@@ -133,12 +133,13 @@ class Periodic(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         d = sched.deactivate()
         return d
 
+    @defer.inlineCallbacks
     def test_start_build_error(self):
         sched = self.makeScheduler(name='test', builderNames=['test'],
                                    periodicBuildTimer=10,
                                    firstBuildError=True)  # error during first build start
 
-        sched.activate()
+        yield sched.activate()
         self.reactor.advance(0)  # let it trigger the first (error) build
         while self.reactor.seconds() < 40:
             self.reactor.advance(1)
@@ -146,8 +147,7 @@ class Periodic(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         self.assertEqual(self.state.get('last_build'), 40)
         self.assertEqual(1, len(self.flushLoggedErrors(ZeroDivisionError)))
 
-        d = sched.deactivate()
-        return d
+        yield sched.deactivate()
 
     def test_iterations_stop_while_starting_build(self):
         sched = self.makeScheduler(name='test', builderNames=['test'],

--- a/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Periodic.py
@@ -23,6 +23,10 @@ from buildbot.test.util import scheduler
 from buildbot.test.util.misc import TestReactorMixin
 
 
+class TestException(Exception):
+    pass
+
+
 class Periodic(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
 
     OBJECTID = 23
@@ -48,7 +52,7 @@ class Periodic(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             # TODO: check branch
             isFirst = (self.events == [])
             if self.reactor.seconds() == 0 and firstBuildError:
-                1 / 0
+                raise TestException()
             self.events.append('B@%d' % self.reactor.seconds())
             if isFirst and firstBuildDuration:
                 d = defer.Deferred()
@@ -145,7 +149,7 @@ class Periodic(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             self.reactor.advance(1)
         self.assertEqual(self.events, ['B@10', 'B@20', 'B@30', 'B@40'])
         self.assertEqual(self.state.get('last_build'), 40)
-        self.assertEqual(1, len(self.flushLoggedErrors(ZeroDivisionError)))
+        self.assertEqual(1, len(self.flushLoggedErrors(TestException)))
 
         yield sched.deactivate()
 


### PR DESCRIPTION
Handling startBuild and _scheduleNextBuild_locked separately during
actuation. This prevents errors in startBuild function to derail
timed scheduler because _scheduleNextBuild_locked is now called
even in this case.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
