### PR TITLE
requirements: Pin mock because newer version requires Python 3.6

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -38,7 +38,8 @@ lz4==2.2.1
 markdown2==2.3.8
 MarkupSafe==1.1.1
 mccabe==0.6.1
-mock==3.0.5
+# pin mock, because 4.x no longer supports Python 3.5
+mock==3.0.5   # pyup: ignore
 moto==1.3.13
 olefile==0.46
 packaging==19.2

--- a/requirements-ciworker.txt
+++ b/requirements-ciworker.txt
@@ -6,7 +6,8 @@ future==0.18.2
 hyperlink==19.0.0
 idna==2.8
 incremental==17.5.0
-mock==3.0.5
+# pin mock, because 4.x no longer supports Python 3.5
+mock==3.0.5  # pyup: ignore
 pbr==5.4.3
 PyHamcrest==1.9.0
 six==1.12.0


### PR DESCRIPTION
We still support Python 3.5.