### PR TITLE
docs: Point to a working lib for lazy module reloading

### DIFF
--- a/master/docs/manual/configuration/intro.rst
+++ b/master/docs/manual/configuration/intro.rst
@@ -162,7 +162,7 @@ This means that buildmaster will be able to start new builds that would otherwis
    Buildbot's reconfiguration system is fragile for a few difficult-to-fix reasons:
 
    * Any modules imported by the configuration file are not automatically reloaded.
-     Python modules such as http://pypi.python.org/pypi/lazy-reload may help here, but reloading modules is fraught with subtleties and difficult-to-decipher failure cases.
+     Python modules such as https://docs.python.org/3/library/importlib.html and `importlib.reload()` may help here, but reloading modules is fraught with subtleties and difficult-to-decipher failure cases.
 
    * During the reconfiguration, active internal objects are divorced from the service hierarchy, leading to tracebacks in the web interface and other components.
      These are ordinarily transient, but with HTTP connection caching (either by the browser or an intervening proxy) they can last for a long time.


### PR DESCRIPTION
lazy-reload doesn't work with python3, so replace by importlib from official
library. It can be used by putting following code in master.cfg:
```python
  import importlib
  import traceback
  import master_workers

  try:
    importlib.reload(master_workers)
  except:
    traceback.print_exc()

  # you can then call any function in master_workers
```