### PR TITLE
Fix plugin import documentation

### DIFF
--- a/master/buildbot/newsfragments/plugin-imports.doc
+++ b/master/buildbot/newsfragments/plugin-imports.doc
@@ -1,0 +1,1 @@
+Fix import path for plugins

--- a/master/docs/developer/plugins-publish.rst
+++ b/master/docs/developer/plugins-publish.rst
@@ -32,7 +32,7 @@ Buildbot supports several kinds of pluggable components:
 * ``changes``
 * ``schedulers``
 * ``steps``
-* ``status``
+* ``reporters``
 * ``util``
 
 (these are described in :doc:`../manual/plugins`), and
@@ -49,7 +49,7 @@ Once you have your component packaged, it's quite straightforward: you just need
         ...
         entry_points = {
             ...,
-            'buildbot.kind': [
+            'buildbot.{kind}': [
                 'PluginName = PluginModule:PluginClass'
             ]
         },
@@ -72,9 +72,9 @@ After that the plugin should be available for Buildbot and you can use it in you
 
 .. code-block:: python
 
-    from buildbot.kind import PluginName
+    from buildbot.plugins import {kind}
 
-    ... PluginName ...
+    ... {kind}.PluginName ...
 
 Publish the package
 ===================


### PR DESCRIPTION
This PR updates the plugin import path in the documentation in the plugin import example, and I also changed the `kind` placeholder to `{kind}` to explicitly indicate that it's a placeholder (because actually trying to run it will generate a syntax error). Previously, it was valid Python code that would hit a runtime error when it tried to import from literally `buildbot.kind`.

Also, the documentation refers to `status` plugins, but I think it should actually be referring to `reporters`s plugins, so I fixed that.

Since this is only a documentation fix, I did not add any unit tests, but I did add a newsfragment.
 
## Contributor Checklist:

* [x] I have updated the unit tests - N/A
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
