### PR TITLE
test: Extract fake DB setup to separate connector component class

### DIFF
--- a/master/buildbot/test/unit/test_db_builders.py
+++ b/master/buildbot/test/unit/test_db_builders.py
@@ -19,11 +19,9 @@ from twisted.trial import unittest
 from buildbot.db import builders
 from buildbot.db import tags
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 
 
 def builderKey(builder):
@@ -249,14 +247,11 @@ class RealTests(Tests):
     pass
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
-        self.master = fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
+        yield self.setUpConnectorComponent()
 
 
 class TestRealDB(unittest.TestCase,

--- a/master/buildbot/test/unit/test_db_buildrequests.py
+++ b/master/buildbot/test/unit/test_db_buildrequests.py
@@ -20,11 +20,9 @@ from twisted.trial import unittest
 
 from buildbot.db import buildrequests
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import db
 from buildbot.test.util import interfaces
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import UTC
 from buildbot.util import epoch2datetime
 
@@ -628,7 +626,7 @@ class Tests(interfaces.InterfaceTests):
             [45, 47, 48])
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
     # Compatibility with some checks in the "real" tests.
 
     class db_engine:
@@ -636,13 +634,10 @@ class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
         class dialect:
             name = 'buildbot_fake'
 
+    @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
-        self.master = fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
-        return self.setUpTests()
+        yield self.setUpConnectorComponent()
+        yield self.setUpTests()
 
 
 class TestRealDB(unittest.TestCase,

--- a/master/buildbot/test/unit/test_db_builds.py
+++ b/master/buildbot/test/unit/test_db_builds.py
@@ -19,11 +19,9 @@ from twisted.trial import unittest
 from buildbot.data import resultspec
 from buildbot.db import builds
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 TIME1 = 1304262222
@@ -470,14 +468,11 @@ class RealTests(Tests):
                          [self.threeBdicts[50], self.threeBdicts[51]])
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
-        self.master = fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
+        yield self.setUpConnectorComponent()
 
 
 class TestRealDB(unittest.TestCase,

--- a/master/buildbot/test/unit/test_db_buildsets.py
+++ b/master/buildbot/test/unit/test_db_buildsets.py
@@ -24,12 +24,10 @@ from twisted.trial import unittest
 
 from buildbot.db import buildsets
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import db
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import UTC
 from buildbot.util import datetime2epoch
 from buildbot.util import epoch2datetime
@@ -482,15 +480,12 @@ class RealTests(Tests):
         yield self.db.pool.do(thd)
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
-        self.master = fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
-        return self.setUpTests()
+        yield self.setUpConnectorComponent()
+        yield self.setUpTests()
 
     @defer.inlineCallbacks
     def test_addBuildset_bad_waited_for(self):

--- a/master/buildbot/test/unit/test_db_changes.py
+++ b/master/buildbot/test/unit/test_db_changes.py
@@ -22,11 +22,9 @@ from buildbot.db import builds
 from buildbot.db import changes
 from buildbot.db import sourcestamps
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 SOMETIME = 20398573
@@ -750,14 +748,11 @@ class RealTests(Tests):
         yield expect(7, ['11th commit'])
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
-        self.master = fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
+        yield self.setUpConnectorComponent()
 
 
 class TestRealDB(unittest.TestCase,

--- a/master/buildbot/test/unit/test_db_changesources.py
+++ b/master/buildbot/test/unit/test_db_changesources.py
@@ -18,12 +18,10 @@ from twisted.trial import unittest
 
 from buildbot.db import changesources
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import db
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 
 
 def changeSourceKey(changeSource):
@@ -276,14 +274,11 @@ class RealTests(Tests):
     pass
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
-        self.master = fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
+        yield self.setUpConnectorComponent()
 
 
 class TestRealDB(db.TestCase,

--- a/master/buildbot/test/unit/test_db_logs.py
+++ b/master/buildbot/test/unit/test_db_logs.py
@@ -26,11 +26,9 @@ from twisted.trial import unittest
 
 from buildbot.db import logs
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 
@@ -574,14 +572,11 @@ class RealTests(Tests):
             self.assertEqual(lines, '')
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
-        self.master = fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
+        yield self.setUpConnectorComponent()
 
 
 class TestRealDB(unittest.TestCase,

--- a/master/buildbot/test/unit/test_db_masters.py
+++ b/master/buildbot/test/unit/test_db_masters.py
@@ -18,11 +18,9 @@ from twisted.trial import unittest
 
 from buildbot.db import masters
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 SOMETIME = 1348971992
@@ -203,15 +201,12 @@ class RealTests(Tests):
         yield self.db.pool.do(thd)
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
+        yield self.setUpConnectorComponent()
         self.reactor.advance(SOMETIME)
-        self.master = fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
 
 
 class TestRealDB(unittest.TestCase,

--- a/master/buildbot/test/unit/test_db_schedulers.py
+++ b/master/buildbot/test/unit/test_db_schedulers.py
@@ -19,12 +19,10 @@ from twisted.trial import unittest
 
 from buildbot.db import schedulers
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import db
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 
 
 class Tests(interfaces.InterfaceTests):
@@ -391,14 +389,11 @@ class RealTests(Tests):
     pass
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
-        self.master = fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
+        yield self.setUpConnectorComponent()
 
     def addClassifications(self, schedulerid, *classifications):
         self.db.schedulers.fakeClassifications(schedulerid,

--- a/master/buildbot/test/unit/test_db_sourcestamps.py
+++ b/master/buildbot/test/unit/test_db_sourcestamps.py
@@ -18,11 +18,9 @@ from twisted.trial import unittest
 
 from buildbot.db import sourcestamps
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 CREATED_AT = 927845299
@@ -364,14 +362,11 @@ class RealTests(Tests):
     pass
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
-        self.master = fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
+        yield self.setUpConnectorComponent()
 
 
 class TestRealDB(unittest.TestCase,

--- a/master/buildbot/test/unit/test_db_steps.py
+++ b/master/buildbot/test/unit/test_db_steps.py
@@ -21,11 +21,9 @@ from twisted.trial import unittest
 
 from buildbot.db import steps
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import interfaces
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import epoch2datetime
 
 TIME1 = 1304262222
@@ -34,7 +32,7 @@ TIME3 = 1304262224
 TIME4 = 1304262235
 
 
-class Tests(TestReactorMixin, interfaces.InterfaceTests):
+class Tests(interfaces.InterfaceTests):
 
     # common sample data
 
@@ -85,9 +83,6 @@ class Tests(TestReactorMixin, interfaces.InterfaceTests):
          'urls': [],
          'hidden': False},
     ]
-
-    def setUp(self):
-        self.setUpTestReactor()
 
     # signature tests
 
@@ -340,14 +335,11 @@ class RealTests(Tests):
         self.assertEqual(stepdict['name'], name)
 
 
-class TestFakeDB(Tests, unittest.TestCase):
+class TestFakeDB(Tests, unittest.TestCase, connector_component.FakeConnectorComponentMixin):
 
+    @defer.inlineCallbacks
     def setUp(self):
-        super().setUp()
-        self.master = fakemaster.make_master(self, wantDb=True)
-        self.db = self.master.db
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
+        yield self.setUpConnectorComponent()
 
 
 class TestRealDB(unittest.TestCase,

--- a/master/buildbot/test/unit/test_db_workers.py
+++ b/master/buildbot/test/unit/test_db_workers.py
@@ -19,12 +19,10 @@ from twisted.trial import unittest
 
 from buildbot.db import workers
 from buildbot.test import fakedb
-from buildbot.test.fake import fakemaster
 from buildbot.test.util import connector_component
 from buildbot.test.util import interfaces
 from buildbot.test.util import querylog
 from buildbot.test.util import validation
-from buildbot.test.util.misc import TestReactorMixin
 
 
 def workerKey(worker):
@@ -649,16 +647,11 @@ class RealTests(Tests):
     pass
 
 
-class TestFakeDB(TestReactorMixin, unittest.TestCase, Tests):
+class TestFakeDB(unittest.TestCase, connector_component.FakeConnectorComponentMixin, Tests):
 
     @defer.inlineCallbacks
     def setUp(self):
-        self.setUpTestReactor()
-        self.master = fakemaster.make_master(self)
-        self.db = fakedb.FakeDBConnector(self)
-        yield self.db.setServiceParent(self.master)
-        self.db.checkForeignKeys = True
-        self.insertTestData = self.db.insertTestData
+        yield self.setUpConnectorComponent()
 
 
 class TestRealDB(unittest.TestCase,

--- a/master/buildbot/test/util/connector_component.py
+++ b/master/buildbot/test/util/connector_component.py
@@ -64,3 +64,16 @@ class ConnectorComponentMixin(TestReactorMixin, db.RealDatabaseMixin):
         del self.db.pool
         del self.db.model
         del self.db
+
+
+class FakeConnectorComponentMixin(TestReactorMixin):
+    # Just like ConnectorComponentMixin, but for working with fake database
+
+    def setUpConnectorComponent(self):
+        self.setUpTestReactor()
+        self.master = fakemaster.make_master(self, wantDb=True)
+        self.db = self.master.db
+        self.db.checkForeignKeys = True
+        self.insertTestData = self.db.insertTestData
+
+        return defer.succeed(None)


### PR DESCRIPTION
This PR reduces duplication in fake DB test code setup. All common setup has been moved to a class that mimics the ConnectorComponentMixin which is used in the real DB case.