### PR TITLE
tests: Cleanup statistics service tests

### DIFF
--- a/master/buildbot/statistics/stats_service.py
+++ b/master/buildbot/statistics/stats_service.py
@@ -37,6 +37,7 @@ class StatsService(service.BuildbotService):
                                 "Should be of type StatsStorageBase, "
                                 "is: {0!r}".format(type(StatsStorageBase)))
 
+    @defer.inlineCallbacks
     def reconfigService(self, storage_backends):
         log.msg(
             "Reconfiguring StatsService with config: {0!r}".format(storage_backends))
@@ -47,8 +48,8 @@ class StatsService(service.BuildbotService):
         for svc in storage_backends:
             self.registeredStorageServices.append(svc)
 
-        self.removeConsumers()
-        self.registerConsumers()
+        yield self.removeConsumers()
+        yield self.registerConsumers()
 
     @defer.inlineCallbacks
     def registerConsumers(self):
@@ -64,7 +65,7 @@ class StatsService(service.BuildbotService):
     @defer.inlineCallbacks
     def stopService(self):
         yield super().stopService()
-        self.removeConsumers()
+        yield self.removeConsumers()
 
     @defer.inlineCallbacks
     def removeConsumers(self):

--- a/master/buildbot/test/fake/fakestats.py
+++ b/master/buildbot/test/fake/fakestats.py
@@ -19,7 +19,6 @@ from twisted.internet import defer
 from buildbot.process import buildstep
 from buildbot.process.results import SUCCESS
 from buildbot.statistics import capture
-from buildbot.statistics import stats_service
 from buildbot.statistics.storage_backends.base import StatsStorageBase
 
 
@@ -59,25 +58,6 @@ class FakeBuildStep(buildstep.BuildStep):
     def start(self):
         self.doSomething()
         return SUCCESS
-
-
-class FakeStatsService(stats_service.StatsService):
-
-    """
-    Fake StatsService for use in fakemaster
-    """
-
-    def __init__(self, master=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.master = master
-
-    @property
-    def master(self):
-        return self._master
-
-    @master.setter
-    def master(self, value):
-        self._master = value
 
 
 class FakeInfluxDBClient:

--- a/master/buildbot/test/fake/fakestats.py
+++ b/master/buildbot/test/fake/fakestats.py
@@ -14,8 +14,6 @@
 # Copyright Buildbot Team Members
 
 
-from twisted.internet import defer
-
 from buildbot.process import buildstep
 from buildbot.process.results import SUCCESS
 from buildbot.statistics import capture
@@ -38,12 +36,10 @@ class FakeStatsStorageService(StatsStorageBase):
         self.name = name
         self.captures = []
 
-    @defer.inlineCallbacks
     def thd_postStatsValue(self, post_data, series_name, context=None):
         if not context:
             context = {}
         self.stored_data.append((post_data, series_name, context))
-        yield defer.succeed(None)
 
 
 class FakeBuildStep(buildstep.BuildStep):

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -39,6 +39,7 @@ class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
     BUILDER_NAMES = ['builder1', 'builder2']
     BUILDER_IDS = [1, 2]
 
+    @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self, wantMq=True, wantData=True,
@@ -53,11 +54,12 @@ class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
                                                             fakestats.FakeStatsStorageService()
                                                         ],
                                                         name="FakeStatsService")
+        yield self.stats_service.setServiceParent(self.master)
+        yield self.master.startService()
 
-        self.stats_service.startService()
-
+    @defer.inlineCallbacks
     def tearDown(self):
-        self.stats_service.stopService()
+        yield self.master.stopService()
 
 
 class DummyStatsStorageBase(StatsStorageBase):
@@ -195,8 +197,9 @@ class TestStatsServicesConsumers(steps.BuildStepMixin, TestStatsServicesBase):
     Test the stats service from a fake step
     """
 
+    @defer.inlineCallbacks
     def setUp(self):
-        super().setUp()
+        yield super().setUp()
         self.routingKey = (
             "builders", self.BUILDER_IDS[0], "builds", 1, "finished")
         self.master.mq.verifyMessages = False

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -62,16 +62,6 @@ class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
         yield self.master.stopService()
 
 
-class DummyStatsStorageBase(StatsStorageBase):
-
-    """
-    A dummy class to test initialization of StatsStorageBase.
-    """
-
-    def thd_postStatsValue(self, *args, **kwargs):
-        pass
-
-
 class TestStatsServicesConfiguration(TestStatsServicesBase):
 
     def test_reconfig_with_no_storage_backends(self):
@@ -182,13 +172,6 @@ class TestInfluxDB(TestStatsServicesBase, logging.LoggingMixin):
         svc._inited = False
         svc.thd_postStatsValue("test", "test", "test")
         self.assertLogged("Service.*not initialized")
-
-    def test_storage_backend_base_failure_on_init(self):
-        svc = DummyStatsStorageBase()
-
-        r = svc.thd_postStatsValue("test", "test", "test")
-        assert isinstance(r, defer.Deferred)
-        assert r.result is None
 
 
 class TestStatsServicesConsumers(steps.BuildStepMixin, TestStatsServicesBase):

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -17,7 +17,6 @@
 import mock
 
 from twisted.internet import defer
-from twisted.internet import threads
 from twisted.trial import unittest
 
 from buildbot import config
@@ -192,7 +191,6 @@ class TestStatsServicesConsumers(steps.BuildStepMixin, TestStatsServicesBase):
         self.routingKey = (
             "builders", self.BUILDER_IDS[0], "builds", 1, "finished")
         self.master.mq.verifyMessages = False
-        self.patch(threads, 'deferToThread', self.identity)
 
     def setupBuild(self):
         self.master.db.insertTestData([
@@ -227,10 +225,6 @@ class TestStatsServicesConsumers(steps.BuildStepMixin, TestStatsServicesBase):
         self.master.db.builds.finishBuild(buildid=1, results=0)
         build = yield self.master.db.builds.getBuild(buildid=1)
         self.master.mq.callConsumer(self.routingKey, self.get_dict(build))
-
-    @staticmethod
-    def identity(f, *args, **kwargs):
-        return f(*args, **kwargs)
 
     @defer.inlineCallbacks
     def test_property_capturing(self):

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -69,7 +69,7 @@ class DummyStatsStorageBase(StatsStorageBase):
     """
 
     def thd_postStatsValue(self, *args, **kwargs):
-        return defer.succeed(None)
+        pass
 
 
 class TestStatsServicesConfiguration(TestStatsServicesBase):

--- a/master/buildbot/test/unit/test_stats_service.py
+++ b/master/buildbot/test/unit/test_stats_service.py
@@ -23,6 +23,7 @@ from twisted.trial import unittest
 from buildbot import config
 from buildbot.errors import CaptureCallbackError
 from buildbot.statistics import capture
+from buildbot.statistics import stats_service
 from buildbot.statistics import storage_backends
 from buildbot.statistics.storage_backends.base import StatsStorageBase
 from buildbot.statistics.storage_backends.influxdb_client import InfluxStorageService
@@ -49,8 +50,7 @@ class TestStatsServicesBase(TestReactorMixin, unittest.TestCase):
             self.master.db.builders.addTestBuilder(
                 builderid=builderid, name=name)
 
-        self.stats_service = fakestats.FakeStatsService(master=self.master,
-                                                        storage_backends=[
+        self.stats_service = stats_service.StatsService(storage_backends=[
                                                             fakestats.FakeStatsStorageService()
                                                         ],
                                                         name="FakeStatsService")


### PR DESCRIPTION
Looks like the statistics service tests weren't correctly setup and there were hacks to mask this problem. The problems were as follows:
 - indirectly passing functions that return Deferreds to deferToThread
 - a number of unwaited Deferreds

This PR fixes all this.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
