### PR TITLE
Initial pyjade port to pypugjs

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1084,6 +1084,7 @@ pyjade
 pylint
 pylint's
 pyparsing
+pypugjs
 pythonpath
 qa
 qmail

--- a/master/buildbot/test/unit/test_www_config.py
+++ b/master/buildbot/test/unit/test_www_config.py
@@ -107,10 +107,10 @@ class IndexResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
     def test_parseCustomTemplateDir(self):
         exp = {'views/builds.html': '<div>\n</div>'}
         try:
-            # we make the test work if pyjade is present or note
-            # It is better than just skip if pyjade is not there
-            import pyjade  # pylint: disable=import-outside-toplevel
-            [pyjade]
+            # we make the test work if pypugjs is present or note
+            # It is better than just skip if pypugjs is not there
+            import pypugjs  # pylint: disable=import-outside-toplevel
+            [pypugjs]
             exp.update({'plugin/views/plugin.html':
                         '<div class="myclass"><pre>this is customized</pre></div>'})
         except ImportError:

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -61,11 +61,11 @@ class IndexResource(resource.Resource):
         res = {}
         allowed_ext = [".html"]
         try:
-            import pyjade   # pylint: disable=import-outside-toplevel
+            import pypugjs  # pylint: disable=import-outside-toplevel
             allowed_ext.append(".jade")
         except ImportError:  # pragma: no cover
-            log.msg("pyjade not installed. Ignoring .jade files from {}".format(template_dir))
-            pyjade = None
+            log.msg("pypugjs not installed. Ignoring .jade files from {}".format(template_dir))
+            pypugjs = None
         for root, dirs, files in os.walk(template_dir):
             if root == template_dir:
                 template_name = posixpath.join("views", "%s.html")
@@ -85,9 +85,9 @@ class IndexResource(resource.Resource):
                 elif ext == ".jade":
                     with open(fn) as f:
                         jade = f.read()
-                        parser = pyjade.parser.Parser(jade)
+                        parser = pypugjs.parser.Parser(jade)
                         block = parser.parse()
-                        compiler = pyjade.ext.html.Compiler(
+                        compiler = pypugjs.ext.html.Compiler(
                             block, pretty=False)
                         html = compiler.compile()
                 res[template_name % (basename,)] = html

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -108,11 +108,11 @@ This server is configured with the ``www`` configuration key, which specifies a 
     You can use this to slightly customize buildbot look for your project, but to add any logic, you will need to create a full-blown plugin.
     if the directory string is relative, it will be joined to the master's basedir.
     Buildbot uses the jade file format natively (which has been renamed to 'pug' in the nodejs ecosystem), but you can also use html format if you prefer.
-    
+
     Either ``*.jade`` files or ``*.html`` files can be used, and will be used to override templates with the same name in the UI.
     On the regular nodejs UI build system, we use nodejs's pug module to compile jade into html.
-    For custom_templates, we use the pyjade interpreter to parse the jade templates, before sending them to the UI.
-    ``pip install pyjade`` is be required to use jade templates.
+    For custom_templates, we use the pypugjs interpreter to parse the jade templates, before sending them to the UI.
+    ``pip install pypugjs`` is be required to use jade templates.
     You can also override plugin's directives, but they have to be in another directory, corresponding to the plugin's name in its ``package.json``.
     For example:
 
@@ -130,6 +130,8 @@ This server is configured with the ``www`` configuration key, which specifies a 
 
         * quotes in attributes are not quoted. https://github.com/syrusakbary/pyjade/issues/132
           This means you should use double quotes for attributes e.g: ``tr(ng-repeat="br in buildrequests | orderBy:'-submitted_at'")``
+
+        * pypugjs may have some differences.  But is is a maintained fork of pyjade. https://github.com/kakulukia/pypugjs
 
 ``change_hook_dialects``
     See :ref:`Change-Hooks`.
@@ -285,7 +287,7 @@ The default templates are very much configurable via the following options.
 .. code-block:: python
 
     {
-        "left_pad"  : 5,  
+        "left_pad"  : 5,
         "left_text": "Build Status",  # text on the left part of the image
         "left_color": "#555",  # color of the left part of the image
         "right_pad" : 5,

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -636,7 +636,7 @@ pyflakes
 Pyflakes
 pyjade
 pypi
-PyPy
+pypugjs
 pysqlite
 pythonic
 Pythonic

--- a/master/setup.py
+++ b/master/setup.py
@@ -490,8 +490,8 @@ test_deps = [
     # http client libraries
     'treq',
     'txrequests',
-    # pyjade required for custom templates tests
-    'pyjade',
+    # pypugjs required for custom templates tests
+    'pypugjs',
     # boto3 and moto required for running EC2 tests
     'boto3',
     'moto',

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -55,7 +55,7 @@ pycodestyle==2.5.0
 pycparser==2.20
 pyenchant==3.0.1
 pyflakes==2.1.1
-pyjade==4.0.0
+pypugjs==5.9.4
 PyJWT==1.7.1
 pylint==2.4.4; python_version >= "3.4"
 pyOpenSSL==19.1.0


### PR DESCRIPTION
Signed-off-by: Brian Dolbec <dolsen@gentoo.org>

This just swaps out the use of pyjade code for a maintained fork of the original pyjade code.
I have a paired down version of this patch which applies to the 2.7.0 release for our Gentoo package repository.  I have tested buildbot both with the test suite and running the example buildbot "Hello world"  master.cfg