### PR TITLE
Allow pushing unencoded json lists via HttpStatusPush

### DIFF
--- a/master/buildbot/newsfragments/README.txt
+++ b/master/buildbot/newsfragments/README.txt
@@ -14,4 +14,4 @@ Buildbot project does not require a tracking ticket to be made for each contribu
 
 Please point to the trac bug using syntax: (:bug:`NNN`)
 Please point to the github bug using syntax: (:issue:`NNN`)
-please point to classes using syntax: :py:class:`~buildbot.reporters.http.HttpStatusBase`
+please point to classes using syntax: :py:class:`~buildbot.reporters.http.HttpStatusPushBase`

--- a/master/buildbot/newsfragments/push-unencoded-json-lists.feature
+++ b/master/buildbot/newsfragments/push-unencoded-json-lists.feature
@@ -1,0 +1,1 @@
+:py:class:`~buildbot.reporters.http.HttpStatusPushBase` now allows you to skip unicode to bytes encoding while pushing data to server

--- a/master/buildbot/newsfragments/updateclass.doc
+++ b/master/buildbot/newsfragments/updateclass.doc
@@ -1,1 +1,1 @@
-Updated newsfragments readme to no longer refer to renamed class :py:class:`~buildbot.reporters.http.HttpStatusBase`
+Updated newsfragments README.txt to no longer refer to renamed class :py:class:`~buildbot.reporters.http.HttpStatusBase`

--- a/master/buildbot/newsfragments/updateclass.doc
+++ b/master/buildbot/newsfragments/updateclass.doc
@@ -1,0 +1,1 @@
+Updated newsfragments readme to no longer refer to renamed class :py:class:`~buildbot.reporters.http.HttpStatusBase`

--- a/master/buildbot/test/fake/httpclientservice.py
+++ b/master/buildbot/test/fake/httpclientservice.py
@@ -60,7 +60,7 @@ class HTTPClientService(service.SharedService):
     """
     quiet = False
 
-    def __init__(self, base_url, auth=None, headers=None, debug=None, verify=None):
+    def __init__(self, base_url, auth=None, headers=None, debug=None, verify=None, skipEncoding=None):
         assert not base_url.endswith("/"), "baseurl should not end with /"
         super().__init__()
         self._base_url = base_url

--- a/master/buildbot/test/unit/test_util_httpclientservice.py
+++ b/master/buildbot/test/unit/test_util_httpclientservice.py
@@ -125,6 +125,32 @@ class HTTPClientServiceTestTxRequest(HTTPClientServiceTestBase):
                                                             })
 
 
+class HTTPClientServiceTestTxRequestNoEncoding(HTTPClientServiceTestBase):
+
+    def setUp(self):
+        super().setUp()
+        self._http = self.successResultOf(
+            httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
+                                                           headers=self.base_headers,
+                                                           skipEncoding=True))
+
+    def test_post_raw(self):
+        self._http.post('/bar', json={'foo': 'bar'})
+        jsonStr = json.dumps(dict(foo='bar'))
+        self._http._session.request.assert_called_once_with('post', 'http://foo/bar',
+                                                            background_callback=mock.ANY,
+                                                            data=jsonStr,
+                                                            headers={'Content-Type': 'application/json'})
+
+    def test_post_rawlist(self):
+        self._http.post('/bar', json=[{'foo': 'bar'}])
+        jsonStr = json.dumps([dict(foo='bar')])
+        self._http._session.request.assert_called_once_with('post', 'http://foo/bar',
+                                                            background_callback=mock.ANY,
+                                                            data=jsonStr,
+                                                            headers={'Content-Type': 'application/json'})
+
+
 class HTTPClientServiceTestTReq(HTTPClientServiceTestBase):
 
     def setUp(self):
@@ -198,6 +224,33 @@ class HTTPClientServiceTestTReq(HTTPClientServiceTestBase):
                                                             auth=auth,
                                                             headers={
                                                             })
+
+
+class HTTPClientServiceTestTReqNoEncoding(HTTPClientServiceTestBase):
+
+    def setUp(self):
+        super().setUp()
+        self.patch(httpclientservice.HTTPClientService, 'PREFER_TREQ', True)
+        self._http = self.successResultOf(
+            httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
+                                                           headers=self.base_headers,
+                                                           skipEncoding=True))
+
+    def test_post_raw(self):
+        self._http.post('/bar', json={'foo': 'bar'})
+        json_str = json.dumps(dict(foo='bar'))
+        httpclientservice.treq.post.assert_called_once_with('http://foo/bar',
+                                                            agent=mock.ANY,
+                                                            data=json_str,
+                                                            headers={'Content-Type': ['application/json']})
+
+    def test_post_rawlist(self):
+        self._http.post('/bar', json=[{'foo': 'bar'}])
+        json_str = json.dumps([dict(foo='bar')])
+        httpclientservice.treq.post.assert_called_once_with('http://foo/bar',
+                                                            agent=mock.ANY,
+                                                            data=json_str,
+                                                            headers={'Content-Type': ['application/json']})
 
 
 class MyResource(resource.Resource):
@@ -375,29 +428,3 @@ class HTTPClientServiceTestFakeE2E(HTTPClientServiceTestTxRequestE2E):
 
     def expect(self, *arg, **kwargs):
         self._http.expect(*arg, **kwargs)
-
-
-class HTTPClientServiceTestTxRequestNoEncoding(HTTPClientServiceTestBase):
-
-    def setUp(self):
-        super().setUp()
-        self._http = self.successResultOf(
-            httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
-                                                           headers=self.base_headers,
-                                                           skipEncoding=True))
-
-    def test_post_raw(self):
-        self._http.post('/bar', json={'foo': 'bar'})
-        jsonStr = json.dumps(dict(foo='bar'))
-        self._http._session.request.assert_called_once_with('post', 'http://foo/bar',
-                                                            background_callback=mock.ANY,
-                                                            data=jsonStr,
-                                                            headers={'Content-Type': 'application/json'})
-
-    def test_post_rawlist(self):
-        self._http.post('/bar', json=[{'foo': 'bar'}])
-        jsonStr = json.dumps([dict(foo='bar')])
-        self._http._session.request.assert_called_once_with('post', 'http://foo/bar',
-                                                            background_callback=mock.ANY,
-                                                            data=jsonStr,
-                                                            headers={'Content-Type': 'application/json'})

--- a/master/buildbot/test/unit/test_util_httpclientservice.py
+++ b/master/buildbot/test/unit/test_util_httpclientservice.py
@@ -375,3 +375,29 @@ class HTTPClientServiceTestFakeE2E(HTTPClientServiceTestTxRequestE2E):
 
     def expect(self, *arg, **kwargs):
         self._http.expect(*arg, **kwargs)
+
+
+class HTTPClientServiceTestTxRequestNoEncoding(HTTPClientServiceTestBase):
+
+    def setUp(self):
+        super().setUp()
+        self._http = self.successResultOf(
+            httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
+                                                           headers=self.base_headers,
+                                                           skipEncoding=True))
+
+    def test_post_raw(self):
+        self._http.post('/bar', json={'foo': 'bar'})
+        jsonStr = json.dumps(dict(foo='bar'))
+        self._http._session.request.assert_called_once_with('post', 'http://foo/bar',
+                                                            background_callback=mock.ANY,
+                                                            data=jsonStr,
+                                                            headers={'Content-Type': 'application/json'})
+
+    def test_post_rawlist(self):
+        self._http.post('/bar', json=[{'foo': 'bar'}])
+        jsonStr = json.dumps([dict(foo='bar')])
+        self._http._session.request.assert_called_once_with('post', 'http://foo/bar',
+                                                            background_callback=mock.ANY,
+                                                            data=jsonStr,
+                                                            headers={'Content-Type': 'application/json'})

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -153,7 +153,7 @@ class HTTPClientService(service.SharedService):
         # we manually do the json encoding in order to automatically convert timestamps
         # for txrequests and treq
         json = kwargs.pop('json', None)
-        if isinstance(json, (dict,list)):
+        if isinstance(json, (dict, list)):
             jsonStr = jsonmodule.dumps(json, default=toJson)
             kwargs['headers']['Content-Type'] = 'application/json'
             if self.skipEncoding:

--- a/master/buildbot/util/httpclientservice.py
+++ b/master/buildbot/util/httpclientservice.py
@@ -86,7 +86,7 @@ class HTTPClientService(service.SharedService):
     PREFER_TREQ = False
     MAX_THREADS = 5
 
-    def __init__(self, base_url, auth=None, headers=None, verify=None, debug=False):
+    def __init__(self, base_url, auth=None, headers=None, verify=None, debug=False, skipEncoding=False):
         assert not base_url.endswith(
             "/"), "baseurl should not end with /: " + base_url
         super().__init__()
@@ -97,6 +97,7 @@ class HTTPClientService(service.SharedService):
         self._session = None
         self.verify = verify
         self.debug = debug
+        self.skipEncoding = skipEncoding
 
     def updateHeaders(self, headers):
         if self._headers is None:
@@ -152,11 +153,14 @@ class HTTPClientService(service.SharedService):
         # we manually do the json encoding in order to automatically convert timestamps
         # for txrequests and treq
         json = kwargs.pop('json', None)
-        if isinstance(json, dict):
+        if isinstance(json, (dict,list)):
             jsonStr = jsonmodule.dumps(json, default=toJson)
-            jsonBytes = unicode2bytes(jsonStr)
             kwargs['headers']['Content-Type'] = 'application/json'
-            kwargs['data'] = jsonBytes
+            if self.skipEncoding:
+                kwargs['data'] = jsonStr
+            else:
+                jsonBytes = unicode2bytes(jsonStr)
+                kwargs['data'] = jsonBytes
         return url, kwargs
 
     @defer.inlineCallbacks

--- a/master/docs/manual/configuration/reporters.rst
+++ b/master/docs/manual/configuration/reporters.rst
@@ -1160,6 +1160,7 @@ It requires either `txrequests`_ or `treq`_ to be installed to allow interaction
     :param boolean wantPreviousBuild: include 'prev_build' in the build dictionary
     :param boolean debug: logs every requests and their response
     :param boolean verify: disable ssl verification for the case you use temporary self signed certificates
+    :param boolean skipEncoding: disables encoding of json data to bytes before pushing to server
 
 Json object spec
 ++++++++++++++++


### PR DESCRIPTION
Certain http push endpoints like Apache kafka have very strict requirements about the format of data posted. Allow `httpclientservice` to skip encoding and accept list as a input to `jsonmodule.dumps` to accommodate the same

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation

@rrajeevan