### PR TITLE
Fix releasing procedure

### DIFF
--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -36,11 +36,16 @@ Then run:
 
 This will create the required tags, make documentation, copy it to bbdocs repo and push everything.
 
-Step 4: Wait for CircleCi to create release tarballs
-----------------------------------------------------
+Step 4: Draft a new release and wait for CircleCi to create release tarballs
+----------------------------------------------------------------------------
 
 The push of tags created during step 3 will activate CircleCi configuration that generates tarballs and uploads them to GitHub.
-This is a good time to draft a release on the GitHub UI at https://github.com/buildbot/buildbot/releases.
+CircleCi will automatically publish a new release when uploading assets.
+The release notes must be added manually by drafting a release on the GitHub UI at https://github.com/buildbot/buildbot/releases.
+
+If you draft the release and publish it before CircleCi, make sure the release name matches the git tag.
+This is a requirement for subsequent release scripts to work.
+Manual publishing is preferred, because the releases created by CircleCi don't contain release notes, thus GitHub notifications are not informative.
 
 Step 5: Upload release to pypi
 ------------------------------

--- a/common/download_release.py
+++ b/common/download_release.py
@@ -33,7 +33,7 @@ def main():
     assets = s.get("https://api.github.com/repos/buildbot/buildbot/releases/{id}/assets".format(id=r['id']))
     assets.raise_for_status()
     assets = assets.json()
-    os.system("mkdir -p dist")
+    os.makedirs('dist', exist_ok=True)
     for url in (a['browser_download_url'] for a in assets):
         if url.endswith(".whl") or url.endswith(".tar.gz"):
             fn = os.path.join('dist', url.split('/')[-1])

--- a/common/download_release.py
+++ b/common/download_release.py
@@ -7,9 +7,10 @@ import yaml
 
 
 def download(url, fn):
-    print(url, fn)
     if os.path.exists(fn):
-        return
+        print('Removing old file {}'.format(fn))
+        os.unlink(fn)
+    print('Downloading {} from {}'.format(fn, url))
     with open(fn, 'wb') as f:
         r = s.get(url, stream=True)
         for c in r.iter_content(1024):

--- a/common/download_release.py
+++ b/common/download_release.py
@@ -13,6 +13,7 @@ def download(session, url, fn):
     print('Downloading {} from {}'.format(fn, url))
     with open(fn, 'wb') as f:
         r = session.get(url, stream=True)
+        r.raise_for_status()
         for c in r.iter_content(1024):
             f.write(c)
 

--- a/common/download_release.py
+++ b/common/download_release.py
@@ -6,19 +6,18 @@ import requests
 import yaml
 
 
-def download(url, fn):
+def download(session, url, fn):
     if os.path.exists(fn):
         print('Removing old file {}'.format(fn))
         os.unlink(fn)
     print('Downloading {} from {}'.format(fn, url))
     with open(fn, 'wb') as f:
-        r = s.get(url, stream=True)
+        r = session.get(url, stream=True)
         for c in r.iter_content(1024):
             f.write(c)
 
 
 def main():
-    global s
     with open(os.path.expanduser("~/.config/hub")) as f:
         conf = yaml.safe_load(f)
         token = conf['github.com'][0]['oauth_token']
@@ -37,11 +36,11 @@ def main():
     for url in (a['browser_download_url'] for a in assets):
         if url.endswith(".whl") or url.endswith(".tar.gz"):
             fn = os.path.join('dist', url.split('/')[-1])
-            download(url, fn)
+            download(s, url, fn)
     # download tag archive
     url = "https://github.com/buildbot/buildbot/archive/{tag}.tar.gz".format(tag=tag)
     fn = os.path.join('dist', "buildbot-{tag}.gitarchive.tar.gz".format(tag=tag))
-    download(url, fn)
+    download(s, url, fn)
     sigfn = fn + ".sig"
     if os.path.exists(sigfn):
         os.unlink(sigfn)


### PR DESCRIPTION
Fixes #5168 for subsequent releases. Turns out that if you publish the release before CircleCi, the release name must match the tag name. 

The PR also cleans up the `download_release.py` script which silently ignored download errors.
