### PR TITLE
test: Skip test_telegram_bot tests due to unreliability

### DIFF
--- a/master/buildbot/test/integration/test_telegram_bot.py
+++ b/master/buildbot/test/integration/test_telegram_bot.py
@@ -34,6 +34,7 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.util import db
 from buildbot.test.util import www
+from buildbot.test.util.decorators import flaky
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.www import auth
@@ -150,6 +151,7 @@ class TelegramBot(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase)
             yield self.master.www.stopService()
         yield self.tearDownRealDatabase()
 
+    @flaky(issueNumber=5120)
     @defer.inlineCallbacks
     def testWebhook(self):
         payload = unicode2bytes(json.dumps({
@@ -178,6 +180,7 @@ class TelegramBot(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase)
         self.assertIn('123456789', self.sent_messages[0][1])
         self.assertIn('-12345678', self.sent_messages[1][1])
 
+    @flaky(issueNumber=5120)
     @defer.inlineCallbacks
     def testReconfig(self):
         tb = self.master.config.services['TelegramBot']
@@ -186,6 +189,7 @@ class TelegramBot(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase)
             chat_ids=[-123456], notify_events=['problem']
         )
 
+    @flaky(issueNumber=5120)
     @defer.inlineCallbacks
     def testLoadState(self):
         tboid = yield self.master.db.state.getObjectId('testbot', 'buildbot.reporters.telegram.TelegramWebhookBot')
@@ -202,6 +206,7 @@ class TelegramBot(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase)
         self.assertEquals(c.channel.notify_events, {'started', 'finished'})
         self.assertEquals(c.channel.missing_workers, {12})
 
+    @flaky(issueNumber=5120)
     @defer.inlineCallbacks
     def testSaveState(self):
         tb = self.master.config.services['TelegramBot']
@@ -228,6 +233,7 @@ class TelegramBot(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase)
         self.assertIn([99, ['cancelled']], notify_events)
         self.assertIn([99, [13]], missing_workers)
 
+    @flaky(issueNumber=5120)
     @defer.inlineCallbacks
     def testMissingWorker(self):
         yield self.insertTestData([fakedb.Worker(id=1, name='local1')])


### PR DESCRIPTION
See #5120. I've identified the problem, but for the time being let's not waste time investigating failed tests.