### PR TITLE
Remove unneeded maybeDeferred in @defer.inlineCallbacks functions

### DIFF
--- a/master/buildbot/pbmanager.py
+++ b/master/buildbot/pbmanager.py
@@ -142,7 +142,7 @@ class Dispatcher(service.AsyncService):
         # stop listening on the port when shut down
         assert self.port
         port, self.port = self.port, None
-        yield defer.maybeDeferred(port.stopListening)
+        yield port.stopListening()
         yield super().stopService()
 
     def register(self, username, password, pfactory):
@@ -203,8 +203,7 @@ class Dispatcher(service.AsyncService):
             if username in self.users:
                 password, _ = self.users[username]
                 password = yield p.render(password)
-                matched = yield defer.maybeDeferred(
-                    creds.checkPassword, unicode2bytes(password))
+                matched = creds.checkPassword(unicode2bytes(password))
                 if not matched:
                     log.msg("invalid login from user '{}'".format(username))
                     raise error.UnauthorizedLogin()

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -268,7 +268,7 @@ class BotMaster(service.ReconfigurableServiceMixin, service.AsyncMultiService, L
                 builder.master = None
                 builder.botmaster = None
 
-                yield defer.maybeDeferred(builder.disownServiceParent)
+                yield builder.disownServiceParent()
 
             for n in added_names:
                 builder = Builder(n)

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -432,7 +432,7 @@ class BuildRequestDistributor(service.AsyncMultiService):
 
         # run it
         try:
-            builders = yield defer.maybeDeferred(sorter, self.master, builders)
+            builders = yield sorter(self.master, builders)
         except Exception:
             log.err(Failure(), "prioritizing builders; order unspecified")
 

--- a/master/buildbot/process/users/manager.py
+++ b/master/buildbot/process/users/manager.py
@@ -36,7 +36,7 @@ class UserManagerManager(util_service.ReconfigurableServiceMixin,
 
         # pylint: disable=cell-var-from-loop
         for mgr in list(self):
-            yield defer.maybeDeferred(mgr.disownServiceParent)
+            yield mgr.disownServiceParent()
 
         for mgr in new_config.user_managers:
             yield mgr.setServiceParent(self)

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -134,7 +134,7 @@ class BaseScheduler(ClusteredBuildbotService, StateMixin):
     def deactivate(self):
         if not self.enabled:
             return None
-        yield defer.maybeDeferred(self._stopConsumingChanges)
+        yield self._stopConsumingChanges()
         return None
 
     # service handling

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -46,7 +46,7 @@ class ValidationErrorCollector:
     def collectValidationErrors(self, name, fn, *args, **kwargs):
         res = None
         try:
-            res = yield defer.maybeDeferred(fn, *args, **kwargs)
+            res = yield fn(*args, **kwargs)
         except CollectedValidationError as e:
             for error_name, e in e.errors.items():
                 self.errors[error_name] = e

--- a/master/buildbot/test/unit/test_schedulers_trysched.py
+++ b/master/buildbot/test/unit/test_schedulers_trysched.py
@@ -789,8 +789,7 @@ class Try_Userpass_Perspective(scheduler.SchedulerMixin, TestReactorMixin,
         sched = self.makeScheduler(name='tsched', builderNames=['a', 'b'],
                                    port='xxx', userpass=[('a', 'b')])
         persp = trysched.Try_Userpass_Perspective(sched, 'a')
-        buildernames = yield defer.maybeDeferred(
-                                persp.perspective_getAvailableBuilderNames)
+        buildernames = yield persp.perspective_getAvailableBuilderNames()
 
         self.assertEqual(buildernames, ['a', 'b'])
 

--- a/master/buildbot/test/unit/test_util_maildir.py
+++ b/master/buildbot/test/unit/test_util_maildir.py
@@ -61,7 +61,7 @@ class TestMaildirService(dirs.DirsMixin, unittest.TestCase):
             messagesReceived.append(filename)
             return defer.succeed(None)
         self.svc.messageReceived = messageReceived
-        yield defer.maybeDeferred(self.svc.startService)
+        yield self.svc.startService()
 
         self.assertEqual(messagesReceived, [])
 

--- a/master/buildbot/test/util/changesource.py
+++ b/master/buildbot/test/util/changesource.py
@@ -48,7 +48,7 @@ class ChangeSourceMixin:
         if not self.started:
             return
         if self.changesource.running:
-            yield defer.maybeDeferred(self.changesource.stopService)
+            yield self.changesource.stopService()
         yield self.changesource.disownServiceParent()
         return
 

--- a/master/buildbot/test/util/scheduler.py
+++ b/master/buildbot/test/util/scheduler.py
@@ -123,7 +123,7 @@ class SchedulerMixin(interfaces.InterfaceTests):
             @defer.inlineCallbacks
             def newMethod():
                 self._parentMethodCalled = False
-                rv = yield defer.maybeDeferred(oldMethod)
+                rv = yield oldMethod()
 
                 self.assertTrue(self._parentMethodCalled,
                                 "'{}' did not call its parent".format(meth))

--- a/master/buildbot/util/poll.py
+++ b/master/buildbot/util/poll.py
@@ -45,7 +45,7 @@ class Poller:
             yield task.deferLater(self._reactor, randint(random_delay_min, random_delay_max),
                                   lambda: None)
         try:
-            yield defer.maybeDeferred(self.fn, self.instance)
+            yield self.fn(self.instance)
         except Exception as e:
             log.err(e, 'while running {}'.format(self.fn))
 

--- a/master/buildbot/util/service.py
+++ b/master/buildbot/util/service.py
@@ -495,7 +495,7 @@ class BuildbotServiceManager(AsyncMultiService, config.ConfiguredMixin,
                     objectid = yield self.master.db.state.getObjectId(
                         child.name, class_name)
                     child.objectid = objectid
-                yield defer.maybeDeferred(child.setServiceParent, self)
+                yield child.setServiceParent(self)
 
         # As the services that were just added got
         # reconfigServiceWithSibling called by

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -87,7 +87,7 @@ class GitHubEventHandler(PullRequestMixin):
         if handler is None:
             raise ValueError('Unknown event: {}'.format(event_type))
 
-        result = yield defer.maybeDeferred(lambda: handler(payload, event_type))
+        result = yield handler(payload, event_type)
         return result
 
     @defer.inlineCallbacks

--- a/master/buildbot/www/service.py
+++ b/master/buildbot/www/service.py
@@ -219,7 +219,7 @@ class WWWService(service.ReconfigurableServiceMixin, service.AsyncMultiService):
 
         if www['port'] != self.port:
             if self.port_service:
-                yield defer.maybeDeferred(self.port_service.disownServiceParent)
+                yield self.port_service.disownServiceParent()
                 self.port_service = None
 
             self.port = www['port']


### PR DESCRIPTION
`yield` in @defer.inlineCallbacks functions automatically handles non-deferred arguments, thus no need for maybeDeferred.