### PR TITLE
latent: Fix tests after worker parent is no longer set after stopService()

### DIFF
--- a/master/buildbot/util/deferwaiter.py
+++ b/master/buildbot/util/deferwaiter.py
@@ -37,6 +37,7 @@ class DeferWaiter:
 
         self._waited.add(id(d))
         d.addBoth(self._finished, d)
+        return d
 
     @defer.inlineCallbacks
     def wait(self):


### PR DESCRIPTION
Many latent worker tests started failing randomly after #5170 has been merged. Interestingly, it's hard to reproduce them locally. This PR makes sure we wait for all unwaited Deferreds in latent worker and thus don't accidentally run any code after service's `stopService` has been finished.