### PR TITLE
tests: Use @defer.inlineCallbacks

### DIFF
--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -240,17 +240,21 @@ class UpgradeTestV090b4(UpgradeTestMixin, unittest.TestCase):
     def verify_thd(self, conn):
         pass
 
+    @defer.inlineCallbacks
     def test_gotError(self):
         def upgrade():
             return defer.fail(sqlite3.DatabaseError('file is encrypted or is not a database'))
         self.db.model.upgrade = upgrade
-        self.failureResultOf(self.do_test_upgrade(), unittest.SkipTest)
+        with self.assertRaises(unittest.SkipTest):
+            yield self.do_test_upgrade()
 
+    @defer.inlineCallbacks
     def test_gotError2(self):
         def upgrade():
             return defer.fail(DatabaseError('file is encrypted or is not a database', None, None))
         self.db.model.upgrade = upgrade
-        self.failureResultOf(self.do_test_upgrade(), unittest.SkipTest)
+        with self.assertRaises(unittest.SkipTest):
+            yield self.do_test_upgrade()
 
 
 class UpgradeTestV087p1(UpgradeTestMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -414,8 +414,9 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
         self.assertEqual(builderid, 13)
         fbi.assert_not_called()
 
+    @defer.inlineCallbacks
     def test_expectations_deprecated(self):
-        self.successResultOf(self.makeBuilder())
+        yield self.makeBuilder()
 
         with assertProducesWarning(
                 Warning,

--- a/master/buildbot/test/unit/test_reporters_pushjet.py
+++ b/master/buildbot/test/unit/test_reporters_pushjet.py
@@ -37,9 +37,9 @@ class TestPushjetNotifier(ConfigErrorsMixin, TestReactorMixin,
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
+    # returns a Deferred
     def setupFakeHttp(self, base_url='https://api.pushjet.io'):
-        return self.successResultOf(fakehttpclientservice.HTTPClientService.getFakeService(
-            self.master, self, base_url))
+        return fakehttpclientservice.HTTPClientService.getFakeService(self.master, self, base_url)
 
     @defer.inlineCallbacks
     def setupPushjetNotifier(self, secret=Interpolate("1234"), **kwargs):
@@ -50,7 +50,7 @@ class TestPushjetNotifier(ConfigErrorsMixin, TestReactorMixin,
 
     @defer.inlineCallbacks
     def test_sendMessage(self):
-        _http = self.setupFakeHttp()
+        _http = yield self.setupFakeHttp()
         pn = yield self.setupPushjetNotifier(levels={'passing': 2})
         _http.expect("post", "/message",
                      data={'secret': "1234", 'level': 2,
@@ -62,7 +62,7 @@ class TestPushjetNotifier(ConfigErrorsMixin, TestReactorMixin,
 
     @defer.inlineCallbacks
     def test_sendNotification(self):
-        _http = self.setupFakeHttp('https://tests.io')
+        _http = yield self.setupFakeHttp('https://tests.io')
         pn = yield self.setupPushjetNotifier(base_url='https://tests.io')
         _http.expect("post", "/message",
                      data={'secret': "1234", 'message': "Test"},

--- a/master/buildbot/test/unit/test_reporters_pushover.py
+++ b/master/buildbot/test/unit/test_reporters_pushover.py
@@ -37,9 +37,10 @@ class TestPushoverNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCas
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
+    # returns a Deferred
     def setupFakeHttp(self):
-        return self.successResultOf(fakehttpclientservice.HTTPClientService.getFakeService(
-            self.master, self, 'https://api.pushover.net'))
+        return fakehttpclientservice.HTTPClientService.getFakeService(self.master, self,
+                                                                      'https://api.pushover.net')
 
     @defer.inlineCallbacks
     def setupPushoverNotifier(self, user_key="1234", api_token=Interpolate("abcd"), **kwargs):
@@ -50,7 +51,7 @@ class TestPushoverNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCas
 
     @defer.inlineCallbacks
     def test_sendMessage(self):
-        _http = self.setupFakeHttp()
+        _http = yield self.setupFakeHttp()
         pn = yield self.setupPushoverNotifier(priorities={'passing': 2})
         _http.expect("post", "/1/messages.json",
                      params={'user': "1234", 'token': "abcd",
@@ -63,7 +64,7 @@ class TestPushoverNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCas
 
     @defer.inlineCallbacks
     def test_sendNotification(self):
-        _http = self.setupFakeHttp()
+        _http = yield self.setupFakeHttp()
         pn = yield self.setupPushoverNotifier(otherParams={'sound': "silent"})
         _http.expect("post", "/1/messages.json",
                      params={'user': "1234", 'token': "abcd",

--- a/master/buildbot/test/unit/test_secret_in_vault.py
+++ b/master/buildbot/test/unit/test_secret_in_vault.py
@@ -33,11 +33,10 @@ class TestSecretInVaultHttpFakeBase(ConfigErrorsMixin, TestReactorMixin,
                                                       vaultToken="someToken",
                                                       apiVersion=version)
         self.master = fakemaster.make_master(self, wantData=True)
-        self._http = self.successResultOf(
-            fakehttpclientservice.HTTPClientService.getFakeService(
-                self.master, self, 'http://vaultServer', headers={'X-Vault-Token': "someToken"}))
+        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+                self.master, self, 'http://vaultServer', headers={'X-Vault-Token': "someToken"})
         yield self.srvcVault.setServiceParent(self.master)
-        self.successResultOf(self.master.startService())
+        yield self.master.startService()
 
     @defer.inlineCallbacks
     def tearDown(self):
@@ -96,9 +95,8 @@ class TestSecretInVaultV1(TestSecretInVaultHttpFakeBase):
 
     @defer.inlineCallbacks
     def testReconfigSecretInVaultService(self):
-        self._http = self.successResultOf(
-            fakehttpclientservice.HTTPClientService.getFakeService(
-                self.master, self, 'serveraddr', headers={'X-Vault-Token': "someToken"}))
+        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+                self.master, self, 'serveraddr', headers={'X-Vault-Token': "someToken"})
         yield self.srvcVault.reconfigService(vaultServer="serveraddr",
                                              vaultToken="someToken")
         self.assertEqual(self.srvcVault.vaultServer, "serveraddr")

--- a/master/buildbot/test/unit/test_steps_source_base_Source.py
+++ b/master/buildbot/test/unit/test_steps_source_base_Source.py
@@ -15,6 +15,7 @@
 
 import mock
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.steps.source import Source
@@ -88,6 +89,7 @@ class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin,
 
         self.assertEqual(step.description, ['updating'])
 
+    @defer.inlineCallbacks
     def test_start_with_codebase(self):
         step = self.setupStep(Source(codebase='codebase'))
         step.branch = 'branch'
@@ -96,7 +98,7 @@ class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin,
         step.build.getSourceStamp.return_value = None
 
         self.assertEqual(step.describe(), ['updating', 'codebase'])
-        step.name = self.successResultOf(step.build.render(step.name))
+        step.name = yield step.build.render(step.name)
         self.assertEqual(step.name, Source.name + "-codebase")
 
         step.startStep(mock.Mock())
@@ -104,6 +106,7 @@ class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin,
 
         self.assertEqual(step.describe(True), ['update', 'codebase'])
 
+    @defer.inlineCallbacks
     def test_start_with_codebase_and_descriptionSuffix(self):
         step = self.setupStep(Source(codebase='my-code',
                                      descriptionSuffix='suffix'))
@@ -113,7 +116,7 @@ class TestSource(sourcesteps.SourceStepMixin, TestReactorMixin,
         step.build.getSourceStamp.return_value = None
 
         self.assertEqual(step.describe(), ['updating', 'suffix'])
-        step.name = self.successResultOf(step.build.render(step.name))
+        step.name = yield step.build.render(step.name)
         self.assertEqual(step.name, Source.name + "-my-code")
 
         step.startStep(mock.Mock())

--- a/master/buildbot/test/unit/test_util_httpclientservice.py
+++ b/master/buildbot/test/unit/test_util_httpclientservice.py
@@ -46,8 +46,9 @@ components.registerAdapter(
     mock.Mock, interfaces.IHttpResponse)
 
 
-class HTTPClientServiceTestBase(unittest.SynchronousTestCase):
+class HTTPClientServiceTestBase(unittest.TestCase):
 
+    @defer.inlineCallbacks
     def setUp(self):
         if httpclientservice.txrequests is None or httpclientservice.treq is None:
             raise unittest.SkipTest('this test requires txrequests and treq')
@@ -56,16 +57,16 @@ class HTTPClientServiceTestBase(unittest.SynchronousTestCase):
         self.parent = service.MasterService()
         self.parent.reactor = reactor
         self.base_headers = {}
-        self.successResultOf(self.parent.startService())
+        yield self.parent.startService()
 
 
 class HTTPClientServiceTestTxRequest(HTTPClientServiceTestBase):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        super().setUp()
-        self._http = self.successResultOf(
-            httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
-                                                           headers=self.base_headers))
+        yield super().setUp()
+        self._http = yield httpclientservice.HTTPClientService.getService(
+            self.parent, 'http://foo', headers=self.base_headers)
 
     def test_get(self):
         self._http.get('/bar')
@@ -108,10 +109,10 @@ class HTTPClientServiceTestTxRequest(HTTPClientServiceTestBase):
                                                                 'X-TOKEN': 'XXXYYY',
                                                                 'Content-Type': 'application/json'})
 
+    @defer.inlineCallbacks
     def test_post_auth(self):
-        self._http = self.successResultOf(
-            httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
-                                                           auth=('user', 'pa$$')))
+        self._http = yield httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
+                                                                          auth=('user', 'pa$$'))
         self._http.post('/bar', json={'foo': 'bar'})
         jsonStr = json.dumps(dict(foo='bar'))
         jsonBytes = unicode2bytes(jsonStr)
@@ -153,12 +154,12 @@ class HTTPClientServiceTestTxRequestNoEncoding(HTTPClientServiceTestBase):
 
 class HTTPClientServiceTestTReq(HTTPClientServiceTestBase):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        super().setUp()
+        yield super().setUp()
         self.patch(httpclientservice.HTTPClientService, 'PREFER_TREQ', True)
-        self._http = self.successResultOf(
-            httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
-                                                           headers=self.base_headers))
+        self._http = yield httpclientservice.HTTPClientService.getService(
+            self.parent, 'http://foo', headers=self.base_headers)
 
     def test_get(self):
         self._http.get('/bar')
@@ -196,10 +197,10 @@ class HTTPClientServiceTestTReq(HTTPClientServiceTestBase):
                                                                 'Content-Type': ['application/json'],
                                                                 'X-TOKEN': ['XXXYYY']})
 
+    @defer.inlineCallbacks
     def test_post_auth(self):
-        self._http = self.successResultOf(
-            httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
-                                                           auth=('user', 'pa$$')))
+        self._http = yield httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
+                                                                          auth=('user', 'pa$$'))
         self._http.post('/bar', json={'foo': 'bar'})
         httpclientservice.treq.post.assert_called_once_with('http://foo/bar',
                                                             agent=mock.ANY,
@@ -210,11 +211,11 @@ class HTTPClientServiceTestTReq(HTTPClientServiceTestBase):
                                                                 'Content-Type': ['application/json'],
                                                             })
 
+    @defer.inlineCallbacks
     def test_post_auth_digest(self):
         auth = HTTPDigestAuth('user', 'pa$$')
-        self._http = self.successResultOf(
-            httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
-                                                           auth=auth))
+        self._http = yield httpclientservice.HTTPClientService.getService(self.parent, 'http://foo',
+                                                                          auth=auth)
         self._http.post('/bar', data={'foo': 'bar'})
         # if digest auth, we don't use treq! we use txrequests
         self._http._session.request.assert_called_once_with('post', 'http://foo/bar',
@@ -415,9 +416,10 @@ class HTTPClientServiceTestTxRequestE2E(unittest.TestCase):
 
 class HTTPClientServiceTestTReqE2E(HTTPClientServiceTestTxRequestE2E):
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.patch(httpclientservice.HTTPClientService, 'PREFER_TREQ', True)
-        return super().setUp()
+        yield super().setUp()
 
 
 class HTTPClientServiceTestFakeE2E(HTTPClientServiceTestTxRequestE2E):

--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -59,7 +59,7 @@ class MockFileBase:
 
 
 class KubeClientServiceTestClusterConfig(
-        MockFileBase, config.ConfigErrorsMixin, unittest.SynchronousTestCase):
+        MockFileBase, config.ConfigErrorsMixin, unittest.TestCase):
 
     file_mock_config = {
         'token': 'BASE64_TOKEN',
@@ -79,10 +79,11 @@ class KubeClientServiceTestClusterConfig(
         with self.assertRaisesConfigError('kube_dir not found:'):
             kubeclientservice.KubeInClusterConfigLoader()
 
+    @defer.inlineCallbacks
     def test_basic(self):
         self.patchExist(True)
         config = kubeclientservice.KubeInClusterConfigLoader()
-        self.successResultOf(config.startService())
+        yield config.startService()
         self.assertEqual(
             config.getConfig(), {
                 'headers': {

--- a/master/buildbot/test/unit/test_worker_docker.py
+++ b/master/buildbot/test/unit/test_worker_docker.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 
+from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
@@ -27,15 +28,16 @@ from buildbot.test.util.misc import TestReactorMixin
 from buildbot.worker import docker as dockerworker
 
 
-class TestDockerLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
+class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
 
+    @defer.inlineCallbacks
     def setupWorker(self, *args, **kwargs):
         self.patch(dockerworker, 'docker', docker)
         worker = dockerworker.DockerLatentWorker(*args, **kwargs)
         master = fakemaster.make_master(self, wantData=True)
         fakemaster.master = master
         worker.setServiceParent(master)
-        self.successResultOf(master.startService())
+        yield master.startService()
         self.addCleanup(master.stopService)
         return worker
 
@@ -46,68 +48,77 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
             image='busybox:latest', builder='docker_worker', distro='wheezy')
         self.patch(dockerworker, 'client', docker)
 
+    @defer.inlineCallbacks
     def test_constructor_nodocker(self):
         self.patch(dockerworker, 'client', None)
         with self.assertRaises(config.ConfigErrors):
-            self.setupWorker('bot', 'pass', 'unix://tmp.sock', 'debian:wheezy',
-                             [])
+            yield self.setupWorker('bot', 'pass', 'unix://tmp.sock', 'debian:wheezy', [])
 
+    @defer.inlineCallbacks
     def test_constructor_noimage_nodockerfile(self):
         with self.assertRaises(config.ConfigErrors):
-            self.setupWorker('bot', 'pass', 'http://localhost:2375')
+            yield self.setupWorker('bot', 'pass', 'http://localhost:2375')
 
+    @defer.inlineCallbacks
     def test_constructor_noimage_dockerfile(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'http://localhost:2375', dockerfile="FROM ubuntu")
         self.assertEqual(bs.dockerfile, "FROM ubuntu")
         self.assertEqual(bs.image, None)
 
+    @defer.inlineCallbacks
     def test_constructor_image_nodockerfile(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'http://localhost:2375', image="myworker")
         self.assertEqual(bs.dockerfile, None)
         self.assertEqual(bs.image, 'myworker')
 
+    @defer.inlineCallbacks
     def test_constructor_minimal(self):
         # Minimal set of parameters
-        bs = self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
+        bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
         self.assertEqual(bs.workername, 'bot')
         self.assertEqual(bs.password, 'pass')
         self.assertEqual(bs.client_args, {'base_url': 'tcp://1234:2375'})
         self.assertEqual(bs.image, 'worker')
         self.assertEqual(bs.command, [])
 
+    @defer.inlineCallbacks
     def test_contruction_minimal_docker_py(self):
         docker.version = "1.10.6"
-        bs = self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
+        id, name = yield bs.start_instance(self.build)
         client = docker.APIClient.latest
         self.assertEqual(client.called_class_name, "Client")
         client = docker.Client.latest
         self.assertNotEqual(client.called_class_name, "APIClient")
 
+    @defer.inlineCallbacks
     def test_contruction_minimal_docker(self):
         docker.version = "2.0.0"
-        bs = self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
+        id, name = yield bs.start_instance(self.build)
         client = docker.Client.latest
         self.assertEqual(client.called_class_name, "APIClient")
         client = docker.APIClient.latest
         self.assertNotEqual(client.called_class_name, "Client")
 
+    @defer.inlineCallbacks
     def test_constructor_nopassword(self):
         # when no password, it is created automatically
-        bs = self.setupWorker('bot', None, 'tcp://1234:2375', 'worker')
+        bs = yield self.setupWorker('bot', None, 'tcp://1234:2375', 'worker')
         self.assertEqual(bs.workername, 'bot')
         self.assertEqual(len(bs.password), 20)
 
+    @defer.inlineCallbacks
     def test_constructor_all_docker_parameters(self):
         # Volumes have their own tests
-        bs = self.setupWorker('bot', 'pass', 'unix:///var/run/docker.sock', 'worker_img', ['/bin/sh'],
-                              dockerfile="FROM ubuntu", version='1.9', tls=True,
-                              hostconfig={'network_mode': 'fake', 'dns': ['1.1.1.1', '1.2.3.4']},
-                              custom_context=False, buildargs=None,
-                              encoding='gzip')
+        bs = yield self.setupWorker('bot', 'pass', 'unix:///var/run/docker.sock', 'worker_img',
+                                    ['/bin/sh'],
+                                    dockerfile="FROM ubuntu", version='1.9', tls=True,
+                                    hostconfig={'network_mode': 'fake', 'dns': ['1.1.1.1', '1.2.3.4']},
+                                    custom_context=False, buildargs=None,
+                                    encoding='gzip')
         self.assertEqual(bs.workername, 'bot')
         self.assertEqual(bs.password, 'pass')
         self.assertEqual(bs.image, 'worker_img')
@@ -122,21 +133,23 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
         self.assertEqual(bs.buildargs, None)
         self.assertEqual(bs.encoding, 'gzip')
 
+    @defer.inlineCallbacks
     def test_start_instance_volume_renderable(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'worker', ['bin/bash'],
             volumes=[Interpolate('/data:/worker/%(kw:builder)s/build',
                                  builder=Property('builder'))])
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         client = docker.Client.latest
         self.assertEqual(len(client.call_args_create_container), 1)
         self.assertEqual(client.call_args_create_container[0]['volumes'],
                          ['/worker/docker_worker/build'])
 
+    @defer.inlineCallbacks
     def test_volume_no_suffix(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'worker', ['bin/bash'], volumes=['/src/webapp:/opt/webapp'])
-        self.successResultOf(bs.start_instance(self.build))
+        yield bs.start_instance(self.build)
         client = docker.Client.latest
         self.assertEqual(len(client.call_args_create_container), 1)
         self.assertEqual(len(client.call_args_create_host_config), 1)
@@ -145,11 +158,12 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
         self.assertEqual(client.call_args_create_host_config[0]['binds'],
                          ["/src/webapp:/opt/webapp"])
 
+    @defer.inlineCallbacks
     def test_volume_ro_rw(self):
-        bs = self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker', ['bin/bash'],
-                              volumes=['/src/webapp:/opt/webapp:ro',
-                                       '~:/backup:rw'])
-        self.successResultOf(bs.start_instance(self.build))
+        bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker', ['bin/bash'],
+                                    volumes=['/src/webapp:/opt/webapp:ro',
+                                             '~:/backup:rw'])
+        yield bs.start_instance(self.build)
         client = docker.Client.latest
         self.assertEqual(len(client.call_args_create_container), 1)
         self.assertEqual(len(client.call_args_create_host_config), 1)
@@ -158,128 +172,146 @@ class TestDockerLatentWorker(unittest.SynchronousTestCase, TestReactorMixin):
         self.assertEqual(client.call_args_create_host_config[0]['binds'],
                          ['/src/webapp:/opt/webapp:ro', '~:/backup:rw'])
 
+    @defer.inlineCallbacks
     def test_volume_bad_format(self):
         with self.assertRaises(config.ConfigErrors):
-            self.setupWorker('bot', 'pass', 'http://localhost:2375',
-                             image="worker",
-                             volumes=['abcd=efgh'])
+            yield self.setupWorker('bot', 'pass', 'http://localhost:2375',
+                                   image="worker",
+                                   volumes=['abcd=efgh'])
 
+    @defer.inlineCallbacks
     def test_volume_bad_format_renderable(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'http://localhost:2375', image="worker",
             volumes=[Interpolate('/data==/worker/%(kw:builder)s/build',
                                  builder=Property('builder'))])
-        f = self.failureResultOf(bs.start_instance(self.build))
-        f.check(config.ConfigErrors)
+        with self.assertRaises(config.ConfigErrors):
+            yield bs.start_instance(self.build)
 
+    @defer.inlineCallbacks
     def test_start_instance_image_no_version(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'busybox', ['bin/bash'])
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'busybox')
 
+    @defer.inlineCallbacks
     def test_start_instance_image_right_version(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'busybox:latest', ['bin/bash'])
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'busybox:latest')
 
+    @defer.inlineCallbacks
     def test_start_instance_image_wrong_version(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'busybox:123', ['bin/bash'])
-        f = self.failureResultOf(bs.start_instance(self.build))
-        f.check(interfaces.LatentWorkerFailedToSubstantiate)
+        with self.assertRaises(interfaces.LatentWorkerCannotSubstantiate):
+            yield bs.start_instance(self.build)
 
+    @defer.inlineCallbacks
     def test_start_instance_image_renderable(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', Property('image'), ['bin/bash'])
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'busybox:latest')
 
+    @defer.inlineCallbacks
     def test_start_instance_noimage_nodockerfile(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'customworker', ['bin/bash'])
-        f = self.failureResultOf(bs.start_instance(self.build))
-        f.check(interfaces.LatentWorkerFailedToSubstantiate)
+        with self.assertRaises(interfaces.LatentWorkerCannotSubstantiate):
+            yield bs.start_instance(self.build)
 
+    @defer.inlineCallbacks
     def test_start_instance_image_and_dockefile(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'customworker', dockerfile='BUG')
-        f = self.failureResultOf(bs.start_instance(self.build))
-        f.check(interfaces.LatentWorkerFailedToSubstantiate)
+        with self.assertRaises(interfaces.LatentWorkerCannotSubstantiate):
+            yield bs.start_instance(self.build)
 
+    @defer.inlineCallbacks
     def test_start_instance_noimage_gooddockerfile(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'customworker', dockerfile='FROM debian:wheezy')
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'customworker')
 
+    @defer.inlineCallbacks
     def test_start_instance_noimage_pull(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'alpine:latest', autopull=True)
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'alpine:latest')
 
+    @defer.inlineCallbacks
     def test_start_instance_image_pull(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'tester:latest', autopull=True)
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'tester:latest')
         client = docker.Client.latest
         self.assertEqual(client._pullCount, 0)
 
+    @defer.inlineCallbacks
     def test_start_instance_image_alwayspull(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'tester:latest', autopull=True, alwaysPull=True)
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'tester:latest')
         client = docker.Client.latest
         self.assertEqual(client._pullCount, 1)
 
+    @defer.inlineCallbacks
     def test_start_instance_image_noauto_alwayspull(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'tester:latest', autopull=False, alwaysPull=True)
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'tester:latest')
         client = docker.Client.latest
         self.assertEqual(client._pullCount, 0)
 
+    @defer.inlineCallbacks
     def test_start_instance_noimage_renderabledockerfile(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'customworker',
             dockerfile=Interpolate('FROM debian:%(kw:distro)s',
                                    distro=Property('distro')))
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'customworker')
 
+    @defer.inlineCallbacks
     def test_start_instance_custom_context_and_buildargs(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'tester:latest',
             dockerfile=Interpolate('FROM debian:latest'), custom_context=True,
             buildargs={'sample_arg1': 'test_val1'})
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'tester:latest')
 
+    @defer.inlineCallbacks
     def test_start_instance_custom_context_no_buildargs(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'tester:latest',
             dockerfile=Interpolate('FROM debian:latest'),
             custom_context=True)
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'tester:latest')
 
+    @defer.inlineCallbacks
     def test_start_instance_buildargs_no_custom_context(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', 'tcp://1234:2375', 'tester:latest',
             dockerfile=Interpolate('FROM debian:latest'),
             buildargs={'sample_arg1': 'test_val1'})
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'tester:latest')
 
+    @defer.inlineCallbacks
     def test_start_worker_but_already_created_with_same_name(self):
-        bs = self.setupWorker(
+        bs = yield self.setupWorker(
             'existing', 'pass', 'tcp://1234:2375', 'busybox:latest', ['bin/bash'])
-        id, name = self.successResultOf(bs.start_instance(self.build))
+        id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'busybox:latest')
 
 


### PR DESCRIPTION
This PR removes most of the remaining uses of functions from SynchronousTestCase which make tests more brittle. For example, using successResultOf() will fail in cases a Deferred is not called immediately, which could happen in certain cases randomly if test reactor is not used.