### PR TITLE
master: Fix GitHub "User Agent" required

### DIFF
--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -28,6 +28,7 @@ from twisted.trial import unittest
 from twisted.web.resource import Resource
 from twisted.web.server import Site
 
+import buildbot
 from buildbot.process.properties import Secret
 from buildbot.secrets.manager import SecretManager
 from buildbot.test.fake.secrets import FakeSecretStorage
@@ -208,7 +209,12 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin,
             FakeResponse(dict(access_token="TOK3N"))]
 
         def fake_get(self, ep, **kwargs):
-            test.assertEqual(self.headers, {'Authorization': 'token TOK3N'})
+            test.assertEqual(
+                self.headers,
+                {
+                    'Authorization': 'token TOK3N',
+                    'User-Agent': 'buildbot/%s' % buildbot.version,
+                })
             if ep == '/user':
                 return dict(
                     login="bar",

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -26,6 +26,7 @@ import requests
 from twisted.internet import defer
 from twisted.internet import threads
 
+import buildbot
 from buildbot import config
 from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
@@ -286,7 +287,10 @@ class GitHubAuth(OAuth2Auth):
 
     def createSessionFromToken(self, token):
         s = requests.Session()
-        s.headers = {'Authorization': 'token ' + token['access_token']}
+        s.headers = {
+            'Authorization': 'token ' + token['access_token'],
+            'User-Agent': 'buildbot/%s' % buildbot.version,
+        }
         s.verify = self.sslVerify
         return s
 


### PR DESCRIPTION
When updating buildbot to include #5189 (31c2caae10f9) GitHub returns and error that a user agent is required. This change updates the requests session to include the User-Agent: buildbot/$buildbot_version

See: https://developer.github.com/v3/#user-agent-required

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
