### PR TITLE
Remove Server Header from buildbot master

### DIFF
--- a/master/buildbot/newsfragments/serverheader.bugfix
+++ b/master/buildbot/newsfragments/serverheader.bugfix
@@ -1,0 +1,1 @@
+Remove server header from response.

--- a/master/buildbot/test/unit/test_www_service.py
+++ b/master/buildbot/test/unit/test_www_service.py
@@ -274,3 +274,20 @@ class TestBuildbotSite(unittest.SynchronousTestCase):
                              algorithms=[service.SESSION_SECRET_ALGORITHM])
         self.assertEqual(decoded['user_info'], {'anonymous': True})
         self.assertIn('exp', decoded)
+
+    def test_absentServerHeader(self):
+
+        class FakeChannel:
+            transport = None
+
+            def isSecure(self):
+                return False
+
+            def getPeer(self):
+                return None
+
+            def getHost(self):
+                return None
+
+        request = Request(FakeChannel(), False)
+        self.assertEqual(request.responseHeaders.hasHeader('Server'), False)

--- a/master/buildbot/test/unit/test_www_service.py
+++ b/master/buildbot/test/unit/test_www_service.py
@@ -37,6 +37,19 @@ from buildbot.www import rest
 from buildbot.www import service
 
 
+class FakeChannel:
+    transport = None
+
+    def isSecure(self):
+        return False
+
+    def getPeer(self):
+        return None
+
+    def getHost(self):
+        return None
+
+
 class NeedsReconfigResource(resource.Resource):
 
     needsReconfig = True
@@ -252,19 +265,6 @@ class TestBuildbotSite(unittest.SynchronousTestCase):
 
     def test_updateSession(self):
         session = self.site.makeSession()
-
-        class FakeChannel:
-            transport = None
-
-            def isSecure(self):
-                return False
-
-            def getPeer(self):
-                return None
-
-            def getHost(self):
-                return None
-
         request = Request(FakeChannel(), False)
         request.sitepath = [b"bb"]
         session.updateSession(request)
@@ -276,18 +276,5 @@ class TestBuildbotSite(unittest.SynchronousTestCase):
         self.assertIn('exp', decoded)
 
     def test_absentServerHeader(self):
-
-        class FakeChannel:
-            transport = None
-
-            def isSecure(self):
-                return False
-
-            def getPeer(self):
-                return None
-
-            def getHost(self):
-                return None
-
         request = Request(FakeChannel(), False)
         self.assertEqual(request.responseHeaders.hasHeader('Server'), False)

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -151,6 +151,10 @@ class BuildbotSite(server.Site):
         return LogFile.fromFullPath(
             path, rotateLength=self.rotateLength, maxRotatedFiles=self.maxRotatedFiles)
 
+    def getResourceFor(self, request):
+        request.responseHeaders.removeHeader('Server')
+        return server.Site.getResourceFor(self, request)
+
     def setSessionSecret(self, secret):
         self.session_secret = secret
 


### PR DESCRIPTION
Removes `Server: TwistedWeb/19.2.1` from all responses.

Signed-off-by: Lucas Ramage <ramage.lucas@protonmail.com>

Closes: https://github.com/buildbot/buildbot/issues/5081

See also: https://stackoverflow.com/q/20304287/8507637

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] <s>I have updated the appropriate documentation</s> N/A
