### PR TITLE
update master Docker container to Alpine 3.11

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -12,12 +12,12 @@
 # which get installed in the final image.
 # This allows us to avoid installing build tools like gcc in the final image.
 
-FROM        alpine:3.7 AS buildbot-build
+FROM        alpine:3.11 AS buildbot-build
 MAINTAINER  Buildbot maintainers
 
 # Last build date - this can be updated whenever there are security updates so
 # that everything is rebuilt
-ENV         security_updates_as_of 2018-04-10
+ENV         security_updates_as_of 2020-05-01
 
 
 COPY . /usr/src/buildbot

--- a/master/buildbot/newsfragments/alpine-311.bugfix
+++ b/master/buildbot/newsfragments/alpine-311.bugfix
@@ -1,0 +1,3 @@
+Updated the `Docker` container `buildbot-master` to `Alpine 3.11` to fix
+segmentation faults caused by an old version of `musl`
+


### PR DESCRIPTION
We've had a lot of segmentation faults in a tar process on the
master. It seems that the problem lies in musl, and upgrading
to Alpine 3.11 made these errors go away.

Closes #5278

## Contributor Checklist:

* ~~[ ] I have updated the unit tests~~
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* ~~[ ] I have updated the appropriate documentation~~
