### PR TITLE
buildbot-www: remove unneeded dependencies from setup.py

### DIFF
--- a/www/base/setup.py
+++ b/www/base/setup.py
@@ -17,13 +17,11 @@
 
 try:
     from buildbot_pkg import setup_www_plugin
-    import mock  # noqa
-    import buildbot  # noqa
 except ImportError:
     import sys
-    print('Please install buildbot, buildbot_pkg, and mock modules in order '
-          'to install that package, or use the pre-build .whl modules '
-          'available on pypi', file=sys.stderr)
+    print('Please install buildbot_pkg module in order to install that '
+          'package, or use the pre-build .whl modules available on pypi',
+          file=sys.stderr)
     sys.exit(1)
 
 setup_www_plugin(
@@ -31,7 +29,8 @@ setup_www_plugin(
     description='Buildbot UI',
     author=u'Pierre Tardy',
     author_email=u'tardyp@gmail.com',
-    setup_requires=['buildbot', 'buildbot_pkg', 'mock'],
+    setup_requires=['buildbot_pkg'],
+    install_requires=['buildbot'],
     url='http://buildbot.net/',
     packages=['buildbot_www'],
     package_data={


### PR DESCRIPTION
They were added in https://github.com/buildbot/buildbot/pull/1209.

### Motivation

I maintain buildbot-related packages for Arch Linux. In buildbot [1], some tests need buildbot-www. I'd like to get rid of circular dependencies (buildbot -> buildbot-www -> buildbot), which makes packaging complex.

If I understand the situation correctly, those Python packages are used only during testing, not building. I propose to remove those dependencies to make packaging easier.

[1] https://www.archlinux.org/packages/community/any/buildbot/

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

(I consider this is a minor change that does not need an announcement)