### PR TITLE
test: Remove duplicate DB shutdown

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -361,6 +361,7 @@ dateutil's
 dave
 david
 dbapi
+DBConnector
 dbpool
 dbs
 ddl

--- a/master/buildbot/test/util/connector_component.py
+++ b/master/buildbot/test/util/connector_component.py
@@ -60,8 +60,6 @@ class ConnectorComponentMixin(TestReactorMixin, db.RealDatabaseMixin):
     @defer.inlineCallbacks
     def tearDownConnectorComponent(self):
         yield self.tearDownRealDatabase()
-
-        self.db_pool.shutdown()
         # break some reference loops, just for fun
         del self.db.pool
         del self.db.model

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -26,6 +26,7 @@ from twisted.trial import unittest
 from buildbot.db import enginestrategy
 from buildbot.db import model
 from buildbot.db import pool
+from buildbot.db.connector import DBConnector
 from buildbot.util.sautils import sa_version
 from buildbot.util.sautils import withoutSqliteForeignKeys
 
@@ -57,17 +58,21 @@ class RealDatabaseMixin:
     @ivar db_url: the DB URL used to run these tests
 
     @ivar db_engine: the engine created for the test database
+
+    Note that this class uses the production database model.  A
+    re-implementation would be virtually identical and just require extra
+    work to keep synchronized.
+
+    Similarly, this class uses the production DB thread pool.  This achieves
+    a few things:
+     - affords more thorough tests for the pool
+     - avoids repetitive implementation
+     - cooperates better at runtime with thread-sensitive DBAPI's
+
+    Finally, it duplicates initialization performed in db.connector.DBConnector.setup().
+    Never call that method in tests that use RealDatabaseMixin, use
+    RealDatabaseWithConnectorMixin.
     """
-
-    # Note that this class uses the production database model.  A
-    # re-implementation would be virtually identical and just require extra
-    # work to keep synchronized.
-
-    # Similarly, this class uses the production DB thread pool.  This achieves
-    # a few things:
-    #  - affords more thorough tests for the pool
-    #  - avoids repetitive implementation
-    #  - cooperates better at runtime with thread-sensitive DBAPI's
 
     def __thd_clean_database(self, conn):
         # In general it's nearly impossible to do "bullet proof" database
@@ -240,6 +245,22 @@ class RealDatabaseMixin:
                         log.msg("while inserting %s - %s" % (row, row.values))
                         raise
         yield self.db_pool.do(thd)
+
+
+class RealDatabaseWithConnectorMixin(RealDatabaseMixin):
+    # Same as RealDatabaseMixin, except that a real DBConnector is also setup in a correct way.
+
+    @defer.inlineCallbacks
+    def setUpRealDatabaseWithConnector(self, master, table_names=None, basedir='basedir',
+                                       want_pool=True, sqlite_memory=True):
+        yield self.setUpRealDatabase(table_names, basedir, want_pool, sqlite_memory)
+        master.config.db['db_url'] = self.db_url
+        master.db = DBConnector(self.basedir)
+        master.db.setServiceParent(master)
+        master.db.pool = self.db_pool
+
+    def tearDownRealDatabaseWithConnector(self):
+        return self.tearDownRealDatabase()
 
 
 class TestCase(unittest.TestCase):


### PR DESCRIPTION
Some of the tests currently create two database pools and shutdown them separately. This PR fixes that.