### PR TITLE
worker: Ensure that worker does not leave pending keepalive requests after shutdown

### DIFF
--- a/master/buildbot/test/fake/fakeprotocol.py
+++ b/master/buildbot/test/fake/fakeprotocol.py
@@ -16,7 +16,31 @@
 
 from twisted.internet import defer
 
+from buildbot.util import subscription
 from buildbot.worker.protocols import base
+
+
+class FakeTrivialConnection:
+
+    info = {}
+
+    def __init__(self):
+        self._disconnectSubs = subscription.SubscriptionPoint("disconnections from Fake")
+
+    def notifyOnDisconnect(self, cb):
+        return self._disconnectSubs.subscribe(cb)
+
+    def waitForNotifyDisconnectedDelivered(self):
+        return self._disconnectSubs.waitForDeliveriesToFinish()
+
+    def notifyDisconnected(self):
+        self._disconnectSubs.deliver()
+
+    def loseConnection(self):
+        self.notifyDisconnected()
+
+    def remoteSetBuilderList(self, builders):
+        return defer.succeed(None)
 
 
 class FakeConnection(base.Connection):

--- a/master/buildbot/test/unit/test_worker_kubernetes.py
+++ b/master/buildbot/test/unit/test_worker_kubernetes.py
@@ -21,6 +21,7 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake.fakebuild import FakeBuildForRendering as FakeBuild
 from buildbot.test.fake.kube import KubeClientService
 from buildbot.test.util.misc import TestReactorMixin
+from buildbot.util import subscription
 from buildbot.util.kubeclientservice import KubeError
 from buildbot.util.kubeclientservice import KubeHardcodedConfig
 from buildbot.worker import kubernetes
@@ -29,16 +30,22 @@ from buildbot.worker import kubernetes
 class FakeBot:
     info = {}
 
-    def notifyOnDisconnect(self, n):
-        self.n = n
+    def __init__(self):
+        self._disconnectSubs = subscription.SubscriptionPoint("disconnections from FakeBot")
 
-    def remoteSetBuilderList(self, builders):
-        return defer.succeed(None)
-
-    def loseConnection(self):
-        self.n()
+    def notifyOnDisconnect(self, cb):
+        return self._disconnectSubs.subscribe(cb)
 
     def waitForNotifyDisconnectedDelivered(self):
+        return self._disconnectSubs.waitForDeliveriesToFinish()
+
+    def notifyDisconnected(self):
+        self._disconnectSubs.deliver()
+
+    def loseConnection(self):
+        self.notifyDisconnected()
+
+    def remoteSetBuilderList(self, builders):
         return defer.succeed(None)
 
 

--- a/master/buildbot/test/unit/test_worker_kubernetes.py
+++ b/master/buildbot/test/unit/test_worker_kubernetes.py
@@ -19,34 +19,12 @@ from twisted.trial import unittest
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake.fakebuild import FakeBuildForRendering as FakeBuild
+from buildbot.test.fake.fakeprotocol import FakeTrivialConnection as FakeBot
 from buildbot.test.fake.kube import KubeClientService
 from buildbot.test.util.misc import TestReactorMixin
-from buildbot.util import subscription
 from buildbot.util.kubeclientservice import KubeError
 from buildbot.util.kubeclientservice import KubeHardcodedConfig
 from buildbot.worker import kubernetes
-
-
-class FakeBot:
-    info = {}
-
-    def __init__(self):
-        self._disconnectSubs = subscription.SubscriptionPoint("disconnections from FakeBot")
-
-    def notifyOnDisconnect(self, cb):
-        return self._disconnectSubs.subscribe(cb)
-
-    def waitForNotifyDisconnectedDelivered(self):
-        return self._disconnectSubs.waitForDeliveriesToFinish()
-
-    def notifyDisconnected(self):
-        self._disconnectSubs.deliver()
-
-    def loseConnection(self):
-        self.notifyDisconnected()
-
-    def remoteSetBuilderList(self, builders):
-        return defer.succeed(None)
 
 
 class FakeResult:

--- a/master/buildbot/test/unit/test_worker_marathon.py
+++ b/master/buildbot/test/unit/test_worker_marathon.py
@@ -22,31 +22,9 @@ from buildbot.process.properties import Properties
 from buildbot.test.fake import fakebuild
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.fake.fakeprotocol import FakeTrivialConnection as FakeBot
 from buildbot.test.util.misc import TestReactorMixin
-from buildbot.util import subscription
 from buildbot.worker.marathon import MarathonLatentWorker
-
-
-class FakeBot:
-    info = {}
-
-    def __init__(self):
-        self._disconnectSubs = subscription.SubscriptionPoint("disconnections from FakeBot")
-
-    def notifyOnDisconnect(self, cb):
-        return self._disconnectSubs.subscribe(cb)
-
-    def waitForNotifyDisconnectedDelivered(self):
-        return self._disconnectSubs.waitForDeliveriesToFinish()
-
-    def notifyDisconnected(self):
-        self._disconnectSubs.deliver()
-
-    def loseConnection(self):
-        self.notifyDisconnected()
-
-    def remoteSetBuilderList(self, builders):
-        return defer.succeed(None)
 
 
 class TestMarathonLatentWorker(unittest.TestCase, TestReactorMixin):

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -113,6 +113,8 @@ class BotFactory(AutoLoginPBFactory):
                 log.msg("Master replied to keepalive, everything's fine")
                 self.currentKeepaliveWaiter.callback(details)
                 self.currentKeepaliveWaiter = None
+            except (pb.PBConnectionLost, pb.DeadReferenceError):
+                log.msg("connection already shut down when attempting keepalive")
             except Exception as e:
                 log.err(e, "error sending keepalive")
             finally:

--- a/worker/buildbot_worker/util/__init__.py
+++ b/worker/buildbot_worker/util/__init__.py
@@ -20,6 +20,7 @@ import textwrap
 import time
 
 from ._hangcheck import HangCheckFactory
+from ._notifier import Notifier
 
 __all__ = [
     "remove_userpassword",
@@ -27,6 +28,7 @@ __all__ = [
     "Obfuscated",
     "rewrap",
     "HangCheckFactory",
+    "Notifier",
 ]
 
 

--- a/worker/buildbot_worker/util/_notifier.py
+++ b/worker/buildbot_worker/util/_notifier.py
@@ -1,0 +1,43 @@
+# Copyright Buildbot Team Members
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+from twisted.internet.defer import Deferred
+
+
+class Notifier:
+    # this is a copy of buildbot.util.Notifier
+
+    def __init__(self):
+        self._waiters = []
+
+    def wait(self):
+        d = Deferred()
+        self._waiters.append(d)
+        return d
+
+    def notify(self, result):
+        waiters, self._waiters = self._waiters, []
+        for waiter in waiters:
+            waiter.callback(result)
+
+    def __bool__(self):
+        return bool(self._waiters)


### PR DESCRIPTION
Previously the worker would not wait for pending keepalives to finish during shutdown which presented a race condition. The worker could potentially be shut down before the pending keepalives finish. In normal circumstances this is not a problem, but this made buildbot.test.integration.test_worker_workerside.TestWorkerConnection.test_pb_keepalive test flaky, because the concurrent connection shutdown could spew various errors. This PR ignores these errors and also makes sure that we don't leave pending keepalives which could break a test that follows.

Fixes #4986.


## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
