### PR TITLE
Python 3.8 support

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -4,7 +4,7 @@ language: python
 
 # Available Python versions:
 python:
-  - "3.5"
+  - "3.8"
 label_mapping:
   TWISTED: tw
   SQLALCHEMY: sqla
@@ -29,6 +29,7 @@ env:
 
   - TWISTED=17.9.0 SQLALCHEMY=latest TESTS=trial
 
+  - TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.7
   - TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.6
   - TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.5
 
@@ -61,21 +62,23 @@ matrix:
   fast_finish: true
   include:
     # flake8, isort, pylint, docs first as they're more likely to find issues
-    - python: "3.7"
+    - python: "3.8"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=flake8
-    - python: "3.7"
+    - python: "3.8"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=isort
-    - python: "3.7"
+    - python: "3.8"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=pylint HYPER_SIZE=m3
-    - python: "3.7"
+    - python: "3.8"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=docs
 
     - python: "3.6"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=trial
     - python: "3.7"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=trial
+    - python: "3.8"
+      env: TWISTED=latest SQLALCHEMY=latest TESTS=trial
 
-    - python: "3.7"
+    - python: "3.8"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=2.7
 
     # keep worker supported on py2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ language: python
 # Available Python versions:
 # http://about.travis-ci.org/docs/user/ci-environment/#Python-VM-images
 python:
-  - "3.7"
+  - "3.8"
 
 env:
   matrix:

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -1119,8 +1119,8 @@ The :bb:chsrc:`BitbucketPullrequestPoller` accepts the following arguments:
     parse each revision's commit timestamp (default is ``True``), or ignore it in favor of the current time (so recently processed commits appear together in the waterfall page)
 
 ``encoding``
-    Set encoding will be used to parse author's name and commit message.
-    Default encoding is ``'utf-8'``.
+    This parameter is deprecated and has no effects.
+    Author's name and commit message are always parsed in ``'utf-8'``.
 
 A minimal configuration for the Bitbucket pull request poller might look like this:
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -4,7 +4,7 @@ asn1crypto==1.1.0
 astroid==2.3.1; python_version >= "3.4"
 attrs==19.2.0
 autobahn==19.10.1
-Automat==0.7.0
+Automat==0.8.0
 Babel==2.7.0
 backports.functools-lru-cache==1.5
 blockdiag==1.5.4

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -1,5 +1,5 @@
 attrs==19.2.0
-Automat==0.7.0
+Automat==0.8.0
 constantly==15.1.0
 funcsigs==1.0.2
 future==0.18.0


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

For now I only make tests pass. Further actions like adding trove classifiers to `setup.py` or a news fragment declaring Python 3.8 support are up to you.