### PR TITLE
scripts: Fix crash in windows service startup code

### DIFF
--- a/master/buildbot/newsfragments/windows-service-crash.bugfix
+++ b/master/buildbot/newsfragments/windows-service-crash.bugfix
@@ -1,0 +1,1 @@
+Fix crash in Buildbot Windows service startup code (:issue:`5344`)

--- a/master/buildbot/scripts/windows_service.py
+++ b/master/buildbot/scripts/windows_service.py
@@ -230,7 +230,7 @@ class BBService(win32serviceutil.ServiceFramework):
             self.info("Starting BuildBot in directory '{}'".format(bbdir))
             hstop = self.hWaitStop
 
-            cmd = '{} --spawn {} start --nodaemon {}'.format(self.runner_prefix, hstop, bbdir)
+            cmd = '{} --spawn {} start --nodaemon {}'.format(self.runner_prefix, int(hstop), bbdir)
             # print "cmd is", cmd
             h, t, output = self.createProcess(cmd)
             child_infos.append((bbdir, h, t, output))


### PR DESCRIPTION
Fixes #5344. Thanks @BeagleJoe for the proposed patch in the GitHub issue.

Issue has been caused by 6bafe09d93fcb40389ff4a1d736347032ad98d96.

This is serious enough issue that it warrants Buildbot 2.8.2, but in order to release we need testing by at least 2 people.

## Contributor Checklist:

* [not available] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not applicable] I have updated the appropriate documentation
