### PR TITLE
docs: Cleanup build

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -175,12 +175,12 @@ script:
   # Build documentation
   - title: docs
     condition: TESTS == "docs"
-    cmd: make docs
+    cmd: make docs-release
 
   # Run spell checker on documentation
   - title: spelling
     condition: TESTS == "docs"
-    cmd: make -C master/docs SPHINXOPTS=-W spelling
+    cmd: make docs-release-spelling
 
   - title: maketarballs
     condition: TESTS == "smokes"

--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -182,11 +182,6 @@ script:
     condition: TESTS == "docs"
     cmd: make -C master/docs SPHINXOPTS=-W spelling
 
-  # Runs Sphinx' external link checker only on post submit build (it is too unstable)
-  - title: linkcheck
-    condition: TESTS == "docs" and not TRAVIS_PULL_REQUEST
-    cmd: make -C master/docs SPHINXOPTS=-q linkcheck
-
   - title: maketarballs
     condition: TESTS == "smokes"
     cmd: make tarballs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           name: run tests
           command: |
             . .venv/bin/activate
-            make docs
+            make docs-release
             make tarballs
             # Note that installing www/base depends on frontend_deps target being built, which is
             # a dependency of the tarballs target.

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ trial: virtualenv
 release_notes: $(VENV_NAME)
 	test ! -z "$(VERSION)"  #  usage: make release_notes VERSION=0.9.2
 	yes | towncrier --version $(VERSION) --date `date -u  +%F`
-	git commit -m "relnotes for $(VERSION)"
+	git commit -m "Release notes for $(VERSION)"
 
 $(ALL_PKGS_TARGETS): cleanup_for_tarballs frontend_deps
 	. $(VENV_NAME)/bin/activate && ./common/maketarball.sh $(patsubst %_pkg,%,$@)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ALL_PKGS_TARGETS := $(addsuffix _pkg,$(ALL_PKGS))
 
 # build rst documentation
 docs:
-	$(MAKE) -C master/docs
+	$(MAKE) -C master/docs dev
 
 docs-towncrier:
 	if command -v towncrier >/dev/null 2>&1 ;\

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,10 @@ docs:
 	$(MAKE) -C master/docs
 
 # check rst documentation
-docschecks:
+docs-spelling:
 	$(MAKE) -C master/docs SPHINXOPTS=-W spelling
+
+docs-linkcheck:
 	$(MAKE) -C master/docs SPHINXOPTS=-q linkcheck
 
 # pylint the whole sourcecode (validate.sh will do that as well, but only process the modified files)

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -15,7 +15,7 @@ This collects the release notes using the `towncrier` tool and then commits the 
 This step is done as a PR so that CI can check for spelling errors and similar issues.
 Local checks are insufficient as spelling check in particular depends on what dictionaries are installed.
 
-It's best to run `make docs` afterwards and check `master/docs/_build/html/relnotes/index.html` file for obvious rendering errors.
+It's best to run `make docs-release` afterwards and check `master/docs/_build/html/relnotes/index.html` file for obvious rendering errors.
 This will have much faster turnaround compared to if the error is noticed after the CI runs.
 If any errors are found, just amend the commit created by `make release_notes`.
 

--- a/master/docs/Makefile
+++ b/master/docs/Makefile
@@ -1,5 +1,7 @@
 all: docs.tgz
 
+dev: clean html
+
 .PHONY: tutorial manual
 
 VERSION := $(shell if [ -n "$$VERSION" ]; then echo $$VERSION; else PYTHONPATH=..:$${PYTHONPATH} python -c 'from buildbot import version; print(version)'; fi)

--- a/master/docs/Makefile
+++ b/master/docs/Makefile
@@ -24,7 +24,7 @@ PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean towncrier html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -48,44 +48,38 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 
-towncrier:
-	if command -v towncrier >/dev/null 2>&1 ;\
-	then \
-	cd ../../; towncrier --draft |grep  'No significant changes.' || yes n | towncrier ;\
-	fi
-
-html: conf.py towncrier
+html: conf.py
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-dirhtml: conf.py towncrier
+dirhtml: conf.py
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
-singlehtml: conf.py towncrier
+singlehtml: conf.py
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
-pickle: conf.py towncrier
+pickle: conf.py
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
-json: conf.py towncrier
+json: conf.py
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
-htmlhelp: conf.py towncrier
+htmlhelp: conf.py
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
-qthelp: conf.py towncrier
+qthelp: conf.py
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
@@ -94,7 +88,7 @@ qthelp: conf.py towncrier
 	@echo "To view the help file:"
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/BuildbotTutorial.qhc"
 
-devhelp: conf.py towncrier
+devhelp: conf.py
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
@@ -103,52 +97,52 @@ devhelp: conf.py towncrier
 	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/BuildbotTutorial"
 	@echo "# devhelp"
 
-epub: conf.py towncrier
+epub: conf.py
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
-latex: conf.py towncrier
+latex: conf.py
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
 	      "(use \`make latexpdf' here to do that automatically)."
 
-latexpdf: conf.py towncrier
+latexpdf: conf.py
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	make -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
-text: conf.py towncrier
+text: conf.py
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
-man: conf.py towncrier
+man: conf.py
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
-changes: conf.py towncrier
+changes: conf.py
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
-linkcheck: conf.py towncrier
+linkcheck: conf.py
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
-spelling: conf.py towncrier
+spelling: conf.py
 	$(SPHINXBUILD) -b spelling $(ALLSPHINXOPTS) $(BUILDDIR)/spelling
 	@echo
 	@echo "Spelling check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/spelling/output.txt."
 
-doctest: conf.py towncrier
+doctest: conf.py
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."


### PR DESCRIPTION
Currently documentation build always invokes towncrier which always creates latest release notes and stages them. This is extremely annoying because one needs to make sure that these staged changes are always unstaged. This PR fixes the situation by making towncrier optional. The master Makefile got a bunch of new rules to invoke various documentation build flavors. This way the developer can quickly regenerate the documentation without invoking everything that's done during release time.

Also, I've removed the linkcheck build in CI as it has failed many times due to ratelimiting. Running it as part of the CI does not bring us any useful information, just noise.