### PR TITLE
Buildstep should release all _acquiringLocks when cancelled to avoid deadlock

### DIFF
--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -187,8 +187,10 @@ class BaseLock:
         A single requester must not have more than one pending waitUntilMaybeAvailable() on a
         single lock.
 
-        If the lock is available, the caller must claim it. When the caller is no longer interested
-        into the lock it must call stopWaitingUntilAvailable().
+        The caller must guarantee, that once the returned deferred is fired, either the lock is
+        checked for availability and claimed if it's available, or the it is indicated as no
+        longer interesting by calling stopWaitingUntilAvailable(). The caller does not need to
+        do this immediately after deferred is fired, an eventual execution is sufficient.
         """
         debuglog("%s waitUntilAvailable(%s)" % (self, owner))
         assert isinstance(access, LockAccess)

--- a/master/buildbot/newsfragments/buildstep-interrupt-deadlock.bugfix
+++ b/master/buildbot/newsfragments/buildstep-interrupt-deadlock.bugfix
@@ -1,0 +1,1 @@
+Fix a potential deadlock when interrupting a step that is waiting for a lock to become available.

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -355,7 +355,7 @@ class BuildStep(results.ResultComputingConfigMixin,
             config.error("BuildStep updateBuildSummaryPolicy must be "
                          "a list of result ids or boolean but it is %r" %
                          (self.updateBuildSummaryPolicy,))
-        self._acquiringLock = None
+        self._acquiringLocks = []
         self.stopped = False
         self.master = None
         self.statistics = {}
@@ -637,7 +637,6 @@ class BuildStep(results.ResultComputingConfigMixin,
         return ok
 
     def acquireLocks(self, res=None):
-        self._acquiringLock = None
         if not self.locks:
             return defer.succeed(None)
         if self.stopped:
@@ -648,12 +647,13 @@ class BuildStep(results.ResultComputingConfigMixin,
                 self._waitingForLocks = True
                 log.msg("step %s waiting for lock %s" % (self, lock))
                 d = lock.waitUntilMaybeAvailable(self, access)
+                self._acquiringLocks.append((lock, access, d))
                 d.addCallback(self.acquireLocks)
-                self._acquiringLock = (lock, access, d)
                 return d
         # all locks are available, claim them all
         for lock, access in self.locks:
             lock.claim(self, access)
+        self._acquiringLocks = []
         self._waitingForLocks = False
         return defer.succeed(None)
 
@@ -744,9 +744,10 @@ class BuildStep(results.ResultComputingConfigMixin,
 
     def interrupt(self, reason):
         self.stopped = True
-        if self._acquiringLock:
-            lock, access, d = self._acquiringLock
-            lock.stopWaitingUntilAvailable(self, access, d)
+        if self._acquiringLocks:
+            for (lock, access, d) in self._acquiringLocks:
+                lock.stopWaitingUntilAvailable(self, access, d)
+            self._acquiringLocks = []
 
         if self._waitingForLocks:
             self.addCompleteLog(

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -643,6 +643,10 @@ class BuildStep(results.ResultComputingConfigMixin,
             return defer.succeed(None)
         log.msg("acquireLocks(step %s, locks %s)" % (self, self.locks))
         for lock, access in self.locks:
+            for waited_lock, _, _ in self._acquiringLocks:
+                if lock is waited_lock:
+                    continue
+
             if not lock.isAvailable(self, access):
                 self._waitingForLocks = True
                 log.msg("step %s waiting for lock %s" % (self, lock))


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

Found in a live buildbot deployment, and I set out to write a unit test to prove it. It looks like the `buildstep` code could cause a deadlock if it requires multiple locks, and it gets cancelled at just the wrong time. My change keeps track of all the `_acquiringLocks` and makes sure to either `claim` and `release` (if the lock is available to us), or `stopWaitingUntilAvailable` if the lock is not available to us.