### PR TITLE
makefile: Do not delete python files in virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ frontend_yarn_upgrade:
 hooks:
 	cp common/hooks/* `git rev-parse --git-dir`/hooks
 rmpyc:
-	find . \( -name '*.pyc' -o -name '*.pyo' \) -exec rm -v {} \;
+	find master worker \( -name '*.pyc' -o -name '*.pyo' \) -exec rm -v {} \;
 
 isort:
 	isort -rc worker master


### PR DESCRIPTION
Find command finds all Python temporary files in Buildbot repository and removes them. Virtualenv directories are also there. Deleting files .pyc and .pyo in virtualenv breakes it.
We only need to delete these files from master and worker directories.
