### PR TITLE
Add owner/repo_name args to BitbucketStatusPush

### DIFF
--- a/master/buildbot/newsfragments/add-owner-repo-to-bitbucketstatuspush.feature
+++ b/master/buildbot/newsfragments/add-owner-repo-to-bitbucketstatuspush.feature
@@ -1,0 +1,1 @@
+Added arguments `owner` and `repo_name` to BitbucketStatusPush for cases the clone URL isn't bitbucket

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -43,7 +43,13 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
     def reconfigService(self, oauth_key, oauth_secret,
                         base_url=_BASE_URL,
                         oauth_url=_OAUTH_URL,
+                        owner=None,
+                        repo_name=None,
                         **kwargs):
+
+        self.owner = owner
+        self.repo_name = repo_name
+
         oauth_key, oauth_secret = yield self.renderSecrets(oauth_key, oauth_secret)
         yield super().reconfigService(**kwargs)
 
@@ -86,7 +92,11 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
                 'url': build['url']
             }
 
-            owner, repo = self.get_owner_and_repo(sourcestamp['repository'])
+            if self.owner and self.repo_name:
+                owner = self.owner
+                repo = self.repo_name
+            else:
+                owner, repo = self.get_owner_and_repo(sourcestamp['repository'])
 
             self._http.updateHeaders({'Authorization': 'Bearer ' + token})
 
@@ -128,3 +138,4 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
         assert len(parts) == 2, 'OWNER/REPONAME is expected'
 
         return parts
+

--- a/master/buildbot/test/unit/test_reporter_bitbucket.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucket.py
@@ -153,6 +153,73 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
         self.assertLogged('This commit is unknown to us')
         self.assertLogged('invalid_commit')
 
+    @defer.inlineCallbacks
+    def test_custom_owner_and_repo(self):
+        build = yield self.setupBuildResults(SUCCESS)
+
+        self.bsp.owner = 'custom_owner'
+        self.bsp.repo_name = 'custom_repo_name'
+
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
+                              content_json={'access_token': 'foo'})
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            'post',
+            '/custom_owner/custom_repo_name/commit/d34db33fd43db33f/statuses/build',
+            json={
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'state': 'INPROGRESS',
+                'key': 'Builder0',
+                'name': 'Builder0'},
+            code=201)
+
+        build['complete'] = False
+        self.bsp.buildStarted(('build', 20, 'started'), build)
+
+    @defer.inlineCallbacks
+    def test_custom_owner_only(self):
+        build = yield self.setupBuildResults(SUCCESS)
+
+        self.bsp.owner = 'custom_owner'
+
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
+                              content_json={'access_token': 'foo'})
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            'post',
+            '/user/repo/commit/d34db33fd43db33f/statuses/build',
+            json={
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'state': 'INPROGRESS',
+                'key': 'Builder0',
+                'name': 'Builder0'},
+            code=201)
+
+        build['complete'] = False
+        self.bsp.buildStarted(('build', 20, 'started'), build)
+
+    @defer.inlineCallbacks
+    def test_custom_repo_only(self):
+        build = yield self.setupBuildResults(SUCCESS)
+
+        self.bsp.repo_name = 'custom_repo_name'
+
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
+                              content_json={'access_token': 'foo'})
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            'post',
+            '/user/repo/commit/d34db33fd43db33f/statuses/build',
+            json={
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'state': 'INPROGRESS',
+                'key': 'Builder0',
+                'name': 'Builder0'},
+            code=201)
+
+        build['complete'] = False
+        self.bsp.buildStarted(('build', 20, 'started'), build)
+
 
 class TestBitbucketStatusPushRepoParsing(unittest.TestCase):
 

--- a/master/docs/manual/configuration/reporters.rst
+++ b/master/docs/manual/configuration/reporters.rst
@@ -1434,12 +1434,20 @@ Give the new consumer a name, eg 'buildbot', and put in any URL as the callback 
 Give the consumer Repositories:Write access.
 After creating the consumer, you will then be able to see the OAuth key and secret.
 
-.. py:class:: BitbucketStatusPush(oauth_key, oauth_secret, base_url='https://api.bitbucket.org/2.0/repositories', oauth_url='https://bitbucket.org/site/oauth2/access_token', builders=None)
+It is possible to override the owner and repository in situations where you need
+to push your build status to bitbucket.org, but you are actually cloning from a
+different repository (ex. a local mirror). To do so, please set the owner and
+repo_name arguments. Note, both owner and repo_name must be specified for the
+override to work.
+
+.. py:class:: BitbucketStatusPush(oauth_key, oauth_secret, base_url='https://api.bitbucket.org/2.0/repositories', oauth_url='https://bitbucket.org/site/oauth2/access_token', owner=None, repo_name=None, builders=None)
 
     :param string oauth_key: The OAuth consumer key. (can be a :ref:`Secret`)
     :param string oauth_secret: The OAuth consumer secret. (can be a :ref:`Secret`)
     :param string base_url: Bitbucket's Build Status API URL
     :param string oauth_url: Bitbucket's OAuth API URL
+    :param string owner: The owner of the repository (ex. git@bitbucket.org:OWNER/reponame.git)
+    :param string repo_name: The repo name of the repository without the .git extension (ex. git@bitbucket.org:owner/REPONAME.git)
     :param list builders: only send update for specified builders
     :param boolean verify: disable ssl verification for the case you use temporary self signed certificates
     :param boolean debug: logs every requests and their response


### PR DESCRIPTION
Allow users to specify a custom owner and repo_name for a BitbucketStatusPush
instance. This is useful when we want to push status to a bitbucket instance
even though we are pulling from a different repository. In cases like this,
extracting the owner and/or repo_name from the sourcestamp may not be possible.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
