### PR TITLE
Bump SQLAlchemy to 1.2.0 and use its features to optimize test results API

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -52,7 +52,7 @@ env:
   #- TWISTED=latest SQLALCHEMY=latest TESTS=trial 'BUILDBOT_TEST_DB_URL=postgresql+pg8000:///bbtest?user=buildbot&password=x'
 
   # Test different versions of SQLAlchemy
-  - TWISTED=17.9.0 SQLALCHEMY=1.1.0 TESTS=trial
+  - TWISTED=17.9.0 SQLALCHEMY=1.2.0 TESTS=trial
   - TWISTED=17.9.0 SQLALCHEMY=latest TESTS=trial
 
   # Tests for the worker on old versions of twisted.

--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -123,6 +123,7 @@ benchmarking
 benjamin
 bennetts
 berlin
+bindparam
 bitbucket
 blahblah
 blamelist

--- a/master/buildbot/newsfragments/sqlalchemy-upgrade.removal
+++ b/master/buildbot/newsfragments/sqlalchemy-upgrade.removal
@@ -1,0 +1,1 @@
+BuildBot now requires SQLAlchemy 1.2.0 or newer.

--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -68,7 +68,7 @@ Jinja2: http://jinja.pocoo.org/
 
 SQLAlchemy: http://www.sqlalchemy.org/
 
-  Buildbot requires SQLAlchemy version 1.1.0 or higher.
+  Buildbot requires SQLAlchemy version 1.2.0 or higher.
   SQLAlchemy allows Buildbot to build database schemas and queries for a wide variety of database systems.
 
 SQLAlchemy-Migrate: https://sqlalchemy-migrate.readthedocs.io/en/latest/

--- a/master/setup.py
+++ b/master/setup.py
@@ -476,7 +476,7 @@ setup_args['install_requires'] = [
     'Jinja2 >= 2.1',
     # required for tests, but Twisted requires this anyway
     'zope.interface >= 4.1.1',
-    'sqlalchemy>=1.1.0',
+    'sqlalchemy>=1.2.0',
     'sqlalchemy-migrate>=0.9',
     'python-dateutil>=1.5',
     'txaio ' + txaio_ver,


### PR DESCRIPTION
SQLAlchemy 1.2.0 supports [expanding bindparam](https://docs.sqlalchemy.org/en/13/core/sqlelement.html#sqlalchemy.sql.expression.bindparam) that improves performance of filtering of large sets significantly. On my machine, the performance of inserting test results has been improved from ~5000 rows/s to ~7500 rows/s. Given SQLAlchemy 1.1.x is EOL, I think this is good time to upgrade.

## Contributor Checklist:

* [n/a] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
