### PR TITLE
Add logging and debugging information.

### DIFF
--- a/master/buildbot/newsfragments/debugging.doc
+++ b/master/buildbot/newsfragments/debugging.doc
@@ -1,0 +1,2 @@
+Documentation how log to stdout instead of twistd.log and
+how to use pdb in a buildbot application was added.

--- a/master/docs/manual/deploy.rst
+++ b/master/docs/manual/deploy.rst
@@ -172,6 +172,32 @@ When the buildmaster is restarted, all workers will be disconnected, and will at
 The reconnect time will depend upon how long the buildmaster is offline (i.e. how far up the exponential backoff curve the workers have travelled).
 Again, :samp:`buildbot-worker restart {BASEDIR}` will speed up the process.
 
+.. _Logging-to-stdout:
+
+Logging to stdout
+~~~~~~~~~~~~~~~~~
+
+It can be useful to let buildbot output it's log to stdout instead of a logfile.
+For example when running via docker, supervisor or when buildbot is started with --no-daemon.
+This can be accomplished by editing :file:`buildbot.tac`. It's already enabled in the docker :file:`buildbot.tac`
+Change the line: `application.setComponent(ILogObserver, FileLogObserver(logfile).emit)`
+to: `application.setComponent(ILogObserver, FileLogObserver(sys.stdout).emit)`
+
+.. _Debugging-with-the-python-debugger:
+
+Debugging with the python debugger
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes it's necessary to see what is happening inside a program.
+To enable this, start buildbot with:
+
+.. code-block:: none
+
+      twistd --no_save -n -b --logfile=- -y buildbot.tac
+
+This will load the debugger on every exception and breakpoints in the program.
+More information on the python debugger can be found here: https://docs.python.org/3/library/pdb.html
+
 .. _Contrib-Scripts:
 
 Contrib Scripts


### PR DESCRIPTION
Add how to log to stdout instead of twistd.log.
This is already the default for the docker buildbot.tac.

Add how to debug buildbot application with the python debugger.

The PR contains documentation that I would've like to have read when I started 
using buildbot. I'm open to suggestions on how to improve this addition to the docs.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
