### PR TITLE
test: Fix incorrect naming of tests

### DIFF
--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -290,21 +290,21 @@ class Build(interfaces.InterfaceTests, TestReactorMixin, unittest.TestCase):
         yield method(*args, **kwargs)
         self.master.mq.assertProductions(exp_events)
 
-    def test_signature_newBuild(self):
+    def test_signature_addBuild(self):
         @self.assertArgSpecMatches(
             self.master.data.updates.addBuild,  # fake
             self.rtype.addBuild)  # real
-        def newBuild(self, builderid, buildrequestid, workerid):
+        def addBuild(self, builderid, buildrequestid, workerid):
             pass
 
-    def test_newBuild(self):
+    def test_addBuild(self):
         return self.do_test_callthrough('addBuild', self.rtype.addBuild,
                                         builderid=10, buildrequestid=13, workerid=20,
                                         exp_kwargs=dict(builderid=10, buildrequestid=13,
                                                         workerid=20, masterid=self.master.masterid,
                                                         state_string='created'))
 
-    def test_newBuildEvent(self):
+    def test_addBuildEvent(self):
 
         @defer.inlineCallbacks
         def addBuild(*args, **kwargs):

--- a/master/buildbot/test/unit/test_data_logs.py
+++ b/master/buildbot/test/unit/test_data_logs.py
@@ -205,15 +205,15 @@ class Log(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
         self.assertIdentical(res, rv)
         m.assert_called_with(*(exp_args or args), **(exp_kwargs or kwargs))
 
-    def test_signature_newLog(self):
+    def test_signature_addLog(self):
         @self.assertArgSpecMatches(
             self.master.data.updates.addLog,  # fake
             self.rtype.addLog)  # real
-        def newLog(self, stepid, name, type):
+        def addLog(self, stepid, name, type):
             pass
 
     @defer.inlineCallbacks
-    def test_newLog_uniquify(self):
+    def test_addLog_uniquify(self):
         tries = []
 
         @self.assertArgSpecMatches(self.master.db.logs.addLog)

--- a/master/buildbot/test/unit/test_data_steps.py
+++ b/master/buildbot/test/unit/test_data_steps.py
@@ -173,15 +173,15 @@ class Step(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
                                              wantData=True)
         self.rtype = steps.Step(self.master)
 
-    def test_signature_newStep(self):
+    def test_signature_addStep(self):
         @self.assertArgSpecMatches(
             self.master.data.updates.addStep,  # fake
             self.rtype.addStep)  # real
-        def newStep(self, buildid, name):
+        def addStep(self, buildid, name):
             pass
 
     @defer.inlineCallbacks
-    def test_newStep(self):
+    def test_addStep(self):
         stepid, number, name = yield self.rtype.addStep(buildid=10,
                                                         name='name')
         msgBody = {
@@ -216,7 +216,7 @@ class Step(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
         })
 
     @defer.inlineCallbacks
-    def test_fake_newStep(self):
+    def test_fake_addStep(self):
         self.assertEqual(
             len((yield self.master.data.updates.addStep(buildid=10,
                                                         name='ten'))),
@@ -226,7 +226,7 @@ class Step(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
         @self.assertArgSpecMatches(
             self.master.data.updates.startStep,  # fake
             self.rtype.startStep)  # real
-        def newStep(self, stepid):
+        def addStep(self, stepid):
             pass
 
     @defer.inlineCallbacks


### PR DESCRIPTION
It looks like some of the data layer tests use an old naming of `new*` which does not match the actual APIs. This PR fixes that.