### PR TITLE
GitHub status push

### DIFF
--- a/master/buildbot/newsfragments/Improve_resiliency_of_GitHubStatusPush.bugfix
+++ b/master/buildbot/newsfragments/Improve_resiliency_of_GitHubStatusPush.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in GitHubStatusPush that would cause silent failures for builders that specified multiple codebases.

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -129,7 +129,6 @@ class GitHubStatusPush(http.HttpStatusPushBase):
         for sourcestamp in sourcestamps:
             project = sourcestamp['project']
 
-            # If branch is None, so is issue
             issue = None
             if 'branch' in props:
                 m = re.search(r"refs/pull/([0-9]*)/merge", props['branch'])

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -123,47 +123,57 @@ class GitHubStatusPush(http.HttpStatusPushBase):
         context = yield props.render(self.context)
 
         sourcestamps = build['buildset'].get('sourcestamps')
-
-        if not sourcestamps or not sourcestamps[0]:
+        if not sourcestamps:
             return
 
-        project = sourcestamps[0]['project']
-
-        branch = props['branch']
-        m = re.search(r"refs/pull/([0-9]*)/merge", branch)
-        if m:
-            issue = m.group(1)
-        else:
-            issue = None
-
-        if "/" in project:
-            repoOwner, repoName = project.split('/')
-        else:
-            giturl = giturlparse(sourcestamps[0]['repository'])
-            repoOwner = giturl.owner
-            repoName = giturl.repo
-
-        if self.verbose:
-            log.msg("Updating github status: repoOwner={repoOwner}, repoName={repoName}".format(
-                repoOwner=repoOwner, repoName=repoName))
-
         for sourcestamp in sourcestamps:
+            project = sourcestamp['project']
+
+            # If branch is None, so is issue
+            issue = None
+            if 'branch' in props:
+                m = re.search(r"refs/pull/([0-9]*)/merge", props['branch'])
+                if m:
+                    issue = m.group(1)
+
+            repoOwner = None
+            repoName = None
+            if "/" in project:
+                repoOwner, repoName = project.split('/')
+            else:
+                giturl = giturlparse(sourcestamp['repository'])
+                if giturl:
+                    repoOwner = giturl.owner
+                    repoName = giturl.repo
+
             sha = sourcestamp['revision']
             response = None
+
+            # If the scheduler specifies multiple codebases, don't bother updating
+            # the ones for which there is no revision
+            if not sha:
+                log.msg(
+                    'Skipped status update for codebase {codebase}, '
+                    'context "{context}", issue {issue}.'.format(
+                        codebase=sourcestamp['codebase'], issue=issue, context=context))
+                continue
+
             try:
+                if self.verbose:
+                    log.msg("Updating github status: repoOwner={repoOwner}, repoName={repoName}".format(
+                        repoOwner=repoOwner, repoName=repoName))
+
                 repo_user = repoOwner
                 repo_name = repoName
                 target_url = build['url']
-                response = yield self.createStatus(
-                    repo_user=repo_user,
-                    repo_name=repo_name,
-                    sha=sha,
-                    state=state,
-                    target_url=target_url,
-                    context=context,
-                    issue=issue,
-                    description=description
-                )
+                response = yield self.createStatus(repo_user=repo_user,
+                                                   repo_name=repo_name,
+                                                   sha=sha,
+                                                   state=state,
+                                                   target_url=target_url,
+                                                   context=context,
+                                                   issue=issue,
+                                                   description=description)
 
                 if not self.isStatus2XX(response.code):
                     raise Exception()

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -136,15 +136,15 @@ class GitHubStatusPush(http.HttpStatusPushBase):
                 if m:
                     issue = m.group(1)
 
-            repoOwner = None
-            repoName = None
+            repo_owner = None
+            repo_name = None
             if "/" in project:
-                repoOwner, repoName = project.split('/')
+                repo_owner, repo_name = project.split('/')
             else:
                 giturl = giturlparse(sourcestamp['repository'])
                 if giturl:
-                    repoOwner = giturl.owner
-                    repoName = giturl.repo
+                    repo_owner = giturl.owner
+                    repo_name = giturl.repo
 
             sha = sourcestamp['revision']
             response = None
@@ -160,17 +160,14 @@ class GitHubStatusPush(http.HttpStatusPushBase):
 
             try:
                 if self.verbose:
-                    log.msg("Updating github status: repoOwner={repoOwner}, repoName={repoName}".format(
-                        repoOwner=repoOwner, repoName=repoName))
+                    log.msg("Updating github status: repo_owner={}, repo_name={}".format(
+                            repo_owner, repo_name))
 
-                repo_user = repoOwner
-                repo_name = repoName
-                target_url = build['url']
-                response = yield self.createStatus(repo_user=repo_user,
+                response = yield self.createStatus(repo_user=repo_owner,
                                                    repo_name=repo_name,
                                                    sha=sha,
                                                    state=state,
-                                                   target_url=target_url,
+                                                   target_url=build['url'],
                                                    context=context,
                                                    issue=issue,
                                                    description=description)
@@ -184,9 +181,9 @@ class GitHubStatusPush(http.HttpStatusPushBase):
 
                 if self.verbose:
                     log.msg(
-                        'Updated status with "{state}" for {repoOwner}/{repoName} '
+                        'Updated status with "{state}" for {repo_owner}/{repo_name} '
                         'at {sha}, context "{context}", issue {issue}.'.format(
-                            state=state, repoOwner=repoOwner, repoName=repoName,
+                            state=state, repo_owner=repo_owner, repo_name=repo_name,
                             sha=sha, issue=issue, context=context))
             except Exception as e:
                 if response:
@@ -196,10 +193,10 @@ class GitHubStatusPush(http.HttpStatusPushBase):
                     content = code = "n/a"
                 log.err(
                     e,
-                    'Failed to update "{state}" for {repoOwner}/{repoName} '
+                    'Failed to update "{state}" for {repo_owner}/{repo_name} '
                     'at {sha}, context "{context}", issue {issue}. '
                     'http {code}, {content}'.format(
-                        state=state, repoOwner=repoOwner, repoName=repoName,
+                        state=state, repo_owner=repo_owner, repo_name=repo_name,
                         sha=sha, issue=issue, context=context,
                         code=code, content=content))
 


### PR DESCRIPTION
If you attempt to use GitHubStatusPush with a builder that specifies multiple codebases, you can currently get runtime failures:
- the existing code assumes that the [0]'th entry of sourcestamps always has valid 'branch' property (it might not, if the codebase is one that is pulled without a branch specification)
- the existing code assumes that *all* entries of sourcestamps have a valid 'revision' property (same reason as above)

This revises the code to be more defensive, and skip the update attempts for sourcestamps that have no revision data (logging the skip in verbose mode).

Note that this is a modestly updated version of https://github.com/buildbot/buildbot/pull/4347, which was offered ~two years ago but eventually rejected; I am resubmitting the PR because this issue seems to have become vastly more problematic for my project after we finally upgraded to more recent versions of buildbot, plus a Py2 -> Py3 conversion.

I have *NOT* updated the unit tests -- it's not at all clear to me what is necessary to adequately provide a unit test for this. If someone can provide concrete guidance I'll attempt to do so.
