### PR TITLE
Fix inconsistent return statements

### DIFF
--- a/common/pylintrc
+++ b/common/pylintrc
@@ -132,7 +132,6 @@ disable=
   bad-continuation,
   keyword-arg-before-vararg,
   unsubscriptable-object,
-  inconsistent-return-statements,
   useless-object-inheritance,
   deprecated-method,
   useless-return,

--- a/master/buildbot/buildbot_net_usage_data.py
+++ b/master/buildbot/buildbot_net_usage_data.py
@@ -165,7 +165,7 @@ def fullData(master):
 
 def computeUsageData(master):
     if master.config.buildbotNetUsageData is None:
-        return
+        return None
     data = basicData(master)
 
     if master.config.buildbotNetUsageData != "basic":

--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -247,6 +247,7 @@ class GerritChangeSourceBase(base.ChangeSource):
             'files': files,
             'category': event["type"],
             'properties': properties})
+        return None
 
     def eventReceived_ref_updated(self, properties, event):
         ref = event["refUpdate"]

--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -230,7 +230,7 @@ class HgPoller(base.PollingChangeSource, StateMixin):
         @d.addCallback
         def results(heads):
             if not heads:
-                return
+                return None
 
             if len(heads.split()) > 1:
                 log.err(("hgpoller: caught several heads in branch %r "
@@ -238,7 +238,7 @@ class HgPoller(base.PollingChangeSource, StateMixin):
                          "You should wait until the situation is normal again "
                          "due to a merge or directly strip if remote repo "
                          "gets stripped later.") % (branch, self.repourl))
-                return
+                return None
 
             # in case of whole reconstruction, are we sure that we'll get the
             # same node -> rev assignations ?

--- a/master/buildbot/changes/mail.py
+++ b/master/buildbot/changes/mail.py
@@ -75,6 +75,7 @@ class MaildirSource(MaildirService, util.ComparableMixin):
                                                           **chdict)
             else:
                 log.msg("no change found in maildir file '{}'".format(filename))
+            return None
 
         return d
 
@@ -224,7 +225,7 @@ class CVSMaildirSource(MaildirSource):
             else:
                 log.msg(
                     'CVSMaildirSource can\'t get path from file list. Ignoring mail')
-                return
+                return None
             fileList = fileList[len(path):].strip()
             singleFileRE = re.compile(
                 r'(.+?),(NONE|(?:\d+\.(?:\d+\.\d+\.)*\d+)),(NONE|(?:\d+\.(?:\d+\.\d+\.)*\d+))(?: |$)')  # noqa pylint: disable=line-too-long

--- a/master/buildbot/changes/svnpoller.py
+++ b/master/buildbot/changes/svnpoller.py
@@ -306,14 +306,14 @@ class SVNPoller(base.PollingChangeSource, util.ComparableMixin):
             log.msg(format="SVNPoller: ignoring path '%(path)s' which doesn't"
                     "start with prefix '%(prefix)s'",
                     path=path, prefix=self._prefix)
-            return
+            return None
         relative_path = path[len(self._prefix):]
         if relative_path.startswith("/"):
             relative_path = relative_path[1:]
         where = self.split_file(relative_path)
         # 'where' is either None, (branch, final_path) or a dict
         if not where:
-            return
+            return None
         if isinstance(where, tuple):
             where = dict(branch=where[0], path=where[1])
         return where

--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -330,6 +330,7 @@ class GitExtractor(SourceStampExtractor):
             d = self.dovc(["remote"])
             d.addCallback(self.fixBranch)
             return d
+        return None
 
     # strip remote prefix from self.branch
     def fixBranch(self, remotes):
@@ -718,6 +719,7 @@ class Try(pb.Referenceable):
             assert self.buildsetStatus
             self._getStatus_1()
             return self.running
+        return None
 
     def _getStatus_1(self, res=None):
         if res:
@@ -810,6 +812,7 @@ class Try(pb.Referenceable):
         if not self.outstanding:
             # all done
             return self.statusDone()
+        return None
 
     def printStatus(self):
         try:

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -648,6 +648,7 @@ class MasterConfig(util.ComparableMixin):
                 return BuilderConfig(**b)
             else:
                 error("%r is not a builder config (in c['builders']" % (b,))
+            return None
         builders = [mapper(b) for b in builders]
 
         for builder in builders:

--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -109,12 +109,12 @@ class BuildNestingMixin:
         else:
             builderid = yield self.getBuilderId(kwargs)
             if builderid is None:
-                return
+                return None
             build = yield self.master.db.builds.getBuildByNumber(
                 builderid=builderid,
                 number=kwargs['build_number'])
             if not build:
-                return
+                return None
             return build['id']
 
     @defer.inlineCallbacks
@@ -124,14 +124,14 @@ class BuildNestingMixin:
         else:
             buildid = yield self.getBuildid(kwargs)
             if buildid is None:
-                return
+                return None
 
             dbdict = yield self.master.db.steps.getStep(buildid=buildid,
                                                         number=kwargs.get(
                                                             'step_number'),
                                                         name=kwargs.get('step_name'))
             if not dbdict:
-                return
+                return None
             return dbdict['id']
 
     def getBuilderId(self, kwargs):

--- a/master/buildbot/data/buildrequests.py
+++ b/master/buildbot/data/buildrequests.py
@@ -37,15 +37,17 @@ class Db2DataMixin:
             return (props
                     if '*' in filters
                     else dict(((k, v) for k, v in props.items() if k in filters)))
+        return None
 
     @defer.inlineCallbacks
     def addPropertiesToBuildRequest(self, buildrequest, filters):
         if not filters:
-            return
+            return None
         props = yield self.master.db.buildsets.getBuildsetProperties(buildrequest['buildsetid'])
         filtered_properties = self._generate_filtered_properties(props, filters)
         if filtered_properties:
             buildrequest['properties'] = filtered_properties
+        return None
 
     def db2data(self, dbdict):
         data = {
@@ -131,6 +133,7 @@ class BuildRequestEndpoint(Db2DataMixin, base.Endpoint):
         # references.
         yield self.master.data.updates.completeBuildRequests([brid],
                                                              results.CANCELLED)
+        return None
 
 
 class BuildRequestsEndpoint(Db2DataMixin, base.Endpoint):

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -39,6 +39,7 @@ class Db2DataMixin:
             return (props
                     if '*' in filters
                     else dict(((k, v) for k, v in props.items() if k in filters)))
+        return None
 
     def db2data(self, dbdict):
         data = {
@@ -86,7 +87,7 @@ class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
         else:
             bldr = yield self.getBuilderId(kwargs)
             if bldr is None:
-                return
+                return None
             num = kwargs['number']
             dbdict = yield self.master.db.builds.getBuildByNumber(bldr, num)
 

--- a/master/buildbot/data/changesources.py
+++ b/master/buildbot/data/changesources.py
@@ -51,7 +51,7 @@ class ChangeSourceEndpoint(Db2DataMixin, base.Endpoint):
             kwargs['changesourceid'])
         if 'masterid' in kwargs:
             if dbdict['masterid'] != kwargs['masterid']:
-                return
+                return None
         return (yield self.db2data(dbdict)) if dbdict else None
 
 

--- a/master/buildbot/data/forceschedulers.py
+++ b/master/buildbot/data/forceschedulers.py
@@ -46,12 +46,14 @@ class ForceSchedulerEndpoint(base.Endpoint):
         for sched in self.master.allSchedulers():
             if sched.name == schedulername and isinstance(sched, forcesched.ForceScheduler):
                 return defer.succeed(sched)
+        return None
 
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
         sched = yield self.findForceScheduler(kwargs['schedulername'])
         if sched is not None:
             return forceScheduler2Data(sched)
+        return None
 
     @defer.inlineCallbacks
     def control(self, action, args, kwargs):

--- a/master/buildbot/data/logchunks.py
+++ b/master/buildbot/data/logchunks.py
@@ -59,7 +59,7 @@ class LogChunkEndpoint(LogChunkEndpointBase):
     def get(self, resultSpec, kwargs):
         logid, dbdict = yield self.getLogIdAndDbDictFromKwargs(kwargs)
         if logid is None:
-            return
+            return None
         firstline = int(resultSpec.offset or 0)
         lastline = None if resultSpec.limit is None else firstline + \
             int(resultSpec.limit) - 1
@@ -70,12 +70,12 @@ class LogChunkEndpoint(LogChunkEndpointBase):
             if not dbdict:
                 dbdict = yield self.master.db.logs.getLog(logid)
             if not dbdict:
-                return
+                return None
             lastline = int(max(0, dbdict['num_lines'] - 1))
 
         # bounds checks
         if firstline < 0 or lastline < 0 or firstline > lastline:
-            return
+            return None
 
         logLines = yield self.master.db.logs.getLogLines(
             logid, firstline, lastline)
@@ -103,12 +103,12 @@ class RawLogChunkEndpoint(LogChunkEndpointBase):
     def get(self, resultSpec, kwargs):
         logid, dbdict = yield self.getLogIdAndDbDictFromKwargs(kwargs)
         if logid is None:
-            return
+            return None
 
         if not dbdict:
             dbdict = yield self.master.db.logs.getLog(logid)
             if not dbdict:
-                return
+                return None
         lastline = max(0, dbdict['num_lines'] - 1)
 
         logLines = yield self.master.db.logs.getLogLines(

--- a/master/buildbot/data/logs.py
+++ b/master/buildbot/data/logs.py
@@ -58,7 +58,7 @@ class LogEndpoint(EndpointMixin, base.BuildNestingMixin, base.Endpoint):
 
         stepid = yield self.getStepid(kwargs)
         if stepid is None:
-            return
+            return None
 
         dbdict = yield self.master.db.logs.getLogBySlug(stepid,
                                                         kwargs.get('log_slug'))

--- a/master/buildbot/data/resultspec.py
+++ b/master/buildbot/data/resultspec.py
@@ -221,6 +221,7 @@ class ResultSpec:
             if f.field == field and f.op == op:
                 self.filters.remove(f)
                 return f.values
+        return None
 
     def popOneFilter(self, field, op):
         v = self.popFilter(field, op)
@@ -233,11 +234,13 @@ class ResultSpec:
         neVals = self.popFilter(field, 'ne')
         if neVals and len(neVals) == 1:
             return not neVals[0]
+        return None
 
     def popStringFilter(self, field):
         eqVals = self.popFilter(field, 'eq')
         if eqVals and len(eqVals) == 1:
             return eqVals[0]
+        return None
 
     def popIntegerFilter(self, field):
         eqVals = self.popFilter(field, 'eq')
@@ -247,6 +250,7 @@ class ResultSpec:
             except ValueError:
                 raise ValueError("Filter value for {} should be integer, but got: {}".format(
                     field, eqVals[0]))
+        return None
 
     def removePagination(self):
         self.limit = self.offset = None

--- a/master/buildbot/data/schedulers.py
+++ b/master/buildbot/data/schedulers.py
@@ -53,7 +53,7 @@ class SchedulerEndpoint(Db2DataMixin, base.Endpoint):
             kwargs['schedulerid'])
         if 'masterid' in kwargs:
             if dbdict['masterid'] != kwargs['masterid']:
-                return
+                return None
         return (yield self.db2data(dbdict)) if dbdict else None
 
     @defer.inlineCallbacks

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -59,7 +59,7 @@ class StepEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
             return (yield self.db2data(dbdict)) if dbdict else None
         buildid = yield self.getBuildid(kwargs)
         if buildid is None:
-            return
+            return None
         dbdict = yield self.master.db.steps.getStep(
             buildid=buildid,
             number=kwargs.get('step_number'),
@@ -83,7 +83,7 @@ class StepsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
         else:
             buildid = yield self.getBuildid(kwargs)
             if buildid is None:
-                return
+                return None
         steps = yield self.master.db.steps.getSteps(buildid=buildid)
         results = []
         for dbdict in steps:

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -64,6 +64,7 @@ class WorkerEndpoint(Db2DataMixin, base.Endpoint):
             builderid=kwargs.get('builderid'))
         if sldict:
             return self.db2data(sldict)
+        return None
 
     @defer.inlineCallbacks
     def control(self, action, args, kwargs):

--- a/master/buildbot/db/changesources.py
+++ b/master/buildbot/db/changesources.py
@@ -68,6 +68,7 @@ class ChangeSourcesConnectorComponent(base.DBConnectorComponent):
         cs = yield self.getChangeSources(_changesourceid=changesourceid)
         if cs:
             return cs[0]
+        return None
 
     # returns a Deferred that returns a value
     def getChangeSources(self, active=None, masterid=None, _changesourceid=None):

--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -147,7 +147,7 @@ class DBConnector(service.ReconfigurableServiceMixin,
         """
         # pass on this if we're not configured yet
         if not self.configured_url:
-            return
+            return None
 
         d = self.changes.pruneChanges(self.master.config.changeHorizon)
         d.addErrback(log.err, 'while pruning changes')

--- a/master/buildbot/db/logs.py
+++ b/master/buildbot/db/logs.py
@@ -202,7 +202,7 @@ class LogsConnectorComponent(base.DBConnectorComponent):
         num_lines = res.fetchone()
         res.close()
         if not num_lines:
-            return  # ignore a missing log
+            return None  # ignore a missing log
 
         return self.thdSplitAndAppendChunk(conn=conn,
                                            logid=logid,

--- a/master/buildbot/db/schedulers.py
+++ b/master/buildbot/db/schedulers.py
@@ -136,7 +136,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                 q = sch_mst_tbl.delete(
                     whereclause=(sch_mst_tbl.c.schedulerid == schedulerid))
                 conn.execute(q).close()
-                return
+                return None
 
             # try a blind insert..
             try:
@@ -155,9 +155,10 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
                 row = conn.execute(q).fetchone()
                 # ok, that was us, so we just do nothing
                 if row['masterid'] == masterid:
-                    return
+                    return None
                 raise SchedulerAlreadyClaimedError(
                     "already claimed by {}".format(row['name']))
+            return None
 
         return self.db.pool.do(thd)
 
@@ -166,6 +167,7 @@ class SchedulersConnectorComponent(base.DBConnectorComponent):
         sch = yield self.getSchedulers(_schedulerid=schedulerid)
         if sch:
             return sch[0]
+        return None
 
     # returns a Deferred that returns a value
     def getSchedulers(self, active=None, masterid=None, _schedulerid=None):

--- a/master/buildbot/db/workers.py
+++ b/master/buildbot/db/workers.py
@@ -123,6 +123,7 @@ class WorkersConnectorComponent(base.DBConnectorComponent):
                                         _name=name, masterid=masterid, builderid=builderid)
         if workers:
             return workers[0]
+        return None
 
     # returns a Deferred that returns a value
     def getWorkers(self, _workerid=None, _name=None, masterid=None,

--- a/master/buildbot/machine/latent.py
+++ b/master/buildbot/machine/latent.py
@@ -146,6 +146,7 @@ class AbstractLatentMachine(Machine):
 
         self.state = States.STOPPED
         self._stop_notifier.notify(None)
+        return None
 
     def notifyBuildStarted(self):
         self._clearMissingTimer()

--- a/master/buildbot/monkeypatches/__init__.py
+++ b/master/buildbot/monkeypatches/__init__.py
@@ -24,7 +24,7 @@ def onlyOnce(fn):
     'Set up FN to only run once within an interpreter instance'
     def wrap(*args, **kwargs):
         if hasattr(fn, 'called'):
-            return
+            return None
         fn.called = 1
         return fn(*args, **kwargs)
     util.mergeFunctionMetadata(fn, wrap)

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -535,6 +535,7 @@ class Build(properties.PropertiesMixin):
         d.addBoth(self._flushProperties)
         d.addCallback(self._stepDone, s)
         d.addErrback(self.buildException)
+        return None
 
     @defer.inlineCallbacks
     def _flushProperties(self, results):

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -158,6 +158,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
             order=['submitted_at'], limit=1)
         if unclaimed:
             return unclaimed[0]['submitted_at']
+        return None
 
     @defer.inlineCallbacks
     def getNewestCompleteTime(self):
@@ -277,7 +278,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
         # don't unnecessarily setup properties for build
         def setupPropsIfNeeded(props):
             if props is not None:
-                return
+                return None
             props = Properties()
             Build.setupPropertiesKnownBeforeBuildStarts(props, [buildrequest],
                                                         self, workerforbuilder)

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -368,6 +368,7 @@ class BuildRequestDistributor(service.AsyncMultiService):
 
         yield self.pending_builders_lock.run(
             resetPendingBuildersList, new_builders)
+        return None
 
     @defer.inlineCallbacks
     def _defaultSorter(self, master, builders):

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -635,7 +635,7 @@ class Interpolate(util.ComparableMixin):
         except ValueError:
             config.error(
                 "invalid Interpolate substitution without selector '{}'".format(fmt))
-            return
+            return None
 
         fn = getattr(self, "_parse_" + key, None)
         if not fn:

--- a/master/buildbot/process/results.py
+++ b/master/buildbot/process/results.py
@@ -32,6 +32,7 @@ def worst_status(a, b):
     for s in (CANCELLED, RETRY, EXCEPTION, FAILURE, WARNINGS, SUCCESS, SKIPPED):
         if s in (a, b):
             return s
+    return None
 
 
 def computeResultAndTermination(obj, result, previousResult):

--- a/master/buildbot/process/users/manual.py
+++ b/master/buildbot/process/users/manual.py
@@ -220,4 +220,5 @@ class CommandlineUserManager(service.AsyncMultiService):
         def unreg(_):
             if self.registration:
                 return self.registration.unregister()
+            return None
         return d

--- a/master/buildbot/reporters/irc.py
+++ b/master/buildbot/reporters/irc.py
@@ -261,6 +261,7 @@ class IrcStatusBot(StatusBot, irc.IRCClient):
             message = message[len("{}:".format(self.nickname)):]
             d = contact.handleMessage(message)
             return d
+        return None
 
     def action(self, user, channel, data):
         user = user.split('!', 1)[0]  # rest is ~user@hostname

--- a/master/buildbot/reporters/pushjet.py
+++ b/master/buildbot/reporters/pushjet.py
@@ -91,7 +91,7 @@ class PushjetNotifier(NotifierBase):
                     logs=None, worker=None):
 
         if worker is not None and worker not in self.watchedWorkers:
-            return
+            return None
 
         msg = {'message': body}
         level = self.levels.get(LEVELS[results] if worker is None else 'worker_missing')

--- a/master/buildbot/reporters/pushover.py
+++ b/master/buildbot/reporters/pushover.py
@@ -105,7 +105,7 @@ class PushoverNotifier(NotifierBase):
                     logs=None, worker=None):
 
         if worker is not None and worker not in self.watchedWorkers:
-            return
+            return None
 
         msg = {'message': body}
         if type == 'html':

--- a/master/buildbot/reporters/telegram.py
+++ b/master/buildbot/reporters/telegram.py
@@ -171,6 +171,7 @@ class TelegramContact(Contact):
                 self.send('\n'.join(response))
         else:
             return super().command_COMMANDS(args)
+        return None
 
     @defer.inlineCallbacks
     def command_GETID(self, args, **kwargs):
@@ -404,6 +405,7 @@ class TelegramContact(Contact):
             text = ""
         self.send(text + "What do you want to do?",
                   reply_markup={'inline_keyboard': keyboard})
+        return None
 
     @defer.inlineCallbacks
     def command_FORCE(self, args, tquery=None, partial=None, **kwargs):

--- a/master/buildbot/reporters/words.py
+++ b/master/buildbot/reporters/words.py
@@ -174,6 +174,7 @@ class Channel(service.AsyncService):
                 return self.workerMissing(msg)
             if key[2] == 'connected':
                 return self.workerConnected(msg)
+            return None
 
         for e, f in (("new", buildStarted),             # BuilderStarted
                      ("finished", buildFinished)):      # BuilderFinished
@@ -467,24 +468,24 @@ class Contact:
         if not meth:
             if message[-1] == '!':
                 self.send("What you say!")
-                return
+                return None
             elif cmd.startswith(self.bot.commandPrefix):
                 self.send("I don't get this '{}'...".format(cmd))
                 meth = self.command_COMMANDS
             else:
                 if self.is_private_chat:
                     self.send("Say what?")
-                return
+                return None
 
         try:
             result = yield meth(args.strip(), **kwargs)
         except UsageError as e:
             self.send(str(e))
-            return
+            return None
         except Exception as e:
             self.bot.log_err(e)
             self.send("Something bad happened (see logs)")
-            return
+            return None
         return result
 
     def splitArgs(self, args):
@@ -550,7 +551,6 @@ class Contact:
                     response.append(worker['name'])
                     response.append("[offline]")
             self.send(' '.join(response))
-            return
 
         elif args[0] == 'changes':
             if all:
@@ -666,6 +666,7 @@ class Contact:
         def watchForCompleteEvent(key, msg):
             if key[-1] in ('finished', 'complete'):
                 return self.channel.buildFinished(msg, watched=True)
+            return None
 
         for build in builds:
             startConsuming = self.master.mq.startConsuming

--- a/master/buildbot/revlinks.py
+++ b/master/buildbot/revlinks.py
@@ -29,6 +29,7 @@ class RevlinkMatch:
             m = url.match(repo)
             if m:
                 return m.expand(self.revlink) % rev
+        return None
 
 
 GithubRevlink = RevlinkMatch(
@@ -77,6 +78,7 @@ class RevlinkMultiplexer:
             url = revlink(rev, repo)
             if url:
                 return url
+        return None
 
 
 default_revlink_matcher = RevlinkMultiplexer(GithubRevlink,

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -115,6 +115,7 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
 
         if not self._enable_consumer:
             yield self.startConsumingEnableEvents()
+        return None
 
     def _enabledCallback(self, key, msg):
         if msg['enabled']:
@@ -132,8 +133,9 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
     @defer.inlineCallbacks
     def deactivate(self):
         if not self.enabled:
-            return
+            return None
         yield defer.maybeDeferred(self._stopConsumingChanges)
+        return None
 
     # service handling
 

--- a/master/buildbot/schedulers/dependent.py
+++ b/master/buildbot/schedulers/dependent.py
@@ -80,7 +80,7 @@ class Dependent(base.BaseScheduler):
     def _buildset_new_cb(self, key, msg):
         # check if this was submitted by our upstream
         if msg['scheduler'] != self.upstream_name:
-            return
+            return None
 
         # record our interest in this buildset
         return self._addUpstreamBuildset(msg['bsid'])

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -97,6 +97,7 @@ class Timed(AbsoluteSourceStampsMixin, base.BaseScheduler):
                                              onlyImportant=self.onlyImportant)
         else:
             yield self.master.db.schedulers.flushChangeClassifications(self.serviceid)
+        return None
 
     @defer.inlineCallbacks
     def deactivate(self):
@@ -115,6 +116,7 @@ class Timed(AbsoluteSourceStampsMixin, base.BaseScheduler):
                 self.actuateAtTimer.cancel()
             self.actuateAtTimer = None
         yield self.actuationLock.run(stop_actuating)
+        return None
 
     # Scheduler methods
 

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -286,9 +286,9 @@ class RemoteBuildRequest(pb.Referenceable):
         # subscribe to any new builds..
         def gotBuild(key, msg):
             if msg['buildrequestid'] != self.brid or key[-1] != 'new':
-                return
+                return None
             if msg['buildid'] in reportedBuilds:
-                return
+                return None
             reportedBuilds.add(msg['buildid'])
             return subscriber.callRemote('newbuild',
                                          RemoteBuild(
@@ -335,6 +335,7 @@ class RemoteBuild(pb.Referenceable):
             elif key[-1] == 'finished':
                 return subscriber.callRemote('stepFinished', self.builderName, self, msg['name'],
                                              None, msg['results'])
+            return None
         self.consumer = yield self.master.mq.startConsuming(
             stepChanged,
             ('builds', str(self.builddict['buildid']), 'steps', None, None))
@@ -390,7 +391,7 @@ class Try_Userpass_Perspective(pbutil.NewCredPerspective):
         # build the intersection of the request and our configured list
         builderNames = self.scheduler.filterBuilderList(builderNames)
         if not builderNames:
-            return
+            return None
 
         reason = "'try' job"
 

--- a/master/buildbot/scripts/base.py
+++ b/master/buildbot/scripts/base.py
@@ -35,6 +35,7 @@ def captureErrors(errors, msg):
         print(msg)
         print(e)
         return 1
+    return None
 
 
 class BusyError(RuntimeError):
@@ -114,11 +115,11 @@ def loadConfig(config, configFileName='master.cfg'):
 
         for msg in e.errors:
             print("  " + msg)
-        return
+        return None
     except Exception:
         print("Errors loading configuration:")
         traceback.print_exc(file=sys.stdout)
-        return
+        return None
 
     return master_cfg
 

--- a/master/buildbot/scripts/logwatcher.py
+++ b/master/buildbot/scripts/logwatcher.py
@@ -121,7 +121,7 @@ class LogWatcher(LineOnlyReceiver):
 
     def lineReceived(self, line):
         if not self.running:
-            return
+            return None
         if b"Log opened." in line:
             self.in_reconfig = True
         if b"beginning configuration update" in line:
@@ -151,3 +151,4 @@ class LogWatcher(LineOnlyReceiver):
             return self.finished("buildmaster")
         if b"BuildMaster startup failed" in line:
             return self.finished(Failure(BuildmasterStartupError()))
+        return None

--- a/master/buildbot/scripts/reconfig.py
+++ b/master/buildbot/scripts/reconfig.py
@@ -35,13 +35,13 @@ class Reconfigurator:
         # Returns "Microsoft" for Vista and "Windows" for other versions
         if platform.system() in ("Windows", "Microsoft"):
             print("Reconfig (through SIGHUP) is not supported on Windows.")
-            return
+            return None
 
         with open(os.path.join(basedir, "twistd.pid"), "rt") as f:
             self.pid = int(f.read().strip())
         if quiet:
             os.kill(self.pid, signal.SIGHUP)
-            return
+            return None
 
         # keep reading twistd.log. Display all messages between "loading
         # configuration from ..." and "configuration update complete" or

--- a/master/buildbot/secrets/manager.py
+++ b/master/buildbot/secrets/manager.py
@@ -43,3 +43,4 @@ class SecretManager(service.BuildbotServiceManager):
             source_name = provider.__class__.__name__
             if value is not None:
                 return SecretDetails(source_name, secret, value)
+        return None

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -193,6 +193,7 @@ class Status(service.ReconfigurableServiceMixin, service.AsyncMultiService):
             if isinstance(thing, changes.Change):
                 change = thing
                 return "{}#changes/{}".format(prefix, change.number)
+        return None
 
     def getChangeSources(self):
         return list(self.master.change_svc)

--- a/master/buildbot/steps/package/deb/pbuilder.py
+++ b/master/buildbot/steps/package/deb/pbuilder.py
@@ -181,6 +181,7 @@ class DebPbuilder(WarningCountingShellCommand):
         else:
             log.msg("{} is not a file or a directory.".format(self.basetgz))
             self.finished(FAILURE)
+        return None
 
     def startBuild(self, cmd):
         if cmd.rc != 0:
@@ -188,6 +189,7 @@ class DebPbuilder(WarningCountingShellCommand):
             self.finished(FAILURE)
         else:
             return super().start()
+        return None
 
     def logConsumer(self):
         r = re.compile(r"dpkg-genchanges  >\.\./(.+\.changes)")

--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -73,6 +73,7 @@ class HLint(ShellCommand):
         self.addCompleteLog("files", "\n".join(self.hlintFiles) + "\n")
 
         super().start()
+        return None
 
     def logConsumer(self):
         while True:

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -559,6 +559,7 @@ class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):
             self.suppressionFile, abandonOnFailure=True)
         d.addCallback(self.uploadDone)
         d.addErrback(self.failed)
+        return None
 
     def uploadDone(self, data):
         lines = data.split("\n")

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -300,3 +300,4 @@ class Source(LoggingBuildStep, CompositeStepMixin):
             patch = None
 
         self.startVC(branch, revision, patch)
+        return None

--- a/master/buildbot/steps/source/bzr.py
+++ b/master/buildbot/steps/source/bzr.py
@@ -261,6 +261,7 @@ class Bzr(Source):
             return None
         elif self.method is None and self.mode == 'full':
             return 'fresh'
+        return None
 
     def parseGotRevision(self, _):
         d = self._dovccmd(["version-info", "--custom", "--template='{revno}"],

--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -368,6 +368,7 @@ class CVS(Source):
             return None
         elif self.method is None and self.mode == 'full':
             return 'fresh'
+        return None
 
     def computeSourceRevision(self, changes):
         if not changes:

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -361,6 +361,7 @@ class Git(Source, GitStepMixin):
             yield self.clobber()
         else:
             raise buildstep.BuildStepFailed()
+        return None
 
     @defer.inlineCallbacks
     def _clone(self, shallowClone):
@@ -501,6 +502,7 @@ class Git(Source, GitStepMixin):
             return None
         elif self.method is None and self.mode == 'full':
             return 'fresh'
+        return None
 
     @defer.inlineCallbacks
     def applyPatch(self, patch):

--- a/master/buildbot/steps/source/mercurial.py
+++ b/master/buildbot/steps/source/mercurial.py
@@ -292,6 +292,7 @@ class Mercurial(Source):
             return None
         elif self.method is None and self.mode == 'full':
             return 'fresh'
+        return None
 
     def _sourcedirIsUpdatable(self):
         return self.pathExists(self.build.path_module.join(self.workdir, '.hg'))

--- a/master/buildbot/steps/source/mtn.py
+++ b/master/buildbot/steps/source/mtn.py
@@ -253,6 +253,7 @@ class Monotone(Source):
                 df.addCallback(lambda _: self._retryPull())
                 reactor.callLater(delay, df.callback, None)
                 yield df
+        return None
 
     @defer.inlineCallbacks
     def parseGotRevision(self):

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -266,6 +266,7 @@ class P4(Source):
             return None
         elif self.method is None and self.mode == 'full':
             return 'fresh'
+        return None
 
     def _sourcedirIsUpdatable(self):
         # In general you should always be able to write to the directory

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -257,6 +257,7 @@ class SVN(Source):
             return None
         elif self.method is None and self.mode == 'full':
             return 'fresh'
+        return None
 
     @defer.inlineCallbacks
     def _sourcedirIsUpdatable(self):

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -82,6 +82,7 @@ class _TransferBuildStep(BuildStep):
         if self.cmd:
             d = self.cmd.interrupt(reason)
             return d
+        return None
 
 
 class FileUpload(_TransferBuildStep):

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -46,3 +46,4 @@ class FakeBotMaster(service.AsyncMultiService, botmaster.LockRetrieverMixin):
         if self.delayShutdown:
             self.shutdownDeferred = defer.Deferred()
             return self.shutdownDeferred
+        return None

--- a/master/buildbot/test/fake/httpclientservice.py
+++ b/master/buildbot/test/fake/httpclientservice.py
@@ -106,6 +106,7 @@ class HTTPClientService(service.SharedService):
         self._expected.append(dict(
             method=method, ep=ep, params=params, data=data, json=json, code=code,
             content=content, files=files))
+        return None
 
     def assertNoOutstanding(self):
         self.case.assertEqual(0, len(self._expected),

--- a/master/buildbot/test/fake/latent.py
+++ b/master/buildbot/test/fake/latent.py
@@ -137,7 +137,7 @@ class LatentController(SeverWorkerConnectionMixin):
     def disconnect_worker(self):
         super().disconnect_worker()
         if self.remote_worker is None:
-            return
+            return None
         self.worker.conn, conn = None, self.worker.conn
         self.remote_worker, worker = None, self.remote_worker
 

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -168,7 +168,7 @@ class WorkerController(SeverWorkerConnectionMixin):
     def disconnect_worker(self):
         super().disconnect_worker()
         if self.remote_worker is None:
-            return
+            return None
         self.worker.conn, conn = None, self.worker.conn
         # LocalWorker does actually disconnect, so we must force disconnection
         # via detached

--- a/master/buildbot/test/integration/test_try_client.py
+++ b/master/buildbot/test/integration/test_try_client.py
@@ -108,7 +108,7 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
         if isinstance(self.sch, trysched.Try_Userpass):
             def getSchedulerPort():
                 if not self.sch.registrations:
-                    return
+                    return None
                 self.serverPort = self.sch.registrations[0].getPort()
                 log.msg("Scheduler registered at port %d" % self.serverPort)
                 return True

--- a/master/buildbot/test/integration/test_upgrade.py
+++ b/master/buildbot/test/integration/test_upgrade.py
@@ -166,6 +166,7 @@ class UpgradeTestMixin(db.RealDatabaseMixin, TestReactorMixin):
                                          ).format(name, tbl.name, gi, ei))
             if diff:
                 return "\n".join(diff)
+            return None
 
         d = self.db.pool.do_with_engine(comp)
 

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -74,6 +74,7 @@ class TestBRDBase(TestReactorMixin, unittest.TestCase):
     def tearDown(self):
         if self.brd.running:
             return self.brd.stopService()
+        return None
 
     def make_workers(self, worker_count):
         rows = self.base_rows[:]

--- a/master/buildbot/test/unit/test_schedulers_base.py
+++ b/master/buildbot/test/unit/test_schedulers_base.py
@@ -619,6 +619,7 @@ class BaseScheduler(scheduler.SchedulerMixin, TestReactorMixin,
                 return ['c']
             elif props.changes[0]['branch'] == 'unstable':
                 return ['a', 'b']
+            return None
 
         sched = self.makeScheduler(name='n', builderNames=names)
 

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -439,6 +439,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin,
                      'revision': '', 'codebase': ''},
                 ])),
         ])
+        return None
 
     def test_StringParameter(self):
         self.do_ParameterTest(value="testedvalue", expect="testedvalue",

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -56,6 +56,7 @@ class SchedulerManager(unittest.TestCase):
     def tearDown(self):
         if self.sm.running:
             return self.sm.stopService()
+        return None
 
     class Sched(base.BaseScheduler):
 

--- a/master/buildbot/test/unit/test_util_kubeclientservice.py
+++ b/master/buildbot/test/unit/test_util_kubeclientservice.py
@@ -204,6 +204,7 @@ class KubeClientServiceTestKubeCtlProxyConfig(config.ConfigErrorsMixin,
     def tearDown(self):
         if self.config is not None:
             return self.config.stopService()
+        return None
 
     @defer.inlineCallbacks
     def test_basic(self):

--- a/master/buildbot/test/unit/test_worker_protocols_pb.py
+++ b/master/buildbot/test/unit/test_worker_protocols_pb.py
@@ -162,6 +162,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
                 return defer.succeed({'x': 1, 'y': 2})
             if 'getVersion' in args:
                 return defer.succeed('TheVersion')
+            return None
 
         self.mind.callRemote.side_effect = side_effect
         conn = pb.Connection(self.master, self.worker, self.mind)
@@ -199,6 +200,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
                 return defer.succeed({'x': 1, 'y': 2})
             if 'getVersion' in args:
                 return defer.succeed('TheVersion')
+            return None
 
         self.mind.callRemote.side_effect = side_effect
         conn = pb.Connection(self.master, self.worker, self.mind)
@@ -234,6 +236,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
                 return defer.succeed({'x': 1, 'y': 2})
             if 'getVersion' in args:
                 return defer.succeed('TheVersion')
+            return None
 
         self.mind.callRemote.side_effect = side_effect
         conn = pb.Connection(self.master, self.worker, self.mind)
@@ -258,6 +261,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
                 return defer.succeed({'x': 1, 'y': 2})
             if 'getVersion' in args:
                 return defer.succeed('TheVersion')
+            return None
 
         self.mind.callRemote.side_effect = side_effect
         conn = pb.Connection(self.master, self.worker, self.mind)
@@ -275,7 +279,7 @@ class TestConnection(TestReactorMixin, unittest.TestCase):
         # This should be real old worker...
         def side_effect(*args, **kwargs):
             if args[0] == 'print':
-                return
+                return None
             return defer.fail(twisted_pb.RemoteError(
                 'twisted.spread.flavors.NoSuchMethod', None, None))
 

--- a/master/buildbot/test/unit/test_www_oauth.py
+++ b/master/buildbot/test/unit/test_www_oauth.py
@@ -229,6 +229,7 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin,
                     dict(login="hello"),
                     dict(login="grp"),
                 ]
+            return None
         self.githubAuth.get = fake_get
 
         res = yield self.githubAuth.verifyCode("code!")

--- a/master/buildbot/test/unit/test_www_sse.py
+++ b/master/buildbot/test/unit/test_www_sse.py
@@ -126,3 +126,4 @@ class EventResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def _toJson(self, obj):
         if isinstance(obj, datetime.datetime):
             return datetime2epoch(obj)
+        return None

--- a/master/buildbot/test/util/config.py
+++ b/master/buildbot/test/util/config.py
@@ -60,6 +60,7 @@ class ConfigErrorsMixin:
             return context
         with context:
             fn()
+        return None
 
     def assertNoConfigErrors(self, errors):
         self.assertEqual(errors.errors, [])

--- a/master/buildbot/test/util/configurators.py
+++ b/master/buildbot/test/util/configurators.py
@@ -39,18 +39,21 @@ class ConfiguratorMixin:
             if isinstance(worker, klass) and worker.name == name:
                 return worker
         self.fail("expected a worker named {} of class {}".format(name, klass))
+        return None
 
     def expectScheduler(self, name, klass):
         for scheduler in self.config_dict['schedulers']:
             if scheduler.name == name and isinstance(scheduler, klass):
                 return scheduler
         self.fail("expected a scheduler named {} of class {}".format(name, klass))
+        return None
 
     def expectBuilder(self, name):
         for builder in self.config_dict['builders']:
             if builder.name == name:
                 return builder
         self.fail("expected a builder named {}".format(name))
+        return None
 
     def expectBuilderHasSteps(self, name, step_classes):
         builder = self.expectBuilder(name)

--- a/master/buildbot/test/util/db.py
+++ b/master/buildbot/test/util/db.py
@@ -212,6 +212,7 @@ class RealDatabaseMixin:
         log.msg("cleaning database {}".format(self.db_url))
         yield self.db_pool.do(self.__thd_clean_database)
         yield self.db_pool.do(self.__thd_create_tables, table_names)
+        return None
 
     @defer.inlineCallbacks
     def tearDownRealDatabase(self):

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -274,6 +274,7 @@ deprecatedModuleAttribute(
 def toJson(obj):
     if isinstance(obj, datetime.datetime):
         return datetime2epoch(obj)
+    return None
 
 
 # changes and schedulers consider None to be a legitimate name for a branch,

--- a/master/buildbot/util/deferwaiter.py
+++ b/master/buildbot/util/deferwaiter.py
@@ -34,7 +34,7 @@ class DeferWaiter:
 
     def add(self, d):
         if not isinstance(d, defer.Deferred):
-            return
+            return None
 
         self._waited[id(d)] = d
         d.addBoth(self._finished, d)

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -365,6 +365,7 @@ class ClusteredBuildbotService(BuildbotService):
             self._activityPollCall.stop()
             self._activityPollCall = None
             return self._activityPollDeferred
+        return None
 
     def _callbackStartServiceDeferred(self):
         if self._startServiceDeferred is not None:

--- a/master/buildbot/wamp/connector.py
+++ b/master/buildbot/wamp/connector.py
@@ -114,7 +114,7 @@ class WampConnector(service.ReconfigurableServiceMixin, service.AsyncMultiServic
             ret = yield service.publish(topic, data, options=options)
         except TransportLost:
             log.err(failure.Failure(), "while publishing event " + topic)
-            return
+            return None
         return ret
 
     @defer.inlineCallbacks

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -600,6 +600,7 @@ class AbstractWorker(service.BuildbotService):
             self.unpause()
         if key[-1] == "kill":
             self.shutdown()
+        return None
 
     def shutdownRequested(self):
         self._graceful = True

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -398,6 +398,7 @@ class EC2LatentWorker(AbstractLatentWorker):
             return [instance_id, image.id, start_time]
         else:
             self.failed_to_start(self.instance.id, self.instance.state['Name'])
+        return None
 
     def stop_instance(self, fast=False):
 

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -354,7 +354,7 @@ class AbstractLatentWorker(AbstractWorker):
 
         # notify people, but only if we're still in the config
         if not self.parent or not self.notify_on_missing:
-            return
+            return None
 
         return self.master.data.updates.workerMissing(
             workerid=self.workerid,

--- a/master/buildbot/worker/libvirt.py
+++ b/master/buildbot/worker/libvirt.py
@@ -192,6 +192,7 @@ class LibVirtWorker(AbstractLatentWorker):
                 break
 
         self.ready = True
+        return None
 
     def canStartBuild(self):
         if not self.ready:

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -186,6 +186,7 @@ class OpenStackLatentWorker(AbstractLatentWorker,
             unknown_source = ("The source type '{}' for UUID '{}' is unknown".format(source_type,
                                                                                      source_uuid))
             raise ValueError(unknown_source)
+        return None
 
     @defer.inlineCallbacks
     def _getImage(self, build):
@@ -280,6 +281,7 @@ class OpenStackLatentWorker(AbstractLatentWorker,
         instance = self.instance
         self.instance = None
         self._stop_instance(instance, fast)
+        return None
 
     def _stop_instance(self, instance, fast):
         try:

--- a/master/buildbot/worker/protocols/pb.py
+++ b/master/buildbot/worker/protocols/pb.py
@@ -52,6 +52,7 @@ class Listener(base.Listener):
                                                            self._getPerspective)
                 self._registrations[username] = (password, portStr, reg)
                 return reg
+        return None
 
     @defer.inlineCallbacks
     def _getPerspective(self, mind, workerName):

--- a/master/buildbot/www/sse.py
+++ b/master/buildbot/www/sse.py
@@ -143,4 +143,4 @@ class EventResource(resource.Resource):
             return server.NOT_DONE_YET
 
         self.finish(request, 200, b"ok")
-        return
+        return None

--- a/worker/buildbot_worker/pb.py
+++ b/worker/buildbot_worker/pb.py
@@ -276,7 +276,7 @@ class Worker(WorkerBase, service.MultiService):
         if not self.bf.perspective:
             log.msg("No active connection, shutting down NOW")
             reactor.stop()
-            return
+            return None
 
         log.msg(
             "Telling the master we want to shutdown after any running builds are finished")

--- a/worker/buildbot_worker/scripts/logwatcher.py
+++ b/worker/buildbot_worker/scripts/logwatcher.py
@@ -106,7 +106,7 @@ class LogWatcher(LineOnlyReceiver):
 
     def lineReceived(self, line):
         if not self.running:
-            return
+            return None
         if b"Log opened." in line:
             self.in_reconfig = True
         if b"loading configuration from" in line:
@@ -117,3 +117,4 @@ class LogWatcher(LineOnlyReceiver):
 
         if b"message from master: attached" in line:
             return self.finished("buildbot-worker")
+        return None

--- a/worker/buildbot_worker/scripts/start.py
+++ b/worker/buildbot_worker/scripts/start.py
@@ -117,6 +117,7 @@ def startWorker(basedir, quiet, nodaemon):
     # watching it before we start the daemon
     time.sleep(0.2)
     launch(nodaemon)
+    return None
 
 
 def launch(nodaemon):

--- a/worker/buildbot_worker/test/unit/test_commands_fs.py
+++ b/worker/buildbot_worker/test/unit/test_commands_fs.py
@@ -353,6 +353,7 @@ class TestListDir(CommandTestMixin, unittest.TestCase):
             for i in items:
                 if i:
                     return True
+            return None
 
         self.assertIn({'rc': 0},
                       self.get_updates(),

--- a/worker/buildbot_worker/test/unit/test_commands_transfer.py
+++ b/worker/buildbot_worker/test/unit/test_commands_transfer.py
@@ -75,6 +75,7 @@ class FakeMasterMethods(object):
             d = defer.Deferred()
             reactor.callLater(0.01, d.callback, None)
             return d
+        return None
 
     def remote_read(self, length):
         if self.count_reads:
@@ -97,6 +98,7 @@ class FakeMasterMethods(object):
         self.add_update('unpack')
         if self.unpack_fail:
             return defer.fail(failure.Failure(RuntimeError("out of space")))
+        return None
 
     def remote_utime(self, accessed_modified):
         self.add_update('utime - {0}'.format(accessed_modified[0]))


### PR DESCRIPTION
PEP 8 suggests: 
> Be consistent in return statements. Either all return statements in a function should return an expression, or none of them should. If any return statement returns an expression, any return statements where no value is returned should explicitly state this as return None, and an explicit return statement should be present at the end of the function (if reachable).

PR fixes inconsistent return cases in this project.

