### PR TITLE
remove uses of status

### DIFF
--- a/master/buildbot/changes/changes.py
+++ b/master/buildbot/changes/changes.py
@@ -18,15 +18,12 @@ import time
 
 from twisted.internet import defer
 from twisted.python import log
-from zope.interface import implementer
 
-from buildbot import interfaces
 from buildbot import util
 from buildbot.process.properties import Properties
 from buildbot.util import datetime2epoch
 
 
-@implementer(interfaces.IStatusEvent)
 class Change:
 
     """I represent a single change to the source tree. This may involve several

--- a/master/buildbot/data/builds.py
+++ b/master/buildbot/data/builds.py
@@ -118,7 +118,7 @@ class BuildEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
             buildid = dbdict['id']
         self.master.mq.produce(("control", "builds",
                                 str(buildid), 'stop'),
-                               dict(reason=kwargs.get('reason', args.get('reason', 'no reason'))))
+                               args)
 
     @defer.inlineCallbacks
     def actionRebuild(self, args, kwargs):

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -43,7 +43,6 @@ from buildbot.process.botmaster import BotMaster
 from buildbot.process.users.manager import UserManagerManager
 from buildbot.schedulers.manager import SchedulerManager
 from buildbot.secrets.manager import SecretManager
-from buildbot.status.master import Status
 from buildbot.util import check_functional_environment
 from buildbot.util import service
 from buildbot.util.eventual import eventually
@@ -179,9 +178,6 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
         self.debug = debug.DebugServices()
         yield self.debug.setServiceParent(self)
-
-        self.status = Status()
-        yield self.status.setServiceParent(self)
 
         self.secrets_manager = SecretManager()
         yield self.secrets_manager.setServiceParent(self)
@@ -439,12 +435,6 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
     # informational methods
     def allSchedulers(self):
         return list(self.scheduler_manager)
-
-    def getStatus(self):
-        """
-        @rtype: L{buildbot.status.builder.Status}
-        """
-        return self.status
 
     # state maintenance (private)
     def getObjectId(self):

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -63,15 +63,12 @@ class Build(properties.PropertiesMixin):
     L{buildbot.process.factory.BuildFactory}
 
     @ivar requests: the list of L{BuildRequest}s that triggered me
-    @ivar build_status: the L{buildbot.status.build.BuildStatus} that
-                        collects our status
     """
 
     VIRTUAL_BUILDERNAME_PROP = "virtual_builder_name"
     VIRTUAL_BUILDERDESCRIPTION_PROP = "virtual_builder_description"
     VIRTUAL_BUILDERTAGS_PROP = "virtual_builder_tags"
     workdir = "build"
-    build_status = None
     reason = "changes"
     finished = False
     results = None
@@ -257,7 +254,6 @@ class Build(properties.PropertiesMixin):
     def setupWorkerForBuilder(self, workerforbuilder):
         self.path_module = workerforbuilder.worker.path_module
         self.workername = workerforbuilder.worker.workername
-        self.build_status.setWorkername(self.workername)
 
     @defer.inlineCallbacks
     def getBuilderId(self):
@@ -283,7 +279,7 @@ class Build(properties.PropertiesMixin):
         return self._builderid
 
     @defer.inlineCallbacks
-    def startBuild(self, build_status, workerforbuilder):
+    def startBuild(self, workerforbuilder):
         """This method sets up the build, then starts it by invoking the
         first Step. It returns a Deferred which will fire when the build
         finishes. This Deferred is guaranteed to never errback."""
@@ -294,7 +290,6 @@ class Build(properties.PropertiesMixin):
 
         log.msg("{}.startBuild".format(self))
 
-        self.build_status = build_status
         # TODO: this will go away when build collapsing is implemented; until
         # then we just assign the build to the first buildrequest
         brid = self.requests[0].id
@@ -327,7 +322,6 @@ class Build(properties.PropertiesMixin):
         # make sure properties are available to people listening on 'new'
         # events
         yield self.master.data.updates.setBuildProperties(self.buildid, self)
-        self.build_status.buildStarted(self)
         yield self.master.data.updates.setBuildStateString(self.buildid, 'starting')
         yield self.master.data.updates.generateNewBuildEvent(self.buildid)
 
@@ -668,9 +662,6 @@ class Build(properties.PropertiesMixin):
                 self.conn = None
             log.msg(" {}: build finished".format(self))
             self.results = worst_status(self.results, results)
-            self.build_status.setText(text)
-            self.build_status.setResults(self.results)
-            self.build_status.buildFinished()
             eventually(self.releaseLocks)
             metrics.MetricCountEvent.log('active_builds', -1)
 

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -745,14 +745,7 @@ class Build(properties.PropertiesMixin):
             lambda: self.finished)
 
     def getWorkerInfo(self):
-        return self.workerforbuilder.worker.worker_status.info
-
-    # IBuildControl
-
-    def getStatus(self):
-        return self.build_status
-
-    # stopBuild is defined earlier
+        return self.workerforbuilder.worker.info
 
 
 components.registerAdapter(

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -189,9 +189,12 @@ def getResponsibleUsersForBuild(master, buildid):
 
 def getURLForBuild(master, builderid, build_number):
     prefix = master.config.buildbotURL
-    return prefix + "#builders/%d/builds/%d" % (
-        builderid,
-        build_number)
+    return prefix + "#builders/{:d}/builds/{:d}".format(builderid, build_number)
+
+
+def getURLForBuildrequest(master, buildrequestid):
+    prefix = master.config.buildbotURL
+    return prefix + "#buildrequests/{:d}".format(buildrequestid)
 
 
 @renderer

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -20,8 +20,8 @@ from buildbot.process import buildstep
 from buildbot.process import properties
 from buildbot.process import remotecommand
 from buildbot.process.buildstep import LoggingBuildStep
-from buildbot.status.builder import FAILURE
-from buildbot.status.builder import SKIPPED
+from buildbot.process.results import FAILURE
+from buildbot.process.results import SKIPPED
 from buildbot.steps.worker import CompositeStepMixin
 from buildbot.util import bytes2unicode
 

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -27,6 +27,8 @@ from buildbot.process.properties import Properties
 from buildbot.process.properties import Property
 from buildbot.process.results import statusToString
 from buildbot.process.results import worst_status
+from buildbot.reporters.utils import getURLForBuild
+from buildbot.reporters.utils import getURLForBuildrequest
 
 
 class Trigger(BuildStep):
@@ -230,7 +232,7 @@ class Trigger(BuildStep):
                             builderDict = yield self.master.data.get(("builders", builderid))
                             builderNames[builderid] = builderDict["name"]
                         num = build['number']
-                        url = self.master.status.getURLForBuild(builderid, num)
+                        url = getURLForBuild(self.master, builderid, num)
                         yield self.addURL("{}: {} #{}".format(statusToString(build["results"]),
                                                               builderNames[builderid], num),
                                           url)
@@ -295,7 +297,7 @@ class Trigger(BuildStep):
             for brid in brids.values():
                 # put the url to the brids, so that we can have the status from
                 # the beginning
-                url = self.master.status.getURLForBuildrequest(brid)
+                url = getURLForBuildrequest(self.master, brid)
                 yield self.addURL("{} #{}".format(sch.name, brid), url)
             dl.append(resultsDeferred)
             triggeredNames.append(sch.name)

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -81,7 +81,7 @@ class FakeBuild(properties.PropertiesMixin):
         return self.builder
 
     def getWorkerInfo(self):
-        return self.workerforbuilder.worker.worker_status.info
+        return self.workerforbuilder.worker.info
 
     def setUniqueStepName(self, step):
         pass

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -14,18 +14,14 @@
 # Copyright Buildbot Team Members
 
 
-import os
 import weakref
 
 import mock
 
 from twisted.internet import defer
 from twisted.internet import reactor
-from zope.interface import implementer
 
 from buildbot import config
-from buildbot import interfaces
-from buildbot.status import build
 from buildbot.test import fakedb
 from buildbot.test.fake import bworkermanager
 from buildbot.test.fake import fakedata
@@ -65,92 +61,6 @@ class FakeCaches:
         return FakeCache(name, miss_fn)
 
 
-class FakeStatus(service.BuildbotService):
-
-    name = "status"
-    lastBuilderStatus = None
-
-    def builderAdded(self, name, basedir, tags=None, description=None):
-        bs = FakeBuilderStatus(self.master)
-        self.lastBuilderStatus = bs
-        return bs
-
-    def getBuilderNames(self):
-        return []
-
-    def getWorkerNames(self):
-        return []
-
-    def workerConnected(self, name):
-        pass
-
-    def build_started(self, brid, buildername, build_status):
-        pass
-
-    def getURLForBuild(self, builder_name, build_number):
-        return "URLForBuild/{}/{}".format(builder_name, build_number)
-
-    def getURLForBuildrequest(self, buildrequestid):
-        return "URLForBuildrequest/%d" % (buildrequestid,)
-
-    def subscribe(self, _):
-        pass
-
-    def getTitle(self):
-        return "myBuildbot"
-
-    def getURLForThing(self, _):
-        return "h://thing"
-
-    def getBuildbotURL(self):
-        return "h://bb.me"
-
-
-@implementer(interfaces.IBuilderStatus)
-class FakeBuilderStatus:
-
-    def __init__(self, master=None, buildername="Builder"):
-        if master:
-            self.master = master
-            self.botmaster = master.botmaster
-            self.basedir = os.path.join(master.basedir, 'bldr')
-        self.lastBuildStatus = None
-        self._tags = None
-        self.name = buildername
-
-    def setDescription(self, description):
-        self._description = description
-
-    def getDescription(self):
-        return self._description
-
-    def getTags(self):
-        return self._tags
-
-    def setTags(self, tags):
-        self._tags = tags
-
-    def matchesAnyTag(self, tags):
-        return set(self._tags) & set(tags)
-
-    def setWorkernames(self, names):
-        pass
-
-    def setCacheSize(self, size):
-        pass
-
-    def setBigState(self, state):
-        pass
-
-    def newBuild(self):
-        bld = build.BuildStatus(self, self.master, 3)
-        self.lastBuildStatus = bld
-        return bld
-
-    def buildStarted(self, builderStatus):
-        pass
-
-
 class FakeLogRotation:
     rotateLength = 42
     maxRotatedFiles = 42
@@ -178,8 +88,6 @@ class FakeMaster(service.MasterService):
         self.basedir = 'basedir'
         self.botmaster = FakeBotMaster()
         self.botmaster.setServiceParent(self)
-        self.status = FakeStatus()
-        self.status.setServiceParent(self)
         self.name = 'fake:/master'
         self.masterid = master_id
         self.workers = bworkermanager.FakeWorkerManager()

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -40,6 +40,7 @@ class FakeWorker:
         self.properties = properties.Properties()
         self.defaultProperties = properties.Properties()
         self.workerid = 383
+        self.info = {'test': 'test'}
 
     def acquireLocks(self):
         pass

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -236,7 +236,7 @@ class Tests(RunFakeMasterTestCase):
         }
         yield self.getMaster(config_dict)
 
-        props = worker.worker_status.info
+        props = worker.info
 
         from buildbot_worker.base import BotBase
 
@@ -246,7 +246,7 @@ class Tests(RunFakeMasterTestCase):
         for key, value in expected_props_dict.items():
             self.assertTrue(isinstance(key, str))
             self.assertTrue(isinstance(value, str))
-            self.assertEqual(props.getProperty(key), value)
+            self.assertEqual(props.get(key), value)
 
     if RemoteWorker is None:
         skip = "buildbot-worker package is not installed"

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -34,7 +34,6 @@ from buildbot import worker
 from buildbot.process import botmaster
 from buildbot.process import builder
 from buildbot.process import factory
-from buildbot.status import master
 from buildbot.test.fake import fakemaster
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util.eventual import eventually
@@ -189,8 +188,6 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
         self.botmaster = botmaster.BotMaster()
         yield self.botmaster.setServiceParent(self.master)
 
-        self.master.status = master.Status()
-        yield self.master.status.setServiceParent(self.master)
         self.master.botmaster = self.botmaster
         self.master.data.updates.workerConfigured = lambda *a, **k: None
         yield self.master.startService()

--- a/master/buildbot/test/integration/test_worker_comm.py
+++ b/master/buildbot/test/integration/test_worker_comm.py
@@ -342,18 +342,17 @@ class TestWorkerComm(unittest.TestCase, TestReactorMixin):
     def test_worker_info(self):
         yield self.addWorker()
         worker = yield self.connectWorker()
-        props = self.buildworker.worker_status.info
+        props = self.buildworker.info
         # check worker info passing
-        self.assertEqual(props.getProperty("info"),
+        self.assertEqual(props["info"],
                          "here")
         # check worker info passing with UTF-8
-        self.assertEqual(props.getProperty("os_release"),
+        self.assertEqual(props["os_release"],
                          b'\xe3\x83\x86\xe3\x82\xb9\xe3\x83\x88'.decode())
-        self.assertEqual(props.getProperty(b'\xe3\x83\xaa\xe3\x83\xaa\xe3\x83\xbc\xe3\x82'
-                                           b'\xb9\xe3\x83\x86\xe3\x82\xb9\xe3\x83\x88'.decode()),
+        self.assertEqual(props[b'\xe3\x83\xaa\xe3\x83\xaa\xe3\x83\xbc\xe3\x82'
+                               b'\xb9\xe3\x83\x86\xe3\x82\xb9\xe3\x83\x88'.decode()],
                          b'\xe3\x83\x86\xe3\x82\xb9\xe3\x83\x88'.decode())
-        self.assertEqual(props.getProperty("none"), None)
-        self.assertEqual(props.getProperty("numcpus"), 1)
+        self.assertEqual(props["numcpus"], 1)
 
         self.workerSideDisconnect(worker)
         yield worker.waitForDetach()

--- a/master/buildbot/test/integration/test_worker_workerside.py
+++ b/master/buildbot/test/integration/test_worker_workerside.py
@@ -32,7 +32,6 @@ from buildbot import worker
 from buildbot.process import botmaster
 from buildbot.process import builder
 from buildbot.process import factory
-from buildbot.status import master
 from buildbot.test.fake import fakemaster
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.worker import manager as workermanager
@@ -137,8 +136,6 @@ class TestWorkerConnection(unittest.TestCase, TestReactorMixin):
         self.botmaster = botmaster.BotMaster()
         yield self.botmaster.setServiceParent(self.master)
 
-        self.master.status = master.Status()
-        yield self.master.status.setServiceParent(self.master)
         self.master.botmaster = self.botmaster
         self.master.data.updates.workerConfigured = lambda *a, **k: None
         yield self.master.startService()

--- a/master/buildbot/test/regressions/test_oldpaths.py
+++ b/master/buildbot/test/regressions/test_oldpaths.py
@@ -98,28 +98,12 @@ class OldImportPaths(unittest.TestCase):
     def test_status_builder_results(self):
         # these symbols are now in buildbot.process.results, but lots of user
         # code references them here:
-        from buildbot.status.builder import SUCCESS, WARNINGS, FAILURE, SKIPPED
-        from buildbot.status.builder import EXCEPTION, RETRY, Results
-        from buildbot.status.builder import worst_status
+        from buildbot.process.results import SUCCESS, WARNINGS, FAILURE, SKIPPED
+        from buildbot.process.results import EXCEPTION, RETRY, Results
+        from buildbot.process.results import worst_status
         # reference the symbols to avoid failure from pyflakes
         (SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY, Results,
          worst_status)
-
-    def test_status_builder_BuildSetStatus(self):
-        from buildbot.status.builder import BuildSetStatus
-        assert BuildSetStatus
-
-    def test_status_builder_Status(self):
-        from buildbot.status.builder import Status
-        assert Status
-
-    def test_status_builder_Event(self):
-        from buildbot.status.builder import Event
-        assert Event
-
-    def test_status_builder_BuildStatus(self):
-        from buildbot.status.builder import BuildStatus
-        assert BuildStatus
 
     def test_steps_source_Source(self):
         from buildbot.steps.source import Source

--- a/master/buildbot/test/test_extra_coverage.py
+++ b/master/buildbot/test/test_extra_coverage.py
@@ -29,7 +29,6 @@ from buildbot.scripts import checkconfig
 from buildbot.scripts import logwatcher
 from buildbot.scripts import reconfig
 from buildbot.scripts import runner
-from buildbot.status import client
 from buildbot.steps import master
 from buildbot.steps import maxq
 from buildbot.steps import python
@@ -48,7 +47,6 @@ modules.extend([p4poller, svnpoller])
 modules.extend([base, sendchange, tryclient])
 modules.extend([subunitlogobserver])
 modules.extend([checkconfig, logwatcher, reconfig, runner])
-modules.extend([client])
 modules.extend([master, maxq, python, python_twisted, subunit])
 modules.extend([trigger, vstudio])
 modules.extend([rpmbuild, rpmlint, rpmspec])

--- a/master/buildbot/test/unit/test_data_builds.py
+++ b/master/buildbot/test/unit/test_data_builds.py
@@ -103,7 +103,7 @@ class BuildEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     def test_action_stop(self):
         yield self.callControl("stop", {}, ('builders', 77, 'builds', 5))
         self.master.mq.assertProductions(
-            [(('control', 'builds', '15', 'stop'), {'reason': 'no reason'})])
+            [(('control', 'builds', '15', 'stop'), {})])
 
     @defer.inlineCallbacks
     def test_action_stop_reason(self):

--- a/master/buildbot/test/unit/test_interpolate_secrets.py
+++ b/master/buildbot/test/unit/test_interpolate_secrets.py
@@ -12,13 +12,6 @@ from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.misc import TestReactorMixin
 
 
-class FakeBuildWithMaster(FakeBuild):
-
-    def __init__(self, master):
-        super(FakeBuildWithMaster, self).__init__()
-        self.master = master
-
-
 class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase,
                              ConfigErrorsMixin):
 
@@ -32,7 +25,7 @@ class TestInterpolateSecrets(TestReactorMixin, unittest.TestCase,
         self.secretsrv = SecretManager()
         self.secretsrv.services = [fakeStorageService]
         yield self.secretsrv.setServiceParent(self.master)
-        self.build = FakeBuildWithMaster(self.master)
+        self.build = FakeBuild(master=self.master)
 
     @defer.inlineCallbacks
     def test_secret(self):
@@ -55,7 +48,7 @@ class TestInterpolateSecretsNoService(TestReactorMixin, unittest.TestCase,
     def setUp(self):
         self.setUpTestReactor()
         self.master = fakemaster.make_master(self)
-        self.build = FakeBuildWithMaster(self.master)
+        self.build = FakeBuild(master=self.master)
 
     @defer.inlineCallbacks
     def test_secret(self):
@@ -78,11 +71,11 @@ class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
         self.secretsrv = SecretManager()
         self.secretsrv.services = [fakeStorageService]
         yield self.secretsrv.setServiceParent(self.master)
-        self.build = FakeBuildWithMaster(self.master)
+        self.build = FakeBuild(master=self.master)
 
     @defer.inlineCallbacks
     def test_secret(self):
         command = Interpolate("echo %(secret:foo)s")
         rendered = yield self.build.render(command)
-        cleantext = self.build.build_status.properties.cleanupTextFromSecrets(rendered)
+        cleantext = self.build.getProperties().cleanupTextFromSecrets(rendered)
         self.assertEqual(cleantext, "echo <foo>")

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -90,8 +90,6 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin,
         # patch out a few other annoying things the master likes to do
         self.patch(monkeypatches, 'patch_all', lambda: None)
         self.patch(signal, 'signal', lambda sig, hdlr: None)
-        # XXX temporary
-        self.patch(master, 'Status', lambda master: mock.Mock())
 
         master.BuildMaster.masterHeartbeatService = mock.Mock()
         self.master = master.BuildMaster(

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -578,11 +578,6 @@ class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
         mastercfg = config.MasterConfig()
         mastercfg.builders = [new_builder_config]
         yield self.bldr.reconfigServiceWithBuildbotConfig(mastercfg)
-        self.assertEqual(
-            dict(description=self.bldr.builder_status.getDescription(),
-                 tags=self.bldr.builder_status.getTags()),
-            dict(description="New",
-                 tags=["NewTag"]))
         self.assertIdentical(self.bldr.config, new_builder_config)
 
         # check that the reconfig grabbed a buliderid

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -143,7 +143,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin,
     def test_getProperty(self):
         bs = buildstep.BuildStep()
         bs.build = fakebuild.FakeBuild()
-        props = bs.build.build_status.properties = mock.Mock()
+        props = bs.build.properties = mock.Mock()
         bs.getProperty("xyz", 'b')
         props.getProperty.assert_called_with("xyz", 'b')
         bs.getProperty("xyz")
@@ -152,7 +152,7 @@ class TestBuildStep(steps.BuildStepMixin, config.ConfigErrorsMixin,
     def test_setProperty(self):
         bs = buildstep.BuildStep()
         bs.build = fakebuild.FakeBuild()
-        props = bs.build.build_status.properties = mock.Mock()
+        props = bs.build.properties = mock.Mock()
         bs.setProperty("x", "y", "t")
         props.setProperty.assert_called_with("x", "y", "t", runtime=True)
         bs.setProperty("x", "abc", "test", runtime=True)

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -28,7 +28,6 @@ from buildbot.process.results import CANCELLED
 from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
-from buildbot.status import master
 from buildbot.steps import trigger
 from buildbot.test import fakedb
 from buildbot.test.util import steps
@@ -106,7 +105,6 @@ class TestTrigger(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
     def tearDown(self):
         return self.tearDownBuildStep()
 
-    @defer.inlineCallbacks
     def setupStep(self, step, sourcestampsInBuild=None, gotRevisionsInBuild=None, *args, **kwargs):
         sourcestamps = sourcestampsInBuild or []
         got_revisions = gotRevisionsInBuild or {}
@@ -121,8 +119,6 @@ class TestTrigger(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         m.db.checkForeignKeys = True
         self.build.builder.botmaster = m.botmaster
         self.build.conn = object()
-        m.status = master.Status()
-        yield m.status.setServiceParent(m)
         m.config.buildbotURL = "baseurl/"
         m.scheduler_manager = FakeSchedulerManager()
 

--- a/master/setup.py
+++ b/master/setup.py
@@ -180,7 +180,6 @@ setup_args = {
         "buildbot.secrets.providers",
         "buildbot.statistics",
         "buildbot.statistics.storage_backends",
-        "buildbot.status",
         "buildbot.steps",
         "buildbot.steps.package",
         "buildbot.steps.package.deb",


### PR DESCRIPTION
So I have spent a couple hour removing the status API, and fix the test.

eventually, the tests are all passing, when additional status code removal commit is applied.
This one PR does everything but delete the status API, so it can be safely merged.

I have split into several reviewable commits, as there are several non trivial changes.
