### PR TITLE
Extract report generation to classes separate to actual reporters

### DIFF
--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -1,0 +1,54 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+
+from buildbot.reporters import utils
+
+from .utils import BuildStatusGeneratorMixin
+
+
+class BuildStatusGenerator(BuildStatusGeneratorMixin):
+
+    def __init__(self, mode=("failing", "passing", "warnings"),
+                 tags=None, builders=None, schedulers=None, branches=None,
+                 subject="Buildbot %(result)s in %(title)s on %(builder)s",
+                 add_logs=False, add_patch=False, message_formatter=None):
+        super().__init__(mode, tags, builders, schedulers, branches, subject, add_logs, add_patch,
+                         message_formatter)
+
+    @defer.inlineCallbacks
+    def generate(self, master, reporter, key, build):
+        br = yield master.data.get(("buildrequests", build['buildrequestid']))
+        buildset = yield master.data.get(("buildsets", br['buildsetid']))
+        yield utils.getDetailsForBuilds(master, buildset, [build],
+                                        wantProperties=self.formatter.wantProperties,
+                                        wantSteps=self.formatter.wantSteps,
+                                        wantPreviousBuild=self._want_previous_build(),
+                                        wantLogs=self.formatter.wantLogs)
+
+        # only include builds for which isMessageNeeded returns true
+        if not self.is_message_needed(build):
+            return None
+
+        report = yield self.build_message(master, reporter, build['builder']['name'], [build],
+                                          build['results'])
+        return report
+
+    def _want_previous_build(self):
+        return "change" in self.mode or "problem" in self.mode
+
+    def _matches_any_tag(self, tags):
+        return self.tags and any(tag for tag in self.tags if tag in tags)

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -1,0 +1,53 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+
+from buildbot.reporters import utils
+
+from .utils import BuildStatusGeneratorMixin
+
+
+class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
+    def __init__(self, mode=("failing", "passing", "warnings"),
+                 tags=None, builders=None, schedulers=None, branches=None,
+                 subject="Buildbot %(result)s in %(title)s on %(builder)s",
+                 add_logs=False, add_patch=False, message_formatter=None):
+        super().__init__(mode, tags, builders, schedulers, branches, subject, add_logs, add_patch,
+                         message_formatter)
+
+    @defer.inlineCallbacks
+    def generate(self, master, reporter, key, message):
+        bsid = message['bsid']
+        res = yield utils.getDetailsForBuildset(master, bsid,
+                                                wantProperties=self.formatter.wantProperties,
+                                                wantSteps=self.formatter.wantSteps,
+                                                wantPreviousBuild=self._want_previous_build(),
+                                                wantLogs=self.formatter.wantLogs)
+
+        builds = res['builds']
+        buildset = res['buildset']
+
+        # only include builds for which isMessageNeeded returns true
+        builds = [build for build in builds if self.is_message_needed(build)]
+        if not builds:
+            return None
+
+        report = yield self.build_message(master, reporter, "whole buildset", builds,
+                                          buildset['results'])
+        return report
+
+    def _want_previous_build(self):
+        return "change" in self.mode or "problem" in self.mode

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -1,0 +1,204 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+
+from buildbot import config
+from buildbot.process.results import CANCELLED
+from buildbot.process.results import EXCEPTION
+from buildbot.process.results import FAILURE
+from buildbot.process.results import SUCCESS
+from buildbot.process.results import WARNINGS
+from buildbot.process.results import Results
+from buildbot.reporters.message import MessageFormatter as DefaultMessageFormatter
+
+
+class BuildStatusGeneratorMixin:
+
+    possible_modes = ("change", "failing", "passing", "problem", "warnings", "exception",
+                      "cancelled")
+
+    def __init__(self, mode, tags, builders, schedulers, branches, subject, add_logs, add_patch,
+                 message_formatter):
+        self.mode = self._compute_shortcut_modes(mode)
+
+        self.tags = tags
+        self.builders = builders
+        self.schedulers = schedulers
+        self.branches = branches
+        self.subject = subject
+        self.add_logs = add_logs
+        self.add_patch = add_patch
+        self.formatter = message_formatter
+        if self.formatter is None:
+            self.formatter = DefaultMessageFormatter()
+
+    def check(self):
+        self._verify_build_generator_mode(self.mode)
+
+        if '\n' in self.subject:
+            config.error('Newlines are not allowed in message subjects')
+
+        # you should either limit on builders or tags, not both
+        if self.builders is not None and self.tags is not None:
+            config.error("Please specify only builders or tags to include - not both.")
+
+    def generate_name(self):
+        name = self.__class__.__name__
+        if self.tags is not None:
+            name += "_tags_" + "+".join(self.tags)
+        if self.builders is not None:
+            name += "_builders_" + "+".join(self.builders)
+        if self.schedulers is not None:
+            name += "_schedulers_" + "+".join(self.schedulers)
+        if self.branches is not None:
+            name += "_branches_" + "+".join(self.branches)
+        name += "_".join(self.mode)
+        return name
+
+    def _should_attach_log(self, log):
+        if isinstance(self.add_logs, bool):
+            return self.add_logs
+
+        if log['name'] in self.add_logs:
+            return True
+
+        long_name = "{}.{}".format(log['stepname'], log['name'])
+        if long_name in self.add_logs:
+            return True
+
+        return False
+
+    def is_message_needed(self, build):
+        # here is where we actually do something.
+        builder = build['builder']
+        scheduler = build['properties'].get('scheduler', [None])[0]
+        branch = build['properties'].get('branch', [None])[0]
+        results = build['results']
+
+        if self.builders is not None and builder['name'] not in self.builders:
+            return False  # ignore this build
+        if self.schedulers is not None and scheduler not in self.schedulers:
+            return False  # ignore this build
+        if self.branches is not None and branch not in self.branches:
+            return False  # ignore this build
+        if self.tags is not None and not self._matches_any_tag(builder['tags']):
+            return False  # ignore this build
+
+        if "change" in self.mode:
+            prev = build['prev_build']
+            if prev and prev['results'] != results:
+                return True
+        if "failing" in self.mode and results == FAILURE:
+            return True
+        if "passing" in self.mode and results == SUCCESS:
+            return True
+        if "problem" in self.mode and results == FAILURE:
+            prev = build['prev_build']
+            if prev and prev['results'] != FAILURE:
+                return True
+        if "warnings" in self.mode and results == WARNINGS:
+            return True
+        if "exception" in self.mode and results == EXCEPTION:
+            return True
+        if "cancelled" in self.mode and results == CANCELLED:
+            return True
+
+        return False
+
+    @defer.inlineCallbacks
+    def build_message(self, master, reporter, name, builds, results):
+        patches = []
+        logs = []
+        body = ""
+        subject = None
+        msgtype = None
+        users = set()
+        for build in builds:
+            if self.add_patch:
+                ss_list = build['buildset']['sourcestamps']
+
+                for ss in ss_list:
+                    if 'patch' in ss and ss['patch'] is not None:
+                        patches.append(ss['patch'])
+
+            if self.add_logs:
+                build_logs = yield self._get_logs_for_build(master, build)
+                if isinstance(self.add_logs, list):
+                    build_logs = [log for log in build_logs if self._should_attach_log(log)]
+                logs.extend(build_logs)
+
+            if 'prev_build' in build and build['prev_build'] is not None:
+                previous_results = build['prev_build']['results']
+            else:
+                previous_results = None
+            blamelist = yield reporter.getResponsibleUsersForBuild(master, build['buildid'])
+            buildmsg = yield self.formatter.formatMessageForBuildResults(
+                self.mode, name, build['buildset'], build, master, previous_results, blamelist)
+            users.update(set(blamelist))
+            msgtype = buildmsg['type']
+            body += buildmsg['body']
+            if 'subject' in buildmsg:
+                subject = buildmsg['subject']
+
+        if subject is None:
+            subject = self.subject % {'result': Results[results],
+                                      'projectName': master.config.title,
+                                      'title': master.config.title,
+                                      'builder': name}
+
+        return {
+            'body': body,
+            'subject': subject,
+            'type': msgtype,
+            'builder_name': name,
+            'results': results,
+            'builds': builds,
+            'users': list(users),
+            'patches': patches,
+            'logs': logs
+        }
+
+    @defer.inlineCallbacks
+    def _get_logs_for_build(self, master, build):
+        all_logs = []
+        steps = yield master.data.get(('builds', build['buildid'], "steps"))
+        for step in steps:
+            logs = yield master.data.get(("steps", step['stepid'], 'logs'))
+            for l in logs:
+                l['stepname'] = step['name']
+                l['content'] = yield master.data.get(("logs", l['logid'], 'contents'))
+                all_logs.append(l)
+        return all_logs
+
+    def _verify_build_generator_mode(self, mode):
+        for m in self._compute_shortcut_modes(mode):
+            if m not in self.possible_modes:
+                if m == "all":
+                    config.error("mode 'all' is not valid in an iterator and must be "
+                                 "passed in as a separate string")
+                else:
+                    config.error("mode {} is not a valid mode".format(m))
+
+    def _compute_shortcut_modes(self, mode):
+        if isinstance(mode, str):
+            if mode == "all":
+                mode = ("failing", "passing", "warnings",
+                        "exception", "cancelled")
+            elif mode == "warnings":
+                mode = ("failing", "warnings")
+            else:
+                mode = (mode,)
+        return mode

--- a/master/buildbot/reporters/generators/worker.py
+++ b/master/buildbot/reporters/generators/worker.py
@@ -1,0 +1,71 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+
+from buildbot import config
+from buildbot.reporters.message import MessageFormatterMissingWorker
+
+ENCODING = 'utf-8'
+
+
+class WorkerMissingGenerator:
+
+    def __init__(self, workers=None, message_formatter=None):
+        self.workers = workers
+        self.formatter = message_formatter
+        if self.formatter is None:
+            self.formatter = MessageFormatterMissingWorker()
+
+    def check(self):
+        if not(self.workers == 'all' or self.workers is None or
+                isinstance(self.workers, (list, tuple, set))):
+            config.error("workers must be 'all', None, or list of worker names")
+
+    @defer.inlineCallbacks
+    def generate(self, master, reporter, key, worker):
+        if not self._is_message_needed(worker):
+            return None
+
+        msg = yield self.formatter.formatMessageForMissingWorker(master, worker)
+        body = msg['body'].encode(ENCODING)
+        if 'subject' in msg:
+            subject = msg['subject']
+        else:
+            subject = "Buildbot worker {name} missing".format(**worker)
+        assert msg['type'] in ('plain', 'html'), \
+            "'{}' message type must be 'plain' or 'html'.".format(msg['type'])
+
+        return {
+            'body': body,
+            'subject': subject,
+            'type': msg['type'],
+            'builder_name': None,
+            'results': None,
+            'builds': None,
+            'users': worker['notify'],
+            'patches': None,
+            'logs': None,
+            'worker': worker['name']
+        }
+
+    def generate_name(self):
+        name = self.__class__.__name__
+        if self.workers is not None:
+            name += "_workers_" + "+".join(self.workers)
+        return name
+
+    def _is_message_needed(self, worker):
+        return (self.workers == 'all' or worker['name'] in self.workers) and worker['notify']

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -35,7 +35,7 @@ from buildbot.util.giturlparse import giturlparse
 HOSTED_BASE_URL = 'https://api.github.com'
 
 
-class GitHubStatusPush(http.HttpStatusPushBase):
+class GitHubStatusPush(http. HttpStatusPushBase):
     name = "GitHubStatusPush"
     neededDetails = dict(wantProperties=True)
 

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -33,11 +33,13 @@ from buildbot import config
 from buildbot import interfaces
 from buildbot import util
 from buildbot.process.properties import Properties
-from buildbot.process.results import Results
 from buildbot.reporters.notifier import ENCODING
 from buildbot.reporters.notifier import NotifierBase
 from buildbot.util import ssl
 from buildbot.util import unicode2bytes
+
+from .utils import merge_reports_prop
+from .utils import merge_reports_prop_take_first
 
 # this incantation teaches email to output utf-8 using 7- or 8-bit encoding,
 # although it has no effect before python-2.7.
@@ -183,13 +185,7 @@ class MailNotifier(NotifierBase):
                     patches=None, logs=None):
         text = msgdict['body']
         type = msgdict['type']
-        if msgdict.get('subject') is not None:
-            subject = msgdict['subject']
-        else:
-            subject = self.subject % {'result': Results[results],
-                                      'projectName': title,
-                                      'title': title,
-                                      'builder': builderName}
+        subject = msgdict['subject']
 
         assert '\n' not in subject, \
             "Subject cannot contain newlines"
@@ -217,26 +213,22 @@ class MailNotifier(NotifierBase):
                 m.attach(a)
         if logs:
             for log in logs:
-                name = "{}.{}".format(log['stepname'],
-                                      log['name'])
-                if (self._shouldAttachLog(log['name']) or
-                        self._shouldAttachLog(name)):
-                    # Use distinct filenames for the e-mail summary
-                    if self.buildSetSummary:
-                        filename = "{}.{}".format(log['buildername'],
-                                                  name)
-                    else:
-                        filename = name
+                # Use distinct filenames for the e-mail summary
+                name = "{}.{}".format(log['stepname'], log['name'])
+                if len(builds) > 1:
+                    filename = "{}.{}".format(log['buildername'], name)
+                else:
+                    filename = name
 
-                    text = log['content']['content']
-                    a = MIMEText(text.encode(ENCODING),
-                                 _charset=ENCODING)
-                    # convert to base64 to conform with RFC 5322 2.1.1
-                    del a['Content-Transfer-Encoding']
-                    encoders.encode_base64(a)
-                    a.add_header('Content-Disposition', "attachment",
-                                 filename=filename)
-                    m.attach(a)
+                text = log['content']['content']
+                a = MIMEText(text.encode(ENCODING),
+                             _charset=ENCODING)
+                # convert to base64 to conform with RFC 5322 2.1.1
+                del a['Content-Transfer-Encoding']
+                encoders.encode_base64(a)
+                a.add_header('Content-Disposition', "attachment",
+                             filename=filename)
+                m.attach(a)
 
         # @todo: is there a better way to do this?
         # Add any extra headers that were requested, doing WithProperties
@@ -258,9 +250,18 @@ class MailNotifier(NotifierBase):
         return m
 
     @defer.inlineCallbacks
-    def sendMessage(self, body, subject=None, type='plain', builderName=None,
-                    results=None, builds=None, users=None,
-                    patches=None, logs=None, worker=None):
+    def sendMessage(self, reports):
+        body = merge_reports_prop(reports, 'body')
+        subject = merge_reports_prop_take_first(reports, 'subject')
+        type = merge_reports_prop_take_first(reports, 'type')
+        builderName = merge_reports_prop_take_first(reports, 'builder_name')
+        results = merge_reports_prop(reports, 'results')
+        builds = merge_reports_prop(reports, 'builds')
+        users = merge_reports_prop(reports, 'users')
+        patches = merge_reports_prop(reports, 'patches')
+        logs = merge_reports_prop(reports, 'logs')
+        worker = merge_reports_prop_take_first(reports, 'worker')
+
         body = unicode2bytes(body)
         msgdict = {'body': body, 'subject': subject, 'type': type}
 
@@ -278,11 +279,6 @@ class MailNotifier(NotifierBase):
         else:
             all_recipients = list(users)
         yield self.sendMail(m, all_recipients)
-
-    def _shouldAttachLog(self, logname):
-        if isinstance(self.addLogs, bool):
-            return self.addLogs
-        return logname in self.addLogs
 
     @defer.inlineCallbacks
     def findInterrestedUsersEmails(self, users):
@@ -359,7 +355,3 @@ class MailNotifier(NotifierBase):
             reactor.connectTCP(self.relayhost, self.smtpPort, sender_factory)
 
         return result
-
-    def isWorkerMessageNeeded(self, worker):
-        return super(MailNotifier, self).isWorkerMessageNeeded(worker) \
-               and worker['notify']

--- a/master/buildbot/reporters/mail.py
+++ b/master/buildbot/reporters/mail.py
@@ -130,6 +130,7 @@ class MailNotifier(NotifierBase):
         if useSmtps:
             ssl.ensureHasSSL(self.__class__.__name__)
 
+    @defer.inlineCallbacks
     def reconfigService(self, fromaddr, mode=("failing", "passing", "warnings"),
                         tags=None, builders=None, addLogs=False,
                         relayhost="localhost", buildSetSummary=False,
@@ -142,8 +143,7 @@ class MailNotifier(NotifierBase):
                         schedulers=None, branches=None,
                         watchedWorkers='all', messageFormatterMissingWorker=None,
                         dumpMailsToLog=False):
-
-        super(MailNotifier, self).reconfigService(
+        yield super().reconfigService(
             mode=mode, tags=tags, builders=builders,
             buildSetSummary=buildSetSummary, messageFormatter=messageFormatter,
             subject=subject, addLogs=addLogs, addPatch=addPatch,

--- a/master/buildbot/reporters/notifier.py
+++ b/master/buildbot/reporters/notifier.py
@@ -18,14 +18,10 @@ import abc
 from twisted.internet import defer
 
 from buildbot import config
-from buildbot.process.results import CANCELLED
-from buildbot.process.results import EXCEPTION
-from buildbot.process.results import FAILURE
-from buildbot.process.results import SUCCESS
-from buildbot.process.results import WARNINGS
 from buildbot.reporters import utils
-from buildbot.reporters.message import MessageFormatter as DefaultMessageFormatter
-from buildbot.reporters.message import MessageFormatterMissingWorker
+from buildbot.reporters.generators.build import BuildStatusGenerator
+from buildbot.reporters.generators.buildset import BuildSetStatusGenerator
+from buildbot.reporters.generators.worker import WorkerMissingGenerator
 from buildbot.util import service
 
 ENCODING = 'utf-8'
@@ -34,9 +30,6 @@ ENCODING = 'utf-8'
 class NotifierBase(service.BuildbotService):
     name = None
     __meta__ = abc.ABCMeta
-
-    possible_modes = ("change", "failing", "passing", "problem", "warnings",
-                      "exception", "cancelled")
 
     def computeShortcutModes(self, mode):
         if isinstance(mode, str):
@@ -49,91 +42,122 @@ class NotifierBase(service.BuildbotService):
                 mode = (mode,)
         return mode
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._buildsetCompleteConsumer = None
+        self._buildCompleteConsumer = None
+        self._workerMissingConsumer = None
+
     def checkConfig(self, mode=("failing", "passing", "warnings"),
                     tags=None, builders=None,
                     buildSetSummary=False, messageFormatter=None,
                     subject="Buildbot %(result)s in %(title)s on %(builder)s",
                     addLogs=False, addPatch=False,
                     schedulers=None, branches=None,
-                    watchedWorkers=None, messageFormatterMissingWorker=None):
+                    watchedWorkers=None, messageFormatterMissingWorker=None,
+                    generators=None
+                    ):
 
-        for m in self.computeShortcutModes(mode):
-            if m not in self.possible_modes:
-                if m == "all":
-                    config.error("mode 'all' is not valid in an iterator and must be "
-                                 "passed in as a separate string")
-                else:
-                    config.error("mode {} is not a valid mode".format(m))
+        # FIXME: TODO: maybe throw deprecation messages for non generator arguments
+        has_old_arg = tags is not None or builders is not None or buildSetSummary or \
+                      messageFormatter is not None or \
+                      subject != "Buildbot %(result)s in %(title)s on %(builder)s" or \
+                      addLogs or addPatch or schedulers is not None or \
+                      branches is not None or watchedWorkers is not None or \
+                      messageFormatterMissingWorker is not None
+        if has_old_arg and generators is not None:
+            config.error("can't specify generators and deprecated notifier arguments at the "
+                         "same time")
+
+        if generators is None:
+            generators = self.create_generators_from_old_args(mode, tags, builders, buildSetSummary,
+                                                              messageFormatter, subject, addLogs,
+                                                              addPatch, schedulers,
+                                                              branches, watchedWorkers,
+                                                              messageFormatterMissingWorker)
+
+        for g in generators:
+            g.check()
+
         if self.name is None:
             self.name = self.__class__.__name__
-            if tags is not None:
-                self.name += "_tags_" + "+".join(tags)
-            if builders is not None:
-                self.name += "_builders_" + "+".join(builders)
-            if schedulers is not None:
-                self.name += "_schedulers_" + "+".join(schedulers)
-            if branches is not None:
-                self.name += "_branches_" + "+".join(branches)
-            self.name += "_".join(mode)
+            for g in generators:
+                self.name += "_" + g.generate_name()
 
-        if '\n' in subject:
-            config.error(
-                'Newlines are not allowed in message subjects')
-
-        # you should either limit on builders or tags, not both
-        if builders is not None and tags is not None:
-            config.error(
-                "Please specify only builders or tags to include - " +
-                "not both.")
-
-        if not(watchedWorkers == 'all' or watchedWorkers is None or
-                isinstance(watchedWorkers, (list, tuple, set))):
-            config.error("watchedWorkers must be 'all', None, or list of worker names")
-
+    @defer.inlineCallbacks
     def reconfigService(self, mode=("failing", "passing", "warnings"),
                         tags=None, builders=None,
                         buildSetSummary=False, messageFormatter=None,
                         subject="Buildbot %(result)s in %(title)s on %(builder)s",
                         addLogs=False, addPatch=False,
                         schedulers=None, branches=None,
-                        watchedWorkers=None, messageFormatterMissingWorker=None):
+                        watchedWorkers=None, messageFormatterMissingWorker=None,
+                        generators=None):
 
-        self.mode = self.computeShortcutModes(mode)
-        self.tags = tags
-        self.builders = builders
-        self.schedulers = schedulers
-        self.branches = branches
-        self.subject = subject
-        self.addLogs = addLogs
-        self.addPatch = addPatch
-        if messageFormatter is None:
-            messageFormatter = DefaultMessageFormatter()
-        self.messageFormatter = messageFormatter
-        if messageFormatterMissingWorker is None:
-            messageFormatterMissingWorker = MessageFormatterMissingWorker()
-        self.messageFormatterMissingWorker = messageFormatterMissingWorker
-        self.buildSetSummary = buildSetSummary
-        self._buildset_complete_consumer = None
-        if watchedWorkers is None:
-            self.watchedWorkers = ()
-        else:
-            self.watchedWorkers = watchedWorkers
+        if generators is None:
+            generators = self.create_generators_from_old_args(mode, tags, builders, buildSetSummary,
+                                                              messageFormatter, subject, addLogs,
+                                                              addPatch, schedulers,
+                                                              branches, watchedWorkers,
+                                                              messageFormatterMissingWorker)
 
-    @defer.inlineCallbacks
-    def startService(self):
-        yield super().startService()
+        self.generators = generators
+
         startConsuming = self.master.mq.startConsuming
-        self._buildsetCompleteConsumer = yield startConsuming(
-            self.buildsetComplete,
-            ('buildsets', None, 'complete'))
-        self._buildCompleteConsumer = yield startConsuming(
-            self.buildComplete,
-            ('builds', None, 'finished'))
-        self._workerMissingConsumer = yield startConsuming(
-            self.workerMissing,
-            ('workers', None, 'missing'))
 
-    @defer.inlineCallbacks
+        needs_buildsets_complete = any(isinstance(g, BuildSetStatusGenerator) for g in generators)
+        needs_build_finished = any(isinstance(g, BuildStatusGenerator) for g in generators)
+        needs_worker_missing = any(isinstance(g, WorkerMissingGenerator) for g in generators)
+
+        if not needs_buildsets_complete and self._buildsetCompleteConsumer is not None:
+            yield self._buildsetCompleteConsumer.stopConsuming()
+            self._buildsetCompleteConsumer = None
+
+        if needs_buildsets_complete and self._buildsetCompleteConsumer is None:
+            self._buildsetCompleteConsumer = yield startConsuming(self.buildsetComplete,
+                                                                  ('buildsets', None, 'complete'))
+
+        if not needs_build_finished and self._buildCompleteConsumer is not None:
+            yield self._buildCompleteConsumer.stopConsuming()
+            self._buildCompleteConsumer = None
+
+        if needs_build_finished and self._buildCompleteConsumer is None:
+            self._buildCompleteConsumer = yield startConsuming(self.buildComplete,
+                                                               ('builds', None, 'finished'))
+
+        if not needs_worker_missing and self._workerMissingConsumer is not None:
+            yield self._workerMissingConsumer.stopConsuming()
+            self._workerMissingConsumer = None
+
+        if needs_worker_missing and self._workerMissingConsumer is None:
+            self._workerMissingConsumer = yield startConsuming(self.workerMissing,
+                                                               ('workers', None, 'missing'))
+
+    def create_generators_from_old_args(self, mode, tags, builders, build_set_summary,
+                                        message_formatter, subject, add_logs, add_patch, schedulers,
+                                        branches, watched_workers,
+                                        message_formatter_missing_worker):
+        generators = []
+        if build_set_summary:
+            generators.append(BuildSetStatusGenerator(mode=mode, tags=tags, builders=builders,
+                                                      schedulers=schedulers, branches=branches,
+                                                      subject=subject, add_logs=add_logs,
+                                                      add_patch=add_patch,
+                                                      message_formatter=message_formatter))
+        else:
+            generators.append(BuildStatusGenerator(mode=mode, tags=tags, builders=builders,
+                                                   schedulers=schedulers, branches=branches,
+                                                   subject=subject, add_logs=add_logs,
+                                                   add_patch=add_patch,
+                                                   message_formatter=message_formatter))
+
+        if watched_workers is not None and len(watched_workers) > 0:
+            generators.append(
+                WorkerMissingGenerator(workers=watched_workers,
+                                       message_formatter=message_formatter_missing_worker))
+
+        return generators
+
     def stopService(self):
         yield super().stopService()
         if self._buildsetCompleteConsumer is not None:
@@ -146,160 +170,37 @@ class NotifierBase(service.BuildbotService):
             yield self._workerMissingConsumer.stopConsuming()
             self._workerMissingConsumer = None
 
-    def wantPreviousBuild(self):
-        return "change" in self.mode or "problem" in self.mode
+    @defer.inlineCallbacks
+    def _send_reports_for_type(self, type, key, msg):
+        reports = []
+        for g in self.generators:
+            if isinstance(g, type):
+                report = yield g.generate(self.master, self, key, msg)
+                if report is not None:
+                    reports.append(report)
+
+        if reports:
+            yield self.sendMessage(reports)
 
     @defer.inlineCallbacks
     def buildsetComplete(self, key, msg):
-        if not self.buildSetSummary:
-            return
-        bsid = msg['bsid']
-        res = yield utils.getDetailsForBuildset(
-            self.master, bsid,
-            wantProperties=self.messageFormatter.wantProperties,
-            wantSteps=self.messageFormatter.wantSteps,
-            wantPreviousBuild=self.wantPreviousBuild(),
-            wantLogs=self.messageFormatter.wantLogs)
-
-        builds = res['builds']
-        buildset = res['buildset']
-
-        # only include builds for which isMessageNeeded returns true
-        builds = [build for build in builds if self.isMessageNeeded(build)]
-        if builds:
-            self.buildMessage("whole buildset", builds, buildset['results'])
+        yield self._send_reports_for_type(BuildSetStatusGenerator, key, msg)
 
     @defer.inlineCallbacks
-    def buildComplete(self, key, build):
-        if self.buildSetSummary:
-            return
-        br = yield self.master.data.get(("buildrequests", build['buildrequestid']))
-        buildset = yield self.master.data.get(("buildsets", br['buildsetid']))
-        yield utils.getDetailsForBuilds(
-            self.master, buildset, [build],
-            wantProperties=self.messageFormatter.wantProperties,
-            wantSteps=self.messageFormatter.wantSteps,
-            wantPreviousBuild=self.wantPreviousBuild(),
-            wantLogs=self.messageFormatter.wantLogs)
-        # only include builds for which isMessageNeeded returns true
-        if self.isMessageNeeded(build):
-            self.buildMessage(
-                build['builder']['name'], [build], build['results'])
-
-    def matchesAnyTag(self, tags):
-        return self.tags and any(tag for tag in self.tags if tag in tags)
-
-    def isMessageNeeded(self, build):
-        # here is where we actually do something.
-        builder = build['builder']
-        scheduler = build['properties'].get('scheduler', [None])[0]
-        branch = build['properties'].get('branch', [None])[0]
-        results = build['results']
-        if self.builders is not None and builder['name'] not in self.builders:
-            return False  # ignore this build
-        if self.schedulers is not None and scheduler not in self.schedulers:
-            return False  # ignore this build
-        if self.branches is not None and branch not in self.branches:
-            return False  # ignore this build
-        if self.tags is not None and \
-                not self.matchesAnyTag(builder['tags']):
-            return False  # ignore this build
-
-        if "change" in self.mode:
-            prev = build['prev_build']
-            if prev and prev['results'] != results:
-                return True
-        if "failing" in self.mode and results == FAILURE:
-            return True
-        if "passing" in self.mode and results == SUCCESS:
-            return True
-        if "problem" in self.mode and results == FAILURE:
-            prev = build['prev_build']
-            if prev and prev['results'] != FAILURE:
-                return True
-        if "warnings" in self.mode and results == WARNINGS:
-            return True
-        if "exception" in self.mode and results == EXCEPTION:
-            return True
-        if "cancelled" in self.mode and results == CANCELLED:
-            return True
-
-        return False
+    def buildComplete(self, key, msg):
+        yield self._send_reports_for_type(BuildStatusGenerator, key, msg)
 
     @defer.inlineCallbacks
-    def getLogsForBuild(self, build):
-        all_logs = []
-        steps = yield self.master.data.get(('builds', build['buildid'], "steps"))
-        for step in steps:
-            logs = yield self.master.data.get(("steps", step['stepid'], 'logs'))
-            for l in logs:
-                l['stepname'] = step['name']
-                l['content'] = yield self.master.data.get(("logs", l['logid'], 'contents'))
-                all_logs.append(l)
-        return all_logs
+    def workerMissing(self, key, msg):
+        yield self._send_reports_for_type(WorkerMissingGenerator, key, msg)
 
     def getResponsibleUsersForBuild(self, master, buildid):
         # Use library method but subclassers may want to override that
         return utils.getResponsibleUsersForBuild(master, buildid)
 
-    @defer.inlineCallbacks
-    def buildMessage(self, name, builds, results):
-        patches = []
-        logs = []
-        body = ""
-        subject = None
-        msgtype = None
-        users = set()
-        for build in builds:
-            if self.addPatch:
-                ss_list = build['buildset']['sourcestamps']
-
-                for ss in ss_list:
-                    if 'patch' in ss and ss['patch'] is not None:
-                        patches.append(ss['patch'])
-            if self.addLogs:
-                build_logs = yield self.getLogsForBuild(build)
-                logs.extend(build_logs)
-
-            if 'prev_build' in build and build['prev_build'] is not None:
-                previous_results = build['prev_build']['results']
-            else:
-                previous_results = None
-            blamelist = yield self.getResponsibleUsersForBuild(self.master, build['buildid'])
-            buildmsg = yield self.messageFormatter.formatMessageForBuildResults(
-                self.mode, name, build['buildset'], build, self.master,
-                previous_results, blamelist)
-            users.update(set(blamelist))
-            msgtype = buildmsg['type']
-            body += buildmsg['body']
-            if 'subject' in buildmsg:
-                subject = buildmsg['subject']
-
-        yield self.sendMessage(body, subject, msgtype, name, results, builds,
-                               list(users), patches, logs)
-
     @abc.abstractmethod
-    def sendMessage(self, body, subject=None, type=None, builderName=None,
-                    results=None, builds=None, users=None, patches=None,
-                    logs=None, worker=None):
+    def sendMessage(self, reports):
         pass
 
     def isWorkerMessageNeeded(self, worker):
         return self.watchedWorkers == 'all' or worker['name'] in self.watchedWorkers
-
-    @defer.inlineCallbacks
-    def workerMissing(self, key, worker):
-        if not self.isWorkerMessageNeeded(worker):
-            return
-        msg = yield self.messageFormatterMissingWorker.formatMessageForMissingWorker(self.master,
-                                                                                     worker)
-        text = msg['body'].encode(ENCODING)
-        if 'subject' in msg:
-            subject = msg['subject']
-        else:
-            subject = "Buildbot worker {name} missing".format(**worker)
-        assert msg['type'] in ('plain', 'html'), \
-            "'{}' message type must be 'plain' or 'html'.".format(msg['type'])
-
-        yield self.sendMessage(text, subject, msg['type'], users=worker['notify'],
-                               worker=worker['name'])

--- a/master/buildbot/reporters/pushjet.py
+++ b/master/buildbot/reporters/pushjet.py
@@ -73,11 +73,11 @@ class PushjetNotifier(NotifierBase):
         if messageFormatterMissingWorker is None:
             messageFormatterMissingWorker = MessageFormatterMissingWorker(
                 template_filename='missing_notification.txt')
-        super(PushjetNotifier, self).reconfigService(mode, tags, builders,
-                                                     buildSetSummary, messageFormatter,
-                                                     subject, False, False,
-                                                     schedulers, branches,
-                                                     watchedWorkers, messageFormatterMissingWorker)
+        yield super().reconfigService(mode, tags, builders,
+                                      buildSetSummary, messageFormatter,
+                                      subject, False, False,
+                                      schedulers, branches,
+                                      watchedWorkers, messageFormatterMissingWorker)
         self.secret = secret
         if levels is None:
             self.levels = {}

--- a/master/buildbot/reporters/pushjet.py
+++ b/master/buildbot/reporters/pushjet.py
@@ -22,11 +22,13 @@ from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
-from buildbot.process.results import Results
 from buildbot.reporters.message import MessageFormatter as DefaultMessageFormatter
 from buildbot.reporters.message import MessageFormatterMissingWorker
 from buildbot.reporters.notifier import NotifierBase
 from buildbot.util import httpclientservice
+
+from .utils import merge_reports_prop
+from .utils import merge_reports_prop_take_first
 
 ENCODING = 'utf8'
 
@@ -86,24 +88,21 @@ class PushjetNotifier(NotifierBase):
         self._http = yield httpclientservice.HTTPClientService.getService(
             self.master, base_url)
 
-    def sendMessage(self, body, subject=None, type=None, builderName=None,
-                    results=None, builds=None, users=None, patches=None,
-                    logs=None, worker=None):
+    def sendMessage(self, reports):
+        body = merge_reports_prop(reports, 'body')
+        subject = merge_reports_prop_take_first(reports, 'subject')
+        results = merge_reports_prop(reports, 'results')
+        worker = merge_reports_prop_take_first(reports, 'worker')
 
-        if worker is not None and worker not in self.watchedWorkers:
-            return None
+        msg = {
+            'message': body,
+            'title': subject
+        }
 
-        msg = {'message': body}
         level = self.levels.get(LEVELS[results] if worker is None else 'worker_missing')
         if level is not None:
             msg['level'] = level
-        if subject is not None:
-            msg['title'] = subject
-        else:
-            msg['title'] = self.subject % {'result': Results[results],
-                                           'projectName': self.master.config.title,
-                                           'title': self.master.config.title,
-                                           'builder': builderName}
+
         return self.sendNotification(msg)
 
     def sendNotification(self, params):

--- a/master/buildbot/reporters/pushover.py
+++ b/master/buildbot/reporters/pushover.py
@@ -82,11 +82,11 @@ class PushoverNotifier(NotifierBase):
         if messageFormatterMissingWorker is None:
             messageFormatterMissingWorker = MessageFormatterMissingWorker(
                 template_filename='missing_notification.txt')
-        super(PushoverNotifier, self).reconfigService(mode, tags, builders,
-                                                      buildSetSummary, messageFormatter,
-                                                      subject, False, False,
-                                                      schedulers, branches,
-                                                      watchedWorkers, messageFormatterMissingWorker)
+        yield super().reconfigService(mode, tags, builders,
+                                      buildSetSummary, messageFormatter,
+                                      subject, False, False,
+                                      schedulers, branches,
+                                      watchedWorkers, messageFormatterMissingWorker)
         self.user_key = user_key
         self.api_token = api_token
         if priorities is None:

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -32,6 +32,7 @@ def getPreviousBuild(master, build):
     n = build['number'] - 1
     while n >= 0:
         prev = yield master.data.get(("builders", build['builderid'], "builds", n))
+
         if prev and prev['results'] != RETRY:
             return prev
         n -= 1
@@ -197,3 +198,23 @@ def getURLForBuild(master, builderid, build_number):
 def URLForBuild(props):
     build = props.getBuild()
     return build.getUrl()
+
+
+def merge_reports_prop(reports, prop):
+    result = None
+    for report in reports:
+        if prop in report and report[prop] is not None:
+            if result is None:
+                result = report[prop]
+            else:
+                result += report[prop]
+
+    return result
+
+
+def merge_reports_prop_take_first(reports, prop):
+    for report in reports:
+        if prop in report and report[prop] is not None:
+            return report[prop]
+
+    return None

--- a/master/buildbot/test/unit/test_reporter_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucketserver.py
@@ -26,6 +26,7 @@ from buildbot.reporters.bitbucketserver import HTTP_CREATED
 from buildbot.reporters.bitbucketserver import HTTP_PROCESSED
 from buildbot.reporters.bitbucketserver import BitbucketServerPRCommentPush
 from buildbot.reporters.bitbucketserver import BitbucketServerStatusPush
+from buildbot.reporters.message import MessageFormatter
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.util.logging import LoggingMixin
@@ -197,12 +198,19 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
             self.master, self, 'serv', auth=('username', 'passwd'), debug=None,
             verify=None)
+
+        formatter = Mock(spec=MessageFormatter)
+        formatter.formatMessageForBuildResults.return_value = {"body": UNICODE_BODY,
+                                                               "type": "text",
+                                                               "subject": "subject"}
+        formatter.wantProperties = True
+        formatter.wantSteps = False
+        formatter.wantLogs = False
+
         self.cp = BitbucketServerPRCommentPush(
-            "serv", Interpolate("username"), Interpolate("passwd"), verbose=verbose, **kwargs)
+            "serv", Interpolate("username"), Interpolate("passwd"), verbose=verbose,
+            messageFormatter=formatter, **kwargs)
         yield self.cp.setServiceParent(self.master)
-        self.cp.messageFormatter = Mock(spec=self.cp.messageFormatter)
-        self.cp.messageFormatter.formatMessageForBuildResults.return_value = \
-            {"body": UNICODE_BODY, "type": "text"}
 
     @defer.inlineCallbacks
     def tearDown(self):

--- a/master/buildbot/test/unit/test_reporters_generators_build.py
+++ b/master/buildbot/test/unit/test_reporters_generators_build.py
@@ -1,0 +1,280 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import copy
+
+from mock import Mock
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.process.results import CANCELLED
+from buildbot.process.results import EXCEPTION
+from buildbot.process.results import FAILURE
+from buildbot.process.results import SUCCESS
+from buildbot.process.results import WARNINGS
+from buildbot.reporters.generators.build import BuildStatusGenerator
+from buildbot.test import fakedb
+from buildbot.test.fake import fakemaster
+from buildbot.test.util.config import ConfigErrorsMixin
+from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.util.notifier import NotifierTestMixin
+
+
+class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
+                         unittest.TestCase, NotifierTestMixin):
+
+    def setUp(self):
+        self.setUpTestReactor()
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
+
+    @defer.inlineCallbacks
+    def test_is_message_needed_ignores_unspecified_tags(self):
+        _, builds = yield self.setupBuildResults(SUCCESS)
+
+        build = builds[0]
+        # force tags
+        build['builder']['tags'] = ['slow']
+        g = BuildStatusGenerator(tags=["fast"])
+        self.assertFalse(g.is_message_needed(build))
+
+    @defer.inlineCallbacks
+    def test_is_message_needed_tags(self):
+        _, builds = yield self.setupBuildResults(SUCCESS)
+
+        build = builds[0]
+        # force tags
+        build['builder']['tags'] = ['fast']
+        g = BuildStatusGenerator(tags=["fast"])
+        self.assertTrue(g.is_message_needed(build))
+
+    @defer.inlineCallbacks
+    def test_is_message_needed_schedulers_sends_mail(self):
+        _, builds = yield self.setupBuildResults(SUCCESS)
+
+        build = builds[0]
+        g = BuildStatusGenerator(schedulers=['checkin'])
+        self.assertTrue(g.is_message_needed(build))
+
+    @defer.inlineCallbacks
+    def test_is_message_needed_schedulers_doesnt_send_mail(self):
+        _, builds = yield self.setupBuildResults(SUCCESS)
+
+        build = builds[0]
+        g = BuildStatusGenerator(schedulers=['some-random-scheduler'])
+        self.assertFalse(g.is_message_needed(build))
+
+    @defer.inlineCallbacks
+    def test_is_message_needed_branches_sends_mail(self):
+        _, builds = yield self.setupBuildResults(SUCCESS)
+
+        build = builds[0]
+        g = BuildStatusGenerator(branches=['master'])
+        self.assertTrue(g.is_message_needed(build))
+
+    @defer.inlineCallbacks
+    def test_is_message_needed_branches_doesnt_send_mail(self):
+        _, builds = yield self.setupBuildResults(SUCCESS)
+
+        build = builds[0]
+        g = BuildStatusGenerator(branches=['some-random-branch'])
+        self.assertFalse(g.is_message_needed(build))
+
+    @defer.inlineCallbacks
+    def run_simple_test_sends_message_for_mode(self, mode, result, should_send=True):
+        _, builds = yield self.setupBuildResults(result)
+
+        g = BuildStatusGenerator(mode=mode)
+
+        self.assertEqual(g.is_message_needed(builds[0]), should_send)
+
+    def run_simple_test_ignores_message_for_mode(self, mode, result):
+        return self.run_simple_test_sends_message_for_mode(mode, result, False)
+
+    def test_is_message_needed_mode_all_for_success(self):
+        return self.run_simple_test_sends_message_for_mode("all", SUCCESS)
+
+    def test_is_message_needed_mode_all_for_failure(self):
+        return self.run_simple_test_sends_message_for_mode("all", FAILURE)
+
+    def test_is_message_needed_mode_all_for_warnings(self):
+        return self.run_simple_test_sends_message_for_mode("all", WARNINGS)
+
+    def test_is_message_needed_mode_all_for_exception(self):
+        return self.run_simple_test_sends_message_for_mode("all", EXCEPTION)
+
+    def test_is_message_needed_mode_all_for_cancelled(self):
+        return self.run_simple_test_sends_message_for_mode("all", CANCELLED)
+
+    def test_is_message_needed_mode_failing_for_success(self):
+        return self.run_simple_test_ignores_message_for_mode("failing", SUCCESS)
+
+    def test_is_message_needed_mode_failing_for_failure(self):
+        return self.run_simple_test_sends_message_for_mode("failing", FAILURE)
+
+    def test_is_message_needed_mode_failing_for_warnings(self):
+        return self.run_simple_test_ignores_message_for_mode("failing", WARNINGS)
+
+    def test_is_message_needed_mode_failing_for_exception(self):
+        return self.run_simple_test_ignores_message_for_mode("failing", EXCEPTION)
+
+    def test_is_message_needed_mode_exception_for_success(self):
+        return self.run_simple_test_ignores_message_for_mode("exception", SUCCESS)
+
+    def test_is_message_needed_mode_exception_for_failure(self):
+        return self.run_simple_test_ignores_message_for_mode("exception", FAILURE)
+
+    def test_is_message_needed_mode_exception_for_warnings(self):
+        return self.run_simple_test_ignores_message_for_mode("exception", WARNINGS)
+
+    def test_is_message_needed_mode_exception_for_exception(self):
+        return self.run_simple_test_sends_message_for_mode("exception", EXCEPTION)
+
+    def test_is_message_needed_mode_warnings_for_success(self):
+        return self.run_simple_test_ignores_message_for_mode("warnings", SUCCESS)
+
+    def test_is_message_needed_mode_warnings_for_failure(self):
+        return self.run_simple_test_sends_message_for_mode("warnings", FAILURE)
+
+    def test_is_message_needed_mode_warnings_for_warnings(self):
+        return self.run_simple_test_sends_message_for_mode("warnings", WARNINGS)
+
+    def test_is_message_needed_mode_warnings_for_exception(self):
+        return self.run_simple_test_ignores_message_for_mode("warnings", EXCEPTION)
+
+    def test_is_message_needed_mode_passing_for_success(self):
+        return self.run_simple_test_sends_message_for_mode("passing", SUCCESS)
+
+    def test_is_message_needed_mode_passing_for_failure(self):
+        return self.run_simple_test_ignores_message_for_mode("passing", FAILURE)
+
+    def test_is_message_needed_mode_passing_for_warnings(self):
+        return self.run_simple_test_ignores_message_for_mode("passing", WARNINGS)
+
+    def test_is_message_needed_mode_passing_for_exception(self):
+        return self.run_simple_test_ignores_message_for_mode("passing", EXCEPTION)
+
+    @defer.inlineCallbacks
+    def run_sends_message_for_problems(self, mode, results1, results2, should_send=True):
+        _, builds = yield self.setupBuildResults(results2)
+
+        g = BuildStatusGenerator(mode=mode)
+
+        build = builds[0]
+        if results1 is not None:
+            build['prev_build'] = copy.deepcopy(builds[0])
+            build['prev_build']['results'] = results1
+        else:
+            build['prev_build'] = None
+        self.assertEqual(g.is_message_needed(builds[0]), should_send)
+
+    def test_is_message_needed_mode_problem_sends_on_problem(self):
+        return self.run_sends_message_for_problems("problem", SUCCESS, FAILURE, True)
+
+    def test_is_message_needed_mode_problem_ignores_successful_build(self):
+        return self.run_sends_message_for_problems("problem", SUCCESS, SUCCESS, False)
+
+    def test_is_message_needed_mode_problem_ignores_two_failed_builds_in_sequence(self):
+        return self.run_sends_message_for_problems("problem", FAILURE, FAILURE, False)
+
+    def test_is_message_needed_mode_change_sends_on_change(self):
+        return self.run_sends_message_for_problems("change", FAILURE, SUCCESS, True)
+
+    def test_is_message_needed_mode_change_sends_on_failure(self):
+        return self.run_sends_message_for_problems("change", SUCCESS, FAILURE, True)
+
+    def test_is_message_needed_mode_change_ignores_first_build(self):
+        return self.run_sends_message_for_problems("change", None, FAILURE, False)
+
+    def test_is_message_needed_mode_change_ignores_first_build2(self):
+        return self.run_sends_message_for_problems("change", None, SUCCESS, False)
+
+    def test_is_message_needed_mode_change_ignores_same_result_in_sequence(self):
+        return self.run_sends_message_for_problems("change", SUCCESS, SUCCESS, False)
+
+    def test_is_message_needed_mode_change_ignores_same_result_in_sequence2(self):
+        return self.run_sends_message_for_problems("change", FAILURE, FAILURE, False)
+
+    @defer.inlineCallbacks
+    def setup_build_message(self, **kwargs):
+
+        _, builds = yield self.setupBuildResults(SUCCESS)
+
+        g = BuildStatusGenerator(**kwargs)
+
+        g.formatter = Mock(spec=g.formatter)
+        g.formatter.formatMessageForBuildResults.return_value = {"body": "body",
+                                                                 "type": "text",
+                                                                 "subject": "subject"}
+
+        reporter = Mock()
+        reporter.getResponsibleUsersForBuild.return_value = []
+
+        report = yield g.build_message(self.master, reporter, "mybldr", builds, SUCCESS)
+        return (g, builds, report)
+
+    @defer.inlineCallbacks
+    def test_build_message_nominal(self):
+        g, builds, report = yield self.setup_build_message(mode=("change",))
+
+        build = builds[0]
+        g.formatter.formatMessageForBuildResults.assert_called_with(
+            ('change',), 'mybldr', build['buildset'], build, self.master, None, [])
+
+        self.assertEqual(report, {
+            'body': 'body',
+            'subject': 'subject',
+            'type': 'text',
+            'builder_name': 'mybldr',
+            'results': SUCCESS,
+            'builds': builds,
+            'users': [],
+            'patches': [],
+            'logs': []
+        })
+
+    @defer.inlineCallbacks
+    def test_build_message_addLogs(self):
+        g, builds, report = yield self.setup_build_message(mode=("change",), add_logs=True)
+        self.assertEqual(report['logs'][0]['logid'], 60)
+        self.assertIn("log with", report['logs'][0]['content']['content'])
+
+    @defer.inlineCallbacks
+    def test_build_message_add_patch(self):
+        g, builds, report = yield self.setup_build_message(mode=("change",), add_patch=True)
+
+        patch_dict = {
+            'author': 'him@foo',
+            'body': b'hello, world',
+            'comment': 'foo',
+            'level': 3,
+            'patchid': 99,
+            'subdir': '/foo'
+        }
+        self.assertEqual(report['patches'], [patch_dict])
+
+    @defer.inlineCallbacks
+    def test_build_message_add_patch_no_patch(self):
+        SourceStamp = fakedb.SourceStamp
+
+        class NoPatchSourcestamp(SourceStamp):
+            def __init__(self, id, patchid):
+                super().__init__(id=id)
+
+        self.patch(fakedb, 'SourceStamp', NoPatchSourcestamp)
+        g, builds, report = yield self.setup_build_message(mode=("change",), add_patch=True)
+        self.assertEqual(report['patches'], [])

--- a/master/buildbot/test/unit/test_reporters_generators_worker.py
+++ b/master/buildbot/test/unit/test_reporters_generators_worker.py
@@ -1,0 +1,49 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.reporters.generators.worker import WorkerMissingGenerator
+from buildbot.test.fake import fakemaster
+from buildbot.test.util.config import ConfigErrorsMixin
+from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.util.notifier import NotifierTestMixin
+
+
+class TestWorkerMissingGenerator(ConfigErrorsMixin, TestReactorMixin,
+                                 unittest.TestCase, NotifierTestMixin):
+
+    def setUp(self):
+        self.setUpTestReactor()
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
+
+    @defer.inlineCallbacks
+    def test_report(self):
+
+        g = WorkerMissingGenerator(workers=['myworker'])
+
+        worker_dict = {
+            'name': 'myworker',
+            'notify': ["workeradmin@example.org"],
+            'workerinfo': {"admin": "myadmin"},
+            'last_connection': "yesterday"
+        }
+        report = yield g.generate(self.master, None, 'worker.98.complete', worker_dict)
+
+        self.assertEqual(report['users'], ['workeradmin@example.org'])
+        self.assertIn(b"has noticed that the worker named myworker went away", report['body'])

--- a/master/buildbot/test/unit/test_reporters_notifier.py
+++ b/master/buildbot/test/unit/test_reporters_notifier.py
@@ -14,29 +14,19 @@
 # Copyright Buildbot Team Members
 
 
-import copy
-import sys
-
 from mock import Mock
 
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config
-from buildbot.process.results import CANCELLED
-from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
-from buildbot.process.results import WARNINGS
+from buildbot.reporters.message import MessageFormatter
 from buildbot.reporters.notifier import NotifierBase
-from buildbot.test import fakedb
 from buildbot.test.fake import fakemaster
 from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.notifier import NotifierTestMixin
-
-py_27 = sys.version_info[0] > 2 or (sys.version_info[0] == 2
-                                    and sys.version_info[1] >= 7)
 
 
 class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
@@ -56,294 +46,58 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
         yield mn.startService()
         return mn
 
-    def test_init_enforces_tags_and_builders_are_mutually_exclusive(self):
-        with self.assertRaises(config.ConfigErrors):
-            NotifierBase(tags=['fast', 'slow'], builders=['a', 'b'])
-
-    def test_init_warns_notifier_mode_all_in_iter(self):
-        with self.assertRaisesConfigError(
-               "mode 'all' is not valid in an iterator and must be passed in as a separate string"):
-            NotifierBase(mode=['all'])
-
-    @defer.inlineCallbacks
-    def test_buildsetComplete_sends_message(self):
-        _, builds = yield self.setupBuildResults(SUCCESS)
-        mn = yield self.setupNotifier(buildSetSummary=True,
-                                      mode=("failing", "passing", "warnings"),
-                                      builders=["Builder1", "Builder2"])
-
-        mn.buildMessage = Mock()
-        yield mn.buildsetComplete('buildset.98.complete',
-                                  dict(bsid=98))
-
-        mn.buildMessage.assert_called_with(
-            "whole buildset",
-            builds, SUCCESS)
-        self.assertEqual(mn.buildMessage.call_count, 1)
-
-    @defer.inlineCallbacks
-    def test_buildsetComplete_doesnt_send_message(self):
-        _, builds = yield self.setupBuildResults(SUCCESS)
-        # disable passing...
-        mn = yield self.setupNotifier(buildSetSummary=True,
-                                      mode=("failing", "warnings"),
-                                      builders=["Builder1", "Builder2"])
-
-        mn.buildMessage = Mock()
-        yield mn.buildsetComplete('buildset.98.complete',
-                                  dict(bsid=98))
-
-        self.assertFalse(mn.buildMessage.called)
-
-    @defer.inlineCallbacks
-    def test_isMessageNeeded_ignores_unspecified_tags(self):
-        _, builds = yield self.setupBuildResults(SUCCESS)
-
-        build = builds[0]
-        # force tags
-        build['builder']['tags'] = ['slow']
-        mn = yield self.setupNotifier(tags=["fast"])
-        self.assertFalse(mn.isMessageNeeded(build))
-
-    @defer.inlineCallbacks
-    def test_isMessageNeeded_tags(self):
-        _, builds = yield self.setupBuildResults(SUCCESS)
-
-        build = builds[0]
-        # force tags
-        build['builder']['tags'] = ['fast']
-        mn = yield self.setupNotifier(tags=["fast"])
-        self.assertTrue(mn.isMessageNeeded(build))
-
-    @defer.inlineCallbacks
-    def test_isMessageNeeded_schedulers_sends_mail(self):
-        _, builds = yield self.setupBuildResults(SUCCESS)
-
-        build = builds[0]
-        # force tags
-        mn = yield self.setupNotifier(schedulers=['checkin'])
-        self.assertTrue(mn.isMessageNeeded(build))
-
-    @defer.inlineCallbacks
-    def test_isMessageNeeded_schedulers_doesnt_send_mail(self):
-        _, builds = yield self.setupBuildResults(SUCCESS)
-
-        build = builds[0]
-        # force tags
-        mn = yield self.setupNotifier(schedulers=['some-random-scheduler'])
-        self.assertFalse(mn.isMessageNeeded(build))
-
-    @defer.inlineCallbacks
-    def test_isMessageNeeded_branches_sends_mail(self):
-        _, builds = yield self.setupBuildResults(SUCCESS)
-
-        build = builds[0]
-        # force tags
-        mn = yield self.setupNotifier(branches=['master'])
-        self.assertTrue(mn.isMessageNeeded(build))
-
-    @defer.inlineCallbacks
-    def test_isMessageNeeded_branches_doesnt_send_mail(self):
-        _, builds = yield self.setupBuildResults(SUCCESS)
-
-        build = builds[0]
-        # force tags
-        mn = yield self.setupNotifier(branches=['some-random-branch'])
-        self.assertFalse(mn.isMessageNeeded(build))
-
-    @defer.inlineCallbacks
-    def run_simple_test_sends_message_for_mode(self, mode, result, shouldSend=True):
-        _, builds = yield self.setupBuildResults(result)
-
-        mn = yield self.setupNotifier(mode=mode)
-
-        self.assertEqual(mn.isMessageNeeded(builds[0]), shouldSend)
-
-    def run_simple_test_ignores_message_for_mode(self, mode, result):
-        return self.run_simple_test_sends_message_for_mode(mode, result, False)
-
-    def test_isMessageNeeded_mode_all_for_success(self):
-        return self.run_simple_test_sends_message_for_mode("all", SUCCESS)
-
-    def test_isMessageNeeded_mode_all_for_failure(self):
-        return self.run_simple_test_sends_message_for_mode("all", FAILURE)
-
-    def test_isMessageNeeded_mode_all_for_warnings(self):
-        return self.run_simple_test_sends_message_for_mode("all", WARNINGS)
-
-    def test_isMessageNeeded_mode_all_for_exception(self):
-        return self.run_simple_test_sends_message_for_mode("all", EXCEPTION)
-
-    def test_isMessageNeeded_mode_all_for_cancelled(self):
-        return self.run_simple_test_sends_message_for_mode("all", CANCELLED)
-
-    def test_isMessageNeeded_mode_failing_for_success(self):
-        return self.run_simple_test_ignores_message_for_mode("failing", SUCCESS)
-
-    def test_isMessageNeeded_mode_failing_for_failure(self):
-        return self.run_simple_test_sends_message_for_mode("failing", FAILURE)
-
-    def test_isMessageNeeded_mode_failing_for_warnings(self):
-        return self.run_simple_test_ignores_message_for_mode("failing", WARNINGS)
-
-    def test_isMessageNeeded_mode_failing_for_exception(self):
-        return self.run_simple_test_ignores_message_for_mode("failing", EXCEPTION)
-
-    def test_isMessageNeeded_mode_exception_for_success(self):
-        return self.run_simple_test_ignores_message_for_mode("exception", SUCCESS)
-
-    def test_isMessageNeeded_mode_exception_for_failure(self):
-        return self.run_simple_test_ignores_message_for_mode("exception", FAILURE)
-
-    def test_isMessageNeeded_mode_exception_for_warnings(self):
-        return self.run_simple_test_ignores_message_for_mode("exception", WARNINGS)
-
-    def test_isMessageNeeded_mode_exception_for_exception(self):
-        return self.run_simple_test_sends_message_for_mode("exception", EXCEPTION)
-
-    def test_isMessageNeeded_mode_warnings_for_success(self):
-        return self.run_simple_test_ignores_message_for_mode("warnings", SUCCESS)
-
-    def test_isMessageNeeded_mode_warnings_for_failure(self):
-        return self.run_simple_test_sends_message_for_mode("warnings", FAILURE)
-
-    def test_isMessageNeeded_mode_warnings_for_warnings(self):
-        return self.run_simple_test_sends_message_for_mode("warnings", WARNINGS)
-
-    def test_isMessageNeeded_mode_warnings_for_exception(self):
-        return self.run_simple_test_ignores_message_for_mode("warnings", EXCEPTION)
-
-    def test_isMessageNeeded_mode_passing_for_success(self):
-        return self.run_simple_test_sends_message_for_mode("passing", SUCCESS)
-
-    def test_isMessageNeeded_mode_passing_for_failure(self):
-        return self.run_simple_test_ignores_message_for_mode("passing", FAILURE)
-
-    def test_isMessageNeeded_mode_passing_for_warnings(self):
-        return self.run_simple_test_ignores_message_for_mode("passing", WARNINGS)
-
-    def test_isMessageNeeded_mode_passing_for_exception(self):
-        return self.run_simple_test_ignores_message_for_mode("passing", EXCEPTION)
-
-    @defer.inlineCallbacks
-    def run_sends_message_for_problems(self, mode, results1, results2, shouldSend=True):
-        _, builds = yield self.setupBuildResults(results2)
-
-        mn = yield self.setupNotifier(mode=mode)
-
-        build = builds[0]
-        if results1 is not None:
-            build['prev_build'] = copy.deepcopy(builds[0])
-            build['prev_build']['results'] = results1
-        else:
-            build['prev_build'] = None
-        self.assertEqual(mn.isMessageNeeded(builds[0]), shouldSend)
-
-    def test_isMessageNeeded_mode_problem_sends_on_problem(self):
-        return self.run_sends_message_for_problems("problem", SUCCESS, FAILURE, True)
-
-    def test_isMessageNeeded_mode_problem_ignores_successful_build(self):
-        return self.run_sends_message_for_problems("problem", SUCCESS, SUCCESS, False)
-
-    def test_isMessageNeeded_mode_problem_ignores_two_failed_builds_in_sequence(self):
-        return self.run_sends_message_for_problems("problem", FAILURE, FAILURE, False)
-
-    def test_isMessageNeeded_mode_change_sends_on_change(self):
-        return self.run_sends_message_for_problems("change", FAILURE, SUCCESS, True)
-
-    def test_isMessageNeeded_mode_change_sends_on_failure(self):
-        return self.run_sends_message_for_problems("change", SUCCESS, FAILURE, True)
-
-    def test_isMessageNeeded_mode_change_ignores_first_build(self):
-        return self.run_sends_message_for_problems("change", None, FAILURE, False)
-
-    def test_isMessageNeeded_mode_change_ignores_first_build2(self):
-        return self.run_sends_message_for_problems("change", None, SUCCESS, False)
-
-    def test_isMessageNeeded_mode_change_ignores_same_result_in_sequence(self):
-        return self.run_sends_message_for_problems("change", SUCCESS, SUCCESS, False)
-
-    def test_isMessageNeeded_mode_change_ignores_same_result_in_sequence2(self):
-        return self.run_sends_message_for_problems("change", FAILURE, FAILURE, False)
-
     @defer.inlineCallbacks
     def setupBuildMessage(self, **mnKwargs):
 
-        _, builds = yield self.setupBuildResults(SUCCESS)
+        _, builds = yield self.setupBuildResults(FAILURE)
 
-        mn = yield self.setupNotifier(**mnKwargs)
+        formatter = Mock(spec=MessageFormatter)
+        formatter.formatMessageForBuildResults.return_value = {"body": "body",
+                                                               "type": "text",
+                                                               "subject": "subject"}
+        formatter.wantProperties = False
+        formatter.wantSteps = False
+        formatter.wantLogs = False
 
-        mn.messageFormatter = Mock(spec=mn.messageFormatter)
-        mn.messageFormatter.formatMessageForBuildResults.return_value = {"body": "body",
-                                                                         "type": "text",
-                                                                         "subject": "subject"}
-        yield mn.buildMessage("mybldr", builds, SUCCESS)
-        return (mn, builds)
+        mn = yield self.setupNotifier(messageFormatter=formatter, **mnKwargs)
+
+        yield mn.buildComplete('', builds[0])
+        return (mn, builds, formatter)
 
     @defer.inlineCallbacks
     def test_buildMessage_nominal(self):
-        mn, builds = yield self.setupBuildMessage(mode=("change",))
+        mn, builds, formatter = yield self.setupBuildMessage(mode=("change",))
 
         build = builds[0]
-        mn.messageFormatter.formatMessageForBuildResults.assert_called_with(
-            ('change',), 'mybldr', build['buildset'], build, self.master,
-            None, ['me@foo'])
+        formatter.formatMessageForBuildResults.assert_called_with(
+            ('change',), 'Builder1', build['buildset'], build, self.master, SUCCESS, ['me@foo'])
+
+        report = {
+            'body': 'body',
+            'subject': 'subject',
+            'type': 'text',
+            'builder_name': 'Builder1',
+            'results': FAILURE,
+            'builds': builds,
+            'users': ['me@foo'],
+            'patches': [],
+            'logs': []
+        }
 
         self.assertEqual(mn.sendMessage.call_count, 1)
-        mn.sendMessage.assert_called_with('body', 'subject', 'text', 'mybldr', SUCCESS, builds,
-                                          ['me@foo'], [], [])
+        mn.sendMessage.assert_called_with([report])
 
     @defer.inlineCallbacks
-    def test_buildMessage_addLogs(self):
-        mn, builds = yield self.setupBuildMessage(mode=("change",), addLogs=True)
-        self.assertEqual(mn.sendMessage.call_count, 1)
-        # make sure the logs are send
-        self.assertEqual(mn.sendMessage.call_args[0][8][0]['logid'], 60)
-        # make sure the log has content
-        self.assertIn(
-            "log with", mn.sendMessage.call_args[0][8][0]['content']['content'])
-
-    @defer.inlineCallbacks
-    def test_buildMessage_addPatch(self):
-        mn, builds = yield self.setupBuildMessage(mode=("change",), addPatch=True)
-        self.assertEqual(mn.sendMessage.call_count, 1)
-        # make sure the patch are sent
-        self.assertEqual(mn.sendMessage.call_args[0][7],
-                         [{'author': 'him@foo',
-                           'body': b'hello, world',
-                           'comment': 'foo',
-                           'level': 3,
-                           'patchid': 99,
-                           'subdir': '/foo'}])
-
-    @defer.inlineCallbacks
-    def test_buildMessage_addPatchNoPatch(self):
-        SourceStamp = fakedb.SourceStamp
-
-        class NoPatchSourcestamp(SourceStamp):
-
-            def __init__(self, id, patchid):
-                super().__init__(id=id)
-        self.patch(fakedb, 'SourceStamp', NoPatchSourcestamp)
-        mn, builds = yield self.setupBuildMessage(mode=("change",), addPatch=True)
-        self.assertEqual(mn.sendMessage.call_count, 1)
-        # make sure no patches are sent
-        self.assertEqual(mn.sendMessage.call_args[0][7], [])
-
-    @defer.inlineCallbacks
-    def test_workerMissingSendMessage(self):
+    def test_worker_missing_sends_message(self):
 
         mn = yield self.setupNotifier(watchedWorkers=['myworker'])
 
-        yield mn.workerMissing('worker.98.complete',
-                               dict(name='myworker',
-                                    notify=["workeradmin@example.org"],
-                                    workerinfo=dict(admin="myadmin"),
-                                    last_connection="yesterday"))
+        worker_dict = {
+            'name': 'myworker',
+            'notify': ["workeradmin@example.org"],
+            'workerinfo': {"admin": "myadmin"},
+            'last_connection': "yesterday"
+        }
+        yield mn.workerMissing('worker.98.complete', worker_dict)
 
         self.assertEqual(mn.sendMessage.call_count, 1)
-        text = mn.sendMessage.call_args[0][0]
-        recipients = mn.sendMessage.call_args[1]['users']
-        self.assertEqual(recipients, ['workeradmin@example.org'])
-        self.assertIn(
-            b"has noticed that the worker named myworker went away", text)

--- a/master/buildbot/test/unit/test_reporters_pushjet.py
+++ b/master/buildbot/test/unit/test_reporters_pushjet.py
@@ -56,7 +56,13 @@ class TestPushjetNotifier(ConfigErrorsMixin, TestReactorMixin,
                      data={'secret': "1234", 'level': 2,
                            'message': "Test", 'title': "Tee"},
                      content_json={'status': 'ok'})
-        n = yield pn.sendMessage(body="Test", subject="Tee", results=SUCCESS)
+
+        n = yield pn.sendMessage([{
+            "body": "Test",
+            "subject": "Tee",
+            "results": SUCCESS
+        }])
+
         j = yield n.json()
         self.assertEqual(j['status'], 'ok')
 

--- a/master/buildbot/test/unit/test_reporters_pushover.py
+++ b/master/buildbot/test/unit/test_reporters_pushover.py
@@ -57,7 +57,13 @@ class TestPushoverNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCas
                      params={'user': "1234", 'token': "abcd",
                              'message': "Test", 'title': "Tee", 'priority': 2},
                      content_json={'status': 1, 'request': '98765'})
-        n = yield pn.sendMessage(body="Test", subject="Tee", results=SUCCESS)
+
+        n = yield pn.sendMessage([{
+            "body": "Test",
+            "subject": "Tee",
+            "results": SUCCESS
+        }])
+
         j = yield n.json()
         self.assertEqual(j['status'], 1)
         self.assertEqual(j['request'], '98765')

--- a/master/buildbot/test/util/notifier.py
+++ b/master/buildbot/test/util/notifier.py
@@ -15,6 +15,7 @@
 
 from twisted.internet import defer
 
+from buildbot.process.results import SUCCESS
 from buildbot.reporters import utils
 from buildbot.test import fakedb
 
@@ -30,10 +31,14 @@ class NotifierTestMixin:
         self.db.insertTestData([
             fakedb.Master(id=92),
             fakedb.Worker(id=13, name='wrk'),
+            fakedb.Buildset(id=97, results=SUCCESS, reason="testReason0"),
             fakedb.Buildset(id=98, results=results, reason="testReason1"),
             fakedb.Builder(id=80, name='Builder1'),
+            fakedb.BuildRequest(id=10, buildsetid=97, builderid=80),
             fakedb.BuildRequest(id=11, buildsetid=98, builderid=80),
-            fakedb.Build(id=20, number=0, builderid=80, buildrequestid=11, workerid=13,
+            fakedb.Build(id=19, number=0, builderid=80, buildrequestid=10, workerid=13,
+                         masterid=92, results=SUCCESS),
+            fakedb.Build(id=20, number=1, builderid=80, buildrequestid=11, workerid=13,
                          masterid=92, results=results),
             fakedb.Step(id=50, buildid=20, number=5, name='make'),
             fakedb.BuildsetSourceStamp(buildsetid=98, sourcestampid=234),

--- a/master/setup.py
+++ b/master/setup.py
@@ -173,6 +173,7 @@ setup_args = {
         "buildbot.process",
         "buildbot.process.users",
         "buildbot.reporters",
+        "buildbot.reporters.generators",
         "buildbot.schedulers",
         "buildbot.scripts",
         "buildbot.secrets",


### PR DESCRIPTION
This is a proof of concept implementing #5285 proposal to `NotifierBase` class.

It only implements the data movement part, not the low level parts of the integration of report generators and the reporters.