### PR TITLE
MailNotifier: allow to dump formatted mails for debugging

### DIFF
--- a/master/buildbot/newsfragments/mail-log-dump.feature
+++ b/master/buildbot/newsfragments/mail-log-dump.feature
@@ -1,0 +1,1 @@
+The new option dumpMailsToLog of MailNotifier allows to dump formatted mails to the log before sending.

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -93,7 +93,8 @@ class MailNotifier(NotifierBase):
                     addPatch=True, useTls=False, useSmtps=False,
                     smtpUser=None, smtpPassword=None, smtpPort=25,
                     schedulers=None, branches=None,
-                    watchedWorkers='all', messageFormatterMissingWorker=None):
+                    watchedWorkers='all', messageFormatterMissingWorker=None,
+                    dumpMailsToLog=False):
         if ESMTPSenderFactory is None:
             config.error("twisted-mail is not installed - cannot "
                          "send mail")
@@ -137,7 +138,8 @@ class MailNotifier(NotifierBase):
                         addPatch=True, useTls=False, useSmtps=False,
                         smtpUser=None, smtpPassword=None, smtpPort=25,
                         schedulers=None, branches=None,
-                        watchedWorkers='all', messageFormatterMissingWorker=None):
+                        watchedWorkers='all', messageFormatterMissingWorker=None,
+                        dumpMailsToLog=False):
 
         super(MailNotifier, self).reconfigService(
             mode=mode, tags=tags, builders=builders,
@@ -161,6 +163,7 @@ class MailNotifier(NotifierBase):
         self.smtpUser = smtpUser
         self.smtpPassword = smtpPassword
         self.smtpPort = smtpPort
+        self.dumpMailsToLog = dumpMailsToLog
 
     def patch_to_attachment(self, patch, index):
         # patches are specifically converted to unicode before entering the db
@@ -319,6 +322,8 @@ class MailNotifier(NotifierBase):
     def sendMail(self, m, recipients):
         s = m.as_string()
         twlog.msg("sending mail ({} bytes) to".format(len(s)), recipients)
+        if self.dumpMailsToLog:
+            twlog.msg("mail data:\n{0}".format(s))
 
         result = defer.Deferred()
 

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -322,7 +322,7 @@ class MailNotifier(NotifierBase):
     def sendMail(self, m, recipients):
         s = m.as_string()
         twlog.msg("sending mail ({} bytes) to".format(len(s)), recipients)
-        if self.dumpMailsToLog:
+        if self.dumpMailsToLog:  # pragma: no cover
             twlog.msg("mail data:\n{0}".format(s))
 
         result = defer.Deferred()

--- a/master/docs/manual/configuration/reporters.rst
+++ b/master/docs/manual/configuration/reporters.rst
@@ -329,6 +329,10 @@ MailNotifier arguments
     This class uses the Jinja2_ templating language to generate the body and optionally the subject of the mails.
     Templates can either be given inline (as string), or read from the filesystem.
 
+``dumpMailsToLog``
+    If set to ``True``, all completely formatted mails will be dumped to the log before being sent. This can be useful to debug problems with your mail provider.
+    Be sure to only turn this on if you really need it, especially if you attach logs to emails. This can dump sensitive information to logs, and make them very large.
+
 
 MessageFormatter arguments
 ++++++++++++++++++++++++++

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -271,6 +271,7 @@ doesn
 dom
 downloadFile
 dropdown
+dumpMailsToLog
 durations
 dustin
 ec


### PR DESCRIPTION
Adds a new option `dumpMailsToLog` which allows to dump formatted mails to the logs before they are sent by `MailNotifier`. This is very useful to debug problems with your mail provider (e.g. to find out why they are rejecting your emails as spam).

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
