### PR TITLE
locks: allow stopWaitingUntilAvailable() in more scenarios

### DIFF
--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -206,7 +206,8 @@ class BaseLock:
 
     def stopWaitingUntilAvailable(self, owner, access, d):
         """ Stop waiting for lock to become available. `d` must be the result of a previous call
-            to `waitUntilMaybeAvailable()`.
+            to `waitUntilMaybeAvailable()`. If `d` has not been woken up already by calling its
+            callback, it will be done as part of this function
         """
         debuglog("%s stopWaitingUntilAvailable(%s)" % (self, owner))
         assert isinstance(access, LockAccess)
@@ -217,6 +218,7 @@ class BaseLock:
         if old_d is not None:
             assert d is old_d, "The supplied deferred must be a result of waitUntilMaybeAvailable()"
             del self.waiting[w_index]
+            d.callback(None)
 
     def isOwner(self, owner, access):
         return (owner, access) in self.owners

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -597,7 +597,6 @@ class Build(properties.PropertiesMixin):
             if self._acquiringLock:
                 lock, access, d = self._acquiringLock
                 lock.stopWaitingUntilAvailable(self, access, d)
-                d.callback(None)
 
     def controlStopBuild(self, key, params):
         return self.stopBuild(**params)
@@ -623,7 +622,6 @@ class Build(properties.PropertiesMixin):
         if self._acquiringLock:
             lock, access, d = self._acquiringLock
             lock.stopWaitingUntilAvailable(self, access, d)
-            d.callback(None)
 
     def allStepsDone(self):
         if self.results == FAILURE:

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -747,7 +747,6 @@ class BuildStep(results.ResultComputingConfigMixin,
         if self._acquiringLock:
             lock, access, d = self._acquiringLock
             lock.stopWaitingUntilAvailable(self, access, d)
-            d.callback(None)
 
         if self._waitingForLocks:
             self.addCompleteLog(

--- a/master/buildbot/test/unit/test_locks.py
+++ b/master/buildbot/test/unit/test_locks.py
@@ -208,6 +208,21 @@ class BaseLockTests(unittest.TestCase):
         lock.release(req_waiter1, access)
 
     @parameterized.expand(['counting', 'exclusive'])
+    def test_duplicate_wait_until_maybe_available_throws(self, mode):
+        req = Requester()
+        req_waiter = Requester()
+
+        lock = BaseLock('test', maxCount=1)
+        access = mock.Mock(spec=LockAccess)
+        access.mode = mode
+
+        lock.claim(req, access)
+        lock.waitUntilMaybeAvailable(req_waiter, access)
+        with self.assertRaises(AssertionError):
+            lock.waitUntilMaybeAvailable(req_waiter, access)
+        lock.release(req, access)
+
+    @parameterized.expand(['counting', 'exclusive'])
     def test_stop_waiting_raises_after_release(self, mode):
         req = Requester()
         req_waiter = Requester()


### PR DESCRIPTION
This is an internal improvement needed for to remove a hack from #5092. 

The PR essentially implements two things:

 - no longer allows two concurrent waiters from the same object via `waitUntilMaybeAvailable()`. If that happens, the previous code would just lose the original Deferred and never execute its callback.

 - allow unwaiting a Deferred via `stopWaitingUntilAvailable()` regardless of when this is done as long as the lock is not claimed. Previously there was a race condition which would cause `stopWaitingUntilAvailable()` to fail if the Deferred has already been called, but the lock was not claimed by the called code yet.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
