### PR TITLE
doc: fixes for debian packaging

### DIFF
--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -33,14 +33,6 @@ except ImportError:
 
 # -- General configuration -----------------------------------------------
 try:
-    import sphinxcontrib.blockdiag
-    assert sphinxcontrib.blockdiag
-except ImportError as e:
-    raise RuntimeError("sphinxcontrib.blockdiag is not installed. "
-                       "Please install documentation dependencies with "
-                       "`pip install buildbot[docs]`") from e
-
-try:
     pkg_resources.require('docutils>=0.8')
 except pkg_resources.ResolutionError as e:
     raise RuntimeError("docutils is not installed or has incompatible version. "
@@ -57,7 +49,6 @@ extensions = [
     'sphinx.ext.extlinks',
     'bbdocs.ext',
     'bbdocs.api_index',
-    'sphinxcontrib.blockdiag',
     'sphinxcontrib.jinja',
     'sphinx_rtd_theme',
 ]
@@ -95,10 +86,6 @@ else:
 
 # The full version, including alpha/beta/rc tags.
 release = version
-
-# blocksiag/seqdiag
-blockdiag_html_image_format = 'svg'
-blocdiag_transparency = True
 
 # add a loud note about python 2
 rst_prolog = textwrap.dedent("""\

--- a/master/docs/developer/js-data-module-mvvm.svg
+++ b/master/docs/developer/js-data-module-mvvm.svg
@@ -1,0 +1,22 @@
+<svg height="120" viewBox="0 0 640 120" width="640" xmlns="http://www.w3.org/2000/svg" xmlns:inkspace="http://www.inkscape.org/namespaces/inkscape" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs id="defs_block">
+    <filter height="1.504" id="filter_blur" inkspace:collect="always" width="1.1575" x="-0.07875" y="-0.252">
+      <feGaussianBlur id="feGaussianBlur3780" inkspace:collect="always" stdDeviation="4.2"></feGaussianBlur>
+    </filter>
+  </defs>
+  <title>Buildbot Javascript Data Module</title>
+  <desc></desc>
+  <rect fill="rgb(0,0,0)" height="40" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" width="128" x="67" y="46"></rect>
+  <rect fill="rgb(0,0,0)" height="40" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" width="128" x="259" y="46"></rect>
+  <rect fill="rgb(0,0,0)" height="40" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" width="128" x="451" y="46"></rect>
+  <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="64" y="40"></rect>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="24" x="128.0" y="66">View</text>
+  <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="256" y="40"></rect>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="30" x="320.0" y="66">Model</text>
+  <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="448" y="40"></rect>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="36" x="512.0" y="66">Server</text>
+  <path d="M 200 60 L 256 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="193,60 200,56 200,64 193,60" stroke="rgb(0,0,0)"></polygon>
+  <path d="M 392 60 L 448 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="385,60 392,56 392,64 385,60" stroke="rgb(0,0,0)"></polygon>
+</svg>

--- a/master/docs/developer/js-data-module-wrappers.svg
+++ b/master/docs/developer/js-data-module-wrappers.svg
@@ -1,0 +1,39 @@
+<svg height="200" viewBox="0 0 832 200" width="832" xmlns="http://www.w3.org/2000/svg" xmlns:inkspace="http://www.inkscape.org/namespaces/inkscape" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs id="defs_block">
+    <filter height="1.504" id="filter_blur" inkspace:collect="always" width="1.1575" x="-0.07875" y="-0.252">
+      <feGaussianBlur id="feGaussianBlur3780" inkspace:collect="always" stdDeviation="4.2"></feGaussianBlur>
+    </filter>
+  </defs>
+  <title>Buildbot Javascript Data Module Wrappers</title>
+  <desc></desc>
+  <rect fill="rgb(0,0,0)" height="40" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" width="128" x="67" y="46"></rect>
+  <rect fill="rgb(0,0,0)" height="40" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" width="128" x="259" y="46"></rect>
+  <rect fill="rgb(0,0,0)" height="40" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" width="128" x="451" y="46"></rect>
+  <rect fill="rgb(0,0,0)" height="40" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" width="128" x="451" y="126"></rect>
+  <rect fill="rgb(0,0,0)" height="40" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" width="128" x="643" y="46"></rect>
+  <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="64" y="40"></rect>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="84" x="128.0" y="66">data.getBuilds</text>
+  <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="256" y="40"></rect>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="320.0" y="66">Collection</text>
+  <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="448" y="40"></rect>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="36" x="512.0" y="66">Builds</text>
+  <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="448" y="120"></rect>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="30" x="512.0" y="146">Steps</text>
+  <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="640" y="40"></rect>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="704.0" y="66">b.getSteps</text>
+  <path d="M 192 60 L 248 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="255,60 248,56 248,64 255,60" stroke="rgb(0,0,0)"></polygon>
+  <path d="M 384 60 L 440 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="447,60 440,56 440,64 447,60" stroke="rgb(0,0,0)"></polygon>
+  <path d="M 384 60 L 416 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <path d="M 416 60 L 416 140" fill="none" stroke="rgb(0,0,0)"></path>
+  <path d="M 416 140 L 440 140" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="447,140 440,136 440,144 447,140" stroke="rgb(0,0,0)"></polygon>
+  <path d="M 576 60 L 632 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="639,60 632,56 632,64 639,60" stroke="rgb(0,0,0)"></polygon>
+  <path d="M 768 60 L 784 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <path d="M 784 60 L 784 25" fill="none" stroke="rgb(0,0,0)"></path>
+  <path d="M 320 25 L 784 25" fill="none" stroke="rgb(0,0,0)"></path>
+  <path d="M 320 25 L 320 32" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="320,39 316,32 324,32 320,39" stroke="rgb(0,0,0)"></polygon>
+</svg>

--- a/master/docs/developer/www-data-module.rst
+++ b/master/docs/developer/www-data-module.rst
@@ -10,11 +10,8 @@ Its main purpose is to handle the 3 way binding.
 2 way binding is the angular MVVM concept, which seamlessly synchronise the view and the model.
 Here, we introduce an additional way of synchronisation, which is from the server to the model.
 
-.. blockdiag::
-
-    blockdiag {
-      View <- Model <- Server;
-    }
+.. image:: js-data-module-mvvm.svg
+   :width: 100%
 
 We use the message queue and the websocket interfaces to maintain synchronisation between the server and the client.
 
@@ -44,12 +41,8 @@ For example, the Change wrapper decodes the author name and email from the "auth
 
 Each wrapper class also has specific access methods, which allow to access more data from the REST hierarchy.
 
-.. blockdiag::
-
-    blockdiag {
-      data.getBuilds -> Collection -> Builds -> b.getSteps -> Collection -> Steps;
-    }
-
+.. image:: js-data-module-wrappers.svg
+   :width: 100%
 
 Installation
 ~~~~~~~~~~~~

--- a/master/docs/manual/configuration/multimaster.rst
+++ b/master/docs/manual/configuration/multimaster.rst
@@ -9,47 +9,8 @@ Multimaster
     There are still some companies using it in production.
     Don't hesitate to use the mailing lists to share your experience.
 
-.. blockdiag::
-
-    blockdiag multimaster {
-       Worker1 -> LoadBalancer -> Master1 -> database
-       Worker2 -> LoadBalancer
-       Worker2 [shape = "dots"];
-       WorkerN -> LoadBalancer -> Master2 -> database
-       User1 -> LoadBalancerUI -> MasterUI1 -> database
-       User2 -> LoadBalancerUI -> MasterUI2 -> database
-       Master1 -> crossbar.io
-       Master2 -> crossbar.io
-       MasterUI1 -> crossbar.io
-       MasterUI2 -> crossbar.io
-       database [shape = "flowchart.database", stacked];
-       LoadBalancerUI [shape = ellipse];
-       LoadBalancer [shape = ellipse];
-       crossbar.io [shape = mail];
-       User1 [shape = actor];
-       User2 [shape = actor];
-       default_shape = roundedbox;
-       default_node_color = "#33b5e5";
-       default_group_color = "#428bca";
-       default_linecolor = "#0099CC";
-       default_textcolor = "#e1f5fe";
-       group {
-          shape = line;
-          Worker1; Worker2; WorkerN
-       }
-       group {
-          shape = line;
-          Master1; Master2; MasterUI1; MasterUI2
-       }
-       group {
-          shape = line;
-          database; crossbar.io;
-       }
-       group {
-          shape = line;
-          User1; User2;
-       }
-    }
+.. image:: multimaster.svg
+   :width: 100%
 
 Buildbot supports interconnection of several masters.
 This has to be done through a multi-master enabled message queue backend.

--- a/master/docs/manual/configuration/multimaster.svg
+++ b/master/docs/manual/configuration/multimaster.svg
@@ -1,0 +1,127 @@
+<svg height="520" viewBox="0 0 832 520" width="832" xmlns="http://www.w3.org/2000/svg" xmlns:inkspace="http://www.inkscape.org/namespaces/inkscape" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs id="defs_block">
+    <filter height="1.504" id="filter_blur" inkspace:collect="always" width="1.1575" x="-0.07875" y="-0.252">
+      <feGaussianBlur id="feGaussianBlur3780" inkspace:collect="always" stdDeviation="4.2"></feGaussianBlur>
+    </filter>
+  </defs>
+  <title>Buildbot Multimaster Architecture</title>
+  <desc></desc>
+  <ellipse cx="323" cy="66" fill="rgb(0,0,0)" rx="64.0" ry="20.0" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></ellipse>
+  <ellipse cx="323" cy="386" fill="rgb(0,0,0)" rx="64.0" ry="20.0" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></ellipse>
+  <path d="M 75 46 L 187 46 A8,8 0 0 1 195 54 L 195 78 A8,8 0 0 1 187 86 L 75 86 A8,8 0 0 1 67 78 L 67 54 A8,8 0 0 1 75 46" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></path>
+  <path d="M 75 206 L 187 206 A8,8 0 0 1 195 214 L 195 238 A8,8 0 0 1 187 246 L 75 246 A8,8 0 0 1 67 238 L 67 214 A8,8 0 0 1 75 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></path>
+  <polygon fill="rgb(0,0,0)" points="133,380 133,383 143,383 143,386 133,386 133,389 141,398 137,398 131,392 125,398 121,398 129,389 129,386 119,386 119,383 129,383 129,380" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></polygon>
+  <ellipse cx="131" cy="377" fill="rgb(0,0,0)" rx="4.0" ry="4.0" stroke="rgb(0,153,204)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></ellipse>
+  <polygon fill="rgb(0,0,0)" points="133,460 133,463 143,463 143,466 133,466 133,469 141,478 137,478 131,472 125,478 121,478 129,469 129,466 119,466 119,463 129,463 129,460" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></polygon>
+  <ellipse cx="131" cy="457" fill="rgb(0,0,0)" rx="4.0" ry="4.0" stroke="rgb(0,153,204)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></ellipse>
+  <path d="M 459 46 L 571 46 A8,8 0 0 1 579 54 L 579 78 A8,8 0 0 1 571 86 L 459 86 A8,8 0 0 1 451 78 L 451 54 A8,8 0 0 1 459 46" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></path>
+  <path d="M 459 126 L 571 126 A8,8 0 0 1 579 134 L 579 158 A8,8 0 0 1 571 166 L 459 166 A8,8 0 0 1 451 158 L 451 134 A8,8 0 0 1 459 126" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></path>
+  <path d="M 459 206 L 571 206 A8,8 0 0 1 579 214 L 579 238 A8,8 0 0 1 571 246 L 459 246 A8,8 0 0 1 451 238 L 451 214 A8,8 0 0 1 459 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></path>
+  <path d="M 459 286 L 571 286 A8,8 0 0 1 579 294 L 579 318 A8,8 0 0 1 571 326 L 459 326 A8,8 0 0 1 451 318 L 451 294 A8,8 0 0 1 459 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></path>
+  <path d="M 651 62 A64,8 0 0 1 779 62 L 779 86 A64,8 0 0 1 651 86 L 651 62" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></path>
+  <path d="M 647 58 A64,8 0 0 1 775 58 L 775 82 A64,8 0 0 1 647 82 L 647 58" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></path>
+  <path d="M 643 54 A64,8 0 0 1 771 54 L 771 78 A64,8 0 0 1 643 78 L 643 54" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></path>
+  <rect fill="rgb(0,0,0)" height="40" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" width="128" x="643" y="126"></rect>
+  <ellipse cx="320" cy="60" fill="rgb(51,181,229)" rx="64.0" ry="20.0" stroke="rgb(0,153,204)"></ellipse>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="72" x="320.0" y="66">LoadBalancer</text>
+  <ellipse cx="320" cy="380" fill="rgb(51,181,229)" rx="64.0" ry="20.0" stroke="rgb(0,153,204)"></ellipse>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="84" x="320.0" y="386">LoadBalancerUI</text>
+  <path d="M 72 40 L 184 40 A8,8 0 0 1 192 48 L 192 72 A8,8 0 0 1 184 80 L 72 80 A8,8 0 0 1 64 72 L 64 48 A8,8 0 0 1 72 40" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="42" x="128.0" y="66">Worker1</text>
+  <ellipse cx="128.0" cy="140.0" fill="rgb(0,153,204)" rx="4.0" ry="4.0" stroke="rgb(0,153,204)"></ellipse>
+  <ellipse cx="128.0" cy="120.0" fill="rgb(0,153,204)" rx="4.0" ry="4.0" stroke="rgb(0,153,204)"></ellipse>
+  <ellipse cx="128.0" cy="160.0" fill="rgb(0,153,204)" rx="4.0" ry="4.0" stroke="rgb(0,153,204)"></ellipse>
+  <path d="M 72 200 L 184 200 A8,8 0 0 1 192 208 L 192 232 A8,8 0 0 1 184 240 L 72 240 A8,8 0 0 1 64 232 L 64 208 A8,8 0 0 1 72 200" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="42" x="128.0" y="226">WorkerN</text>
+  <polygon fill="rgb(51,181,229)" points="130,374 130,377 140,377 140,380 130,380 130,383 138,392 134,392 128,386 122,392 118,392 126,383 126,380 116,380 116,377 126,377 126,374" stroke="rgb(0,153,204)"></polygon>
+  <ellipse cx="128" cy="371" fill="rgb(51,181,229)" rx="4.0" ry="4.0" stroke="rgb(0,153,204)"></ellipse>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="30" x="128.0" y="405">User1</text>
+  <polygon fill="rgb(51,181,229)" points="130,454 130,457 140,457 140,460 130,460 130,463 138,472 134,472 128,466 122,472 118,472 126,463 126,460 116,460 116,457 126,457 126,454" stroke="rgb(0,153,204)"></polygon>
+  <ellipse cx="128" cy="451" fill="rgb(51,181,229)" rx="4.0" ry="4.0" stroke="rgb(0,153,204)"></ellipse>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="30" x="128.0" y="485">User2</text>
+  <path d="M 456 40 L 568 40 A8,8 0 0 1 576 48 L 576 72 A8,8 0 0 1 568 80 L 456 80 A8,8 0 0 1 448 72 L 448 48 A8,8 0 0 1 456 40" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="42" x="512.0" y="66">Master1</text>
+  <path d="M 456 120 L 568 120 A8,8 0 0 1 576 128 L 576 152 A8,8 0 0 1 568 160 L 456 160 A8,8 0 0 1 448 152 L 448 128 A8,8 0 0 1 456 120" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="42" x="512.0" y="146">Master2</text>
+  <path d="M 456 200 L 568 200 A8,8 0 0 1 576 208 L 576 232 A8,8 0 0 1 568 240 L 456 240 A8,8 0 0 1 448 232 L 448 208 A8,8 0 0 1 456 200" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="54" x="512.0" y="226">MasterUI1</text>
+  <path d="M 456 280 L 568 280 A8,8 0 0 1 576 288 L 576 312 A8,8 0 0 1 568 320 L 456 320 A8,8 0 0 1 448 312 L 448 288 A8,8 0 0 1 456 280" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="54" x="512.0" y="306">MasterUI2</text>
+  <path d="M 648 56 A64,8 0 0 1 776 56 L 776 80 A64,8 0 0 1 648 80 L 648 56" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <path d="M 776 56 A64,8 0 0 1 648 56" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <path d="M 644 52 A64,8 0 0 1 772 52 L 772 76 A64,8 0 0 1 644 76 L 644 52" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <path d="M 772 52 A64,8 0 0 1 644 52" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <path d="M 640 48 A64,8 0 0 1 768 48 L 768 72 A64,8 0 0 1 640 72 L 640 48" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <path d="M 768 48 A64,8 0 0 1 640 48" fill="rgb(51,181,229)" stroke="rgb(0,153,204)"></path>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="704.0" y="70">database</text>
+  <rect fill="rgb(51,181,229)" height="40" stroke="rgb(0,153,204)" width="128" x="640" y="120"></rect>
+  <path d="M 640 120 L 704 136" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 704 136 L 768 120" fill="none" stroke="rgb(0,153,204)"></path>
+  <text fill="rgb(225,245,254)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="66" x="704.0" y="154">crossbar.io</text>
+  <path d="M 384 60 L 440 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="447,60 440,56 440,64 447,60" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 384 60 L 416 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 416 60 L 416 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 416 140 L 440 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="447,140 440,136 440,144 447,140" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 384 380 L 432 380" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 432 380 L 432 220" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 432 220 L 440 220" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="447,220 440,216 440,224 447,220" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 384 380 L 432 380" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 432 380 L 432 300" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 432 300 L 440 300" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="447,300 440,296 440,304 447,300" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 192 60 L 248 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="255,60 248,56 248,64 255,60" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 192 140 L 240 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 240 140 L 240 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 240 60 L 248 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="255,60 248,56 248,64 255,60" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 192 220 L 240 220" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 240 220 L 240 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 240 60 L 248 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="255,60 248,56 248,64 255,60" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 140 380 L 248 380" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="255,380 248,376 248,384 255,380" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 140 460 L 240 460" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 240 460 L 240 380" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 240 380 L 248 380" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="255,380 248,376 248,384 255,380" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 576 60 L 632 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="639,60 632,56 632,64 639,60" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 576 60 L 608 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 608 60 L 608 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 608 140 L 620.0 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 620.0 140.0 A4.0,4.0 0 0 1 628.0 140.0" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 628.0 140 L 632 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="639,140 632,136 632,144 639,140" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 576 140 L 624 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 624 140 L 624 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 624 60 L 632 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="639,60 632,56 632,64 639,60" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 576 140 L 620.0 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 620.0 140.0 A4.0,4.0 0 0 1 628.0 140.0" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 628.0 140 L 632 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="639,140 632,136 632,144 639,140" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 576 220 L 624 220" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 624 220 L 624 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 624 60 L 632 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="639,60 632,56 632,64 639,60" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 576 220 L 624 220" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 624 220 L 624 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 624 140 L 632 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="639,140 632,136 632,144 639,140" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 576 300 L 624 300" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 624 300 L 624 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 624 60 L 632 60" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="639,60 632,56 632,64 639,60" stroke="rgb(0,153,204)"></polygon>
+  <path d="M 576 300 L 624 300" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 624 300 L 624 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <path d="M 624 140 L 632 140" fill="none" stroke="rgb(0,153,204)"></path>
+  <polygon fill="rgb(0,153,204)" points="639,140 632,136 632,144 639,140" stroke="rgb(0,153,204)"></polygon>
+  <rect fill="none" height="220" stroke="rgb(66,139,202)" stroke-width="3" width="144" x="56" y="30"></rect>
+  <rect fill="none" height="140" stroke="rgb(66,139,202)" stroke-width="3" width="144" x="56" y="350"></rect>
+  <rect fill="none" height="300" stroke="rgb(66,139,202)" stroke-width="3" width="144" x="440" y="30"></rect>
+  <rect fill="none" height="140" stroke="rgb(66,139,202)" stroke-width="3" width="144" x="632" y="30"></rect>
+</svg>

--- a/master/docs/manual/configuration/www-authorization.svg
+++ b/master/docs/manual/configuration/www-authorization.svg
@@ -1,0 +1,44 @@
+<svg height="120" viewBox="0 0 1216 120" width="1216" xmlns="http://www.w3.org/2000/svg" xmlns:inkspace="http://www.inkscape.org/namespaces/inkscape" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs id="defs_block">
+    <filter height="1.504" id="filter_blur" inkspace:collect="always" width="1.1575" x="-0.07875" y="-0.252">
+      <feGaussianBlur id="feGaussianBlur3780" inkspace:collect="always" stdDeviation="4.2"></feGaussianBlur>
+    </filter>
+  </defs>
+  <title>Buildbot User Authorization</title>
+  <desc></desc>
+  <polygon fill="rgb(0,0,0)" points="133,60 133,63 143,63 143,66 133,66 133,69 141,78 137,78 131,72 125,78 121,78 129,69 129,66 119,66 119,63 129,63 129,60" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></polygon>
+  <ellipse cx="131" cy="57" fill="rgb(0,0,0)" rx="4.0" ry="4.0" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></ellipse>
+  <polygon fill="rgb(0,0,0)" points="325,60 325,63 335,63 335,66 325,66 325,69 333,78 329,78 323,72 317,78 313,78 321,69 321,66 311,66 311,63 321,63 321,60" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></polygon>
+  <ellipse cx="323" cy="57" fill="rgb(0,0,0)" rx="4.0" ry="4.0" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></ellipse>
+  <polygon fill="rgb(0,0,0)" points="515,38 587,66 515,94 443,66 515,38" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></polygon>
+  <rect fill="rgb(0,0,0)" height="40" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" width="128" x="643" y="46"></rect>
+  <polygon fill="rgb(0,0,0)" points="899,38 971,66 899,94 827,66 899,38" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1"></polygon>
+  <rect fill="rgb(0,0,0)" height="40" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" width="128" x="1027" y="46"></rect>
+  <polygon fill="rgb(255,255,255)" points="130,54 130,57 140,57 140,60 130,60 130,63 138,72 134,72 128,66 122,72 118,72 126,63 126,60 116,60 116,57 126,57 126,54" stroke="rgb(0,0,0)"></polygon>
+  <ellipse cx="128" cy="51" fill="rgb(255,255,255)" rx="4.0" ry="4.0" stroke="rgb(0,0,0)"></ellipse>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="24" x="128.0" y="85">User</text>
+  <polygon fill="rgb(255,255,255)" points="322,54 322,57 332,57 332,60 322,60 322,63 330,72 326,72 320,66 314,72 310,72 318,63 318,60 308,60 308,57 318,57 318,54" stroke="rgb(0,0,0)"></polygon>
+  <ellipse cx="320" cy="51" fill="rgb(255,255,255)" rx="4.0" ry="4.0" stroke="rgb(0,0,0)"></ellipse>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="102" x="320.0" y="85">AuthenticatedUser</text>
+  <polygon fill="rgb(255,255,255)" points="512,32 584,60 512,88 440,60 512,32" stroke="rgb(0,0,0)"></polygon>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="66" x="512.0" y="66">RoleMatcher</text>
+  <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="640" y="40"></rect>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="24" x="704.0" y="66">Role</text>
+  <polygon fill="rgb(255,255,255)" points="896,32 968,60 896,88 824,60 896,32" stroke="rgb(0,0,0)"></polygon>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="72" x="896.0" y="59">EndpointMatc</text>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="18" x="896.0" y="72">her</text>
+  <rect fill="rgb(255,255,255)" height="40" stroke="rgb(0,0,0)" width="128" x="1024" y="40"></rect>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="102" x="1088.0" y="66">REST API Endpoint</text>
+  <path d="M 140 60 L 300 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="307,60 300,56 300,64 307,60" stroke="rgb(0,0,0)"></polygon>
+  <path d="M 332 60 L 432 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="439,60 432,56 432,64 439,60" stroke="rgb(0,0,0)"></polygon>
+  <path d="M 584 60 L 632 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="639,60 632,56 632,64 639,60" stroke="rgb(0,0,0)"></polygon>
+  <path d="M 776 60 L 824 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="769,60 776,56 776,64 769,60" stroke="rgb(0,0,0)"></polygon>
+  <path d="M 976 60 L 1024 60" fill="none" stroke="rgb(0,0,0)"></path>
+  <polygon fill="rgb(0,0,0)" points="969,60 976,56 976,64 969,60" stroke="rgb(0,0,0)"></polygon>
+  <rect fill="white" height="15" stroke="rgb(0,0,0)" width="40" x="204" y="38"></rect>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="24" x="224.0" y="51">Auth</text>
+</svg>

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -882,17 +882,8 @@ Authorization framework is tightly coupled to the REST API.
 Authorization framework only works for HTTP, not for other means of interaction like IRC or try scheduler.
 It allows or denies access to the REST APIs according to rules.
 
-.. blockdiag::
-
-    blockdiag {
-      User -> AuthenticatedUser [label = Auth];
-      AuthenticatedUser -> "RoleMatcher" -> Role <- "EndpointMatcher" <- "REST API Endpoint"
-
-      User  [shape = actor];
-      AuthenticatedUser  [shape = actor];
-      RoleMatcher [shape = diamond];
-      EndpointMatcher [shape = diamond];
-    }
+.. image:: www-authorization.svg
+   :width: 100%
 
 - Roles is a label that you give to a user.
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -556,7 +556,6 @@ setup_args['extras_require'] = {
         'docutils>=0.16.0',
         'sphinx>=3.2.0',
         'sphinx-rtd-theme>=0.5',
-        'sphinxcontrib-blockdiag',
         'sphinxcontrib-spelling',
         'sphinxcontrib-websupport',
         'pyenchant',

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -8,7 +8,6 @@ autobahn==21.3.1;  python_version >= "3.7"
 Automat==20.2.0
 Babel==2.9.1
 backports.functools-lru-cache==1.6.4
-blockdiag==2.0.1
 boto==2.49.0
 boto3==1.18.1
 botocore==1.21.1
@@ -23,7 +22,6 @@ dicttoxml==1.7.4
 docker==5.0.0
 docutils==0.17.1
 flake8==3.9.2
-funcparserlib==0.3.6
 funcsigs==1.0.2
 future==0.18.2
 graphql-core==3.1.5

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -1,7 +1,6 @@
 Sphinx==4.1.1
 sphinx-jinja==1.1.0
 sphinx-rtd-theme==0.5.2
-sphinxcontrib-blockdiag==2.0.0
 sphinxcontrib-spelling==7.2.1
 sphinxcontrib-websupport==1.2.4
 Pygments==2.9.0


### PR DESCRIPTION
These are patches that are required to build in debian.

https://salsa.debian.org/python-team/applications/buildbot/blob/debian/master/debian/patches/0002-docs-bundle-sphinxcontrib.jinja-extension.patch
https://salsa.debian.org/python-team/applications/buildbot/blob/debian/master/debian/patches/0005-docs-convert-blockdiag-diagrams-to-ascii.patch

Since I am having a hard time rebasing them for each release, I figured it would be a good thing to apply them upstream.

The sphinxcontrib-jinja package could be integrated into debian, but it would take me quite some time. Also, I am not sure the package is used outside buildbot.

The sphinxcontrib-blockdiag project does not seem maintained anymore. Maybe it is a sane thing to get rid of the dependency. ASCII diagrams should be enough for our use.