### PR TITLE
deferwaiter improvements

### DIFF
--- a/master/buildbot/test/unit/test_util_deferwaiter.py
+++ b/master/buildbot/test/unit/test_util_deferwaiter.py
@@ -54,6 +54,20 @@ class WaiterTests(unittest.TestCase):
         d1.callback(None)
         self.assertTrue(d.called)
 
+    @defer.inlineCallbacks
+    def test_passes_result(self):
+        w = DeferWaiter()
+
+        d1 = defer.Deferred()
+        w.add(d1)
+
+        d1.callback(123)
+        res = yield d1
+        self.assertEqual(res, 123)
+
+        d = w.wait()
+        self.assertTrue(d.called)
+
 
 class RepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):
 

--- a/master/buildbot/test/unit/test_util_deferwaiter.py
+++ b/master/buildbot/test/unit/test_util_deferwaiter.py
@@ -68,6 +68,37 @@ class WaiterTests(unittest.TestCase):
         d = w.wait()
         self.assertTrue(d.called)
 
+    @defer.inlineCallbacks
+    def test_cancel_not_called(self):
+        w = DeferWaiter()
+
+        d1 = defer.Deferred()
+        w.add(d1)
+
+        w.cancel()
+        d = w.wait()
+        self.assertTrue(d.called)
+        with self.assertRaises(defer.CancelledError):
+            yield d1
+
+    @defer.inlineCallbacks
+    def test_cancel_called(self):
+        w = DeferWaiter()
+
+        d1_waited = defer.Deferred()
+        d1 = defer.succeed(None)
+        d1.addCallback(lambda _: d1_waited)
+        w.add(d1)
+
+        w.cancel()
+
+        d = w.wait()
+        self.assertTrue(d.called)
+        self.assertTrue(d1.called)
+        self.assertTrue(d1_waited.called)
+        with self.assertRaises(defer.CancelledError):
+            yield d1
+
 
 class RepeatedActionHandlerTests(unittest.TestCase, TestReactorMixin):
 

--- a/master/buildbot/util/deferwaiter.py
+++ b/master/buildbot/util/deferwaiter.py
@@ -26,10 +26,11 @@ class DeferWaiter:
         self._waited = set()
         self._finish_notifier = Notifier()
 
-    def _finished(self, _, d):
+    def _finished(self, result, d):
         self._waited.remove(id(d))
         if not self._waited:
             self._finish_notifier.notify(None)
+        return result
 
     def add(self, d):
         if not isinstance(d, defer.Deferred):


### PR DESCRIPTION
This PR fixes a bug in deferwaiter implementation that resulted in results of the registered `Deferred`s being not passed along. Also, a `cancel()` method is added.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
