### PR TITLE
Enable warnings on more files

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -111,6 +111,8 @@ basicauth
 baz
 bb
 bbot
+bbindex
+bbreftargetdirective
 bc
 bdict
 bdictlist
@@ -403,6 +405,7 @@ distutils
 dn
 dnotify
 doclobber
+docname
 doconfig
 docopy
 docstring
@@ -660,6 +663,7 @@ i'm
 impl
 ina
 incrementing
+indextemplates
 indices
 influxdb
 infos
@@ -784,6 +788,7 @@ listentcp
 liveness
 loadconfig
 localhost
+localname
 localtime
 lockaccess
 lockclass
@@ -916,6 +921,7 @@ multiservice's
 multithreading
 mumbo
 munge
+mydashboard
 mysql
 mysqlclient
 mysqld
@@ -1021,6 +1027,7 @@ pluggableauthenticationmoduleschecker
 plugin
 plugins
 pn
+png
 pollatlaunch
 pollatreconfigure
 poller
@@ -1068,6 +1075,7 @@ pullrequests
 pushjet
 pwd
 py
+py's
 pycrypto
 pyd
 pyflakes
@@ -1253,6 +1261,7 @@ setupmailnotifier
 setupsite
 setupsourcestep
 setupstep
+setuptools
 sha
 shellcommand
 shlex
@@ -1292,6 +1301,7 @@ spawnprocess
 specdir
 specfile
 specfiles
+spellcheck
 split
 splitter
 spulec
@@ -1395,6 +1405,7 @@ sys
 tac
 taichino
 tarball
+targetname
 tbl
 tcp
 tcpdump
@@ -1486,6 +1497,7 @@ unencrypted
 unexpectedsuccesses
 ungrouped
 unhandled
+unhighlighted
 unicast
 unicode
 unicoded

--- a/master/Makefile
+++ b/master/Makefile
@@ -1,12 +1,11 @@
 # developer utilities
 pylint:
-	pylint -j4 --rcfile=../common/pylintrc buildbot
+	pylint -j4 --rcfile=../common/pylintrc buildbot docs/*.py setup.py
 	@test ! -f fail
 
 tutorial:
 	cd docs/tutorial; $(MAKE) html
 flake8:
-	flake8 --config=../common/flake8rc buildbot
-	flake8 --config=../common/flake8rc docs/conf.py
+	flake8 --config=../common/flake8rc buildbot docs/*.py setup.py
 rmpyc:
 	make -C .. rmpyc

--- a/master/docs/bbdocs/ext.py
+++ b/master/docs/bbdocs/ext.py
@@ -369,8 +369,8 @@ class BBDomain(Domain):
                     self_path = '{0}#{1}'.format(self.env.doc2path(self_data[target_name][0]),
                                                  self_data[target_name][1])
 
-                    other_path = '{0}#{1}'.format(self.env.doc2path(other_path[target_name][0]),
-                                                  other_path[target_name][1])
+                    other_path = '{0}#{1}'.format(self.env.doc2path(other_data[target_name][0]),
+                                                  other_data[target_name][1])
 
                     logger.warning(('Duplicate index {} reference {} in {}, '
                                     'other instance in {}').format(typ, target_name,

--- a/master/docs/bbdocs/ext.py
+++ b/master/docs/bbdocs/ext.py
@@ -267,7 +267,8 @@ class BBDomain(Domain):
                                            has_content=True,
                                            name_annotation='resource type:',
                                            doc_field_types=[
-                                               TypedField('attr', label='Attributes', names=('attr',),
+                                               TypedField('attr', label='Attributes',
+                                                          names=('attr',),
                                                           typenames=('type',), can_collapse=True),
                                            ]),
         'rpath': make_ref_target_directive('rpath',

--- a/master/docs/bbdocs/highlighterrors.py
+++ b/master/docs/bbdocs/highlighterrors.py
@@ -52,16 +52,16 @@ def patched_unhighlighted(self, source):
             anonymous expression.
             """) % indented_source
         raise UnhighlightedError(msg)
-    else:
-        msg = textwrap.dedent("""\
-            Unhighlighted block:
 
-            %s
+    msg = textwrap.dedent("""\
+        Unhighlighted block:
 
-            """) % indented_source
-        sys.stderr.write(msg.encode('ascii', 'ignore'))
+        %s
 
-        return orig_unhiglighted(self, source)
+        """) % indented_source
+    sys.stderr.write(msg.encode('ascii', 'ignore'))
+
+    return orig_unhiglighted(self, source)
 
 # Compatible with PygmentsBridge.highlight_block since Sphinx'
 # 1860:19b394207746 changeset (v0.6.6 release)

--- a/master/docs/bbdocs/highlighterrors.py
+++ b/master/docs/bbdocs/highlighterrors.py
@@ -4,7 +4,7 @@ import sys
 import textwrap
 from pkg_resources import parse_version
 
-# Monkey-patch Sphinx to treat unhiglighted code as error.
+# Monkey-patch Sphinx to treat unhighlighted code as error.
 import sphinx
 import sphinx.highlighting
 from sphinx.errors import SphinxWarning

--- a/master/setup.py
+++ b/master/setup.py
@@ -335,7 +335,10 @@ setup_args = {
             ('buildbot.reporters.github', ['GitHubStatusPush', 'GitHubCommentPush']),
             ('buildbot.reporters.gitlab', ['GitLabStatusPush']),
             ('buildbot.reporters.stash', ['StashStatusPush']),
-            ('buildbot.reporters.bitbucketserver', ['BitbucketServerStatusPush', 'BitbucketServerPRCommentPush']),
+            ('buildbot.reporters.bitbucketserver', [
+                'BitbucketServerStatusPush',
+                'BitbucketServerPRCommentPush'
+            ]),
             ('buildbot.reporters.bitbucket', ['BitbucketStatusPush']),
             ('buildbot.reporters.irc', ['IRC']),
             ('buildbot.reporters.telegram', ['TelegramBot']),
@@ -392,7 +395,9 @@ setup_args = {
                 ('repo.DownloadsFromProperties',
                  'RepoDownloadsFromProperties')]),
             ('buildbot.steps.shellsequence', ['ShellArg']),
-            ('buildbot.util.kubeclientservice', ['KubeHardcodedConfig', 'KubeCtlProxyConfigLoader', 'KubeInClusterConfigLoader']),
+            ('buildbot.util.kubeclientservice', [
+                'KubeHardcodedConfig', 'KubeCtlProxyConfigLoader', 'KubeInClusterConfigLoader'
+            ]),
             ('buildbot.www.avatar', ['AvatarGravatar']),
             ('buildbot.www.auth', [
                 'UserPasswordAuth', 'HTPasswdAuth', 'RemoteUserAuth', 'CustomAuth']),
@@ -408,7 +413,9 @@ setup_args = {
                 'RolesFromDomain']),
             ('buildbot.www.authz.endpointmatchers', [
                 'AnyEndpointMatcher', 'StopBuildEndpointMatcher', 'ForceBuildEndpointMatcher',
-                'RebuildBuildEndpointMatcher', 'AnyControlEndpointMatcher', 'EnableSchedulerEndpointMatcher']),
+                'RebuildBuildEndpointMatcher', 'AnyControlEndpointMatcher',
+                'EnableSchedulerEndpointMatcher'
+            ]),
         ]),
         ('buildbot.webhooks', [
             ('buildbot.www.hooks.base', ['base']),

--- a/master/setup.py
+++ b/master/setup.py
@@ -33,10 +33,7 @@ from setuptools import setup
 
 from buildbot import version
 
-if "bdist_wheel" in sys.argv:
-    BUILDING_WHEEL = True
-else:
-    BUILDING_WHEEL = False
+BUILDING_WHEEL = bool("bdist_wheel" in sys.argv)
 
 
 def include(d, e):

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -1,9 +1,9 @@
 # developer utilities
 pylint:
-	pylint -j4 --rcfile=../common/pylintrc buildbot_worker
+	pylint -j4 --rcfile=../common/pylintrc buildbot_worker setup.py
 
 flake8:
-	flake8 --config=../common/flake8rc buildbot_worker
+	flake8 --config=../common/flake8rc buildbot_worker setup.py
 
 .PHONY: Dockerfile.py3
 

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -99,7 +99,7 @@ setup_args = {
         'console_scripts': [
             'buildbot-worker=buildbot_worker.scripts.runner:run',
             # this will also be shipped on non windows :-(
-            'buildbot_worker_windows_service=buildbot_worker.scripts.windows_service:HandleCommandLine',
+            'buildbot_worker_windows_service=buildbot_worker.scripts.windows_service:HandleCommandLine',  # noqa pylint: disable=line-too-long
         ]}
 }
 

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -24,7 +24,6 @@ from __future__ import print_function
 
 import os
 import sys
-from distutils.command.install_data import install_data
 from distutils.command.sdist import sdist
 from distutils.core import setup
 
@@ -115,7 +114,7 @@ twisted_ver = ">= 17.9.0"
 try:
     # If setuptools is installed, then we'll add setuptools-specific arguments
     # to the setup args.
-    import setuptools  # @UnusedImport
+    import setuptools  # noqa pylint: disable=unused-import
 except ImportError:
     pass
 else:


### PR DESCRIPTION
Looks like that flake8 and pylint skip a lot of files when searching for issues. Enabling the warnings on these files and fixing them led to resolution of at least one bug.