### PR TITLE
docs: unpin sphinx, fix building and improve dashboard example

### DIFF
--- a/master/buildbot/newsfragments/update-sphinx.doc
+++ b/master/buildbot/newsfragments/update-sphinx.doc
@@ -1,0 +1,1 @@
+Make docs build with the latest sphinx and improve rendering of the example HTML file for custom dashboard

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -1252,7 +1252,7 @@ Then you need a ``templates/mydashboard.html`` file near your ``master.cfg``.
 This template is a standard Jinja_ template which is the default templating engine of Flask_.
 
 .. literalinclude:: mydashboard.html
-   :language: guess
+   :language: html+django
 
 
 .. _Flask: http://flask.pocoo.org/

--- a/requirements-cidocs.txt
+++ b/requirements-cidocs.txt
@@ -1,4 +1,4 @@
-Sphinx==2.0.1 # pyup: ignore
+Sphinx==2.4.4
 sphinx-jinja==1.1.0
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-blockdiag==2.0.0

--- a/smokes/templates/mydashboard.html
+++ b/smokes/templates/mydashboard.html
@@ -2,7 +2,7 @@
     <style>
     /* only modify th from this dashboard! */
     .mydashboard table th {
-        font-size 24pt;
+        font-size: 24pt;
     }
     </style>
     <!-- Create a table of builds organised by builders in columns -->


### PR DESCRIPTION
sphinx was pinned due to a sphinx bug [1][2], which is fixed since
sphinx 2.2.0. However, due to another sphinx bug, `:language: guess`
no longer works [4]. As the guessed language is xml+django, which is
not as good as html+django, which highlights CSS, I choose to fix
CSS in the example html and specify the language explicitly.

[1] https://github.com/buildbot/buildbot/pull/4852
[2] https://github.com/sphinx-doc/sphinx/issues/6474
[3] https://github.com/sphinx-doc/sphinx/pull/6624
[4] https://github.com/sphinx-doc/sphinx/issues/7139

Here is a partial screenshot for the improved example HTML:

![image](https://user-images.githubusercontent.com/1937689/76672969-0340a480-65dc-11ea-9a62-c7e1c92dbb8e.png)

Which looks better than the one on https://docs.buildbot.net/latest/manual/customization.html

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
