### PR TITLE
fix transfer steps debugability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             env
             python3 -m venv .venv
             . .venv/bin/activate
-            pip install -U 'pip<19' setuptools
+            pip install -U 'pip<19' 'setuptools<45.0.0'
             pip install -r requirements-ci.txt
             pip install -r requirements-cidocs.txt
             pip install pyinstaller

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             env
             python3 -m venv .venv
             . .venv/bin/activate
-            pip install -U 'pip<19' 'setuptools<45.0.0'
+            pip install -U pip 'setuptools<45.0.0'
             pip install -r requirements-ci.txt
             pip install -r requirements-cidocs.txt
             pip install pyinstaller

--- a/master/buildbot/newsfragments/transfer_stdio.bugfix
+++ b/master/buildbot/newsfragments/transfer_stdio.bugfix
@@ -1,0 +1,1 @@
+transfer steps now correctly report errors from workers :issue:`5058`

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -134,7 +134,7 @@ class RemoteCommand(base.RemoteCommandImpl):
     @defer.inlineCallbacks
     def _finished(self, failure=None):
         self.active = False
-        # the rc is send asynchrounously and there is a chance it is still in the callback queue
+        # the rc is send asynchronously and there is a chance it is still in the callback queue
         # when finished is received, we have to workaround in the master because worker might be older
         timeout = 10
         while self.rc is None and timeout > 0:

--- a/master/buildbot/process/remotecommand.py
+++ b/master/buildbot/process/remotecommand.py
@@ -131,8 +131,15 @@ class RemoteCommand(base.RemoteCommandImpl):
                                          self.args)
         return d
 
+    @defer.inlineCallbacks
     def _finished(self, failure=None):
         self.active = False
+        # the rc is send asynchrounously and there is a chance it is still in the callback queue
+        # when finished is received, we have to workaround in the master because worker might be older
+        timeout = 10
+        while self.rc is None and timeout > 0:
+            yield util.asyncSleep(.1)
+            timeout -= 1
         # call .remoteComplete. If it raises an exception, or returns the
         # Failure that we gave it, our self.deferred will be errbacked. If
         # it does not (either it ate the Failure or there the step finished

--- a/master/buildbot/test/integration/interop/test_transfer.py
+++ b/master/buildbot/test/integration/interop/test_transfer.py
@@ -19,7 +19,8 @@ import shutil
 
 from twisted.internet import defer
 
-from buildbot.process.results import SUCCESS, FAILURE
+from buildbot.process.results import FAILURE
+from buildbot.process.results import SUCCESS
 from buildbot.test.util.decorators import flaky
 from buildbot.test.util.integration import RunMasterBase
 

--- a/master/buildbot/test/integration/interop/test_transfer.py
+++ b/master/buildbot/test/integration/interop/test_transfer.py
@@ -43,6 +43,42 @@ class TransferStepsMasterPb(RunMasterBase):
                     contents[fn] = f.read()
         return contents
 
+    def get_config_single_step(self, step):
+        c = {}
+        from buildbot.config import BuilderConfig
+        from buildbot.process.factory import BuildFactory
+        from buildbot.plugins import steps, schedulers
+
+        c['schedulers'] = [
+            schedulers.ForceScheduler(
+                name="force",
+                builderNames=["testy"])]
+
+        f = BuildFactory()
+
+        f.addStep(steps.FileUpload(workersrc="dir/noexist_path", masterdest="master_dest"))
+        c['builders'] = [
+            BuilderConfig(name="testy",
+                          workernames=["local1"],
+                          factory=f)
+        ]
+        return c
+
+    def get_non_existing_file_upload_config(self):
+        from buildbot.plugins import steps
+        step = steps.FileUpload(workersrc="dir/noexist_path", masterdest="master_dest")
+        return self.get_config_single_step(step)
+
+    def get_non_existing_directory_upload_config(self):
+        from buildbot.plugins import steps
+        step = steps.DirectoryUpload(workersrc="dir/noexist_path", masterdest="master_dest")
+        return self.get_config_single_step(step)
+
+    def get_non_existing_multiple_file_upload_config(self):
+        from buildbot.plugins import steps
+        step = steps.MultipleFileUpload(workersrcs=["dir/noexist_path"], masterdest="master_dest")
+        return self.get_config_single_step(step)
+
     @flaky(bugNumber=4407, onPlatform='win32')
     @defer.inlineCallbacks
     def test_transfer(self):
@@ -77,12 +113,29 @@ class TransferStepsMasterPb(RunMasterBase):
         shutil.rmtree("dest")
 
     @defer.inlineCallbacks
-    def test_noExistTransfer(self):
-        yield self.setupConfig(notExistingFileMasterConfig())
+    def test_no_exist_file_upload(self):
+        yield self.setupConfig(self.get_non_existing_file_upload_config())
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
         self.assertEqual(build['results'], FAILURE)
         res = yield self.checkBuildStepLogExist(build, "Cannot open file")
         self.assertTrue(res)
+
+    @defer.inlineCallbacks
+    def test_no_exist_directory_upload(self):
+        yield self.setupConfig(self.get_non_existing_directory_upload_config())
+        build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
+        self.assertEqual(build['results'], FAILURE)
+        res = yield self.checkBuildStepLogExist(build, "Cannot open file")
+        self.assertTrue(res)
+
+    @defer.inlineCallbacks
+    def test_no_exist_multiple_file_upload(self):
+        yield self.setupConfig(self.get_non_existing_multiple_file_upload_config())
+        build = yield self.doForceBuild(wantSteps=True, wantLogs=True)
+        self.assertEqual(build['results'], FAILURE)
+        res = yield self.checkBuildStepLogExist(build, "Cannot open file")
+        self.assertTrue(res)
+
 
 class TransferStepsMasterNull(TransferStepsMasterPb):
     proto = "null"
@@ -160,29 +213,5 @@ def masterGlobConfig():
     c['builders'] = [
         BuilderConfig(
             name="testy", workernames=["local1"], factory=f)
-    ]
-    return c
-
-
-# master configuration
-def notExistingFileMasterConfig():
-    c = {}
-    from buildbot.config import BuilderConfig
-    from buildbot.process.factory import BuildFactory
-    from buildbot.plugins import steps, schedulers
-
-    c['schedulers'] = [
-        schedulers.ForceScheduler(
-            name="force",
-            builderNames=["testy"])]
-
-    f = BuildFactory()
-
-    f.addStep(
-        steps.FileUpload(workersrc="dir/noexist_file.txt", masterdest="master.txt"))
-    c['builders'] = [
-        BuilderConfig(name="testy",
-                      workernames=["local1"],
-                      factory=f)
     ]
     return c

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+import json
 import os
 import shutil
 import stat
@@ -104,7 +105,8 @@ class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def testConstructorModeType(self):
         with self.assertRaises(config.ConfigErrors):
-            transfer.FileUpload(workersrc=__file__, masterdest='xyz', mode='g+rwx')
+            transfer.FileUpload(workersrc=__file__,
+                                masterdest='xyz', mode='g+rwx')
 
     def testBasic(self):
         self.setupStep(
@@ -175,7 +177,7 @@ class TestFileUpload(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
     def testDescriptionDone(self):
         self.setupStep(
             transfer.FileUpload(workersrc=__file__, masterdest=self.destfile, url="http://server/file",
-                descriptionDone="Test File Uploaded"))
+                                descriptionDone="Test File Uploaded"))
 
         self.step.addURL = Mock()
 
@@ -389,7 +391,7 @@ class TestDirectoryUpload(steps.BuildStepMixin, TestReactorMixin,
 
         self.assertEqual(behavior.writer.cancel.called, True)
         self.assertEqual(
-                len(self.flushLoggedErrors(RuntimeError)), 1)
+            len(self.flushLoggedErrors(RuntimeError)), 1)
 
     def test_init_workersrc_keyword(self):
         step = transfer.DirectoryUpload(
@@ -531,7 +533,8 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             transfer.MultipleFileUpload(
                 workersrcs=["src*"], masterdest=self.destdir, glob=True))
         self.expectCommands(
-            Expect('glob', dict(path=os.path.join('wkdir', 'src*'), logEnviron=False))
+            Expect('glob', dict(path=os.path.join(
+                'wkdir', 'src*'), logEnviron=False))
             + Expect.update('files', ["srcfile"])
             + 0,
             Expect('stat', dict(file="srcfile",
@@ -555,11 +558,13 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
             transfer.MultipleFileUpload(
                 workersrcs=["src*"], masterdest=self.destdir, glob=True))
         self.expectCommands(
-            Expect('glob', {'path': os.path.join('wkdir', 'src*'), 'logEnviron': False})
+            Expect('glob', {'path': os.path.join(
+                'wkdir', 'src*'), 'logEnviron': False})
             + Expect.update('files', [])
             + 1,
         )
-        self.expectOutcome(result=SKIPPED, state_string="uploading 0 files (skipped)")
+        self.expectOutcome(
+            result=SKIPPED, state_string="uploading 0 files (skipped)")
         d = self.runStep()
         return d
 
@@ -684,7 +689,7 @@ class TestMultipleFileUpload(steps.BuildStepMixin, TestReactorMixin,
 
         self.assertEqual(behavior.writer.cancel.called, True)
         self.assertEqual(
-                len(self.flushLoggedErrors(RuntimeError)), 1)
+            len(self.flushLoggedErrors(RuntimeError)), 1)
 
     @defer.inlineCallbacks
     def testSubclass(self):
@@ -860,8 +865,8 @@ class TestStringDownload(steps.BuildStepMixin, TestReactorMixin,
 
     def testModeConfError(self):
         with self.assertRaisesRegex(config.ConfigErrors,
-                "StringDownload step's mode must be an integer or None,"
-                " got 'not-a-number'"):
+                                    "StringDownload step's mode must be an integer or None,"
+                                    " got 'not-a-number'"):
             transfer.StringDownload("string", "file", mode="not-a-number")
 
     @defer.inlineCallbacks
@@ -1040,7 +1045,9 @@ class TestJSONPropertiesDownload(steps.BuildStepMixin, TestReactorMixin, unittes
         self.expectOutcome(
             result=SUCCESS, state_string="downloading to props.json")
         yield self.runStep()
-        self.assertEqual(b''.join(read), b'{"properties": {"key1": "value1"}, "sourcestamps": []}')
+        # we decode as key order is dependent of python version
+        self.assertEqual(json.loads(b''.join(read)), {
+                         "properties": {"key1": "value1"}, "sourcestamps": []})
 
     def test_init_workerdest_keyword(self):
         step = transfer.JSONPropertiesDownload(workerdest='dstfile')

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -1046,7 +1046,7 @@ class TestJSONPropertiesDownload(steps.BuildStepMixin, TestReactorMixin, unittes
             result=SUCCESS, state_string="downloading to props.json")
         yield self.runStep()
         # we decode as key order is dependent of python version
-        self.assertEqual(json.loads(b''.join(read)), {
+        self.assertEqual(json.loads((b''.join(read)).decode()), {
                          "properties": {"key1": "value1"}, "sourcestamps": []})
 
     def test_init_workerdest_keyword(self):

--- a/master/buildbot/test/util/sandboxed_worker.py
+++ b/master/buildbot/test/util/sandboxed_worker.py
@@ -57,7 +57,8 @@ class SandboxedWorker(AsyncService):
 
         res = subprocess.run([self.sandboxed_worker_path, "create-worker", '-q', self.workerdir,
                              self.masterhost + ":" + str(self.port), self.workername, self.workerpasswd],
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             check=False)
         if res.returncode != 0:
             # we do care about finding out why it failed though
             raise RuntimeError("\n".join([

--- a/master/buildbot/test/util/sandboxed_worker.py
+++ b/master/buildbot/test/util/sandboxed_worker.py
@@ -14,7 +14,7 @@
 # Copyright Buildbot Team Members
 
 
-from subprocess import check_call
+import subprocess
 
 from twisted.internet import defer
 from twisted.internet import protocol
@@ -48,13 +48,23 @@ class SandboxedWorker(AsyncService):
         self.workerpasswd = passwd
         self.workerdir = workerdir
         self.sandboxed_worker_path = sandboxed_worker_path
+        self.worker = None
 
     def startService(self):
 
         # Note that we create the worker with sync API
         # We don't really care as we are in tests
-        check_call([self.sandboxed_worker_path, "create-worker", '-q', self.workerdir,
-                    self.masterhost + ":" + str(self.port), self.workername, self.workerpasswd])
+
+        res = subprocess.run([self.sandboxed_worker_path, "create-worker", '-q', self.workerdir,
+                             self.masterhost + ":" + str(self.port), self.workername, self.workerpasswd],
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if res.returncode != 0:
+            # we do care about finding out why it failed though
+            raise RuntimeError("\n".join([
+                "Unable to create worker!",
+                res.stdout.decode(),
+                res.stderr.decode()
+            ]))
 
         self.processprotocol = processProtocol = WorkerProcessProtocol()
         # we need to spawn the worker asynchronously though
@@ -66,6 +76,8 @@ class SandboxedWorker(AsyncService):
 
     @defer.inlineCallbacks
     def shutdownWorker(self):
+        if self.worker is None:
+            return
         # on windows, we killing a process does not work well.
         # we use the graceful shutdown feature of buildbot-worker instead to kill the worker
         # but we must do that before the master is stopping.

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -102,7 +102,7 @@ class WorkerFileUploadCommand(TransferCommand):
             if self.debug:
                 log.msg("Cannot open file '{0}' for upload".format(self.path))
 
-        self.sendStatus({'header': "sending {0}".format(self.path)})
+        self.sendStatus({'header': "sending {0}\n".format(self.path)})
 
         d = defer.Deferred()
         self._reactor.callLater(0, self._loop, d)

--- a/worker/buildbot_worker/commands/transfer.py
+++ b/worker/buildbot_worker/commands/transfer.py
@@ -230,7 +230,7 @@ class WorkerDirectoryUploadCommand(WorkerFileUploadCommand):
         # Transfer it
         self.fp.seek(0)
 
-        self.sendStatus({'header': "sending {0}".format(self.path)})
+        self.sendStatus({'header': "sending {0}\n".format(self.path)})
 
         d = defer.Deferred()
         self._reactor.callLater(0, self._loop, d)

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -146,7 +146,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
         yield self.run_command()
 
         self.assertUpdates([
-            {'header': 'sending {0}'.format(self.datafile)},
+            {'header': 'sending {0}\n'.format(self.datafile)},
             'write 64', 'write 64', 'write 52', 'close',
             {'rc': 0}
         ])
@@ -167,7 +167,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
         yield self.run_command()
 
         self.assertUpdates([
-            {'header': 'sending {0}'.format(self.datafile)},
+            {'header': 'sending {0}\n'.format(self.datafile)},
             'write 64', 'write 36', 'close',
             {'rc': 1,
              'stderr': "Maximum filesize reached, truncating file '{0}'".format(self.datafile)}
@@ -188,7 +188,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
 
         df = self.datafile + "-nosuch"
         self.assertUpdates([
-            {'header': 'sending {0}'.format(df)},
+            {'header': 'sending {0}\n'.format(df)},
             'close',
             {'rc': 1,
              'stderr': "Cannot open file '{0}' for upload".format(df)}
@@ -211,7 +211,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
         yield self.assertFailure(self.run_command(), RuntimeError)
 
         self.assertUpdates([
-            {'header': 'sending {0}'.format(self.datafile)},
+            {'header': 'sending {0}\n'.format(self.datafile)},
             'write 64', 'close',
             {'rc': 1}
         ])
@@ -243,7 +243,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
         yield defer.DeferredList([d, interrupt_d])
 
         self.assertUpdates([
-            {'header': 'sending {0}'.format(self.datafile)},
+            {'header': 'sending {0}\n'.format(self.datafile)},
             'write(s)', 'close', {'rc': 1}
         ])
 
@@ -265,7 +265,7 @@ class TestUploadFile(CommandTestMixin, unittest.TestCase):
         yield self.run_command()
 
         self.assertUpdates([
-            {'header': 'sending {0}'.format(self.datafile)},
+            {'header': 'sending {0}\n'.format(self.datafile)},
             'write 64', 'write 64', 'write 52',
             'close', 'utime - {0}'.format(timestamp[0]),
             {'rc': 0}
@@ -311,7 +311,7 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
         yield self.run_command()
 
         self.assertUpdates([
-            {'header': 'sending {0}'.format(self.datadir)},
+            {'header': 'sending {0}\n'.format(self.datadir)},
             'write(s)', 'unpack',  # note no 'close"
             {'rc': 0}
         ])
@@ -354,7 +354,7 @@ class TestWorkerDirectoryUpload(CommandTestMixin, unittest.TestCase):
         yield self.assertFailure(self.run_command(), RuntimeError)
 
         self.assertUpdates([
-            {'header': 'sending {0}'.format(self.datadir)},
+            {'header': 'sending {0}\n'.format(self.datadir)},
             'write(s)', 'unpack',
             {'rc': 1}
         ])


### PR DESCRIPTION
When transfer step failed, no meaningful information was displayed
This was because stdio log was not propertly initialized

Fixes: #5058

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
