### PR TITLE
readme: Remove the license scan badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ lothar . com>`_, and currently maintained by `the Botherders
 
 Visit us on http://buildbot.net !
 
-|travis-badge|_ |codecov-badge|_ |readthedocs-badge|_ |fossa-badge|_
+|travis-badge|_ |codecov-badge|_ |readthedocs-badge|_
 
 Buildbot consists of several components:
 
@@ -37,5 +37,3 @@ Related repositories:
 .. _codecov-badge: http://codecov.io/github/buildbot/buildbot?branch=master
 .. |readthedocs-badge| image:: https://readthedocs.org/projects/buildbot/badge/?version=latest
 .. _readthedocs-badge: https://readthedocs.org/projects/buildbot/builds/
-.. |fossa-badge| image:: https://app.fossa.io/api/projects/git%2Bgithub.com%2Fbuildbot%2Fbuildbot.svg?type=shield
-.. _fossa-badge: https://app.fossa.io/projects/git%2Bgithub.com%2Fbuildbot%2Fbuildbot?ref=badge_shield


### PR DESCRIPTION
Looks like the license scan badge is completely useless. The linked page claims that Buildbot is licensed under MIT. Given that this is completely incorrect and Buildbot has a pretty clear license in the root of the project I don't think we should trust this service to get this right.