### PR TITLE
latent: Fix issues in stopService()

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -680,6 +680,7 @@ insubstantiate
 insubstantiated
 insubstantiating
 insubstantiation
+insubstantiations
 integrations
 internet
 interoperability

--- a/master/buildbot/newsfragments/fix_crash_latent_stopservice.bugfix
+++ b/master/buildbot/newsfragments/fix_crash_latent_stopservice.bugfix
@@ -1,0 +1,1 @@
+Fix crash in latent worker stopService() when the worker is insubstantiating (:issue:`4935`).

--- a/master/buildbot/newsfragments/fix_race_condition_latent_stopservice.bugfix
+++ b/master/buildbot/newsfragments/fix_race_condition_latent_stopservice.bugfix
@@ -1,0 +1,1 @@
+Fix race condition between latent worker's stopService() and substantiate().

--- a/master/buildbot/newsfragments/latent_worker_does_not_wait_builds_finish.bugfix
+++ b/master/buildbot/newsfragments/latent_worker_does_not_wait_builds_finish.bugfix
@@ -1,0 +1,2 @@
+Latent workers will no longer wait for builds to finish when worker is reconfigured.
+The builds will still be retried on other workers and the operators will not need to potentially wait multiple hours for builds to finish.

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -13,12 +13,14 @@
 #
 # Copyright Buildbot Team Members
 
+from parameterized import parameterized
 
 from twisted.internet import defer
 from twisted.python.failure import Failure
 from twisted.spread import pb
 
 from buildbot.config import BuilderConfig
+from buildbot.config import MasterConfig
 from buildbot.interfaces import LatentWorkerCannotSubstantiate
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate
 from buildbot.interfaces import LatentWorkerSubstantiatiationCancelled
@@ -130,6 +132,15 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         ]
 
         return controller, master, builder_ids
+
+    def reconfig_workers_remove_all(self, master):
+        # returns a deferred that fires when the worker has been successfully removed
+        config_dict = {
+            'workers': [],
+            'multiMaster': True
+        }
+        config = MasterConfig.loadFromDict(config_dict, '<dict>')
+        return master.workers.reconfigServiceWithBuildbotConfig(config)
 
     @defer.inlineCallbacks
     def test_latent_workers_start_in_parallel(self):
@@ -461,7 +472,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield self.assertBuildResults(1, RETRY)
 
     @defer.inlineCallbacks
-    def test_insubstantiation_during_stop_service_waits_for_insubstantiation(self):
+    def test_stopservice_during_insubstantiation_completes(self):
         """
         When stopService is called and a worker is insubstantiating, we should wait for this
         process to complete.
@@ -476,12 +487,43 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield self.assertBuildResults(1, SUCCESS)
         self.assertTrue(controller.started)
 
-        # Wait until worker starts insubstantiation and then shutdown master
+        # Wait until worker starts insubstantiation and then shutdown worker
         self.reactor.advance(1)
         self.assertTrue(controller.stopping)
 
-        d = master.stopService()
+        d = self.reconfig_workers_remove_all(master)
         self.assertFalse(d.called)
+        yield controller.stop_instance(True)
+        yield d
+
+    @parameterized.expand([
+        ('with_substantiation_failure', False, False),
+        ('without_worker_connecting', True, False),
+        ('with_worker_connecting', True, True),
+    ])
+    @defer.inlineCallbacks
+    def test_stopservice_during_substantiation_completes(self, name, subst_success,
+                                                         worker_connects):
+        """
+        When stopService is called and a worker is substantiating, we should wait for this
+        process to complete.
+        """
+        controller, master, builder_id = yield self.create_single_worker_config(
+            controller_kwargs=dict(build_wait_timeout=1))
+        controller.auto_connect_worker = worker_connects
+
+        # Substantiate worker via a build
+        yield self.createBuildrequest(master, [builder_id])
+        self.assertTrue(controller.starting)
+
+        d = self.reconfig_workers_remove_all(master)
+        self.assertFalse(d.called)
+
+        yield controller.start_instance(subst_success)
+
+        # we should stop the instance immediately after it substantiates regardless of the result
+        self.assertTrue(controller.stopping)
+
         yield controller.stop_instance(True)
         yield d
 

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -460,13 +460,6 @@ class AbstractLatentWorker(AbstractWorker):
 
     @defer.inlineCallbacks
     def _soft_disconnect(self, fast=False, stopping_service=False):
-        if self.building:
-            # If there are builds running or about to start on this worker, don't disconnect.
-            # soft_disconnect happens during master reconfiguration or shutdown. It's not a good
-            # reason to kill these builds. We effectively slow down reconfig until all workers
-            # that have been unconfigured finish their builds.
-            return
-
         # a negative build_wait_timeout means the worker should never be shut
         # down, so just disconnect.
         if not stopping_service and self.build_wait_timeout < 0:

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -61,6 +61,10 @@ class States(enum.Enum):
     # When in this state self.substantiation_build is not None.
     INSUBSTANTIATING_SUBSTANTIATING = 5
 
+    # This state represents a worker that is shut down. Effectively, it's NOT_SUBSTANTIATED
+    # plus that we will abort if anyone tries to substantiate it.
+    SHUT_DOWN = 6
+
 
 @implementer(ILatentWorker)
 class AbstractLatentWorker(AbstractWorker):
@@ -148,7 +152,9 @@ class AbstractLatentWorker(AbstractWorker):
         then either of:
             INSUBSTANTIATING_SUBSTANTIATING -> SUBSTANTIATING
             INSUBSTANTIATING -> NOT_SUBSTANTIATED
-        """
+
+    stopService():
+        NOT_SUBSTANTIATED -> SHUT_DOWN
     '''
 
     def checkConfig(self, name, password,
@@ -208,6 +214,9 @@ class AbstractLatentWorker(AbstractWorker):
 
     def substantiate(self, wfb, build):
         log.msg("substantiating worker %s" % (wfb,))
+
+        if self.state == States.SHUT_DOWN:
+            return defer.succeed(False)
 
         if self.state == States.SUBSTANTIATED and self.conn is not None:
             self._setBuildWaitTimer()
@@ -416,7 +425,7 @@ class AbstractLatentWorker(AbstractWorker):
             assert self.state not in [States.INSUBSTANTIATING,
                                       States.INSUBSTANTIATING_SUBSTANTIATING]
 
-            if self.state == States.NOT_SUBSTANTIATED:
+            if self.state in [States.NOT_SUBSTANTIATED, States.SHUT_DOWN]:
                 return
 
             prev_state = self.state
@@ -482,16 +491,26 @@ class AbstractLatentWorker(AbstractWorker):
 
     @defer.inlineCallbacks
     def stopService(self):
-        # the worker might be insubstantiating from buildWaitTimeout
-        if self.state in [States.INSUBSTANTIATING,
-                          States.INSUBSTANTIATING_SUBSTANTIATING]:
-            self._log_start_stop_locked('stopService')
-            yield self._start_stop_lock.acquire()
-            self._start_stop_lock.release()
+        # stops the service. Waits for any pending substantiations, insubstantiations or builds
+        # that are running or about to start to complete.
+        while self.state not in [States.NOT_SUBSTANTIATED, States.SHUT_DOWN]:
+            if self.state in [States.INSUBSTANTIATING,
+                              States.INSUBSTANTIATING_SUBSTANTIATING,
+                              States.SUBSTANTIATING,
+                              States.SUBSTANTIATING_STARTING]:
+                self._log_start_stop_locked('stopService')
+                yield self._start_stop_lock.acquire()
+                self._start_stop_lock.release()
 
-        if self.conn is not None or self.state in [States.SUBSTANTIATING,
-                                                   States.SUBSTANTIATED]:
-            yield self._soft_disconnect(stopping_service=True)
+            if self.conn is not None or self.state in [States.SUBSTANTIATED,
+                                                       States.SUBSTANTIATING_STARTING]:
+                yield self._soft_disconnect(stopping_service=True)
+
+        # prevent any race conditions with any future builds that are in the process of
+        # being started.
+        if self.state == States.NOT_SUBSTANTIATED:
+            self.state = States.SHUT_DOWN
+
         self._clearBuildWaitTimer()
         res = yield super().stopService()
         return res

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -492,7 +492,9 @@ class AbstractLatentWorker(AbstractWorker):
         # the worker might be insubstantiating from buildWaitTimeout
         if self.state in [States.INSUBSTANTIATING,
                           States.INSUBSTANTIATING_SUBSTANTIATING]:
-            yield self._insubstantiation_notifier.wait()
+            self._log_start_stop_locked('stopService')
+            yield self._start_stop_lock.acquire()
+            self._start_stop_lock.release()
 
         if self.conn is not None or self.state in [States.SUBSTANTIATING,
                                                    States.SUBSTANTIATED]:

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -393,6 +393,7 @@ inlineCallbacks
 inrepo
 inrepos
 instantiation
+insubstantiating
 insubstantiation
 integrators
 interCaps


### PR DESCRIPTION
Fixes #4935.

Additionally, there's a potential race condition between `stopService()` and `substantiate()`. This PR fixes that too.

Finally, currently workers will wait for current builds to finish during reconfiguration or master shutdown. I believe we don't want to do this during reconfiguration, because in many setups builds take tens of minutes and maybe even hours, it does not make sense for the operator to wait as terminated builds will be retried anyway. During master shutdown the master will wait for builds to finish if the master is shutting down cleanly anyway. Thus I removed this feature.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
