### PR TITLE
spec: Fix definition of bbget trait

### DIFF
--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -8,7 +8,7 @@ traits:
             200:
                 body:
                     application/json:
-                        type: responseObjects.libraries.types.<<bbtype>>
+                        type: <<bbtype>>[]
             404:
                 body:
                     text/plain:


### PR DESCRIPTION
Some digging through RAML docs showed that it's likely the definition of the bbget trait is incorrect. It attempts to reference `responseObjects.libraries.types` which is not imported to the spec file.