### PR TITLE
Implement files for GitHub PRs in github web hook

### DIFF
--- a/master/buildbot/newsfragments/add_filenames.bugfix
+++ b/master/buildbot/newsfragments/add_filenames.bugfix
@@ -1,0 +1,1 @@
+Fix :py:class:`GitHubEventHandler` to include files in `Change` that comes from a github PR (:issue:`5294`)

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -449,6 +449,12 @@ gitJsonPayloadCommit = {
     "files": []
 }
 
+gitJsonPayloadFiles = [
+  {
+    "filename": "README.md"
+  }
+]
+
 gitPRproperties = {
     'github.head.sha': '05c588ba8cd510ecbe112d020f215facb17817a7',
     'github.state': 'open',
@@ -857,19 +863,24 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
                          "Update the README with new information\n"
                          "This is a pretty simple change that we need to pull into master.")
         self.assertEqual(change["branch"], "refs/pull/50/merge")
+        self.assertEqual(change['files'], ['README.md'])
         self.assertEqual(change["revlink"],
                          "https://github.com/defunkt/github/pull/50")
         self.assertEqual(change['properties']['basename'], "master")
         self.assertDictSubset(gitPRproperties, change["properties"])
 
     def test_git_with_pull_encoded(self):
-        api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
-        self._http.expect('get', api_endpoint, content_json=gitJsonPayloadCommit)
+        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
         self._check_git_with_pull([gitJsonPayloadPullRequest])
 
     def test_git_with_pull_json(self):
-        api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
-        self._http.expect('get', api_endpoint, content_json=gitJsonPayloadCommit)
+        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
         self._check_git_with_pull(gitJsonPayloadPullRequest)
 
     @defer.inlineCallbacks
@@ -932,8 +943,12 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(
     @defer.inlineCallbacks
     def test_git_pull_request_with_custom_ref(self):
         commit = deepcopy([gitJsonPayloadPullRequest])
-        api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
-        self._http.expect('get', api_endpoint, content_json=gitJsonPayloadCommit)
+
+        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
+
         self.request = _prepare_request('pull_request', commit)
         yield self.request.test_render(self.changeHook)
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
@@ -1014,11 +1029,14 @@ class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase,
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request_no_skip(self):
-        api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
+
         commit = deepcopy(gitJsonPayloadCommit)
         commit['commit']['message'] = 'black magic [skip bb]'  # pattern not matched
 
-        self._http.expect('get', api_endpoint, content_json=commit)
         self._check_pull_request_no_skip(gitJsonPayloadPullRequest)
 
 
@@ -1050,9 +1068,11 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request(self):
-        api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
 
-        self._http.expect('get', api_endpoint, content_json=gitJsonPayloadCommit)
         self._check_pull_request(gitJsonPayloadPullRequest)
 
 
@@ -1082,9 +1102,11 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase,
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request(self):
-        api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
 
-        self._http.expect('get', api_endpoint, content_json=gitJsonPayloadCommit)
         self._check_pull_request(gitJsonPayloadPullRequest)
 
 
@@ -1118,9 +1140,11 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase,
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request(self):
-        api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
 
-        self._http.expect('get', api_endpoint, content_json=gitJsonPayloadCommit)
         self._check_pull_request(gitJsonPayloadPullRequest)
 
 

--- a/master/buildbot/test/unit/test_www_hooks_github.py
+++ b/master/buildbot/test/unit/test_www_hooks_github.py
@@ -450,9 +450,9 @@ gitJsonPayloadCommit = {
 }
 
 gitJsonPayloadFiles = [
-  {
-    "filename": "README.md"
-  }
+    {
+        "filename": "README.md"
+    }
 ]
 
 gitPRproperties = {
@@ -870,17 +870,17 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
         self.assertDictSubset(gitPRproperties, change["properties"])
 
     def test_git_with_pull_encoded(self):
-        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
-        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
-        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
-        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
+        commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_endpoint, content_json=gitJsonPayloadFiles)
         self._check_git_with_pull([gitJsonPayloadPullRequest])
 
     def test_git_with_pull_json(self):
-        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
-        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
-        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
-        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
+        commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_endpoint, content_json=gitJsonPayloadFiles)
         self._check_git_with_pull(gitJsonPayloadPullRequest)
 
     @defer.inlineCallbacks
@@ -944,10 +944,10 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(
     def test_git_pull_request_with_custom_ref(self):
         commit = deepcopy([gitJsonPayloadPullRequest])
 
-        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
-        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
-        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
-        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
+        commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_endpoint, content_json=gitJsonPayloadFiles)
 
         self.request = _prepare_request('pull_request', commit)
         yield self.request.test_render(self.changeHook)
@@ -1029,10 +1029,10 @@ class TestChangeHookConfiguredWithCustomSkips(unittest.TestCase,
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request_no_skip(self):
-        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
-        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
-        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
-        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
+        commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_endpoint, content_json=gitJsonPayloadFiles)
 
         commit = deepcopy(gitJsonPayloadCommit)
         commit['commit']['message'] = 'black magic [skip bb]'  # pattern not matched
@@ -1068,10 +1068,10 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request(self):
-        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
-        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
-        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
-        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
+        commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_endpoint, content_json=gitJsonPayloadFiles)
 
         self._check_pull_request(gitJsonPayloadPullRequest)
 
@@ -1102,10 +1102,10 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase,
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request(self):
-        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
-        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
-        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
-        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
+        commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_endpoint, content_json=gitJsonPayloadFiles)
 
         self._check_pull_request(gitJsonPayloadPullRequest)
 
@@ -1140,10 +1140,10 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase,
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request(self):
-        commit_api_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
-        files_api_endpoint = '/repos/defunkt/github/pulls/50/files'
-        self._http.expect('get', commit_api_endpoint, content_json=gitJsonPayloadCommit)
-        self._http.expect('get', files_api_endpoint, content_json=gitJsonPayloadFiles)
+        commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_endpoint, content_json=gitJsonPayloadCommit)
+        self._http.expect('get', files_endpoint, content_json=gitJsonPayloadFiles)
 
         self._check_pull_request(gitJsonPayloadPullRequest)
 

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -251,7 +251,7 @@ class GitHubEventHandler(PullRequestMixin):
         Get Files that belong to the Pull Request
         :param repo: the repo full name, ``{owner}/{project}``.
             e.g. ``buildbot/buildbot``
-        :param numer: the pullrequest number.
+        :param number: the pull request number.
         """
         headers = {"User-Agent": "Buildbot"}
         if self._token:

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -192,6 +192,8 @@ class GitHubEventHandler(PullRequestMixin):
             log.msg("GitHub PR #{} {}, ignoring".format(number, action))
             return (changes, 'git')
 
+        files = yield self._get_pr_files(repo_full_name, number)
+
         properties = self.extractProperties(payload['pull_request'])
         properties.update({'event': event})
         properties.update({'basename': basename})
@@ -199,6 +201,7 @@ class GitHubEventHandler(PullRequestMixin):
             'revision': payload['pull_request']['head']['sha'],
             'when_timestamp': dateparse(payload['pull_request']['created_at']),
             'branch': refname,
+            'files': files,
             'revlink': payload['pull_request']['_links']['html']['href'],
             'repository': payload['repository']['html_url'],
             'project': payload['pull_request']['base']['repo']['full_name'],
@@ -241,6 +244,30 @@ class GitHubEventHandler(PullRequestMixin):
         data = yield res.json()
         msg = data.get('commit', {'message': 'No message field'})['message']
         return msg
+
+    @defer.inlineCallbacks
+    def _get_pr_files(self, repo, number):
+        """
+        Get Files that belong to the Pull Request
+        :param repo: the repo full name, ``{owner}/{project}``.
+            e.g. ``buildbot/buildbot``
+        :param numer: the pullrequest number.
+        """
+        headers = {"User-Agent": "Buildbot"}
+        if self._token:
+            headers["Authorization"] = "token " + self._token
+
+        url = "/repos/{}/pulls/{}/files".format(repo, number)
+        http = yield httpclientservice.HTTPClientService.getService(
+            self.master,
+            self.github_api_endpoint,
+            headers=headers,
+            debug=self.debug,
+            verify=self.verify,
+        )
+        res = yield http.get(url)
+        data = yield res.json()
+        return [f["filename"] for f in data]
 
     def _process_change(self, payload, user, repo, repo_url, project, event,
                         properties):


### PR DESCRIPTION
The github webhook now populates Changes with filenames for
PullRequests. This was already implemented for Github Push events.

The PullRequest webhook doesn't have a files changed field.
It's only possible to get the changed files for a pull request by
querying:

/repos/{organisation}/{repo}/pulls/{number}/files

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
