### PR TITLE
Make sure any Deferreds returned by setServiceParent() are waited upon

### DIFF
--- a/master/buildbot/changes/pb.py
+++ b/master/buildbot/changes/pb.py
@@ -142,25 +142,25 @@ class PBChangeSource(base.ChangeSource):
         # and, if it's changed, re-register
         if port != self.registered_port and self.isActive():
             yield self._unregister()
-            self._register(port)
+            yield self._register(port)
 
         yield super().reconfigServiceWithBuildbotConfig(new_config)
 
+    @defer.inlineCallbacks
     def activate(self):
         port = self._calculatePort(self.master.config)
-        self._register(port)
-        return defer.succeed(None)
+        yield self._register(port)
 
     def deactivate(self):
         return self._unregister()
 
+    @defer.inlineCallbacks
     def _register(self, port):
         if not port:
             return
         self.registered_port = port
-        self.registration = self.master.pbmanager.register(
-            port, self.user, self.passwd,
-            self.getPerspective)
+        self.registration = yield self.master.pbmanager.register(port, self.user, self.passwd,
+                                                                 self.getPerspective)
 
     def _unregister(self):
         self.registered_port = None

--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -80,8 +80,9 @@ class DBConnector(service.ReconfigurableServiceMixin,
         self._engine = None  # set up in reconfigService
         self.pool = None  # set up in reconfigService
 
+    @defer.inlineCallbacks
     def setServiceParent(self, p):
-        d = super().setServiceParent(p)
+        yield super().setServiceParent(p)
         self.model = model.Model(self)
         self.changes = changes.ChangesConnectorComponent(self)
         self.changesources = changesources.ChangeSourcesConnectorComponent(
@@ -104,8 +105,7 @@ class DBConnector(service.ReconfigurableServiceMixin,
         self.cleanup_timer = internet.TimerService(self.CLEANUP_PERIOD,
                                                    self._doCleanup)
         self.cleanup_timer.clock = self.master.reactor
-        self.cleanup_timer.setServiceParent(self)
-        return d
+        yield self.cleanup_timer.setServiceParent(self)
 
     @defer.inlineCallbacks
     def setup(self, check_version=True, verbose=True):

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -268,7 +268,7 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
                 self.reactor.stop()
                 return
 
-            self.mq.setup()
+            yield self.mq.setup()
 
             if hasattr(signal, "SIGHUP"):
                 def sighup(*args):

--- a/master/buildbot/mq/connector.py
+++ b/master/buildbot/mq/connector.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 
+from twisted.internet import defer
 from twisted.python.reflect import namedObject
 
 from buildbot.util import service
@@ -38,6 +39,7 @@ class MQConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         self.impl = None  # set in setup
         self.impl_type = None  # set in setup
 
+    @defer.inlineCallbacks
     def setup(self):
         assert not self.impl
 
@@ -50,7 +52,7 @@ class MQConnector(service.ReconfigurableServiceMixin, service.AsyncMultiService)
         self.impl = cls()
 
         # set up the impl as a child service
-        self.impl.setServiceParent(self)
+        yield self.impl.setServiceParent(self)
 
         # configure it (early)
         self.impl.reconfigServiceWithBuildbotConfig(self.master.config)

--- a/master/buildbot/pbmanager.py
+++ b/master/buildbot/pbmanager.py
@@ -47,6 +47,7 @@ class PBManager(service.AsyncMultiService):
         self.setName('pbmanager')
         self.dispatchers = {}
 
+    @defer.inlineCallbacks
     def register(self, portstr, username, password, pfactory):
         """
         Register a perspective factory PFACTORY to be executed when a PB
@@ -61,7 +62,7 @@ class PBManager(service.AsyncMultiService):
 
         if portstr not in self.dispatchers:
             disp = self.dispatchers[portstr] = Dispatcher(portstr)
-            disp.setServiceParent(self)
+            yield disp.setServiceParent(self)
         else:
             disp = self.dispatchers[portstr]
 
@@ -69,6 +70,7 @@ class PBManager(service.AsyncMultiService):
 
         return reg
 
+    @defer.inlineCallbacks
     def _unregister(self, registration):
         disp = self.dispatchers[registration.portstr]
         disp.unregister(registration.username)
@@ -76,8 +78,7 @@ class PBManager(service.AsyncMultiService):
         if not disp.users:
             disp = self.dispatchers[registration.portstr]
             del self.dispatchers[registration.portstr]
-            return defer.maybeDeferred(disp.disownServiceParent)
-        return defer.succeed(None)
+            yield disp.disownServiceParent()
 
 
 class Registration:

--- a/master/buildbot/process/users/manual.py
+++ b/master/buildbot/process/users/manual.py
@@ -205,15 +205,15 @@ class CommandlineUserManager(service.AsyncMultiService):
         self.port = port
         self.registration = None
 
+    @defer.inlineCallbacks
     def startService(self):
         # set up factory and register with buildbot.pbmanager
         def factory(mind, username):
             return CommandlineUserManagerPerspective(self.master)
-        self.registration = self.master.pbmanager.register(self.port,
-                                                           self.username,
-                                                           self.passwd,
-                                                           factory)
-        return super().startService()
+
+        self.registration = yield self.master.pbmanager.register(self.port, self.username,
+                                                                 self.passwd, factory)
+        yield super().startService()
 
     def stopService(self):
         d = defer.maybeDeferred(service.AsyncMultiService.stopService, self)

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -447,9 +447,8 @@ class Try_Userpass(TryBase):
         def factory(mind, username):
             return Try_Userpass_Perspective(self, username)
         for user, passwd in self.userpass:
-            self.registrations.append(
-                self.master.pbmanager.register(
-                    self.port, user, passwd, factory))
+            reg = yield self.master.pbmanager.register(self.port, user, passwd, factory)
+            self.registrations.append(reg)
 
     @defer.inlineCallbacks
     def deactivate(self):

--- a/master/buildbot/scripts/dataspec.py
+++ b/master/buildbot/scripts/dataspec.py
@@ -30,7 +30,7 @@ from buildbot.util import in_reactor
 def dataspec(config):
     master = yield fakemaster.make_master(None, wantRealReactor=True)
     data = connector.DataConnector()
-    data.setServiceParent(master)
+    yield data.setServiceParent(master)
     if config['out'] != '--':
         dirs = os.path.dirname(config['out'])
         if dirs and not os.path.exists(dirs):

--- a/master/buildbot/scripts/upgrade_master.py
+++ b/master/buildbot/scripts/upgrade_master.py
@@ -98,7 +98,7 @@ def upgradeDatabase(config, master_cfg):
         master.config = master_cfg
         master.db.disownServiceParent()
         db = connector.DBConnector(basedir=config['basedir'])
-        db.setServiceParent(master)
+        yield db.setServiceParent(master)
         yield db.setup(check_version=False, verbose=not config['quiet'])
         yield db.model.upgrade()
         yield db.masters.setAllMastersActiveLongTimeAgo()

--- a/master/buildbot/test/fake/pbmanager.py
+++ b/master/buildbot/test/fake/pbmanager.py
@@ -31,7 +31,7 @@ class FakePBManager(service.AsyncMultiService):
         if (portstr, username) not in self._registrations:
             reg = FakeRegistration(self, portstr, username)
             self._registrations.append((portstr, username, password))
-            return reg
+            return defer.succeed(reg)
         else:
             raise KeyError("username '%s' is already registered on port %s"
                            % (username, portstr))

--- a/master/buildbot/test/integration/test_telegram_bot.py
+++ b/master/buildbot/test/integration/test_telegram_bot.py
@@ -93,11 +93,11 @@ class TelegramBot(db.RealDatabaseWithConnectorMixin, www.RequiresWwwMixin, unitt
                                                   sqlite_memory=False)
 
         master.data = dataconnector.DataConnector()
-        master.data.setServiceParent(master)
+        yield master.data.setServiceParent(master)
 
         master.config.mq = dict(type='simple')
         master.mq = mqconnector.MQConnector()
-        master.mq.setServiceParent(master)
+        yield master.mq.setServiceParent(master)
         master.mq.setup()
 
         master.config.www = dict(
@@ -108,7 +108,7 @@ class TelegramBot(db.RealDatabaseWithConnectorMixin, www.RequiresWwwMixin, unitt
             avatar_methods=[],
             logfileName='http.log')
         master.www = wwwservice.WWWService()
-        master.www.setServiceParent(master)
+        yield master.www.setServiceParent(master)
         yield master.www.startService()
         yield master.www.reconfigServiceWithBuildbotConfig(master.config)
         session = mock.Mock()
@@ -133,7 +133,7 @@ class TelegramBot(db.RealDatabaseWithConnectorMixin, www.RequiresWwwMixin, unitt
             chat_ids=[-123456], notify_events=['worker']
         )
         tb._get_http = self.get_http
-        tb.setServiceParent(self.master)
+        yield tb.setServiceParent(self.master)
         self.bot_url = self.url + b"telegram12345:secret"
 
         yield tb.startService()

--- a/master/buildbot/test/integration/test_telegram_bot.py
+++ b/master/buildbot/test/integration/test_telegram_bot.py
@@ -98,7 +98,7 @@ class TelegramBot(db.RealDatabaseWithConnectorMixin, www.RequiresWwwMixin, unitt
         master.config.mq = dict(type='simple')
         master.mq = mqconnector.MQConnector()
         yield master.mq.setServiceParent(master)
-        master.mq.setup()
+        yield master.mq.setup()
 
         master.config.www = dict(
             port='tcp:0:interface=127.0.0.1',

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -92,7 +92,7 @@ class UpgradeTestMixin(db.RealDatabaseMixin, TestReactorMixin):
         self.master = master = fakemaster.make_master(self)
         master.config.db['db_url'] = self.db_url
         self.db = connector.DBConnector(self.basedir)
-        self.db.setServiceParent(master)
+        yield self.db.setServiceParent(master)
         yield self.db.setup(check_version=False)
 
         self._sql_log_handler = querylog.start_log_queries()

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -171,20 +171,20 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
         # set the worker port to a loopback address with unspecified
         # port
         self.pbmanager = self.master.pbmanager = pbmanager.PBManager()
-        self.pbmanager.setServiceParent(self.master)
+        yield self.pbmanager.setServiceParent(self.master)
 
         # remove the fakeServiceParent from fake service hierarchy, and replace
         # by a real one
         yield self.master.workers.disownServiceParent()
         self.workers = self.master.workers = workermanager.WorkerManager(
             self.master)
-        self.workers.setServiceParent(self.master)
+        yield self.workers.setServiceParent(self.master)
 
         self.botmaster = botmaster.BotMaster()
-        self.botmaster.setServiceParent(self.master)
+        yield self.botmaster.setServiceParent(self.master)
 
         self.master.status = master.Status()
-        self.master.status.setServiceParent(self.master)
+        yield self.master.status.setServiceParent(self.master)
         self.master.botmaster = self.botmaster
         self.master.data.updates.workerConfigured = lambda *a, **k: None
         yield self.master.startService()

--- a/master/buildbot/test/integration/test_worker_workerside.py
+++ b/master/buildbot/test/integration/test_worker_workerside.py
@@ -125,20 +125,20 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
         # set the worker port to a loopback address with unspecified
         # port
         self.pbmanager = self.master.pbmanager = pbmanager.PBManager()
-        self.pbmanager.setServiceParent(self.master)
+        yield self.pbmanager.setServiceParent(self.master)
 
         # remove the fakeServiceParent from fake service hierarchy, and replace
         # by a real one
         yield self.master.workers.disownServiceParent()
         self.workers = self.master.workers = workermanager.WorkerManager(
             self.master)
-        self.workers.setServiceParent(self.master)
+        yield self.workers.setServiceParent(self.master)
 
         self.botmaster = botmaster.BotMaster()
-        self.botmaster.setServiceParent(self.master)
+        yield self.botmaster.setServiceParent(self.master)
 
         self.master.status = master.Status()
-        self.master.status.setServiceParent(self.master)
+        yield self.master.status.setServiceParent(self.master)
         self.master.botmaster = self.botmaster
         self.master.data.updates.workerConfigured = lambda *a, **k: None
         yield self.master.startService()

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -73,16 +73,16 @@ class Www(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase):
 
         master.config.db = dict(db_url=self.db_url)
         master.db = dbconnector.DBConnector('basedir')
-        master.db.setServiceParent(master)
+        yield master.db.setServiceParent(master)
         yield master.db.setup(check_version=False)
 
         master.config.mq = dict(type='simple')
         master.mq = mqconnector.MQConnector()
-        master.mq.setServiceParent(master)
+        yield master.mq.setServiceParent(master)
         master.mq.setup()
 
         master.data = dataconnector.DataConnector()
-        master.data.setServiceParent(master)
+        yield master.data.setServiceParent(master)
 
         master.config.www = dict(
             port='tcp:0:interface=127.0.0.1',
@@ -92,7 +92,7 @@ class Www(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase):
             avatar_methods=[],
             logfileName='http.log')
         master.www = wwwservice.WWWService()
-        master.www.setServiceParent(master)
+        yield master.www.setServiceParent(master)
         yield master.www.startService()
         yield master.www.reconfigServiceWithBuildbotConfig(master.config)
         session = mock.Mock()

--- a/master/buildbot/test/integration/test_www.py
+++ b/master/buildbot/test/integration/test_www.py
@@ -79,7 +79,7 @@ class Www(db.RealDatabaseMixin, www.RequiresWwwMixin, unittest.TestCase):
         master.config.mq = dict(type='simple')
         master.mq = mqconnector.MQConnector()
         yield master.mq.setServiceParent(master)
-        master.mq.setup()
+        yield master.mq.setup()
 
         master.data = dataconnector.DataConnector()
         yield master.data.setServiceParent(master)

--- a/master/buildbot/test/unit/test_changes_gitpoller.py
+++ b/master/buildbot/test/unit/test_changes_gitpoller.py
@@ -196,7 +196,7 @@ class TestGitPollerBase(gpo.GetProcessOutputMixin,
         yield self.setUpChangeSource()
 
         self.poller = self.createPoller()
-        self.poller.setServiceParent(self.master)
+        yield self.poller.setServiceParent(self.master)
 
     def tearDown(self):
         return self.tearDownChangeSource()

--- a/master/buildbot/test/unit/test_changes_hgpoller.py
+++ b/master/buildbot/test/unit/test_changes_hgpoller.py
@@ -59,7 +59,7 @@ class TestHgPollerBase(gpo.GetProcessOutputMixin,
                                         bookmarks=self.bookmarks,
                                         revlink=lambda branch, revision:
                                             self.remote_hgweb.format(revision))
-        self.poller.setServiceParent(self.master)
+        yield self.poller.setServiceParent(self.master)
         self.poller._isRepositoryReady = _isRepositoryReady
 
         yield self.master.db.setup()

--- a/master/buildbot/test/unit/test_changes_manager.py
+++ b/master/buildbot/test/unit/test_changes_manager.py
@@ -27,12 +27,13 @@ from buildbot.test.util.misc import TestReactorMixin
 
 class TestChangeManager(unittest.TestCase, TestReactorMixin):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self, wantData=True)
         self.cm = manager.ChangeManager()
         self.master.startService()
-        self.cm.setServiceParent(self.master)
+        yield self.cm.setServiceParent(self.master)
         self.new_config = mock.Mock()
 
     def tearDown(self):
@@ -46,7 +47,7 @@ class TestChangeManager(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def test_reconfigService_add(self):
         src1, src2 = self.make_sources(2)
-        src1.setServiceParent(self.cm)
+        yield src1.setServiceParent(self.cm)
         self.new_config.change_sources = [src1, src2]
 
         yield self.cm.reconfigServiceWithBuildbotConfig(self.new_config)
@@ -57,7 +58,7 @@ class TestChangeManager(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def test_reconfigService_remove(self):
         src1, = self.make_sources(1)
-        src1.setServiceParent(self.cm)
+        yield src1.setServiceParent(self.cm)
         self.new_config.change_sources = []
 
         self.assertTrue(src1.running)
@@ -68,7 +69,7 @@ class TestChangeManager(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def test_reconfigService_change_reconfigurable(self):
         src1, = self.make_sources(1, base.ReconfigurablePollingChangeSource, pollInterval=1)
-        src1.setServiceParent(self.cm)
+        yield src1.setServiceParent(self.cm)
 
         src2, = self.make_sources(1, base.ReconfigurablePollingChangeSource, pollInterval=2)
 
@@ -85,7 +86,7 @@ class TestChangeManager(unittest.TestCase, TestReactorMixin):
     @defer.inlineCallbacks
     def test_reconfigService_change_legacy(self):
         src1, = self.make_sources(1, base.PollingChangeSource, pollInterval=1)
-        src1.setServiceParent(self.cm)
+        yield src1.setServiceParent(self.cm)
 
         src2, = self.make_sources(1, base.PollingChangeSource, pollInterval=2)
 

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1594,11 +1594,11 @@ class ReconfigurableServiceMixin(unittest.TestCase):
     def test_multiservice(self):
         svc = FakeMultiService()
         ch1 = FakeService()
-        ch1.setServiceParent(svc)
+        yield ch1.setServiceParent(svc)
         ch2 = FakeMultiService()
-        ch2.setServiceParent(svc)
+        yield ch2.setServiceParent(svc)
         ch3 = FakeService()
-        ch3.setServiceParent(ch2)
+        yield ch3.setServiceParent(ch2)
         yield svc.reconfigServiceWithBuildbotConfig(mock.Mock())
 
         self.assertTrue(svc.called)
@@ -1610,13 +1610,13 @@ class ReconfigurableServiceMixin(unittest.TestCase):
     def test_multiservice_priority(self):
         parent = FakeMultiService()
         svc128 = FakeService()
-        svc128.setServiceParent(parent)
+        yield svc128.setServiceParent(parent)
 
         services = [svc128]
         for i in range(20, 1, -1):
             svc = FakeService()
             svc.reconfig_priority = i
-            svc.setServiceParent(parent)
+            yield svc.setServiceParent(parent)
             services.append(svc)
 
         yield parent.reconfigServiceWithBuildbotConfig(mock.Mock())
@@ -1629,7 +1629,7 @@ class ReconfigurableServiceMixin(unittest.TestCase):
     def test_multiservice_nested_failure(self):
         svc = FakeMultiService()
         ch1 = FakeService()
-        ch1.setServiceParent(svc)
+        yield ch1.setServiceParent(svc)
         ch1.succeed = False
         try:
             yield svc.reconfigServiceWithBuildbotConfig(mock.Mock())

--- a/master/buildbot/test/unit/test_data_connector.py
+++ b/master/buildbot/test/unit/test_data_connector.py
@@ -99,22 +99,24 @@ class TestFakeData(TestReactorMixin, unittest.TestCase, Tests):
 
 class TestDataConnector(TestReactorMixin, unittest.TestCase, Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self, wantMq=True)
         self.data = connector.DataConnector()
-        self.data.setServiceParent(self.master)
+        yield self.data.setServiceParent(self.master)
 
 
 class DataConnector(TestReactorMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self)
         # don't load by default
         self.patch(connector.DataConnector, 'submodules', [])
         self.data = connector.DataConnector()
-        self.data.setServiceParent(self.master)
+        yield self.data.setServiceParent(self.master)
 
     def patchFooPattern(self):
         cls = type('FooEndpoint', (base.Endpoint,), {})

--- a/master/buildbot/test/unit/test_data_root.py
+++ b/master/buildbot/test/unit/test_data_root.py
@@ -49,12 +49,13 @@ class SpecEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     endpointClass = root.SpecEndpoint
     resourceTypeClass = root.Spec
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpEndpoint()
         # replace fakeConnector with real DataConnector
         self.master.data.disownServiceParent()
         self.master.data = connector.DataConnector()
-        self.master.data.setServiceParent(self.master)
+        yield self.master.data.setServiceParent(self.master)
 
     def tearDown(self):
         self.tearDownEndpoint()

--- a/master/buildbot/test/unit/test_db_connector.py
+++ b/master/buildbot/test/unit/test_db_connector.py
@@ -47,7 +47,7 @@ class TestDBConnector(TestReactorMixin, db.RealDatabaseMixin,
         self.master = fakemaster.make_master(self)
         self.master.config = config.MasterConfig()
         self.db = connector.DBConnector(os.path.abspath('basedir'))
-        self.db.setServiceParent(self.master)
+        yield self.db.setServiceParent(self.master)
 
     @defer.inlineCallbacks
     def tearDown(self):

--- a/master/buildbot/test/unit/test_db_workers.py
+++ b/master/buildbot/test/unit/test_db_workers.py
@@ -655,11 +655,12 @@ class RealTests(Tests):
 
 class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self)
         self.db = fakedb.FakeDBConnector(self)
-        self.db.setServiceParent(self.master)
+        yield self.db.setServiceParent(self.master)
         self.db.checkForeignKeys = True
         self.insertTestData = self.db.insertTestData
 

--- a/master/buildbot/test/unit/test_fake_httpclientservice.py
+++ b/master/buildbot/test/unit/test_fake_httpclientservice.py
@@ -39,26 +39,31 @@ class myTestedService(service.BuildbotService):
         return res_json
 
 
-class Test(unittest.SynchronousTestCase):
+class Test(unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         baseurl = 'http://127.0.0.1:8080'
         self.parent = service.MasterService()
-        self._http = self.successResultOf(fakehttpclientservice.HTTPClientService.getFakeService(
-            self.parent, self, baseurl))
+        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+            self.parent, self, baseurl)
         self.tested = myTestedService(baseurl)
 
-        self.successResultOf(self.tested.setServiceParent(self.parent))
-        self.successResultOf(self.parent.startService())
+        yield self.tested.setServiceParent(self.parent)
+        yield self.parent.startService()
 
+    @defer.inlineCallbacks
     def test_root(self):
         self._http.expect("get", "/", content_json={'foo': 'bar'})
 
-        response = self.successResultOf(self.tested.doGetRoot())
+        response = yield self.tested.doGetRoot()
         self.assertEqual(response, {'foo': 'bar'})
 
+    @defer.inlineCallbacks
     def test_root_error(self):
         self._http.expect("get", "/", content_json={'foo': 'bar'}, code=404)
 
-        response = self.failureResultOf(self.tested.doGetRoot())
-        self.assertEqual(response.getErrorMessage(), '404: server did not succeed')
+        try:
+            yield self.tested.doGetRoot()
+        except Exception as e:
+            self.assertEqual(str(e), '404: server did not succeed')

--- a/master/buildbot/test/unit/test_interpolate_secrets.py
+++ b/master/buildbot/test/unit/test_interpolate_secrets.py
@@ -22,6 +22,7 @@ class FakeBuildWithMaster(FakeBuild):
 class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase,
                              ConfigErrorsMixin):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self)
@@ -30,7 +31,7 @@ class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase,
                                                        "other": "value"})
         self.secretsrv = SecretManager()
         self.secretsrv.services = [fakeStorageService]
-        self.secretsrv.setServiceParent(self.master)
+        yield self.secretsrv.setServiceParent(self.master)
         self.build = FakeBuildWithMaster(self.master)
 
     @defer.inlineCallbacks
@@ -67,6 +68,7 @@ class TestInterpolateSecretsNoService(TestReactorMixin, unittest.TestCase,
 
 class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self)
@@ -75,7 +77,7 @@ class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
                                                        "other": "value"})
         self.secretsrv = SecretManager()
         self.secretsrv.services = [fakeStorageService]
-        self.secretsrv.setServiceParent(self.master)
+        yield self.secretsrv.setServiceParent(self.master)
         self.build = FakeBuildWithMaster(self.master)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -98,12 +98,12 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin,
         self.master.sendBuildbotNetUsageData = mock.Mock()
         self.master.botmaster = FakeBotMaster()
         self.db = self.master.db = fakedb.FakeDBConnector(self)
-        self.db.setServiceParent(self.master)
+        yield self.db.setServiceParent(self.master)
         self.mq = self.master.mq = fakemq.FakeMQConnector(self)
-        self.mq.setServiceParent(self.master)
+        yield self.mq.setServiceParent(self.master)
         self.data = self.master.data = fakedata.FakeDataConnector(
             self.master, self)
-        self.data.setServiceParent(self.master)
+        yield self.data.setServiceParent(self.master)
 
     def tearDown(self):
         return self.tearDownDirs()

--- a/master/buildbot/test/unit/test_mq.py
+++ b/master/buildbot/test/unit/test_mq.py
@@ -144,8 +144,9 @@ class TestFakeMQ(TestReactorMixin, unittest.TestCase, Tests):
 
 class TestSimpleMQ(TestReactorMixin, unittest.TestCase, RealTests):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self)
         self.mq = simple.SimpleMQ()
-        self.mq.setServiceParent(self.master)
+        yield self.mq.setServiceParent(self.master)

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -56,15 +56,17 @@ class MQConnector(TestReactorMixin, unittest.TestCase):
                     {'class': 'buildbot.test.unit.test_mq_connector.FakeMQ'},
                     })
 
+    @defer.inlineCallbacks
     def test_setup_unknown_type(self):
         self.mqconfig['type'] = 'unknown'
         with self.assertRaises(AssertionError):
-            self.conn.setup()
+            yield self.conn.setup()
 
+    @defer.inlineCallbacks
     def test_setup_simple_type(self):
         self.patchFakeMQ(name='simple')
         self.mqconfig['type'] = 'simple'
-        self.conn.setup()
+        yield self.conn.setup()
         self.assertIsInstance(self.conn.impl, FakeMQ)
         self.assertEqual(self.conn.impl.produce, self.conn.produce)
         self.assertEqual(self.conn.impl.startConsuming,
@@ -85,7 +87,7 @@ class MQConnector(TestReactorMixin, unittest.TestCase):
     def test_reconfigService_change_type(self):
         self.patchFakeMQ()
         self.mqconfig['type'] = 'fake'
-        self.conn.setup()
+        yield self.conn.setup()
         new_config = mock.Mock()
         new_config.mq = dict(type='other')
         try:

--- a/master/buildbot/test/unit/test_mq_connector.py
+++ b/master/buildbot/test/unit/test_mq_connector.py
@@ -42,12 +42,13 @@ class FakeMQ(service.ReconfigurableServiceMixin, base.MQBase):
 
 class MQConnector(TestReactorMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self)
         self.mqconfig = self.master.config.mq = {}
         self.conn = connector.MQConnector()
-        self.conn.setServiceParent(self.master)
+        yield self.conn.setServiceParent(self.master)
 
     def patchFakeMQ(self, name='fake'):
         self.patch(connector.MQConnector, 'classes',

--- a/master/buildbot/test/unit/test_mq_wamp.py
+++ b/master/buildbot/test/unit/test_mq_wamp.py
@@ -105,12 +105,13 @@ class WampMQ(TestReactorMixin, unittest.TestCase):
         A router which only accepts one subscriber on one topic
     """
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self)
         self.master.wamp = FakeWampConnector()
         self.mq = wamp.WampMQ()
-        self.mq.setServiceParent(self.master)
+        yield self.mq.setServiceParent(self.master)
 
     @defer.inlineCallbacks
     def test_startConsuming_basic(self):

--- a/master/buildbot/test/unit/test_pbmanager.py
+++ b/master/buildbot/test/unit/test_pbmanager.py
@@ -39,9 +39,10 @@ class FakeMaster:
 
 class TestPBManager(unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.pbm = pbmanager.PBManager()
-        self.pbm.setServiceParent(FakeMaster())
+        yield self.pbm.setServiceParent(FakeMaster())
         self.pbm.startService()
         self.connections = []
 

--- a/master/buildbot/test/unit/test_pbmanager.py
+++ b/master/buildbot/test/unit/test_pbmanager.py
@@ -56,8 +56,9 @@ class TestPBManager(unittest.TestCase):
         self.connections.append(username)
         return defer.succeed(persp)
 
+    @defer.inlineCallbacks
     def test_repr(self):
-        reg = self.pbm.register(
+        reg = yield self.pbm.register(
             'tcp:0:interface=127.0.0.1', "x", "y", self.perspectiveFactory)
         self.assertEqual(repr(self.pbm.dispatchers['tcp:0:interface=127.0.0.1']),
                          '<pbmanager.Dispatcher for x on tcp:0:interface=127.0.0.1>')
@@ -67,8 +68,7 @@ class TestPBManager(unittest.TestCase):
     @defer.inlineCallbacks
     def test_register_unregister(self):
         portstr = "tcp:0:interface=127.0.0.1"
-        reg = self.pbm.register(
-            portstr, "boris", "pass", self.perspectiveFactory)
+        reg = yield self.pbm.register(portstr, "boris", "pass", self.perspectiveFactory)
 
         # make sure things look right
         self.assertIn(portstr, self.pbm.dispatchers)
@@ -93,8 +93,8 @@ class TestPBManager(unittest.TestCase):
     @defer.inlineCallbacks
     def test_double_register_unregister(self):
         portstr = "tcp:0:interface=127.0.0.1"
-        reg1 = self.pbm.register(portstr, "boris", "pass", None)
-        reg2 = self.pbm.register(portstr, "ivona", "pass", None)
+        reg1 = yield self.pbm.register(portstr, "boris", "pass", None)
+        reg2 = yield self.pbm.register(portstr, "ivona", "pass", None)
 
         # make sure things look right
         self.assertEqual(len(self.pbm.dispatchers), 1)
@@ -117,8 +117,7 @@ class TestPBManager(unittest.TestCase):
     @defer.inlineCallbacks
     def test_requestAvatarId_noinitLock(self):
         portstr = "tcp:0:interface=127.0.0.1"
-        reg = self.pbm.register(
-            portstr, "boris", "pass", self.perspectiveFactory)
+        reg = yield self.pbm.register(portstr, "boris", "pass", self.perspectiveFactory)
 
         disp = self.pbm.dispatchers[portstr]
 
@@ -131,8 +130,7 @@ class TestPBManager(unittest.TestCase):
     @defer.inlineCallbacks
     def test_requestAvatarId_initLock(self):
         portstr = "tcp:0:interface=127.0.0.1"
-        reg = self.pbm.register(
-            portstr, "boris", "pass", self.perspectiveFactory)
+        reg = yield self.pbm.register(portstr, "boris", "pass", self.perspectiveFactory)
 
         disp = self.pbm.dispatchers[portstr]
 

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -29,11 +29,12 @@ from buildbot.test.util.misc import TestReactorMixin
 
 class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self, wantData=True)
         self.botmaster = BotMaster()
-        self.botmaster.setServiceParent(self.master)
+        yield self.botmaster.setServiceParent(self.master)
         self.botmaster.startService()
 
     def assertReactorStopped(self, _=None):
@@ -147,13 +148,14 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
 
 class TestBotMaster(TestReactorMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantData=True)
         self.master.mq = self.master.mq
         self.master.botmaster.disownServiceParent()
         self.botmaster = BotMaster()
-        self.botmaster.setServiceParent(self.master)
+        yield self.botmaster.setServiceParent(self.master)
         self.new_config = mock.Mock()
         self.botmaster.startService()
 

--- a/master/buildbot/test/unit/test_process_debug.py
+++ b/master/buildbot/test/unit/test_process_debug.py
@@ -41,7 +41,7 @@ class TestDebugServices(TestReactorMixin, unittest.TestCase):
     def test_reconfigService_manhole(self):
         master = fakemaster.make_master(self)
         ds = debug.DebugServices()
-        ds.setServiceParent(master)
+        yield ds.setServiceParent(master)
         yield master.startService()
 
         # start off with no manhole

--- a/master/buildbot/test/unit/test_process_users_manual.py
+++ b/master/buildbot/test/unit/test_process_users_manual.py
@@ -219,13 +219,14 @@ class TestCommandlineUserManagerPerspective(TestReactorMixin,
 class TestCommandlineUserManager(TestReactorMixin, unittest.TestCase,
                                  ManualUsersMixin):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.setUpManualUsers()
         self.manual_component = manual.CommandlineUserManager(username="user",
                                                               passwd="userpw",
                                                               port="9990")
-        self.manual_component.setServiceParent(self.master)
+        yield self.manual_component.setServiceParent(self.master)
 
     def test_no_userpass(self):
         d = defer.maybeDeferred(manual.CommandlineUserManager)

--- a/master/buildbot/test/unit/test_process_users_manual.py
+++ b/master/buildbot/test/unit/test_process_users_manual.py
@@ -237,6 +237,7 @@ class TestCommandlineUserManager(TestReactorMixin, unittest.TestCase,
                                 username="x", passwd="y")
         return self.assertFailure(d, AssertionError)
 
+    @defer.inlineCallbacks
     def test_service(self):
         # patch out the pbmanager's 'register' command both to be sure
         # the registration is correct and to get a copy of the factory
@@ -248,13 +249,13 @@ class TestCommandlineUserManager(TestReactorMixin, unittest.TestCase,
             self.assertEqual([portstr, user, passwd],
                              ['9990', 'user', 'userpw'])
             self.got_factory = factory
-            return registration
+            return defer.succeed(registration)
         self.master.pbmanager.register = register
 
-        self.manual_component.startService()
+        yield self.manual_component.startService()
 
         persp = self.got_factory(mock.Mock(), 'user')
         self.assertTrue(
             isinstance(persp, manual.CommandlineUserManagerPerspective))
 
-        return self.manual_component.stopService()
+        yield self.manual_component.stopService()

--- a/master/buildbot/test/unit/test_reporter_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucketserver.py
@@ -199,7 +199,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             verify=None)
         self.cp = BitbucketServerPRCommentPush(
             "serv", Interpolate("username"), Interpolate("passwd"), verbose=verbose, **kwargs)
-        self.cp.setServiceParent(self.master)
+        yield self.cp.setServiceParent(self.master)
         self.cp.messageFormatter = Mock(spec=self.cp.messageFormatter)
         self.cp.messageFormatter.formatMessageForBuildResults.return_value = \
             {"body": UNICODE_BODY, "type": "text"}

--- a/master/buildbot/test/unit/test_reporters_telegram.py
+++ b/master/buildbot/test/unit/test_reporters_telegram.py
@@ -114,10 +114,11 @@ class TestTelegramContact(ContactMixin, unittest.TestCase):
             self.stickers += 1
         self.bot.send_sticker = send_sticker
 
+    @defer.inlineCallbacks
     def setUp(self):
         ContactMixin.setUp(self)
         self.contact1 = self.contactClass(user=self.USER, channel=self.channelClass(self.bot, self.PRIVATE))
-        self.contact1.channel.setServiceParent(self.master)
+        yield self.contact1.channel.setServiceParent(self.master)
 
     def test_list_notified_events(self):
         self.patch_send()

--- a/master/buildbot/test/unit/test_reporters_words.py
+++ b/master/buildbot/test/unit/test_reporters_words.py
@@ -41,6 +41,7 @@ class ContactMixin(TestReactorMixin):
     BUILDER_NAMES = ['builder1', 'builder2']
     BUILDER_IDS = [23, 45]
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.patch(reactor, 'callLater', self.reactor.callLater)
@@ -79,8 +80,8 @@ class ContactMixin(TestReactorMixin):
 
         self.contact = self.contactClass(user=self.USER,
                                          channel=self.bot.getChannel(self.CHANNEL))
-        self.contact.channel.setServiceParent(self.master)
-        return self.master.startService()
+        yield self.contact.channel.setServiceParent(self.master)
+        yield self.master.startService()
 
     def patch_send(self):
         self.sent = []

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -24,6 +24,7 @@ from buildbot.schedulers import manager
 
 class SchedulerManager(unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.next_objectid = 13
         self.objectids = {}
@@ -49,8 +50,8 @@ class SchedulerManager(unittest.TestCase):
         self.new_config = mock.Mock()
 
         self.sm = manager.SchedulerManager()
-        self.sm.setServiceParent(self.master)
-        return self.sm.startService()
+        yield self.sm.setServiceParent(self.master)
+        yield self.sm.startService()
 
     def tearDown(self):
         if self.sm.running:

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -813,6 +813,7 @@ class Try_Userpass(scheduler.SchedulerMixin, TestReactorMixin,
                                      self.OBJECTID, self.SCHEDULERID)
         return sched
 
+    @defer.inlineCallbacks
     def test_service(self):
         sched = self.makeScheduler(name='tsched', builderNames=['a'],
                                    port='tcp:9999', userpass=[('fred', 'derf')])
@@ -826,15 +827,16 @@ class Try_Userpass(scheduler.SchedulerMixin, TestReactorMixin,
             self.assertEqual([portstr, user, passwd],
                              ['tcp:9999', 'fred', 'derf'])
             self.got_factory = factory
-            return registration
+            return defer.succeed(registration)
+
         sched.master.pbmanager.register = register
         # start it
-        sched.startService()
+        yield sched.startService()
         # make a fake connection by invoking the factory, and check that we
         # get the correct perspective
         persp = self.got_factory(mock.Mock(), 'fred')
         self.assertTrue(isinstance(persp, trysched.Try_Userpass_Perspective))
-        return sched.stopService()
+        yield sched.stopService()
 
     @defer.inlineCallbacks
     def test_service_but_not_active(self):

--- a/master/buildbot/test/unit/test_secret_in_vault.py
+++ b/master/buildbot/test/unit/test_secret_in_vault.py
@@ -26,6 +26,7 @@ from buildbot.test.util.misc import TestReactorMixin
 class TestSecretInVaultHttpFakeBase(ConfigErrorsMixin, TestReactorMixin,
                                     unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self, version):
         self.setUpTestReactor()
         self.srvcVault = HashiCorpVaultSecretProvider(vaultServer="http://vaultServer",
@@ -35,7 +36,7 @@ class TestSecretInVaultHttpFakeBase(ConfigErrorsMixin, TestReactorMixin,
         self._http = self.successResultOf(
             fakehttpclientservice.HTTPClientService.getFakeService(
                 self.master, self, 'http://vaultServer', headers={'X-Vault-Token': "someToken"}))
-        self.srvcVault.setServiceParent(self.master)
+        yield self.srvcVault.setServiceParent(self.master)
         self.successResultOf(self.master.startService())
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_secret_rendered_service.py
+++ b/master/buildbot/test/unit/test_secret_rendered_service.py
@@ -28,6 +28,7 @@ class FakeServiceUsingSecrets(BuildbotService):
 
 class TestRenderSecrets(TestReactorMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self)
@@ -35,10 +36,10 @@ class TestRenderSecrets(TestReactorMixin, unittest.TestCase):
                                                        "other": "value"})
         self.secretsrv = SecretManager()
         self.secretsrv.services = [fakeStorageService]
-        self.secretsrv.setServiceParent(self.master)
+        yield self.secretsrv.setServiceParent(self.master)
         self.srvtest = FakeServiceUsingSecrets()
-        self.srvtest.setServiceParent(self.master)
-        self.successResultOf(self.master.startService())
+        yield self.srvtest.setServiceParent(self.master)
+        yield self.master.startService()
 
     @defer.inlineCallbacks
     def tearDown(self):

--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -265,12 +265,13 @@ class RealKubeClientServiceTest(TestReactorMixin, unittest.TestCase):
     def expect(self, *args, **kwargs):
         pass
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self)
         self.createKube()
-        self.kube.setServiceParent(self.master)
-        return self.master.startService()
+        yield self.kube.setServiceParent(self.master)
+        yield self.master.startService()
 
     def tearDown(self):
         return self.master.stopService()

--- a/master/buildbot/test/unit/test_util_service.py
+++ b/master/buildbot/test/unit/test_util_service.py
@@ -45,9 +45,10 @@ class AsyncMultiService(unittest.TestCase):
         yield self.svc.startService()
         yield self.svc.stopService()
 
+    @defer.inlineCallbacks
     def test_waits_for_child_services(self):
         child = DeferredStartStop()
-        child.setServiceParent(self.svc)
+        yield child.setServiceParent(self.svc)
 
         d = self.svc.startService()
         self.assertFalse(d.called)
@@ -59,9 +60,10 @@ class AsyncMultiService(unittest.TestCase):
         child.d.callback(None)
         self.assertTrue(d.called)
 
+    @defer.inlineCallbacks
     def test_child_fails(self):
         child = DeferredStartStop()
-        child.setServiceParent(self.svc)
+        yield child.setServiceParent(self.svc)
 
         d = self.svc.startService()
         self.assertFalse(d.called)
@@ -752,48 +754,51 @@ class UnderTestDependentService(service.AsyncService):
         assert self.dependent.running
 
 
-class SharedService(unittest.SynchronousTestCase):
+class SharedService(unittest.TestCase):
+    @defer.inlineCallbacks
     def test_bad_constructor(self):
         parent = service.AsyncMultiService()
-        self.failureResultOf(
-            UnderTestSharedService.getService(parent, arg2="foo"))
+        with self.assertRaises(Exception):
+            yield UnderTestSharedService.getService(parent, arg2="foo")
 
+    @defer.inlineCallbacks
     def test_creation(self):
         parent = service.AsyncMultiService()
-        r = self.successResultOf(UnderTestSharedService.getService(parent))
-        r2 = self.successResultOf(UnderTestSharedService.getService(parent))
-        r3 = self.successResultOf(
-            UnderTestSharedService.getService(parent, "arg1"))
-        r4 = self.successResultOf(
-            UnderTestSharedService.getService(parent, "arg1"))
+        r = yield UnderTestSharedService.getService(parent)
+        r2 = yield UnderTestSharedService.getService(parent)
+        r3 = yield UnderTestSharedService.getService(parent, "arg1")
+        r4 = yield UnderTestSharedService.getService(parent, "arg1")
         self.assertIdentical(r, r2)
         self.assertNotIdentical(r, r3)
         self.assertIdentical(r3, r4)
         self.assertEqual(len(list(iter(parent))), 2)
 
+    @defer.inlineCallbacks
     def test_startup(self):
         """the service starts when parent starts and stop"""
         parent = service.AsyncMultiService()
-        r = self.successResultOf(UnderTestSharedService.getService(parent))
+        r = yield UnderTestSharedService.getService(parent)
         self.assertEqual(r.running, 0)
-        self.successResultOf(parent.startService())
+        yield parent.startService()
         self.assertEqual(r.running, 1)
-        self.successResultOf(parent.stopService())
+        yield parent.stopService()
         self.assertEqual(r.running, 0)
 
+    @defer.inlineCallbacks
     def test_already_started(self):
         """the service starts during the getService if parent already started"""
         parent = service.AsyncMultiService()
-        self.successResultOf(parent.startService())
-        r = self.successResultOf(UnderTestSharedService.getService(parent))
+        yield parent.startService()
+        r = yield UnderTestSharedService.getService(parent)
         self.assertEqual(r.running, 1)
         # then we stop the parent, and the shared service stops
-        self.successResultOf(parent.stopService())
+        yield parent.stopService()
         self.assertEqual(r.running, 0)
 
+    @defer.inlineCallbacks
     def test_already_stopped_last(self):
         parent = service.AsyncMultiService()
         o = UnderTestDependentService()
         o.setServiceParent(parent)
-        self.successResultOf(parent.startService())
-        self.successResultOf(parent.stopService())
+        yield parent.startService()
+        yield parent.stopService()

--- a/master/buildbot/test/unit/test_util_service.py
+++ b/master/buildbot/test/unit/test_util_service.py
@@ -799,6 +799,6 @@ class SharedService(unittest.TestCase):
     def test_already_stopped_last(self):
         parent = service.AsyncMultiService()
         o = UnderTestDependentService()
-        o.setServiceParent(parent)
+        yield o.setServiceParent(parent)
         yield parent.startService()
         yield parent.stopService()

--- a/master/buildbot/test/unit/test_worker_manager.py
+++ b/master/buildbot/test/unit/test_worker_manager.py
@@ -47,17 +47,18 @@ class FakeWorker2(FakeWorker):
 
 class TestWorkerManager(TestReactorMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantData=True)
         self.master.mq = self.master.mq
         self.workers = workermanager.WorkerManager(self.master)
-        self.workers.setServiceParent(self.master)
+        yield self.workers.setServiceParent(self.master)
         # workers expect a botmaster as well as a manager.
         self.master.botmaster.disownServiceParent()
         self.botmaster = botmaster.BotMaster()
         self.master.botmaster = self.botmaster
-        self.master.botmaster.setServiceParent(self.master)
+        yield self.master.botmaster.setServiceParent(self.master)
 
         self.new_config = mock.Mock()
         self.workers.startService()
@@ -85,7 +86,7 @@ class TestWorkerManager(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_reconfigServiceWorkers_reconfig(self):
         worker = FakeWorker('worker1')
-        worker.setServiceParent(self.workers)
+        yield worker.setServiceParent(self.workers)
         worker.parent = self.master
         worker.manager = self.workers
         worker.botmaster = self.master.botmaster
@@ -101,7 +102,7 @@ class TestWorkerManager(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_reconfigServiceWorkers_class_changes(self):
         worker = FakeWorker('worker1')
-        worker.setServiceParent(self.workers)
+        yield worker.setServiceParent(self.workers)
 
         worker_new = FakeWorker2('worker1')
         self.new_config.workers = [worker_new]

--- a/master/buildbot/test/unit/test_worker_marathon.py
+++ b/master/buildbot/test/unit/test_worker_marathon.py
@@ -56,7 +56,7 @@ class TestMarathonLatentWorker(unittest.TestCase, TestReactorMixin):
         master = fakemaster.make_master(self, wantData=True)
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
                 master, self, 'tcp://marathon.local', auth=kwargs.get('auth'))
-        worker.setServiceParent(master)
+        yield worker.setServiceParent(master)
         worker.reactor = self.reactor
         yield master.startService()
         worker.masterhash = "masterhash"

--- a/master/buildbot/test/unit/test_worker_protocols_base.py
+++ b/master/buildbot/test/unit/test_worker_protocols_base.py
@@ -15,6 +15,7 @@
 
 import mock
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.test.fake import fakemaster
@@ -26,11 +27,12 @@ from buildbot.worker.protocols import base
 
 class TestListener(TestReactorMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def test_constructor(self):
         self.setUpTestReactor()
         master = fakemaster.make_master(self)
         listener = base.Listener()
-        listener.setServiceParent(master)
+        yield listener.setServiceParent(master)
         self.assertEqual(listener.master, master)
 
 

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -32,19 +32,21 @@ class TestListener(TestReactorMixin, unittest.TestCase):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self)
 
+    @defer.inlineCallbacks
     def makeListener(self):
         listener = pb.Listener()
-        listener.setServiceParent(self.master)
+        yield listener.setServiceParent(self.master)
         return listener
 
+    @defer.inlineCallbacks
     def test_constructor(self):
-        listener = self.makeListener()
+        listener = yield self.makeListener()
         self.assertEqual(listener.master, self.master)
         self.assertEqual(listener._registrations, {})
 
     @defer.inlineCallbacks
     def test_updateRegistration_simple(self):
-        listener = self.makeListener()
+        listener = yield self.makeListener()
         reg = yield listener.updateRegistration('example', 'pass', 'tcp:1234')
         self.assertEqual(self.master.pbmanager._registrations,
                          [('tcp:1234', 'example', 'pass')])
@@ -53,7 +55,7 @@ class TestListener(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_updateRegistration_pass_changed(self):
-        listener = self.makeListener()
+        listener = yield self.makeListener()
         listener.updateRegistration('example', 'pass', 'tcp:1234')
         reg1 = yield listener.updateRegistration('example', 'pass1', 'tcp:1234')
         self.assertEqual(
@@ -63,7 +65,7 @@ class TestListener(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_updateRegistration_port_changed(self):
-        listener = self.makeListener()
+        listener = yield self.makeListener()
         listener.updateRegistration('example', 'pass', 'tcp:1234')
         reg1 = yield listener.updateRegistration('example', 'pass', 'tcp:4321')
         self.assertEqual(
@@ -73,7 +75,7 @@ class TestListener(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_getPerspective(self):
-        listener = self.makeListener()
+        listener = yield self.makeListener()
         worker = mock.Mock()
         worker.workername = 'test'
         mind = mock.Mock()

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -59,6 +59,7 @@ class FakeResponse:
 class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin,
                  unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         if requests is None:
@@ -93,7 +94,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin,
                                                          "client-secret": "secretClientSecret"})
         secret_service = SecretManager()
         secret_service.services = [fake_storage_service]
-        secret_service.setServiceParent(self._master)
+        yield secret_service.setServiceParent(self._master)
         self.githubAuth_secret.reconfigAuth(master, master.config)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_www_service.py
+++ b/master/buildbot/test/unit/test_www_service.py
@@ -61,11 +61,12 @@ class NeedsReconfigResource(resource.Resource):
 
 class Test(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = self.make_master(url='h:/a/b/')
         self.svc = self.master.www = service.WWWService()
-        self.svc.setServiceParent(self.master)
+        yield self.svc.setServiceParent(self.master)
 
     def makeConfig(self, **kwargs):
         w = dict(port=None, auth=auth.NoAuth(), logfileName='l')

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -256,7 +256,7 @@ class RealDatabaseWithConnectorMixin(RealDatabaseMixin):
         yield self.setUpRealDatabase(table_names, basedir, want_pool, sqlite_memory)
         master.config.db['db_url'] = self.db_url
         master.db = DBConnector(self.basedir)
-        master.db.setServiceParent(master)
+        yield master.db.setServiceParent(master)
         master.db.pool = self.db_pool
 
     def tearDownRealDatabaseWithConnector(self):

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -194,7 +194,7 @@ class RunMasterBase(unittest.TestCase):
             self.w = None
 
         if self.w is not None:
-            self.w.setServiceParent(m)
+            yield self.w.setServiceParent(m)
 
         @defer.inlineCallbacks
         def dump():

--- a/master/buildbot/test/util/migration.py
+++ b/master/buildbot/test/util/migration.py
@@ -50,7 +50,7 @@ class MigrateTestMixin(TestReactorMixin, db.RealDatabaseMixin, dirs.DirsMixin):
 
         master = fakemaster.make_master(self)
         self.db = connector.DBConnector(self.basedir)
-        self.db.setServiceParent(master)
+        yield self.db.setServiceParent(master)
         self.db.pool = self.db_pool
 
     def tearDownMigrateTest(self):

--- a/master/buildbot/util/maildir.py
+++ b/master/buildbot/util/maildir.py
@@ -63,6 +63,7 @@ class MaildirService(service.BuildbotService):
         self.newdir = os.path.join(self.basedir, "new")
         self.curdir = os.path.join(self.basedir, "cur")
 
+    @defer.inlineCallbacks
     def startService(self):
         if not os.path.isdir(self.newdir) or not os.path.isdir(self.curdir):
             raise NoSuchMaildir("invalid maildir '%s'" % self.basedir)
@@ -81,9 +82,9 @@ class MaildirService(service.BuildbotService):
         if not self.dnotify:
             self.timerService = internet.TimerService(
                 self.pollinterval, self.poll)
-            self.timerService.setServiceParent(self)
+            yield self.timerService.setServiceParent(self)
         self.poll()
-        return super().startService()
+        yield super().startService()
 
     def dnotify_callback(self):
         log.msg("dnotify noticed something, now polling")

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -48,8 +48,8 @@ class Listener(base.Listener):
                 yield currentReg.unregister()
                 del self._registrations[username]
             if portStr and password:
-                reg = self.master.pbmanager.register(
-                    portStr, username, password, self._getPerspective)
+                reg = yield self.master.pbmanager.register(portStr, username, password,
+                                                           self._getPerspective)
                 self._registrations[username] = (password, portStr, reg)
                 return reg
 

--- a/worker/buildbot_worker/base.py
+++ b/worker/buildbot_worker/base.py
@@ -70,8 +70,9 @@ class WorkerForBuilderBase(service.Service):
     def __repr__(self):
         return "<WorkerForBuilder '{0}' at {1}>".format(self.name, id(self))
 
+    @defer.inlineCallbacks
     def setServiceParent(self, parent):
-        service.Service.setServiceParent(self, parent)
+        yield service.Service.setServiceParent(self, parent)
         self.bot = self.parent
         # note that self.parent will go away when the buildmaster's config
         # file changes and this Builder is removed (possibly because it has


### PR DESCRIPTION
In many cases we don't wait for the result of `setServiceParent()`. This may result in test unreliability, because some actions performed by `setServiceParent()` may end up being being done after the specific unit test ends. This PR improves the situation.