### PR TITLE
GitHubAuth: uses Authentication header instead of query params

### DIFF
--- a/master/buildbot/newsfragments/github_oauth.bugfix
+++ b/master/buildbot/newsfragments/github_oauth.bugfix
@@ -1,0 +1,1 @@
+:class:`GitHubAuth` is not using `Authorization` headers instead of `access_token` query parameter, as the later was deprecated by Github. (:issue:`5188`)

--- a/master/buildbot/newsfragments/github_oauth.bugfix
+++ b/master/buildbot/newsfragments/github_oauth.bugfix
@@ -1,1 +1,1 @@
-:class:`GitHubAuth` is not using `Authorization` headers instead of `access_token` query parameter, as the later was deprecated by Github. (:issue:`5188`)
+:class:`GitHubAuth` is now using `Authorization` headers instead of `access_token` query parameter, as the latter was deprecated by Github. (:issue:`5188`)

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -284,6 +284,12 @@ class GitHubAuth(OAuth2Auth):
                     username=user['login'],
                     groups=[org['login'] for org in orgs])
 
+    def createSessionFromToken(self, token):
+        s = requests.Session()
+        s.headers = {'Authorization': 'token ' + token['access_token']}
+        s.verify = self.sslVerify
+        return s
+
     def getUserInfoFromOAuthClient_v4(self, c):
         graphql_query = textwrap.dedent('''
             query {


### PR DESCRIPTION
query param is deprecated way of authenticating api with github.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [NA] I have updated the appropriate documentation
