### PR TITLE
Include buildbot.test.fakedb in the source distribution

### DIFF
--- a/master/buildbot/newsfragments/sdist_fakedb.bugfix
+++ b/master/buildbot/newsfragments/sdist_fakedb.bugfix
@@ -1,0 +1,1 @@
+Fixed source distribution missing required buildbot.test.fakedb module for unit tests.

--- a/master/setup.py
+++ b/master/setup.py
@@ -195,6 +195,7 @@ setup_args = {
         "buildbot.test",
         "buildbot.test.util",
         "buildbot.test.fake",
+        "buildbot.test.fakedb",
         "buildbot.test.fuzz",
         "buildbot.test.integration",
         "buildbot.test.integration.interop",


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
 * Not sure if this is possible
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
 * AFAIK there is none for this


During fixup of my travis CI scripts for my buildbot plugin I've noticed that an import inside buildbot was not working and upon further inspection, that the new fakedb module is missing from source builds of buildbot.

I cannot really test this, as a custom `sdist` does not install any of the `test` modules, so I am not sure if any other module is missing.
 
See the following travis CI log for further info: https://travis-ci.org/github/lab132/buildbot-gitea/builds/693579780

Regards,
Marvin