### PR TITLE
docs: Clarify introduction into BuildBot

### DIFF
--- a/master/docs/manual/configuration/buildsets.rst
+++ b/master/docs/manual/configuration/buildsets.rst
@@ -1,0 +1,36 @@
+.. _BuildSet:
+
+Build Sets
+==========
+
+A :class:`BuildSet` represents a set of :class:`Build`\s that all compile and/or test the same version of the source tree.
+Usually, these builds are created by multiple :class:`Builder`\s and will thus execute different steps.
+
+The :class:`BuildSet` is tracked as a single unit, which fails if any of the component :class:`Build`\s have failed, and therefore can succeed only if *all* of the component :class:`Build`\s have succeeded.
+There are two kinds of status notification messages that can be emitted for a :class:`BuildSet`: the ``firstFailure`` type (which fires as soon as we know the :class:`BuildSet` will fail), and the ``Finished`` type (which fires once the :class:`BuildSet` has completely finished, regardless of whether the overall set passed or failed).
+
+A :class:`BuildSet` is created with set of one or more *source stamp* tuples of ``(branch, revision, changes, patch)``, some of which may be ``None``, and a list of :class:`Builder`\s on which it is to be run.
+They are then given to the BuildMaster, which is responsible for creating a separate :class:`BuildRequest` for each :class:`Builder`.
+
+There are a couple of different likely values for the ``SourceStamp``:
+
+:samp:`(revision=None, changes={CHANGES}, patch=None)`
+    This is a :class:`SourceStamp` used when a series of :class:`Change`\s have triggered a build.
+    The VC step will attempt to check out a tree that contains *CHANGES* (and any changes that occurred before *CHANGES*, but not any that occurred after them.)
+
+:samp:`(revision=None, changes=None, patch=None)`
+    This builds the most recent code on the default branch.
+    This is the sort of :class:`SourceStamp` that would be used on a :class:`Build` that was triggered by a user request, or a :bb:sched:`Periodic` scheduler.
+    It is also possible to configure the VC Source Step to always check out the latest sources rather than paying attention to the :class:`Change`\s in the :class:`SourceStamp`, which will result in same behavior as this.
+
+:samp:`(branch={BRANCH}, revision=None, changes=None, patch=None)`
+    This builds the most recent code on the given *BRANCH*.
+    Again, this is generally triggered by a user request or a :bb:sched:`Periodic` scheduler.
+
+:samp:`(revision={REV}, changes=None, patch=({LEVEL}, {DIFF}, {SUBDIR_ROOT}))`
+    This checks out the tree at the given revision *REV*, then applies a patch (using ``patch -pLEVEL <DIFF``) from inside the relative directory *SUBDIR_ROOT*.
+    Item *SUBDIR_ROOT* is optional and defaults to the builder working directory.
+    The :bb:cmdline:`try` command creates this kind of :class:`SourceStamp`.
+    If ``patch`` is ``None``, the patching step is bypassed.
+
+The buildmaster is responsible for turning the :class:`BuildSet` into a set of :class:`BuildRequest` objects and queueing them on the appropriate :class:`Builder`\s.

--- a/master/docs/manual/configuration/index.rst
+++ b/master/docs/manual/configuration/index.rst
@@ -19,6 +19,7 @@ The next section, :doc:`../customization`, describes this approach, with frequen
     workers
     builders
     buildfactories
+    buildsets
     properties
     buildsteps
     interlocks

--- a/master/docs/manual/introduction.rst
+++ b/master/docs/manual/introduction.rst
@@ -4,12 +4,12 @@ Introduction
 ============
 
 Buildbot is a system to automate the compile/test cycle required by most software projects to validate code changes.
-By automatically rebuilding and testing the tree each time something has changed, build problems are pinpointed quickly, before other developers are inconvenienced by the failure.
+By automatically rebuilding and testing the project each time something has changed, build problems are pinpointed quickly, before other developers are inconvenienced by the failure.
 The guilty developer can be identified and harassed without human intervention.
 By running the builds on a variety of platforms, developers who do not have the facilities to test their changes everywhere before checkin will at least know shortly afterwards whether they have broken the build or not.
 Warning counts, lint checks, image size, compile time, and other build parameters can be tracked over time, are more visible, and are therefore easier to improve.
 
-The overall goal is to reduce tree breakage and provide a platform to run tests or code-quality checks that are too annoying or pedantic for any human to waste their time with.
+The overall goal is to reduce project breakage and provide a platform to run tests or code-quality checks that are too annoying or pedantic for any human to waste their time with.
 Developers get immediate (and potentially public) feedback about their changes, encouraging them to be more careful about testing before checkin.
 
 Features:
@@ -31,8 +31,8 @@ History and Philosophy
 
 The Buildbot was inspired by a similar project built for a development team writing a cross-platform embedded system.
 The various components of the project were supposed to compile and run on several flavors of unix (linux, solaris, BSD), but individual developers had their own preferences and tended to stick to a single platform.
-From time to time, incompatibilities would sneak in (some unix platforms want to use :file:`string.h`, some prefer :file:`strings.h`), and then the tree would compile for some developers but not others.
-The Buildbot was written to automate the human process of walking into the office, updating a tree, compiling (and discovering the breakage), finding the developer at fault, and complaining to them about the problem they had introduced.
+From time to time, incompatibilities would sneak in (some unix platforms want to use :file:`string.h`, some prefer :file:`strings.h`), and then the project would compile for some developers but not others.
+The Buildbot was written to automate the human process of walking into the office, updating a project, compiling (and discovering the breakage), finding the developer at fault, and complaining to them about the problem they had introduced.
 With multiple platforms it was difficult for developers to do the right thing (compile their potential change on all platforms); the Buildbot offered a way to help.
 
 Another problem was when programmers would change the behavior of a library without warning its users, or change internal aspects that other code was (unfortunately) depending upon.
@@ -40,7 +40,7 @@ Adding unit tests to the codebase helps here: if an application's unit tests pas
 Many developers complained that the unit tests were inconvenient or took too long to run: having the Buildbot run them reduces the developer's workload to a minimum.
 
 In general, having more visibility into the project is always good, and automation makes it easier for developers to do the right thing.
-When everyone can see the status of the project, developers are encouraged to keep the tree in good working order.
+When everyone can see the status of the project, developers are encouraged to keep the project in good working order.
 Unit tests that aren't run on a regular basis tend to suffer from bitrot just like code does: exercising them on a regular basis helps to keep them functioning and useful.
 
 The current version of the Buildbot is additionally targeted at distributed free-software projects, where resources and platforms are only available when provided by interested volunteers.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -489,6 +489,7 @@ MaxQ
 maxWarnCount
 mbcs
 md
+mergeability
 mergeable
 metabuildbot
 metacharacters

--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -19,6 +19,21 @@ For those more familiar with Docker_, there also exists a :ref:`docker version o
 
 You should be able to cut and paste each shell block from this tutorial directly into a terminal.
 
+Simple introduction to BuildBot
+-------------------------------
+
+Before trying to run BuildBot it's helpful to know what BuildBot is.
+
+BuildBot is a continuous integration framework written in Python.
+It consists of a master daemon and potentially many worker daemons that usually run on other machines.
+The master daemon runs a web server that allows the end user to start new builds and to control the behaviour of the BuildBot instance.
+The master also distributes builds to the workers.
+The worker daemons connect to the master daemon and execute builds whenever master tells them to do so.
+
+In this tutorial we will run a single master and a single worker on the same machine.
+
+A more throughout explanation can be found in the :ref:`manual section <Introduction>` of the Buildbot documentation.
+
 .. _Docker: https://docker.com
 
 .. _getting-code-label:
@@ -81,6 +96,8 @@ Now that buildbot is installed, it's time to create the master:
   buildbot create-master master
 
 Buildbot's activity is controlled by a configuration file.
+Buildbot by default uses configuration from file at ``master.cfg``.
+Buildbot comes with a sample configuration file named ``master.cfg.sample``.
 We will use the sample configuration file unchanged:
 
 .. code-block:: bash
@@ -187,7 +204,7 @@ You should now be able to go to http://localhost:8010, where you will see a web 
 .. image:: _images/index.png
    :alt: index page
 
-Click on "Builds" at the left to open the submenu and then `Builders <http://localhost:8010/#/builders>`_ to see that the worker you just started has connected to the master:
+Click on "Builds" at the left to open the submenu and then `Builders <http://localhost:8010/#/builders>`_ to see that the worker you just started (identified by the green bubble) has connected to the master:
 
 .. image:: _images/builders.png
    :alt: builder runtests is active.

--- a/master/docs/tutorial/tour.rst
+++ b/master/docs/tutorial/tour.rst
@@ -28,7 +28,7 @@ Let's start simple by looking at where you would customize the buildbot's projec
 
 We continue where we left off in the :ref:`first-run-label` tutorial.
 
-Open a new terminal, and first enter the same sandbox you created before (where ``$EDITOR`` is your editor of choice like vim, gedit, or emacs):
+Open a new terminal, go to the directory you created master in, activate the same virtualenv instance you created before, and open the master configuration file with an editor (here ``$EDITOR`` is your editor of choice like vim, gedit, or emacs):
 
 .. code-block:: bash
 
@@ -162,7 +162,7 @@ Buildbot includes an IRC bot that you can tell to join a channel and control to 
 
 .. note:: Security Note
 
-    Please note that any user having access to your irc channel or can PM the bot will be able to create or stop builds :bug:`3377`.
+    Please note that any user having access to your irc channel or can send the private message to the bot will be able to create or stop builds :bug:`3377`.
 
 First, start an IRC client of your choice, connect to irc.freenode.net and join an empty channel.
 In this example we will use ``#buildbot-test``, so go join that channel.


### PR DESCRIPTION
In the current introduction many parts were unclear and overloaded with unnecessary information for introduction. Usually the details are explained in later parts of documentation.