### PR TITLE
config: Warn if Buildbot title is too long

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -726,6 +726,7 @@ jobfiles
 jobid
 joe
 jonathan
+js
 json
 jsonable
 jsonapi

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -389,6 +389,15 @@ class MasterConfig(util.ComparableMixin):
                        check_type=(str,), check_type_name='a string')
 
         copy_str_param('title', alt_key='projectName')
+
+        max_title_len = 18
+        if len(self.title) > max_title_len:
+            # Warn if the title length limiting logic in www/base/src/app/app.route.js
+            # would hide the title.
+            warnings.warn('WARNING: Title is too long to be displayed. ' +
+                          '"Buildbot" will be used instead.',
+                          category=ConfigWarning)
+
         copy_str_param('titleURL', alt_key='projectURL')
         copy_str_param('buildbotURL')
 

--- a/master/buildbot/newsfragments/warn-if-title-too-long.bugfix
+++ b/master/buildbot/newsfragments/warn-if-title-too-long.bugfix
@@ -1,0 +1,1 @@
+Warn if Buildbot title in the configuration is too long and will be ignored.

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -465,6 +465,11 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
     def test_load_global_title(self):
         self.do_test_load_global(dict(title='hi'), title='hi')
 
+    def test_load_global_title_too_long(self):
+        with assertProducesWarning(config.ConfigWarning,
+                                   message_pattern=r"Title is too long"):
+            self.do_test_load_global(dict(title="Very very very very very long title"))
+
     def test_load_global_projectURL(self):
         self.do_test_load_global(dict(projectName='hey'), title='hey')
 

--- a/www/base/src/app/app.route.js
+++ b/www/base/src/app/app.route.js
@@ -9,12 +9,17 @@ class Route {
         $urlRouterProvider.otherwise(config.default_page || '/');
         // the app title needs to be < 18 chars else the UI looks bad
         // we try to find best option
+
+        // Note that we warn about too long title in master/buildbot/config.py.
+        // Adjust that code if the maximum length changes.
+        let max_title_len = 18;
+
         if (config.title != null) {
             apptitle = `Buildbot: ${config.title}`;
-            if (apptitle.length > 18) {
+            if (apptitle.length > max_title_len) {
                 apptitle = config.title;
             }
-            if (apptitle.length > 18) {
+            if (apptitle.length > max_title_len) {
                 apptitle = "Buildbot";
             }
         } else {


### PR DESCRIPTION
While changing Buildbot title, no warning is thrown if title is too long. There is no way to know why it is not working.
This PR adds a warning for this case.