### PR TITLE
requirements: Upgrade zope.interface to 4.7.0 for Python 3.8 support

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -86,7 +86,7 @@ webcolors==1.10
 Werkzeug==0.16.0
 wrapt==1.11.2
 xmltodict==0.12.0
-zope.interface==4.6.0
+zope.interface==4.7.0
 coverage==4.5.4
 codecov==2.0.15
 -e master

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -11,5 +11,5 @@ pbr==5.4.3
 PyHamcrest==1.9.0
 six==1.12.0
 Twisted==19.7.0
-zope.interface==4.6.0
+zope.interface==4.7.0
 -e worker


### PR DESCRIPTION
Tests started failing during requirements installation due to incompatibility of zope.interface==4.6.0 and Python 3.8 (see e.g. https://buildbot.buildbot.net/#/builders/61/builds/374/steps/5/logs/stdio). This PR fixes this problem.