### PR TITLE
common: Raise exception on duplicate asset upload to github

### DIFF
--- a/common/download_release.py
+++ b/common/download_release.py
@@ -36,6 +36,10 @@ def main():
     assets = assets.json()
     os.makedirs('dist', exist_ok=True)
     for url in (a['browser_download_url'] for a in assets):
+        if 'gitarchive' in url:
+            raise Exception('The git archive has already been uploaded. Are you trying to fix '
+                            'broken upload? If this is the case, delete the asset in the GitHub '
+                            'UI and retry this command')
         if url.endswith(".whl") or url.endswith(".tar.gz"):
             fn = os.path.join('dist', url.split('/')[-1])
             download(s, url, fn)


### PR DESCRIPTION
This PR fixes script failure when retrying after failed upload during release. An exception with appropriate error message is thrown instead of weird failure.