### PR TITLE
Fix pyinstaller interop tests

### DIFF
--- a/master/buildbot/test/util/sandboxed_worker.py
+++ b/master/buildbot/test/util/sandboxed_worker.py
@@ -69,8 +69,8 @@ class SandboxedWorker(AsyncService):
 
         self.processprotocol = processProtocol = WorkerProcessProtocol()
         # we need to spawn the worker asynchronously though
-        self.process = reactor.spawnProcess(
-            processProtocol, self.sandboxed_worker_path, args=['bbw', 'start', '--nodaemon', self.workerdir])
+        args = [self.sandboxed_worker_path, 'start', '--nodaemon', self.workerdir]
+        self.process = reactor.spawnProcess(processProtocol, self.sandboxed_worker_path, args=args)
 
         self.worker = self.master.workers.getWorkerByName(self.workername)
         return super().startService()


### PR DESCRIPTION
Looks like pyinstaller interop tests failed https://circleci.com/gh/buildbot/buildbot/9430?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link.

I think this could be caused by an upgrade changing how pyinstaller works. The fix is obvious and low-risk, so I didn't verify whether this hypothesis is correct.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
