### PR TITLE
tests: Cleanup BuildStep test setup

### DIFF
--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -880,6 +880,7 @@ class TestFakeItfc(unittest.TestCase,
 
     def setUp(self):
         self.setUpTestReactor()
+        self.setUpBuildStep()
         self.setupStep(buildstep.BuildStep())
 
 

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -105,6 +105,9 @@ class BuildStepMixin:
     """
 
     def setUpBuildStep(self):
+        if not hasattr(self, 'reactor'):
+            raise Exception('Reactor has not yet been setup for step')
+
         # make an (admittedly global) reference to this test case so that
         # the fakes can call back to us
         remotecommand.FakeRemoteCommand.testcase = self

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -16,7 +16,6 @@
 import mock
 
 from twisted.internet import defer
-from twisted.internet import task
 from twisted.python import log
 from twisted.python.reflect import namedModule
 
@@ -104,7 +103,18 @@ class BuildStepMixin:
     @ivar properties: build properties (L{Properties} instance)
     """
 
-    def setUpBuildStep(self):
+    def setUpBuildStep(self, wantData=True, wantDb=False, wantMq=False):
+        """
+        @param wantData(bool): Set to True to add data API connector to master.
+            Default value: True.
+
+        @param wantDb(bool): Set to True to add database connector to master.
+            Default value: False.
+
+        @param wantMq(bool): Set to True to add mq connector to master.
+            Default value: False.
+        """
+
         if not hasattr(self, 'reactor'):
             raise Exception('Reactor has not yet been setup for step')
 
@@ -117,6 +127,8 @@ class BuildStepMixin:
             self.patch(module, 'RemoteShellCommand',
                        remotecommand.FakeRemoteShellCommand)
         self.expected_remote_commands = []
+
+        self.master = fakemaster.make_master(self, wantData=wantData, wantDb=wantDb, wantMq=wantMq)
 
     def tearDownBuildStep(self):
         # delete the reference added in setUp
@@ -132,8 +144,7 @@ class BuildStepMixin:
         return getWorkerCommandVersion
 
     def setupStep(self, step, worker_version=None, worker_env=None,
-                  buildFiles=None, wantDefaultWorkdir=True, wantData=True,
-                  wantDb=False, wantMq=False):
+                  buildFiles=None, wantDefaultWorkdir=True):
         """
         Set up C{step} for testing.  This begins by using C{step} as a factory
         to create a I{new} step instance, thereby testing that the factory
@@ -148,15 +159,6 @@ class BuildStepMixin:
             commands.
 
         @param worker_env: environment from the worker at worker startup
-
-        @param wantData(bool): Set to True to add data API connector to master.
-            Default value: True.
-
-        @param wantDb(bool): Set to True to add database connector to master.
-            Default value: False.
-
-        @param wantMq(bool): Set to True to add mq connector to master.
-            Default value: False.
         """
         if worker_version is None:
             worker_version = {
@@ -172,12 +174,6 @@ class BuildStepMixin:
         factory = interfaces.IBuildStepFactory(step)
 
         step = self.step = factory.buildStep()
-        self.master = fakemaster.make_master(self, wantData=wantData,
-                                             wantDb=wantDb, wantMq=wantMq)
-
-        # mock out the reactor for updateSummary's debouncing
-        self.debounceClock = task.Clock()
-        self.master.reactor = self.debounceClock
 
         # set defaults
         if wantDefaultWorkdir:
@@ -322,7 +318,7 @@ class BuildStepMixin:
         result = yield self.step.startStep(self.conn)
 
         # finish up the debounced updateSummary before checking
-        self.debounceClock.advance(1)
+        self.reactor.advance(1)
         if self.expected_remote_commands:
             log.msg("un-executed remote commands:")
             for rc in self.expected_remote_commands:


### PR DESCRIPTION
This PR fixes a problem that `BuildStepMixin.setupStep` creates a new fake master every time it's called. To fix this, master setup is moved to `setupBuildStep` function that is called in the test `setUp` functions.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
