### PR TITLE
service: Don't set parent back to master after disownServiceParent()

### DIFF
--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -484,10 +484,6 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
                 # it has already called, so do not call it again
                 child.stopService = lambda: None
                 yield child.disownServiceParent()
-                # HACK: we still keep a reference to the master for some cleanup tasks which are not waited by
-                # to stopService (like the complex worker disconnection mechanism)
-                # http://trac.buildbot.net/ticket/3583
-                child.parent = self.master
 
             for n in added_names:
                 child = new_by_name[n]


### PR DESCRIPTION
We no longer need this hack after #5109. This PR will potentially expose other similar issues we don't know about yet, I think it makes sense to catch and fix them just because of that race conditions like this make tests unreliable and waste way more time than it takes to fix them.