### PR TITLE
deferwaiter: Add a way to check whether there are waited deferreds

### DIFF
--- a/master/buildbot/test/unit/test_util_deferwaiter.py
+++ b/master/buildbot/test/unit/test_util_deferwaiter.py
@@ -33,12 +33,16 @@ class WaiterTests(unittest.TestCase):
     def test_add_deferred_called(self):
         w = DeferWaiter()
         w.add(defer.succeed(None))
+        self.assertFalse(w.has_waited())
+
         d = w.wait()
         self.assertTrue(d.called)
 
     def test_add_non_deferred(self):
         w = DeferWaiter()
         w.add(2)
+        self.assertFalse(w.has_waited())
+
         d = w.wait()
         self.assertTrue(d.called)
 
@@ -47,11 +51,13 @@ class WaiterTests(unittest.TestCase):
 
         d1 = defer.Deferred()
         w.add(d1)
+        self.assertTrue(w.has_waited())
 
         d = w.wait()
         self.assertFalse(d.called)
 
         d1.callback(None)
+        self.assertFalse(w.has_waited())
         self.assertTrue(d.called)
 
     @defer.inlineCallbacks
@@ -74,8 +80,11 @@ class WaiterTests(unittest.TestCase):
 
         d1 = defer.Deferred()
         w.add(d1)
+        self.assertTrue(w.has_waited())
 
         w.cancel()
+        self.assertFalse(w.has_waited())
+
         d = w.wait()
         self.assertTrue(d.called)
         with self.assertRaises(defer.CancelledError):

--- a/master/buildbot/util/deferwaiter.py
+++ b/master/buildbot/util/deferwaiter.py
@@ -45,6 +45,9 @@ class DeferWaiter:
             d.cancel()
         self._waited.clear()
 
+    def has_waited(self):
+        return bool(self._waited)
+
     @defer.inlineCallbacks
     def wait(self):
         if not self._waited:


### PR DESCRIPTION
This change allows to check whether calling `yield waiter.wait()` would block.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
