### PR TITLE
fix missing entry point: GerritEventLogPoller

### DIFF
--- a/master/buildbot/newsfragments/gerrit-event-log-poller.bugfix
+++ b/master/buildbot/newsfragments/gerrit-event-log-poller.bugfix
@@ -1,0 +1,1 @@
+Fix :py:class:`GerritEventLogPoller` class to be declared as entry_point (can be used in master.cfg file)

--- a/master/setup.py
+++ b/master/setup.py
@@ -228,7 +228,8 @@ setup_args = {
             ('buildbot.changes.bitbucket', ['BitbucketPullrequestPoller']),
             ('buildbot.changes.github', ['GitHubPullrequestPoller']),
             ('buildbot.changes.bonsaipoller', ['BonsaiPoller']),
-            ('buildbot.changes.gerritchangesource', ['GerritChangeSource']),
+            ('buildbot.changes.gerritchangesource', [
+                'GerritChangeSource', 'GerritEventLogPoller']),
             ('buildbot.changes.gitpoller', ['GitPoller']),
             ('buildbot.changes.hgpoller', ['HgPoller']),
             ('buildbot.changes.p4poller', ['P4Source']),


### PR DESCRIPTION
when trying to use GerritEventLogPoller in configuration:
```
c['change_source'].append(changes.GerritEventLogPoller('gerrit', auth=('login', 'pass'), gitBaseURL="ssh://someuser@somehost:29418"))
```
an exception is raised:
```
Traceback (most recent call last):
  File "/home/wm/src/buildbot/sandbox.whl/lib/python3.7/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/home/wm/src/buildbot/sandbox.whl/lib/python3.7/site-packages/buildbot/scripts/checkconfig.py", line 57, in checkconfig
    return _loadConfig(basedir=basedir, configFile=configFile, quiet=quiet)
  File "/home/wm/src/buildbot/sandbox.whl/lib/python3.7/site-packages/buildbot/scripts/checkconfig.py", line 27, in _loadConfig
    config.FileLoader(basedir, configFile).loadConfig()
  File "/home/wm/src/buildbot/sandbox.whl/lib/python3.7/site-packages/buildbot/config.py", line 166, in loadConfig
    self.basedir, self.configFileName)
--- <exception caught here> ---
  File "/home/wm/src/buildbot/sandbox.whl/lib/python3.7/site-packages/buildbot/config.py", line 128, in loadConfigDict
    execfile(filename, localDict)
  File "/home/wm/src/buildbot/sandbox.whl/lib/python3.7/site-packages/twisted/python/compat.py", line 247, in execfile
    exec(code, globals, locals)
  File "workdir/master.cfg", line 24, in <module>
    c['change_source'].append(changes.GerritEventLogPoller(
  File "/home/wm/src/buildbot/sandbox.whl/lib/python3.7/site-packages/buildbot/plugins/db.py", line 270, in __getattr__
    raise AttributeError(str(err))
builtins.AttributeError: Unknown component name: GerritEventLogPoller
```
The issue is that GerritEventLogPoller is not declared as entry_point in setyp.py and thus not installed into _PluginDB.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
