### PR TITLE
Base64 encoding logs/patches in mail reporter

### DIFF
--- a/master/buildbot/newsfragments/base64-encode-logs-and-attachments.bugfix
+++ b/master/buildbot/newsfragments/base64-encode-logs-and-attachments.bugfix
@@ -1,0 +1,1 @@
+Base64 encoding logs and attachments sent via email so emails conform to RFC 5322 2.1.1

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -15,6 +15,7 @@
 
 import re
 from email import charset
+from email import encoders
 from email.header import Header
 from email.message import Message
 from email.mime.multipart import MIMEMultipart
@@ -170,6 +171,9 @@ class MailNotifier(NotifierBase):
     def patch_to_attachment(self, patch, index):
         # patches are specifically converted to unicode before entering the db
         a = MIMEText(patch['body'].encode(ENCODING), _charset=ENCODING)
+        # convert to base64 to conform with RFC 5322 2.1.1
+        del a['Content-Transfer-Encoding']
+        encoders.encode_base64(a)
         a.add_header('Content-Disposition', "attachment",
                      filename="source patch " + str(index))
         return a
@@ -227,6 +231,9 @@ class MailNotifier(NotifierBase):
                     text = log['content']['content']
                     a = MIMEText(text.encode(ENCODING),
                                  _charset=ENCODING)
+                    # convert to base64 to conform with RFC 5322 2.1.1
+                    del a['Content-Transfer-Encoding']
+                    encoders.encode_base64(a)
                     a.add_header('Content-Disposition', "attachment",
                                  filename=filename)
                     m.attach(a)


### PR DESCRIPTION
* This should make emails comformant with RFC 5322 2.1.1
* This should also fix errors that arise when email servers check for
  line lengths > 998.

* [ ] I have updated the unit tests
    * Wasn't quite sure what the implication would be of adding an assertion making sure
        the attachments were base64-encoded given the mixed Python2/3 support.
    * Another test that might be interesting here is to create an email with a line length
        longer than the RFC allows, and then verify that the resulting as_string() call does
        not contain lines longer than the spec. A simple regex should be able to do that.
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
    * I didn't see a good reason to update the documentation for this patch, feel free to let
       me know if there is an appropriate place for it.