### PR TITLE
www: Fix instability in forceandstop e2e tests

### DIFF
--- a/smokes/e2e/buildsnavigation.scenarios.ts
+++ b/smokes/e2e/buildsnavigation.scenarios.ts
@@ -25,7 +25,7 @@ describe('previousnextlink', function() {
 
     it('should navigate in the builds history by using the previous next links', async () => {
         await builder.go();
-        const lastbuild = await builder.getLastSuccessBuildNumber();
+        const lastbuild = await builder.getLastFinishedBuildNumber();
         // Build #1
         await builder.goForce();
         await force.clickStartButtonAndWaitRedirectToBuild();

--- a/smokes/e2e/buildsnavigation.scenarios.ts
+++ b/smokes/e2e/buildsnavigation.scenarios.ts
@@ -28,12 +28,12 @@ describe('previousnextlink', function() {
         const lastbuild = await builder.getLastSuccessBuildNumber();
         // Build #1
         await builder.goForce();
-        await force.clickStartButton();
+        await force.clickStartButtonAndWaitRedirectToBuild();
         await builder.go();
         await builder.waitNextBuildFinished(lastbuild);
         // Build #2
         await builder.goForce();
-        await force.clickStartButton();
+        await force.clickStartButtonAndWaitRedirectToBuild();
         await builder.go();
         await builder.waitNextBuildFinished(+lastbuild + 1);
         await builder.goBuild(+lastbuild + 2);
@@ -65,7 +65,7 @@ describe('forceandstop', function() {
     it('should create a build with a dedicated reason and stop it during execution', async () => {
 
         await builder.goForce();
-        await force.clickStartButton();
+        await force.clickStartButtonAndWaitRedirectToBuild();
         expect(await browser.getCurrentUrl()).toMatch("/builders/\[1-9]/builds/\[1-9]");
         let stopButton = builder.getStopButton();
         await browser.wait(EC.elementToBeClickable(stopButton),

--- a/smokes/e2e/dashboard.scenarios.ts
+++ b/smokes/e2e/dashboard.scenarios.ts
@@ -34,7 +34,7 @@ describe('dashboard page', function() {
 
     it('should go to the dashboard page and see no error', async () => {
         await builder.goForce();
-        await force.clickStartButton();
+        await force.clickStartButtonAndWaitRedirectToBuild();
         await home.waitAllBuildsFinished();
         await dashboard.go();
     });

--- a/smokes/e2e/force.scenarios.ts
+++ b/smokes/e2e/force.scenarios.ts
@@ -23,7 +23,7 @@ describe('force', function() {
     it('should create a build', async () => {
         let lastbuild = 0;
         await builder.go();
-        lastbuild = await builder.getLastSuccessBuildNumber();
+        lastbuild = await builder.getLastFinishedBuildNumber();
         await builder.goForce();
         await force.clickStartButtonAndWaitRedirectToBuild();
         await builder.go();

--- a/smokes/e2e/force.scenarios.ts
+++ b/smokes/e2e/force.scenarios.ts
@@ -25,7 +25,7 @@ describe('force', function() {
         await builder.go();
         lastbuild = await builder.getLastSuccessBuildNumber();
         await builder.goForce();
-        await force.clickStartButton();
+        await force.clickStartButtonAndWaitRedirectToBuild();
         await builder.go();
         await builder.waitNextBuildFinished(lastbuild);
     });

--- a/smokes/e2e/home.scenarios.ts
+++ b/smokes/e2e/home.scenarios.ts
@@ -26,7 +26,7 @@ describe('home page', function() {
         };
         await builder.go();
         await builder.goForce();
-        await force.clickStartButton();
+        await force.clickStartButtonAndWaitRedirectToBuild();
         await home.go();
         const panel0 = home.getPanel(0);
         expect(await panel0.getText()).toContain(builderName[0]);

--- a/smokes/e2e/hook.scenarios.ts
+++ b/smokes/e2e/hook.scenarios.ts
@@ -20,7 +20,7 @@ describe('change hook', function() {
 
     it('should create a build', async () => {
         await builder.go();
-        let lastbuild = await builder.getLastSuccessBuildNumber();
+        let lastbuild = await builder.getLastFinishedBuildNumber();
         await post(`${testPageUrl}/change_hook/base`).form({
             comments:'sd',
             project:'pyflakes',

--- a/smokes/e2e/pages/builder.ts
+++ b/smokes/e2e/pages/builder.ts
@@ -50,8 +50,15 @@ export class BuilderPage extends BasePage {
         await buildLink.click();
     }
 
-    async getLastSuccessBuildNumber() {
-        let elements = await element.all(By.css('span.badge-status.results_SUCCESS'));
+    async getLastFinishedBuildNumber() {
+        let finishedBuildCss = 'span.badge-status.results_SUCCESS, ' +
+                               'span.badge-status.results_WARNINGS, ' +
+                               'span.badge-status.results_FAILURE, ' +
+                               'span.badge-status.results_SKIPPED, ' +
+                               'span.badge-status.results_EXCEPTION, ' +
+                               'span.badge-status.results_RETRY, ' +
+                               'span.badge-status.results_CANCELLED ';
+        let elements = await element.all(By.css(finishedBuildCss));
         if (elements.length === 0) {
             return 0;
         }
@@ -66,7 +73,7 @@ export class BuilderPage extends BasePage {
     async waitNextBuildFinished(reference) {
         const self = this;
         async function buildCountIncrement() {
-            let currentBuildCount = await self.getLastSuccessBuildNumber();
+            let currentBuildCount = await self.getLastFinishedBuildNumber();
             return currentBuildCount == (reference + 1);
         }
         await browser.wait(buildCountIncrement, 20000);

--- a/smokes/e2e/pages/force.ts
+++ b/smokes/e2e/pages/force.ts
@@ -49,6 +49,17 @@ export class ForcePage extends BasePage {
         await button.click();
     }
 
+    async clickStartButtonAndWaitRedirectToBuild() {
+        let previousUrl = await browser.getCurrentUrl();
+        await this.clickStartButton();
+        await browser.wait(EC.not(EC.urlIs(previousUrl)),
+                           5000,
+                           "failed to create a buildrequest");
+        await browser.wait(EC.not(EC.urlContains('redirect_to_build=true')),
+                           5000,
+                           "failed to create a build");
+    }
+
     async clickCancelWholeQueue() {
         let button = this.getCancelWholeQueue();
         await browser.wait(EC.elementToBeClickable(button),

--- a/smokes/e2e/reason_force.scenarios.ts
+++ b/smokes/e2e/reason_force.scenarios.ts
@@ -22,7 +22,7 @@ describe('force and cancel', function() {
 
     it('should create a build', async () => {
         await builder.go();
-        let lastbuild = await builder.getLastSuccessBuildNumber();
+        let lastbuild = await builder.getLastFinishedBuildNumber();
         await builder.goForce();
         await force.clickStartButtonAndWaitRedirectToBuild();
         await builder.go();

--- a/smokes/e2e/reason_force.scenarios.ts
+++ b/smokes/e2e/reason_force.scenarios.ts
@@ -43,7 +43,7 @@ describe('force and cancel', function() {
         await builder.go();
         await builder.goForce();
         await force.setReason("New Test Reason");
-        await force.setYourName("FaceLess User");
+        await force.setYourName("user@example.com");
         await force.setProjectName("BBOT9");
         await force.setBranchName("Gerrit Branch");
         await force.setRepo("http//name.com");

--- a/smokes/e2e/reason_force.scenarios.ts
+++ b/smokes/e2e/reason_force.scenarios.ts
@@ -24,7 +24,7 @@ describe('force and cancel', function() {
         await builder.go();
         let lastbuild = await builder.getLastSuccessBuildNumber();
         await builder.goForce();
-        await force.clickStartButton();
+        await force.clickStartButtonAndWaitRedirectToBuild();
         await builder.go();
         await builder.waitNextBuildFinished(lastbuild);
     });
@@ -48,6 +48,6 @@ describe('force and cancel', function() {
         await force.setBranchName("Gerrit Branch");
         await force.setRepo("http//name.com");
         await force.setRevisionName("12345");
-        await force.clickStartButton();
+        await force.clickStartButtonAndWaitRedirectToBuild();
     });
 });

--- a/smokes/e2e/rebuilds.scenarios.ts
+++ b/smokes/e2e/rebuilds.scenarios.ts
@@ -26,7 +26,7 @@ describe('rebuilds', function() {
         await builder.go();
         const lastbuild: number = await builder.getLastSuccessBuildNumber();
         await builder.goForce();
-        await force.clickStartButton();
+        await force.clickStartButtonAndWaitRedirectToBuild();
         await builder.go();
         await builder.waitNextBuildFinished(lastbuild);
         await builder.goBuild(lastbuild);

--- a/smokes/e2e/rebuilds.scenarios.ts
+++ b/smokes/e2e/rebuilds.scenarios.ts
@@ -24,7 +24,7 @@ describe('rebuilds', function() {
 
     it('should navigate to a dedicated build and to use the rebuild button', async () => {
         await builder.go();
-        const lastbuild: number = await builder.getLastSuccessBuildNumber();
+        const lastbuild: number = await builder.getLastFinishedBuildNumber();
         await builder.goForce();
         await force.clickStartButtonAndWaitRedirectToBuild();
         await builder.go();


### PR DESCRIPTION
This PR fixes an issue in the forceandstop e2e test which does not wait for the forced build to go to the build page. Previously, if the master is slow to create the build, the test might check the buildrequest page and break. Now we always wait to enter the build page before proceeding with subsequent tests.

Additionally, this PR fixes a couple of other issues that were uncovered by these changes.

Fixes #5104.