### PR TITLE
Add more deprecation warnings for buildbot.status removal

### DIFF
--- a/master/buildbot/newsfragments/status-reporter.removal
+++ b/master/buildbot/newsfragments/status-reporter.removal
@@ -1,0 +1,1 @@
+Deprecation warnings have been added to the `buildbot.status` module. It has been deprecated in documentation v0.9.0.

--- a/master/buildbot/status/base.py
+++ b/master/buildbot/status/base.py
@@ -20,6 +20,12 @@ from buildbot import pbutil
 from buildbot import util
 from buildbot.interfaces import IStatusReceiver
 from buildbot.util import service
+from buildbot.warnings import warn_deprecated
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.base has been deprecated, consume the buildbot.data APIs'
+)
 
 
 @implementer(IStatusReceiver)

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -20,6 +20,12 @@ from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot import util
+from buildbot.warnings import warn_deprecated
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.build has been deprecated, consume the buildbot.data APIs'
+)
 
 
 @implementer(interfaces.IBuildStatus, interfaces.IStatusEvent)

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -37,9 +37,16 @@ from buildbot.status.build import BuildStatus
 from buildbot.status.buildrequest import BuildRequestStatus
 from buildbot.status.event import Event
 from buildbot.util.lru import LRUCache
+from buildbot.warnings import warn_deprecated
 
 _hush_pyflakes = [SUCCESS, WARNINGS, FAILURE, SKIPPED,
                   EXCEPTION, RETRY, CANCELLED, Results, worst_status]
+
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.worker has been deprecated, consume the buildbot.data APIs'
+)
 
 
 @implementer(interfaces.IBuilderStatus, interfaces.IEventSource)

--- a/master/buildbot/status/buildrequest.py
+++ b/master/buildbot/status/buildrequest.py
@@ -20,6 +20,12 @@ from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.util.eventual import eventually
+from buildbot.warnings import warn_deprecated
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.buildrequest has been deprecated, consume the buildbot.data APIs'
+)
 
 
 @implementer(interfaces.IBuildRequestStatus)

--- a/master/buildbot/status/buildset.py
+++ b/master/buildbot/status/buildset.py
@@ -20,6 +20,12 @@ from zope.interface import implementer
 from buildbot import interfaces
 from buildbot.data import resultspec
 from buildbot.status.buildrequest import BuildRequestStatus
+from buildbot.warnings import warn_deprecated
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.buildset has been deprecated, consume the buildbot.data APIs'
+)
 
 
 @implementer(interfaces.IBuildSetStatus)

--- a/master/buildbot/status/event.py
+++ b/master/buildbot/status/event.py
@@ -18,6 +18,12 @@ from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot import util
+from buildbot.warnings import warn_deprecated
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.event has been deprecated, consume the buildbot.data APIs'
+)
 
 
 @implementer(interfaces.IStatusEvent)

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -30,6 +30,12 @@ from buildbot.util import bbcollections
 from buildbot.util import bytes2unicode
 from buildbot.util import service
 from buildbot.util.eventual import eventually
+from buildbot.warnings import warn_deprecated
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.master has been deprecated, consume the buildbot.data APIs'
+)
 
 
 @implementer(interfaces.IStatus)

--- a/master/buildbot/status/worker.py
+++ b/master/buildbot/status/worker.py
@@ -22,6 +22,12 @@ from buildbot import interfaces
 from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
 from buildbot.util.eventual import eventually
+from buildbot.warnings import warn_deprecated
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.worker has been deprecated, consume the buildbot.data APIs'
+)
 
 
 @implementer(interfaces.IWorkerStatus)

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -19,6 +19,9 @@ import warnings
 from distutils.version import LooseVersion
 
 from buildbot import monkeypatches
+from buildbot.test.util.warnings import assertProducesWarning  # noqa pylint: disable=wrong-import-position
+from buildbot.test.util.warnings import assertProducesWarnings  # noqa pylint: disable=wrong-import-position
+from buildbot.warnings import DeprecatedApiWarning  # noqa pylint: disable=wrong-import-position
 
 # import mock so we bail out early if it's not installed
 try:
@@ -37,6 +40,28 @@ warnings.filterwarnings('always', category=DeprecationWarning)
 if LooseVersion(mock.__version__) < LooseVersion("0.8"):
     raise ImportError("\nBuildbot tests require mock version 0.8.0 or "
                       "higher; try 'pip install -U mock'")
+
+
+# This is where we load deprecated module-level APIs to ignore warning produced by importing them.
+# After the deprecated API has been removed, leave at least one instance of the import in a
+# commented state as reference.
+
+
+with assertProducesWarnings(DeprecatedApiWarning,
+                            messages_patterns=[
+                                r" buildbot\.status\.build has been deprecated",
+                                r" buildbot\.status\.buildrequest has been deprecated",
+                                r" buildbot\.status\.event has been deprecated",
+                                r" buildbot\.status\.worker has been deprecated",
+                                r" buildbot\.status\.buildset has been deprecated",
+                                r" buildbot\.status\.master has been deprecated",
+                                r" buildbot\.status\.base has been deprecated",
+                            ]):
+    import buildbot.status.base as _  # noqa
+
+with assertProducesWarning(DeprecatedApiWarning,
+                           message_pattern=r" buildbot\.status\.worker has been deprecated"):
+    import buildbot.status.worker as _  # noqa
 
 # All deprecated modules should be loaded, consider future warnings in tests as errors.
 # In order to not pollute the test outputs,

--- a/master/docs/developer/cls-buildsetsummarynotifiermixin.rst
+++ b/master/docs/developer/cls-buildsetsummarynotifiermixin.rst
@@ -12,6 +12,7 @@ BuildSetSummaryNotifierMixin
 
 .. py:class:: buildbot.status.buildset.BuildSetSummaryNotifierMixin::
 
+    (deprecated)
     This class provides some helper methods for implementing a status notification that provides notifications for all build results for a buildset at once.
 
     This class provides the following methods:

--- a/master/docs/developer/cls-remotecommands.rst
+++ b/master/docs/developer/cls-remotecommands.rst
@@ -107,7 +107,7 @@ RemoteCommand
 
     .. py:attribute:: logs
 
-        A dictionary of :class:`~buildbot.status.logfile.LogFile` instances representing active logs.
+        A dictionary of :class:`~buildbot.process.log.Log` instances representing active logs.
         Do not modify this directly -- use :meth:`useLog` instead.
 
     .. py:attribute:: rc
@@ -124,8 +124,8 @@ RemoteCommand
 
     .. py:method:: useLog(log, closeWhenFinished=False, logfileName=None)
 
-        :param log: the :class:`~buildbot.status.logfile.LogFile` instance to add to.
-        :param closeWhenFinished: if true, call :meth:`~buildbot.status.logfile.LogFile.finish` when the command is finished.
+        :param log: the :class:`~buildbot.process.log.Log` instance to add to.
+        :param closeWhenFinished: if true, call :meth:`~buildbot.process.log.Log.finish` when the command is finished.
         :param logfileName: the name of the logfile, as given to the worker.
                             This is ``stdio`` for standard streams.
 
@@ -138,7 +138,7 @@ RemoteCommand
         :param logfileName: the name of the logfile, as given to the worker.
                             This is ``stdio`` for standard streams.
         :param activateCallback: callback for when the log is added; see below
-        :param closeWhenFinished: if true, call :meth:`~buildbot.status.logfile.LogFile.finish` when the command is finished.
+        :param closeWhenFinished: if true, call :meth:`~buildbot.process.log.Log.finish` when the command is finished.
 
         Similar to :meth:`useLog`, but the logfile is only actually added when an update arrives for it.
         The callback, ``activateCallback``, will be called with the :class:`~buildbot.process.remotecommand.RemoteCommand` instance when the first update for the log is delivered.

--- a/master/docs/developer/master-overview.rst
+++ b/master/docs/developer/master-overview.rst
@@ -71,7 +71,7 @@ The master has a number of useful attributes:
     A :py:class:`buildbot.process.debug.DebugServices` instance that manages
     debugging-related access -- the manhole, in particular.
 
-``master.status``
+``master.status`` (deprecated)
     A :py:class:`buildbot.status.master.Status` instance that provides access
     to all status data.  This instance is also the service parent for all
     status listeners.

--- a/master/docs/manual/concepts.rst
+++ b/master/docs/manual/concepts.rst
@@ -309,7 +309,7 @@ This means the User-to-address mapping only has to be set up once, in your :clas
 IRC Nicknames
 ~~~~~~~~~~~~~
 
-Like :class:`MailNotifier`, the :class:`buildbot.status.words.IRC` class provides a status target which can announce the results of each build.
+Like :class:`MailNotifier`, the :class:`buildbot.reporters.irc.IRC` class provides a status target which can announce the results of each build.
 It also provides an interactive interface by responding to online queries posted in the channel or sent as private messages.
 
 In the future, the buildbot can be configured to map User names to IRC nicknames, to watch for the recent presence of these nicknames, and to deliver build status messages to the interested parties.

--- a/master/docs/manual/configuration/buildsteps.rst
+++ b/master/docs/manual/configuration/buildsteps.rst
@@ -23,7 +23,7 @@ The basic behavior for a :class:`BuildStep` is to:
 * run for a while, then stop
 * possibly invoke some RemoteCommands on the attached worker
 * possibly produce a set of log files
-* finish with a status described by one of four values defined in :mod:`buildbot.status.builder`: ``SUCCESS``, ``WARNINGS``, ``FAILURE``, ``SKIPPED``
+* finish with a status described by one of four values defined in :mod:`buildbot.process.results`: ``SUCCESS``, ``WARNINGS``, ``FAILURE``, ``SKIPPED``
 * provide a list of short strings to describe the step
 
 The rest of this section describes all the standard :class:`BuildStep` objects available for use in a :class:`Build`, and the parameters which can be used to control each.

--- a/master/docs/manual/configuration/reporters.rst
+++ b/master/docs/manual/configuration/reporters.rst
@@ -1026,7 +1026,7 @@ Revisions that are stored as hashes are shortened to 7 characters in length, as 
 GerritStatusPush
 ~~~~~~~~~~~~~~~~
 
-.. py:currentmodule:: buildbot.status.status_gerrit
+.. py:currentmodule:: buildbot.reporters.status_gerrit
 
 :class:`GerritStatusPush` sends review of the :class:`Change` back to the Gerrit server, optionally also sending a message when a build is started.
 GerritStatusPush can send a separate review for each build that completes, or a single review summarizing the results for all of the builds.


### PR DESCRIPTION
`buildbot.status` has been deprecated since 0.9.0. It makes sense to remove it as that code is not covered by tests well and is probably already broken. Before that, we must ensure that warnings are shown in the logs to all users for at least one release.

This PR depends on #5353, so it will be hard to review until that PR is merged.