### PR TITLE
docs: Add an API index with all documented classes and functions

### DIFF
--- a/master/docs/bbdocs/api_index.py
+++ b/master/docs/bbdocs/api_index.py
@@ -1,0 +1,53 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from sphinx.domains import Index
+from sphinx.domains.std import StandardDomain
+
+
+class PythonAPIIndex(Index):
+
+    objecttype = 'class'
+    name = 'apiindex'
+    localname = 'Public API Index'
+    shortname = 'classes'
+
+    def generate(self, docnames=None):
+        unsorted_objects = [(refname, entry.docname, entry.objtype)
+                            for (refname, entry) in self.domain.data['objects'].items()
+                            if entry.objtype in ['class', 'function']]
+        objects = sorted(unsorted_objects,
+                         key=lambda x: x[0].lower())
+
+        entries = []
+
+        for refname, docname, objtype in objects:
+            if docnames and docname not in docnames:
+                continue
+
+            extra_info = objtype
+            display_name = refname
+            if objtype == 'function':
+                display_name += '()'
+            entries.append([display_name, 0, docname, refname, extra_info, '', ''])
+
+        return [('', entries)], False
+
+
+def setup(app):
+    app.add_index_to_domain('py', PythonAPIIndex)
+    StandardDomain.initial_data['labels']['apiindex'] = ('py-apiindex', '', 'Public API Index')
+    StandardDomain.initial_data['anonlabels']['apiindex'] = ('py-apiindex', '')
+    return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/master/docs/bbdocs/ext.py
+++ b/master/docs/bbdocs/ext.py
@@ -46,6 +46,19 @@ class BBRefTargetDirective(Directive):
     final_argument_whitespace = True
     option_spec = {}
     domain = 'bb'
+    doc_field_types = []
+
+    def get_field_type_map(self):
+        # This is the same as DocFieldTransformer.preprocess_fieldtype which got removed in
+        # Sphinx 4.0
+        typemap = {}
+        for fieldtype in self.doc_field_types:
+            for name in fieldtype.names:
+                typemap[name] = fieldtype, False
+            if fieldtype.is_typed:
+                for name in fieldtype.typenames:
+                    typemap[name] = fieldtype, True
+        return typemap
 
     def run(self):
         self.env = env = self.state.document.settings.env

--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -247,7 +247,7 @@ html_sidebars = {
 # html_domain_indices = True
 
 html_use_index = True
-html_use_modindex = True
+html_use_modindex = False
 
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False

--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -56,6 +56,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.extlinks',
     'bbdocs.ext',
+    'bbdocs.api_index',
     'sphinxcontrib.blockdiag',
     'sphinxcontrib.jinja',
     'sphinx_rtd_theme',

--- a/master/docs/indices.rst
+++ b/master/docs/indices.rst
@@ -13,5 +13,6 @@ Indices and Tables
 * :bb:index:`rtype`
 * :bb:index:`rpath`
 * :bb:index:`raction`
+* :ref:`apiindex`
 * :ref:`modindex`
 * :ref:`search`

--- a/master/docs/indices.rst
+++ b/master/docs/indices.rst
@@ -14,4 +14,3 @@ API Indices
 * :bb:index:`rpath`
 * :bb:index:`raction`
 * :ref:`apiindex`
-* :ref:`search`

--- a/master/docs/indices.rst
+++ b/master/docs/indices.rst
@@ -14,5 +14,4 @@ Indices and Tables
 * :bb:index:`rpath`
 * :bb:index:`raction`
 * :ref:`apiindex`
-* :ref:`modindex`
 * :ref:`search`

--- a/master/docs/indices.rst
+++ b/master/docs/indices.rst
@@ -1,7 +1,7 @@
 API Indices
 ===========
 
-* :ref:`genindex`
+* :ref:`apiindex`
 * :bb:index:`cfg`
 * :bb:index:`sched`
 * :bb:index:`chsrc`
@@ -13,4 +13,4 @@ API Indices
 * :bb:index:`rtype`
 * :bb:index:`rpath`
 * :bb:index:`raction`
-* :ref:`apiindex`
+* :ref:`genindex`

--- a/master/docs/indices.rst
+++ b/master/docs/indices.rst
@@ -1,5 +1,5 @@
-Indices and Tables
-==================
+API Indices
+===========
 
 * :ref:`genindex`
 * :bb:index:`cfg`


### PR DESCRIPTION
The existing API indexes are almost useless for a developer who looks into BuildBot internals as there's no easy way to see an overview of all classes or functions that are provided by BuildBot. The modindex, for example, only shows the modules and one needs to scroll the whole page containing the documentation of a module to understand what functions or classes it provides. This PR improves this by adding an index with all classes and functions in one place.