### PR TITLE
Fix Cache-control header to be compliant with RFC 7234

### DIFF
--- a/master/buildbot/newsfragments/cache_control.bugfix
+++ b/master/buildbot/newsfragments/cache_control.bugfix
@@ -1,0 +1,1 @@
+Fix Cache-control header to be compliant with RFC 7234 (:issue:`5220`) 

--- a/master/buildbot/www/config.py
+++ b/master/buildbot/www/config.py
@@ -117,7 +117,7 @@ class IndexResource(resource.Resource):
     def renderIndex(self, request):
         config = {}
         request.setHeader(b"content-type", b'text/html')
-        request.setHeader(b"Cache-Control", b"public;max-age=0")
+        request.setHeader(b"Cache-Control", b"public,max-age=0")
 
         try:
             yield self.config['auth'].maybeAutoLogin(request)


### PR DESCRIPTION
Trivial change ; -> ,

According to ABNF Cache-Control comma should be used as delimiter (not semicolon).

Cache-Control = *( "," OWS ) cache-directive *( OWS "," [ OWS
    cache-directive ] )
 cache-directive = token [ "=" ( token / quoted-string ) ]

See: https://tools.ietf.org/html/rfc7234#appendix-C

Fixes #5220


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
