### PR TITLE
Implement APIs for test results functionality (v2)

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1376,6 +1376,7 @@ subdirectory
 subfields
 sublicense
 submittedat
+submitters
 submodule
 submodules
 suboption

--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -54,6 +54,8 @@ class DataConnector(service.AsyncService):
         'buildbot.data.forceschedulers',
         'buildbot.data.root',
         'buildbot.data.properties',
+        'buildbot.data.test_results',
+        'buildbot.data.test_result_sets',
     ]
     name = "data"
 

--- a/master/buildbot/data/test_result_sets.py
+++ b/master/buildbot/data/test_result_sets.py
@@ -1,0 +1,142 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.internet import defer
+
+from buildbot.data import base
+from buildbot.data import types
+
+
+class Db2DataMixin:
+
+    def db2data(self, dbdict):
+        data = {
+            'test_result_setid': dbdict['id'],
+            'builderid': dbdict['builderid'],
+            'buildid': dbdict['buildid'],
+            'stepid': dbdict['stepid'],
+            'description': dbdict['description'],
+            'category': dbdict['category'],
+            'value_unit': dbdict['value_unit'],
+            'tests_passed': dbdict['tests_passed'],
+            'tests_failed': dbdict['tests_failed'],
+            'complete': bool(dbdict['complete']),
+        }
+        return defer.succeed(data)
+
+
+class TestResultSetsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+
+    isCollection = True
+    pathPatterns = """
+        /builders/n:builderid/test_result_sets
+        /builders/i:buildername/test_result_sets
+        /builds/n:buildid/test_result_sets
+        /steps/n:stepid/test_result_sets
+        """
+
+    @defer.inlineCallbacks
+    def get(self, resultSpec, kwargs):
+
+        complete = resultSpec.popBooleanFilter('complete')
+        if 'stepid' in kwargs:
+            step_dbdict = yield self.master.db.steps.getStep(kwargs['stepid'])
+            build_dbdict = yield self.master.db.builds.getBuild(step_dbdict['buildid'])
+
+            sets = yield self.master.db.test_result_sets.getTestResultSets(
+                    build_dbdict['builderid'],
+                    buildid=step_dbdict['buildid'],
+                    stepid=kwargs['stepid'],
+                    complete=complete,
+                    result_spec=resultSpec)
+        elif 'buildid' in kwargs:
+            build_dbdict = yield self.master.db.builds.getBuild(kwargs['buildid'])
+
+            sets = yield self.master.db.test_result_sets.getTestResultSets(
+                    build_dbdict['builderid'],
+                    buildid=kwargs['buildid'],
+                    complete=complete,
+                    result_spec=resultSpec)
+
+        else:
+            # The following is true: 'buildername' in kwargs or 'builderid' in kwargs:
+            builderid = yield self.getBuilderId(kwargs)
+            sets = yield self.master.db.test_result_sets.getTestResultSets(
+                    builderid, complete=complete, result_spec=resultSpec)
+
+        results = []
+        for dbdict in sets:
+            results.append((yield self.db2data(dbdict)))
+        return results
+
+
+class TestResultSetEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+
+    isCollection = False
+    pathPatterns = """
+        /test_result_sets/n:test_result_setid
+    """
+
+    @defer.inlineCallbacks
+    def get(self, resultSpec, kwargs):
+        dbdict = yield self.master.db.test_result_sets.getTestResultSet(kwargs['test_result_setid'])
+        return (yield self.db2data(dbdict)) if dbdict else None
+
+
+class TestResultSet(base.ResourceType):
+
+    name = "test_result_set"
+    plural = "test_result_sets"
+    endpoints = [TestResultSetsEndpoint, TestResultSetEndpoint]
+    keyFields = ['test_result_setid']
+    eventPathPatterns = """
+        /test_result_sets/:test_result_setid
+    """
+
+    class EntityType(types.Entity):
+        test_result_setid = types.Integer()
+        builderid = types.Integer()
+        buildid = types.Integer()
+        stepid = types.Integer()
+        description = types.NoneOk(types.String())
+        category = types.String()
+        value_unit = types.String()
+        tests_passed = types.NoneOk(types.Integer())
+        tests_failed = types.NoneOk(types.Integer())
+        complete = types.Boolean()
+    entityType = EntityType(name)
+
+    @defer.inlineCallbacks
+    def generateEvent(self, test_result_setid, event):
+        test_result_set = yield self.master.data.get(('test_result_sets', test_result_setid))
+        self.produceEvent(test_result_set, event)
+
+    @base.updateMethod
+    @defer.inlineCallbacks
+    def addTestResultSet(self, builderid, buildid, stepid, description, category, value_unit):
+        test_result_setid = \
+            yield self.master.db.test_result_sets.addTestResultSet(builderid, buildid, stepid,
+                                                                   description, category,
+                                                                   value_unit)
+        yield self.generateEvent(test_result_setid, 'new')
+        return test_result_setid
+
+    @base.updateMethod
+    @defer.inlineCallbacks
+    def completeTestResultSet(self, test_result_setid, tests_passed=None, tests_failed=None):
+        yield self.master.db.test_result_sets.completeTestResultSet(test_result_setid,
+                                                                    tests_passed, tests_failed)
+        yield self.generateEvent(test_result_setid, 'completed')

--- a/master/buildbot/data/test_results.py
+++ b/master/buildbot/data/test_results.py
@@ -1,0 +1,92 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.internet import defer
+
+from buildbot.data import base
+from buildbot.data import types
+
+
+class Db2DataMixin:
+
+    def db2data(self, dbdict):
+        data = {
+            'test_resultid': dbdict['id'],
+            'builderid': dbdict['builderid'],
+            'test_result_setid': dbdict['test_result_setid'],
+            'test_name': dbdict['test_name'],
+            'test_code_path': dbdict['test_code_path'],
+            'line': dbdict['line'],
+            'value': dbdict['value'],
+        }
+        return defer.succeed(data)
+
+
+class TestResultsEndpoint(Db2DataMixin, base.Endpoint):
+
+    isCollection = True
+    pathPatterns = """
+        /test_result_sets/n:test_result_setid/results
+        """
+
+    @defer.inlineCallbacks
+    def get(self, resultSpec, kwargs):
+        set_dbdict = \
+            yield self.master.db.test_result_sets.getTestResultSet(kwargs['test_result_setid'])
+
+        if set_dbdict is None:
+            return []
+
+        result_dbdicts = \
+            yield self.master.db.test_results.getTestResults(set_dbdict['builderid'],
+                                                             kwargs['test_result_setid'],
+                                                             result_spec=resultSpec)
+
+        results = []
+        for dbdict in result_dbdicts:
+            results.append((yield self.db2data(dbdict)))
+        return results
+
+
+class TestResult(base.ResourceType):
+
+    name = "test_result"
+    plural = "test_results"
+    endpoints = [TestResultsEndpoint]
+    keyFields = ['test_resultid']
+    eventPathPatterns = """
+        /test_result_sets/:test_result_setid/results
+    """
+
+    class EntityType(types.Entity):
+        test_resultid = types.Integer()
+        builderid = types.Integer()
+        test_result_setid = types.Integer()
+        test_name = types.NoneOk(types.String())
+        test_code_path = types.NoneOk(types.String())
+        line = types.NoneOk(types.Integer())
+        value = types.String()
+    entityType = EntityType(name)
+
+    @base.updateMethod
+    @defer.inlineCallbacks
+    def addTestResults(self, builderid, test_result_setid, result_values):
+        # We're not adding support for emitting any messages, because in all cases all test results
+        # will be part of a test result set. The users should wait for a 'complete' event on a
+        # test result set and only then fetch the test results, which won't change from that time
+        # onward.
+        yield self.master.db.test_results.addTestResults(builderid, test_result_setid,
+                                                         result_values)

--- a/master/buildbot/data/test_results.py
+++ b/master/buildbot/data/test_results.py
@@ -30,6 +30,7 @@ class Db2DataMixin:
             'test_name': dbdict['test_name'],
             'test_code_path': dbdict['test_code_path'],
             'line': dbdict['line'],
+            'duration_ns': dbdict['duration_ns'],
             'value': dbdict['value'],
         }
         return defer.succeed(data)
@@ -78,6 +79,7 @@ class TestResult(base.ResourceType):
         test_name = types.NoneOk(types.String())
         test_code_path = types.NoneOk(types.String())
         line = types.NoneOk(types.Integer())
+        duration_ns = types.NoneOk(types.Integer())
         value = types.String()
     entityType = EntityType(name)
 

--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -38,6 +38,8 @@ from buildbot.db import sourcestamps
 from buildbot.db import state
 from buildbot.db import steps
 from buildbot.db import tags
+from buildbot.db import test_result_sets
+from buildbot.db import test_results
 from buildbot.db import users
 from buildbot.db import workers
 from buildbot.util import service
@@ -101,6 +103,8 @@ class DBConnector(service.ReconfigurableServiceMixin,
         self.steps = steps.StepsConnectorComponent(self)
         self.tags = tags.TagsConnectorComponent(self)
         self.logs = logs.LogsConnectorComponent(self)
+        self.test_results = test_results.TestResultsConnectorComponent(self)
+        self.test_result_sets = test_result_sets.TestResultSetsConnectorComponent(self)
 
         self.cleanup_timer = internet.TimerService(self.CLEANUP_PERIOD,
                                                    self._doCleanup)

--- a/master/buildbot/db/migrate/versions/056_add_test_result_tables.py
+++ b/master/buildbot/db/migrate/versions/056_add_test_result_tables.py
@@ -94,6 +94,8 @@ def upgrade(migrate_engine):
 
         sa.Column('line', sa.Integer, nullable=True),
 
+        sa.Column('duration_ns', sa.Integer, nullable=True),
+
         sa.Column('value', sa.Text, nullable=False),
     )
 

--- a/master/buildbot/db/migrate/versions/056_add_test_result_tables.py
+++ b/master/buildbot/db/migrate/versions/056_add_test_result_tables.py
@@ -1,0 +1,130 @@
+# This file is part of Buildbot. Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import sqlalchemy as sa
+
+from buildbot.util import sautils
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+
+    sautils.Table(
+        'builds', metadata,
+        sa.Column('id', sa.Integer, primary_key=True),
+        # ...
+    )
+
+    sautils.Table(
+        'builders', metadata,
+        sa.Column('id', sa.Integer, primary_key=True),
+        # ...
+    )
+
+    sautils.Table(
+        'steps', metadata,
+        sa.Column('id', sa.Integer, primary_key=True),
+        # ...
+    )
+
+    test_result_sets = sautils.Table(
+        'test_result_sets', metadata,
+
+        sa.Column('id', sa.Integer, primary_key=True),
+
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('buildid', sa.Integer,
+                  sa.ForeignKey('builds.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('stepid', sa.Integer,
+                  sa.ForeignKey('steps.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('description', sa.Text, nullable=True),
+
+        sa.Column('category', sa.Text, nullable=False),
+
+        sa.Column('value_unit', sa.Text, nullable=False),
+
+        sa.Column('tests_passed', sa.Integer, nullable=True),
+
+        sa.Column('tests_failed', sa.Integer, nullable=True),
+
+        sa.Column('complete', sa.SmallInteger, nullable=False),
+    )
+
+    test_results = sautils.Table(
+        'test_results', metadata,
+
+        sa.Column('id', sa.Integer, primary_key=True),
+
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('test_result_setid', sa.Integer,
+                  sa.ForeignKey('test_result_sets.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('test_nameid', sa.Integer,
+                  sa.ForeignKey('test_names.id', ondelete='CASCADE'),
+                  nullable=True),
+
+        sa.Column('test_code_pathid', sa.Integer,
+                  sa.ForeignKey('test_code_paths.id', ondelete='CASCADE'),
+                  nullable=True),
+
+        sa.Column('line', sa.Integer, nullable=True),
+
+        sa.Column('value', sa.Text, nullable=False),
+    )
+
+    test_names = sautils.Table(
+        'test_names', metadata,
+
+        sa.Column('id', sa.Integer, primary_key=True),
+
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('name', sa.Text, nullable=False),
+    )
+
+    test_code_paths = sautils.Table(
+        'test_code_paths', metadata,
+
+        sa.Column('id', sa.Integer, primary_key=True),
+
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('path', sa.Text, nullable=False),
+    )
+
+    # create the tables
+    test_result_sets.create()
+    test_names.create()
+    test_code_paths.create()
+    test_results.create()
+
+    # TODO FIXME indexes

--- a/master/buildbot/db/migrate/versions/056_add_test_result_tables.py
+++ b/master/buildbot/db/migrate/versions/056_add_test_result_tables.py
@@ -127,4 +127,11 @@ def upgrade(migrate_engine):
     test_code_paths.create()
     test_results.create()
 
-    # TODO FIXME indexes
+    # create indexes
+    idx = sa.Index('test_names_name', test_names.c.builderid, test_names.c.name,
+                   mysql_length={'name': 255})
+    idx.create()
+
+    idx = sa.Index('test_code_paths_path', test_code_paths.c.builderid, test_code_paths.c.path,
+                   mysql_length={'path': 255})
+    idx.create()

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -897,6 +897,10 @@ class Model(base.DBConnectorComponent):
     sa.Index('logs_slug', logs.c.stepid, logs.c.slug, unique=True)
     sa.Index('logchunks_firstline', logchunks.c.logid, logchunks.c.first_line)
     sa.Index('logchunks_lastline', logchunks.c.logid, logchunks.c.last_line)
+    sa.Index('test_names_name', test_names.c.builderid, test_names.c.name,
+             mysql_length={'name': 255})
+    sa.Index('test_code_paths_path', test_code_paths.c.builderid, test_code_paths.c.path,
+             mysql_length={'path': 255})
 
     # MySQL creates indexes for foreign keys, and these appear in the
     # reflection.  This is a list of (table, index) names that should be

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -609,6 +609,118 @@ class Model(base.DBConnectorComponent):
                   nullable=False),
     )
 
+    # Tables related to test results
+    # ------------------------------
+
+    # Represents a single test result set. A step can any number of test result sets,
+    # each of which may contain any number of test results.
+    test_result_sets = sautils.Table(
+        'test_result_sets', metadata,
+
+        sa.Column('id', sa.Integer, primary_key=True),
+
+        # In the future we will want to rearrange the underlying data in the database according
+        # to (builderid, buildid) tuple, so that huge number of entries in the table does not
+        # reduce the efficiency of retrieval of data for a particular build.
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('buildid', sa.Integer,
+                  sa.ForeignKey('builds.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('stepid', sa.Integer,
+                  sa.ForeignKey('steps.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        # The free-form description of the source of the test data that represent the test result
+        # set.
+        sa.Column('description', sa.Text, nullable=True),
+
+        sa.Column('category', sa.Text, nullable=False),
+
+        sa.Column('value_unit', sa.Text, nullable=False),
+
+        # The number of passed tests in cases when the pass or fail criteria depends only on how
+        # that single test runs.
+        sa.Column('tests_passed', sa.Integer, nullable=True),
+
+        # The number of failed tests in cases when the pass or fail criteria depends only on how
+        # that single test runs.
+        sa.Column('tests_failed', sa.Integer, nullable=True),
+
+        # true when all test results associated with test result set have been generated.
+        sa.Column('complete', sa.SmallInteger, nullable=False),
+    )
+
+    # Represents a test result. A single test result set will represent thousands of test results
+    # in any significant codebase that's tested.
+    #
+    # A common table is used for all tests results regardless of what data they carry. Most serious
+    # database engines will be able to optimize nullable fields out, so extra columns are almost
+    # free when not used in such cases.
+    test_results = sautils.Table(
+        'test_results', metadata,
+
+        sa.Column('id', sa.Integer, primary_key=True),
+
+        # The builder ID of the test result set that the test result belongs to.
+        # This is included for future partitioning support.
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('test_result_setid', sa.Integer,
+                  sa.ForeignKey('test_result_sets.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('test_nameid', sa.Integer,
+                  sa.ForeignKey('test_names.id', ondelete='CASCADE'),
+                  nullable=True),
+
+        sa.Column('test_code_pathid', sa.Integer,
+                  sa.ForeignKey('test_code_paths.id', ondelete='CASCADE'),
+                  nullable=True),
+
+        # The code line that the test originated from
+        sa.Column('line', sa.Integer, nullable=True),
+
+        # The result of the test converted to a string.
+        sa.Column('value', sa.Text, nullable=False),
+    )
+
+    # Represents the test names of test results.
+    test_names = sautils.Table(
+        'test_names', metadata,
+
+        sa.Column('id', sa.Integer, primary_key=True),
+
+        # The builder ID of the test result set that the test result belongs to.
+        # This is included for future partitioning support and also for querying all test names
+        # for a builder.
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('name', sa.Text, nullable=False),
+    )
+
+    # Represents the file paths of test results.
+    test_code_paths = sautils.Table(
+        'test_code_paths', metadata,
+
+        sa.Column('id', sa.Integer, primary_key=True),
+
+        # The builder ID of the test result set that the test result belongs to.
+        # This is included for future partitioning support
+        sa.Column('builderid', sa.Integer,
+                  sa.ForeignKey('builders.id', ondelete='CASCADE'),
+                  nullable=False),
+
+        sa.Column('path', sa.Text, nullable=False),
+    )
+
     # Tables related to objects
     # -------------------------
 

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -686,6 +686,9 @@ class Model(base.DBConnectorComponent):
         # The code line that the test originated from
         sa.Column('line', sa.Integer, nullable=True),
 
+        # The duration of the test execution itself
+        sa.Column('duration_ns', sa.Integer, nullable=True),
+
         # The result of the test converted to a string.
         sa.Column('value', sa.Text, nullable=False),
     )

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -930,6 +930,41 @@ class Model(base.DBConnectorComponent):
         ('changes',
             dict(unique=False, column_names=['parent_changeids'],
                  name='parent_changeids')),
+        ('test_result_sets', {
+            'name': 'builderid',
+            'column_names': ['builderid'],
+            'unique': False,
+        }),
+        ('test_result_sets', {
+            'name': 'buildid',
+            'column_names': ['buildid'],
+            'unique': False,
+        }),
+        ('test_result_sets', {
+            'name': 'stepid',
+            'column_names': ['stepid'],
+            'unique': False,
+        }),
+        ('test_results', {
+            'name': 'test_result_setid',
+            'column_names': ['test_result_setid'],
+            'unique': False,
+        }),
+        ('test_results', {
+            'name': 'test_code_pathid',
+            'column_names': ['test_code_pathid'],
+            'unique': False,
+        }),
+        ('test_results', {
+            'name': 'builderid',
+            'column_names': ['builderid'],
+            'unique': False,
+        }),
+        ('test_results', {
+            'name': 'test_nameid',
+            'column_names': ['test_nameid'],
+            'unique': False,
+        }),
     ]
 
     # Migration support

--- a/master/buildbot/db/test_result_sets.py
+++ b/master/buildbot/db/test_result_sets.py
@@ -1,0 +1,118 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+
+from buildbot.db import base
+
+
+class TestResultSetDict(dict):
+    pass
+
+
+class TestResultSetAlreadyCompleted(Exception):
+    pass
+
+
+class TestResultSetsConnectorComponent(base.DBConnectorComponent):
+    # Documentation is in developer/db.rst
+
+    @defer.inlineCallbacks
+    def addTestResultSet(self, builderid, buildid, stepid, description, category, value_unit):
+        # Returns the id of the new result set
+        def thd(conn):
+            sets_table = self.db.model.test_result_sets
+
+            insert_values = {
+                'builderid': builderid,
+                'buildid': buildid,
+                'stepid': stepid,
+                'description': description,
+                'category': category,
+                'value_unit': value_unit,
+                'complete': 0
+            }
+
+            q = sets_table.insert().values(insert_values)
+            r = conn.execute(q)
+            return r.inserted_primary_key[0]
+
+        res = yield self.db.pool.do(thd)
+        return res
+
+    @defer.inlineCallbacks
+    def getTestResultSet(self, test_result_setid):
+        def thd(conn):
+            sets_table = self.db.model.test_result_sets
+            q = sets_table.select().where(sets_table.c.id == test_result_setid)
+            res = conn.execute(q)
+            row = res.fetchone()
+            if not row:
+                return None
+            return self._thd_row2dict(conn, row)
+        res = yield self.db.pool.do(thd)
+        return res
+
+    @defer.inlineCallbacks
+    def getTestResultSets(self, builderid, buildid=None, stepid=None, complete=None,
+                          result_spec=None):
+        def thd(conn):
+            sets_table = self.db.model.test_result_sets
+            q = sets_table.select().where(sets_table.c.builderid == builderid)
+            if buildid is not None:
+                q = q.where(sets_table.c.buildid == buildid)
+            if stepid is not None:
+                q = q.where(sets_table.c.stepid == stepid)
+            if complete is not None:
+                q = q.where(sets_table.c.complete == (1 if complete else 0))
+            if result_spec is not None:
+                return result_spec.thd_execute(conn, q, lambda x: self._thd_row2dict(conn, x))
+            res = conn.execute(q)
+            return [self._thd_row2dict(conn, row) for row in res.fetchall()]
+        res = yield self.db.pool.do(thd)
+        return res
+
+    @defer.inlineCallbacks
+    def completeTestResultSet(self, test_result_setid, tests_passed=None, tests_failed=None):
+        def thd(conn):
+            sets_table = self.db.model.test_result_sets
+
+            values = {'complete': 1}
+            if tests_passed is not None:
+                values['tests_passed'] = tests_passed
+            if tests_failed is not None:
+                values['tests_failed'] = tests_failed
+
+            q = sets_table.update().values(values)
+            q = q.where((sets_table.c.id == test_result_setid) &
+                        (sets_table.c.complete == 0))
+
+            res = conn.execute(q)
+            if res.rowcount == 0:
+                raise TestResultSetAlreadyCompleted(('Test result set {} is already completed '
+                                                     'or does not exist').format(test_result_setid))
+        yield self.db.pool.do(thd)
+
+    def _thd_row2dict(self, conn, row):
+        return TestResultSetDict(id=row.id,
+                                 builderid=row.builderid,
+                                 buildid=row.buildid,
+                                 stepid=row.stepid,
+                                 description=row.description,
+                                 category=row.category,
+                                 value_unit=row.value_unit,
+                                 tests_passed=row.tests_passed,
+                                 tests_failed=row.tests_failed,
+                                 complete=bool(row.complete))

--- a/master/buildbot/db/test_results.py
+++ b/master/buildbot/db/test_results.py
@@ -1,0 +1,273 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+
+from twisted.internet import defer
+
+from buildbot.db import base
+
+
+class TestResultDict(dict):
+    pass
+
+
+class TestResultsConnectorComponent(base.DBConnectorComponent):
+    # Documentation is in developer/db.rst
+
+    @defer.inlineCallbacks
+    def _add_code_paths(self, builderid, paths):
+        # returns a dictionary of path to id in the test_code_paths table.
+        # For paths that already exist, the id of the row in the test_code_paths is retrieved.
+        assert isinstance(paths, set)
+
+        def thd(conn):
+
+            paths_to_ids = {}
+            paths_table = self.db.model.test_code_paths
+
+            for path_batch in self.doBatch(paths):
+
+                path_batch = set(path_batch)
+
+                while path_batch:
+                    q = paths_table.select().where((paths_table.c.path.in_(paths)) &
+                                                   (paths_table.c.builderid == builderid))
+                    res = conn.execute(q)
+                    for row in res.fetchall():
+                        paths_to_ids[row.path] = row.id
+                        path_batch.remove(row.path)
+
+                    # paths now contains all the paths that need insertion.
+                    try:
+                        insert_values = [{'builderid': builderid, 'path': path}
+                                         for path in path_batch]
+
+                        q = paths_table.insert().values(insert_values)
+
+                        if self.db.pool.engine.dialect.name in ['postgresql', 'mssql']:
+                            # Use RETURNING, this way we won't need an additional select query
+                            q = q.returning(paths_table.c.id, paths_table.c.path)
+
+                            res = conn.execute(q)
+                            for row in res.fetchall():
+                                paths_to_ids[row.path] = row.id
+                                path_batch.remove(row.path)
+                        else:
+                            conn.execute(q)
+
+                    except sa.exc.IntegrityError:
+                        # There was a competing addCodePaths() call that added a path for the same
+                        # builder. Depending on the DB driver, none or some rows were inserted, but
+                        # we will re-check what's got inserted in the next iteration of the loop
+                        pass
+
+            return paths_to_ids
+
+        paths_to_id = yield self.db.pool.do(thd)
+        return paths_to_id
+
+    @defer.inlineCallbacks
+    def getTestCodePaths(self, builderid, path_prefix=None, result_spec=None):
+        def thd(conn):
+            paths_table = self.db.model.test_code_paths
+            q = paths_table.select()
+            if path_prefix is not None:
+                q = q.where(paths_table.c.path.startswith(path_prefix))
+            if result_spec is not None:
+                return result_spec.thd_execute(conn, q, lambda x: x['path'])
+            res = conn.execute(q)
+            return [row['path'] for row in res.fetchall()]
+        res = yield self.db.pool.do(thd)
+        return res
+
+    @defer.inlineCallbacks
+    def _add_names(self, builderid, names):
+        # returns a dictionary of name to id in the test_names table.
+        # For names that already exist, the id of the row in the test_names is retrieved.
+        assert isinstance(names, set)
+
+        def thd(conn):
+
+            names_to_ids = {}
+            names_table = self.db.model.test_names
+
+            for name_batch in self.doBatch(names):
+
+                name_batch = set(name_batch)
+                while name_batch:
+                    q = names_table.select().where((names_table.c.name.in_(name_batch)) &
+                                                   (names_table.c.builderid == builderid))
+                    res = conn.execute(q)
+                    for row in res.fetchall():
+                        names_to_ids[row.name] = row.id
+                        name_batch.remove(row.name)
+
+                    # names now contains all the names that need insertion.
+                    try:
+                        insert_values = [{'builderid': builderid, 'name': name}
+                                         for name in name_batch]
+
+                        q = names_table.insert().values(insert_values)
+
+                        if self.db.pool.engine.dialect.name in ['postgresql', 'mssql']:
+                            # Use RETURNING, this way we won't need an additional select query
+                            q = q.returning(names_table.c.id, names_table.c.name)
+
+                            res = conn.execute(q)
+                            for row in res.fetchall():
+                                names_to_ids[row.name] = row.id
+                                name_batch.remove(row.name)
+                        else:
+                            conn.execute(q)
+
+                    except sa.exc.IntegrityError:
+                        # There was a competing addNames() call that added a name for the same
+                        # builder. Depending on the DB driver, none or some rows were inserted, but
+                        # we will re-check what's got inserted in the next iteration of the loop
+                        pass
+
+            return names_to_ids
+
+        names_to_id = yield self.db.pool.do(thd)
+        return names_to_id
+
+    @defer.inlineCallbacks
+    def getTestNames(self, builderid, name_prefix=None, result_spec=None):
+        def thd(conn):
+            names_table = self.db.model.test_names
+            q = names_table.select().where(names_table.c.builderid == builderid)
+            if name_prefix is not None:
+                q = q.where(names_table.c.name.startswith(name_prefix))
+            if result_spec is not None:
+                return result_spec.thd_execute(conn, q, lambda x: x['name'])
+            res = conn.execute(q)
+            return [row['name'] for row in res.fetchall()]
+        res = yield self.db.pool.do(thd)
+        return res
+
+    @defer.inlineCallbacks
+    def addTestResults(self, builderid, test_result_setid, result_values):
+        # Adds multiple test results for a specific test result set.
+        # result_values is a list of dictionaries each of which must contain 'value' key and at
+        # least one of 'test_name', 'test_code_path'. 'line' key is optional.
+        # The function returns nothing.
+
+        # Build values list for insertion.
+        insert_values = []
+
+        insert_names = set()
+        insert_code_paths = set()
+        for result_value in result_values:
+            if 'value' not in result_value:
+                raise KeyError('Each of result_values must contain \'value\' key')
+
+            if 'test_name' not in result_value and 'test_code_path' not in result_value:
+                raise KeyError('Each of result_values must contain at least one of '
+                               '\'test_name\' or \'test_code_path\' keys')
+
+            if 'test_name' in result_value:
+                insert_names.add(result_value['test_name'])
+            if 'test_code_path' in result_value:
+                insert_code_paths.add(result_value['test_code_path'])
+
+        code_path_to_id = yield self._add_code_paths(builderid, insert_code_paths)
+        name_to_id = yield self._add_names(builderid, insert_names)
+
+        for result_value in result_values:
+            insert_value = {
+                'value': result_value['value'],
+                'builderid': builderid,
+                'test_result_setid': test_result_setid,
+                'test_nameid': None,
+                'test_code_pathid': None,
+                'line': None,
+            }
+
+            if 'test_name' in result_value:
+                insert_value['test_nameid'] = name_to_id[result_value['test_name']]
+            if 'test_code_path' in result_value:
+                insert_value['test_code_pathid'] = code_path_to_id[result_value['test_code_path']]
+            if 'line' in result_value:
+                insert_value['line'] = result_value['line']
+
+            insert_values.append(insert_value)
+
+        def thd(conn):
+            results_table = self.db.model.test_results
+            q = results_table.insert().values(insert_values)
+            conn.execute(q)
+
+        yield self.db.pool.do(thd)
+
+    @defer.inlineCallbacks
+    def getTestResult(self, test_resultid):
+        def thd(conn):
+            results_table = self.db.model.test_results
+            code_paths_table = self.db.model.test_code_paths
+            names_table = self.db.model.test_names
+
+            j = results_table.outerjoin(code_paths_table).outerjoin(names_table)
+
+            q = sa.select([results_table, code_paths_table.c.path, names_table.c.name])
+            q = q.select_from(j).where(results_table.c.id == test_resultid)
+
+            res = conn.execute(q)
+            row = res.fetchone()
+            if not row:
+                return None
+            return self._thd_row2dict(conn, row)
+        res = yield self.db.pool.do(thd)
+        return res
+
+    @defer.inlineCallbacks
+    def getTestResults(self, builderid, test_result_setid, result_spec=None):
+        def thd(conn):
+            results_table = self.db.model.test_results
+            code_paths_table = self.db.model.test_code_paths
+            names_table = self.db.model.test_names
+
+            # specify join ON clauses manually to force filtering of code_paths_table and
+            # names_table before join
+
+            j = results_table.outerjoin(
+                code_paths_table,
+                (results_table.c.test_code_pathid == code_paths_table.c.id) &
+                (code_paths_table.c.builderid == builderid))
+
+            j = j.outerjoin(
+                names_table,
+                (results_table.c.test_nameid == names_table.c.id) &
+                (names_table.c.builderid == builderid))
+
+            q = sa.select([results_table, code_paths_table.c.path, names_table.c.name])
+            q = q.select_from(j).where((results_table.c.builderid == builderid) &
+                                       (results_table.c.test_result_setid == test_result_setid))
+
+            if result_spec is not None:
+                return result_spec.thd_execute(conn, q, lambda x: self._thd_row2dict(conn, x))
+            res = conn.execute(q)
+            return [self._thd_row2dict(conn, row) for row in res.fetchall()]
+        res = yield self.db.pool.do(thd)
+        return res
+
+    def _thd_row2dict(self, conn, row):
+        return TestResultDict(id=row.id,
+                              builderid=row.builderid,
+                              test_result_setid=row.test_result_setid,
+                              test_name=row.name,
+                              test_code_path=row.path,
+                              line=row.line,
+                              value=row.value)

--- a/master/buildbot/db/test_results.py
+++ b/master/buildbot/db/test_results.py
@@ -38,7 +38,7 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
             paths_to_ids = {}
             paths_table = self.db.model.test_code_paths
 
-            for path_batch in self.doBatch(paths):
+            for path_batch in self.doBatch(paths, batch_n=3000):
 
                 path_batch = set(path_batch)
 
@@ -104,7 +104,7 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
             names_to_ids = {}
             names_table = self.db.model.test_names
 
-            for name_batch in self.doBatch(names):
+            for name_batch in self.doBatch(names, batch_n=3000):
 
                 name_batch = set(name_batch)
                 while name_batch:

--- a/master/buildbot/db/test_results.py
+++ b/master/buildbot/db/test_results.py
@@ -194,6 +194,7 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
                 'test_nameid': None,
                 'test_code_pathid': None,
                 'line': None,
+                'duration_ns': None,
             }
 
             if 'test_name' in result_value:
@@ -202,6 +203,8 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
                 insert_value['test_code_pathid'] = code_path_to_id[result_value['test_code_path']]
             if 'line' in result_value:
                 insert_value['line'] = result_value['line']
+            if 'duration_ns' in result_value:
+                insert_value['duration_ns'] = result_value['duration_ns']
 
             insert_values.append(insert_value)
 
@@ -270,4 +273,5 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
                               test_name=row.name,
                               test_code_path=row.path,
                               line=row.line,
+                              duration_ns=row.duration_ns,
                               value=row.value)

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -658,10 +658,11 @@ class BuildStep(results.ResultComputingConfigMixin,
         self._test_result_submitters[setid] = sub
         return setid
 
-    def addTestResult(self, setid, value, test_name=None, test_code_path=None, line=None):
+    def addTestResult(self, setid, value, test_name=None, test_code_path=None, line=None,
+                      duration_ns=None):
         self._test_result_submitters[setid].add_test_result(value, test_name=test_name,
                                                             test_code_path=test_code_path,
-                                                            line=line)
+                                                            line=line, duration_ns=duration_ns)
 
     def acquireLocks(self, res=None):
         if not self.locks:

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -56,6 +56,7 @@ from buildbot.process.results import worst_status
 from buildbot.util import bytes2unicode
 from buildbot.util import debounce
 from buildbot.util import flatten
+from buildbot.util.test_result_submitter import TestResultSubmitter
 
 
 class BuildStepFailed(Exception):
@@ -365,6 +366,7 @@ class BuildStep(results.ResultComputingConfigMixin,
         self.stepid = None
         self.results = None
         self._start_unhandled_deferreds = None
+        self._test_result_submitters = {}
 
     def __new__(klass, *args, **kwargs):
         self = object.__new__(klass)
@@ -565,6 +567,7 @@ class BuildStep(results.ResultComputingConfigMixin,
 
             # run -- or skip -- the step
             if doStep:
+                yield self.addTestResultSets()
                 try:
                     self._running = True
                     self.results = yield self.run()
@@ -622,6 +625,11 @@ class BuildStep(results.ResultComputingConfigMixin,
         all_finished = yield self.finishUnfinishedLogs()
         if not all_finished:
             self.results = EXCEPTION
+
+        # finish unfinished test result submitters
+        for sub in self._test_result_submitters.values():
+            yield sub.finish()
+
         self.releaseLocks()
 
         return self.results
@@ -638,6 +646,22 @@ class BuildStep(results.ResultComputingConfigMixin,
                 log.err(res, "when trying to finish a log")
                 ok = False
         return ok
+
+    def addTestResultSets(self):
+        return defer.succeed(None)
+
+    @defer.inlineCallbacks
+    def addTestResultSet(self, description, category, value_unit):
+        sub = TestResultSubmitter()
+        yield sub.setup(self, description, category, value_unit)
+        setid = sub.get_test_result_set_id()
+        self._test_result_submitters[setid] = sub
+        return setid
+
+    def addTestResult(self, setid, value, test_name=None, test_code_path=None, line=None):
+        self._test_result_submitters[setid].add_test_result(value, test_name=test_name,
+                                                            test_code_path=test_code_path,
+                                                            line=line)
 
     def acquireLocks(self, res=None):
         if not self.locks:

--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -58,6 +58,8 @@ types:
     patch: !include types/patch.raml
     spec: !include types/spec.raml
     step: !include types/step.raml
+    test_result: !include types/test_result.raml
+    test_result_set: !include types/test_result_set.raml
 /:
     get:
         is:
@@ -298,6 +300,28 @@ types:
             get:
                 is:
                 - bbget: {bbtype: master}
+
+        /test_result_sets:
+            description: |
+                This selects all test result sets that have been created for a particular builder
+            get:
+                is:
+                - bbget: {bbtype: test_result_set}
+
+        /test_code_paths:
+            description: |
+                This selects all test code paths that have been created for a particular builder
+            get:
+                is:
+                - bbget: {bbtype: string}
+
+        /test_names:
+            description: |
+                This selects all test names that have been created for a particular builder
+            get:
+                is:
+                - bbget: {bbtype: string}
+
 /buildrequests:
     /{buildrequestid}:
         uriParameters:
@@ -413,6 +437,19 @@ types:
                                     This path downloads the whole log
                                 is:
                                 - bbgetraw:
+                /test_result_sets:
+                    description: |
+                        This selects all test result sets that have been created for a particular step
+                    get:
+                        is:
+                        - bbget: {bbtype: test_result_set}
+        /test_result_sets:
+            description: |
+                This selects all test result sets that have been created for a particular build
+            get:
+                is:
+                - bbget: {bbtype: test_result_set}
+
 /buildsets:
     description: this path selects all buildsets
     get:
@@ -700,3 +737,32 @@ types:
                             This path downloads the whole log
                         is:
                         - bbgetraw:
+        /test_result_sets:
+            description: |
+                This selects all test result sets that have been created for a particular step
+            get:
+                is:
+                - bbget: {bbtype: test_result_set}
+
+/test_result_sets:
+    /{test_result_setid}:
+        description: Selects a test result set by id
+        uriParameters:
+            test_result_setid:
+                type: number
+                description: the id of the test result set
+        get:
+            description: This path selects specific test result set.
+            is:
+            - bbget: {bbtype: test_result_set}
+        /results:
+            description: This path selects all test results for the given test result set
+            get:
+                is:
+                - bbget: {bbtype: test_result}
+        /raw_results:
+            description: This path selects the raw data for the test result set, if available
+            get:
+                is:
+                - bbget: {bbtype: test_raw_result}
+

--- a/master/buildbot/spec/types/test_result.raml
+++ b/master/buildbot/spec/types/test_result.raml
@@ -1,0 +1,44 @@
+#%RAML 1.0 DataType
+displayName: Test result
+description: |
+    This resource represents a test result.
+    Test results that are produced by a single test run are grouped by a relation to a test result set.
+    Single test result set may represent thousands of test results.
+
+    Update Methods
+    --------------
+
+    TODO
+
+properties:
+    test_resultid:
+        description: the unique ID of this test result.
+        type: integer
+    builderid:
+        description: id of the builder for this test result.
+        type: integer
+    test_result_setid:
+        description: id of the test result set that the test result belongs to.
+        type: integer
+    test_name?:
+        description: id of the test name
+        type: integer
+    test_code_path?:
+        description: the code path associated to test, if any
+        type: integer
+    line?:
+        description: the number of the line in the code path that produced this result, if any
+        type: integer
+    value:
+        description: the value of the test.
+        type: string
+
+type: object
+example:
+    test_resultid: 1042
+    builderid: 14
+    test_result_setid: 412
+    test_name: 'test.perf.buildbot.api.123'
+    test_code_path: 'master/buildbot/spec/types/test_result.raml'
+    line: 123
+    value: '31.1382'

--- a/master/buildbot/spec/types/test_result.raml
+++ b/master/buildbot/spec/types/test_result.raml
@@ -33,6 +33,9 @@ description: |
              - ``line`` (optional): An integer containing the line within the source file
                 corresponding to the test.
 
+             - ``duration_ns`` (optional): An integer defining the duration of the test in
+                nanoseconds.
+
             At least one of ``test_name``, ``test_code_path`` must be specified.
 
             The function returns nothing.
@@ -56,6 +59,9 @@ properties:
     line?:
         description: the number of the line in the code path that produced this result, if any
         type: integer
+    duration_ns?:
+        description: the number of nanoseconds it took to perform the test, if available.
+        type: integer
     value:
         description: the value of the test.
         type: string
@@ -67,5 +73,6 @@ example:
     test_result_setid: 412
     test_name: 'test.perf.buildbot.api.123'
     test_code_path: 'master/buildbot/spec/types/test_result.raml'
+    duration_ns: 120410
     line: 123
     value: '31.1382'

--- a/master/buildbot/spec/types/test_result.raml
+++ b/master/buildbot/spec/types/test_result.raml
@@ -8,7 +8,34 @@ description: |
     Update Methods
     --------------
 
-    TODO
+    All update methods are available as attributes of ``master.data.updates``.
+
+    .. py:class:: buildbot.data.test_result_sets.TestResult
+
+        .. py:method:: addTestResults(builderid, test_result_setid, result_values)
+
+            :param integer builderid: The ID of the builder corresponding to the test result set.
+            :param integer test_result_setid: The ID of the test result set for which to add results.
+            :param integer result_values: A list of dictionaries that define the test results.
+
+            Creates one or more new test results.
+            This is a batch-based method as large number of test results are usually associated to a
+            single test result set.
+
+            The dictionaries in ``result_value`` may have the following keys:
+
+             - ``value`` (required): A string containing the value of the test result.
+
+             - ``test_name`` (optional): A string containing the name of the test that.
+
+             - ``test_code_path`` (optional): A string containing the path of the test.
+
+             - ``line`` (optional): An integer containing the line within the source file
+                corresponding to the test.
+
+            At least one of ``test_name``, ``test_code_path`` must be specified.
+
+            The function returns nothing.
 
 properties:
     test_resultid:

--- a/master/buildbot/spec/types/test_result_set.raml
+++ b/master/buildbot/spec/types/test_result_set.raml
@@ -15,8 +15,32 @@ description: |
     Update Methods
     --------------
 
-    TODO
-    TODO: maybe describe that builderid and buildid are extraneous data
+    All update methods are available as attributes of ``master.data.updates``.
+
+    .. py:class:: buildbot.data.test_result_sets.TestResultSet
+
+        .. py:method:: addTestResultSet(builderid, buildid, stepid, description, category, value_unit)
+
+            :param integer builderid: The ID of the builder for which the test result set is to be created.
+            :param integer buildid: The ID of the build for which the test result set is to be created.
+            :param integer stepid: The ID of the step for which the test result set is to be created.
+            :param description: Description of the test result set.
+            :param category: The category of the test result set.
+            :param value_unit: Defines the unit of the values stored in the test results.
+
+            Creates a new test result set.
+            Returns the ID of the new test result set.
+
+        .. py:method:: completeTestResultSet(test_result_setid, tests_passed=None, tests_failed=None):
+
+            :param integer test_result_setid: The ID of the test result set to complete.
+            :param integer tests_passed: The number of passed tests, if known
+            :param integer tests_failed: The number of failed tests, if known
+
+            Marks a test result set as complete.
+            The total number of passed and failed tests may be passed to have this information
+            cached as part of a test result set so that expensive re-computations don't need to
+            be performed.
 
 properties:
     test_result_setid:
@@ -39,9 +63,57 @@ properties:
         description: |
             The category of the test result set.
             This describes what data the test results contain.
+
+            Any value is allowed. The following standard categories are defined:
+
+            - ``pass_fail``: The test result set contains results that can indicate success or
+              failure of specific test. The values of test results contain success or failure
+              values.
+
+            - ``pass_only``: The test result set contains results that can only indicate success
+              of specific test. This is used in cases when failed tests are not reported.
+
+            - ``fail_only``: The test result set contains results that can only indicate failure
+              of specific test. This is used in tests when passed tests are not reported.
+
+            - ``code_issue``: The test result set contains issues within the code reported by
+              various tooling. This is effectively a subset of ``fail_only``.
+
+            - ``performance``: The test result set contains performance results.
+              The values of test results contain some kind of performance metric such as time per
+              operation or the number of operations completed in a time period.
+
+            - ``binary_size``: The test result set contains evaluation of binary size.
+              The values of test results contain a binary size metric.
+
+            - ``memory_use``: The test result set contains evaluation of dynamic memory use.
+              The values of test results contain a memory use metric.
         type: string
     value_unit:
-        description: Describes the unit of the values stored within the test results.
+        description: |
+            Describes the unit of the values stored within the test results.
+
+            Any value is allowed. The following standard units are defined:
+
+            - ``ps``: Picoseconds
+            - ``ns``: Nanoseconds
+            - ``us``: Microseconds
+            - ``ms``: Milliseconds
+            - ``s``: Seconds
+            - ``boolean``: A boolean value (0 or 1)
+            - ``B``: Bytes
+            - ``KB``: Kilobytes (1000-based)
+            - ``KiB``: Kibibytes (1024-based)
+            - ``MB``: Megabytes (1000-based)
+            - ``MiB``: Mebibytes (1024-based)
+            - ``GB``: Gigabytes (1000-based)
+            - ``GiB``: Gibibytes (1024-based)
+            - ``TB``: Gigabytes (1000-based)
+            - ``TiB``: Gibibytes (1024-based)
+            - ``message``: Arbitrary string message
+
+            Note that the value of the test result is always stored as string.
+
         type: string
     tests_passed?:
         description: |

--- a/master/buildbot/spec/types/test_result_set.raml
+++ b/master/buildbot/spec/types/test_result_set.raml
@@ -1,0 +1,73 @@
+#%RAML 1.0 DataType
+displayName: Test result set
+description: |
+    This resource represents a test result set.
+    A test result set consists of a number of related test results.
+    These test results need to be related in that they represent the same type of data and are produced by a single step.
+    In reasonably tested codebases the number of test results in a test result set will approach several or even tens of thousands.
+
+    There may be a long delay between the creation of the test result set and full creation of the corresponding test results.
+    This is tracked by the ``complete`` property.
+    If it's ``true``, then the full set of test results have been committed to the database.
+
+    The ``test_result_unparsed_set`` object tracks test result sets that have not been parsed yet.
+
+    Update Methods
+    --------------
+
+    TODO
+    TODO: maybe describe that builderid and buildid are extraneous data
+
+properties:
+    test_result_setid:
+        description: the unique ID of this test result set.
+        type: integer
+    builderid:
+        description: id of the builder for this test result set.
+        type: integer
+    buildid:
+        description: id of the build for this test result set.
+        type: integer
+    stepid:
+        description: id of the step for this test result set.
+        type: integer
+    description:
+        description: |
+            Free-form description of the source of the test data
+        type: string
+    category:
+        description: |
+            The category of the test result set.
+            This describes what data the test results contain.
+        type: string
+    value_unit:
+        description: Describes the unit of the values stored within the test results.
+        type: string
+    tests_passed?:
+        description: |
+            The number of passed tests in cases when the pass or fail criteria depends only on how
+            that single test runs. For example, performance tests that track regressions across
+            multiple tests do not have the number of passed tests defined.
+        type: integer
+    tests_failed?:
+        description: |
+            The number of failed tests in cases when the pass or fail criteria depends only on how
+            that single test runs. For example, performance tests that track regressions across
+            multiple tests do not have the number of failed tests defined.
+        type: integer
+    complete:
+        description: |
+            ``true`` if all test results associated with test result set have been generated.
+            Once set to ``true`` this property will never be set back to ``false``
+        type: boolean
+
+type: object
+example:
+    test_result_setid: 412
+    builderid: 14
+    buildid: 31
+    stepid: 3
+    description: "Performance test via BenchmarkDotNet"
+    category: "performance"
+    value_unit: "ms"
+    complete: True

--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -15,6 +15,8 @@
 
 import re
 
+from twisted.internet import defer
+
 from buildbot import config
 from buildbot.process import logobserver
 from buildbot.process.results import FAILURE
@@ -202,40 +204,56 @@ class PyLint(ShellCommand):
 
     _msgtypes_re_str = '(?P<errtype>[{}])'.format(''.join(list(_MESSAGES)))
     _default_line_re = re.compile(r'^{}(\d+)?: *\d+(, *\d+)?:.+'.format(_msgtypes_re_str))
-    _parseable_line_re = re.compile(r'[^:]+:\d+: \[{}(\d+)?(\([a-z-]+\))?[,\]] .+'.format(
-            _msgtypes_re_str))
+    _parseable_line_re = re.compile(
+        r'(?P<path>[^:]+):(?P<line>\d+): \[{}(\d+)?(\([a-z-]+\))?[,\]] .+'.format(_msgtypes_re_str))
 
-    def __init__(self, **kwargs):
+    def __init__(self, store_results=True, **kwargs):
         super().__init__(**kwargs)
+        self._store_results = store_results
         self.counts = {}
         self.summaries = {}
         self.addLogObserver(
             'stdio', logobserver.LineConsumerLogObserver(self.logConsumer))
+
+    # returns (message type, path, line) tuple if line has been matched, or None otherwise
+    def _match_line(self, line):
+        m = self._parseable_line_re.match(line)
+        if m:
+            try:
+                line_int = int(m.group('line'))
+            except ValueError:
+                line_int = None
+            return (m.group('errtype'), m.group('path'), line_int)
+
+        m = self._default_line_re.match(line)
+        if m:
+            return (m.group('errtype'), None, None)
+
+        return None
 
     def logConsumer(self):
         for m in self._MESSAGES:
             self.counts[m] = 0
             self.summaries[m] = []
 
-        line_re = None  # decide after first match
         while True:
             stream, line = yield
             if stream == 'h':
                 continue
-            if not line_re:
-                # need to test both and then decide on one
-                if self._parseable_line_re.match(line):
-                    line_re = self._parseable_line_re
-                elif self._default_line_re.match(line):
-                    line_re = self._default_line_re
-                else:  # no match yet
-                    continue
-            mo = line_re.match(line)
-            if mo:
-                msgtype = mo.group('errtype')
-                assert msgtype in self._MESSAGES
-                self.summaries[msgtype].append(line)
-                self.counts[msgtype] += 1
+
+            ret = self._match_line(line)
+            if not ret:
+                continue
+
+            msgtype, path, line_number = ret
+
+            assert msgtype in self._MESSAGES
+            self.summaries[msgtype].append(line)
+            self.counts[msgtype] += 1
+
+            if self._store_results and path is not None:
+                self.addTestResult(self._result_setid, line, test_name=None, test_code_path=path,
+                                   line=line_number)
 
     def createSummary(self, log):
         counts, summaries = self.counts, self.summaries
@@ -256,6 +274,12 @@ class PyLint(ShellCommand):
         if self.getProperty("pylint-total"):
             return WARNINGS
         return SUCCESS
+
+    @defer.inlineCallbacks
+    def addTestResultSets(self):
+        if not self._store_results:
+            return
+        self._result_setid = yield self.addTestResultSet('Pylint warnings', 'code_issue', 'message')
 
 
 class Sphinx(ShellCommand):

--- a/master/buildbot/steps/python.py
+++ b/master/buildbot/steps/python.py
@@ -200,13 +200,10 @@ class PyLint(ShellCommand):
 
     _flunkingIssues = ("F", "E")  # msg categories that cause FAILURE
 
-    _re_groupname = 'errtype'
-    _msgtypes_re_str = '(?P<%s>[%s])' % (
-        _re_groupname, ''.join(list(_MESSAGES)))
-    _default_line_re = re.compile(
-        r'^%s(\d{4})?: *\d+(, *\d+)?:.+' % _msgtypes_re_str)
-    _parseable_line_re = re.compile(
-        r'[^:]+:\d+: \[%s(\d{4})?(\([a-z-]+\))?[,\]] .+' % _msgtypes_re_str)
+    _msgtypes_re_str = '(?P<errtype>[{}])'.format(''.join(list(_MESSAGES)))
+    _default_line_re = re.compile(r'^{}(\d+)?: *\d+(, *\d+)?:.+'.format(_msgtypes_re_str))
+    _parseable_line_re = re.compile(r'[^:]+:\d+: \[{}(\d+)?(\([a-z-]+\))?[,\]] .+'.format(
+            _msgtypes_re_str))
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -235,7 +232,7 @@ class PyLint(ShellCommand):
                     continue
             mo = line_re.match(line)
             if mo:
-                msgtype = mo.group(self._re_groupname)
+                msgtype = mo.group('errtype')
                 assert msgtype in self._MESSAGES
                 self.summaries[msgtype].append(line)
                 self.counts[msgtype] += 1

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -424,6 +424,41 @@ class FakeUpdates(service.AsyncService):
             paused=paused,
             graceful=graceful)
 
+    # methods from TestResultSet resource
+    @defer.inlineCallbacks
+    def addTestResultSet(self, builderid, buildid, stepid, description, category, value_unit):
+        validation.verifyType(self.testcase, 'builderid', builderid, validation.IntValidator())
+        validation.verifyType(self.testcase, 'buildid', buildid, validation.IntValidator())
+        validation.verifyType(self.testcase, 'stepid', stepid, validation.IntValidator())
+        validation.verifyType(self.testcase, 'description', description,
+                              validation.StringValidator())
+        validation.verifyType(self.testcase, 'category', category, validation.StringValidator())
+        validation.verifyType(self.testcase, 'value_unit', value_unit, validation.StringValidator())
+
+        test_result_setid = \
+            yield self.master.db.test_result_sets.addTestResultSet(builderid, buildid, stepid,
+                                                                   description, category,
+                                                                   value_unit)
+        return test_result_setid
+
+    @defer.inlineCallbacks
+    def completeTestResultSet(self, test_result_setid, tests_passed=None, tests_failed=None):
+        validation.verifyType(self.testcase, 'test_result_setid', test_result_setid,
+                              validation.IntValidator())
+        validation.verifyType(self.testcase, 'tests_passed', tests_passed,
+                              validation.NoneOk(validation.IntValidator()))
+        validation.verifyType(self.testcase, 'tests_failed', tests_failed,
+                              validation.NoneOk(validation.IntValidator()))
+
+        yield self.master.db.test_result_sets.completeTestResultSet(test_result_setid,
+                                                                    tests_passed, tests_failed)
+
+    # methods from TestResult resource
+    @defer.inlineCallbacks
+    def addTestResults(self, builderid, test_result_setid, result_values):
+        yield self.master.db.test_results.addTestResults(builderid, test_result_setid,
+                                                         result_values)
+
 
 class FakeDataConnector(service.AsyncMultiService):
     # FakeDataConnector delegates to the real DataConnector so it can get all

--- a/master/buildbot/test/fakedb/__init__.py
+++ b/master/buildbot/test/fakedb/__init__.py
@@ -62,6 +62,12 @@ from .steps import FakeStepsComponent
 from .steps import Step
 from .tags import FakeTagsComponent
 from .tags import Tag
+from .test_result_sets import FakeTestResultSetsComponent
+from .test_result_sets import TestResultSet
+from .test_results import FakeTestResultsComponent
+from .test_results import TestCodePath
+from .test_results import TestName
+from .test_results import TestResult
 from .users import FakeUsersComponent
 from .users import User
 from .users import UserInfo
@@ -104,6 +110,8 @@ __all__ = [
     'FakeStateComponent',
     'FakeStepsComponent',
     'FakeTagsComponent',
+    'FakeTestResultSetsComponent',
+    'FakeTestResultsComponent',
     'FakeUsersComponent',
     'FakeWorkersComponent',
     'Log',
@@ -118,6 +126,10 @@ __all__ = [
     'SourceStamp',
     'Step',
     'Tag',
+    'TestCodePath',
+    'TestName',
+    'TestResultSet',
+    'TestResult',
     'User',
     'UserInfo',
     'Worker',

--- a/master/buildbot/test/fakedb/connector.py
+++ b/master/buildbot/test/fakedb/connector.py
@@ -29,6 +29,8 @@ from buildbot.test.fakedb.sourcestamps import FakeSourceStampsComponent
 from buildbot.test.fakedb.state import FakeStateComponent
 from buildbot.test.fakedb.steps import FakeStepsComponent
 from buildbot.test.fakedb.tags import FakeTagsComponent
+from buildbot.test.fakedb.test_result_sets import FakeTestResultSetsComponent
+from buildbot.test.fakedb.test_results import FakeTestResultsComponent
 from buildbot.test.fakedb.users import FakeUsersComponent
 from buildbot.test.fakedb.workers import FakeWorkersComponent
 from buildbot.util import service
@@ -81,6 +83,10 @@ class FakeDBConnector(service.AsyncMultiService):
         self.builders = comp = FakeBuildersComponent(self, testcase)
         self._components.append(comp)
         self.tags = comp = FakeTagsComponent(self, testcase)
+        self._components.append(comp)
+        self.test_results = comp = FakeTestResultsComponent(self, testcase)
+        self._components.append(comp)
+        self.test_result_sets = comp = FakeTestResultSetsComponent(self, testcase)
         self._components.append(comp)
 
     def setup(self):

--- a/master/buildbot/test/fakedb/row.py
+++ b/master/buildbot/test/fakedb/row.py
@@ -26,7 +26,7 @@ class Row:
     Parent class for row classes, which are used to specify test data for
     database-related tests.
 
-    @cvar defaults: default values for columns
+    @cvar defaults: the column names and their default values
     @type defaults: dictionary
 
     @cvar table: the table name
@@ -128,7 +128,8 @@ class Row:
     def __repr__(self):
         return '{}(**{})'.format(self.__class__.__name__, repr(self.values))
 
-    def nextId(self):
+    @staticmethod
+    def nextId():
         id = Row._next_id if Row._next_id is not None else 1
         Row._next_id = id + 1
         return id
@@ -157,6 +158,7 @@ class Row:
             sourcestampid=db.sourcestamps.getSourceStamp,
             schedulerid=db.schedulers.getScheduler,
             brid=db.buildrequests.getBuildRequest,
+            stepid=db.steps.getStep,
             masterid=db.masters.getMaster)
         for foreign_key in self.foreignKeys:
             if foreign_key in accessors:

--- a/master/buildbot/test/fakedb/test_result_sets.py
+++ b/master/buildbot/test/fakedb/test_result_sets.py
@@ -1,0 +1,115 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+
+from buildbot.db.test_result_sets import TestResultSetAlreadyCompleted
+from buildbot.test.fakedb.base import FakeDBComponent
+from buildbot.test.fakedb.row import Row
+
+
+class TestResultSet(Row):
+    table = 'test_result_sets'
+
+    defaults = {
+        'id': None,
+        'builderid': None,
+        'buildid': None,
+        'stepid': None,
+        'description': None,
+        'category': None,
+        'value_unit': None,
+        'tests_passed': None,
+        'tests_failed': None,
+        'complete': None,
+    }
+
+    id_column = 'id'
+    foreignKeys = ('builderid', 'buildid', 'stepid')
+    required_columns = ('builderid', 'buildid', 'stepid', 'category', 'value_unit', 'complete')
+
+
+class FakeTestResultSetsComponent(FakeDBComponent):
+
+    def setUp(self):
+        self.result_sets = {}
+
+    def insertTestData(self, rows):
+        for row in rows:
+            if isinstance(row, TestResultSet):
+                self.result_sets[row.id] = row.values.copy()
+
+    def addTestResultSet(self, builderid, buildid, stepid, description, category, value_unit):
+        id = Row.nextId()
+        self.result_sets[id] = {
+            'id': id,
+            'builderid': builderid,
+            'buildid': buildid,
+            'stepid': stepid,
+            'description': description,
+            'category': category,
+            'value_unit': value_unit,
+            'tests_failed': None,
+            'tests_passed': None,
+            'complete': False
+        }
+        return defer.succeed(id)
+
+    def _row2dict(self, row):
+        row = row.copy()
+        row['complete'] = bool(row['complete'])
+        return row
+
+    # returns a Deferred
+    def getTestResultSet(self, test_result_setid):
+        if test_result_setid not in self.result_sets:
+            return defer.succeed(None)
+        return defer.succeed(self._row2dict(self.result_sets[test_result_setid]))
+
+    # returns a Deferred
+    def getTestResultSets(self, builderid, buildid=None, stepid=None, complete=None,
+                          result_spec=None):
+        ret = []
+        for id, row in self.result_sets.items():
+            if row['builderid'] != builderid:
+                continue
+            if buildid is not None and row['buildid'] != buildid:
+                continue
+            if stepid is not None and row['stepid'] != stepid:
+                continue
+            if complete is not None and row['complete'] != complete:
+                continue
+            ret.append(self._row2dict(row))
+
+        if result_spec is not None:
+            ret = self.applyResultSpec(ret, result_spec)
+
+        return defer.succeed(ret)
+
+    # returns a Deferred
+    def completeTestResultSet(self, test_result_setid, tests_passed=None, tests_failed=None):
+        if test_result_setid not in self.result_sets:
+            raise TestResultSetAlreadyCompleted(('Test result set {} is already completed '
+                                                 'or does not exist').format(test_result_setid))
+        row = self.result_sets[test_result_setid]
+        if row['complete'] != 0:
+            raise TestResultSetAlreadyCompleted(('Test result set {} is already completed '
+                                                 'or does not exist').format(test_result_setid))
+        row['complete'] = 1
+        if tests_passed is not None:
+            row['tests_passed'] = tests_passed
+        if tests_failed is not None:
+            row['tests_failed'] = tests_failed
+        return defer.succeed(None)

--- a/master/buildbot/test/fakedb/test_results.py
+++ b/master/buildbot/test/fakedb/test_results.py
@@ -1,0 +1,247 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+
+from buildbot.test.fakedb.base import FakeDBComponent
+from buildbot.test.fakedb.row import Row
+
+
+class TestName(Row):
+    table = 'test_names'
+
+    defaults = {
+        'id': None,
+        'builderid': None,
+        'name': 'nam'
+    }
+
+    id_column = 'id'
+    foreignKeys = ('builderid',)
+    required_columns = ('builderid', 'name')
+
+
+class TestCodePath(Row):
+    table = 'test_code_paths'
+
+    defaults = {
+        'id': None,
+        'builderid': None,
+        'path': 'path/to/file'
+    }
+
+    id_column = 'id'
+    foreignKeys = ('builderid',)
+    required_columns = ('builderid', 'path')
+
+
+class TestResult(Row):
+    table = 'test_results'
+
+    defaults = {
+        'id': None,
+        'builderid': None,
+        'test_result_setid': None,
+        'test_nameid': None,
+        'test_code_pathid': None,
+        'line': None,
+        'value': None
+    }
+
+    id_column = 'id'
+    foreignKeys = ('builderid', 'test_result_setid', 'test_nameid', 'test_code_pathid')
+    required_columns = ('builderid', 'test_result_setid', 'value')
+
+
+class FakeTestResultsComponent(FakeDBComponent):
+
+    def setUp(self):
+        self.results = {}
+        self.code_paths = {}
+        self.names = {}
+
+    def insertTestData(self, rows):
+        for row in rows:
+            if isinstance(row, TestName):
+                self.names[row.id] = row.values.copy()
+
+        for row in rows:
+            if isinstance(row, TestCodePath):
+                self.code_paths[row.id] = row.values.copy()
+
+        for row in rows:
+            if isinstance(row, TestResult):
+                if row.test_nameid is not None:
+                    assert row.test_nameid in self.names
+                if row.test_code_pathid is not None:
+                    assert row.test_code_pathid in self.code_paths
+
+                self.results[row.id] = row.values.copy()
+
+    def _add_code_paths(self, builderid, paths):
+        path_to_id = {}
+
+        for path in sorted(paths):
+            id = self._get_code_path_id(builderid, path)
+            if id is not None:
+                path_to_id[path] = id
+                continue
+
+            id = Row.nextId()
+            self.code_paths[id] = {
+                'builderid': builderid,
+                'path': path
+            }
+            path_to_id[path] = id
+
+        return path_to_id
+
+    def _get_code_path_id(self, builderid, path):
+        for id, path_dict in self.code_paths.items():
+            if path_dict['builderid'] == builderid and path_dict['path'] == path:
+                return id
+        return None
+
+    def _add_names(self, builderid, names):
+        name_to_id = {}
+
+        for name in sorted(names):
+            id = self._get_name_id(builderid, name)
+            if id is not None:
+                name_to_id[name] = id
+                continue
+
+            id = Row.nextId()
+            self.names[id] = {
+                'builderid': builderid,
+                'name': name
+            }
+            name_to_id[name] = id
+
+        return name_to_id
+
+    def _get_name_id(self, builderid, name):
+        for id, name_dict in self.names.items():
+            if name_dict['builderid'] == builderid and name_dict['name'] == name:
+                return id
+        return None
+
+    @defer.inlineCallbacks
+    def addTestResults(self, builderid, test_result_setid, result_values):
+        insert_code_paths = set()
+        insert_names = set()
+        for result_value in result_values:
+            if 'value' not in result_value:
+                raise KeyError('Each of result_values must contain \'value\' key')
+
+            if 'test_name' not in result_value and 'test_code_path' not in result_value:
+                raise KeyError('Each of result_values must contain at least one of '
+                               '\'test_name\' or \'test_code_path\' keys')
+
+            if 'test_name' in result_value:
+                insert_names.add(result_value['test_name'])
+            if 'test_code_path' in result_value:
+                insert_code_paths.add(result_value['test_code_path'])
+
+        code_path_to_id = yield self._add_code_paths(builderid, insert_code_paths)
+        name_to_id = yield self._add_names(builderid, insert_names)
+
+        for result_value in result_values:
+            insert_value = {
+                'value': result_value['value'],
+                'builderid': builderid,
+                'test_result_setid': test_result_setid,
+                'test_nameid': None,
+                'test_code_pathid': None,
+                'line': None,
+            }
+
+            if 'test_name' in result_value:
+                insert_value['test_nameid'] = name_to_id[result_value['test_name']]
+            if 'test_code_path' in result_value:
+                insert_value['test_code_pathid'] = code_path_to_id[result_value['test_code_path']]
+            if 'line' in result_value:
+                insert_value['line'] = result_value['line']
+
+            self.results[Row.nextId()] = insert_value
+
+    # returns a Deferred
+    def getTestNames(self, builderid, name_prefix=None, result_spec=None):
+        ret = []
+        for id, row in sorted(self.names.items()):
+            if row['builderid'] != builderid:
+                continue
+            if name_prefix is not None and not row['name'].startswith(name_prefix):
+                continue
+            ret.append(row['name'])
+
+        if result_spec is not None:
+            ret = self.applyResultSpec(ret, result_spec)
+
+        return defer.succeed(ret)
+
+    # returns a Deferred
+    def getTestCodePaths(self, builderid, path_prefix=None, result_spec=None):
+        ret = []
+        for id, row in sorted(self.code_paths.items()):
+            if row['builderid'] != builderid:
+                continue
+            if path_prefix is not None and not row['path'].startswith(path_prefix):
+                continue
+            ret.append(row['path'])
+
+        if result_spec is not None:
+            ret = self.applyResultSpec(ret, result_spec)
+
+        return defer.succeed(ret)
+
+    def _fill_extra_data(self, id, row):
+        row = row.copy()
+        row['id'] = id
+
+        if row['test_nameid'] is not None:
+            row['test_name'] = self.names[row['test_nameid']]['name']
+        else:
+            row['test_name'] = None
+        del row['test_nameid']
+
+        if row['test_code_pathid'] is not None:
+            row['test_code_path'] = self.code_paths[row['test_code_pathid']]['path']
+        else:
+            row['test_code_path'] = None
+        del row['test_code_pathid']
+
+        return row
+
+    # returns a Deferred
+    def getTestResult(self, test_resultid):
+        if test_resultid not in self.results:
+            return defer.succeed(None)
+        return defer.succeed(self._fill_extra_data(test_resultid, self.results[test_resultid]))
+
+    # returns a Deferred
+    def getTestResults(self, builderid, test_result_setid, result_spec=None):
+        ret = []
+        for id, row in sorted(self.results.items()):
+            if row['builderid'] != builderid:
+                continue
+            if row['test_result_setid'] != test_result_setid:
+                continue
+            ret.append(self._fill_extra_data(id, row))
+
+        if result_spec is not None:
+            ret = self.applyResultSpec(ret, result_spec)
+
+        return defer.succeed(ret)

--- a/master/buildbot/test/fakedb/test_results.py
+++ b/master/buildbot/test/fakedb/test_results.py
@@ -57,6 +57,7 @@ class TestResult(Row):
         'test_nameid': None,
         'test_code_pathid': None,
         'line': None,
+        'duration_ns': None,
         'value': None
     }
 
@@ -165,6 +166,7 @@ class FakeTestResultsComponent(FakeDBComponent):
                 'test_result_setid': test_result_setid,
                 'test_nameid': None,
                 'test_code_pathid': None,
+                'duration_ns': None,
                 'line': None,
             }
 
@@ -174,6 +176,8 @@ class FakeTestResultsComponent(FakeDBComponent):
                 insert_value['test_code_pathid'] = code_path_to_id[result_value['test_code_path']]
             if 'line' in result_value:
                 insert_value['line'] = result_value['line']
+            if 'duration_ns' in result_value:
+                insert_value['duration_ns'] = result_value['duration_ns']
 
             self.results[Row.nextId()] = insert_value
 

--- a/master/buildbot/test/unit/test_data_test_result_sets.py
+++ b/master/buildbot/test/unit/test_data_test_result_sets.py
@@ -1,0 +1,262 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.data import test_result_sets
+from buildbot.test import fakedb
+from buildbot.test.fake import fakemaster
+from buildbot.test.util import endpoint
+from buildbot.test.util import interfaces
+from buildbot.test.util.misc import TestReactorMixin
+
+
+class TestResultSetEndpoint(endpoint.EndpointMixin, unittest.TestCase):
+
+    endpointClass = test_result_sets.TestResultSetEndpoint
+    resourceTypeClass = test_result_sets.TestResultSet
+
+    def setUp(self):
+        self.setUpEndpoint()
+        self.db.insertTestData([
+            fakedb.Worker(id=47, name='linux'),
+            fakedb.Buildset(id=20),
+            fakedb.Builder(id=88, name='b1'),
+            fakedb.BuildRequest(id=41, buildsetid=20, builderid=88),
+            fakedb.Master(id=88),
+            fakedb.Build(id=30, buildrequestid=41, number=7, masterid=88,
+                         builderid=88, workerid=47),
+            fakedb.Step(id=131, number=132, name='step132', buildid=30),
+            fakedb.TestResultSet(id=13, builderid=88, buildid=30, stepid=131, description='desc',
+                                 category='cat', value_unit='ms', complete=1),
+        ])
+
+    def tearDown(self):
+        self.tearDownEndpoint()
+
+    @defer.inlineCallbacks
+    def test_get_existing_result_set(self):
+        result = yield self.callGet(('test_result_sets', 13))
+        self.validateData(result)
+        self.assertEqual(result, {
+            'test_result_setid': 13,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc',
+            'category': 'cat',
+            'value_unit': 'ms',
+            'tests_passed': None,
+            'tests_failed': None,
+            'complete': True
+        })
+
+    @defer.inlineCallbacks
+    def test_get_missing_result_set(self):
+        results = yield self.callGet(('test_result_sets', 14))
+        self.assertIsNone(results)
+
+
+class TestResultSetsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
+
+    endpointClass = test_result_sets.TestResultSetsEndpoint
+    resourceTypeClass = test_result_sets.TestResultSet
+
+    def setUp(self):
+        self.setUpEndpoint()
+        self.db.insertTestData([
+            fakedb.Worker(id=47, name='linux'),
+            fakedb.Buildset(id=20),
+            fakedb.Builder(id=88, name='b1'),
+            fakedb.BuildRequest(id=41, buildsetid=20, builderid=88),
+            fakedb.Master(id=88),
+            fakedb.Build(id=30, buildrequestid=41, number=7, masterid=88,
+                         builderid=88, workerid=47),
+            fakedb.Step(id=131, number=132, name='step132', buildid=30),
+            fakedb.TestResultSet(id=13, builderid=88, buildid=30, stepid=131, description='desc',
+                                 category='cat', value_unit='ms', complete=1),
+            fakedb.TestResultSet(id=14, builderid=88, buildid=30, stepid=131, description='desc',
+                                 category='cat', value_unit='ms', complete=1),
+        ])
+
+    def tearDown(self):
+        self.tearDownEndpoint()
+
+    @defer.inlineCallbacks
+    def test_get_result_sets_builders_builderid(self):
+        results = yield self.callGet(('builders', 88, 'test_result_sets'))
+        for result in results:
+            self.validateData(result)
+        self.assertEqual([r['test_result_setid'] for r in results], [13, 14])
+
+    @defer.inlineCallbacks
+    def test_get_result_sets_builders_buildername(self):
+        results = yield self.callGet(('builders', 'b1', 'test_result_sets'))
+        for result in results:
+            self.validateData(result)
+        self.assertEqual([r['test_result_setid'] for r in results], [13, 14])
+
+    @defer.inlineCallbacks
+    def test_get_result_sets_builds_buildid(self):
+        results = yield self.callGet(('builds', 30, 'test_result_sets'))
+        for result in results:
+            self.validateData(result)
+        self.assertEqual([r['test_result_setid'] for r in results], [13, 14])
+
+    @defer.inlineCallbacks
+    def test_get_result_sets_steps_stepid(self):
+        results = yield self.callGet(('steps', 131, 'test_result_sets'))
+        for result in results:
+            self.validateData(result)
+        self.assertEqual([r['test_result_setid'] for r in results], [13, 14])
+
+
+class TestResultSet(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
+
+    def setUp(self):
+        self.setUpTestReactor()
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
+        self.rtype = test_result_sets.TestResultSet(self.master)
+
+    def test_signature_add_test_result_set(self):
+        @self.assertArgSpecMatches(self.master.data.updates.addTestResultSet,
+                                   self.rtype.addTestResultSet)
+        def addTestResultSet(self, builderid, buildid, stepid, description, category, value_unit):
+            pass
+
+    def test_signature_complete_test_result_set(self):
+        @self.assertArgSpecMatches(self.master.data.updates.completeTestResultSet,
+                                   self.rtype.completeTestResultSet)
+        def completeTestResultSet(self, test_result_setid, tests_passed=None, tests_failed=None):
+            pass
+
+    @defer.inlineCallbacks
+    def test_add_test_result_set(self):
+        test_result_setid = yield self.rtype.addTestResultSet(builderid=1, buildid=2, stepid=3,
+                                                              description='desc',
+                                                              category='cat4', value_unit='ms')
+
+        msg_body = {
+            'test_result_setid': test_result_setid,
+            'builderid': 1,
+            'buildid': 2,
+            'stepid': 3,
+            'description': 'desc',
+            'category': 'cat4',
+            'value_unit': 'ms',
+            'tests_passed': None,
+            'tests_failed': None,
+            'complete': False,
+        }
+
+        self.master.mq.assertProductions([
+            (('test_result_sets', str(test_result_setid), 'new'), msg_body),
+        ])
+
+        result = yield self.master.db.test_result_sets.getTestResultSet(test_result_setid)
+        self.assertEqual(result, {
+            'id': test_result_setid,
+            'builderid': 1,
+            'buildid': 2,
+            'stepid': 3,
+            'description': 'desc',
+            'category': 'cat4',
+            'value_unit': 'ms',
+            'tests_passed': None,
+            'tests_failed': None,
+            'complete': False,
+        })
+
+    @defer.inlineCallbacks
+    def test_complete_test_result_set_no_results(self):
+        test_result_setid = \
+            yield self.master.db.test_result_sets.addTestResultSet(builderid=1, buildid=2, stepid=3,
+                                                                   description='desc',
+                                                                   category='cat4', value_unit='ms')
+
+        yield self.rtype.completeTestResultSet(test_result_setid)
+
+        msg_body = {
+            'test_result_setid': test_result_setid,
+            'builderid': 1,
+            'buildid': 2,
+            'stepid': 3,
+            'description': 'desc',
+            'category': 'cat4',
+            'value_unit': 'ms',
+            'tests_passed': None,
+            'tests_failed': None,
+            'complete': True,
+        }
+
+        self.master.mq.assertProductions([
+            (('test_result_sets', str(test_result_setid), 'completed'), msg_body),
+        ])
+
+        result = yield self.master.db.test_result_sets.getTestResultSet(test_result_setid)
+        self.assertEqual(result, {
+            'id': test_result_setid,
+            'builderid': 1,
+            'buildid': 2,
+            'stepid': 3,
+            'description': 'desc',
+            'category': 'cat4',
+            'value_unit': 'ms',
+            'tests_passed': None,
+            'tests_failed': None,
+            'complete': True,
+        })
+
+    @defer.inlineCallbacks
+    def test_complete_test_result_set_with_results(self):
+        test_result_setid = \
+            yield self.master.db.test_result_sets.addTestResultSet(builderid=1, buildid=2, stepid=3,
+                                                                   description='desc',
+                                                                   category='cat4', value_unit='ms')
+
+        yield self.rtype.completeTestResultSet(test_result_setid, tests_passed=12, tests_failed=34)
+
+        msg_body = {
+            'test_result_setid': test_result_setid,
+            'builderid': 1,
+            'buildid': 2,
+            'stepid': 3,
+            'description': 'desc',
+            'category': 'cat4',
+            'value_unit': 'ms',
+            'tests_passed': 12,
+            'tests_failed': 34,
+            'complete': True,
+        }
+
+        self.master.mq.assertProductions([
+            (('test_result_sets', str(test_result_setid), 'completed'), msg_body),
+        ])
+
+        result = yield self.master.db.test_result_sets.getTestResultSet(test_result_setid)
+        self.assertEqual(result, {
+            'id': test_result_setid,
+            'builderid': 1,
+            'buildid': 2,
+            'stepid': 3,
+            'description': 'desc',
+            'category': 'cat4',
+            'value_unit': 'ms',
+            'tests_passed': 12,
+            'tests_failed': 34,
+            'complete': True,
+        })

--- a/master/buildbot/test/unit/test_data_test_results.py
+++ b/master/buildbot/test/unit/test_data_test_results.py
@@ -51,7 +51,8 @@ class TestResultsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             fakedb.TestResult(id=102, builderid=88, test_result_setid=13,
                               test_nameid=301, test_code_pathid=401, line=401, value='v102'),
             fakedb.TestResult(id=103, builderid=88, test_result_setid=13,
-                              test_nameid=302, test_code_pathid=402, line=402, value='v103'),
+                              test_nameid=302, test_code_pathid=402, line=402,
+                              duration_ns=1012, value='v103'),
         ])
 
     def tearDown(self):
@@ -87,9 +88,10 @@ class TestResult(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase)
     def test_add_test_results(self):
         result_values = [
             {'test_name': 'name1', 'value': '1'},
-            {'test_name': 'name2', 'test_code_path': 'path2', 'value': '2'},
-            {'test_name': 'name3', 'test_code_path': 'path3', 'value': '3'},
-            {'test_name': 'name4', 'test_code_path': 'path4', 'line': 4, 'value': '4'},
+            {'test_name': 'name2', 'duration_ns': 1000, 'value': '1'},
+            {'test_name': 'name3', 'test_code_path': 'path2', 'value': '2'},
+            {'test_name': 'name4', 'test_code_path': 'path3', 'value': '3'},
+            {'test_name': 'name5', 'test_code_path': 'path4', 'line': 4, 'value': '4'},
             {'test_code_path': 'path5', 'line': 5, 'value': '5'},
         ]
         yield self.rtype.addTestResults(builderid=88, test_result_setid=13,
@@ -101,14 +103,16 @@ class TestResult(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase)
                                                                    test_result_setid=13)
         resultid = results[0]['id']
         self.assertEqual(results, [
-            {'id': resultid, 'builderid': 88, 'test_result_setid': 13,
-             'test_name': 'name1', 'test_code_path': None, 'line': None, 'value': '1'},
+            {'id': resultid, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name1',
+             'test_code_path': None, 'line': None, 'duration_ns': None, 'value': '1'},
             {'id': resultid + 1, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name2',
-             'test_code_path': 'path2', 'line': None, 'value': '2'},
+             'test_code_path': None, 'line': None, 'duration_ns': 1000, 'value': '1'},
             {'id': resultid + 2, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name3',
-             'test_code_path': 'path3', 'line': None, 'value': '3'},
+             'test_code_path': 'path2', 'line': None, 'duration_ns': None, 'value': '2'},
             {'id': resultid + 3, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name4',
-             'test_code_path': 'path4', 'line': 4, 'value': '4'},
-            {'id': resultid + 4, 'builderid': 88, 'test_result_setid': 13, 'test_name': None,
-             'test_code_path': 'path5', 'line': 5, 'value': '5'},
+             'test_code_path': 'path3', 'line': None, 'duration_ns': None, 'value': '3'},
+            {'id': resultid + 4, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name5',
+             'test_code_path': 'path4', 'line': 4, 'duration_ns': None, 'value': '4'},
+            {'id': resultid + 5, 'builderid': 88, 'test_result_setid': 13, 'test_name': None,
+             'test_code_path': 'path5', 'line': 5, 'duration_ns': None, 'value': '5'},
         ])

--- a/master/buildbot/test/unit/test_data_test_results.py
+++ b/master/buildbot/test/unit/test_data_test_results.py
@@ -1,0 +1,114 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.data import test_results
+from buildbot.test import fakedb
+from buildbot.test.fake import fakemaster
+from buildbot.test.util import endpoint
+from buildbot.test.util import interfaces
+from buildbot.test.util.misc import TestReactorMixin
+
+
+class TestResultsEndpoint(endpoint.EndpointMixin, unittest.TestCase):
+
+    endpointClass = test_results.TestResultsEndpoint
+    resourceTypeClass = test_results.TestResult
+
+    def setUp(self):
+        self.setUpEndpoint()
+        self.db.insertTestData([
+            fakedb.Worker(id=47, name='linux'),
+            fakedb.Buildset(id=20),
+            fakedb.Builder(id=88, name='b1'),
+            fakedb.BuildRequest(id=41, buildsetid=20, builderid=88),
+            fakedb.Master(id=88),
+            fakedb.Build(id=30, buildrequestid=41, number=7, masterid=88,
+                         builderid=88, workerid=47),
+            fakedb.Step(id=131, number=132, name='step132', buildid=30),
+            fakedb.TestResultSet(id=13, builderid=88, buildid=30, stepid=131, description='desc',
+                                 category='cat', value_unit='ms', complete=1),
+            fakedb.TestName(id=301, builderid=88, name='name301'),
+            fakedb.TestName(id=302, builderid=88, name='name302'),
+            fakedb.TestCodePath(id=401, builderid=88, path='path401'),
+            fakedb.TestCodePath(id=402, builderid=88, path='path402'),
+            fakedb.TestResult(id=101, builderid=88, test_result_setid=13, line=400, value='v101'),
+            fakedb.TestResult(id=102, builderid=88, test_result_setid=13,
+                              test_nameid=301, test_code_pathid=401, line=401, value='v102'),
+            fakedb.TestResult(id=103, builderid=88, test_result_setid=13,
+                              test_nameid=302, test_code_pathid=402, line=402, value='v103'),
+        ])
+
+    def tearDown(self):
+        self.tearDownEndpoint()
+
+    @defer.inlineCallbacks
+    def test_get_existing_results(self):
+        results = yield self.callGet(('test_result_sets', 13, 'results'))
+        for result in results:
+            self.validateData(result)
+        self.assertEqual([r['test_resultid'] for r in results], [101, 102, 103])
+
+    @defer.inlineCallbacks
+    def test_get_missing_results(self):
+        results = yield self.callGet(('test_result_sets', 14, 'results'))
+        self.assertEqual(results, [])
+
+
+class TestResult(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
+
+    def setUp(self):
+        self.setUpTestReactor()
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
+        self.rtype = test_results.TestResult(self.master)
+
+    def test_signature_add_test_results(self):
+        @self.assertArgSpecMatches(self.master.data.updates.addTestResults,
+                                   self.rtype.addTestResults)
+        def addTestResults(self, builderid, test_result_setid, result_values):
+            pass
+
+    @defer.inlineCallbacks
+    def test_add_test_results(self):
+        result_values = [
+            {'test_name': 'name1', 'value': '1'},
+            {'test_name': 'name2', 'test_code_path': 'path2', 'value': '2'},
+            {'test_name': 'name3', 'test_code_path': 'path3', 'value': '3'},
+            {'test_name': 'name4', 'test_code_path': 'path4', 'line': 4, 'value': '4'},
+            {'test_code_path': 'path5', 'line': 5, 'value': '5'},
+        ]
+        yield self.rtype.addTestResults(builderid=88, test_result_setid=13,
+                                        result_values=result_values)
+
+        self.master.mq.assertProductions([])
+
+        results = yield self.master.db.test_results.getTestResults(builderid=88,
+                                                                   test_result_setid=13)
+        resultid = results[0]['id']
+        self.assertEqual(results, [
+            {'id': resultid, 'builderid': 88, 'test_result_setid': 13,
+             'test_name': 'name1', 'test_code_path': None, 'line': None, 'value': '1'},
+            {'id': resultid + 1, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name2',
+             'test_code_path': 'path2', 'line': None, 'value': '2'},
+            {'id': resultid + 2, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name3',
+             'test_code_path': 'path3', 'line': None, 'value': '3'},
+            {'id': resultid + 3, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name4',
+             'test_code_path': 'path4', 'line': 4, 'value': '4'},
+            {'id': resultid + 4, 'builderid': 88, 'test_result_setid': 13, 'test_name': None,
+             'test_code_path': 'path5', 'line': 5, 'value': '5'},
+        ])

--- a/master/buildbot/test/unit/test_db_migrate_versions_056_add_test_result_tables.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_056_add_test_result_tables.py
@@ -1,0 +1,102 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def test_migration(self):
+        def setup_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            sautils.Table(
+                'builds', metadata,
+                sa.Column('id', sa.Integer, primary_key=True),
+                # ...
+            ).create()
+
+            sautils.Table(
+                'builders', metadata,
+                sa.Column('id', sa.Integer, primary_key=True),
+                # ...
+            ).create()
+
+            sautils.Table(
+                'steps', metadata,
+                sa.Column('id', sa.Integer, primary_key=True),
+                # ...
+            ).create()
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            test_result_sets = sautils.Table('test_result_sets', metadata, autoload=True)
+
+            q = sa.select([
+                test_result_sets.c.builderid,
+                test_result_sets.c.buildid,
+                test_result_sets.c.stepid,
+                test_result_sets.c.description,
+                test_result_sets.c.category,
+                test_result_sets.c.value_unit,
+                test_result_sets.c.tests_passed,
+                test_result_sets.c.tests_failed,
+                test_result_sets.c.complete,
+            ])
+            self.assertEqual(conn.execute(q).fetchall(), [])
+
+            test_results = sautils.Table('test_results', metadata, autoload=True)
+
+            q = sa.select([
+                test_results.c.builderid,
+                test_results.c.test_result_setid,
+                test_results.c.test_nameid,
+                test_results.c.test_code_pathid,
+                test_results.c.line,
+                test_results.c.value,
+            ])
+            self.assertEqual(conn.execute(q).fetchall(), [])
+
+            test_names = sautils.Table('test_names', metadata, autoload=True)
+
+            q = sa.select([
+                test_names.c.builderid,
+                test_names.c.name,
+            ])
+            self.assertEqual(conn.execute(q).fetchall(), [])
+
+            test_code_paths = sautils.Table('test_code_paths', metadata, autoload=True)
+
+            q = sa.select([
+                test_code_paths.c.builderid,
+                test_code_paths.c.path,
+            ])
+            self.assertEqual(conn.execute(q).fetchall(), [])
+
+        return self.do_test_migration(55, 56, setup_thd, verify_thd)

--- a/master/buildbot/test/unit/test_db_migrate_versions_056_add_test_result_tables.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_056_add_test_result_tables.py
@@ -79,6 +79,7 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
                 test_results.c.test_nameid,
                 test_results.c.test_code_pathid,
                 test_results.c.line,
+                test_results.c.duration_ns,
                 test_results.c.value,
             ])
             self.assertEqual(conn.execute(q).fetchall(), [])

--- a/master/buildbot/test/unit/test_db_migrate_versions_056_add_test_result_tables.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_056_add_test_result_tables.py
@@ -99,4 +99,14 @@ class Migration(migration.MigrateTestMixin, unittest.TestCase):
             ])
             self.assertEqual(conn.execute(q).fetchall(), [])
 
+            insp = sa.inspect(conn)
+
+            indexes = insp.get_indexes('test_names')
+            index_names = [item['name'] for item in indexes]
+            self.assertTrue('test_names_name' in index_names)
+
+            indexes = insp.get_indexes('test_code_paths')
+            index_names = [item['name'] for item in indexes]
+            self.assertTrue('test_code_paths_path' in index_names)
+
         return self.do_test_migration(55, 56, setup_thd, verify_thd)

--- a/master/buildbot/test/unit/test_db_test_result_sets.py
+++ b/master/buildbot/test/unit/test_db_test_result_sets.py
@@ -1,0 +1,239 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.db import test_result_sets
+from buildbot.test import fakedb
+from buildbot.test.util import connector_component
+from buildbot.test.util import interfaces
+from buildbot.test.util import validation
+
+
+class Tests(interfaces.InterfaceTests):
+
+    common_data = [
+        fakedb.Worker(id=47, name='linux'),
+        fakedb.Buildset(id=20),
+        fakedb.Builder(id=88, name='b1'),
+        fakedb.Builder(id=89, name='b2'),
+        fakedb.BuildRequest(id=41, buildsetid=20, builderid=88),
+        fakedb.BuildRequest(id=42, buildsetid=20, builderid=88),
+        fakedb.BuildRequest(id=43, buildsetid=20, builderid=88),
+        fakedb.Master(id=88),
+        fakedb.Build(id=30, buildrequestid=41, number=7, masterid=88,
+                     builderid=88, workerid=47),
+        fakedb.Build(id=31, buildrequestid=42, number=8, masterid=88,
+                     builderid=88, workerid=47),
+        fakedb.Build(id=40, buildrequestid=43, number=9, masterid=88,
+                     builderid=89, workerid=47),
+        fakedb.Step(id=131, number=231, name='step231', buildid=30),
+        fakedb.Step(id=132, number=232, name='step232', buildid=30),
+        fakedb.Step(id=141, number=241, name='step241', buildid=31),
+        fakedb.Step(id=142, number=242, name='step242', buildid=40),
+    ]
+
+    common_test_result_set_data = [
+        fakedb.TestResultSet(id=91, builderid=88, buildid=30, stepid=131, description='desc1',
+                             category='cat', value_unit='ms', tests_failed=None,
+                             tests_passed=None,
+                             complete=0),
+        fakedb.TestResultSet(id=92, builderid=88, buildid=30, stepid=131, description='desc2',
+                             category='cat', value_unit='ms', tests_failed=None,
+                             tests_passed=None,
+                             complete=1),
+    ]
+
+    def test_signature_add_test_result_set(self):
+        @self.assertArgSpecMatches(self.db.test_result_sets.addTestResultSet)
+        def addTestResultSet(self, builderid, buildid, stepid, description, category, value_unit):
+            pass
+
+    def test_signature_get_test_result_set(self):
+        @self.assertArgSpecMatches(self.db.test_result_sets.getTestResultSet)
+        def getTestResultSet(self, test_result_setid):
+            pass
+
+    def test_signature_get_test_result_sets(self):
+        @self.assertArgSpecMatches(self.db.test_result_sets.getTestResultSets)
+        def getTestResultSets(self, builderid, buildid=None, stepid=None, complete=None,
+                              result_spec=None):
+            pass
+
+    def test_signature_complete_test_result_set(self):
+        @self.assertArgSpecMatches(self.db.test_result_sets.completeTestResultSet)
+        def completeTestResultSet(self, test_result_setid, tests_passed=None, tests_failed=None):
+            pass
+
+    @defer.inlineCallbacks
+    def test_add_set_get_set(self):
+        yield self.insertTestData(self.common_data)
+        set_id = yield self.db.test_result_sets.addTestResultSet(builderid=88, buildid=30,
+                                                                 stepid=131,
+                                                                 description='desc', category='cat',
+                                                                 value_unit='ms')
+        set_dict = yield self.db.test_result_sets.getTestResultSet(set_id)
+        validation.verifyDbDict(self, 'test_result_setdict', set_dict)
+        self.assertEqual(set_dict, {
+            'id': set_id,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc',
+            'category': 'cat',
+            'value_unit': 'ms',
+            'tests_failed': None,
+            'tests_passed': None,
+            'complete': False
+        })
+
+    @defer.inlineCallbacks
+    def test_get_sets(self):
+        yield self.insertTestData(self.common_data + [
+            fakedb.TestResultSet(id=91, builderid=88, buildid=30, stepid=131, description='desc1',
+                                 category='cat', value_unit='ms', tests_failed=None,
+                                 tests_passed=None,
+                                 complete=0),
+            fakedb.TestResultSet(id=92, builderid=89, buildid=40, stepid=142, description='desc2',
+                                 category='cat', value_unit='ms', tests_failed=None,
+                                 tests_passed=None,
+                                 complete=1),
+            fakedb.TestResultSet(id=93, builderid=88, buildid=31, stepid=141, description='desc3',
+                                 category='cat', value_unit='ms', tests_failed=None,
+                                 tests_passed=None,
+                                 complete=1),
+            fakedb.TestResultSet(id=94, builderid=88, buildid=30, stepid=132, description='desc4',
+                                 category='cat', value_unit='ms', tests_failed=None,
+                                 tests_passed=None,
+                                 complete=1),
+            fakedb.TestResultSet(id=95, builderid=88, buildid=30, stepid=131, description='desc4',
+                                 category='cat', value_unit='ms', tests_failed=None,
+                                 tests_passed=None,
+                                 complete=0),
+        ])
+
+        set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=88)
+        self.assertEqual([d['id'] for d in set_dicts], [91, 93, 94, 95])
+        for d in set_dicts:
+            validation.verifyDbDict(self, 'test_result_setdict', d)
+
+        set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=89)
+        self.assertEqual([d['id'] for d in set_dicts], [92])
+        set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=88, buildid=30)
+        self.assertEqual([d['id'] for d in set_dicts], [91, 94, 95])
+        set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=88, buildid=31)
+        self.assertEqual([d['id'] for d in set_dicts], [93])
+        set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=88, stepid=131)
+        self.assertEqual([d['id'] for d in set_dicts], [91, 95])
+        set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=88, stepid=132)
+        self.assertEqual([d['id'] for d in set_dicts], [94])
+        set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=88, complete=True)
+        self.assertEqual([d['id'] for d in set_dicts], [93, 94])
+        set_dicts = yield self.db.test_result_sets.getTestResultSets(builderid=88, complete=False)
+        self.assertEqual([d['id'] for d in set_dicts], [91, 95])
+
+    @defer.inlineCallbacks
+    def test_get_set_from_data(self):
+        yield self.insertTestData(self.common_data + self.common_test_result_set_data)
+
+        set_dict = yield self.db.test_result_sets.getTestResultSet(91)
+        self.assertEqual(set_dict, {
+            'id': 91,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc1',
+            'category': 'cat',
+            'value_unit': 'ms',
+            'tests_failed': None,
+            'tests_passed': None,
+            'complete': False
+        })
+
+    @defer.inlineCallbacks
+    def test_get_non_existing_set(self):
+        set_dict = yield self.db.test_result_sets.getTestResultSet(91)
+        self.assertEqual(set_dict, None)
+
+    @defer.inlineCallbacks
+    def test_complete_already_completed_set(self):
+        yield self.insertTestData(self.common_data + self.common_test_result_set_data)
+        with self.assertRaises(test_result_sets.TestResultSetAlreadyCompleted):
+            yield self.db.test_result_sets.completeTestResultSet(92)
+        self.flushLoggedErrors(test_result_sets.TestResultSetAlreadyCompleted)
+
+    @defer.inlineCallbacks
+    def test_complete_set_with_test_counts(self):
+        yield self.insertTestData(self.common_data + self.common_test_result_set_data)
+
+        yield self.db.test_result_sets.completeTestResultSet(91, tests_passed=12, tests_failed=2)
+
+        set_dict = yield self.db.test_result_sets.getTestResultSet(91)
+        self.assertEqual(set_dict, {
+            'id': 91,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc1',
+            'category': 'cat',
+            'value_unit': 'ms',
+            'tests_failed': 2,
+            'tests_passed': 12,
+            'complete': True
+        })
+
+    @defer.inlineCallbacks
+    def test_complete_set_without_test_counts(self):
+        yield self.insertTestData(self.common_data + self.common_test_result_set_data)
+
+        yield self.db.test_result_sets.completeTestResultSet(91)
+
+        set_dict = yield self.db.test_result_sets.getTestResultSet(91)
+        self.assertEqual(set_dict, {
+            'id': 91,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc1',
+            'category': 'cat',
+            'value_unit': 'ms',
+            'tests_failed': None,
+            'tests_passed': None,
+            'complete': True
+        })
+
+
+class TestFakeDB(Tests, connector_component.FakeConnectorComponentMixin, unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.setUpConnectorComponent()
+
+
+class TestRealDB(unittest.TestCase,
+                 connector_component.ConnectorComponentMixin,
+                 Tests):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.setUpConnectorComponent(
+            table_names=['steps', 'builds', 'builders', 'masters', 'buildrequests', 'buildsets',
+                         'workers', 'test_result_sets'])
+
+        self.db.test_result_sets = test_result_sets.TestResultSetsConnectorComponent(self.db)
+
+    def tearDown(self):
+        return self.tearDownConnectorComponent()

--- a/master/buildbot/test/unit/test_db_test_results.py
+++ b/master/buildbot/test/unit/test_db_test_results.py
@@ -1,0 +1,173 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.db import test_results
+from buildbot.test import fakedb
+from buildbot.test.util import connector_component
+from buildbot.test.util import interfaces
+from buildbot.test.util import validation
+
+
+class Tests(interfaces.InterfaceTests):
+
+    common_data = [
+        fakedb.Worker(id=47, name='linux'),
+        fakedb.Buildset(id=20),
+        fakedb.Builder(id=88, name='b1'),
+        fakedb.BuildRequest(id=41, buildsetid=20, builderid=88),
+        fakedb.Master(id=88),
+        fakedb.Build(id=30, buildrequestid=41, number=7, masterid=88,
+                     builderid=88, workerid=47),
+        fakedb.Step(id=131, number=132, name='step132', buildid=30),
+        fakedb.TestResultSet(id=13, builderid=88, buildid=30, stepid=131, description='desc',
+                             category='cat', value_unit='ms', complete=1),
+    ]
+
+    def test_signature_get_test_code_paths(self):
+        @self.assertArgSpecMatches(self.db.test_results.getTestCodePaths)
+        def getTestCodePaths(self, builderid, path_prefix=None, result_spec=None):
+            pass
+
+    def test_signature_get_test_names(self):
+        @self.assertArgSpecMatches(self.db.test_results.getTestNames)
+        def getTestNames(self, builderid, name_prefix=None, result_spec=None):
+            pass
+
+    def test_signature_add_test_results(self):
+        @self.assertArgSpecMatches(self.db.test_results.addTestResults)
+        def addTestResults(self, builderid, test_result_setid, result_values):
+            pass
+
+    def test_signature_get_test_result(self):
+        @self.assertArgSpecMatches(self.db.test_results.getTestResult)
+        def getTestResult(self, test_resultid):
+            pass
+
+    def test_signature_get_test_results(self):
+        @self.assertArgSpecMatches(self.db.test_results.getTestResults)
+        def getTestResults(self, builderid, test_result_setid, result_spec=None):
+            pass
+
+    @defer.inlineCallbacks
+    def test_add_set_results(self):
+        yield self.insertTestData(self.common_data)
+
+        result_values = [
+            {'test_name': 'name1', 'value': '1'},
+            {'test_name': 'name2', 'test_code_path': 'path2', 'value': '2'},
+            {'test_name': 'name3', 'test_code_path': 'path3', 'value': '3'},
+            {'test_name': 'name4', 'test_code_path': 'path4', 'line': 4, 'value': '4'},
+            {'test_code_path': 'path5', 'line': 5, 'value': '5'},
+        ]
+
+        yield self.db.test_results.addTestResults(builderid=88, test_result_setid=13,
+                                                 result_values=result_values)
+
+        result_dicts = yield self.db.test_results.getTestResults(builderid=88, test_result_setid=13)
+        for d in result_dicts:
+            validation.verifyDbDict(self, 'test_resultdict', d)
+
+        resultid = result_dicts[0]['id']
+        self.assertEqual(result_dicts, [
+            {'id': resultid, 'builderid': 88, 'test_result_setid': 13,
+             'test_name': 'name1', 'test_code_path': None, 'line': None, 'value': '1'},
+            {'id': resultid + 1, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name2',
+             'test_code_path': 'path2', 'line': None, 'value': '2'},
+            {'id': resultid + 2, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name3',
+             'test_code_path': 'path3', 'line': None, 'value': '3'},
+            {'id': resultid + 3, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name4',
+             'test_code_path': 'path4', 'line': 4, 'value': '4'},
+            {'id': resultid + 4, 'builderid': 88, 'test_result_setid': 13, 'test_name': None,
+             'test_code_path': 'path5', 'line': 5, 'value': '5'},
+        ])
+
+        result_dict = yield self.db.test_results.getTestResult(test_resultid=resultid)
+        self.assertEqual(result_dict, {
+            'id': resultid, 'builderid': 88, 'test_result_setid': 13,
+            'test_name': 'name1', 'test_code_path': None, 'line': None, 'value': '1'
+        })
+
+    @defer.inlineCallbacks
+    def test_get_names(self):
+        yield self.insertTestData(self.common_data + [
+            fakedb.TestName(id=103, builderid=88, name='name103'),
+            fakedb.TestName(id=104, builderid=88, name='name104'),
+            fakedb.TestName(id=105, builderid=88, name='name105'),
+            fakedb.TestName(id=116, builderid=88, name='name116'),
+            fakedb.TestName(id=117, builderid=88, name='name117'),
+        ])
+
+        name_dicts = yield self.db.test_results.getTestNames(builderid=88)
+        self.assertEqual(name_dicts, ['name103', 'name104', 'name105', 'name116', 'name117'])
+
+        name_dicts = yield self.db.test_results.getTestNames(builderid=88,
+                                                             name_prefix='non_existing')
+        self.assertEqual(name_dicts, [])
+
+        name_dicts = yield self.db.test_results.getTestNames(builderid=88, name_prefix='name10')
+        self.assertEqual(name_dicts, ['name103', 'name104', 'name105'])
+
+        name_dicts = yield self.db.test_results.getTestNames(builderid=88, name_prefix='name11')
+        self.assertEqual(name_dicts, ['name116', 'name117'])
+
+    @defer.inlineCallbacks
+    def test_get_code_paths(self):
+        yield self.insertTestData(self.common_data + [
+            fakedb.TestCodePath(id=103, builderid=88, path='path103'),
+            fakedb.TestCodePath(id=104, builderid=88, path='path104'),
+            fakedb.TestCodePath(id=105, builderid=88, path='path105'),
+            fakedb.TestCodePath(id=116, builderid=88, path='path116'),
+            fakedb.TestCodePath(id=117, builderid=88, path='path117'),
+        ])
+
+        path_dicts = yield self.db.test_results.getTestCodePaths(builderid=88)
+        self.assertEqual(path_dicts, ['path103', 'path104', 'path105', 'path116', 'path117'])
+
+        path_dicts = yield self.db.test_results.getTestCodePaths(builderid=88,
+                                                             path_prefix='non_existing')
+        self.assertEqual(path_dicts, [])
+
+        path_dicts = yield self.db.test_results.getTestCodePaths(builderid=88, path_prefix='path10')
+        self.assertEqual(path_dicts, ['path103', 'path104', 'path105'])
+
+        path_dicts = yield self.db.test_results.getTestCodePaths(builderid=88, path_prefix='path11')
+        self.assertEqual(path_dicts, ['path116', 'path117'])
+
+
+class TestFakeDB(Tests, connector_component.FakeConnectorComponentMixin, unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.setUpConnectorComponent()
+
+
+class TestRealDB(unittest.TestCase,
+                 connector_component.ConnectorComponentMixin,
+                 Tests):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.setUpConnectorComponent(
+            table_names=['steps', 'builds', 'builders', 'masters', 'buildrequests', 'buildsets',
+                         'workers', 'test_names', 'test_code_paths', 'test_results',
+                         'test_result_sets'])
+
+        self.db.test_results = test_results.TestResultsConnectorComponent(self.db)
+
+    def tearDown(self):
+        return self.tearDownConnectorComponent()

--- a/master/buildbot/test/unit/test_db_test_results.py
+++ b/master/buildbot/test/unit/test_db_test_results.py
@@ -69,10 +69,11 @@ class Tests(interfaces.InterfaceTests):
 
         result_values = [
             {'test_name': 'name1', 'value': '1'},
-            {'test_name': 'name2', 'test_code_path': 'path2', 'value': '2'},
-            {'test_name': 'name3', 'test_code_path': 'path3', 'value': '3'},
-            {'test_name': 'name4', 'test_code_path': 'path4', 'line': 4, 'value': '4'},
-            {'test_code_path': 'path5', 'line': 5, 'value': '5'},
+            {'test_name': 'name1', 'duration_ns': 1000, 'value': '2'},
+            {'test_name': 'name2', 'test_code_path': 'path2', 'value': '3'},
+            {'test_name': 'name3', 'test_code_path': 'path3', 'value': '4'},
+            {'test_name': 'name4', 'test_code_path': 'path4', 'line': 4, 'value': '5'},
+            {'test_code_path': 'path5', 'line': 5, 'value': '6'},
         ]
 
         yield self.db.test_results.addTestResults(builderid=88, test_result_setid=13,
@@ -85,21 +86,26 @@ class Tests(interfaces.InterfaceTests):
         resultid = result_dicts[0]['id']
         self.assertEqual(result_dicts, [
             {'id': resultid, 'builderid': 88, 'test_result_setid': 13,
-             'test_name': 'name1', 'test_code_path': None, 'line': None, 'value': '1'},
-            {'id': resultid + 1, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name2',
-             'test_code_path': 'path2', 'line': None, 'value': '2'},
-            {'id': resultid + 2, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name3',
-             'test_code_path': 'path3', 'line': None, 'value': '3'},
-            {'id': resultid + 3, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name4',
-             'test_code_path': 'path4', 'line': 4, 'value': '4'},
-            {'id': resultid + 4, 'builderid': 88, 'test_result_setid': 13, 'test_name': None,
-             'test_code_path': 'path5', 'line': 5, 'value': '5'},
+             'test_name': 'name1', 'test_code_path': None, 'line': None,
+             'duration_ns': None, 'value': '1'},
+            {'id': resultid + 1, 'builderid': 88, 'test_result_setid': 13,
+             'test_name': 'name1', 'test_code_path': None, 'line': None,
+             'duration_ns': 1000, 'value': '2'},
+            {'id': resultid + 2, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name2',
+             'test_code_path': 'path2', 'line': None, 'duration_ns': None, 'value': '3'},
+            {'id': resultid + 3, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name3',
+             'test_code_path': 'path3', 'line': None, 'duration_ns': None, 'value': '4'},
+            {'id': resultid + 4, 'builderid': 88, 'test_result_setid': 13, 'test_name': 'name4',
+             'test_code_path': 'path4', 'line': 4, 'duration_ns': None, 'value': '5'},
+            {'id': resultid + 5, 'builderid': 88, 'test_result_setid': 13, 'test_name': None,
+             'test_code_path': 'path5', 'line': 5, 'duration_ns': None, 'value': '6'},
         ])
 
         result_dict = yield self.db.test_results.getTestResult(test_resultid=resultid)
         self.assertEqual(result_dict, {
             'id': resultid, 'builderid': 88, 'test_result_setid': 13,
-            'test_name': 'name1', 'test_code_path': None, 'line': None, 'value': '1'
+            'test_name': 'name1', 'test_code_path': None, 'line': None, 'duration_ns': None,
+            'value': '1'
         })
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_db_test_results.py
+++ b/master/buildbot/test/unit/test_db_test_results.py
@@ -83,6 +83,7 @@ class Tests(interfaces.InterfaceTests):
         for d in result_dicts:
             validation.verifyDbDict(self, 'test_resultdict', d)
 
+        result_dicts = sorted(result_dicts, key=lambda x: x['id'])
         resultid = result_dicts[0]['id']
         self.assertEqual(result_dicts, [
             {'id': resultid, 'builderid': 88, 'test_result_setid': 13,

--- a/master/buildbot/test/unit/test_steps_python.py
+++ b/master/buildbot/test/unit/test_steps_python.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from parameterized import parameterized
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -153,18 +155,29 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
     def tearDown(self):
         return self.tearDownBuildStep()
 
-    def test_success(self):
-        self.setupStep(python.PyLint(command=['pylint']))
+    @parameterized.expand([
+        ('no_results', True),
+        ('with_results', False)
+    ])
+    def test_success(self, name, store_results):
+        self.setupStep(python.PyLint(command=['pylint'], store_results=store_results))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log('stdio',
                               stdout='Your code has been rated at 10/10')
             + python.PyLint.RC_OK)
         self.expectOutcome(result=SUCCESS, state_string='pylint')
+        if store_results:
+            self.expectTestResultSets([('Pylint warnings', 'code_issue', 'message')])
+            self.expectTestResults([])
         return self.runStep()
 
-    def test_error(self):
-        self.setupStep(python.PyLint(command=['pylint']))
+    @parameterized.expand([
+        ('no_results', True),
+        ('with_results', False)
+    ])
+    def test_error(self, name, store_results):
+        self.setupStep(python.PyLint(command=['pylint'], store_results=store_results))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log(
@@ -176,10 +189,13 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
                            state_string='pylint error=1 warning=1 (failure)')
         self.expectProperty('pylint-warning', 1)
         self.expectProperty('pylint-error', 1)
+        if store_results:
+            self.expectTestResultSets([('Pylint warnings', 'code_issue', 'message')])
+            # note that no results are submitted for tests where we don't know the location
         return self.runStep()
 
     def test_header_output(self):
-        self.setupStep(python.PyLint(command=['pylint']))
+        self.setupStep(python.PyLint(command=['pylint'], store_results=False))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log(
@@ -190,7 +206,7 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.runStep()
 
     def test_failure(self):
-        self.setupStep(python.PyLint(command=['pylint']))
+        self.setupStep(python.PyLint(command=['pylint'], store_results=False))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log(
@@ -207,7 +223,7 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
     def test_failure_zero_returncode(self):
         # Make sure that errors result in a failed step when pylint's
         # return code is 0, e.g. when run through a wrapper script.
-        self.setupStep(python.PyLint(command=['pylint']))
+        self.setupStep(python.PyLint(command=['pylint'], store_results=False))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log(
@@ -222,7 +238,7 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.runStep()
 
     def test_regex_text(self):
-        self.setupStep(python.PyLint(command=['pylint']))
+        self.setupStep(python.PyLint(command=['pylint'], store_results=False))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log(
@@ -239,7 +255,7 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def test_regex_text_0_24(self):
         # pylint >= 0.24.0 prints out column offsets when using text format
-        self.setupStep(python.PyLint(command=['pylint']))
+        self.setupStep(python.PyLint(command=['pylint'], store_results=False))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log(
@@ -257,7 +273,7 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
     def test_regex_text_131(self):
         # at least pylint 1.3.1 prints out space padded column offsets when
         # using text format
-        self.setupStep(python.PyLint(command=['pylint']))
+        self.setupStep(python.PyLint(command=['pylint'], store_results=False))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log(
@@ -273,7 +289,7 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         return self.runStep()
 
     def test_regex_text_ids(self):
-        self.setupStep(python.PyLint(command=['pylint']))
+        self.setupStep(python.PyLint(command=['pylint'], store_results=False))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log(
@@ -290,7 +306,7 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
 
     def test_regex_text_ids_0_24(self):
         # pylint >= 0.24.0 prints out column offsets when using text format
-        self.setupStep(python.PyLint(command=['pylint']))
+        self.setupStep(python.PyLint(command=['pylint'], store_results=False))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log(
@@ -305,8 +321,12 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expectProperty('pylint-total', 2)
         return self.runStep()
 
-    def test_regex_parseable_ids(self):
-        self.setupStep(python.PyLint(command=['pylint']))
+    @parameterized.expand([
+        ('no_results', True),
+        ('with_results', False)
+    ])
+    def test_regex_parseable_ids(self, name, store_results):
+        self.setupStep(python.PyLint(command=['pylint'], store_results=store_results))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log(
@@ -319,10 +339,16 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expectProperty('pylint-warning', 1)
         self.expectProperty('pylint-convention', 1)
         self.expectProperty('pylint-total', 2)
+        if store_results:
+            self.expectTestResultSets([('Pylint warnings', 'code_issue', 'message')])
+            self.expectTestResults([
+                (1000, 'test.py:9: [W0311] Bad indentation.', None, 'test.py', 9),
+                (1000, 'test.py:3: [C0111, foo123] Missing docstring', None, 'test.py', 3),
+            ])
         return self.runStep()
 
     def test_regex_parseable(self):
-        self.setupStep(python.PyLint(command=['pylint']))
+        self.setupStep(python.PyLint(command=['pylint'], store_results=False))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log(
@@ -342,7 +368,7 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         that, this is also the new recommended format string:
             --msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
         """
-        self.setupStep(python.PyLint(command=['pylint']))
+        self.setupStep(python.PyLint(command=['pylint'], store_results=False))
         self.expectCommands(
             ExpectShell(workdir='wkdir', command=['pylint'])
             + ExpectShell.log('stdio',

--- a/master/buildbot/test/unit/test_steps_python.py
+++ b/master/buildbot/test/unit/test_steps_python.py
@@ -342,8 +342,8 @@ class PyLint(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         if store_results:
             self.expectTestResultSets([('Pylint warnings', 'code_issue', 'message')])
             self.expectTestResults([
-                (1000, 'test.py:9: [W0311] Bad indentation.', None, 'test.py', 9),
-                (1000, 'test.py:3: [C0111, foo123] Missing docstring', None, 'test.py', 3),
+                (1000, 'test.py:9: [W0311] Bad indentation.', None, 'test.py', 9, None),
+                (1000, 'test.py:3: [C0111, foo123] Missing docstring', None, 'test.py', 3, None),
             ])
         return self.runStep()
 

--- a/master/buildbot/test/unit/test_util_test_result_submitter.py
+++ b/master/buildbot/test/unit/test_util_test_result_submitter.py
@@ -1,0 +1,308 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.test import fakedb
+from buildbot.test.fake import fakemaster
+from buildbot.test.util.misc import TestReactorMixin
+from buildbot.util.test_result_submitter import TestResultSubmitter
+
+
+class TestTestResultSubmitter(TestReactorMixin, unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setUpTestReactor()
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True)
+        yield self.master.startService()
+
+        self.master.db.insertTestData([
+            fakedb.Worker(id=47, name='linux'),
+            fakedb.Buildset(id=20),
+            fakedb.Builder(id=88, name='b1'),
+            fakedb.BuildRequest(id=41, buildsetid=20, builderid=88),
+            fakedb.Master(id=88),
+            fakedb.Build(id=30, buildrequestid=41, number=7, masterid=88,
+                         builderid=88, workerid=47),
+            fakedb.Step(id=131, number=132, name='step132', buildid=30),
+        ])
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.master.stopService()
+
+    @defer.inlineCallbacks
+    def test_complete_empty(self):
+        sub = TestResultSubmitter()
+        yield sub.setup_by_ids(self.master, 88, 30, 131, 'desc', 'cat', 'unit')
+
+        setid = sub.get_test_result_set_id()
+        sets = yield self.master.data.get(('builds', 30, 'test_result_sets'))
+        self.assertEqual(list(sets), [{
+            'test_result_setid': setid,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc',
+            'category': 'cat',
+            'value_unit': 'unit',
+            'tests_passed': None,
+            'tests_failed': None,
+            'complete': False
+        }])
+
+        yield sub.finish()
+
+        sets = yield self.master.data.get(('builds', 30, 'test_result_sets'))
+        self.assertEqual(list(sets), [{
+            'test_result_setid': setid,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc',
+            'category': 'cat',
+            'value_unit': 'unit',
+            'tests_passed': None,
+            'tests_failed': None,
+            'complete': True
+        }])
+
+    @defer.inlineCallbacks
+    def test_submit_result(self):
+        sub = TestResultSubmitter(batch_n=3)
+        yield sub.setup_by_ids(self.master, 88, 30, 131, 'desc', 'cat', 'unit')
+        sub.add_test_result('1', 'name1')
+        yield sub.finish()
+
+        setid = sub.get_test_result_set_id()
+
+        sets = yield self.master.data.get(('builds', 30, 'test_result_sets'))
+        self.assertEqual(list(sets), [{
+            'test_result_setid': setid,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc',
+            'category': 'cat',
+            'value_unit': 'unit',
+            'tests_passed': None,
+            'tests_failed': None,
+            'complete': True
+        }])
+
+        results = yield self.master.data.get(('test_result_sets', setid, 'results'))
+        self.assertEqual(list(results), [{
+            'test_resultid': 1002,
+            'builderid': 88,
+            'test_result_setid': setid,
+            'test_name': 'name1',
+            'test_code_path': None,
+            'line': None,
+            'value': '1'
+        }])
+
+    def filter_results_value_name(self, results):
+        return [{'test_name': r['test_name'], 'value': r['value']} for r in results]
+
+    @defer.inlineCallbacks
+    def test_batchs_last_batch_full(self):
+        sub = TestResultSubmitter(batch_n=3)
+        yield sub.setup_by_ids(self.master, 88, 30, 131, 'desc', 'cat', 'unit')
+        sub.add_test_result('1', 'name1')
+        sub.add_test_result('2', 'name2')
+        sub.add_test_result('3', 'name3')
+        sub.add_test_result('4', 'name4')
+        sub.add_test_result('5', 'name5')
+        sub.add_test_result('6', 'name6')
+        yield sub.finish()
+
+        setid = sub.get_test_result_set_id()
+
+        results = yield self.master.data.get(('test_result_sets', setid, 'results'))
+        results = self.filter_results_value_name(results)
+        self.assertEqual(results, [
+            {'test_name': 'name1', 'value': '1'},
+            {'test_name': 'name2', 'value': '2'},
+            {'test_name': 'name3', 'value': '3'},
+            {'test_name': 'name4', 'value': '4'},
+            {'test_name': 'name5', 'value': '5'},
+            {'test_name': 'name6', 'value': '6'},
+        ])
+
+    @defer.inlineCallbacks
+    def test_batchs_last_batch_not_full(self):
+        sub = TestResultSubmitter(batch_n=3)
+        yield sub.setup_by_ids(self.master, 88, 30, 131, 'desc', 'cat', 'unit')
+        sub.add_test_result('1', 'name1')
+        sub.add_test_result('2', 'name2')
+        sub.add_test_result('3', 'name3')
+        sub.add_test_result('4', 'name4')
+        sub.add_test_result('5', 'name5')
+        yield sub.finish()
+
+        setid = sub.get_test_result_set_id()
+
+        results = yield self.master.data.get(('test_result_sets', setid, 'results'))
+        results = self.filter_results_value_name(results)
+        self.assertEqual(results, [
+            {'test_name': 'name1', 'value': '1'},
+            {'test_name': 'name2', 'value': '2'},
+            {'test_name': 'name3', 'value': '3'},
+            {'test_name': 'name4', 'value': '4'},
+            {'test_name': 'name5', 'value': '5'},
+        ])
+
+    @defer.inlineCallbacks
+    def test_counts_pass_fail(self):
+        sub = TestResultSubmitter(batch_n=3)
+        yield sub.setup_by_ids(self.master, 88, 30, 131, 'desc', 'pass_fail', 'boolean')
+        sub.add_test_result('0', 'name1')
+        sub.add_test_result('0', 'name2')
+        sub.add_test_result('1', 'name3')
+        sub.add_test_result('1', 'name4')
+        sub.add_test_result('0', 'name5')
+        yield sub.finish()
+
+        setid = sub.get_test_result_set_id()
+        sets = yield self.master.data.get(('builds', 30, 'test_result_sets'))
+        self.assertEqual(list(sets), [{
+            'test_result_setid': setid,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc',
+            'category': 'pass_fail',
+            'value_unit': 'boolean',
+            'tests_passed': 2,
+            'tests_failed': 3,
+            'complete': True
+        }])
+
+    @defer.inlineCallbacks
+    def test_counts_pass_fail_invalid_values(self):
+        sub = TestResultSubmitter(batch_n=3)
+        yield sub.setup_by_ids(self.master, 88, 30, 131, 'desc', 'pass_fail', 'boolean')
+        sub.add_test_result('0', 'name1')
+        sub.add_test_result('0', 'name2')
+        sub.add_test_result('1', 'name3')
+        sub.add_test_result('1', 'name4')
+        sub.add_test_result('invalid', 'name5')
+        yield sub.finish()
+
+        setid = sub.get_test_result_set_id()
+        sets = yield self.master.data.get(('builds', 30, 'test_result_sets'))
+        self.assertEqual(list(sets), [{
+            'test_result_setid': setid,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc',
+            'category': 'pass_fail',
+            'value_unit': 'boolean',
+            'tests_passed': 2,
+            'tests_failed': 2,
+            'complete': True
+        }])
+
+        # also check whether we preserve the "invalid" values in the database.
+        results = yield self.master.data.get(('test_result_sets', setid, 'results'))
+        results = self.filter_results_value_name(results)
+        self.assertEqual(results, [
+            {'test_name': 'name1', 'value': '0'},
+            {'test_name': 'name2', 'value': '0'},
+            {'test_name': 'name3', 'value': '1'},
+            {'test_name': 'name4', 'value': '1'},
+            {'test_name': 'name5', 'value': 'invalid'},
+        ])
+
+        self.flushLoggedErrors(ValueError)
+
+    @defer.inlineCallbacks
+    def test_counts_pass_only(self):
+        sub = TestResultSubmitter(batch_n=3)
+        yield sub.setup_by_ids(self.master, 88, 30, 131, 'desc', 'pass_only', 'some_unit')
+        sub.add_test_result('string1', 'name1')
+        sub.add_test_result('string2', 'name2')
+        sub.add_test_result('string3', 'name3')
+        sub.add_test_result('string4', 'name4')
+        sub.add_test_result('string5', 'name5')
+        yield sub.finish()
+
+        setid = sub.get_test_result_set_id()
+        sets = yield self.master.data.get(('builds', 30, 'test_result_sets'))
+        self.assertEqual(list(sets), [{
+            'test_result_setid': setid,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc',
+            'category': 'pass_only',
+            'value_unit': 'some_unit',
+            'tests_passed': 5,
+            'tests_failed': 0,
+            'complete': True
+        }])
+
+        results = yield self.master.data.get(('test_result_sets', setid, 'results'))
+        results = self.filter_results_value_name(results)
+        self.assertEqual(results, [
+            {'test_name': 'name1', 'value': 'string1'},
+            {'test_name': 'name2', 'value': 'string2'},
+            {'test_name': 'name3', 'value': 'string3'},
+            {'test_name': 'name4', 'value': 'string4'},
+            {'test_name': 'name5', 'value': 'string5'},
+        ])
+
+        self.flushLoggedErrors(ValueError)
+
+    @defer.inlineCallbacks
+    def test_counts_fail_only(self):
+        sub = TestResultSubmitter(batch_n=3)
+        yield sub.setup_by_ids(self.master, 88, 30, 131, 'desc', 'fail_only', 'some_unit')
+        sub.add_test_result('string1', 'name1')
+        sub.add_test_result('string2', 'name2')
+        sub.add_test_result('string3', 'name3')
+        sub.add_test_result('string4', 'name4')
+        sub.add_test_result('string5', 'name5')
+        yield sub.finish()
+
+        setid = sub.get_test_result_set_id()
+        sets = yield self.master.data.get(('builds', 30, 'test_result_sets'))
+        self.assertEqual(list(sets), [{
+            'test_result_setid': setid,
+            'builderid': 88,
+            'buildid': 30,
+            'stepid': 131,
+            'description': 'desc',
+            'category': 'fail_only',
+            'value_unit': 'some_unit',
+            'tests_passed': 0,
+            'tests_failed': 5,
+            'complete': True
+        }])
+
+        results = yield self.master.data.get(('test_result_sets', setid, 'results'))
+        results = self.filter_results_value_name(results)
+        self.assertEqual(results, [
+            {'test_name': 'name1', 'value': 'string1'},
+            {'test_name': 'name2', 'value': 'string2'},
+            {'test_name': 'name3', 'value': 'string3'},
+            {'test_name': 'name4', 'value': 'string4'},
+            {'test_name': 'name5', 'value': 'string5'},
+        ])
+
+        self.flushLoggedErrors(ValueError)

--- a/master/buildbot/test/unit/test_util_test_result_submitter.py
+++ b/master/buildbot/test/unit/test_util_test_result_submitter.py
@@ -111,12 +111,29 @@ class TestTestResultSubmitter(TestReactorMixin, unittest.TestCase):
             'test_result_setid': setid,
             'test_name': 'name1',
             'test_code_path': None,
+            'duration_ns': None,
             'line': None,
             'value': '1'
         }])
 
     def filter_results_value_name(self, results):
         return [{'test_name': r['test_name'], 'value': r['value']} for r in results]
+
+    @defer.inlineCallbacks
+    def test_submit_result_wrong_argument_types(self):
+        sub = TestResultSubmitter()
+        yield sub.setup_by_ids(self.master, 88, 30, 131, 'desc', 'cat', 'unit')
+
+        with self.assertRaises(TypeError):
+            sub.add_test_result(1, 'name1')
+        with self.assertRaises(TypeError):
+            sub.add_test_result('1', test_name=123)
+        with self.assertRaises(TypeError):
+            sub.add_test_result('1', 'name1', test_code_path=123)
+        with self.assertRaises(TypeError):
+            sub.add_test_result('1', 'name1', line='123')
+        with self.assertRaises(TypeError):
+            sub.add_test_result('1', 'name1', duration_ns='123')
 
     @defer.inlineCallbacks
     def test_batchs_last_batch_full(self):

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -256,8 +256,10 @@ class BuildStepMixin:
 
         self._got_test_results = []
 
-        def add_test_result(setid, value, test_name=None, test_code_path=None, line=None):
-            self._got_test_results.append((setid, value, test_name, test_code_path, line))
+        def add_test_result(setid, value, test_name=None, test_code_path=None, line=None,
+                            duration_ns=None):
+            self._got_test_results.append((setid, value, test_name, test_code_path, line,
+                                           duration_ns))
         step.addTestResult = add_test_result
 
         # expectations

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -304,6 +304,13 @@ class BuildStepMixin:
         self.exp_exception = exception_class
         self.expectOutcome(EXCEPTION)
 
+    def _dump_logs(self):
+        for l in self.step.logs.values():
+            if l.stdout:
+                log.msg("{0} stdout:\n{1}".format(l.name, l.stdout))
+            if l.stderr:
+                log.msg("{0} stderr:\n{1}".format(l.name, l.stderr))
+
     @defer.inlineCallbacks
     def runStep(self):
         """
@@ -329,11 +336,7 @@ class BuildStepMixin:
         # debugging failing tests
         if result != self.exp_result:
             log.msg("unexpected result from step; dumping logs")
-            for l in self.step.logs.values():
-                if l.stdout:
-                    log.msg("{0} stdout:\n{1}".format(l.name, l.stdout))
-                if l.stderr:
-                    log.msg("{0} stderr:\n{1}".format(l.name, l.stderr))
+            self._dump_logs()
             raise AssertionError("unexpected result; see logs")
 
         if self.exp_state_string:

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -645,6 +645,64 @@ dbdict['logdict'] = DictValidator(
     num_lines=IntValidator(),
     type=IdentifierValidator(1))
 
+# test results sets
+
+_test_result_set_msgdict = DictValidator(
+    builderid=IntValidator(),
+    buildid=IntValidator(),
+    stepid=IntValidator(),
+    description=NoneOk(StringValidator()),
+    category=StringValidator(),
+    value_unit=StringValidator(),
+    tests_passed=NoneOk(IntValidator()),
+    tests_failed=NoneOk(IntValidator()),
+    complete=BooleanValidator()
+)
+
+message['test_result_sets'] = Selector()
+message['test_result_sets'].add(None,
+                                MessageValidator(events=[b'new', b'completed'],
+                                                 messageValidator=_test_result_set_msgdict))
+
+dbdict['test_result_setdict'] = DictValidator(
+    id=IntValidator(),
+    builderid=IntValidator(),
+    buildid=IntValidator(),
+    stepid=IntValidator(),
+    description=NoneOk(StringValidator()),
+    category=StringValidator(),
+    value_unit=StringValidator(),
+    tests_passed=NoneOk(IntValidator()),
+    tests_failed=NoneOk(IntValidator()),
+    complete=BooleanValidator()
+)
+
+# test results
+
+_test_results_msgdict = DictValidator(
+    builderid=IntValidator(),
+    test_result_setid=IntValidator(),
+    test_name=NoneOk(StringValidator()),
+    test_code_path=NoneOk(StringValidator()),
+    line=NoneOk(IntValidator()),
+    value=StringValidator(),
+)
+
+message['test_results'] = Selector()
+message['test_results'].add(None,
+                            MessageValidator(events=[b'new'],
+                                             messageValidator=_test_results_msgdict))
+
+dbdict['test_resultdict'] = DictValidator(
+    id=IntValidator(),
+    builderid=IntValidator(),
+    test_result_setid=IntValidator(),
+    test_name=NoneOk(StringValidator()),
+    test_code_path=NoneOk(StringValidator()),
+    line=NoneOk(IntValidator()),
+    value=StringValidator(),
+)
+
 
 # external functions
 

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -685,6 +685,7 @@ _test_results_msgdict = DictValidator(
     test_name=NoneOk(StringValidator()),
     test_code_path=NoneOk(StringValidator()),
     line=NoneOk(IntValidator()),
+    duration_ns=NoneOk(IntValidator()),
     value=StringValidator(),
 )
 
@@ -700,6 +701,7 @@ dbdict['test_resultdict'] = DictValidator(
     test_name=NoneOk(StringValidator()),
     test_code_path=NoneOk(StringValidator()),
     line=NoneOk(IntValidator()),
+    duration_ns=NoneOk(IntValidator()),
     value=StringValidator(),
 )
 

--- a/master/buildbot/util/test_result_submitter.py
+++ b/master/buildbot/util/test_result_submitter.py
@@ -118,12 +118,23 @@ class TestResultSubmitter:
             log.err(e, 'When parsing test result success status')
 
     def add_test_result(self, value, test_name=None, test_code_path=None, line=None):
+        if not isinstance(value, str):
+            raise TypeError('value must be a string')
         result = {'value': value}
+
         if test_name is not None:
+            if not isinstance(test_name, str):
+                raise TypeError('test_name must be a string')
             result['test_name'] = test_name
+
         if test_code_path is not None:
+            if not isinstance(test_code_path, str):
+                raise TypeError('test_code_path must be a string')
             result['test_code_path'] = test_code_path
+
         if line is not None:
+            if not isinstance(line, int):
+                raise TypeError('line must be an integer')
             result['line'] = line
 
         if self._add_pass_fail_result is not None:

--- a/master/buildbot/util/test_result_submitter.py
+++ b/master/buildbot/util/test_result_submitter.py
@@ -117,7 +117,8 @@ class TestResultSubmitter:
         except Exception as e:
             log.err(e, 'When parsing test result success status')
 
-    def add_test_result(self, value, test_name=None, test_code_path=None, line=None):
+    def add_test_result(self, value, test_name=None, test_code_path=None, line=None,
+                        duration_ns=None):
         if not isinstance(value, str):
             raise TypeError('value must be a string')
         result = {'value': value}
@@ -136,6 +137,11 @@ class TestResultSubmitter:
             if not isinstance(line, int):
                 raise TypeError('line must be an integer')
             result['line'] = line
+
+        if duration_ns is not None:
+            if not isinstance(duration_ns, int):
+                raise TypeError('duration_ns must be an integer')
+            result['duration_ns'] = duration_ns
 
         if self._add_pass_fail_result is not None:
             self._add_pass_fail_result(value)

--- a/master/buildbot/util/test_result_submitter.py
+++ b/master/buildbot/util/test_result_submitter.py
@@ -1,0 +1,134 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.python import log
+
+from buildbot.util import deferwaiter
+
+
+class TestResultSubmitter:
+
+    def __init__(self, batch_n=500):
+        self._batch_n = batch_n
+        self._curr_batch = []
+        self._pending_batches = []
+        self._waiter = deferwaiter.DeferWaiter()
+        self._master = None
+        self._builderid = None
+
+        self._add_pass_fail_result = None  # will be set to a callable if enabled
+        self._tests_passed = None
+        self._tests_failed = None
+
+    @defer.inlineCallbacks
+    def setup(self, step, description, category, value_unit):
+        builderid = yield step.build.getBuilderId()
+        yield self.setup_by_ids(step.master, builderid, step.build.buildid, step.stepid,
+                                description, category, value_unit)
+
+    @defer.inlineCallbacks
+    def setup_by_ids(self, master, builderid, buildid, stepid, description, category, value_unit):
+        self._master = master
+        self._category = category
+        self._value_unit = value_unit
+
+        self._initialize_pass_fail_recording_if_needed()
+
+        self._builderid = builderid
+        self._setid = yield self._master.data.updates.addTestResultSet(builderid, buildid, stepid,
+                                                                       description, category,
+                                                                       value_unit)
+
+    @defer.inlineCallbacks
+    def finish(self):
+        self._submit_batch()
+        yield self._waiter.wait()
+        yield self._master.data.updates.completeTestResultSet(self._setid,
+                                                              tests_passed=self._tests_passed,
+                                                              tests_failed=self._tests_failed)
+
+    def get_test_result_set_id(self):
+        return self._setid
+
+    def _submit_batch(self):
+        batch = self._curr_batch
+        self._curr_batch = []
+
+        if not batch:
+            return
+
+        self._pending_batches.append(batch)
+        if self._waiter.has_waited():
+            return
+
+        self._waiter.add(self._process_batches())
+
+    @defer.inlineCallbacks
+    def _process_batches(self):
+        # at most one instance of this function may be running at the same time
+        while self._pending_batches:
+            batch = self._pending_batches.pop(0)
+            yield self._master.data.updates.addTestResults(self._builderid, self._setid, batch)
+
+    def _initialize_pass_fail_recording(self, function):
+        self._add_pass_fail_result = function
+        self._compute_pass_fail = True
+        self._tests_passed = 0
+        self._tests_failed = 0
+
+    def _initialize_pass_fail_recording_if_needed(self):
+        if self._category == 'pass_fail' and self._value_unit == 'boolean':
+            self._initialize_pass_fail_recording(self._add_pass_fail_result_category_pass_fail)
+            return
+        if self._category == 'pass_only':
+            self._initialize_pass_fail_recording(self._add_pass_fail_result_category_pass_only)
+            return
+        if self._category == 'fail_only' or self._category == 'code_issue':
+            self._initialize_pass_fail_recording(self._add_pass_fail_result_category_fail_only)
+            return
+
+    def _add_pass_fail_result_category_fail_only(self, value):
+        self._tests_failed += 1
+
+    def _add_pass_fail_result_category_pass_only(self, value):
+        self._tests_passed += 1
+
+    def _add_pass_fail_result_category_pass_fail(self, value):
+        try:
+            is_success = bool(int(value))
+            if is_success:
+                self._tests_passed += 1
+            else:
+                self._tests_failed += 1
+
+        except Exception as e:
+            log.err(e, 'When parsing test result success status')
+
+    def add_test_result(self, value, test_name=None, test_code_path=None, line=None):
+        result = {'value': value}
+        if test_name is not None:
+            result['test_name'] = test_name
+        if test_code_path is not None:
+            result['test_code_path'] = test_code_path
+        if line is not None:
+            result['line'] = line
+
+        if self._add_pass_fail_result is not None:
+            self._add_pass_fail_result(value)
+
+        self._curr_batch.append(result)
+        if len(self._curr_batch) >= self._batch_n:
+            self._submit_batch()

--- a/master/buildbot/util/test_result_submitter.py
+++ b/master/buildbot/util/test_result_submitter.py
@@ -21,7 +21,7 @@ from buildbot.util import deferwaiter
 
 class TestResultSubmitter:
 
-    def __init__(self, batch_n=500):
+    def __init__(self, batch_n=3000):
         self._batch_n = batch_n
         self._curr_batch = []
         self._pending_batches = []

--- a/master/docs/developer/cls-buildsteps.rst
+++ b/master/docs/developer/cls-buildsteps.rst
@@ -314,13 +314,15 @@ BuildStep
 
         There are standard values of the ``category`` and ``value_unit`` parameters, see TODO.
 
-    .. py:method:: addTestResult(setid, value, test_name=None, test_code_path=None, line=None)
+    .. py:method:: addTestResult(setid, value, test_name=None, test_code_path=None, line=None,
+                                 duration_ns=None)
 
         :param setid: The ID of a test result set returned by ``addTestResultSet``.
         :param value: The value of the result as a string
         :param test_name: The name of the test.
         :param test_code_path: The path to the code file that resulted in this test result.
         :param line: The line within ``test_code_path`` file that resulted in this test result.
+        :param duration_ns: The duration of the test itself, in nanoseconds.
 
         Creates a test result.
         Either ``test_name`` or ``test_code_path`` must be specified.

--- a/master/docs/developer/cls-buildsteps.rst
+++ b/master/docs/developer/cls-buildsteps.rst
@@ -296,6 +296,41 @@ BuildStep
             This method is not called for new-style steps.
             Instead, override :py:meth:`getCurrentSummary` and :py:meth:`getResultSummary`.
 
+
+    .. py:method:: addTestResultSets()
+
+        The steps may override this to add any test result sets for this step via ``self.addTestResultSet()``.
+        This function is called just before the step execution is started.
+        The function is not called if the step is skipped or otherwise not run.
+
+    .. py:method:: addTestResultSet(description, category, value_unit)
+
+        :param description: Description of the test result set
+        :param category: Category of the test result set
+        :param value_unit: The value unit of the test result set
+        :returns: The ID of the created test result set via a Deferred.
+
+        Creates a new test result set to which test results can be associated.
+
+        There are standard values of the ``category`` and ``value_unit`` parameters, see TODO.
+
+    .. py:method:: addTestResult(setid, value, test_name=None, test_code_path=None, line=None)
+
+        :param setid: The ID of a test result set returned by ``addTestResultSet``.
+        :param value: The value of the result as a string
+        :param test_name: The name of the test.
+        :param test_code_path: The path to the code file that resulted in this test result.
+        :param line: The line within ``test_code_path`` file that resulted in this test result.
+
+        Creates a test result.
+        Either ``test_name`` or ``test_code_path`` must be specified.
+        The function queues the test results and will submit them to the database when enough test
+        results are added so that performance impact is minimized.
+
+    .. py:method:: finishTestResultSets()
+
+        The steps may override this to finish submission of any test results for the step.
+
     Build steps have statistics, a simple key/value store of data which can later be aggregated over all steps in a build.
     Note that statistics are not preserved after a build is complete.
 

--- a/master/docs/developer/raml/index.rst
+++ b/master/docs/developer/raml/index.rst
@@ -27,4 +27,6 @@ This section documents the available REST APIs according to the RAML specificati
     spec
     step
     worker
+    test_result
+    test_result_set
     raw-endpoints

--- a/master/docs/developer/raml/test_result.rst
+++ b/master/docs/developer/raml/test_result.rst
@@ -1,0 +1,2 @@
+.. jinja:: data_api_test_result
+    :file: templates/raml.jinja

--- a/master/docs/developer/raml/test_result_set.rst
+++ b/master/docs/developer/raml/test_result_set.rst
@@ -1,0 +1,2 @@
+.. jinja:: data_api_test_result_set
+    :file: templates/raml.jinja

--- a/master/docs/manual/configuration/buildsteps.rst
+++ b/master/docs/manual/configuration/buildsteps.rst
@@ -2266,6 +2266,12 @@ There is no default.
 
     f.addStep(steps.PyLint(command=["pylint", "src"]))
 
+This step takes the following arguments:
+
+``store_results``
+   (optional) Boolean, ``true`` if the test results should be stored in the test database.
+   The default value is ``true``.
+
 .. bb:step:: Trial
 
 .. _Step-Trial:

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -337,6 +337,7 @@ getRecipients
 getter
 getters
 GiB
+gibibytes
 github
 GitHub
 GitLab
@@ -500,6 +501,7 @@ metabuildbot
 metacharacters
 metadata
 MiB
+mebibytes
 minified
 minifies
 minimalistic


### PR DESCRIPTION
This PR implements the API for the test results functionality described in #5164.

This PR contains:
 - API spec
 - database model
 - data layer implementation
 - integration with BuildStep
 - enhancement of the PyLint step to submit test results for the issues it finds

The test result submission performance is around ~5000 results per second to a postgres database on my desktop. The bottleneck is on the Python side, the database server stays at ~10% CPU usage on my desktop.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not yet] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
