### PR TITLE
worker: add option to delete leftover dirs

### DIFF
--- a/master/buildbot/newsfragments/worker_deleteleftoverdirs.feature
+++ b/master/buildbot/newsfragments/worker_deleteleftoverdirs.feature
@@ -1,0 +1,1 @@
+New ``buildbot-worker create-worker --delete-leftover-dirs`` option to automatically remove obsolete builder directories

--- a/master/docs/manual/installation/worker.rst
+++ b/master/docs/manual/installation/worker.rst
@@ -171,6 +171,12 @@ To use these, just include them on the ``buildbot-worker create-worker`` command
     If set, the generated connection string starts with ``tls`` instead of with ``tcp``, allowing encrypted connection to the buildmaster.
     Make sure the worker trusts the buildmasters certificate. If you have an non-authoritative certificate (CA is self-signed) see ``connection_string`` below.
 
+.. option:: --delete-leftover-dirs
+
+    Can also be passed directly to the Worker constructor in :file:`buildbot.tac`.
+    If set, unexpected directories in worker base directory will be removed.
+    Otherwise, a warning will be displayed in :file:`twistd.log` so that you can manually remove them.
+
 .. _Other-Worker-Configuration:
 
 Other Worker Configuration

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -179,7 +179,8 @@ class Worker(WorkerBase, service.MultiService):
     def __init__(self, buildmaster_host, port, name, passwd, basedir,
                  keepalive, usePTY=None, keepaliveTimeout=None, umask=None,
                  maxdelay=None, numcpus=None, unicode_encoding=None, useTls=None,
-                 allow_shutdown=None, maxRetries=None, connection_string=None):
+                 allow_shutdown=None, maxRetries=None, connection_string=None,
+                 delete_leftover_dirs=False):
 
         assert usePTY is None, "worker-side usePTY is not supported anymore"
         assert (connection_string is None or
@@ -189,7 +190,8 @@ class Worker(WorkerBase, service.MultiService):
 
         service.MultiService.__init__(self)
         WorkerBase.__init__(
-            self, name, basedir, umask=umask, unicode_encoding=unicode_encoding)
+            self, name, basedir, umask=umask, unicode_encoding=unicode_encoding,
+            delete_leftover_dirs=delete_leftover_dirs)
         if keepalive == 0:
             keepalive = None
 

--- a/worker/buildbot_worker/scripts/create_worker.py
+++ b/worker/buildbot_worker/scripts/create_worker.py
@@ -59,11 +59,13 @@ numcpus = %(numcpus)s
 allow_shutdown = %(allow-shutdown)s
 maxretries = %(maxretries)s
 use_tls = %(use-tls)s
+delete_leftover_dirs = %(delete-leftover-dirs)s
 
 s = Worker(buildmaster_host, port, workername, passwd, basedir,
            keepalive, umask=umask, maxdelay=maxdelay,
            numcpus=numcpus, allow_shutdown=allow_shutdown,
-           maxRetries=maxretries, useTls=use_tls)
+           maxRetries=maxretries, useTls=use_tls,
+           delete_leftover_dirs=delete_leftover_dirs)
 s.setServiceParent(application)
 """]
 

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -108,6 +108,8 @@ class CreateWorkerOptions(MakerBase):
          "Do not permit buildmaster rotate logs by itself"],
         ['use-tls', None,
          "Uses TLS to connect to master"],
+        ['delete-leftover-dirs', None,
+         'Delete folders that are not required by the master on connection'],
     ]
     optParameters = [
         ["keepalive", "k", 600,

--- a/worker/docker/buildbot.tac
+++ b/worker/docker/buildbot.tac
@@ -33,8 +33,10 @@ umask = None
 maxdelay = 300
 allow_shutdown = None
 maxretries = 10
+delete_leftover_dirs = False
 
 s = Worker(buildmaster_host, port, workername, passwd, basedir,
            keepalive, umask=umask, maxdelay=maxdelay,
-           allow_shutdown=allow_shutdown, maxRetries=maxretries)
+           allow_shutdown=allow_shutdown, maxRetries=maxretries,
+           delete_leftover_dirs=delete_leftover_dirs)
 s.setServiceParent(application)

--- a/worker/docs/buildbot-worker.1
+++ b/worker/docs/buildbot-worker.1
@@ -62,6 +62,9 @@ create-worker
 .I COUNT
 ]
 [
+.BR \-\-delete\-leftover\-dirs
+]
+[
 .BR \-\-verbose
 ]
 .I PATH
@@ -167,6 +170,9 @@ for more details.
 Set whether child processes should be run in a pty (0 means do not run in a
 pty).
 Default value is 0.
+.TP
+.BR \-\-delete\-leftover\-dirs
+Set to remove unexpected directories in worker base directory.
 .TP
 .I PATH
 Path to worker base directory.


### PR DESCRIPTION
Removing these leftover directories can be forgotten resulting in
increasing disk usage.

Add an option to create-workers to remove these directories when
detected (disabled by default to keep current behaviour).

> $ buildbot-worker create-worker --delete-leftover-dirs <dir> <server>
<name> <password>
> mkdir -p <dir>/TFA-test
> 2020-01-17 14:38:55+0100 [Broker,client] Deleting directory 'TFA-test' that is not being used by the buildmaster

Signed-off-by: Robin Jarry <robin@jarry.cc>
Signed-off-by: Thomas Faivre <thomas.faivre@6wind.com>

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
