### PR TITLE
Fix broken links

### DIFF
--- a/master/buildbot/steps/http.py
+++ b/master/buildbot/steps/http.py
@@ -21,7 +21,7 @@ from buildbot.process.buildstep import FAILURE
 from buildbot.process.buildstep import SUCCESS
 from buildbot.process.buildstep import BuildStep
 
-# use the 'requests' lib: http://python-requests.org
+# use the 'requests' lib: https://requests.readthedocs.io/en/master/
 try:
     import txrequests
     import requests

--- a/master/docs/developer/cls-auth.rst
+++ b/master/docs/developer/cls-auth.rst
@@ -97,4 +97,4 @@ Authentication
 
         This method is called after a successful authentication to get additional information about the user from the oauth2 provider.
 
-.. _requests: http://docs.python-requests.org/en/latest/
+.. _requests: https://requests.readthedocs.io/en/master/

--- a/master/docs/developer/cls-forcesched.rst
+++ b/master/docs/developer/cls-forcesched.rst
@@ -69,7 +69,7 @@ This section contains information to help users or developers who are interested
 
            A string identifying the type that the parameter conforms to.
            It is used by the angular application to find which angular directive to use for showing the form widget.
-           The available values are visible in :src:`www/base/src/app/common/directives/forcefields/forcefields.directive.coffee`.
+           The available values are visible in :src:`www/base/src/app/common/directives/forcefields/forcefields.directive.js`.
 
            Examples of how to create a custom parameter widgets are available in the buildbot source code in directories:
 

--- a/master/docs/developer/database.rst
+++ b/master/docs/developer/database.rst
@@ -1807,7 +1807,7 @@ Next, modify :src:`master/buildbot/db/model.py` to represent the updated schema.
 Buildbot's automated tests perform a rudimentary comparison of an upgraded database with the model, but it is important to check the details - key length, nullability, and so on can sometimes be missed by the checks.
 If the schema and the upgrade scripts get out of sync, bizarre behavior can result.
 
-Also, adjust the fake database table definitions in :src:`master/buildbot/test/fake/fakedb.py` according to your changes.
+Also, adjust the fake database table definitions in :src:`master/buildbot/test/fakedb` according to your changes.
 
 Your upgrade script should have unit tests.  The classes in :src:`master/buildbot/test/util/migration.py` make this straightforward.
 Unit test scripts should be named e.g., :file:`test_db_migrate_versions_015_remove_bad_master_objectid.py`.

--- a/master/docs/manual/configuration/buildsteps.rst
+++ b/master/docs/manual/configuration/buildsteps.rst
@@ -2207,7 +2207,7 @@ Sphinx
 
 .. py:class:: buildbot.steps.python.Sphinx
 
-`Sphinx <http://sphinx.pocoo.org/>`_ is the Python Documentation Generator.
+`Sphinx <https://www.sphinx-doc.org/en/master/>`_ is the Python Documentation Generator.
 It uses `RestructuredText <http://docutils.sourceforge.net/rst.html>`_ as input format.
 
 The :bb:step:`Sphinx` step will run :program:`sphinx-build` or any other program specified in its ``sphinx`` argument and count the various warnings and error it detects.
@@ -3150,7 +3150,7 @@ Using the :bb:step:`HTTPStep` step, it is possible to perform HTTP requests in o
 
 .. note::
 
-   This step requires the `txrequests <https://pypi.python.org/pypi/txrequests>`_ and `requests <http://python-requests.org>`_ Python libraries.
+   This step requires the `txrequests <https://pypi.python.org/pypi/txrequests>`_ and `requests <https://requests.readthedocs.io/en/master>`_ Python libraries.
 
 The parameters are the following:
 
@@ -3172,7 +3172,7 @@ The parameters are the following:
 
 ``other params``
     Any other keywords supported by the ``requests``
-    `api <http://docs.python-requests.org/en/master/api/#main-interface>`_
+    `api <https://2.python-requests.org/en/master/api/#main-interface>`_
     can be passed to this step.
 
     .. note::

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -40,7 +40,7 @@ Beware that in this case, overall performance will depend on how many builds the
     More in `master setup`_.
 
 .. _CoreOS: https://coreos.com/
-.. _boot2docker: http://boot2docker.io/
+.. _boot2docker: https://github.com/boot2docker/boot2docker
 .. _docker-py: https://pypi.python.org/pypi/docker-py
 
 CoreOS
@@ -316,7 +316,7 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Ma
 .. _Marathon API: http://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-apps
 .. _txrequests: https://pypi.python.org/pypi/txrequests
 .. _treq: https://pypi.python.org/pypi/treq
-.. _requests authentication plugin: http://docs.python-requests.org/en/master/user/authentication/
+.. _requests authentication plugin: https://2.python-requests.org/en/master/user/authentication/
 
 Kubernetes latent worker
 ========================

--- a/master/docs/manual/configuration/workers-ec2.rst
+++ b/master/docs/manual/configuration/workers-ec2.rst
@@ -53,7 +53,7 @@ Here are a few additional hints.
 * When an instance of the image starts, it needs to automatically start a buildbot worker that connects to your master (to create a buildbot worker, :ref:`Creating-a-worker`; to make a daemon, :ref:`Launching-the-daemons`).
 * You may want to make an instance of the buildbot worker, configure it as a standard worker in the master (i.e., not as a latent worker), and test and debug it that way before you turn it into an AMI and convert to a latent worker in the master.
 * In order to avoid extra costs in case of master failure, you should configure the worker of the AMI with ``maxretries`` option (see :ref:`Worker-Options`)
-  Also see `example systemd unit file example <https://github.com/buildbot/buildbot-contrib/blob/master/master/contrib/systemd/worker.service>`_
+  Also see `example systemd unit file example <https://github.com/buildbot/buildbot-contrib/blob/master/worker/contrib/systemd/buildbot-worker%40.service>`_
 
 Configure the Master with an :class:`~buildbot.worker.ec2.EC2LatentWorker`
 --------------------------------------------------------------------------

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -1261,7 +1261,7 @@ This template is a standard Jinja_ template which is the default templating engi
 .. _Bottle: https://bottlepy.org/docs/dev/
 .. _Bootstrap: http://getbootstrap.com/css/
 .. _Jinja: http://jinja.pocoo.org/
-.. _python-requests: http://docs.python-requests.org/en/master/
+.. _python-requests: https://requests.readthedocs.io/en/master/
 
 
 A Somewhat Whimsical Example (or "It's now customized, how do I deploy it?")

--- a/master/docs/manual/installation/misc.rst
+++ b/master/docs/manual/installation/misc.rst
@@ -45,7 +45,7 @@ There may be fewer environment variables specified, and the :envvar:`PATH` may b
 It is a good idea to test out this method of launching the worker by using a cron job with a time in the near future, with the same command, and then check :file:`twistd.log` to make sure the worker actually started correctly.
 Common problems here are for :file:`/usr/local` or :file:`~/bin` to not be on your :envvar:`PATH`, or for :envvar:`PYTHONPATH` to not be set correctly.
 Sometimes :envvar:`HOME` is messed up too. If using systemd to launch :command:`buildbot-worker` it may be a good idea to specify a fixed :envvar:`PATH` using the :envvar:`Environment` directive,
-see `systemd unit file example <https://github.com/buildbot/buildbot-contrib/blob/master/master/contrib/systemd/worker.service>`_
+see `systemd unit file example <https://github.com/buildbot/buildbot-contrib/blob/master/worker/contrib/systemd/buildbot-worker%40.service>`_
 
 Some distributions may include conveniences to make starting buildbot at boot time easy.
 For instance, with the default buildbot package in Debian-based distributions, you may only need to modify :file:`/etc/default/buildbot` (see also :file:`/etc/init.d/buildbot`, which reads the configuration in :file:`/etc/default/buildbot`).


### PR DESCRIPTION
A few links still not working:
* https://pushjet.io
* https://hyper.sh
* https://api.pushjet.io
* https://api.hipchat.com (see https://github.com/buildbot/buildbot/issues/5242)

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
