### PR TITLE
worker: add --useTls option

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1543,6 +1543,7 @@ usepty
 usererrors
 username
 usetestcasenames
+usetls
 usr
 utc
 utf

--- a/master/buildbot/newsfragments/add-useTLS-arg.feature
+++ b/master/buildbot/newsfragments/add-useTLS-arg.feature
@@ -1,0 +1,1 @@
+Add the parameter --useTLS to `buildbot-worker create-worker` to automatically enable TLS in the connection string

--- a/master/buildbot/newsfragments/add-useTLS-arg.feature
+++ b/master/buildbot/newsfragments/add-useTLS-arg.feature
@@ -1,1 +1,1 @@
-Add the parameter --useTLS to `buildbot-worker create-worker` to automatically enable TLS in the connection string
+Add the parameter --use-tls to `buildbot-worker create-worker` to automatically enable TLS in the connection string

--- a/master/docs/manual/installation/worker.rst
+++ b/master/docs/manual/installation/worker.rst
@@ -168,7 +168,7 @@ To use these, just include them on the ``buildbot-worker create-worker`` command
 .. option:: --useTLS
 
     Can also be passed directly to the Worker constructor in :file:`buildbot.tac`.
-    If set, the generated connecition string starts with ``tls`` instead of with ``tcp``, allowing encrypted conneciton to the buildmaster.
+    If set, the generated connection string starts with ``tls`` instead of with ``tcp``, allowing encrypted connection to the buildmaster.
     Make sure the worker trusts the buildmasters certificate. If you have an non-authoritative certificate (CA is self-signed) see ``connection_string`` below.
 
 .. _Other-Worker-Configuration:

--- a/master/docs/manual/installation/worker.rst
+++ b/master/docs/manual/installation/worker.rst
@@ -165,7 +165,7 @@ To use these, just include them on the ``buildbot-worker create-worker`` command
 
     Both master and worker must be at least version 0.8.3 for this feature to work.
 
-.. option:: --useTLS
+.. option:: --use-tls
 
     Can also be passed directly to the Worker constructor in :file:`buildbot.tac`.
     If set, the generated connection string starts with ``tls`` instead of with ``tcp``, allowing encrypted connection to the buildmaster.
@@ -195,7 +195,7 @@ Worker TLS Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``tls``
-    See ``--useTLS`` option above as an alternative to setting the ``conneciton_string`` manually.
+    See ``--useTls`` option above as an alternative to setting the ``conneciton_string`` manually.
 
 
 ``connection_string``

--- a/master/docs/manual/installation/worker.rst
+++ b/master/docs/manual/installation/worker.rst
@@ -165,6 +165,12 @@ To use these, just include them on the ``buildbot-worker create-worker`` command
 
     Both master and worker must be at least version 0.8.3 for this feature to work.
 
+.. option:: --useTLS
+
+    Can also be passed directly to the Worker constructor in :file:`buildbot.tac`.
+    If set, the generated connecition string starts with ``tls`` instead of with ``tcp``, allowing encrypted conneciton to the buildmaster.
+    Make sure the worker trusts the buildmasters certificate. If you have an non-authoritative certificate (CA is self-signed) see ``connection_string`` below.
+
 .. _Other-Worker-Configuration:
 
 Other Worker Configuration
@@ -187,6 +193,10 @@ Other Worker Configuration
 
 Worker TLS Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~
+
+``tls``
+    See ``--useTLS`` option above as an alternative to setting the ``conneciton_string`` manually.
+
 
 ``connection_string``
     For TLS connections to the master the ``connection_string``-argument must be used to ``Worker.__init__`` function. ``buildmaster_host`` and ``port`` must then be ``None``.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -811,6 +811,7 @@ testsuite
 textarea
 tgrid
 tgz
+tls
 th
 timestamp
 Todo
@@ -885,7 +886,7 @@ userlist
 username
 Username
 usernames
-useTLS
+useTls
 utf
 UTF
 util

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -885,6 +885,7 @@ userlist
 username
 Username
 usernames
+useTLS
 utf
 UTF
 util

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -178,7 +178,7 @@ class Worker(WorkerBase, service.MultiService):
 
     def __init__(self, buildmaster_host, port, name, passwd, basedir,
                  keepalive, usePTY=None, keepaliveTimeout=None, umask=None,
-                 maxdelay=None, numcpus=None, unicode_encoding=None, useTLS=None,
+                 maxdelay=None, numcpus=None, unicode_encoding=None, useTls=None,
                  allow_shutdown=None, maxRetries=None, connection_string=None):
 
         assert usePTY is None, "worker-side usePTY is not supported anymore"
@@ -211,7 +211,7 @@ class Worker(WorkerBase, service.MultiService):
         bf.startLogin(
             credentials.UsernamePassword(name, passwd), client=self.bot)
         if connection_string is None:
-            if useTLS:
+            if useTls:
                 connection_type = 'tls'
             else:
                 connection_type = 'tcp'

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -178,7 +178,7 @@ class Worker(WorkerBase, service.MultiService):
 
     def __init__(self, buildmaster_host, port, name, passwd, basedir,
                  keepalive, usePTY=None, keepaliveTimeout=None, umask=None,
-                 maxdelay=None, numcpus=None, unicode_encoding=None,
+                 maxdelay=None, numcpus=None, unicode_encoding=None, useTLS=None,
                  allow_shutdown=None, maxRetries=None, connection_string=None):
 
         assert usePTY is None, "worker-side usePTY is not supported anymore"
@@ -211,7 +211,13 @@ class Worker(WorkerBase, service.MultiService):
         bf.startLogin(
             credentials.UsernamePassword(name, passwd), client=self.bot)
         if connection_string is None:
-            connection_string = 'tcp:host={}:port={}'.format(
+            if useTLS:
+                connection_type = 'tls'
+            else:
+                connection_type = 'tcp'
+
+            connection_string = '{}:host={}:port={}'.format(
+                connection_type,
                 buildmaster_host.replace(':', r'\:'),  # escape ipv6 addresses
                 port)
         endpoint = clientFromString(reactor, connection_string)

--- a/worker/buildbot_worker/scripts/create_worker.py
+++ b/worker/buildbot_worker/scripts/create_worker.py
@@ -58,11 +58,12 @@ maxdelay = %(maxdelay)d
 numcpus = %(numcpus)s
 allow_shutdown = %(allow-shutdown)s
 maxretries = %(maxretries)s
+use_tls = %(use-tls)s
 
 s = Worker(buildmaster_host, port, workername, passwd, basedir,
            keepalive, umask=umask, maxdelay=maxdelay,
            numcpus=numcpus, allow_shutdown=allow_shutdown,
-           maxRetries=maxretries)
+           maxRetries=maxretries, useTls=use_tls)
 s.setServiceParent(application)
 """]
 

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -105,7 +105,9 @@ class CreateWorkerOptions(MakerBase):
         ["relocatable", "r",
          "Create a relocatable buildbot.tac"],
         ["no-logrotate", "n",
-         "Do not permit buildmaster rotate logs by itself"]
+         "Do not permit buildmaster rotate logs by itself"],
+        ['use-tls', None,
+         "Uses TLS to connect to master"],
     ]
     optParameters = [
         ["keepalive", "k", 600,

--- a/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
@@ -726,6 +726,31 @@ class TestCreateWorker(misc.StdoutAssertionsMixin, unittest.TestCase):
         # check that correct info message was printed
         self.assertStdoutEqual("worker configured in bdir\n")
 
+    def testUseTLS(self):
+        """
+        test that when --useTLS options is used, correct connection_string
+        is generated
+        """
+        options = self.options.copy()
+        options["useTLS"] = True
+
+        # patch _make*() functions to do nothing
+        self.setUpMakeFunctions()
+
+        # call createWorker() and check that we get success exit code
+        self.assertEqual(create_worker.createWorker(options), 0,
+                         "unexpected exit code")
+
+        # check _make*() functions were called with correct arguments
+        expected_tac_contents = (create_worker.workerTACTemplate[0] +
+                                 create_worker.workerTACTemplate[2]) % options
+        self.assertMakeFunctionsCalls(self.options["basedir"],
+                                      expected_tac_contents,
+                                      self.options["quiet"])
+
+        # check that correct info message was printed
+        self.assertStdoutEqual("worker configured in bdir\n")
+
     def testWithOpts(self):
         """
         test calling createWorker() with --relocatable and --allow-shutdown

--- a/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
@@ -479,6 +479,7 @@ class TestCreateWorker(misc.StdoutAssertionsMixin, unittest.TestCase):
         "no-logrotate": False,
         "relocatable": False,
         "quiet": False,
+        "use-tls": False,
         # options
         "basedir": "bdir",
         "allow-shutdown": None,
@@ -621,6 +622,7 @@ class TestCreateWorker(misc.StdoutAssertionsMixin, unittest.TestCase):
             maxdelay=options["maxdelay"],
             allow_shutdown=options["allow-shutdown"],
             maxRetries=options["maxretries"],
+            useTls=options["use-tls"],
             )
 
         # check that Worker instance attached to application
@@ -728,11 +730,11 @@ class TestCreateWorker(misc.StdoutAssertionsMixin, unittest.TestCase):
 
     def testUseTLS(self):
         """
-        test that when --useTLS options is used, correct connection_string
+        test that when --use-tls options is used, correct connection_string
         is generated
         """
         options = self.options.copy()
-        options["useTLS"] = True
+        options["use-tls"] = True
 
         # patch _make*() functions to do nothing
         self.setUpMakeFunctions()
@@ -742,8 +744,7 @@ class TestCreateWorker(misc.StdoutAssertionsMixin, unittest.TestCase):
                          "unexpected exit code")
 
         # check _make*() functions were called with correct arguments
-        expected_tac_contents = (create_worker.workerTACTemplate[0] +
-                                 create_worker.workerTACTemplate[2]) % options
+        expected_tac_contents = ("".join(create_worker.workerTACTemplate)) % options
         self.assertMakeFunctionsCalls(self.options["basedir"],
                                       expected_tac_contents,
                                       self.options["quiet"])


### PR DESCRIPTION
The options sets the connection type within the `connection_string` to
`tls` instead of `tcp`. This allows to use an encrypted connection via
the `buildbot-worker --create-worker` command, instead of requiring to
edit the `buildbot.tac` afterwards.

Signed-off-by: Paul Spooren <mail@aparcar.org>

I'll create a unit test once this approach is approved.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
