### PR TITLE
Parse /etc/os-release and expose it as worker info

### DIFF
--- a/master/buildbot/newsfragments/os-release.feature
+++ b/master/buildbot/newsfragments/os-release.feature
@@ -1,0 +1,2 @@
+bb:cfg:`workers` will now attempt to read ``/etc/os-release`` and stores them into worker info as ``os_<field>`` items.
+Add new interpolation ``worker`` that can be used for accessing worker info items.

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -755,6 +755,9 @@ class Build(properties.PropertiesMixin):
             ('builds', str(self.buildid), 'finished'),
             lambda: self.finished)
 
+    def getWorkerInfo(self):
+        return self.workerforbuilder.worker.worker_status.info
+
     # IBuildControl
 
     def getStatus(self):

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -461,6 +461,16 @@ _thePropertyDict = _PropertyDict()
 
 
 @implementer(IRenderable)
+class _WorkerPropertyDict:
+
+    def getRenderingFor(self, build):
+        return build.getBuild().getWorkerInfo()
+
+
+_theWorkerPropertyDict = _WorkerPropertyDict()
+
+
+@implementer(IRenderable)
 class _SecretRenderer:
 
     def __init__(self, secret_name):
@@ -602,6 +612,13 @@ class Interpolate(util.ComparableMixin):
                 "Attribute must be alphanumeric for src Interpolation '%s'" % arg)
             codebase = attr = repl = None
         return _SourceStampDict(codebase), attr, repl
+
+    def _parse_worker(self, arg):
+        try:
+            prop, repl = arg.split(":", 1)
+        except ValueError:
+            prop, repl = arg, None
+        return _theWorkerPropertyDict, prop, repl
 
     def _parse_kw(self, arg):
         try:

--- a/master/buildbot/status/worker.py
+++ b/master/buildbot/status/worker.py
@@ -19,6 +19,7 @@ import time
 from zope.interface import implementer
 
 from buildbot import interfaces
+from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
 from buildbot.util.eventual import eventually
 
@@ -41,6 +42,7 @@ class WorkerStatus:
         self.graceful_callbacks = []
         self.pause_callbacks = []
         self.connect_times = []
+        self.info = Properties()
 
     def getName(self):
         return self.name

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -66,6 +66,14 @@ components.registerAdapter(
     FakeBuildStatus, interfaces.IProperties)
 
 
+class FakeWorkerStatus(properties.PropertiesMixin):
+
+    def __init__(self, name):
+        self.name = name
+        self.info = properties.Properties()
+        self.info.setProperty("test", "test", "Worker")
+
+
 class FakeBuild(properties.PropertiesMixin):
 
     def __init__(self, props=None, master=None):
@@ -74,6 +82,7 @@ class FakeBuild(properties.PropertiesMixin):
         self.workerforbuilder = mock.Mock(
             spec=workerforbuilder.WorkerForBuilder)
         self.workerforbuilder.worker = mock.Mock(spec=base.Worker)
+        self.workerforbuilder.worker.worker_status = FakeWorkerStatus("mock")
         self.builder.config = config.BuilderConfig(
             name='bldr',
             workernames=['a'],
@@ -115,6 +124,9 @@ class FakeBuild(properties.PropertiesMixin):
 
     def getBuilder(self):
         return self.builder
+
+    def getWorkerInfo(self):
+        return self.workerforbuilder.worker.worker_status.info
 
 
 components.registerAdapter(

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -94,7 +94,12 @@ class FakeWorkerWorker(pb.Referenceable):
             'info': 'here',
             'worker_commands': {
                 'x': 1,
-            }
+            },
+            'numcpus': 1,
+            'none': None,
+            'os_release': b'\xe3\x83\x86\xe3\x82\xb9\xe3\x83\x88'.decode(),
+            b'\xe3\x83\xaa\xe3\x83\xaa\xe3\x83\xbc\xe3\x82\xb9\xe3'
+            b'\x83\x86\xe3\x82\xb9\xe3\x83\x88'.decode(): b'\xe3\x83\x86\xe3\x82\xb9\xe3\x83\x88'.decode(),
         }
 
     def remote_getVersion(self):
@@ -333,6 +338,26 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
         self.workerSideDisconnect(worker)
 
         # wait for the resulting detach
+        yield worker.waitForDetach()
+
+    @defer.inlineCallbacks
+    def test_worker_info(self):
+        yield self.addWorker()
+        worker = yield self.connectWorker()
+        props = self.buildworker.worker_status.info
+        # check worker info passing
+        self.assertEqual(props.getProperty("info"),
+                         "here")
+        # check worker info passing with UTF-8
+        self.assertEqual(props.getProperty("os_release"),
+                         b'\xe3\x83\x86\xe3\x82\xb9\xe3\x83\x88'.decode())
+        self.assertEqual(props.getProperty(b'\xe3\x83\xaa\xe3\x83\xaa\xe3\x83\xbc\xe3\x82'
+                                           b'\xb9\xe3\x83\x86\xe3\x82\xb9\xe3\x83\x88'.decode()),
+                         b'\xe3\x83\x86\xe3\x82\xb9\xe3\x83\x88'.decode())
+        self.assertEqual(props.getProperty("none"), None)
+        self.assertEqual(props.getProperty("numcpus"), 1)
+
+        self.workerSideDisconnect(worker)
         yield worker.waitForDetach()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -1534,6 +1534,11 @@ class Renderer(unittest.TestCase):
         self.assertIn('args=[\'a\']', repr(rend))
         self.assertIn('kwargs={\'kwarg\': \'kw\'}', repr(rend))
 
+    @defer.inlineCallbacks
+    def test_interpolate_worker(self):
+        rend = yield self.build.render(Interpolate("%(worker:test)s"))
+        self.assertEqual(rend, "test")
+
 
 class Compare(unittest.TestCase):
 
@@ -1584,6 +1589,11 @@ class Compare(unittest.TestCase):
         self.assertEqual(
             Interpolate('testing: %(kw:test)s', test="test", other=3),
             Interpolate('testing: %(kw:test)s', test="test", other=3))
+
+    def test_Interpolate_worker(self):
+        self.assertEqual(
+            Interpolate('testing: %(worker:test)s'),
+            Interpolate('testing: %(worker:test)s'))
 
     def test_renderer(self):
         self.assertNotEqual(

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -229,6 +229,12 @@ class AbstractWorker(service.BuildbotService):
         self.worker_status.setAccessURI(info.get("access_uri", None))
         self.worker_status.setVersion(info.get("version", "(unknown)"))
 
+        # store everything as Properties
+        for k, v in info.items():
+            if k in ('environ', 'worker_commands'):
+                continue
+            self.worker_status.info.setProperty(k, v, "Worker")
+
     @defer.inlineCallbacks
     def _getWorkerInfo(self):
         worker = yield self.master.data.get(

--- a/master/docs/manual/configuration/properties.rst
+++ b/master/docs/manual/configuration/properties.rst
@@ -218,6 +218,9 @@ The following selectors are supported.
 ``secrets``
     The key refers to a secret provided by a provider declared in :bb:cfg:`secretsProviders` .
 
+``worker``
+    The key refers to a info item provided by :bb:cfg:`workers`.
+
 The following ways of interpreting the value are available.
 
 ``-replacement``

--- a/master/docs/manual/configuration/workers.rst
+++ b/master/docs/manual/configuration/workers.rst
@@ -64,6 +64,11 @@ You may use the ``defaultProperties`` parameter that will only be added to :ref:
                      defaultProperties={'parallel_make': 10}),
    ]
 
+:class:`Worker` collects and exposes ``/etc/os-release`` fields for :ref:<interpolation `Interpolate-DictStyle`>.
+These can be used to determine details about the running operating system, such as distribution and version.
+See https://www.linux.org/docs/man5/os-release.html for details on possible fields.
+Each field is imported with ``os_`` prefix and in lower case. ``os_id``, ``os_id_like``, ``os_version_id`` and ``os_version_codename`` are always set, but can be null.
+
 Limiting Concurrency
 ++++++++++++++++++++
 

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -48,7 +48,21 @@ class TestBot(unittest.TestCase):
             shutil.rmtree(self.basedir)
         os.makedirs(self.basedir)
 
+        # create test-release-file
+        with open("%s/test-release-file" % self.basedir, "w") as fout:
+            fout.write(
+"""
+# unit test release file
+OS_NAME="Test"
+VERSION="1.0"
+ID=test
+ID_LIKE=generic
+PRETTY_NAME="Test 1.0 Generic"
+VERSION_ID="1"
+"""
+            )
         self.real_bot = base.BotBase(self.basedir, False)
+        self.real_bot.setOsReleaseFile("%s/test-release-file" % self.basedir)
         self.real_bot.startService()
 
         self.bot = FakeRemote(self.real_bot)

--- a/worker/buildbot_worker/test/unit/test_bot.py
+++ b/worker/buildbot_worker/test/unit/test_bot.py
@@ -86,6 +86,9 @@ class TestBot(unittest.TestCase):
 
         info = yield self.bot.callRemote("getWorkerInfo")
 
+        # remove any os_ fields as they are dependent on the test environment
+        info = {k: v for k, v in info.items() if not k.startswith("os_")}
+
         self.assertEqual(info, dict(
             admin='testy!', foo='bar',
             environ=os.environ, system=os.name, basedir=self.basedir,
@@ -96,6 +99,8 @@ class TestBot(unittest.TestCase):
     @defer.inlineCallbacks
     def test_getWorkerInfo_nodir(self):
         info = yield self.bot.callRemote("getWorkerInfo")
+
+        info = {k: v for k, v in info.items() if not k.startswith("os_")}
 
         self.assertEqual(set(info.keys()), set(
             ['environ', 'system', 'numcpus', 'basedir', 'worker_commands', 'version']))


### PR DESCRIPTION
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

Closes  #5114

This patch makes Worker read /etc/os-release. It also exposes all Worker info fields via new interpolation `Interpolate("worker:field")s`