### PR TITLE
Support option '--submodules' for git-repo

### DIFF
--- a/master/buildbot/steps/source/repo.py
+++ b/master/buildbot/steps/source/repo.py
@@ -96,7 +96,7 @@ class Repo(Source):
     name = 'repo'
     renderables = ["manifestURL", "manifestBranch", "manifestFile", "tarball", "jobs",
                    "syncAllBranches", "updateTarballAge", "manifestOverrideUrl",
-                   "repoDownloads", "depth"]
+                   "repoDownloads", "depth", "submodules"]
 
     ref_not_found_re = re.compile(r"fatal: Couldn't find remote ref")
     cherry_pick_error_re = re.compile(r"|".join([r"Automatic cherry-pick failed",
@@ -121,6 +121,7 @@ class Repo(Source):
                  manifestOverrideUrl=None,
                  repoDownloads=None,
                  depth=0,
+                 submodules=False,
                  syncQuietly=False,
                  **kwargs):
         """
@@ -153,6 +154,9 @@ class Repo(Source):
         @param depth: optional depth parameter to repo init.
                           If specified, create a shallow clone with given depth.
 
+        @type submodules: string
+        @param submodules: optional submodules parameter to repo init.
+
         @type syncQuietly: bool.
         @param syncQuietly: true, then suppress verbose output from repo sync.
         """
@@ -168,6 +172,7 @@ class Repo(Source):
             repoDownloads = []
         self.repoDownloads = repoDownloads
         self.depth = depth
+        self.submodules = submodules
         self.syncQuietly = syncQuietly
         super().__init__(**kwargs)
 
@@ -288,11 +293,17 @@ class Repo(Source):
             self.willRetryInCaseOfFailure = False
             yield self.doClobberStart()
         yield self.doCleanup()
-        yield self._repoCmd(['init',
-                             '-u', self.manifestURL,
-                             '-b', self.manifestBranch,
-                             '-m', self.manifestFile,
-                             '--depth', str(self.depth)])
+
+        command = ['init',
+                   '-u', self.manifestURL,
+                   '-b', self.manifestBranch,
+                   '-m', self.manifestFile,
+                   '--depth', str(self.depth)])
+
+        if self.submodules:
+            command.append('--submodules')
+
+        yield self._repoCmd(cmd)
 
         if self.manifestOverrideUrl:
             self.stdio_log.addHeader(


### PR DESCRIPTION
This commit allows you to use git-repo's options '--submodules'.
See https://gerrit.googlesource.com/git-repo for details.

