### PR TITLE
Move config and deprecation warnings to a separate module

### DIFF
--- a/master/buildbot/changes/bitbucket.py
+++ b/master/buildbot/changes/bitbucket.py
@@ -22,12 +22,12 @@ from twisted.internet import defer
 from twisted.python import log
 from twisted.web import client
 
-from buildbot import config
 from buildbot.changes import base
 from buildbot.util import bytes2unicode
 from buildbot.util import datetime2epoch
 from buildbot.util import deferredLocked
 from buildbot.util import epoch2datetime
+from buildbot.warnings import warn_deprecated
 
 _UNSPECIFIED = object()
 
@@ -57,7 +57,7 @@ class BitbucketPullrequestPoller(base.PollingChangeSource):
         super().__init__(name='/'.join([owner, slug]), pollInterval=pollInterval,
                          pollAtLaunch=pollAtLaunch)
         if encoding != _UNSPECIFIED:
-            config.warnDeprecated('2.6.0', 'encoding of BitbucketPullrequestPoller is deprecated.')
+            warn_deprecated('2.6.0', 'encoding of BitbucketPullrequestPoller is deprecated.')
 
         if hasattr(pullrequest_filter, '__call__'):
             self.pullrequest_filter = pullrequest_filter

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -38,6 +38,8 @@ from buildbot.util import config as util_config
 from buildbot.util import identifiers as util_identifiers
 from buildbot.util import safeTranslate
 from buildbot.util import service as util_service
+from buildbot.warnings import ConfigWarning
+from buildbot.warnings import warn_deprecated
 from buildbot.www import auth
 from buildbot.www import avatar
 from buildbot.www.authz import authz
@@ -76,19 +78,6 @@ def error(error, always_raise=False):
         _errors.addError(error)
     else:
         raise ConfigErrors([error])
-
-
-class DeprecatedConfigWarning(Warning):
-    """
-    Warning for deprecated configuration options.
-    """
-
-
-def warnDeprecated(version, msg):
-    warnings.warn(
-        "[{} and later] {}".format(version, msg),
-        category=DeprecatedConfigWarning,
-    )
 
 
 _in_unit_tests = False
@@ -389,7 +378,7 @@ class MasterConfig(util.ComparableMixin):
             # would hide the title.
             warnings.warn('WARNING: Title is too long to be displayed. ' +
                           '"Buildbot" will be used instead.',
-                          category=DeprecatedConfigWarning)
+                          category=ConfigWarning)
 
         copy_str_param('titleURL', alt_key='projectURL')
         copy_str_param('buildbotURL')
@@ -403,27 +392,26 @@ class MasterConfig(util.ComparableMixin):
             if _in_unit_tests:
                 self.buildbotNetUsageData = None
             else:
-                warnDeprecated(
-                    '0.9.0',
+                warnings.warn(
                     '`buildbotNetUsageData` is not configured and defaults to basic.\n'
                     'This parameter helps the buildbot development team to understand'
                     ' the installation base.\n'
                     'No personal information is collected.\n'
                     'Only installation software version info and plugin usage is sent.\n'
                     'You can `opt-out` by setting this variable to None.\n'
-                    'Or `opt-in` for more information by setting it to "full".\n'
-                )
+                    'Or `opt-in` for more information by setting it to "full".\n',
+                    category=ConfigWarning)
         copy_str_or_callable_param('buildbotNetUsageData')
 
         for horizon in ('logHorizon', 'buildHorizon', 'eventHorizon'):
             if horizon in config_dict:
-                warnDeprecated(
+                warn_deprecated(
                     '0.9.0',
                     "NOTE: `{}` is deprecated and ignored "
                     "They are replaced by util.JanitorConfigurator".format(horizon))
 
         if 'status' in config_dict:
-            warnDeprecated(
+            warn_deprecated(
                 '0.9.0',
                 "NOTE: `status` targets are deprecated and ignored "
                 "They are replaced by reporters")
@@ -533,7 +521,7 @@ class MasterConfig(util.ComparableMixin):
             config_dict = db
 
         if 'db_poll_interval' in config_dict and throwErrors:
-            warnDeprecated(
+            warn_deprecated(
                 "0.8.7", "db_poll_interval is deprecated and will be ignored")
 
         # we don't attempt to parse db URLs here - the engine strategy will do
@@ -656,7 +644,7 @@ class MasterConfig(util.ComparableMixin):
                 warnings.warn(
                     ("Absolute path '{}' for builder may cause mayhem. Perhaps you meant to "
                      "specify workerbuilddir instead.").format(builder.builddir),
-                    category=DeprecatedConfigWarning,
+                    category=ConfigWarning,
                 )
 
         self.builders = builders
@@ -989,9 +977,9 @@ class BuilderConfig(util_config.ConfiguredMixin):
             error(("builder '{}': builder categories are deprecated and "
                    "replaced by tags; you should only specify tags").format(name))
         if category:
-            warnDeprecated("0.9", ("builder '{}': builder categories are "
-                                   "deprecated and should be replaced with "
-                                   "'tags=[cat]'").format(name))
+            warn_deprecated("0.9", ("builder '{}': builder categories are "
+                                    "deprecated and should be replaced with "
+                                    "'tags=[cat]'").format(name))
             if not isinstance(category, str):
                 error("builder '{}': category must be a string".format(name))
             tags = [category]
@@ -1020,7 +1008,7 @@ class BuilderConfig(util_config.ConfiguredMixin):
             argCount = self._countFuncArgs(nextWorker)
             if (argCount == 2 or (isinstance(nextWorker, MethodType) and
                                   argCount == 3)):
-                warnDeprecated(
+                warn_deprecated(
                     "0.9", "nextWorker now takes a "
                     "3rd argument (build request)")
                 self.nextWorker = lambda x, y, z: nextWorker(

--- a/master/buildbot/process/factory.py
+++ b/master/buildbot/process/factory.py
@@ -14,7 +14,6 @@
 # Copyright Buildbot Team Members
 
 
-import warnings
 from contextlib import contextmanager
 
 from twisted.python import deprecate
@@ -33,6 +32,7 @@ from buildbot.steps.shell import ShellCommand
 from buildbot.steps.shell import Test
 from buildbot.steps.source.cvs import CVS
 from buildbot.steps.source.svn import SVN
+from buildbot.warnings import warn_deprecated
 
 
 # deprecated, use BuildFactory.addStep
@@ -73,10 +73,9 @@ class BuildFactory(util.ComparableMixin):
 
     def addStep(self, step, **kwargs):
         if kwargs or (isinstance(step, type(BuildStep)) and issubclass(step, BuildStep)):
-            warnings.warn(
-                "Passing a BuildStep subclass to factory.addStep is "
-                "deprecated. Please pass a BuildStep instance instead.",
-                DeprecationWarning, stacklevel=2)
+            warn_deprecated("0.8.8",
+                            "Passing a BuildStep subclass to factory.addStep is "
+                            "deprecated. Please pass a BuildStep instance instead.")
             step = step(**kwargs)
         self.steps.append(interfaces.IBuildStepFactory(step))
 

--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -23,6 +23,7 @@ from buildbot import config
 from buildbot.reporters import utils
 from buildbot.util import httpclientservice
 from buildbot.util import service
+from buildbot.warnings import warn_deprecated
 
 
 class HttpStatusPushBase(service.BuildbotService):
@@ -95,8 +96,7 @@ class HttpStatusPush(HttpStatusPushBase):
         if user is not None and auth is not None:
             config.error("Only one of user/password or auth must be given")
         if user is not None:
-            config.warnDeprecated("0.9.1",
-                                  "user/password is deprecated, use 'auth=(user, password)'")
+            warn_deprecated("0.9.1", "user/password is deprecated, use 'auth=(user, password)'")
         if (format_fn is not None) and not callable(format_fn):
             config.error("format_fn must be a function")
         super().checkConfig(**kwargs)

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -29,6 +29,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.process.results import statusToString
 from buildbot.reporters import utils
+from buildbot.warnings import warn_deprecated
 
 
 class MessageFormatterBase(util.ComparableMixin):
@@ -98,7 +99,7 @@ class MessageFormatter(MessageFormatterBase):
                  wantProperties=True, wantSteps=False, wantLogs=False):
 
         if template_name is not None:
-            config.warnDeprecated('0.9.1', "template_name is deprecated, use template_filename")
+            warn_deprecated('0.9.1', "template_name is deprecated, use template_filename")
             template_filename = template_name
         super().__init__(template_dir=template_dir,
                          template_filename=template_filename,

--- a/master/buildbot/test/integration/test_configs.py
+++ b/master/buildbot/test/integration/test_configs.py
@@ -23,6 +23,7 @@ from buildbot import config
 from buildbot.scripts import runner
 from buildbot.test.util import dirs
 from buildbot.test.util.warnings import assertNotProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class RealConfigs(dirs.DirsMixin, unittest.TestCase):
@@ -37,13 +38,13 @@ class RealConfigs(dirs.DirsMixin, unittest.TestCase):
 
     def test_sample_config(self):
         filename = util.sibpath(runner.__file__, 'sample.cfg')
-        with assertNotProducesWarnings(config.DeprecatedConfigWarning):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
             config.FileLoader(self.basedir, filename).loadConfig()
 
     def test_0_9_0b5_api_renamed_config(self):
         with open(self.filename, "w") as f:
             f.write(sample_0_9_0b5_api_renamed)
-        with assertNotProducesWarnings(config.DeprecatedConfigWarning):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
             config.FileLoader(self.basedir, self.filename).loadConfig()
 
 

--- a/master/buildbot/test/regressions/test_oldpaths.py
+++ b/master/buildbot/test/regressions/test_oldpaths.py
@@ -16,6 +16,8 @@
 
 from twisted.trial import unittest
 
+from buildbot.warnings import DeprecatedApiWarning
+
 
 def deprecatedImport(fn):
     def wrapper(self):
@@ -25,7 +27,7 @@ def deprecatedImport(fn):
         if len(warnings) == 2 and warnings[0] == warnings[1]:
             del warnings[1]
         self.assertEqual(len(warnings), 1, "got: %r" % (warnings,))
-        self.assertEqual(warnings[0]['category'], DeprecationWarning)
+        self.assertEqual(warnings[0]['category'], DeprecatedApiWarning)
     return wrapper
 
 

--- a/master/buildbot/test/unit/test_buildbot_net_usage_data.py
+++ b/master/buildbot/test/unit/test_buildbot_net_usage_data.py
@@ -28,13 +28,13 @@ from buildbot.buildbot_net_usage_data import _sendBuildbotNetUsageData
 from buildbot.buildbot_net_usage_data import computeUsageData
 from buildbot.buildbot_net_usage_data import linux_distribution
 from buildbot.config import BuilderConfig
-from buildbot.config import DeprecatedConfigWarning
 from buildbot.master import BuildMaster
 from buildbot.plugins import steps
 from buildbot.process.factory import BuildFactory
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.test.util.integration import DictLoader
 from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.warnings import ConfigWarning
 from buildbot.worker.base import Worker
 
 
@@ -71,7 +71,7 @@ class Tests(unittest.TestCase):
     def test_basic(self):
         self.patch(config, "_in_unit_tests", False)
         with assertProducesWarning(
-                DeprecatedConfigWarning,
+                ConfigWarning,
                 message_pattern=r"`buildbotNetUsageData` is not configured and defaults to basic."):
             master = self.getMaster(self.getBaseConfig())
         data = computeUsageData(master)

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -44,6 +44,8 @@ from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.warnings import assertNotProducesWarnings
 from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.util import service
+from buildbot.warnings import ConfigWarning
+from buildbot.warnings import DeprecatedApiWarning
 
 try:
     # Python 2
@@ -465,8 +467,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.do_test_load_global(dict(title='hi'), title='hi')
 
     def test_load_global_title_too_long(self):
-        with assertProducesWarning(config.DeprecatedConfigWarning,
-                                   message_pattern=r"Title is too long"):
+        with assertProducesWarning(ConfigWarning, message_pattern=r"Title is too long"):
             self.do_test_load_global(dict(title="Very very very very very long title"))
 
     def test_load_global_projectURL(self):
@@ -485,13 +486,13 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.do_test_load_global(dict(changeHorizon=None), changeHorizon=None)
 
     def test_load_global_eventHorizon(self):
-        with assertProducesWarning(config.DeprecatedConfigWarning,
+        with assertProducesWarning(DeprecatedApiWarning,
                                    message_pattern=r"`eventHorizon` is deprecated and ignored"):
             self.do_test_load_global(
                 dict(eventHorizon=10))
 
     def test_load_global_status(self):
-        with assertProducesWarning(config.DeprecatedConfigWarning,
+        with assertProducesWarning(DeprecatedApiWarning,
                                    message_pattern=r"`status` targets are deprecated and ignored"):
             self.do_test_load_global(
                 dict(status=[]))
@@ -499,7 +500,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
     def test_load_global_buildbotNetUsageData(self):
         self.patch(config, "_in_unit_tests", False)
         with assertProducesWarning(
-                config.DeprecatedConfigWarning,
+                ConfigWarning,
                 message_pattern=r"`buildbotNetUsageData` is not configured and defaults to basic."):
             self.do_test_load_global(
                 dict())
@@ -632,7 +633,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
     def test_load_db_db_poll_interval(self):
         # value is ignored, but no error
         with assertProducesWarning(
-                config.DeprecatedConfigWarning,
+                DeprecatedApiWarning,
                 message_pattern=r"db_poll_interval is deprecated and will be ignored"):
             self.cfg.load_db(self.filename, dict(db_poll_interval=2))
         self.assertResults(
@@ -641,7 +642,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
     def test_load_db_dict(self):
         # db_poll_interval value is ignored, but no error
         with assertProducesWarning(
-                config.DeprecatedConfigWarning,
+                DeprecatedApiWarning,
                 message_pattern=r"db_poll_interval is deprecated and will be ignored"):
             self.cfg.load_db(self.filename,
                              dict(db=dict(db_url='abcd', db_poll_interval=10)))
@@ -649,7 +650,7 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
 
     def test_load_db_unk_keys(self):
         with assertProducesWarning(
-                config.DeprecatedConfigWarning,
+                DeprecatedApiWarning,
                 message_pattern=r"db_poll_interval is deprecated and will be ignored"):
             self.cfg.load_db(self.filename,
                              dict(db=dict(db_url='abcd', db_poll_interval=10, bar='bar')))
@@ -1289,7 +1290,7 @@ class MasterConfig_old_worker_api(unittest.TestCase):
         self.cfg = config.MasterConfig()
 
     def test_workers_new_api(self):
-        with assertNotProducesWarnings(config.DeprecatedConfigWarning):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
             self.assertEqual(self.cfg.workers, [])
 
 
@@ -1348,7 +1349,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
 
     def test_bogus_category(self):
         with assertProducesWarning(
-                config.DeprecatedConfigWarning,
+                DeprecatedApiWarning,
                 message_pattern=r"builder categories are deprecated and should be replaced with"):
             with self.assertRaisesConfigError("category must be a string"):
                 config.BuilderConfig(category=13,
@@ -1493,7 +1494,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
         self.assertEqual(cfg.workernames, ['a'])
 
     def test_init_workername_positional(self):
-        with assertNotProducesWarnings(config.DeprecatedConfigWarning):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
             cfg = config.BuilderConfig(
                 'a b c', 'a', factory=self.factory)
 
@@ -1506,7 +1507,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
         self.assertEqual(cfg.workernames, ['a'])
 
     def test_init_workernames_positional(self):
-        with assertNotProducesWarnings(config.DeprecatedConfigWarning):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
             cfg = config.BuilderConfig(
                 'a b c', None, ['a'], factory=self.factory)
 
@@ -1520,7 +1521,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
         self.assertEqual(cfg.workerbuilddir, 'dir')
 
     def test_init_workerbuilddir_positional(self):
-        with assertNotProducesWarnings(config.DeprecatedConfigWarning):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
             cfg = config.BuilderConfig(
                 'a b c', 'a', None, None, 'dir', factory=self.factory)
 
@@ -1536,7 +1537,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
 
     def test_init_next_worker_positional(self):
         f = lambda: None
-        with assertNotProducesWarnings(config.DeprecatedConfigWarning):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
             cfg = config.BuilderConfig(
                 'a b c', 'a', None, None, None, self.factory, None, None, f)
 

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor.py
@@ -31,6 +31,7 @@ from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.warnings import assertProducesWarning
 from buildbot.util import epoch2datetime
 from buildbot.util.eventual import fireEventually
+from buildbot.warnings import DeprecatedApiWarning
 
 
 def nth_worker(n):
@@ -735,7 +736,7 @@ class TestMaybeStartBuilds(TestBRDBase):
                                         factory=factory.BuildFactory(),
                                         nextWorker=nextWorker)
         if exp_warning:
-            with assertProducesWarning(config.DeprecatedConfigWarning,
+            with assertProducesWarning(DeprecatedApiWarning,
                                        message_pattern=r"nextWorker now takes a 3rd argument"):
                 builder_config = makeBuilderConfig()
         else:

--- a/master/buildbot/test/unit/test_process_factory.py
+++ b/master/buildbot/test/unit/test_process_factory.py
@@ -25,6 +25,8 @@ from buildbot.process.factory import BuildFactory
 from buildbot.process.factory import GNUAutoconf
 from buildbot.process.factory import s
 from buildbot.steps.shell import Configure
+from buildbot.test.util.warnings import assertProducesWarning
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestBuildFactory(unittest.TestCase):
@@ -57,29 +59,22 @@ class TestBuildFactory(unittest.TestCase):
         Passing keyword arguments to L{BuildFactory.addStep} is deprecated,
         but pass the arguments to the first argument, to construct a step.
         """
-        self.factory.addStep(BuildStep, name='test')
+        with assertProducesWarning(DeprecatedApiWarning):
+            self.factory.addStep(BuildStep, name='test')
 
         self.assertEqual(self.factory.steps[-1],
                          _BuildStepFactory(BuildStep, name='test'))
-
-        warnings = self.flushWarnings(
-            [self.test_addStep_deprecated_withArguments])
-        self.assertEqual(len(warnings), 1)
-        self.assertEqual(warnings[0]['category'], DeprecationWarning)
 
     def test_addStep_deprecated(self):
         """
         Passing keyword arguments to L{BuildFactory.addStep} is deprecated,
         but pass the arguments to the first argument, to construct a step.
         """
-        self.factory.addStep(BuildStep)
+        with assertProducesWarning(DeprecatedApiWarning):
+            self.factory.addStep(BuildStep)
 
         self.assertEqual(self.factory.steps[-1],
                          _BuildStepFactory(BuildStep))
-
-        warnings = self.flushWarnings([self.test_addStep_deprecated])
-        self.assertEqual(len(warnings), 1)
-        self.assertEqual(warnings[0]['category'], DeprecationWarning)
 
     def test_s(self):
         """

--- a/master/buildbot/test/unit/test_process_remotecommand.py
+++ b/master/buildbot/test/unit/test_process_remotecommand.py
@@ -17,12 +17,12 @@ import mock
 
 from twisted.trial import unittest
 
-from buildbot import config
 from buildbot.process import remotecommand
 from buildbot.test.fake import logfile
 from buildbot.test.fake import remotecommand as fakeremotecommand
 from buildbot.test.util import interfaces
 from buildbot.test.util.warnings import assertNotProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestRemoteShellCommand(unittest.TestCase):
@@ -183,19 +183,19 @@ class TestFakeRunCommand(unittest.TestCase, Tests):
 class TestWorkerTransition(unittest.TestCase):
 
     def test_RemoteShellCommand_usePTY(self):
-        with assertNotProducesWarnings(config.DeprecatedConfigWarning):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
             cmd = remotecommand.RemoteShellCommand(
                 'workdir', 'command')
 
         self.assertTrue(cmd.args['usePTY'] is None)
 
-        with assertNotProducesWarnings(config.DeprecatedConfigWarning):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
             cmd = remotecommand.RemoteShellCommand(
                 'workdir', 'command', usePTY=True)
 
         self.assertTrue(cmd.args['usePTY'])
 
-        with assertNotProducesWarnings(config.DeprecatedConfigWarning):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
             cmd = remotecommand.RemoteShellCommand(
                 'workdir', 'command', usePTY=False)
 

--- a/master/buildbot/test/unit/test_worker_ec2.py
+++ b/master/buildbot/test/unit/test_worker_ec2.py
@@ -18,10 +18,10 @@ import os
 
 from twisted.trial import unittest
 
-from buildbot import config
 from buildbot.test.util.decorators import flaky
 from buildbot.test.util.warnings import assertNotProducesWarnings
 from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 try:
     from moto import mock_ec2
@@ -245,7 +245,7 @@ class TestEC2LatentWorker(unittest.TestCase):
 
         amis = list(r.images.all())
         with assertProducesWarnings(
-                config.DeprecatedConfigWarning,
+                DeprecatedApiWarning,
                 messages_patterns=[
                     r"Use of dict value to 'block_device_map' of EC2LatentWorker "
                     r"constructor is deprecated. Please use a list matching the AWS API"
@@ -572,7 +572,7 @@ class TestEC2LatentWorkerDefaultKeyairSecurityGroup(unittest.TestCase):
     def test_use_non_default_keypair_security(self):
         c, r = self.botoSetup()
         amis = list(r.images.all())
-        with assertNotProducesWarnings(config.DeprecatedConfigWarning):
+        with assertNotProducesWarnings(DeprecatedApiWarning):
             bs = ec2.EC2LatentWorker('bot1', 'sekrit', 'm1.large',
                                      identifier='publickey',
                                      secret_identifier='privatekey',

--- a/master/buildbot/warnings.py
+++ b/master/buildbot/warnings.py
@@ -14,12 +14,26 @@
 # Copyright Buildbot Team Members
 
 
-from buildbot.reporters.bitbucketserver import BitbucketServerStatusPush
-from buildbot.warnings import warn_deprecated
+import warnings
 
 
-def StashStatusPush(*args, **kwargs):
-    warn_deprecated('0.9.8',
-                    "The 'StashStatusPush' class was renamed to "
-                    "'BitbucketServer.BitbucketServerStatusPush'")
-    return BitbucketServerStatusPush(*args, **kwargs)
+class ConfigWarning(Warning):
+    """
+    Warning for issues in the configuration. Use DeprecatedApiWarning for deprecated APIs
+    """
+
+
+# DeprecationWarning or PendingDeprecationWarning may be used as
+# the base class, but by default deprecation warnings are disabled in Python,
+# so by default old-API usage warnings will be ignored - this is not what
+# we want.
+class DeprecatedApiWarning(Warning):
+    """
+    Warning for deprecated configuration options.
+    """
+
+
+def warn_deprecated(version, msg, stacklevel=2):
+    warnings.warn("[{} and later] {}".format(version, msg),
+                  category=DeprecatedApiWarning,
+                  stacklevel=stacklevel)

--- a/master/buildbot/worker/ec2.py
+++ b/master/buildbot/worker/ec2.py
@@ -29,6 +29,7 @@ from twisted.python import log
 
 from buildbot import config
 from buildbot.interfaces import LatentWorkerFailedToSubstantiate
+from buildbot.warnings import warn_deprecated
 from buildbot.worker import AbstractLatentWorker
 
 try:
@@ -274,7 +275,7 @@ class EC2LatentWorker(AbstractLatentWorker):
                     ebs.setdefault('DeleteOnTermination', True)
             return mapping_definitions
 
-        config.warnDeprecated(
+        warn_deprecated(
             '0.9.0',
             "Use of dict value to 'block_device_map' of EC2LatentWorker "
             "constructor is deprecated. Please use a list matching the AWS API "


### PR DESCRIPTION
This is to prepare to add a bunch of deprecation warnings in the modules that are already deprecated. In order to still test them, we need a way to import just the minimal set of functionality that reports warnings. Thus we can't have these classes in the buildbot.config module.