### PR TITLE
Add `count` to locks

### DIFF
--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -324,15 +324,12 @@ class LockAccess(util.ComparableMixin):
 
     compare_attrs = ('lockid', 'mode')
 
-    def __init__(self, lockid, mode, _skipChecks=False):
+    def __init__(self, lockid, mode):
         self.lockid = lockid
         self.mode = mode
 
-        if not _skipChecks:
-            # these checks fail with mock < 0.8.0 when lockid is a Mock
-            # TODO: remove this in Buildbot-0.9.0+
-            assert isinstance(lockid, (MasterLock, WorkerLock))
-            assert mode in ['counting', 'exclusive']
+        assert isinstance(lockid, (MasterLock, WorkerLock))
+        assert mode in ['counting', 'exclusive']
 
 
 class BaseLockId(util.ComparableMixin):

--- a/master/buildbot/newsfragments/add_count_to_locks.feature
+++ b/master/buildbot/newsfragments/add_count_to_locks.feature
@@ -1,0 +1,1 @@
+Added argument `count` to lock access to allow a lock to consume a variable amount of units

--- a/master/buildbot/newsfragments/skipchecks-removed-from-lockaccess.removal
+++ b/master/buildbot/newsfragments/skipchecks-removed-from-lockaccess.removal
@@ -1,0 +1,1 @@
+Removed `_skipChecks` from `LockAccess` as it's obsolete

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1106,7 +1106,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
             lock = locks.MasterLock(name)
             if bare_builder_lock:
                 return lock
-            return locks.LockAccess(lock, "counting")
+            return locks.LockAccess(lock, "counting", count=1)
 
         b1, b2 = bldr('b1'), bldr('b2')
         self.cfg.builders = [b1, b2]

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1106,7 +1106,7 @@ class MasterConfig_checkers(ConfigErrorsMixin, unittest.TestCase):
             lock = locks.MasterLock(name)
             if bare_builder_lock:
                 return lock
-            return locks.LockAccess(lock, "counting", _skipChecks=True)
+            return locks.LockAccess(lock, "counting")
 
         b1, b2 = bldr('b1'), bldr('b2')
         self.cfg.builders = [b1, b2]

--- a/master/buildbot/test/unit/test_locks.py
+++ b/master/buildbot/test/unit/test_locks.py
@@ -35,37 +35,69 @@ class Requester:
 
 class BaseLockTests(unittest.TestCase):
 
-    @parameterized.expand(['counting', 'exclusive'])
-    def test_is_available_empty(self, mode):
+    @parameterized.expand([
+        ('counting', 0, 0),
+        ('counting', 0, 1),
+        ('counting', 1, 1),
+        ('counting', 0, 2),
+        ('counting', 1, 2),
+        ('counting', 2, 2),
+        ('counting', 0, 3),
+        ('counting', 1, 3),
+        ('counting', 2, 3),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
+    def test_is_available_empty(self, mode, count, maxCount):
         req = Requester()
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         self.assertTrue(lock.isAvailable(req, access))
 
-    @parameterized.expand(['counting', 'exclusive'])
-    def test_is_available_without_waiter(self, mode):
+    @parameterized.expand([
+        ('counting', 0, 0),
+        ('counting', 0, 1),
+        ('counting', 1, 1),
+        ('counting', 0, 2),
+        ('counting', 1, 2),
+        ('counting', 2, 2),
+        ('counting', 0, 3),
+        ('counting', 1, 3),
+        ('counting', 2, 3),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
+    def test_is_available_without_waiter(self, mode, count, maxCount):
         req = Requester()
         req_waiter = Requester()
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         lock.claim(req, access)
         lock.release(req, access)
         self.assertTrue(lock.isAvailable(req, access))
         self.assertTrue(lock.isAvailable(req_waiter, access))
 
-    @parameterized.expand(['counting', 'exclusive'])
-    def test_is_available_with_waiter(self, mode):
+    @parameterized.expand([
+        ('counting', 1, 1),
+        ('counting', 2, 2),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
+    def test_is_available_with_waiter(self, mode, count, maxCount):
         req = Requester()
         req_waiter = Requester()
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         lock.claim(req, access)
         lock.waitUntilMaybeAvailable(req_waiter, access)
@@ -78,15 +110,21 @@ class BaseLockTests(unittest.TestCase):
         self.assertTrue(lock.isAvailable(req, access))
         self.assertTrue(lock.isAvailable(req_waiter, access))
 
-    @parameterized.expand(['counting', 'exclusive'])
-    def test_is_available_with_multiple_waiters(self, mode):
+    @parameterized.expand([
+        ('counting', 1, 1),
+        ('counting', 2, 2),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
+    def test_is_available_with_multiple_waiters(self, mode, count, maxCount):
         req = Requester()
         req_waiter1 = Requester()
         req_waiter2 = Requester()
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         lock.claim(req, access)
         lock.waitUntilMaybeAvailable(req_waiter1, access)
@@ -118,6 +156,7 @@ class BaseLockTests(unittest.TestCase):
         lock = BaseLock('test', maxCount=2)
         access = mock.Mock(spec=LockAccess)
         access.mode = 'counting'
+        access.count = 1
 
         lock.claim(req1, access)
         lock.claim(req2, access)
@@ -162,6 +201,7 @@ class BaseLockTests(unittest.TestCase):
         lock = BaseLock('test', maxCount=2)
         access = mock.Mock(spec=LockAccess)
         access.mode = 'counting'
+        access.count = 1
 
         lock.claim(req1, access)
         lock.claim(req2, access)
@@ -207,14 +247,21 @@ class BaseLockTests(unittest.TestCase):
         lock.claim(req_waiter1, access)
         lock.release(req_waiter1, access)
 
-    @parameterized.expand(['counting', 'exclusive'])
-    def test_duplicate_wait_until_maybe_available_throws(self, mode):
+    @parameterized.expand([
+        ('counting', 1, 1),
+        ('counting', 2, 2),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
+    def test_duplicate_wait_until_maybe_available_throws(self, mode, count,
+            maxCount):
         req = Requester()
         req_waiter = Requester()
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         lock.claim(req, access)
         lock.waitUntilMaybeAvailable(req_waiter, access)
@@ -222,14 +269,21 @@ class BaseLockTests(unittest.TestCase):
             lock.waitUntilMaybeAvailable(req_waiter, access)
         lock.release(req, access)
 
-    @parameterized.expand(['counting', 'exclusive'])
-    def test_stop_waiting_ensures_deferred_was_previous_result_of_wait(self, mode):
+    @parameterized.expand([
+        ('counting', 1, 1),
+        ('counting', 2, 2),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
+    def test_stop_waiting_ensures_deferred_was_previous_result_of_wait(self,
+            mode, count, maxCount):
         req = Requester()
         req_waiter = Requester()
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         lock.claim(req, access)
 
@@ -240,14 +294,21 @@ class BaseLockTests(unittest.TestCase):
 
         lock.release(req, access)
 
-    @parameterized.expand(['counting', 'exclusive'])
-    def test_stop_waiting_fires_deferred_if_not_woken(self, mode):
+    @parameterized.expand([
+        ('counting', 1, 1),
+        ('counting', 2, 2),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
+    def test_stop_waiting_fires_deferred_if_not_woken(self, mode, count,
+            maxCount):
         req = Requester()
         req_waiter = Requester()
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         lock.claim(req, access)
         d = lock.waitUntilMaybeAvailable(req_waiter, access)
@@ -256,15 +317,22 @@ class BaseLockTests(unittest.TestCase):
 
         lock.release(req, access)
 
-    @parameterized.expand(['counting', 'exclusive'])
+    @parameterized.expand([
+        ('counting', 1, 1),
+        ('counting', 2, 2),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
     @defer.inlineCallbacks
-    def test_stop_waiting_does_not_fire_deferred_if_already_woken(self, mode):
+    def test_stop_waiting_does_not_fire_deferred_if_already_woken(self, mode,
+            count, maxCount):
         req = Requester()
         req_waiter = Requester()
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         lock.claim(req, access)
         d = lock.waitUntilMaybeAvailable(req_waiter, access)
@@ -276,14 +344,21 @@ class BaseLockTests(unittest.TestCase):
         # inside Twisted.
         lock.stopWaitingUntilAvailable(req_waiter, access, d)
 
-    @parameterized.expand(['counting', 'exclusive'])
-    def test_stop_waiting_does_not_raise_after_release(self, mode):
+    @parameterized.expand([
+        ('counting', 1, 1),
+        ('counting', 2, 2),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
+    def test_stop_waiting_does_not_raise_after_release(self, mode, count,
+            maxCount):
         req = Requester()
         req_waiter = Requester()
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         lock.claim(req, access)
         d = lock.waitUntilMaybeAvailable(req_waiter, access)
@@ -296,15 +371,21 @@ class BaseLockTests(unittest.TestCase):
         lock.claim(req_waiter, access)
         lock.release(req_waiter, access)
 
-    @parameterized.expand(['counting', 'exclusive'])
-    def test_stop_waiting_removes_non_called_waiter(self, mode):
+    @parameterized.expand([
+        ('counting', 1, 1),
+        ('counting', 2, 2),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
+    def test_stop_waiting_removes_non_called_waiter(self, mode, count, maxCount):
         req = Requester()
         req_waiter1 = Requester()
         req_waiter2 = Requester()
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         lock.claim(req, access)
         d1 = lock.waitUntilMaybeAvailable(req_waiter1, access)
@@ -328,16 +409,23 @@ class BaseLockTests(unittest.TestCase):
         self.assertTrue(lock.isAvailable(req_waiter1, access))
         self.assertTrue(lock.isAvailable(req_waiter2, access))
 
-    @parameterized.expand(['counting', 'exclusive'])
+    @parameterized.expand([
+        ('counting', 1, 1),
+        ('counting', 2, 2),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
     @defer.inlineCallbacks
-    def test_stop_waiting_wakes_up_next_deferred_if_already_woken(self, mode):
+    def test_stop_waiting_wakes_up_next_deferred_if_already_woken(self, mode,
+            count, maxCount):
         req = Requester()
         req_waiter1 = Requester()
         req_waiter2 = Requester()
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         lock.claim(req, access)
         d1 = lock.waitUntilMaybeAvailable(req_waiter1, access)
@@ -353,14 +441,20 @@ class BaseLockTests(unittest.TestCase):
         yield flushEventualQueue()
         self.assertTrue(d2.called)
 
-    @parameterized.expand(['counting', 'exclusive'])
-    def test_can_release_non_waited_lock(self, mode):
+    @parameterized.expand([
+        ('counting', 1, 1),
+        ('counting', 2, 2),
+        ('counting', 3, 3),
+        ('exclusive', 1, 1),
+    ])
+    def test_can_release_non_waited_lock(self, mode, count, maxCount):
         req = Requester()
         req_not_waited = Requester()
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access = mock.Mock(spec=LockAccess)
         access.mode = mode
+        access.count = count
 
         lock.release(req_not_waited, access)
 
@@ -371,22 +465,25 @@ class BaseLockTests(unittest.TestCase):
         lock.release(req_not_waited, access)
 
     @parameterized.expand([
-        ('counting', 'counting'),
-        ('counting', 'exclusive'),
-        ('exclusive', 'counting'),
-        ('exclusive', 'exclusive'),
+        ('counting', 'counting', 1, 1, 1),
+        ('counting', 'exclusive', 1, 1, 1),
+        ('exclusive', 'counting', 1, 1, 1),
+        ('exclusive', 'exclusive', 1, 1, 1),
     ])
     @defer.inlineCallbacks
-    def test_release_calls_waiters_in_fifo_order(self, mode1, mode2):
+    def test_release_calls_waiters_in_fifo_order(self, mode1, mode2, count1,
+            count2, maxCount):
         req = Requester()
 
         req_waiters = [Requester() for _ in range(5)]
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access1 = mock.Mock(spec=LockAccess)
         access1.mode = mode1
+        access1.count = count1
         access2 = mock.Mock(spec=LockAccess)
         access2.mode = mode2
+        access2.count = count2
 
         accesses = [access1, access2, access1, access2, access1]
         expected_called = [False] * 5
@@ -417,8 +514,11 @@ class BaseLockTests(unittest.TestCase):
         lock.claim(req_waiters[4], accesses[4])
         lock.release(req_waiters[4], accesses[4])
 
+    @parameterized.expand([
+        (1, ),
+    ])
     @defer.inlineCallbacks
-    def test_release_calls_multiple_waiters_on_release(self):
+    def test_release_calls_multiple_waiters_on_release(self, count):
         req = Requester()
 
         req_waiters = [Requester() for _ in range(5)]
@@ -426,8 +526,10 @@ class BaseLockTests(unittest.TestCase):
         lock = BaseLock('test', maxCount=5)
         access_counting = mock.Mock(spec=LockAccess)
         access_counting.mode = 'counting'
+        access_counting.count = count
         access_excl = mock.Mock(spec=LockAccess)
         access_excl.mode = 'exclusive'
+        access_excl.count = 1
 
         lock.claim(req, access_excl)
         deferreds = [lock.waitUntilMaybeAvailable(req_waiter, access_counting)
@@ -439,15 +541,20 @@ class BaseLockTests(unittest.TestCase):
 
         self.assertEqual([d.called for d in deferreds], [True] * 5)
 
+    @parameterized.expand([
+        (1, 1),
+    ])
     @defer.inlineCallbacks
-    def test_release_calls_multiple_waiters_on_setMaxCount(self):
+    def test_release_calls_multiple_waiters_on_setMaxCount(self, count,
+            maxCount):
         req = Requester()
 
         req_waiters = [Requester() for _ in range(5)]
 
-        lock = BaseLock('test', maxCount=1)
+        lock = BaseLock('test', maxCount=maxCount)
         access_counting = mock.Mock(spec=LockAccess)
         access_counting.mode = 'counting'
+        access_counting.count = count
 
         lock.claim(req, access_counting)
         deferreds = [lock.waitUntilMaybeAvailable(req_waiter, access_counting)
@@ -463,6 +570,142 @@ class BaseLockTests(unittest.TestCase):
         yield flushEventualQueue()
 
         self.assertEqual([d.called for d in deferreds], [True] * 5)
+
+    @parameterized.expand([
+        (2, 2),
+        (3, 3),
+        (4, 4),
+        (5, 5),
+    ])
+    def test_exclusive_must_have_count_one(self, count,
+            maxCount):
+        req = Requester()
+
+        lock = BaseLock('test', maxCount=maxCount)
+        access = mock.Mock(spec=LockAccess)
+        access.mode = 'exclusive'
+        access.count = count
+
+        with self.assertRaises(AssertionError):
+            lock.claim(req, access)
+
+    @parameterized.expand([
+        (0, 1),
+        (1, 1),
+        (0, 2),
+        (1, 2),
+        (2, 2),
+        (0, 3),
+        (1, 3),
+        (2, 3),
+        (3, 3),
+    ])
+    def test_counting_count_zero_always_succeeds(self, count,
+            maxCount):
+
+        reqs = [Requester() for _ in range(10)]
+        req_waiters = [Requester() for _ in range(10)]
+        req_nonzero = Requester()
+
+        lock = BaseLock('test', maxCount=maxCount)
+        access_zero = mock.Mock(spec=LockAccess)
+        access_zero.mode = 'counting'
+        access_zero.count = 0
+
+        access_nonzero = mock.Mock(spec=LockAccess)
+        access_nonzero.mode = 'counting'
+        access_nonzero.count = count
+
+        lock.claim(req_nonzero, access_nonzero)
+        for req in reqs:
+            self.assertTrue(lock.isAvailable(req, access_zero))
+            lock.claim(req, access_zero)
+        for req_waiter in req_waiters:
+            self.assertTrue(lock.isAvailable(req_waiter, access_zero))
+        for req in reqs:
+            self.assertTrue(lock.isAvailable(req, access_zero))
+            lock.release(req, access_zero)
+        lock.release(req_nonzero, access_nonzero)
+
+    @parameterized.expand([
+        (1, 0),
+        (2, 0),
+        (2, 1),
+        (3, 0),
+        (3, 1),
+        (3, 2),
+    ])
+    def test_count_cannot_be_larger_than_maxcount(self, count,
+            maxCount):
+
+        req = Requester()
+
+        lock = BaseLock('test', maxCount=maxCount)
+        access = mock.Mock(spec=LockAccess)
+        access.mode = 'counting'
+        access.count = count
+
+        self.assertFalse(lock.isAvailable(req, access))
+
+    @parameterized.expand([
+        (0, 1, 1),
+        (0, 1, 2),
+        (1, 2, 3),
+        (1, 2, 4),
+        (1, 3, 4),
+        (1, 3, 5),
+        (2, 3, 5),
+        (2, 3, 6),
+    ])
+    def test_different_counts_below_limit(self, count1, count2,
+            maxCount):
+
+        req1 = Requester()
+        req2 = Requester()
+
+        lock = BaseLock('test', maxCount=maxCount)
+        access1 = mock.Mock(spec=LockAccess)
+        access1.mode = 'counting'
+        access1.count = count1
+        access2 = mock.Mock(spec=LockAccess)
+        access2.mode = 'counting'
+        access2.count = count2
+
+        self.assertTrue(lock.isAvailable(req1, access1))
+        lock.claim(req1, access1)
+        self.assertTrue(lock.isAvailable(req2, access2))
+        lock.release(req1, access1)
+
+    @parameterized.expand([
+        (0, 2, 1),
+        (0, 3, 1),
+        (0, 3, 2),
+        (1, 2, 2),
+        (1, 3, 3),
+        (1, 4, 3),
+        (2, 3, 2),
+        (2, 3, 3),
+        (2, 3, 4),
+        (2, 4, 4),
+    ])
+    def test_different_counts_over_limit(self, count1, count2,
+            maxCount):
+
+        req1 = Requester()
+        req2 = Requester()
+
+        lock = BaseLock('test', maxCount=maxCount)
+        access1 = mock.Mock(spec=LockAccess)
+        access1.mode = 'counting'
+        access1.count = count1
+        access2 = mock.Mock(spec=LockAccess)
+        access2.mode = 'counting'
+        access2.count = count2
+
+        self.assertTrue(lock.isAvailable(req1, access1))
+        lock.claim(req1, access1)
+        self.assertFalse(lock.isAvailable(req2, access2))
+        lock.release(req1, access1)
 
 
 class RealLockTests(unittest.TestCase):

--- a/master/docs/manual/configuration/interlocks.rst
+++ b/master/docs/manual/configuration/interlocks.rst
@@ -39,6 +39,10 @@ Count
 Often, not all workers are equal.
 To allow for this situation, Buildbot allows to have a separate upper limit on the count for each worker.
 In this way, you can have at most 3 concurrent builds at a fast worker, 2 at a slightly older worker, and 1 at all other workers.
+You can also specify the count during access request. This specifies how many
+units an access consumes from the lock. This way, you can for balance a shared
+resource which workers consume unevenly, for example the amount of memory or
+the number of CPU cores.
 
 Scope
 ~~~~~
@@ -80,7 +84,15 @@ In the latter case, the lock is claimed for use just before the step starts, and
 To prevent deadlocks, [#]_ it is not possible to claim or release locks at other times.
 
 To use locks, you add them with a ``locks`` argument to a build or a step.
-Each use of a lock is either in counting mode (that is, possibly shared with other builds) or in exclusive mode, and this is indicated with the syntax ``lock.access(mode)``, where :data:`mode` is one of ``"counting"`` or ``"exclusive"``.
+Each use of a lock is either in counting mode (that is, possibly shared with
+other builds) or in exclusive mode, and this is indicated with the syntax
+``lock.access(mode, count)``, where :data:`mode` is one of ``"counting"`` or
+``"exclusive"``.
+
+The optional argument :data:`count` is a non-negative integer (for counting
+locks) or 1 (for exclusive locks). If unspecified, it defaults to 1. If 0, the
+access always succeeds. This argument allows to use locks for balancing a
+shared resource that is utilized unevenly.
 
 A build or build step proceeds only when it has acquired all locks.
 If a build or step needs a lot of locks, it may be starved [#]_ by other builds that need fewer locks.


### PR DESCRIPTION
- allows lock access to use up a variable amount of units
- replaces the `_skipChecks` argument from `LockAccess` as that's obsolete
- defaults to `1` for backwards compatibility
- count `0` has the same effect as not using the lock at all
- old tests have been made compatible and pass, no new tests have been written
  yet

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation