### PR TITLE
Repeat master-side keepalive requests

### DIFF
--- a/master/buildbot/newsfragments/master-side-keepalive-repeat.bugfix
+++ b/master/buildbot/newsfragments/master-side-keepalive-repeat.bugfix
@@ -1,0 +1,1 @@
+Master side keep-alive requests are now repeated instead of being single-shot (:issue:`3630`).

--- a/master/buildbot/test/fake/fakeprotocol.py
+++ b/master/buildbot/test/fake/fakeprotocol.py
@@ -27,6 +27,9 @@ class FakeTrivialConnection:
     def __init__(self):
         self._disconnectSubs = subscription.SubscriptionPoint("disconnections from Fake")
 
+    def waitShutdown(self):
+        return defer.succeed(None)
+
     def notifyOnDisconnect(self, cb):
         return self._disconnectSubs.subscribe(cb)
 

--- a/master/buildbot/test/unit/test_util_deferwaiter.py
+++ b/master/buildbot/test/unit/test_util_deferwaiter.py
@@ -13,17 +13,22 @@
 #
 # Copyright Buildbot Team Members
 
+from parameterized import parameterized
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
+from buildbot.test.util.misc import TestReactorMixin
+from buildbot.util import asyncSleep
 from buildbot.util.deferwaiter import DeferWaiter
+from buildbot.util.deferwaiter import RepeatedActionHandler
 
 
 class TestException(Exception):
     pass
 
 
-class Tests(unittest.TestCase):
+class WaiterTests(unittest.TestCase):
 
     def test_add_deferred_called(self):
         w = DeferWaiter()
@@ -48,3 +53,179 @@ class Tests(unittest.TestCase):
 
         d1.callback(None)
         self.assertTrue(d.called)
+
+
+class RepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):
+
+    def setUp(self):
+        self.setUpTestReactor()
+
+    @defer.inlineCallbacks
+    def test_does_not_add_action_on_start(self):
+        w = DeferWaiter()
+        times = []
+
+        def action():
+            times.append(self.reactor.seconds())
+
+        h = RepeatedActionHandler(self.reactor, w, 1, action)
+
+        self.reactor.advance(2)
+
+        h.stop()
+        self.assertEqual(len(times), 0)
+        d = w.wait()
+        self.assertTrue(d.called)
+        yield d
+
+    @parameterized.expand([
+        ('after_action', True),
+        ('before_action', False),
+    ])
+    @defer.inlineCallbacks
+    def test_runs_action_with_timer(self, name, timer_after_action):
+        w = DeferWaiter()
+        times = []
+
+        def action():
+            times.append(round(self.reactor.seconds(), 1))
+
+        h = RepeatedActionHandler(self.reactor, w, 1, action,
+                                  start_timer_after_action_completes=timer_after_action)
+        h.start()
+        self.reactor.pump([0.1] * 35)
+
+        self.assertEqual(times, [1.1, 2.1, 3.1])
+
+        h.stop()
+        d = w.wait()
+        self.assertTrue(d.called)
+        yield d
+
+    @parameterized.expand([
+        ('after_action', True),
+        ('before_action', False),
+    ])
+    @defer.inlineCallbacks
+    def test_runs_action_after_exception_with_timer(self, name, timer_after_action):
+        w = DeferWaiter()
+        times = []
+
+        def action():
+            times.append(round(self.reactor.seconds(), 1))
+            if len(times) == 2:
+                raise TestException()
+
+        h = RepeatedActionHandler(self.reactor, w, 1, action,
+                                  start_timer_after_action_completes=timer_after_action)
+        h.start()
+        self.reactor.pump([0.1] * 35)
+
+        self.assertEqual(times, [1.1, 2.1, 3.1])
+
+        h.stop()
+        d = w.wait()
+        self.assertTrue(d.called)
+
+        self.flushLoggedErrors(TestException)
+
+        yield d
+
+    @defer.inlineCallbacks
+    def test_ignores_duplicate_start_or_stop(self):
+        w = DeferWaiter()
+        times = []
+
+        def action():
+            times.append(round(self.reactor.seconds(), 1))
+
+        h = RepeatedActionHandler(self.reactor, w, 1, action)
+        h.start()
+        h.start()
+        self.reactor.pump([0.1] * 35)
+
+        self.assertEqual(times, [1.1, 2.1, 3.1])
+
+        h.stop()
+        h.stop()
+        d = w.wait()
+        self.assertTrue(d.called)
+        yield d
+
+    @defer.inlineCallbacks
+    def test_can_update_interval(self):
+        w = DeferWaiter()
+        times = []
+
+        def action():
+            times.append(round(self.reactor.seconds(), 1))
+
+        h = RepeatedActionHandler(self.reactor, w, 1, action)
+        h.start()
+        self.reactor.pump([0.1] * 15)
+        h.setInterval(2)
+        self.reactor.pump([0.1] * 50)
+
+        self.assertEqual(times, [1.1, 2.1, 4.1, 6.2])
+
+        h.stop()
+        d = w.wait()
+        self.assertTrue(d.called)
+        yield d
+
+    @parameterized.expand([
+        ('after_action', True, [1.1, 2.6, 4.1]),
+        ('before_action', False, [1.1, 2.1, 3.1, 4.1]),
+    ])
+    @defer.inlineCallbacks
+    def test_runs_action_with_timer_delay(self, name, timer_after_action, expected_times):
+        w = DeferWaiter()
+        times = []
+
+        @defer.inlineCallbacks
+        def action():
+            times.append(round(self.reactor.seconds(), 1))
+            yield asyncSleep(0.5, reactor=self.reactor)
+
+        h = RepeatedActionHandler(self.reactor, w, 1, action,
+                                  start_timer_after_action_completes=timer_after_action)
+        h.start()
+        self.reactor.pump([0.1] * 47)
+
+        self.assertEqual(times, expected_times)
+
+        h.stop()
+        d = w.wait()
+        self.assertTrue(d.called)
+        yield d
+
+    @parameterized.expand([
+        ('after_action', True),
+        ('before_action', False),
+    ])
+    @defer.inlineCallbacks
+    def test_waiter_waits_for_action_timer_starts(self, name, timer_after_action):
+
+        w = DeferWaiter()
+        times = []
+
+        @defer.inlineCallbacks
+        def action():
+            times.append(round(self.reactor.seconds(), 1))
+            yield asyncSleep(0.5, reactor=self.reactor)
+
+        h = RepeatedActionHandler(self.reactor, w, 1, action,
+                                  start_timer_after_action_completes=timer_after_action)
+        h.start()
+        self.reactor.pump([0.1] * 12)
+
+        self.assertEqual(times, [1.1])
+
+        d = w.wait()
+        self.assertFalse(d.called)
+        h.stop()
+        self.assertFalse(d.called)
+
+        self.reactor.pump([0.1] * 5)  # action started on 1.1, will end at 1.6
+        self.assertTrue(d.called)
+        yield d

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -384,8 +384,12 @@ def string2boolean(str):
     }[str.lower()]
 
 
-def asyncSleep(delay):
-    from twisted.internet import reactor, defer
+def asyncSleep(delay, reactor=None):
+    from twisted.internet import defer
+    from twisted.internet import reactor as internet_reactor
+    if reactor is None:
+        reactor = internet_reactor
+
     d = defer.Deferred()
     reactor.callLater(delay, d.callback, None)
     return d

--- a/master/buildbot/util/deferwaiter.py
+++ b/master/buildbot/util/deferwaiter.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 from twisted.internet import defer
+from twisted.python import log
 
 from buildbot.util import Notifier
 
@@ -42,3 +43,61 @@ class DeferWaiter:
         if not self._waited:
             return
         yield self._finish_notifier.wait()
+
+
+class RepeatedActionHandler:
+    """ This class handles a repeated action such as submitting keepalive requests. It integrates
+        with DeferWaiter to correctly control shutdown of such process.
+    """
+
+    def __init__(self, reactor, waiter, interval, action,
+                 start_timer_after_action_completes=False):
+        self._reactor = reactor
+        self._waiter = waiter
+        self._interval = interval
+        self._action = action
+        self._enabled = False
+        self._timer = None
+        self._start_timer_after_action_completes = start_timer_after_action_completes
+
+    def setInterval(self, interval):
+        self._interval = interval
+
+    def start(self):
+        if self._enabled:
+            return
+        self._enabled = True
+        self._start_timer()
+
+    def stop(self):
+        if not self._enabled:
+            return
+
+        self._enabled = False
+        if self._timer and self._timer.active():
+            self._timer.cancel()
+            self._timer = None
+
+    def _start_timer(self):
+        self._timer = self._reactor.callLater(self._interval, self._handle_timeout)
+
+    @defer.inlineCallbacks
+    def _do_action(self):
+        try:
+            yield self._action()
+        except Exception as e:
+            log.err(e, 'Got exception in RepeatedActionHandler')
+
+    def _handle_timeout(self):
+        self._waiter.add(self._handle_action())
+
+    @defer.inlineCallbacks
+    def _handle_action(self):
+        if self._start_timer_after_action_completes:
+            yield self._do_action()
+
+        if self._enabled:
+            self._start_timer()
+
+        if not self._start_timer_after_action_completes:
+            yield self._do_action()

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -494,6 +494,7 @@ class AbstractWorker(service.BuildbotService):
 
         self._handle_disconnection_delivery_notifier()
 
+        yield self.conn.waitShutdown()
         self.conn = None
         self._old_builder_list = []
         self.worker_status.setConnected(False)

--- a/master/buildbot/worker/protocols/base.py
+++ b/master/buildbot/worker/protocols/base.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from twisted.internet import defer
+
 from buildbot.util import service
 from buildbot.util import subscription
 
@@ -41,6 +43,9 @@ class Connection:
             newargs[k] = v
         return newargs
     # disconnection handling
+
+    def waitShutdown(self):
+        return defer.succeed(None)
 
     def notifyOnDisconnect(self, cb):
         return self._disconnectSubs.subscribe(cb)

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -200,10 +200,12 @@ Several small utilities are available at the top-level :mod:`buildbot.util` pack
     It returns the result of the wrapped function.
     If the wrapped function fails, its traceback will be printed, the reactor halted, and ``None`` returned.
 
-.. py:function:: asyncSleep(secs)
+.. py:function:: asyncSleep(secs, reactor=None)
 
     Yield a deferred that will fire with no result after ``secs`` seconds.
     This is the asynchronous equivalent to ``time.sleep``, and can be useful in tests.
+    In case a custom reactor is used, the ``reactor`` parameter may be set.
+    By default, ``twisted.internet.reactor`` is used.
 
 .. py:function:: stripUrlPassword(url)
 


### PR DESCRIPTION
Fixes issue #3630.

This PR improves the master-side keepalive behavior to send keepalive requests continuously instead of a single time like it was before. Additionally, one direct use of real `reactor` has been removed which could have been a source of test instability (we should always use `master.reactor`).

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
