### PR TITLE
reporter: Wait for more currently unwaited Deferreds

### DIFF
--- a/master/buildbot/newsfragments/telegram-wait-poll-finishes-shutdown.bugfix
+++ b/master/buildbot/newsfragments/telegram-wait-poll-finishes-shutdown.bugfix
@@ -1,0 +1,1 @@
+The Telegram reporter will now wait until in-progress polls finish during shutdown.

--- a/master/buildbot/reporters/irc.py
+++ b/master/buildbot/reporters/irc.py
@@ -143,11 +143,11 @@ class IRCContact(Contact):
     @defer.inlineCallbacks
     def command_MUTE(self, args, **kwargs):
         if (yield self.op_required('mute')):
-            self.send("Only channel operators or explicitly allowed users "
-                      "can mute me here, {}... Blah, blah, blah...".format(self.user_id))
+            yield self.send("Only channel operators or explicitly allowed users "
+                            "can mute me here, {}... Blah, blah, blah...".format(self.user_id))
             return
         # The order of these is important! ;)
-        self.send("Shutting up for now.")
+        yield self.send("Shutting up for now.")
         self.channel.muted = True
     command_MUTE.usage = "mute - suppress all messages until a corresponding 'unmute' is issued"
 
@@ -158,9 +158,9 @@ class IRCContact(Contact):
                 return
             # The order of these is important! ;)
             self.channel.muted = False
-            self.send("I'm baaaaaaaaaaack!")
+            yield self.send("I'm baaaaaaaaaaack!")
         else:
-            self.send(
+            yield self.send(
                 "No one had told me to be quiet, but it's the thought that counts, right?")
     command_UNMUTE.usage = "unmute - disable a previous 'mute'"
 
@@ -171,9 +171,9 @@ class IRCContact(Contact):
             argv = self.splitArgs(args)
             if argv and argv[0] in ('on', 'off') and \
                     (yield self.op_required('notify')):
-                self.send("Only channel operators can change notified events for this channel. "
-                          "And you, {}, are neither!"
-                          .format(self.user_id))
+                yield self.send("Only channel operators can change notified events for this channel. "
+                                "And you, {}, are neither!"
+                                .format(self.user_id))
                 return
         super().command_NOTIFY(args, **kwargs)
 

--- a/master/buildbot/reporters/telegram.py
+++ b/master/buildbot/reporters/telegram.py
@@ -656,6 +656,7 @@ class TelegramStatusBot(StatusBot):
                 new_channel.setServiceParent(self)
             return new_channel
 
+    @defer.inlineCallbacks
     def process_update(self, update):
         data = {}
 
@@ -664,7 +665,7 @@ class TelegramStatusBot(StatusBot):
             query = update.get('callback_query')
             if query is None:
                 self.log('No message in Telegram update object')
-                return defer.succeed('no message')
+                return 'no message'
             original_message = query.get('message', {})
             data = query.get('data', 0)
             try:
@@ -705,22 +706,22 @@ class TelegramStatusBot(StatusBot):
         user = message.get('from')
         if user is None:
             self.log('No user in incoming message')
-            return defer.succeed('no user')
+            return 'no user'
 
         text = message.get('text')
         if not text:
-            return defer.succeed('no text in the message')
+            return 'no text in the message'
 
         contact = self.getContact(user=user, channel=chat)
         data['tmessage'] = message
         template, contact.template = contact.template, None
         if text.startswith(self.commandPrefix):
-            d = contact.handleMessage(text, **data)
+            result = yield contact.handleMessage(text, **data)
         else:
             if template:
                 text = template.format(shlex.quote(text))
-            d = contact.handleMessage(text, **data)
-        return d
+            result = yield contact.handleMessage(text, **data)
+        return result
 
     @defer.inlineCallbacks
     def post(self, path, **kwargs):

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -145,12 +145,13 @@ class Channel(service.AsyncService):
                           "(Success|Warnings|Failure|Exception))$").match(event):
             raise UsageError("Try '" + self.bot.commandPrefix + "notify on|off _EVENT_'.")
 
+    @defer.inlineCallbacks
     def list_notified_events(self):
         if self.notify_events:
-            self.send("The following events are being notified: {}."
-                      .format(", ".join(sorted(self.notify_events))))
+            yield self.send("The following events are being notified: {}."
+                            .format(", ".join(sorted(self.notify_events))))
         else:
-            self.send("No events are being notified.")
+            yield self.send("No events are being notified.")
 
     def notify_for(self, *events):
         for event in events:
@@ -602,6 +603,7 @@ class Contact:
             self.send('\n'.join(response))
     command_STATUS.usage = "status [_which_] - list status of a builder (or all builders)"
 
+    @defer.inlineCallbacks
     def command_NOTIFY(self, args, **kwargs):
         """notify me about build events"""
         args = self.splitArgs(args)
@@ -617,7 +619,7 @@ class Contact:
             self.channel.add_notification_events(events)
 
             if action == "on":
-                self.channel.list_notified_events()
+                yield self.channel.list_notified_events()
             self.bot.saveNotifyEvents()
 
         elif action in ("off", "off-quiet"):
@@ -627,11 +629,11 @@ class Contact:
                 self.channel.remove_all_notification_events()
 
             if action == "off":
-                self.channel.list_notified_events()
+                yield self.channel.list_notified_events()
             self.bot.saveNotifyEvents()
 
         elif action == "list":
-            self.channel.list_notified_events()
+            yield self.channel.list_notified_events()
 
         else:
             raise UsageError("Try '" + self.bot.commandPrefix + "notify on|off|list [_EVENT_]'.")

--- a/master/buildbot/test/unit/test_reporters_telegram.py
+++ b/master/buildbot/test/unit/test_reporters_telegram.py
@@ -120,18 +120,20 @@ class TestTelegramContact(ContactMixin, unittest.TestCase):
         self.contact1 = self.contactClass(user=self.USER, channel=self.channelClass(self.bot, self.PRIVATE))
         yield self.contact1.channel.setServiceParent(self.master)
 
+    @defer.inlineCallbacks
     def test_list_notified_events(self):
         self.patch_send()
         channel = telegram.TelegramChannel(self.bot, self.CHANNEL)
         channel.notify_events = {'success'}
-        channel.list_notified_events()
+        yield channel.list_notified_events()
         self.assertEquals(self.sent[0][1], "The following events are being notified:\n🔔 **success**")
 
+    @defer.inlineCallbacks
     def test_list_notified_events_empty(self):
         self.patch_send()
         channel = telegram.TelegramChannel(self.bot, self.CHANNEL)
         channel.notify_events = set()
-        channel.list_notified_events()
+        yield channel.list_notified_events()
         self.assertEquals(self.sent[0][1], "🔕 No events are being notified.")
 
     def testDescribeUser(self):

--- a/master/buildbot/test/unit/test_reporters_telegram.py
+++ b/master/buildbot/test/unit/test_reporters_telegram.py
@@ -539,7 +539,7 @@ class TestPollingBot(telegram.TelegramPollingBot):
     def process_update(self, update):
         self.__updates -= 1
         if not self.__updates:
-            self.running = False
+            self._polling_continue = False
         return super().process_update(update)
 
 
@@ -819,7 +819,7 @@ class TestTelegramService(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_polling(self):
         bot = self.makePollingBot(2)
-        bot.running = True
+        bot._polling_continue = True
         bot.http_client.expect("post", "/deleteWebhook", content_json={"ok": 1})
         bot.http_client.expect(
             "post", "/getUpdates",
@@ -923,7 +923,7 @@ class TestTelegramService(TestReactorMixin, unittest.TestCase):
         bot = self.makePollingBot(1)
         bot.reactor = self.reactor
         bot.http_client = self.setupFakeHttpWithErrors(1, 2)
-        bot.running = True
+        bot._polling_continue = True
         bot.http_client.expect("post", "/deleteWebhook", content_json={"ok": 1})
         bot.http_client.expect(
             "post", "/getUpdates",

--- a/master/buildbot/test/unit/test_reporters_words.py
+++ b/master/buildbot/test/unit/test_reporters_words.py
@@ -116,7 +116,7 @@ class ContactMixin(TestReactorMixin):
             else:
                 self.fail("no UsageError")
         else:
-            cmd(args, **kwargs)
+            yield cmd(args, **kwargs)
         if clock_ticks:
             self.reactor.pump(clock_ticks)
 


### PR DESCRIPTION
This PR fixes a number of cases where Deferreds are currently left unwaited. Additionally, the Telegram reporter will now wait until in-progress polls finish during shutdown.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
