### PR TITLE
telegram: Wait until setServiceParent() finishes during reconfiguration

### DIFF
--- a/master/buildbot/newsfragments/telegram-fix-race-conditions.bugfix
+++ b/master/buildbot/newsfragments/telegram-fix-race-conditions.bugfix
@@ -1,0 +1,1 @@
+Fix multiple race conditions in Telegram reporter that were visible in tests.

--- a/master/buildbot/reporters/telegram.py
+++ b/master/buildbot/reporters/telegram.py
@@ -992,4 +992,4 @@ class TelegramBot(service.BuildbotService):
             if self.bot.nickname is None:
                 raise RuntimeError("No bot username specified and I cannot get it from Telegram")
 
-        self.bot.setServiceParent(self)
+        yield self.bot.setServiceParent(self)


### PR DESCRIPTION
This fixes the remaining issue that broke the Telegram integration tests. Together with #5122, #5123, #5124 this fixes the database accesses being done after the test finishes.