### PR TITLE
tests: Improve tests that involve database by waiting until database is closed after tests

### DIFF
--- a/master/buildbot/test/fake/fakeprotocol.py
+++ b/master/buildbot/test/fake/fakeprotocol.py
@@ -35,6 +35,9 @@ class FakeConnection(base.Connection):
             'system': 'nt',
         }
 
+    def loseConnection(self):
+        self.notifyDisconnected()
+
     def remotePrint(self, message):
         self.remoteCalls.append(('remotePrint', message))
         return defer.succeed(None)

--- a/master/buildbot/test/integration/test_telegram_bot.py
+++ b/master/buildbot/test/integration/test_telegram_bot.py
@@ -148,6 +148,7 @@ class TelegramBot(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase)
     def tearDown(self):
         if self.master:
             yield self.master.www.stopService()
+        yield self.tearDownRealDatabase()
 
     @defer.inlineCallbacks
     def testWebhook(self):

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -124,6 +124,7 @@ class Www(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase):
             yield self.pool.closeCachedConnections()
         if self.master:
             yield self.master.www.stopService()
+        yield self.tearDownRealDatabase()
 
     @defer.inlineCallbacks
     def apiGet(self, url, expect200=True):

--- a/master/buildbot/test/unit/test_db_dbconfig.py
+++ b/master/buildbot/test/unit/test_db_dbconfig.py
@@ -80,6 +80,10 @@ class TestDbConfigNotInitialized(db.RealDatabaseMixin, unittest.TestCase):
         # as we will open the db twice, we can't use in memory sqlite
         yield self.setUpRealDatabase(table_names=[], sqlite_memory=False)
 
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.tearDownRealDatabase()
+
     def createDbConfig(self, db_url=None):
         return dbconfig.DbConfig({"db_url": db_url or self.db_url}, self.basedir)
 

--- a/master/buildbot/test/unit/test_db_pool.py
+++ b/master/buildbot/test/unit/test_db_pool.py
@@ -38,8 +38,9 @@ class Basic(unittest.TestCase):
         self.engine.optimal_thread_pool_size = 1
         self.pool = pool.DBThreadPool(self.engine, reactor=reactor)
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        self.pool.shutdown()
+        yield self.pool.shutdown()
 
     @defer.inlineCallbacks
     def test_do(self):
@@ -119,8 +120,9 @@ class Stress(unittest.TestCase):
         self.engine.optimal_thread_pool_size = 2
         self.pool = pool.DBThreadPool(self.engine, reactor=reactor)
 
+    @defer.inlineCallbacks
     def tearDown(self):
-        self.pool.shutdown()
+        yield self.pool.shutdown()
         os.unlink("test.sqlite")
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_db_pool.py
+++ b/master/buildbot/test/unit/test_db_pool.py
@@ -181,7 +181,11 @@ class Native(unittest.TestCase, db.RealDatabaseMixin):
         def thd(conn):
             native_tests.drop(bind=self.db_engine, checkfirst=True)
         yield self.pool.do(thd)
+
+        # tearDownRealDatabase() won't shutdown the pool as want_pool was false in
+        # setUpRealDatabase call
         yield self.pool.shutdown()
+
         yield self.tearDownRealDatabase()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_scripts_cleanupdb.py
+++ b/master/buildbot/test/unit/test_scripts_cleanupdb.py
@@ -27,7 +27,6 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.util import db
 from buildbot.test.util import dirs
 from buildbot.test.util import misc
-from buildbot.test.util.decorators import flaky
 from buildbot.test.util.misc import TestReactorMixin
 
 from . import test_db_logs
@@ -131,6 +130,7 @@ class TestCleanupDb(misc.StdoutAssertionsMixin, dirs.DirsMixin,
         for k in d2.keys():
             self.assertApproximates(d1[k], d2[k], 10)
 
+
 class TestCleanupDbRealDb(db.RealDatabaseMixin, TestCleanupDb):
 
     @defer.inlineCallbacks
@@ -149,7 +149,6 @@ class TestCleanupDbRealDb(db.RealDatabaseMixin, TestCleanupDb):
     def tearDown(self):
         yield self.tearDownRealDatabase()
 
-    @flaky(bugNumber=4406, onPlatform='win32')
     @defer.inlineCallbacks
     def test_cleanup(self):
         # we reuse the fake db background data from db.logs unit tests

--- a/master/buildbot/test/unit/test_worker_kubernetes.py
+++ b/master/buildbot/test/unit/test_worker_kubernetes.py
@@ -37,6 +37,9 @@ class FakeBot:
     def loseConnection(self):
         self.n()
 
+    def waitForNotifyDisconnectedDelivered(self):
+        return defer.succeed(None)
+
 
 class FakeResult:
     code = 204

--- a/master/buildbot/test/unit/test_worker_marathon.py
+++ b/master/buildbot/test/unit/test_worker_marathon.py
@@ -38,6 +38,9 @@ class FakeBot:
     def loseConnection(self):
         self.n()
 
+    def waitForNotifyDisconnectedDelivered(self):
+        return defer.succeed(None)
+
 
 class TestMarathonLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
     def setUp(self):

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -213,6 +213,7 @@ class RealDatabaseMixin:
     def tearDownRealDatabase(self):
         if self.__want_pool:
             yield self.db_pool.do(self.__thd_clean_database)
+            yield self.db_pool.shutdown()
 
     @defer.inlineCallbacks
     def insertTestData(self, rows):

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -77,6 +77,8 @@ def getMaster(case, reactor, config_dict):
     master.db.setup = lambda: None
 
     yield master.startService()
+
+    case.addCleanup(master.db.pool.shutdown)
     case.addCleanup(master.stopService)
 
     return master

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -45,6 +45,9 @@ class Connection:
     def notifyOnDisconnect(self, cb):
         return self._disconnectSubs.subscribe(cb)
 
+    def waitForNotifyDisconnectedDelivered(self):
+        return self._disconnectSubs.waitForDeliveriesToFinish()
+
     def notifyDisconnected(self):
         self._disconnectSubs.deliver()
 


### PR DESCRIPTION
It looks like that many tests either don't properly close the database they operate and/or don't shutdown the database thread pool. This could be a source of database-related test problems recently as unclosed database thread pool presents a potential race condition if a subsequent test opens the same database and performs stuff.

This PR hopefully improves test reliability in this regard by fixing two major issues:

 - First one was that many tests didn't bother to tear down the database component at all if they instantiated it themselves. 

 - Second one was that in non-test environment we always shutdown the DB thread pool on reactor stop, but this never happens in the test setup. One issue that complicated the situation was that the master shutdown path did not wait for callbacks registered by worker connection's `notifyOnDisconnect` method to finish. This lead to various accesses to the database even after master was completely shut down.

I couldn't reproduce the test instabilities on my local machine, but I think it's a reasonable guess that the above problems could easily cause at least part of our test instabilities.

Fixes #4406.