### PR TITLE
mq: Wait until delivered callbacks are completed during shutdown

### DIFF
--- a/master/buildbot/mq/base.py
+++ b/master/buildbot/mq/base.py
@@ -18,11 +18,21 @@ from twisted.internet import defer
 from twisted.python import failure
 from twisted.python import log
 
+from buildbot.util import deferwaiter
 from buildbot.util import service
 
 
 class MQBase(service.AsyncService):
     name = 'mq-implementation'
+
+    def __init__(self):
+        super().__init__()
+        self._deferwaiter = deferwaiter.DeferWaiter()
+
+    @defer.inlineCallbacks
+    def stopService(self):
+        yield self._deferwaiter.wait()
+        yield super().stopService()
 
     @defer.inlineCallbacks
     def waitUntilEvent(self, filter, check_callback):
@@ -39,6 +49,9 @@ class MQBase(service.AsyncService):
         yield buildCompleteConsumer.stopConsuming()
         return res
 
+    def invokeQref(self, qref, routingKey, data):
+        self._deferwaiter.add(qref.invoke(routingKey, data))
+
 
 class QueueRef:
 
@@ -48,16 +61,18 @@ class QueueRef:
         self.callback = callback
 
     def invoke(self, routing_key, data):
+        # Potentially returns a Deferred
         if not self.callback:
-            return
+            return None
 
         try:
             x = self.callback(routing_key, data)
         except Exception:
             log.err(failure.Failure(), 'while invoking %r' % (self.callback,))
-            return
+            return None
         if isinstance(x, defer.Deferred):
             x.addErrback(log.err, 'while invoking %r' % (self.callback,))
+        return x
 
     def stopConsuming(self):
         # This method may return a Deferred.

--- a/master/buildbot/mq/base.py
+++ b/master/buildbot/mq/base.py
@@ -60,5 +60,6 @@ class QueueRef:
             x.addErrback(log.err, 'while invoking %r' % (self.callback,))
 
     def stopConsuming(self):
-        # subclasses should set self.callback to None in this method
+        # This method may return a Deferred.
+        # subclasses should set self.callback to None in this method.
         raise NotImplementedError

--- a/master/buildbot/mq/simple.py
+++ b/master/buildbot/mq/simple.py
@@ -41,7 +41,7 @@ class SimpleMQ(service.ReconfigurableServiceMixin, base.MQBase):
             log.msg("MSG: %s\n%s" % (routingKey, pprint.pformat(data)))
         for qref in self.qrefs:
             if tuplematch.matchTuple(routingKey, qref.filter):
-                qref.invoke(routingKey, data)
+                self.invokeQref(qref, routingKey, data)
 
     def startConsuming(self, callback, filter, persistent_name=None):
         if any(not isinstance(k, str) and k is not None for k in filter):

--- a/master/buildbot/newsfragments/mq-stopconsuming-deferred.doc
+++ b/master/buildbot/newsfragments/mq-stopconsuming-deferred.doc
@@ -1,0 +1,1 @@
+Mention that QueueRef.stopConsuming() may return a Deferred.

--- a/master/buildbot/newsfragments/mq-wait-deferreds-stopservice.bugfix
+++ b/master/buildbot/newsfragments/mq-wait-deferreds-stopservice.bugfix
@@ -1,0 +1,1 @@
+The message queues will now wait until the delivered callbacks are fully completed during shutdown.

--- a/master/buildbot/test/unit/test_util_deferwaiter.py
+++ b/master/buildbot/test/unit/test_util_deferwaiter.py
@@ -1,0 +1,50 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.util.deferwaiter import DeferWaiter
+
+
+class TestException(Exception):
+    pass
+
+
+class Tests(unittest.TestCase):
+
+    def test_add_deferred_called(self):
+        w = DeferWaiter()
+        w.add(defer.succeed(None))
+        d = w.wait()
+        self.assertTrue(d.called)
+
+    def test_add_non_deferred(self):
+        w = DeferWaiter()
+        w.add(2)
+        d = w.wait()
+        self.assertTrue(d.called)
+
+    def test_add_deferred_not_called_and_call_later(self):
+        w = DeferWaiter()
+
+        d1 = defer.Deferred()
+        w.add(d1)
+
+        d = w.wait()
+        self.assertFalse(d.called)
+
+        d1.callback(None)
+        self.assertTrue(d.called)

--- a/master/buildbot/util/deferwaiter.py
+++ b/master/buildbot/util/deferwaiter.py
@@ -1,0 +1,44 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+
+from buildbot.util import Notifier
+
+
+class DeferWaiter:
+    """ This class manages a set of Deferred objects and allows waiting for their completion
+    """
+    def __init__(self):
+        self._waited = set()
+        self._finish_notifier = Notifier()
+
+    def _finished(self, _, d):
+        self._waited.remove(id(d))
+        if not self._waited:
+            self._finish_notifier.notify(None)
+
+    def add(self, d):
+        if not isinstance(d, defer.Deferred):
+            return
+
+        self._waited.add(id(d))
+        d.addBoth(self._finished, d)
+
+    @defer.inlineCallbacks
+    def wait(self):
+        if not self._waited:
+            return
+        yield self._finish_notifier.wait()

--- a/master/docs/developer/mq.rst
+++ b/master/docs/developer/mq.rst
@@ -108,6 +108,8 @@ For a filter to match a routing key, it must have the same length, and each elem
         Stop invoking the ``callback`` passed to :py:meth:`~MQConnector.startConsuming`.
         This method can be called multiple times for the same :py:class:`QueueRef` instance without harm.
 
+        This method potentially returns a Deferred.
+
         After the first call to this method has returned, the callback will not be invoked.
 
 Implementations


### PR DESCRIPTION
Currently message queues are fire the callbacks without any regard to when they are completed. This has issues during shutdown, because some of the callbacks may not be completed. If message queues don't wait for their completion and proceed to stop the service, sometimes the resources needed for the callbacks to succeed are pulled from under their feet. This fortunately only affects tests.

This PR improves the queues to manage a set of all pending deferreds that have resulted from callbacks and only proceed to return from `stopService()` when all these deferreds fire.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
