### PR TITLE
test_buildbot_net_usage.py: Add "gentoo" to the VERSION_ID check excl…

### DIFF
--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -151,5 +151,5 @@ class Tests(unittest.TestCase):
         self.assertEqual(len(distro), 2)
         self.assertNotIn("unknown", distro[0])
         # Rolling distributions like Arch Linux (arch) does not have VERSION_ID
-        if distro[0] != "arch":
+        if distro[0] not in ["arch", "gentoo"]:
             self.assertNotIn("unknown", distro[1])


### PR DESCRIPTION
…usion

Make the exclusions test into a list (slight speed improvement, easier to extend) and add "gentoo".

Signed-off-by: Brian Dolbec <dolsen@gentoo.org>