### PR TITLE
Windows worker service description fixup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ install:
   - "python -c \"import sys; print(sys.executable)\""
   - "python -V -V"
   # Twisted requires pywin32 on Windows in order to spawn processes.
+  - "python -m pip install \"pywin32==225\""
   - "python -m pip install \"pypiwin32\""
 
   # TODO: There is no binary wheel for pysqlite and building on Windows is

--- a/master/buildbot/newsfragments/windows-worker-service-description.bugfix
+++ b/master/buildbot/newsfragments/windows-worker-service-description.bugfix
@@ -1,0 +1,1 @@
+Updated url in description of worker service for Windows (no functionality impact).

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -78,7 +78,7 @@ termcolor==1.1.0
 toml==0.10.0
 towncrier==19.2.0
 treq==18.6.0
-Twisted==19.7.0
+Twisted==19.10.0
 txaio==18.8.1
 txrequests==0.9.6
 typing==3.7.4.1

--- a/worker/buildbot_worker/scripts/windows_service.py
+++ b/worker/buildbot_worker/scripts/windows_service.py
@@ -112,7 +112,7 @@ class BBService(win32serviceutil.ServiceFramework):
     _svc_name_ = 'BuildBot'
     _svc_display_name_ = _svc_name_
     _svc_description_ = 'Manages local buildbot workers and masters - ' \
-                        'see http://buildbot.sourceforge.net'
+                        'see https://buildbot.net'
 
     def __init__(self, args):
         win32serviceutil.ServiceFramework.__init__(self, args)


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

Today I've noticed there on Windows worker machine there is probably obsolete url in the description of Windows service so I'm sending PR. I don't think it is worthy mention in newssfragment. Basically it is typo fix. Feel free to remove created newsfragments or drop it from the final changelog for the release.