### PR TITLE
When using Haiku, the "tail" utility is in /bin/tail, not /usr/bin/tail.

### DIFF
--- a/master/buildbot/newsfragments/haiku-bin-tail.bugfix
+++ b/master/buildbot/newsfragments/haiku-bin-tail.bugfix
@@ -1,0 +1,1 @@
+Log watcher looks for the "tail" utility in the right location on Haiku OS.

--- a/master/buildbot/scripts/logwatcher.py
+++ b/master/buildbot/scripts/logwatcher.py
@@ -79,6 +79,8 @@ class LogWatcher(LineOnlyReceiver):
         # an IOError.
         if platform.system().lower() == 'sunos' and os.path.exists('/usr/xpg4/bin/tail'):
             tailBin = "/usr/xpg4/bin/tail"
+        elif platform.system().lower() == 'haiku' and os.path.exists('/bin/tail'):
+            tailBin = "/bin/tail"
         else:
             tailBin = "/usr/bin/tail"
 

--- a/worker/buildbot_worker/scripts/logwatcher.py
+++ b/worker/buildbot_worker/scripts/logwatcher.py
@@ -72,6 +72,8 @@ class LogWatcher(LineOnlyReceiver):
         # an IOError.
         if platform.system().lower() == 'sunos' and os.path.exists('/usr/xpg4/bin/tail'):
             tailBin = "/usr/xpg4/bin/tail"
+        elif platform.system().lower() == 'haiku' and os.path.exists('/bin/tail'):
+            tailBin = "/bin/tail"
         else:
             tailBin = "/usr/bin/tail"
         self.p = reactor.spawnProcess(self.pp, tailBin,


### PR DESCRIPTION
Spending some time to get buildbot-worker up and running on Haiku ( https://haiku-os.org ). The 0.8 series ran fine, once upon a time, so I suspect there are a handful of extremely small issues to clean out, such as this one: Haiku has its "tail" program in a different place than most POSIX systems.

I fixed this on the worker and master, but I'm only trying to get the worker to run on Haiku.

I didn't think this change was worthy of a newsfragment; let me know if I should push one, though!

Thanks,
--ryan.
