### PR TITLE
MailNotifier: fix email To: and CC: header escaping

### DIFF
--- a/master/buildbot/newsfragments/mail-recipients-formatting.bugfix
+++ b/master/buildbot/newsfragments/mail-recipients-formatting.bugfix
@@ -1,0 +1,1 @@
+Fix mail recipient formatting to make sure address comments are separately escaped instead of escaping the whole To: or CC: header, which is not RFC compliant.

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -15,6 +15,7 @@
 
 import re
 from email import charset
+from email.header import Header
 from email.message import Message
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -301,6 +302,12 @@ class MailNotifier(NotifierBase):
 
         return recipients
 
+    def formatAddress(self, addr):
+        r = parseaddr(addr)
+        if not r[0]:
+            return r[1]
+        return "\"%s\" <%s>" % (Header(r[0], 'utf-8').encode(), r[1])
+
     def processRecipients(self, blamelist, m):
         to_recipients = set(blamelist)
         cc_recipients = set()
@@ -313,9 +320,9 @@ class MailNotifier(NotifierBase):
         else:
             to_recipients.update(self.extraRecipients)
 
-        m['To'] = ", ".join(sorted(to_recipients))
+        m['To'] = ", ".join([self.formatAddress(addr) for addr in sorted(to_recipients)])
         if cc_recipients:
-            m['CC'] = ", ".join(sorted(cc_recipients))
+            m['CC'] = ", ".join([self.formatAddress(addr) for addr in sorted(cc_recipients)])
 
         return list(to_recipients | cc_recipients)
 

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -244,19 +244,19 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
             lookup="example.org",
             exp_called_with=['Big Bob <bob@mayhem.net>',
                              'narrator@example.org'],
-            exp_TO="Big Bob <bob@mayhem.net>, "
-            "narrator@example.org")
+            exp_TO='"=?utf-8?q?Big_Bob?=" <bob@mayhem.net>, '
+            'narrator@example.org')
 
     def test_buildMessage_sendToInterestedUsers_no_lookup(self):
         return self.do_test_sendToInterestedUsers(
             exp_called_with=['Big Bob <bob@mayhem.net>'],
-            exp_TO="Big Bob <bob@mayhem.net>")
+            exp_TO='"=?utf-8?q?Big_Bob?=" <bob@mayhem.net>')
 
     def test_buildMessage_sendToInterestedUsers_extraRecipients(self):
         return self.do_test_sendToInterestedUsers(
             extraRecipients=["marla@mayhem.net"],
             exp_called_with=['Big Bob <bob@mayhem.net>', 'marla@mayhem.net'],
-            exp_TO="Big Bob <bob@mayhem.net>",
+            exp_TO='"=?utf-8?q?Big_Bob?=" <bob@mayhem.net>',
             exp_CC="marla@mayhem.net")
 
     def test_sendToInterestedUsers_False(self):


### PR DESCRIPTION
Currently, recipients are added to To: and CC: headers by concatenating the addresses with `", "`. If one of the addresses contains a non-ASCII character, this causes the whole header to be UTF8-escaped. Unfortunately, for To: and CC:, this seems not to be RFC compliant (according to our mail provider, who classified the mails as spam because of this).

This change makes sure that the addresses are parsed, and the comment for every address (i.e. the human-readable name) will be separately escaped. This solves the problem for me: if I change my git name locally to something with umlauts/accents and use it to add a broken commit, the tests run by our Buildbot instance fail and the resulting email's To: header is correctly escaped (checked with #5101) and the mail is not rejected by our mail provider.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
