### PR TITLE
[ui] Do not display building time once a build is started

### DIFF
--- a/www/base/src/app/common/filters/moment/moment.filter.js
+++ b/www/base/src/app/common/filters/moment/moment.filter.js
@@ -13,6 +13,8 @@ class Duration {
 class Durationformat {
     constructor(MOMENT) {
         return function(time) {
+            if (time < 0)
+                return ""
             const d = MOMENT.duration(time * 1000);
             const m = MOMENT.utc(d.asMilliseconds());
             const days = Math.floor(d.asDays());


### PR DESCRIPTION
Issue: [Running build show wrong time](https://github.com/buildbot/buildbot/issues/3714)  

When build is active (yellow) and you click on pulsing bubble, then window below appear. First 500-1000 ms its building time string looks like at picture (and this is exactly negative time since epoch).

![](https://user-images.githubusercontent.com/2385765/31951103-da95aa58-b8e5-11e7-9237-5f1be76b9471.png)

Fixed this by not displaying the building time when the timestamp is negative. 
![chrome_GaOPo5rRrD](https://user-images.githubusercontent.com/33851317/80540796-fdc6d000-8977-11ea-9505-74a91419ae69.png)