### PR TITLE
Include buildbot.test.fakedb in the source distribution (2.8.x)

### DIFF
--- a/master/buildbot/newsfragments/sdist_fakedb.bugfix
+++ b/master/buildbot/newsfragments/sdist_fakedb.bugfix
@@ -1,0 +1,1 @@
+Fixed source distribution missing required buildbot.test.fakedb module for unit tests.

--- a/master/setup.py
+++ b/master/setup.py
@@ -194,6 +194,7 @@ setup_args = {
         "buildbot.test",
         "buildbot.test.util",
         "buildbot.test.fake",
+        "buildbot.test.fakedb",
         "buildbot.test.fuzz",
         "buildbot.test.integration",
         "buildbot.test.integration.interop",


### PR DESCRIPTION
This is cherry-pick of  https://github.com/buildbot/buildbot/pull/5322 to 2.8.x branch.