### PR TITLE
Fix typo in the description of Role matchers

### DIFF
--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -908,7 +908,7 @@ In this case, you can look at the source code for detailed examples on how to wr
 
 Role matchers
 +++++++++++++
-Endpoint matchers are responsible for creating rules to match people and grant them roles.
+Role matchers are responsible for creating rules to match people and grant them roles.
 You can grant roles from groups information provided by the Auth plugins, or if you prefer directly to people's email.
 
 


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/buildbot/buildbot/5068)
<!-- Reviewable:end -->
