### PR TITLE
trigger: Fix unimportantSchedulerNames when user uses renderables (2.8.x)

### DIFF
--- a/master/buildbot/newsfragments/trigger.bugfix
+++ b/master/buildbot/newsfragments/trigger.bugfix
@@ -1,0 +1,2 @@
+fix crash in trigger step when renderables are used for scheduler names (:issue:`5312`)
+

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -17,6 +17,7 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot import config
+from buildbot.interfaces import IRenderable
 from buildbot.interfaces import ITriggerableScheduler
 from buildbot.process.buildstep import CANCELLED
 from buildbot.process.buildstep import EXCEPTION
@@ -65,10 +66,18 @@ class Trigger(BuildStep):
             config.error(
                 "You can't specify both alwaysUseLatest and updateSourceStamp"
             )
-        if not set(schedulerNames).issuperset(set(unimportantSchedulerNames)):
-            config.error(
-                "unimportantSchedulerNames must be a subset of schedulerNames"
-            )
+
+        def hasRenderable(l):
+            for s in l:
+                if IRenderable.providedBy(s):
+                    return True
+            return False
+
+        if not hasRenderable(schedulerNames) and not hasRenderable(unimportantSchedulerNames):
+            if not set(schedulerNames).issuperset(set(unimportantSchedulerNames)):
+                config.error(
+                    "unimportantSchedulerNames must be a subset of schedulerNames"
+                )
 
         self.schedulerNames = schedulerNames
         self.unimportantSchedulerNames = unimportantSchedulerNames

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -270,7 +270,12 @@ class TestTrigger(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
     def test_unimportantSchedulerNames_not_in_schedulerNames(self):
         with self.assertRaises(config.ConfigErrors):
             trigger.Trigger(schedulerNames=['a'],
-                            unimportantsShedulerNames=['b'])
+                            unimportantSchedulerNames=['b'])
+
+    def test_unimportantSchedulerNames_not_in_schedulerNames_but_rendered(self):
+        # should not raise
+        trigger.Trigger(schedulerNames=[properties.Interpolate('a')],
+                        unimportantSchedulerNames=['b'])
 
     def test_sourceStamp_and_updateSourceStamp(self):
         with self.assertRaises(config.ConfigErrors):
@@ -654,7 +659,7 @@ class TestTrigger(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         yield self.runStep()
 
     @defer.inlineCallbacks
-    def test_unimportantsShedulerNames(self):
+    def test_unimportantSchedulerNames(self):
         yield self.setupStep(trigger.Trigger(schedulerNames=['a', 'b'],
                                              unimportantSchedulerNames=['b']))
         self.scheduler_a.result = SUCCESS
@@ -664,7 +669,7 @@ class TestTrigger(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         yield self.runStep()
 
     @defer.inlineCallbacks
-    def test_unimportantsShedulerNames_with_more_brids_for_bsid(self):
+    def test_unimportantSchedulerNames_with_more_brids_for_bsid(self):
         yield self.setupStep(trigger.Trigger(schedulerNames=['a', 'c'],
                                              unimportantSchedulerNames=['c']))
         self.scheduler_a.result = SUCCESS


### PR DESCRIPTION
This is cherry-pick of https://github.com/buildbot/buildbot/pull/5314 to 2.8.x branch.