### PR TITLE
worker: Allow ipv6 address for master connection on buildbot-worker

### DIFF
--- a/master/buildbot/newsfragments/buildbot-worker-ipv6.bugfix
+++ b/master/buildbot/newsfragments/buildbot-worker-ipv6.bugfix
@@ -1,0 +1,1 @@
+Command `buildbot-worker create-worker` now supports ipv6 address for buildmaster connection.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -408,6 +408,7 @@ iPhone
 IProperties
 iptables
 IPv
+ipv
 irc
 Irc
 IRenderable

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -158,11 +158,24 @@ class CreateWorkerOptions(MakerBase):
         if master_arg[:5] == "http:":
             raise usage.UsageError("<master> is not a URL - do not use URL")
 
-        if ":" not in master_arg:
+        if master_arg.startswith("[") and "]" in master_arg:
+            # detect ipv6 address with format [2001:1:2:3:4::1]:4321
+            master, port_tmp = master_arg.split("]")
+            master = master[1:]
+            if ":" not in port_tmp:
+                port = 9989
+            else:
+                port = port_tmp.split(":")[1]
+
+        elif ":" not in master_arg:
             master = master_arg
             port = 9989
         else:
-            master, port = master_arg.split(":")
+            try:
+                master, port = master_arg.split(":")
+            except ValueError:
+                raise usage.UsageError("invalid <master> argument '{}', "
+                                       "if it is an ipv6 address, it must be enclosed by []".format(master_arg))
 
         if not master:
             raise usage.UsageError("invalid <master> argument '{}'".format(

--- a/worker/buildbot_worker/test/unit/test_scripts_runner.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_runner.py
@@ -282,12 +282,63 @@ class TestCreateWorkerOptions(OptionsMixin, unittest.TestCase):
     def test_validateMasterArgument_ok(self):
         """
         test calling CreateWorkerOptions.validateMasterArgument()
-        on <master> without host and port parts specified.
+        on <master> with host and port parts specified.
         """
         opts = runner.CreateWorkerOptions()
         self.assertEqual(opts.validateMasterArgument("mstrhost:4321"),
                          ("mstrhost", 4321),
                          "incorrect master host and/or port")
+
+    def test_validateMasterArgument_ipv4(self):
+        """
+        test calling CreateWorkerOptions.validateMasterArgument()
+        on <master> with ipv4 host specified.
+        """
+        opts = runner.CreateWorkerOptions()
+        self.assertEqual(opts.validateMasterArgument("192.168.0.0"),
+                         ("192.168.0.0", 9989),
+                         "incorrect master host and/or port")
+
+    def test_validateMasterArgument_ipv4_port(self):
+        """
+        test calling CreateWorkerOptions.validateMasterArgument()
+        on <master> with ipv4 host and port parts specified.
+        """
+        opts = runner.CreateWorkerOptions()
+        self.assertEqual(opts.validateMasterArgument("192.168.0.0:4321"),
+                         ("192.168.0.0", 4321),
+                         "incorrect master host and/or port")
+
+    def test_validateMasterArgument_ipv6(self):
+        """
+        test calling CreateWorkerOptions.validateMasterArgument()
+        on <master> with ipv6 host specified.
+        """
+        opts = runner.CreateWorkerOptions()
+        self.assertEqual(opts.validateMasterArgument("[2001:1:2:3:4::1]"),
+                         ("2001:1:2:3:4::1", 9989),
+                         "incorrect master host and/or port")
+
+    def test_validateMasterArgument_ipv6_port(self):
+        """
+        test calling CreateWorkerOptions.validateMasterArgument()
+        on <master> with ipv6 host and port parts specified.
+        """
+        opts = runner.CreateWorkerOptions()
+        self.assertEqual(opts.validateMasterArgument("[2001:1:2:3:4::1]:4321"),
+                         ("2001:1:2:3:4::1", 4321),
+                         "incorrect master host and/or port")
+
+    def test_validateMasterArgument_ipv6_no_bracket(self):
+        """
+        test calling CreateWorkerOptions.validateMasterArgument()
+        on <master> with ipv6 without [] specified.
+        """
+        opts = runner.CreateWorkerOptions()
+        with self.assertRaisesRegex(usage.UsageError,
+                              r"invalid <master> argument '2001:1:2:3:4::1:4321', "
+                              r"if it is an ipv6 address, it must be enclosed by \[\]"):
+            opts.validateMasterArgument("2001:1:2:3:4::1:4321")
 
 
 class TestOptions(misc.StdoutAssertionsMixin, unittest.TestCase):


### PR DESCRIPTION
This fixes #5155.

## Contributor Checklist:

* [X] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)