### PR TITLE
Use `self.master.reactor` instead of twisted.internet.reactor

### DIFF
--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.python import log
 
 from buildbot import locks
@@ -103,7 +102,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
         self.brd.setServiceParent(self)
 
     @defer.inlineCallbacks
-    def cleanShutdown(self, quickMode=False, stopReactor=True, _reactor=reactor):
+    def cleanShutdown(self, quickMode=False, stopReactor=True):
         """Shut down the entire process, once all currently-running builds are
         complete.
         quickMode will mark all builds as retry (except the ones that were triggered)
@@ -168,7 +167,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
             else:
                 if stopReactor and self.shuttingDown:
                     log.msg("Stopping reactor")
-                    _reactor.stop()
+                    self.master.reactor.stop()
                 break
 
         if not self.shuttingDown:

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -21,7 +21,6 @@ from datetime import datetime
 from dateutil.tz import tzutc
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.python import log
 from twisted.python.failure import Failure
 
@@ -487,7 +486,7 @@ class BuildRequestDistributor(service.AsyncMultiService):
         self.active = False
 
     @defer.inlineCallbacks
-    def _maybeStartBuildsOnBuilder(self, bldr, _reactor=reactor):
+    def _maybeStartBuildsOnBuilder(self, bldr):
         # create a chooser to give us our next builds
         # this object is temporary and will go away when we're done
         bc = self.createBuildChooser(bldr, self.master)
@@ -499,7 +498,7 @@ class BuildRequestDistributor(service.AsyncMultiService):
 
             # claim brid's
             brids = [br.id for br in breqs]
-            claimed_at_epoch = _reactor.seconds()
+            claimed_at_epoch = self.master.reactor.seconds()
             claimed_at = epoch2datetime(claimed_at_epoch)
             if not (yield self.master.data.updates.claimBuildRequests(
                     brids, claimed_at=claimed_at)):

--- a/master/buildbot/test/integration/test_process_botmaster.py
+++ b/master/buildbot/test/integration/test_process_botmaster.py
@@ -52,9 +52,7 @@ class Tests(RunFakeMasterTestCase):
         # give time for any delayed actions to complete
         self.reactor.advance(1)
 
-        yield master.botmaster.cleanShutdown(quickMode=quick_mode,
-                                             _reactor=self.reactor,
-                                             stopReactor=False)
+        yield master.botmaster.cleanShutdown(quickMode=quick_mode, stopReactor=False)
         self.flushLoggedErrors(PingException)
 
     def test_terminates_ping_on_shutdown_quick_mode(self):

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -73,20 +73,20 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
 
     def test_shutdown_idle(self):
         """Test that the master shuts down when it's idle"""
-        self.botmaster.cleanShutdown(_reactor=self.reactor)
+        self.botmaster.cleanShutdown()
         self.assertReactorStopped()
 
     def test_shutdown_busy(self):
         """Test that the master shuts down after builds finish"""
         self.makeFakeBuild()
 
-        self.botmaster.cleanShutdown(_reactor=self.reactor)
+        self.botmaster.cleanShutdown()
 
         # check that we haven't stopped yet, since there's a running build
         self.assertReactorNotStopped()
 
         # try to shut it down again, just to check that this does not fail
-        self.botmaster.cleanShutdown(_reactor=self.reactor)
+        self.botmaster.cleanShutdown()
 
         # Now we cause the build to finish
         self.finishFakeBuild()
@@ -98,7 +98,7 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
         """Test that the master shuts down after builds finish"""
         self.makeFakeBuild()
 
-        self.botmaster.cleanShutdown(quickMode=True, _reactor=self.reactor)
+        self.botmaster.cleanShutdown(quickMode=True)
 
         # And now we should be stopped
         self.assertReactorStopped()
@@ -108,7 +108,7 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
         """Test that the master shuts down after builds finish"""
         self.makeFakeBuild(waitedFor=True)
 
-        self.botmaster.cleanShutdown(quickMode=True, _reactor=self.reactor)
+        self.botmaster.cleanShutdown(quickMode=True)
 
         # And now we should be stopped
         self.assertReactorStopped()
@@ -124,7 +124,7 @@ class TestCleanShutdown(TestReactorMixin, unittest.TestCase):
         """Test that we can cancel a shutdown"""
         self.makeFakeBuild()
 
-        self.botmaster.cleanShutdown(_reactor=self.reactor)
+        self.botmaster.cleanShutdown()
 
         # Next we check that we haven't stopped yet, since there's a running
         # build.

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -18,7 +18,6 @@ import random
 import mock
 
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.python import failure
 from twisted.trial import unittest
 
@@ -111,7 +110,7 @@ class TestBRDBase(TestReactorMixin, unittest.TestCase):
         def maybeStartBuild(worker, builds):
             self.startedBuilds.append((worker.name, builds))
             d = defer.Deferred()
-            reactor.callLater(0, d.callback, True)
+            self.reactor.callLater(0, d.callback, True)
             return d
         bldr.maybeStartBuild = maybeStartBuild
         bldr.getCollapseRequestsFn = lambda: False
@@ -193,7 +192,7 @@ class Test(TestBRDBase):
         def slow_sorter(master, bldrs):
             bldrs.sort(key=lambda b1: b1.name)
             d = defer.Deferred()
-            reactor.callLater(0, d.callback, bldrs)
+            self.reactor.callLater(0, d.callback, bldrs)
 
             def done(_):
                 return _
@@ -217,8 +216,7 @@ class Test(TestBRDBase):
         def _maybeStartBuildsOnBuilder(n):
             # fail slowly, so that the activity loop doesn't exit too soon
             d = defer.Deferred()
-            reactor.callLater(0,
-                              d.errback, failure.Failure(RuntimeError("oh noes")))
+            self.reactor.callLater(0, d.errback, failure.Failure(RuntimeError("oh noes")))
             return d
         self.brd._maybeStartBuildsOnBuilder = _maybeStartBuildsOnBuilder
 
@@ -460,7 +458,7 @@ class TestMaybeStartBuilds(TestBRDBase):
             res_d = old_getBuildRequests(*args, **kwargs)
             long_d = defer.Deferred()
             long_d.addCallback(lambda _: res_d)
-            reactor.callLater(0, long_d.callback, None)
+            self.reactor.callLater(0, long_d.callback, None)
             return long_d
         self.master.db.buildrequests.getBuildRequests = longGetBuildRequests
 


### PR DESCRIPTION
This PR removes a couple of uses of the real reactor in common code paths. We should use `self.master.reactor` in these cases to prevent race conditions in tests.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
