### PR TITLE
Make generator support in NotifierBase generic

### DIFF
--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -22,6 +22,10 @@ from .utils import BuildStatusGeneratorMixin
 
 class BuildStatusGenerator(BuildStatusGeneratorMixin):
 
+    wanted_event_keys = [
+        ('builds', None, 'finished'),
+    ]
+
     def __init__(self, mode=("failing", "passing", "warnings"),
                  tags=None, builders=None, schedulers=None, branches=None,
                  subject="Buildbot %(result)s in %(title)s on %(builder)s",

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -21,6 +21,11 @@ from .utils import BuildStatusGeneratorMixin
 
 
 class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
+
+    wanted_event_keys = [
+        ('buildsets', None, 'complete'),
+    ]
+
     def __init__(self, mode=("failing", "passing", "warnings"),
                  tags=None, builders=None, schedulers=None, branches=None,
                  subject="Buildbot %(result)s in %(title)s on %(builder)s",

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -16,6 +16,7 @@
 from twisted.internet import defer
 
 from buildbot import config
+from buildbot import util
 from buildbot.process.results import CANCELLED
 from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
@@ -25,10 +26,13 @@ from buildbot.process.results import Results
 from buildbot.reporters.message import MessageFormatter as DefaultMessageFormatter
 
 
-class BuildStatusGeneratorMixin:
+class BuildStatusGeneratorMixin(util.ComparableMixin):
 
     possible_modes = ("change", "failing", "passing", "problem", "warnings", "exception",
                       "cancelled")
+
+    compare_attrs = ['mode', 'tags', 'builders', 'schedulers', 'branches', 'subject', 'add_logs',
+                     'add_patch', 'formatter']
 
     def __init__(self, mode, tags, builders, schedulers, branches, subject, add_logs, add_patch,
                  message_formatter):

--- a/master/buildbot/reporters/generators/worker.py
+++ b/master/buildbot/reporters/generators/worker.py
@@ -26,6 +26,10 @@ class WorkerMissingGenerator(util.ComparableMixin):
 
     compare_attrs = ['workers', 'formatter']
 
+    wanted_event_keys = [
+        ('workers', None, 'missing'),
+    ]
+
     def __init__(self, workers=None, message_formatter=None):
         self.workers = workers
         self.formatter = message_formatter

--- a/master/buildbot/reporters/generators/worker.py
+++ b/master/buildbot/reporters/generators/worker.py
@@ -16,12 +16,15 @@
 from twisted.internet import defer
 
 from buildbot import config
+from buildbot import util
 from buildbot.reporters.message import MessageFormatterMissingWorker
 
 ENCODING = 'utf-8'
 
 
-class WorkerMissingGenerator:
+class WorkerMissingGenerator(util.ComparableMixin):
+
+    compare_attrs = ['workers', 'formatter']
 
     def __init__(self, workers=None, message_formatter=None):
         self.workers = workers

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -21,6 +21,7 @@ import jinja2
 from twisted.internet import defer
 
 from buildbot import config
+from buildbot import util
 from buildbot.process.results import CANCELLED
 from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
@@ -30,9 +31,11 @@ from buildbot.process.results import statusToString
 from buildbot.reporters import utils
 
 
-class MessageFormatterBase:
+class MessageFormatterBase(util.ComparableMixin):
     template_filename = 'default_mail.txt'
     template_type = 'plain'
+
+    compare_attrs = ['body_template', 'subject_teblate', 'template_type']
 
     def __init__(self, template_dir=None,
                  template_filename=None, template=None,
@@ -85,6 +88,8 @@ class MessageFormatterBase:
 class MessageFormatter(MessageFormatterBase):
     template_filename = 'default_mail.txt'
     template_type = 'plain'
+
+    compare_attrs = ['wantProperties', 'wantSteps', 'wantLogs']
 
     def __init__(self, template_dir=None,
                  template_filename=None, template=None, template_name=None,

--- a/master/buildbot/reporters/notifier.py
+++ b/master/buildbot/reporters/notifier.py
@@ -31,6 +31,8 @@ class NotifierBase(service.BuildbotService):
     name = None
     __meta__ = abc.ABCMeta
 
+    compare_attrs = ['generators']
+
     def computeShortcutModes(self, mode):
         if isinstance(mode, str):
             if mode == "all":
@@ -44,6 +46,7 @@ class NotifierBase(service.BuildbotService):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.generators = None
         self._buildsetCompleteConsumer = None
         self._buildCompleteConsumer = None
         self._workerMissingConsumer = None

--- a/master/buildbot/reporters/notifier.py
+++ b/master/buildbot/reporters/notifier.py
@@ -131,6 +131,7 @@ class NotifierBase(service.BuildbotService):
 
         return generators
 
+    @defer.inlineCallbacks
     def stopService(self):
         for consumer in self._event_consumers:
             yield consumer.stopConsuming()

--- a/master/buildbot/reporters/notifier.py
+++ b/master/buildbot/reporters/notifier.py
@@ -33,17 +33,6 @@ class NotifierBase(service.BuildbotService):
 
     compare_attrs = ['generators']
 
-    def computeShortcutModes(self, mode):
-        if isinstance(mode, str):
-            if mode == "all":
-                mode = ("failing", "passing", "warnings",
-                        "exception", "cancelled")
-            elif mode == "warnings":
-                mode = ("failing", "warnings")
-            else:
-                mode = (mode,)
-        return mode
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.generators = None
@@ -204,6 +193,3 @@ class NotifierBase(service.BuildbotService):
     @abc.abstractmethod
     def sendMessage(self, reports):
         pass
-
-    def isWorkerMessageNeeded(self, worker):
-        return self.watchedWorkers == 'all' or worker['name'] in self.watchedWorkers

--- a/master/buildbot/test/unit/test_reporter_bitbucketserver.py
+++ b/master/buildbot/test/unit/test_reporter_bitbucketserver.py
@@ -236,7 +236,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             code=HTTP_CREATED)
         build["complete"] = True
         self.setUpLogging()
-        yield self.cp.buildComplete(("build", 20, "finished"), build)
+        yield self.cp._got_event(("builds", 20, "finished"), build)
         self.assertLogged('Comment sent to {}'.format(PR_URL))
 
     @defer.inlineCallbacks
@@ -251,7 +251,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             code=HTTP_CREATED)
         build["complete"] = True
         self.setUpLogging()
-        yield self.cp.buildComplete(("build", 20, "finished"), build)
+        yield self.cp._got_event(("builds", 20, "finished"), build)
 
         self.assertNotLogged('Comment sent to {}'.format(PR_URL))
 
@@ -262,7 +262,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
         build = builds[0]
         build["complete"] = True
         # we don't expect any request
-        yield self.cp.buildComplete(("builds", 20, "finished"), build)
+        yield self.cp._got_event(("builds", 20, "finished"), build)
 
     @defer.inlineCallbacks
     def test_missing_worker_does_nothing(self):
@@ -278,7 +278,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             EXPECTED_API,
             json={"text": UNICODE_BODY},
             code=HTTP_CREATED)
-        yield self.cp.buildsetComplete(("buildsets", 20, "complete"), buildset)
+        yield self.cp._got_event(("buildsets", 20, "complete"), buildset)
 
     @defer.inlineCallbacks
     def test_reporter_logs_error_code_and_content_on_invalid_return_code(self):
@@ -298,7 +298,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             content_json=error_body)
         self.setUpLogging()
         build['complete'] = True
-        yield self.cp.buildComplete(("builds", 20, "finished"), build)
+        yield self.cp._got_event(("builds", 20, "finished"), build)
 
         self.assertLogged(
             "^{}: Unable to send a comment: ".format(http_error_code))
@@ -317,7 +317,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             code=http_error_code)
         self.setUpLogging()
         build['complete'] = True
-        yield self.cp.buildComplete(("builds", 20, "finished"), build)
+        yield self.cp._got_event(("builds", 20, "finished"), build)
         self.assertLogged("^{}: Unable to send a comment: ".format(
             http_error_code))
 
@@ -335,5 +335,5 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             code=http_code)
         self.setUpLogging()
         build['complete'] = True
-        yield self.cp.buildComplete(("builds", 20, "finished"), build)
+        yield self.cp._got_event(("builds", 20, "finished"), build)
         self.assertNotLogged("^{}:".format(http_code))

--- a/master/buildbot/test/unit/test_reporters_mail.py
+++ b/master/buildbot/test/unit/test_reporters_mail.py
@@ -210,7 +210,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
         mn.createEmail = Mock(spec=mn.createEmail)
         mn.createEmail.return_value = "<email>"
         mn.sendMail = Mock(spec=mn.sendMail)
-        yield mn.buildComplete("", builds[0])
+        yield mn._got_event(('builds', 10, 'finished'), builds[0])
         return (mn, builds, formatter)
 
     @defer.inlineCallbacks
@@ -348,7 +348,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
         mn.createEmail = Mock(spec=mn.createEmail)
         mn.createEmail.return_value.as_string = Mock(return_value="<email>")
 
-        yield mn.buildComplete("", builds[0])
+        yield mn._got_event(('builds', 10, 'finished'), builds[0])
         return (mn, builds)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/test_reporters_notifier.py
+++ b/master/buildbot/test/unit/test_reporters_notifier.py
@@ -61,7 +61,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
 
         mn = yield self.setupNotifier(messageFormatter=formatter, **mnKwargs)
 
-        yield mn.buildComplete('', builds[0])
+        yield mn._got_event(('builds', 97, 'finished'), builds[0])
         return (mn, builds, formatter)
 
     @defer.inlineCallbacks
@@ -98,6 +98,6 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
             'workerinfo': {"admin": "myadmin"},
             'last_connection': "yesterday"
         }
-        yield mn.workerMissing('worker.98.complete', worker_dict)
+        yield mn._got_event(('workers', 98, 'missing'), worker_dict)
 
         self.assertEqual(mn.sendMessage.call_count, 1)

--- a/master/buildbot/test/unit/test_reporters_notifier.py
+++ b/master/buildbot/test/unit/test_reporters_notifier.py
@@ -14,7 +14,7 @@
 # Copyright Buildbot Team Members
 
 
-from mock import Mock
+import mock
 
 from twisted.internet import defer
 from twisted.trial import unittest
@@ -29,7 +29,7 @@ from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.notifier import NotifierTestMixin
 
 
-class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
+class TestNotifierBase(ConfigErrorsMixin, TestReactorMixin,
                        unittest.TestCase, NotifierTestMixin):
 
     def setUp(self):
@@ -40,7 +40,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
     @defer.inlineCallbacks
     def setupNotifier(self, *args, **kwargs):
         mn = NotifierBase(*args, **kwargs)
-        mn.sendMessage = Mock(spec=mn.sendMessage)
+        mn.sendMessage = mock.Mock(spec=mn.sendMessage)
         mn.sendMessage.return_value = "<message>"
         yield mn.setServiceParent(self.master)
         yield mn.startService()
@@ -51,7 +51,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
 
         _, builds = yield self.setupBuildResults(FAILURE)
 
-        formatter = Mock(spec=MessageFormatter)
+        formatter = mock.Mock(spec=MessageFormatter)
         formatter.formatMessageForBuildResults.return_value = {"body": "body",
                                                                "type": "text",
                                                                "subject": "subject"}


### PR DESCRIPTION
This PR is a followup of #5286. In that PR a defect was noticed that NotifierBase refers child report generators by type. Additionally, NotifierBase effectively became an event router.

I was able to solve the first problem easily. Now the reporters advertise their wanted event keys that the notifier uses to build a list of events it listens to and when an event comes, the notifier uses its key to retrieve the reports from the generators that were interested into that event.

I've investigated making report generators proper child services of NotifierBase and unfortunately it seems we can't do this without removing functionality. One of the main ideas behind splitting reporters and report generator concepts was that it would be possible to generate multiple types of reports for a single event and then the reporter would take useful information out of all of them and present it as a single report specific to the reporter. If the generators consume the events themselves it becomes almost impossible to merge the reports produced by the same event.

I think that in this case we should consider report generators not as a independent services, but as reusable components of e.g. NotifierBase. It is the reporter which reacts to the event and produces a report to it, generators only define what data will be placed into the report. Thus it should be the reporter which consumes the events, not the generators.

As a bonus, the current implementation is much simplier and easier to understand than the one that is based on independent services. After coding both approaches I think that while upgrading generators to services looks nicer on architectural level, there aren't practical benefits of doing so.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
