### PR TITLE
Renderable Comparison

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -882,6 +882,7 @@ microsoft
 middleware
 miguel
 milner
+mimic
 mingw
 minidom
 minidom's

--- a/master/buildbot/newsfragments/RenderableOperatorsMixin.feature
+++ b/master/buildbot/newsfragments/RenderableOperatorsMixin.feature
@@ -1,0 +1,1 @@
+:class:`Property` and :class:`Interpolate` objects can now be compared. This will generate a renderable that will be evaluated at runtime. see :ref:`RenderableComparison`.

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -470,7 +470,6 @@ class Build(properties.PropertiesMixin):
             step = factory.buildStep()
             step.setBuild(self)
             step.setWorker(self.workerforbuilder.worker)
-            self.setUniqueStepName(step)
             steps.append(step)
 
             if self.useProgress:

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -504,6 +504,7 @@ class BuildStep(results.ResultComputingConfigMixin,
         # create and start the step, noting that the name may be altered to
         # ensure uniqueness
         self.name = yield self.build.render(self.name)
+        self.build.setUniqueStepName(self)
         self.stepid, self.number, self.name = yield self.master.data.updates.addStep(
             buildid=self.build.buildid,
             name=util.bytes2unicode(self.name))

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -128,6 +128,9 @@ class FakeBuild(properties.PropertiesMixin):
     def getWorkerInfo(self):
         return self.workerforbuilder.worker.worker_status.info
 
+    def setUniqueStepName(self, step):
+        pass
+
 
 components.registerAdapter(
     lambda build: build.build_status.properties,

--- a/master/buildbot/test/integration/test_stop_build.py
+++ b/master/buildbot/test/integration/test_stop_build.py
@@ -41,7 +41,7 @@ class ShellMaster(RunMasterBase):
         build = yield self.doForceBuild(wantSteps=True, wantLogs=True, wantProperties=True)
         self.assertEqual(build['buildid'], 1)
 
-        # make sure the cancel reason is transfered all the way to the step log
+        # make sure the cancel reason is transferred all the way to the step log
         cancel_log = build['steps'][1]['logs'][-1]
         self.assertEqual(cancel_log['name'], 'cancelled')
         self.assertIn('cancelled by test', cancel_log['contents']['content'])

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -831,7 +831,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
         self.assertEqual(b.results, SUCCESS)
-        expected_names = ["a", "b", "c_1", "c_2", "c"]
+        expected_names = ["a", "b", "c", "c_1", "c_2"]
         executed_names = [s.name for s in b.executedSteps]
         self.assertEqual(executed_names, expected_names)
 

--- a/master/buildbot/test/unit/test_process_properties.py
+++ b/master/buildbot/test/unit/test_process_properties.py
@@ -1262,7 +1262,9 @@ class TestProperty(unittest.TestCase):
     @defer.inlineCallbacks
     def testCompLt(self):
         self.props.setProperty("do-tests", 1, "scheduler")
-        result = yield self.build.render(Property("do-tests") < 2)
+        x = Property("do-tests") < 2
+        self.assertEqual(repr(x), 'Property(do-tests) < 2')
+        result = yield self.build.render(x)
         self.assertEqual(result, True)
 
     @defer.inlineCallbacks
@@ -1302,6 +1304,57 @@ class TestProperty(unittest.TestCase):
         self.props.setProperty("do-tests", 1, "scheduler")
         result = yield self.build.render(Property("do-tests") >= Property("do-tests"))
         self.assertEqual(result, True)
+
+    @defer.inlineCallbacks
+    def testPropAdd(self):
+        self.props.setProperty("do-tests", 1, "scheduler")
+        result = yield self.build.render(Property("do-tests") + Property("do-tests"))
+        self.assertEqual(result, 2)
+
+    @defer.inlineCallbacks
+    def testPropSub(self):
+        self.props.setProperty("do-tests", 1, "scheduler")
+        result = yield self.build.render(Property("do-tests") - Property("do-tests"))
+        self.assertEqual(result, 0)
+
+    @defer.inlineCallbacks
+    def testPropDiv(self):
+        self.props.setProperty("do-tests", 1, "scheduler")
+        self.props.setProperty("do-tests2", 3, "scheduler")
+        result = yield self.build.render(Property("do-tests") / Property("do-tests2"))
+        self.assertEqual(result, 1 / 3)
+
+    @defer.inlineCallbacks
+    def testPropFDiv(self):
+        self.props.setProperty("do-tests", 5, "scheduler")
+        self.props.setProperty("do-tests2", 2, "scheduler")
+        result = yield self.build.render(Property("do-tests") // Property("do-tests2"))
+        self.assertEqual(result, 2)
+
+    @defer.inlineCallbacks
+    def testPropMod(self):
+        self.props.setProperty("do-tests", 5, "scheduler")
+        self.props.setProperty("do-tests2", 3, "scheduler")
+        result = yield self.build.render(Property("do-tests") % Property("do-tests2"))
+        self.assertEqual(result, 2)
+
+    @defer.inlineCallbacks
+    def testPropMult(self):
+        self.props.setProperty("do-tests", 2, "scheduler")
+        result = yield self.build.render(Property("do-tests") * Interpolate("%(prop:do-tests)s"))
+        self.assertEqual(result, '22')
+
+    @defer.inlineCallbacks
+    def testPropIn(self):
+        self.props.setProperty("do-tests", 2, "scheduler")
+        result = yield self.build.render(Property("do-tests").in_([1, 2]))
+        self.assertEqual(result, True)
+
+    @defer.inlineCallbacks
+    def testPropIn2(self):
+        self.props.setProperty("do-tests", 2, "scheduler")
+        result = yield self.build.render(Property("do-tests").in_([1, 3]))
+        self.assertEqual(result, False)
 
 
 class TestRenderableAdapters(unittest.TestCase):

--- a/master/buildbot/util/__init__.py
+++ b/master/buildbot/util/__init__.py
@@ -184,6 +184,17 @@ class ComparableMixin:
             return False
         return self_list == them_list
 
+    @staticmethod
+    def isEquivalent(us, them):
+        if isinstance(them, ComparableMixin):
+            them, us = us, them
+        if isinstance(us, ComparableMixin):
+            (isComparable, us_list, them_list) = us._cmp_common(them)
+            if not isComparable:
+                return False
+            return all(ComparableMixin.isEquivalent(v, them_list[i]) for i, v in enumerate(us_list))
+        return us == them
+
     def __ne__(self, them):
         (isComparable, self_list, them_list) = self._cmp_common(them)
         if not isComparable:

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -197,7 +197,7 @@ class BuildbotService(AsyncMultiService, config.ConfiguredMixin, util.Comparable
         # only reconfigure if sibling is configured differently.
         # sibling == self is using ComparableMixin's implementation
         # only compare compare_attrs
-        if self.configured and sibling == self:
+        if self.configured and util.ComparableMixin.isEquivalent(sibling, self):
             return None
         self.configured = True
         # render renderables in parallel
@@ -467,7 +467,7 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
                 added_names.add(n)
             # compare using ComparableMixin if they don't support reconfig
             elif not hasattr(old, 'reconfigServiceWithBuildbotConfig'):
-                if old != new:
+                if not util.ComparableMixin.isEquivalent(old, new):
                     removed_names.add(n)
                     added_names.add(n)
 

--- a/master/docs/manual/configuration/properties.rst
+++ b/master/docs/manual/configuration/properties.rst
@@ -534,3 +534,30 @@ For this you can use a special custom renderer as following:
     from buildbot.plugins import *
 
     ShellCommand(command=['make', util.Interpolate('BUILDURL=%(kw:url)s', url=util.URLForBuild)])
+
+
+.. _RenderableComparison:
+
+Renderable Comparison
++++++++++++++++++++++
+
+Its common to need to make basic comparison or calculation with properties.
+The :class:`Property` and :class:`Interpolate` objects contain necessary operator overload to make this possible
+
+.. code-block:: python
+
+    from buildbot.plugins import *
+
+    ShellCommand(command=['make'], doStepIf=Interpolate("worker:os_id")  == 'ubuntu')
+
+In previous code, the value of the comparison can only be computed at runtime, so the result of the comparison is actually a renderable which will be computed at the start of the step.
+
+.. code-block:: python
+
+    from buildbot.plugins import *
+
+    ShellCommand(command=['make'], doStepIf=Interpolate("worker:os_id").in_(['debian', 'ubuntu']))
+
+'in' operator cannot be overloaded, so we add a simple ``in_`` method to :class:`Property` and :class:`Interpolate`.
+
+Currently supported operators are ``, ``==``, ``!=``, ``<``, ``<=``, ``>``, ``>=``, ``+``, ``-``, ``*``, ``/``, ``//``, ``%``.


### PR DESCRIPTION
From discussion with @cmouse on IRC, the UX is not very good when trying to compare Interpolate objects
There is a need to create a rendered function for things that can be expressed simply with operators.

The feature was actually already there but barely documented, and working only for Property object

Playing with tests, I realized that this feature of Property was actually

clashing with ComparableMixin, which resulted in unnecesary reconfiguration if Property was used in step arguments.


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
