### PR TITLE
Handling BitbucketStatusPush response code of 200

### DIFF
--- a/master/buildbot/newsfragments/bitbucketstatuspush-response-code-200.bugfix
+++ b/master/buildbot/newsfragments/bitbucketstatuspush-response-code-200.bugfix
@@ -1,0 +1,1 @@
+Handling the case where the BitbucketStatusPush return code is not 200

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -94,7 +94,7 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
                 '/'.join([owner, repo, 'commit', sha, 'statuses', 'build'])
 
             response = yield self._http.post(bitbucket_uri, json=body)
-            if response.code != 201:
+            if response.code != 200 and response.code != 201:
                 content = yield response.content()
                 log.error("{code}: unable to upload Bitbucket status {content}",
                           code=response.code, content=content)

--- a/master/buildbot/test/unit/test_reporter_bitbucket.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucket.py
@@ -117,6 +117,46 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
         self.bsp.buildFinished(('build', 20, 'finished'), build)
 
     @defer.inlineCallbacks
+    def test_success_return_codes(self):
+        build = yield self.setupBuildResults(SUCCESS)
+
+        # make sure a 201 return code does not trigger an error
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
+                              content_json={'access_token': 'foo'})
+        self._http.expect(
+            'post',
+            '/user/repo/commit/d34db33fd43db33f/statuses/build',
+            json={
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'state': 'SUCCESSFUL',
+                'key': 'Builder0',
+                'name': 'Builder0'},
+            code=201)
+
+        build['complete'] = True
+        self.setUpLogging()
+        self.bsp.buildStarted(('build', 20, 'started'), build)
+        self.assertNotLogged('201: unable to upload Bitbucket status')
+
+        # make sure a 200 return code does not trigger an error
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
+                              content_json={'access_token': 'foo'})
+        self._http.expect(
+            'post',
+            '/user/repo/commit/d34db33fd43db33f/statuses/build',
+            json={
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'state': 'SUCCESSFUL',
+                'key': 'Builder0',
+                'name': 'Builder0'},
+            code=200)
+
+        build['complete'] = True
+        self.setUpLogging()
+        self.bsp.buildStarted(('build', 20, 'finished'), build)
+        self.assertNotLogged('200: unable to upload Bitbucket status')
+
+    @defer.inlineCallbacks
     def test_unable_to_authenticate(self):
         build = yield self.setupBuildResults(SUCCESS)
 


### PR DESCRIPTION
* Before, we were only considering the request failed if it's return
  code wasn't 201. We will now consider the request failed if the return
  code is not 200 and 201.
* This patch resolves an issue where false positive errors were being
  thrown when BitBucket was responding with 200, which the code
  considered an error.

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
    * I took a look and I don't think it's necessary to describe this change in behavior in the documentation.