### PR TITLE
OpenStackLatentWorker: Support passing full auth parameters

### DIFF
--- a/master/buildbot/newsfragments/openstack.bugfix
+++ b/master/buildbot/newsfragments/openstack.bugfix
@@ -1,0 +1,1 @@
+Updated :py:class:`OpenstackLatentWorker` to use checkConfig/reconfigService structure.

--- a/master/buildbot/newsfragments/os-auth.feature
+++ b/master/buildbot/newsfragments/os-auth.feature
@@ -1,0 +1,1 @@
+Use ``os_auth_args`` to pass in authentication for :py:class:`OpenstackLatentWorker`.

--- a/master/buildbot/test/fake/openstack.py
+++ b/master/buildbot/test/fake/openstack.py
@@ -155,13 +155,22 @@ class NotFound(Exception):
 
 
 def get_plugin_loader(plugin_type):
-    return PasswordLoader()
+    if plugin_type == 'password':
+        return PasswordLoader()
+    if plugin_type == 'token':
+        return TokenLoader()
+    raise ValueError("plugin_type '{}' is not supported".format(plugin_type))
 
 
 class PasswordLoader():
 
     def load_from_options(self, **kwargs):
         return PasswordAuth(**kwargs)
+
+
+class TokenLoader():
+    def load_from_options(self, **kwargs):
+        return TokenAuth(**kwargs)
 
 
 class PasswordAuth():
@@ -174,6 +183,16 @@ class PasswordAuth():
         self.username = username
         self.user_domain_name = user_domain_name
         self.project_domain_name = project_domain_name
+
+
+class TokenAuth():
+    def __init__(self, auth_url, token):
+        self.auth_url = auth_url
+        self.token = token
+        self.project_name = 'tenant'
+        self.username = 'testuser'
+        self.user_domain_name = 'token'
+        self.project_domain_name = 'token'
 
 
 class Session():

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -24,10 +24,12 @@ from buildbot import config
 from buildbot import interfaces
 from buildbot.process.properties import Interpolate
 from buildbot.process.properties import Properties
+from buildbot.test.fake import fakemaster
+from buildbot.test.util.misc import TestReactorMixin
 from buildbot.worker import openstack
 
 
-class TestOpenStackWorker(unittest.TestCase):
+class TestOpenStackWorker(TestReactorMixin, unittest.TestCase):
     os_auth = dict(
         os_username='user',
         os_password='pass',
@@ -39,23 +41,37 @@ class TestOpenStackWorker(unittest.TestCase):
         **os_auth)
 
     def setUp(self):
+        self.setUpTestReactor()
         self.patch(openstack, "client", novaclient)
         self.patch(openstack, "loading", novaclient)
         self.patch(openstack, "session", novaclient)
         self.build = Properties(image=novaclient.TEST_UUIDS['image'])
 
+    @defer.inlineCallbacks
+    def setupWorker(self, *args, **kwargs):
+        worker = openstack.OpenStackLatentWorker(*args, **kwargs)
+        master = fakemaster.make_master(self, wantData=True)
+        fakemaster.master = master
+        worker.setServiceParent(master)
+        yield master.startService()
+        self.addCleanup(master.stopService)
+        return worker
+
+    @defer.inlineCallbacks
     def test_constructor_nonova(self):
         self.patch(openstack, "client", None)
         with self.assertRaises(config.ConfigErrors):
-            openstack.OpenStackLatentWorker('bot', 'pass', **self.bs_image_args)
+            yield self.setupWorker('bot', 'pass', **self.bs_image_args)
 
+    @defer.inlineCallbacks
     def test_constructor_nokeystoneauth(self):
         self.patch(openstack, "loading", None)
         with self.assertRaises(config.ConfigErrors):
-            openstack.OpenStackLatentWorker('bot', 'pass', **self.bs_image_args)
+            yield self.setupWorker('bot', 'pass', **self.bs_image_args)
 
+    @defer.inlineCallbacks
     def test_constructor_minimal(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         self.assertEqual(bs.workername, 'bot')
         self.assertEqual(bs.password, 'pass')
@@ -64,8 +80,9 @@ class TestOpenStackWorker(unittest.TestCase):
         self.assertEqual(bs.block_devices, None)
         self.assertIsInstance(bs.novaclient, novaclient.Client)
 
+    @defer.inlineCallbacks
     def test_constructor_minimal_keystone_v3(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', os_user_domain='test_oud', os_project_domain='test_opd',
             **self.bs_image_args)
         self.assertEqual(bs.workername, 'bot')
@@ -77,16 +94,18 @@ class TestOpenStackWorker(unittest.TestCase):
         self.assertEqual(bs.novaclient.session.auth.user_domain_name, 'test_oud')
         self.assertEqual(bs.novaclient.session.auth.project_domain_name, 'test_opd')
 
+    @defer.inlineCallbacks
     def test_constructor_region(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', region="test-region", **self.bs_image_args)
         self.assertEqual(bs.novaclient.client.region_name, "test-region")
 
+    @defer.inlineCallbacks
     def test_constructor_block_devices_default(self):
         block_devices = [{'uuid': 'uuid', 'volume_size': 10}]
-        bs = openstack.OpenStackLatentWorker('bot', 'pass', flavor=1,
-                                             block_devices=block_devices,
-                                             **self.os_auth)
+        bs = yield self.setupWorker('bot', 'pass', flavor=1,
+                                    block_devices=block_devices,
+                                    **self.os_auth)
         self.assertEqual(bs.image, None)
         self.assertEqual(len(bs.block_devices), 1)
         self.assertEqual(bs.block_devices, [{'boot_index': 0,
@@ -113,9 +132,9 @@ class TestOpenStackWorker(unittest.TestCase):
             self.assertEqual(block_devices[2]['volume_size'], 4)
             self.assertEqual(block_devices[3]['volume_size'], 2)
 
-        lw = openstack.OpenStackLatentWorker('bot', 'pass', flavor=1,
-                                             block_devices=block_devices,
-                                             **self.os_auth)
+        lw = yield self.setupWorker('bot', 'pass', flavor=1,
+                                    block_devices=block_devices,
+                                    **self.os_auth)
         self.assertEqual(lw.image, None)
         self.assertEqual(lw.block_devices, [{'boot_index': 0,
                                              'delete_on_termination': True,
@@ -146,23 +165,24 @@ class TestOpenStackWorker(unittest.TestCase):
             {'source_type': 'image', 'uuid': '9fb2e6e8-110d-4388-8c23-0fcbd1e2fcc1'},
         ]
 
-        lw = openstack.OpenStackLatentWorker('bot', 'pass', flavor=1,
-                                             block_devices=block_devices,
-                                             **self.os_auth)
+        lw = yield self.setupWorker('bot', 'pass', flavor=1,
+                                    block_devices=block_devices,
+                                    **self.os_auth)
         yield self.assertFailure(lw.start_instance(self.build),
                                  novaclient.NotFound)
 
+    @defer.inlineCallbacks
     def test_constructor_no_image(self):
         """
         Must have one of image or block_devices specified.
         """
         with self.assertRaises(ValueError):
-            openstack.OpenStackLatentWorker('bot', 'pass', flavor=1,
-                                            **self.os_auth)
+            yield self.setupWorker('bot', 'pass', flavor=1,
+                                   **self.os_auth)
 
     @defer.inlineCallbacks
     def test_getImage_string(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         image_uuid = yield bs._getImage(self.build)
         self.assertEqual('image-uuid', image_uuid)
@@ -173,8 +193,8 @@ class TestOpenStackWorker(unittest.TestCase):
             filtered = [i for i in images if i.id == 'uuid1']
             return filtered[0].id
 
-        bs = openstack.OpenStackLatentWorker('bot', 'pass', flavor=1,
-                                             image=image_callable, **self.os_auth)
+        bs = yield self.setupWorker('bot', 'pass', flavor=1,
+                                    image=image_callable, **self.os_auth)
         os_client = bs.novaclient
         os_client.images._add_items([
             novaclient.Image('uuid1', 'name1', 1),
@@ -186,22 +206,22 @@ class TestOpenStackWorker(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_getImage_renderable(self):
-        bs = openstack.OpenStackLatentWorker('bot', 'pass', flavor=1,
-                                             image=Interpolate('%(prop:image)s'),
-                                             **self.os_auth)
+        bs = yield self.setupWorker('bot', 'pass', flavor=1,
+                                    image=Interpolate('%(prop:image)s'),
+                                    **self.os_auth)
         image_uuid = yield bs._getImage(self.build)
         self.assertEqual(novaclient.TEST_UUIDS['image'], image_uuid)
 
     @defer.inlineCallbacks
     def test_start_instance_already_exists(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         bs.instance = mock.Mock()
         yield self.assertFailure(bs.start_instance(self.build), ValueError)
 
     @defer.inlineCallbacks
     def test_start_instance_first_fetch_fail(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         bs._poll_resolution = 0
         self.patch(novaclient.Servers, 'fail_to_get', True)
@@ -211,7 +231,7 @@ class TestOpenStackWorker(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_start_instance_fail_to_find(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         bs._poll_resolution = 0
         self.patch(novaclient.Servers, 'fail_to_get', True)
@@ -220,7 +240,7 @@ class TestOpenStackWorker(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_start_instance_fail_to_start(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         bs._poll_resolution = 0
         self.patch(novaclient.Servers, 'fail_to_start', True)
@@ -229,7 +249,7 @@ class TestOpenStackWorker(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_start_instance_success(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         bs._poll_resolution = 0
         uuid, image_uuid, time_waiting = yield bs.start_instance(self.build)
@@ -240,8 +260,8 @@ class TestOpenStackWorker(unittest.TestCase):
     @defer.inlineCallbacks
     def test_start_instance_check_meta(self):
         meta_arg = {'some_key': 'some-value'}
-        bs = openstack.OpenStackLatentWorker('bot', 'pass', meta=meta_arg,
-                                             **self.bs_image_args)
+        bs = yield self.setupWorker('bot', 'pass', meta=meta_arg,
+                                    **self.bs_image_args)
         bs._poll_resolution = 0
         uuid, image_uuid, time_waiting = yield bs.start_instance(self.build)
         self.assertIn('meta', bs.instance.boot_kwargs)
@@ -252,14 +272,15 @@ class TestOpenStackWorker(unittest.TestCase):
         """
         Test stopping the instance but with no instance to stop.
         """
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         bs.instance = None
         stopped = yield bs.stop_instance()
         self.assertEqual(stopped, None)
 
+    @defer.inlineCallbacks
     def test_stop_instance_missing(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         instance = mock.Mock()
         instance.id = 'uuid'
@@ -267,8 +288,9 @@ class TestOpenStackWorker(unittest.TestCase):
         # TODO: Check log for instance not found.
         bs.stop_instance()
 
+    @defer.inlineCallbacks
     def test_stop_instance_fast(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         # Make instance immediately active.
         self.patch(novaclient.Servers, 'gets_until_active', 0)
@@ -278,8 +300,9 @@ class TestOpenStackWorker(unittest.TestCase):
         bs.stop_instance(fast=True)
         self.assertNotIn(inst.id, s.instances)
 
+    @defer.inlineCallbacks
     def test_stop_instance_notfast(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         # Make instance immediately active.
         self.patch(novaclient.Servers, 'gets_until_active', 0)
@@ -289,8 +312,9 @@ class TestOpenStackWorker(unittest.TestCase):
         bs.stop_instance(fast=False)
         self.assertNotIn(inst.id, s.instances)
 
+    @defer.inlineCallbacks
     def test_stop_instance_unknown(self):
-        bs = openstack.OpenStackLatentWorker(
+        bs = yield self.setupWorker(
             'bot', 'pass', **self.bs_image_args)
         # Make instance immediately active.
         self.patch(novaclient.Servers, 'gets_until_active', 0)

--- a/master/buildbot/test/unit/test_worker_openstack.py
+++ b/master/buildbot/test/unit/test_worker_openstack.py
@@ -35,6 +35,12 @@ class TestOpenStackWorker(TestReactorMixin, unittest.TestCase):
         os_password='pass',
         os_tenant_name='tenant',
         os_auth_url='auth')
+
+    os_auth_custom = dict(
+        token='openstack-token',
+        auth_type='token',
+        auth_url='auth')
+
     bs_image_args = dict(
         flavor=1,
         image='image-uuid',
@@ -93,6 +99,19 @@ class TestOpenStackWorker(TestReactorMixin, unittest.TestCase):
         self.assertIsInstance(bs.novaclient, novaclient.Client)
         self.assertEqual(bs.novaclient.session.auth.user_domain_name, 'test_oud')
         self.assertEqual(bs.novaclient.session.auth.project_domain_name, 'test_opd')
+
+    @defer.inlineCallbacks
+    def test_constructor_token_keystone_v3(self):
+        bs = yield self.setupWorker(
+            'bot', 'pass', os_auth_args=self.os_auth_custom, **self.bs_image_args)
+        self.assertEqual(bs.workername, 'bot')
+        self.assertEqual(bs.password, 'pass')
+        self.assertEqual(bs.flavor, 1)
+        self.assertEqual(bs.image, 'image-uuid')
+        self.assertEqual(bs.block_devices, None)
+        self.assertIsInstance(bs.novaclient, novaclient.Client)
+        self.assertEqual(bs.novaclient.session.auth.user_domain_name, 'token')
+        self.assertEqual(bs.novaclient.session.auth.project_domain_name, 'token')
 
     @defer.inlineCallbacks
     def test_constructor_region(self):

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -107,6 +107,7 @@ class OpenStackLatentWorker(AbstractLatentWorker,
         self.flavor = flavor
         self.client_version = client_version
         if client:
+            os_username, os_password = yield self.renderSecrets(os_username, os_password)
             self.novaclient = self._constructClient(
                 client_version, os_username, os_user_domain, os_password, os_tenant_name, os_project_domain,
                 os_auth_url)

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -52,24 +52,23 @@ class OpenStackLatentWorker(AbstractLatentWorker,
     instance = None
     _poll_resolution = 5  # hook point for tests
 
-    def __init__(self, name, password,
-                 flavor,
-                 os_username,
-                 os_password,
-                 os_tenant_name,
-                 os_auth_url,
-                 os_user_domain=None,
-                 os_project_domain=None,
-                 block_devices=None,
-                 region=None,
-                 image=None,
-                 meta=None,
-                 # Have a nova_args parameter to allow passing things directly
-                 # to novaclient.
-                 nova_args=None,
-                 client_version='2',
-                 **kwargs):
-
+    def checkConfig(self, name, password,
+                    flavor,
+                    os_username,
+                    os_password,
+                    os_tenant_name,
+                    os_auth_url,
+                    os_user_domain=None,
+                    os_project_domain=None,
+                    block_devices=None,
+                    region=None,
+                    image=None,
+                    meta=None,
+                    # Have a nova_args parameter to allow passing things directly
+                    # to novaclient.
+                    nova_args=None,
+                    client_version='2',
+                    **kwargs):
         if not client:
             config.error("The python module 'novaclient' is needed  "
                          "to use a OpenStackLatentWorker. "
@@ -79,17 +78,38 @@ class OpenStackLatentWorker(AbstractLatentWorker,
                          "to use a OpenStackLatentWorker. "
                          "Please install the 'keystoneauth1' package.")
 
-        if not block_devices and not image:
+        if block_devices is None and image is None:
             raise ValueError('One of block_devices or image must be given')
 
-        super().__init__(name, password, **kwargs)
+        super().checkConfig(name, password, **kwargs)
+
+    @defer.inlineCallbacks
+    def reconfigService(self, name, password,
+                        flavor,
+                        os_username,
+                        os_password,
+                        os_tenant_name,
+                        os_auth_url,
+                        os_user_domain=None,
+                        os_project_domain=None,
+                        block_devices=None,
+                        region=None,
+                        image=None,
+                        meta=None,
+                        # Have a nova_args parameter to allow passing things directly
+                        # to novaclient.
+                        nova_args=None,
+                        client_version='2',
+                        **kwargs):
+
+        yield super().reconfigService(name, password, **kwargs)
 
         self.flavor = flavor
         self.client_version = client_version
         if client:
-            self.novaclient = self._constructClient(client_version, os_username, os_user_domain,
-                                                    os_password, os_tenant_name, os_project_domain,
-                                                    os_auth_url)
+            self.novaclient = self._constructClient(
+                client_version, os_username, os_user_domain, os_password, os_tenant_name, os_project_domain,
+                os_auth_url)
             if region is not None:
                 self.novaclient.client.region_name = region
 
@@ -102,18 +122,15 @@ class OpenStackLatentWorker(AbstractLatentWorker,
         self.meta = meta
         self.nova_args = nova_args if nova_args is not None else {}
 
-    @staticmethod
-    def _constructClient(client_version, username, user_domain, password, project_name,
-                         project_domain, auth_url):
+    def _constructClient(self, client_version, username, user_domain, password, project_name, project_domain,
+                         auth_url):
         """Return a novaclient from the given args."""
         loader = loading.get_plugin_loader('password')
 
         # These only work with v3
         if user_domain is not None or project_domain is not None:
-            auth = loader.load_from_options(auth_url=auth_url, username=username,
-                                            user_domain_name=user_domain, password=password,
-                                            project_name=project_name,
-                                            project_domain_name=project_domain)
+            auth = loader.load_from_options(auth_url=auth_url, username=username, user_domain_name=user_domain,
+                                            password=password, project_name=project_name, project_domain_name=project_domain)
         else:
             auth = loader.load_from_options(auth_url=auth_url, username=username,
                                             password=password, project_name=project_name)

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -54,12 +54,13 @@ class OpenStackLatentWorker(AbstractLatentWorker,
 
     def checkConfig(self, name, password,
                     flavor,
-                    os_username,
-                    os_password,
-                    os_tenant_name,
-                    os_auth_url,
+                    os_username=None,
+                    os_password=None,
+                    os_tenant_name=None,
+                    os_auth_url=None,
                     os_user_domain=None,
                     os_project_domain=None,
+                    os_auth_args=None,
                     block_devices=None,
                     region=None,
                     image=None,
@@ -81,17 +82,30 @@ class OpenStackLatentWorker(AbstractLatentWorker,
         if block_devices is None and image is None:
             raise ValueError('One of block_devices or image must be given')
 
+        if os_auth_args is None:
+            if os_auth_url is None:
+                config.error("Missing os_auth_url OpenStackLatentWorker "
+                             "and os_auth_args not provided.")
+            if os_username is None or os_password is None:
+                config.error("Missing os_username / os_password for OpenStackLatentWorker "
+                             "and os_auth_args not provided.")
+        else:
+            # ensure that at least auth_url is provided
+            if os_auth_args.get('auth_url') is None:
+                config.error("Missing 'auth_url' from os_auth_args for OpenStackLatentWorker")
+
         super().checkConfig(name, password, **kwargs)
 
     @defer.inlineCallbacks
     def reconfigService(self, name, password,
                         flavor,
-                        os_username,
-                        os_password,
-                        os_tenant_name,
-                        os_auth_url,
+                        os_username=None,
+                        os_password=None,
+                        os_tenant_name=None,
+                        os_auth_url=None,
                         os_user_domain=None,
                         os_project_domain=None,
+                        os_auth_args=None,
                         block_devices=None,
                         region=None,
                         image=None,
@@ -101,16 +115,26 @@ class OpenStackLatentWorker(AbstractLatentWorker,
                         nova_args=None,
                         client_version='2',
                         **kwargs):
-
         yield super().reconfigService(name, password, **kwargs)
+
+        if os_auth_args is None:
+            os_auth_args = {
+                    'auth_url': os_auth_url,
+                    'username': os_username,
+                    'password': os_password
+            }
+            if os_tenant_name is not None:
+                os_auth_args['project_name'] = os_tenant_name
+            if os_user_domain is not None:
+                os_auth_args['user_domain_name'] = os_user_domain
+            if os_project_domain is not None:
+                os_auth_args['project_domain_name'] = os_project_domain
 
         self.flavor = flavor
         self.client_version = client_version
         if client:
-            os_username, os_password = yield self.renderSecrets(os_username, os_password)
-            self.novaclient = self._constructClient(
-                client_version, os_username, os_user_domain, os_password, os_tenant_name, os_project_domain,
-                os_auth_url)
+            os_auth_args = yield self.renderSecrets(os_auth_args)
+            self.novaclient = self._constructClient(client_version, os_auth_args)
             if region is not None:
                 self.novaclient.client.region_name = region
 
@@ -123,18 +147,13 @@ class OpenStackLatentWorker(AbstractLatentWorker,
         self.meta = meta
         self.nova_args = nova_args if nova_args is not None else {}
 
-    def _constructClient(self, client_version, username, user_domain, password, project_name, project_domain,
-                         auth_url):
+    def _constructClient(self, client_version, auth_args):
         """Return a novaclient from the given args."""
-        loader = loading.get_plugin_loader('password')
 
-        # These only work with v3
-        if user_domain is not None or project_domain is not None:
-            auth = loader.load_from_options(auth_url=auth_url, username=username, user_domain_name=user_domain,
-                                            password=password, project_name=project_name, project_domain_name=project_domain)
-        else:
-            auth = loader.load_from_options(auth_url=auth_url, username=username,
-                                            password=password, project_name=project_name)
+        auth_plugin = auth_args.pop('auth_type', 'password')
+        loader = loading.get_plugin_loader(auth_plugin)
+
+        auth = loader.load_from_options(**auth_args)
 
         sess = session.Session(auth=auth)
         return client.Client(client_version, session=sess)

--- a/master/docs/manual/configuration/workers-openstack.rst
+++ b/master/docs/manual/configuration/workers-openstack.rst
@@ -72,6 +72,14 @@ These are the same details set in either environment variables or passed as opti
     The OpenStack authentication needed to create and delete instances.
     These are the same as the environment variables with uppercase names of the arguments.
 
+``os_auth_args``
+    Arguments passed directly to keystone.
+    If this is specified, other authentication parameters (see above) are ignored.
+    You can use ``auth_type`` to specify auth plugin to load.
+    See `OpenStack documentation <https://docs.openstack.org/python-keystoneclient/>` for more information.
+    Usually this should contain ``auth_url``, ``username``, ``password``, ``project_domain_name``
+    and ``user_domain_name``.
+
 ``block_devices``
     A list of dictionaries.
     Each dictionary specifies a block device to set up during instance creation.


### PR DESCRIPTION
Allow passing in any openstack supported keystone options. This is needed to support more than username/password authencation e.g. token based authentication or using application credentials.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
