### PR TITLE
Add LineProcessProtocol and use it

### DIFF
--- a/master/buildbot/test/unit/test_util_protocol.py
+++ b/master/buildbot/test/unit/test_util_protocol.py
@@ -1,0 +1,51 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.trial import unittest
+
+from buildbot.util.protocol import LineProcessProtocol
+
+
+class FakeLineProcessProtocol(LineProcessProtocol):
+
+    def __init__(self):
+        super().__init__()
+        self.out_lines = []
+        self.err_lines = []
+
+    def outLineReceived(self, line):
+        self.out_lines.append(line)
+
+    def errLineReceived(self, line):
+        self.err_lines.append(line)
+
+
+class TestLineProcessProtocol(unittest.TestCase):
+
+    def test_stdout(self):
+        p = FakeLineProcessProtocol()
+        p.outReceived(b'\nline2\nline3\nli')
+        p.outReceived(b'ne4\nli')
+        self.assertEqual(p.out_lines, [b'', b'line2', b'line3', b'line4'])
+        p.processEnded(0)
+        self.assertEqual(p.out_lines, [b'', b'line2', b'line3', b'line4', b'li'])
+
+    def test_stderr(self):
+        p = FakeLineProcessProtocol()
+        p.errReceived(b'\nline2\nline3\nli')
+        p.errReceived(b'ne4\nli')
+        self.assertEqual(p.err_lines, [b'', b'line2', b'line3', b'line4'])
+        p.processEnded(0)
+        self.assertEqual(p.err_lines, [b'', b'line2', b'line3', b'line4', b'li'])

--- a/master/buildbot/util/protocol.py
+++ b/master/buildbot/util/protocol.py
@@ -1,0 +1,79 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Portions Copyright Buildbot Team Members
+
+
+from twisted.internet import protocol
+
+
+class LineBuffer:
+    def __init__(self):
+        self._buffer = b''
+
+    def add_data(self, data):
+        # returns lines that have been processed, if any
+        lines = (self._buffer + data).split(b'\n')
+        self._buffer = lines.pop(-1)
+        for l in lines:
+            yield l.rstrip(b'\r')
+
+    def get_trailing_line(self):
+        if self._buffer:
+            ret = [self._buffer]
+            self._buffer = b''
+            return ret
+        return []
+
+
+class LineProcessProtocol(protocol.ProcessProtocol):
+
+    def __init__(self):
+        self._out_buffer = LineBuffer()
+        self._err_buffer = LineBuffer()
+
+    def outReceived(self, data):
+        """
+        Translates bytes into lines, and calls outLineReceived.
+        """
+        for line in self._out_buffer.add_data(data):
+            self.outLineReceived(line)
+
+    def errReceived(self, data):
+        """
+        Translates bytes into lines, and calls errLineReceived.
+        """
+        for line in self._err_buffer.add_data(data):
+            self.errLineReceived(line)
+
+    def processEnded(self, status):
+        for line in self._out_buffer.get_trailing_line():
+            self.outLineReceived(line)
+        for line in self._err_buffer.get_trailing_line():
+            self.errLineReceived(line)
+
+    def outLineReceived(self, line):
+        """
+        Callback to which stdout lines will be sent.
+        Any line that is not terminated by a newline will be processed once the next line comes,
+        or when processEnded is called.
+        """
+        raise NotImplementedError
+
+    def errLineReceived(self, line):
+        """
+        Callback to which stdout lines will be sent.
+        Any line that is not terminated by a newline will be processed once the next line comes,
+        or when processEnded is called.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
This slightly simplifies the codebase by no longer needing to implement line handling in various places.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
