### PR TITLE
tests: skip telegram tests when buildbot-www is not installed

### DIFF
--- a/master/buildbot/test/unit/test_reporters_telegram.py
+++ b/master/buildbot/test/unit/test_reporters_telegram.py
@@ -15,11 +15,13 @@
 
 import json
 import sys
+from unittest.case import SkipTest
 
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.trial import unittest
 
+from buildbot.plugins.db import get_plugins
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.reporters import telegram
@@ -563,6 +565,9 @@ class TestTelegramService(TestReactorMixin, unittest.TestCase):
         if chat_ids is None:
             chat_ids = []
         http = self.setupFakeHttp()
+        www = get_plugins('www', None, load_now=True)
+        if 'base' not in www:
+            raise SkipTest('telegram tests need buildbot-www installed')
         return telegram.TelegramWebhookBot('12345:secret', http, chat_ids, authz, *args, **kwargs)
 
     def test_getContact(self):


### PR DESCRIPTION
For example, on debian, buildbot-www is not available. The unit tests fail with the following error:

```
Traceback (most recent call last):
  File "buildbot/test/unit/test_reporters_telegram.py", line 621, in test_set_webhook_cert
    bot = self.makeBot()
  File "buildbot/test/unit/test_reporters_telegram.py", line 566, in makeBot
    return telegram.TelegramWebhookBot('12345:secret', http, chat_ids, authz, *args, **kwargs)
  File "buildbot/reporters/telegram.py", line 829, in __init__
    self.webhook = WebhookResource('telegram' + token)
  File "buildbot/reporters/words.py", line 1273, in __init__
    raise RuntimeError("could not find buildbot-www; is it installed?")
builtins.RuntimeError: could not find buildbot-www; is it installed?
```

Skip the telegram tests when buildbot-www is not installed.