### PR TITLE
Add a way for builds to store transient data

### DIFF
--- a/master/buildbot/data/build_data.py
+++ b/master/buildbot/data/build_data.py
@@ -87,6 +87,6 @@ class BuildData(base.ResourceType):
     entityType = EntityType(name)
 
     @base.updateMethod
-    @defer.inlineCallbacks
     def setBuildData(self, buildid, name, value, source):
-        yield self.master.db.build_data.setBuildData(buildid, name, value, source)
+        # forward deferred directly
+        return self.master.db.build_data.setBuildData(buildid, name, value, source)

--- a/master/buildbot/data/build_data.py
+++ b/master/buildbot/data/build_data.py
@@ -1,0 +1,92 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+from twisted.internet import defer
+
+from buildbot.data import base
+from buildbot.data import types
+
+
+class Db2DataMixin:
+
+    def db2data(self, dbdict):
+        data = {
+            'buildid': dbdict['buildid'],
+            'name': dbdict['name'],
+            'value': dbdict['value'],
+            'source': dbdict['source'],
+        }
+        return defer.succeed(data)
+
+
+class BuildDatasNoValueEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+
+    isCollection = True
+    pathPatterns = """
+        /builders/n:builderid/builds/n:build_number/data
+        /builders/i:buildername/builds/n:build_number/data
+        /builds/n:buildid/data
+        """
+
+    @defer.inlineCallbacks
+    def get(self, resultSpec, kwargs):
+        buildid = yield self.getBuildid(kwargs)
+
+        build_datadicts = yield self.master.db.build_data.getAllBuildDataNoValues(buildid)
+
+        results = []
+        for dbdict in build_datadicts:
+            results.append((yield self.db2data(dbdict)))
+        return results
+
+
+class BuildDataEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+
+    isCollection = False
+    pathPatterns = """
+        /builders/n:builderid/builds/n:build_number/data/i:name
+        /builders/i:buildername/builds/n:build_number/data/i:name
+        /builds/n:buildid/data/i:name
+    """
+
+    @defer.inlineCallbacks
+    def get(self, resultSpec, kwargs):
+        buildid = yield self.getBuildid(kwargs)
+        name = kwargs['name']
+
+        build_datadict = yield self.master.db.build_data.getBuildData(buildid, name)
+
+        return (yield self.db2data(build_datadict)) if build_datadict else None
+
+
+class BuildData(base.ResourceType):
+
+    name = "build_data"
+    plural = "build_data"
+    endpoints = [BuildDatasNoValueEndpoint, BuildDataEndpoint]
+    keyFields = []
+
+    class EntityType(types.Entity):
+        buildid = types.Integer()
+        name = types.String()
+        value = types.NoneOk(types.Binary())
+        source = types.String()
+    entityType = EntityType(name)
+
+    @base.updateMethod
+    @defer.inlineCallbacks
+    def setBuildData(self, buildid, name, value, source):
+        yield self.master.db.build_data.setBuildData(buildid, name, value, source)

--- a/master/buildbot/db/build_data.py
+++ b/master/buildbot/db/build_data.py
@@ -1,0 +1,130 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+
+from twisted.internet import defer
+
+from buildbot.db import base
+
+
+class BuildDataDict(dict):
+    pass
+
+
+class BuildDataConnectorComponent(base.DBConnectorComponent):
+
+    def _insert_race_hook(self, conn):
+        # called so tests can simulate a race condition during insertion
+        pass
+
+    @defer.inlineCallbacks
+    def setBuildData(self, buildid, name, value, source):
+        def thd(conn):
+            build_data_table = self.db.model.build_data
+
+            update_values = {
+                'value': value,
+                'source': source
+            }
+
+            insert_values = {
+                'buildid': buildid,
+                'name': name,
+                'value': value,
+                'source': source,
+            }
+
+            while True:
+                q = build_data_table.update()
+                q = q.where((build_data_table.c.buildid == buildid) &
+                            (build_data_table.c.name == name))
+                q = q.values(update_values)
+                r = conn.execute(q)
+                if r.rowcount > 0:
+                    return
+                r.close()
+
+                self._insert_race_hook(conn)
+
+                try:
+                    q = build_data_table.insert().values(insert_values)
+                    r = conn.execute(q)
+                    return
+                except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
+                    # there's been a competing insert, retry
+                    pass
+
+        yield self.db.pool.do(thd)
+
+    @defer.inlineCallbacks
+    def getBuildData(self, buildid, name):
+        def thd(conn):
+            build_data_table = self.db.model.build_data
+
+            q = build_data_table.select().where((build_data_table.c.buildid == buildid) &
+                                                (build_data_table.c.name == name))
+            res = conn.execute(q)
+            row = res.fetchone()
+            if not row:
+                return None
+            return self._row2dict(conn, row)
+        res = yield self.db.pool.do(thd)
+        return res
+
+    @defer.inlineCallbacks
+    def getBuildDataNoValue(self, buildid, name):
+        def thd(conn):
+            build_data_table = self.db.model.build_data
+
+            q = sa.select([build_data_table.c.buildid,
+                           build_data_table.c.name,
+                           build_data_table.c.source])
+            q = q.where((build_data_table.c.buildid == buildid) &
+                        (build_data_table.c.name == name))
+            res = conn.execute(q)
+            row = res.fetchone()
+            if not row:
+                return None
+            return self._row2dict_novalue(conn, row)
+        res = yield self.db.pool.do(thd)
+        return res
+
+    @defer.inlineCallbacks
+    def getAllBuildDataNoValues(self, buildid):
+        def thd(conn):
+            build_data_table = self.db.model.build_data
+
+            q = sa.select([build_data_table.c.buildid,
+                           build_data_table.c.name,
+                           build_data_table.c.source])
+            q = q.where(build_data_table.c.buildid == buildid)
+
+            return [self._row2dict_novalue(conn, row)
+                    for row in conn.execute(q).fetchall()]
+        res = yield self.db.pool.do(thd)
+        return res
+
+    def _row2dict(self, conn, row):
+        return BuildDataDict(buildid=row.buildid,
+                             name=row.name,
+                             value=row.value,
+                             source=row.source)
+
+    def _row2dict_novalue(self, conn, row):
+        return BuildDataDict(buildid=row.buildid,
+                             name=row.name,
+                             value=None,
+                             source=row.source)

--- a/master/buildbot/db/connector.py
+++ b/master/buildbot/db/connector.py
@@ -21,6 +21,7 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot import util
+from buildbot.db import build_data
 from buildbot.db import builders
 from buildbot.db import buildrequests
 from buildbot.db import builds
@@ -96,6 +97,7 @@ class DBConnector(service.ReconfigurableServiceMixin,
             self)
         self.state = state.StateConnectorComponent(self)
         self.builds = builds.BuildsConnectorComponent(self)
+        self.build_data = build_data.BuildDataConnectorComponent(self)
         self.workers = workers.WorkersConnectorComponent(self)
         self.users = users.UsersConnectorComponent(self)
         self.masters = masters.MastersConnectorComponent(self)

--- a/master/buildbot/db/migrate/versions/057_add_build_data_tables.py
+++ b/master/buildbot/db/migrate/versions/057_add_build_data_tables.py
@@ -1,0 +1,49 @@
+# This file is part of Buildbot. Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import sqlalchemy as sa
+
+from buildbot.util import sautils
+
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+
+    sautils.Table(
+        'builds', metadata,
+        sa.Column('id', sa.Integer, primary_key=True),
+        # ...
+    )
+
+    build_data = sautils.Table(
+        'build_data', metadata,
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('buildid', sa.Integer,
+                  sa.ForeignKey('builds.id', ondelete='CASCADE'),
+                  nullable=False),
+        sa.Column('name', sa.String(256), nullable=False),
+        sa.Column('value', sa.LargeBinary().with_variant(sa.dialects.mysql.LONGBLOB, "mysql"),
+                  nullable=False),
+        sa.Column('source', sa.String(256), nullable=False),
+    )
+
+    # create the tables
+    build_data.create()
+
+    # create indexes
+    idx = sa.Index('build_data_buildid_name', build_data.c.buildid, build_data.c.name, unique=True)
+    idx.create()

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -130,6 +130,19 @@ class Model(base.DBConnectorComponent):
         sa.Column('source', sa.String(256), nullable=False),
     )
 
+    # This table contains transient build state.
+    build_data = sautils.Table(
+        'build_data', metadata,
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('buildid', sa.Integer,
+                  sa.ForeignKey('builds.id', ondelete='CASCADE'),
+                  nullable=False),
+        sa.Column('name', sa.String(256), nullable=False),
+        sa.Column('value', sa.LargeBinary().with_variant(sa.dialects.mysql.LONGBLOB, "mysql"),
+                  nullable=False),
+        sa.Column('source', sa.String(256), nullable=False),
+    )
+
     # This table contains basic information about each build.
     builds = sautils.Table(
         'builds', metadata,
@@ -817,6 +830,7 @@ class Model(base.DBConnectorComponent):
     sa.Index('buildrequests_builderid', buildrequests.c.builderid)
     sa.Index('buildrequests_complete', buildrequests.c.complete)
     sa.Index('build_properties_buildid', build_properties.c.buildid)
+    sa.Index('build_data_buildid_name', build_data.c.buildid, build_data.c.name, unique=True)
     sa.Index('builds_buildrequestid', builds.c.buildrequestid)
     sa.Index('buildsets_complete', buildsets.c.complete)
     sa.Index('buildsets_submitted_at', buildsets.c.submitted_at)

--- a/master/buildbot/db/test_results.py
+++ b/master/buildbot/db/test_results.py
@@ -72,7 +72,7 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
                         else:
                             conn.execute(q)
 
-                    except sa.exc.IntegrityError:
+                    except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                         # There was a competing addCodePaths() call that added a path for the same
                         # builder. Depending on the DB driver, none or some rows were inserted, but
                         # we will re-check what's got inserted in the next iteration of the loop
@@ -140,7 +140,7 @@ class TestResultsConnectorComponent(base.DBConnectorComponent):
                         else:
                             conn.execute(q)
 
-                    except sa.exc.IntegrityError:
+                    except (sa.exc.IntegrityError, sa.exc.ProgrammingError):
                         # There was a competing addNames() call that added a name for the same
                         # builder. Depending on the DB driver, none or some rows were inserted, but
                         # we will re-check what's got inserted in the next iteration of the loop

--- a/master/buildbot/newsfragments/build-data.feature
+++ b/master/buildbot/newsfragments/build-data.feature
@@ -1,0 +1,1 @@
+A per-build key-value store and related APIs have been created for transient and potentially large per-build data.

--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -43,6 +43,7 @@ types:
     builder: !include types/builder.raml
     buildrequest: !include types/buildrequest.raml
     buildset: !include types/buildset.raml
+    build_data: !include types/build_data.raml
     worker: !include types/worker.raml
     change: !include types/change.raml
     changesource: !include types/changesource.raml
@@ -128,6 +129,21 @@ types:
                         body:
                             application/json:
                                 description: no parameter are needed
+                /data:
+                    description: This path selects all build data set for the build
+                    get:
+                        is:
+                        - bbget: {bbtype: build_data}
+                    /{build_data_name}:
+                        uriParameters:
+                            build_data_name:
+                                type: string
+                                description: The name of build data
+                        description: This path selects a build data with specific name.
+                        get:
+                            is:
+                            - bbget: {bbtype: build_data}
+
                 /steps:
                     description: This path selects all steps for the given build.
                     get:
@@ -394,6 +410,22 @@ types:
             get:
                 is:
                 - bbget: {bbtype: sourcedproperties}
+
+        /data:
+            description: This path selects all build data set for the build
+            get:
+                is:
+                - bbget: {bbtype: build_data}
+            /{build_data_name}:
+                uriParameters:
+                    build_data_name:
+                        type: string
+                        description: The name of build data
+                description: This path selects a build data with specific name.
+                get:
+                    is:
+                    - bbget: {bbtype: build_data}
+
         /steps:
             description: |
                 This path selects all steps of a build

--- a/master/buildbot/spec/types/build_data.raml
+++ b/master/buildbot/spec/types/build_data.raml
@@ -1,0 +1,47 @@
+#%RAML 1.0 DataType
+displayName: Build data
+description: |
+    This resource represents a key-value data pair associated to a build.
+    A build can have any number of key-value pairs.
+    The data is intended to be used for temporary purposes, until the build and all actions associated to it (such as reporters) are finished.
+
+    The value is a binary of potentially large size.
+    Certain APIs allow to retrieve the list of keys set to a build without fetching the values.
+
+    Update Methods
+    --------------
+
+    All update methods are available as attributes of ``master.data.updates``.
+
+    .. py:class:: buildbot.data.build_data.BuildData
+
+        .. py:method:: setBuildData(buildid, name, value, source)
+
+            :param integer buildid: build id to attach data to
+            :param unicode name: the name of the data
+            :param bytestr value: the value of the data as ``bytes``.
+            :parma unicode source: a string identifying the source of the data
+            :returns: Deferred
+
+            Adds or replaces build data attached to the build.
+
+properties:
+    buildid:
+        description: id of the build the build data is attached to.
+        type: integer
+    name:
+        description: the name of the build data.
+        type: string
+    value?:
+        description: the value of the build data.
+        type: string
+    source:
+        description: a string identifying the source of the data
+        type: string
+
+type: object
+example:
+    buildid: 31
+    name: "stored_data_name"
+    value: "stored data value"
+    source: "Step XYZ"

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -424,6 +424,15 @@ class FakeUpdates(service.AsyncService):
             paused=paused,
             graceful=graceful)
 
+    # methods form BuildData resource
+    @defer.inlineCallbacks
+    def setBuildData(self, buildid, name, value, source):
+        validation.verifyType(self.testcase, 'buildid', buildid, validation.IntValidator())
+        validation.verifyType(self.testcase, 'name', name, validation.StringValidator())
+        validation.verifyType(self.testcase, 'value', value, validation.BinaryValidator())
+        validation.verifyType(self.testcase, 'source', source, validation.StringValidator())
+        yield self.master.db.build_data.setBuildData(buildid, name, value, source)
+
     # methods from TestResultSet resource
     @defer.inlineCallbacks
     def addTestResultSet(self, builderid, buildid, stepid, description, category, value_unit):

--- a/master/buildbot/test/fakedb/__init__.py
+++ b/master/buildbot/test/fakedb/__init__.py
@@ -20,6 +20,8 @@ the real connector components.
 """
 
 from .base import FakeDBComponent
+from .build_data import BuildData
+from .build_data import FakeBuildDataComponent
 from .builders import Builder
 from .builders import BuilderMaster
 from .builders import BuildersTags
@@ -78,6 +80,7 @@ from .workers import Worker
 
 __all__ = [
     'Build',
+    'BuildData',
     'BuildProperty',
     'BuildRequest',
     'BuildRequestClaim',
@@ -99,6 +102,7 @@ __all__ = [
     'FakeBuildersComponent',
     'FakeBuildsComponent',
     'FakeBuildsetsComponent',
+    'FakeBuildDataComponent',
     'FakeChangeSourcesComponent',
     'FakeChangesComponent',
     'FakeDBComponent',

--- a/master/buildbot/test/fakedb/build_data.py
+++ b/master/buildbot/test/fakedb/build_data.py
@@ -1,0 +1,105 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+
+from buildbot.test.fakedb.base import FakeDBComponent
+from buildbot.test.fakedb.row import Row
+
+
+class BuildData(Row):
+    table = 'build_data'
+
+    defaults = {
+        'id': None,
+        'buildid': None,
+        'name': None,
+        'value': None,
+        'source': None,
+    }
+
+    id_column = 'id'
+    foreignKeys = ('buildid',)
+    required_columns = ('buildid', 'name', 'value', 'source')
+    binary_columns = ('value',)
+
+
+class FakeBuildDataComponent(FakeDBComponent):
+
+    def setUp(self):
+        self.build_data = {}
+
+    def insertTestData(self, rows):
+        for row in rows:
+            if isinstance(row, BuildData):
+                self.build_data[row.id] = row.values.copy()
+
+    def _get_build_data_row(self, buildid, name):
+        for row in self.build_data.values():
+            if row['buildid'] == buildid and row['name'] == name:
+                return row
+        return None
+
+    def setBuildData(self, buildid, name, value, source):
+        assert isinstance(value, bytes)
+        row = self._get_build_data_row(buildid, name)
+        if row is not None:
+            row['value'] = value
+            row['source'] = source
+            return
+
+        id = Row.nextId()
+        self.build_data[id] = {
+            'id': id,
+            'buildid': buildid,
+            'name': name,
+            'value': value,
+            'source': source
+        }
+
+    # returns a Deferred
+    def getBuildData(self, buildid, name):
+        row = self._get_build_data_row(buildid, name)
+        if row is not None:
+            return defer.succeed(self._row2dict(row))
+        return defer.succeed(None)
+
+    # returns a Deferred
+    def getBuildDataNoValue(self, buildid, name):
+        row = self._get_build_data_row(buildid, name)
+        if row is not None:
+            return defer.succeed(self._row2dict_novalue(row))
+        return defer.succeed(None)
+
+    # returns a Deferred
+    def getAllBuildDataNoValues(self, buildid):
+        ret = []
+        for row in self.build_data.values():
+            if row['buildid'] != buildid:
+                continue
+            ret.append(self._row2dict_novalue(row))
+
+        return defer.succeed(ret)
+
+    def _row2dict(self, row):
+        ret = row.copy()
+        del ret['id']
+        return ret
+
+    def _row2dict_novalue(self, row):
+        ret = row.copy()
+        del ret['id']
+        ret['value'] = None
+        return ret

--- a/master/buildbot/test/fakedb/build_data.py
+++ b/master/buildbot/test/fakedb/build_data.py
@@ -93,6 +93,28 @@ class FakeBuildDataComponent(FakeDBComponent):
 
         return defer.succeed(ret)
 
+    # returns a Deferred
+    def deleteOldBuildData(self, older_than_timestamp):
+        buildids_to_keep = []
+        for build_dict in self.db.builds.builds.values():
+            if build_dict['complete_at'] is None or \
+                    build_dict['complete_at'] >= older_than_timestamp:
+                buildids_to_keep.append(build_dict['id'])
+
+        count_before = len(self.build_data)
+
+        build_dataids_to_remove = []
+        for build_datadict in self.build_data.values():
+            if build_datadict['buildid'] not in buildids_to_keep:
+                build_dataids_to_remove.append(build_datadict['id'])
+
+        for id in build_dataids_to_remove:
+            self.build_data.pop(id)
+
+        count_after = len(self.build_data)
+
+        return defer.succeed(count_before - count_after)
+
     def _row2dict(self, row):
         ret = row.copy()
         del ret['id']

--- a/master/buildbot/test/fakedb/connector.py
+++ b/master/buildbot/test/fakedb/connector.py
@@ -15,6 +15,7 @@
 
 from twisted.internet import defer
 
+from buildbot.test.fakedb.build_data import FakeBuildDataComponent
 from buildbot.test.fakedb.builders import FakeBuildersComponent
 from buildbot.test.fakedb.buildrequests import FakeBuildRequestsComponent
 from buildbot.test.fakedb.builds import FakeBuildsComponent
@@ -71,6 +72,8 @@ class FakeDBConnector(service.AsyncMultiService):
         self.buildrequests = comp = FakeBuildRequestsComponent(self, testcase)
         self._components.append(comp)
         self.builds = comp = FakeBuildsComponent(self, testcase)
+        self._components.append(comp)
+        self.build_data = comp = FakeBuildDataComponent(self, testcase)
         self._components.append(comp)
         self.steps = comp = FakeStepsComponent(self, testcase)
         self._components.append(comp)

--- a/master/buildbot/test/unit/test_data_build_data.py
+++ b/master/buildbot/test/unit/test_data_build_data.py
@@ -1,0 +1,216 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from parameterized import parameterized
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.data import build_data
+from buildbot.test import fakedb
+from buildbot.test.fake import fakemaster
+from buildbot.test.util import endpoint
+from buildbot.test.util import interfaces
+from buildbot.test.util.misc import TestReactorMixin
+
+
+class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
+
+    endpointClass = build_data.BuildDataEndpoint
+    resourceTypeClass = build_data.BuildData
+
+    def setUp(self):
+        self.setUpEndpoint()
+        self.db.insertTestData([
+            fakedb.Worker(id=47, name='linux'),
+            fakedb.Buildset(id=20),
+            fakedb.Builder(id=88, name='b1'),
+            fakedb.BuildRequest(id=41, buildsetid=20, builderid=88),
+            fakedb.Master(id=88),
+            fakedb.Build(id=30, buildrequestid=41, number=7, masterid=88, builderid=88,
+                         workerid=47),
+            fakedb.BuildData(id=91, buildid=30, name='name1', value=b'value1', source='source1'),
+        ])
+
+    def tearDown(self):
+        self.tearDownEndpoint()
+
+    @defer.inlineCallbacks
+    def test_get_existing_build_data_by_build_id(self):
+        result = yield self.callGet(('builds', 30, 'data', 'name1'))
+        self.validateData(result)
+        self.assertEqual(result, {
+            'buildid': 30,
+            'name': 'name1',
+            'value': b'value1',
+            'source': 'source1',
+        })
+
+    @defer.inlineCallbacks
+    def test_get_existing_build_data_by_builder_name_build_number(self):
+        result = yield self.callGet(('builders', 'b1', 'builds', 7, 'data', 'name1'))
+        self.validateData(result)
+        self.assertEqual(result, {
+            'buildid': 30,
+            'name': 'name1',
+            'value': b'value1',
+            'source': 'source1',
+        })
+
+    @defer.inlineCallbacks
+    def test_get_existing_build_data_by_builder_id_build_number(self):
+        result = yield self.callGet(('builders', 88, 'builds', 7, 'data', 'name1'))
+        self.validateData(result)
+        self.assertEqual(result, {
+            'buildid': 30,
+            'name': 'name1',
+            'value': b'value1',
+            'source': 'source1',
+        })
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_build_id_missing_build(self):
+        result = yield self.callGet(('builds', 31, 'data', 'name1'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_build_id_missing_name(self):
+        result = yield self.callGet(('builds', 30, 'data', 'name_missing'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_name_build_number_missing_builder(self):
+        result = yield self.callGet(('builders', 'b_missing', 'builds', 7, 'data', 'name1'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_name_build_number_missing_build(self):
+        result = yield self.callGet(('builders', 'b1', 'builds', 17, 'data', 'name1'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_name_build_number_missing_name(self):
+        result = yield self.callGet(('builders', 'b1', 'builds', 7, 'data', 'name_missing'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_id_build_number_missing_builder(self):
+        result = yield self.callGet(('builders', 188, 'builds', 7, 'data', 'name1'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_id_build_number_missing_build(self):
+        result = yield self.callGet(('builders', 88, 'builds', 17, 'data', 'name1'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_id_build_number_missing_name(self):
+        result = yield self.callGet(('builders', 88, 'builds', 7, 'data', 'name_missing'))
+        self.assertIsNone(result)
+
+
+class TestBuildDatasNoValueEndpoint(endpoint.EndpointMixin, unittest.TestCase):
+
+    endpointClass = build_data.BuildDatasNoValueEndpoint
+    resourceTypeClass = build_data.BuildData
+
+    def setUp(self):
+        self.setUpEndpoint()
+        self.db.insertTestData([
+            fakedb.Worker(id=47, name='linux'),
+            fakedb.Buildset(id=20),
+            fakedb.Builder(id=88, name='b1'),
+            fakedb.Master(id=88),
+            fakedb.BuildRequest(id=41, buildsetid=20, builderid=88),
+            fakedb.BuildRequest(id=42, buildsetid=20, builderid=88),
+            fakedb.BuildRequest(id=43, buildsetid=20, builderid=88),
+            fakedb.Build(id=30, buildrequestid=41, number=7, masterid=88, builderid=88,
+                         workerid=47),
+            fakedb.Build(id=31, buildrequestid=42, number=8, masterid=88, builderid=88,
+                         workerid=47),
+            fakedb.Build(id=32, buildrequestid=42, number=9, masterid=88, builderid=88,
+                         workerid=47),
+            fakedb.BuildData(id=91, buildid=30, name='name1', value=b'value1', source='source1'),
+            fakedb.BuildData(id=92, buildid=30, name='name2', value=b'value2', source='source2'),
+            fakedb.BuildData(id=93, buildid=31, name='name3', value=b'value3', source='source3'),
+        ])
+
+    def tearDown(self):
+        self.tearDownEndpoint()
+
+    @parameterized.expand([
+        ('multiple_values', 7, ['name1', 'name2']),
+        ('single_value', 8, ['name3']),
+        ('no_values', 9, []),
+        ('not_existing', 10, []),
+    ])
+    @defer.inlineCallbacks
+    def test_get_builders_builder_name(self, name, build_number, exp_names):
+        results = yield self.callGet(('builders', 'b1', 'builds', build_number, 'data'))
+        for result in results:
+            self.validateData(result)
+        self.assertEqual([r['name'] for r in results], exp_names)
+
+    @parameterized.expand([
+        ('multiple_values', 7, ['name1', 'name2']),
+        ('single_value', 8, ['name3']),
+        ('no_values', 9, []),
+        ('not_existing', 10, []),
+    ])
+    @defer.inlineCallbacks
+    def test_get_builders_builder_id(self, name, build_number, exp_names):
+        results = yield self.callGet(('builders', 88, 'builds', build_number, 'data'))
+        for result in results:
+            self.validateData(result)
+        self.assertEqual([r['name'] for r in results], exp_names)
+
+    @parameterized.expand([
+        ('multiple_values', 30, ['name1', 'name2']),
+        ('single_value', 31, ['name3']),
+        ('no_values', 32, []),
+        ('not_existing', 33, []),
+    ])
+    @defer.inlineCallbacks
+    def test_get_builds_id(self, name, buildid, exp_names):
+        results = yield self.callGet(('builds', buildid, 'data'))
+        for result in results:
+            self.validateData(result)
+        self.assertEqual([r['name'] for r in results], exp_names)
+
+
+class TestBuildData(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCase):
+
+    def setUp(self):
+        self.setUpTestReactor()
+        self.master = fakemaster.make_master(self, wantMq=True, wantDb=True, wantData=True)
+        self.rtype = build_data.BuildData(self.master)
+
+    def test_signature_set_build_data(self):
+        @self.assertArgSpecMatches(self.master.data.updates.setBuildData,
+                                   self.rtype.setBuildData)
+        def setBuildData(self, buildid, name, value, source):
+            pass
+
+    @defer.inlineCallbacks
+    def test_set_build_data(self):
+        yield self.rtype.setBuildData(buildid=2, name='name1', value=b'value1', source='source1')
+
+        result = yield self.master.db.build_data.getBuildData(2, 'name1')
+        self.assertEqual(result, {
+            'buildid': 2,
+            'name': 'name1',
+            'value': b'value1',
+            'source': 'source1',
+        })

--- a/master/buildbot/test/unit/test_db_build_data.py
+++ b/master/buildbot/test/unit/test_db_build_data.py
@@ -1,0 +1,193 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.db import build_data
+from buildbot.test import fakedb
+from buildbot.test.util import connector_component
+from buildbot.test.util import interfaces
+from buildbot.test.util import validation
+
+
+class Tests(interfaces.InterfaceTests):
+
+    common_data = [
+        fakedb.Worker(id=47, name='linux'),
+        fakedb.Buildset(id=20),
+        fakedb.Builder(id=88, name='b1'),
+        fakedb.Builder(id=89, name='b2'),
+        fakedb.BuildRequest(id=41, buildsetid=20, builderid=88),
+        fakedb.BuildRequest(id=42, buildsetid=20, builderid=88),
+        fakedb.BuildRequest(id=43, buildsetid=20, builderid=89),
+        fakedb.Master(id=88),
+        fakedb.Build(id=30, buildrequestid=41, number=7, masterid=88, builderid=88, workerid=47),
+        fakedb.Build(id=31, buildrequestid=42, number=8, masterid=88, builderid=88, workerid=47),
+        fakedb.Build(id=40, buildrequestid=43, number=9, masterid=88, builderid=89, workerid=47),
+    ]
+
+    def test_signature_add_build_data(self):
+        @self.assertArgSpecMatches(self.db.build_data.setBuildData)
+        def setBuildData(self, buildid, name, value, source):
+            pass
+
+    def test_signature_get_build_data(self):
+        @self.assertArgSpecMatches(self.db.build_data.getBuildData)
+        def getBuildData(self, buildid, name):
+            pass
+
+    def test_signature_get_build_data_no_value(self):
+        @self.assertArgSpecMatches(self.db.build_data.getBuildDataNoValue)
+        def getBuildDataNoValue(self, buildid, name):
+            pass
+
+    def test_signature_get_all_build_data_no_values(self):
+        @self.assertArgSpecMatches(self.db.build_data.getAllBuildDataNoValues)
+        def getAllBuildDataNoValues(self, buildid):
+            pass
+
+    @defer.inlineCallbacks
+    def test_add_data_get_data(self):
+        yield self.insertTestData(self.common_data)
+        yield self.db.build_data.setBuildData(buildid=30, name='mykey', value=b'myvalue',
+                                              source='mysource')
+        data_dict = yield self.db.build_data.getBuildData(buildid=30, name='mykey')
+        validation.verifyDbDict(self, 'build_datadict', data_dict)
+        self.assertEqual(data_dict, {
+            'buildid': 30,
+            'name': 'mykey',
+            'value': b'myvalue',
+            'source': 'mysource'
+        })
+
+    @defer.inlineCallbacks
+    def test_get_data_non_existing(self):
+        yield self.insertTestData(self.common_data)
+        data_dict = yield self.db.build_data.getBuildData(buildid=30, name='mykey')
+        self.assertIsNone(data_dict)
+
+    @defer.inlineCallbacks
+    def test_add_data_replace_value(self):
+        yield self.insertTestData(self.common_data)
+        yield self.db.build_data.setBuildData(buildid=30, name='mykey', value=b'myvalue',
+                                              source='mysource')
+        yield self.db.build_data.setBuildData(buildid=30, name='mykey', value=b'myvalue2',
+                                              source='mysource2')
+
+        data_dict = yield self.db.build_data.getBuildData(buildid=30, name='mykey')
+        validation.verifyDbDict(self, 'build_datadict', data_dict)
+        self.assertEqual(data_dict, {
+            'buildid': 30,
+            'name': 'mykey',
+            'value': b'myvalue2',
+            'source': 'mysource2'
+        })
+
+    @defer.inlineCallbacks
+    def test_add_data_insert_race(self):
+        yield self.insertTestData(self.common_data)
+
+        def hook(conn):
+            insert_values = {
+                'buildid': 30,
+                'name': 'mykey',
+                'value': b'myvalue_old',
+                'source': 'mysourec_old'
+            }
+            q = self.db.model.build_data.insert().values(insert_values)
+            conn.execute(q)
+        self.db.build_data._test_timing_hook = hook
+
+        yield self.db.build_data.setBuildData(buildid=30, name='mykey', value=b'myvalue',
+                                              source='mysource')
+
+        data_dict = yield self.db.build_data.getBuildData(buildid=30, name='mykey')
+        validation.verifyDbDict(self, 'build_datadict', data_dict)
+        self.assertEqual(data_dict, {
+            'buildid': 30,
+            'name': 'mykey',
+            'value': b'myvalue',
+            'source': 'mysource'
+        })
+
+    @defer.inlineCallbacks
+    def test_add_data_get_data_no_value(self):
+        yield self.insertTestData(self.common_data)
+        yield self.db.build_data.setBuildData(buildid=30, name='mykey', value=b'myvalue',
+                                              source='mysource')
+        data_dict = yield self.db.build_data.getBuildDataNoValue(buildid=30, name='mykey')
+        validation.verifyDbDict(self, 'build_datadict', data_dict)
+        self.assertEqual(data_dict, {
+            'buildid': 30,
+            'name': 'mykey',
+            'value': None,
+            'source': 'mysource'
+        })
+
+    @defer.inlineCallbacks
+    def test_get_data_no_values_non_existing(self):
+        yield self.insertTestData(self.common_data)
+        data_dict = yield self.db.build_data.getBuildDataNoValue(buildid=30, name='mykey')
+        self.assertIsNone(data_dict)
+
+    @defer.inlineCallbacks
+    def test_get_all_build_data_no_values(self):
+        yield self.insertTestData(self.common_data + [
+            fakedb.BuildData(id=91, buildid=30, name='name1', value=b'value1', source='source1'),
+            fakedb.BuildData(id=92, buildid=30, name='name2', value=b'value2', source='source2'),
+            fakedb.BuildData(id=93, buildid=31, name='name3', value=b'value3', source='source3'),
+        ])
+
+        data_dicts = yield self.db.build_data.getAllBuildDataNoValues(30)
+        self.assertEqual([d['name'] for d in data_dicts], ['name1', 'name2'])
+        for d in data_dicts:
+            validation.verifyDbDict(self, 'build_datadict', d)
+
+        # note that value is not in dict
+        self.assertEqual(data_dicts[0], {
+            'buildid': 30,
+            'name': 'name1',
+            'value': None,
+            'source': 'source1'
+        })
+
+        data_dicts = yield self.db.build_data.getAllBuildDataNoValues(31)
+        self.assertEqual([d['name'] for d in data_dicts], ['name3'])
+        data_dicts = yield self.db.build_data.getAllBuildDataNoValues(32)
+        self.assertEqual([d['name'] for d in data_dicts], [])
+
+
+class TestFakeDB(Tests, connector_component.FakeConnectorComponentMixin, unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.setUpConnectorComponent()
+
+
+class TestRealDB(unittest.TestCase,
+                 connector_component.ConnectorComponentMixin,
+                 Tests):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield self.setUpConnectorComponent(
+            table_names=['builds', 'builders', 'masters', 'buildrequests', 'buildsets',
+                         'workers', 'build_data'])
+
+        self.db.build_data = build_data.BuildDataConnectorComponent(self.db)
+
+    def tearDown(self):
+        return self.tearDownConnectorComponent()

--- a/master/buildbot/test/unit/test_db_build_data.py
+++ b/master/buildbot/test/unit/test_db_build_data.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from parameterized import parameterized
+
 from twisted.internet import defer
 from twisted.trial import unittest
 
@@ -168,6 +170,44 @@ class Tests(interfaces.InterfaceTests):
         self.assertEqual([d['name'] for d in data_dicts], ['name3'])
         data_dicts = yield self.db.build_data.getAllBuildDataNoValues(32)
         self.assertEqual([d['name'] for d in data_dicts], [])
+
+    @parameterized.expand([
+        (1000000, 0, ['name1', 'name2', 'name3', 'name4', 'name5', 'name6']),
+        (1000001, 0, ['name1', 'name2', 'name3', 'name4', 'name5', 'name6']),
+        (1000002, 2, ['name1', 'name2', 'name5', 'name6']),
+        (1000003, 3, ['name1', 'name2', 'name6']),
+        (1000004, 4, ['name1', 'name2']),
+        (1000005, 4, ['name1', 'name2']),
+    ])
+    @defer.inlineCallbacks
+    def test_remove_old_build_data(self, older_than_timestamp, exp_num_deleted,
+                                   exp_remaining_names):
+        yield self.insertTestData(self.common_data + [
+            fakedb.Build(id=50, buildrequestid=41, number=17, masterid=88,
+                         builderid=88, workerid=47, complete_at=None),
+            fakedb.Build(id=51, buildrequestid=42, number=18, masterid=88,
+                         builderid=88, workerid=47, complete_at=1000001),
+            fakedb.Build(id=52, buildrequestid=43, number=19, masterid=88,
+                         builderid=89, workerid=47, complete_at=1000002),
+            fakedb.Build(id=53, buildrequestid=43, number=20, masterid=88,
+                         builderid=89, workerid=47, complete_at=1000003),
+            fakedb.BuildData(id=91, buildid=50, name='name1', value=b'value1', source='src1'),
+            fakedb.BuildData(id=92, buildid=50, name='name2', value=b'value2', source='src2'),
+            fakedb.BuildData(id=93, buildid=51, name='name3', value=b'value3', source='src3'),
+            fakedb.BuildData(id=94, buildid=51, name='name4', value=b'value4', source='src4'),
+            fakedb.BuildData(id=95, buildid=52, name='name5', value=b'value5', source='src5'),
+            fakedb.BuildData(id=96, buildid=53, name='name6', value=b'value6', source='src6'),
+        ])
+
+        num_deleted = yield self.db.build_data.deleteOldBuildData(older_than_timestamp)
+        self.assertEqual(num_deleted, exp_num_deleted)
+
+        remaining_names = []
+        for buildid in [50, 51, 52, 53]:
+            data_dicts = yield self.db.build_data.getAllBuildDataNoValues(buildid)
+            remaining_names += [d['name'] for d in data_dicts]
+
+        self.assertEqual(sorted(remaining_names), sorted(exp_remaining_names))
 
 
 class TestFakeDB(Tests, connector_component.FakeConnectorComponentMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_db_migrate_versions_057_add_build_data_tables.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_057_add_build_data_tables.py
@@ -1,0 +1,63 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def test_migration(self):
+        def setup_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            sautils.Table(
+                'builds', metadata,
+                sa.Column('id', sa.Integer, primary_key=True),
+                # ...
+            ).create()
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            build_data = sautils.Table('build_data', metadata, autoload=True)
+
+            q = sa.select([
+                build_data.c.buildid,
+                build_data.c.name,
+                build_data.c.value,
+                build_data.c.source,
+            ])
+            self.assertEqual(conn.execute(q).fetchall(), [])
+
+            insp = sa.inspect(conn)
+
+            indexes = insp.get_indexes('build_data')
+            index_names = [item['name'] for item in indexes]
+            self.assertTrue('build_data_buildid_name' in index_names)
+
+        return self.do_test_migration(56, 57, setup_thd, verify_thd)

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -585,6 +585,27 @@ dbdict['dbbuilddict'] = buildbase = DictValidator(
 dbdict['builddict'] = DictValidator(
     properties=NoneOk(SourcedPropertiesValidator()), **buildbase.keys)
 
+# build data
+
+_build_data_msgdict = DictValidator(
+    buildid=IntValidator(),
+    name=StringValidator(),
+    value=NoneOk(BinaryValidator()),
+    source=StringValidator(),
+)
+
+message['build_data'] = Selector()
+message['build_data'].add(None,
+                          MessageValidator(events=[],
+                                           messageValidator=_build_data_msgdict))
+
+dbdict['build_datadict'] = DictValidator(
+    buildid=IntValidator(),
+    name=StringValidator(),
+    value=NoneOk(BinaryValidator()),
+    source=StringValidator(),
+)
+
 # steps
 
 _step = dict(

--- a/master/docs/developer/database/build_data.rst
+++ b/master/docs/developer/database/build_data.rst
@@ -1,0 +1,62 @@
+Build data connector
+~~~~~~~~~~~~~~~~~~~~
+
+.. py:module:: buildbot.db.build_data
+
+.. py:class:: BuildDataConnectorComponent
+
+    This class handles build data.
+    Build data is potentially large transient text data attached to the build that the steps can use for their operations.
+    One of the use cases is to carry large amount of data from one step to another where storing that data on the worker is not feasible.
+    This effectively forms a key-value store for each build.
+    It is valid only until build finishes and all reporters finish reporting the build result.
+    After that the data may be removed from the database.
+
+    An instance of this class is available at ``master.db.build_data``.
+
+    Builds are indexed by *build_dataid* and their contents represented as *build_datadicts* (build data dictionaries), with the following keys:
+
+    * ``id`` (the build data ID, globally unique)
+    * ``buildid`` (the ID of the build that the data is attached to)
+    * ``name`` (the name of the data)
+    * ``value`` (the value of the data. It must be an instance of ``bytes``)
+    * ``source`` (an string identifying the source of this value)
+
+    .. py:method:: setBuildData(buildid, name, value, source)
+
+        :param integer buildid: build id to attach data to
+        :param unicode name: the name of the data
+        :param bytestr value: the value of the data as ``bytes``.
+        :parma unicode source: the source of the data
+        :returns: Deferred
+
+        Adds or replaces build data attached to the build.
+
+    .. py:method:: getBuildData(buildid, name)
+
+        :param integer buildid: build id retrieve data for
+        :param unicode name: the name of the data
+        :returns: Build data dictionary as above or ``None``, via Deferred
+
+        Get a single build data, in the format described above, specified by build and by name.
+        Returns ``None`` if build has no data with such name.
+
+    .. py:method:: getBuildDataNoValue(buildid, name)
+
+        :param integer buildid: build id retrieve data for
+        :param unicode name: the name of the data
+        :returns: Build data dictionary as above or ``None``, via Deferred
+
+        Get a single build data, in the format described above, specified by build and by name.
+        The ``value`` field is omitted.
+        Returns ``None`` if build has no data with such name.
+
+    .. py:method:: getAllBuildDataNoValues(buildid, name=None)
+
+        :param integer buildid: build id retrieve data for
+        :param unicode name: the name of the data
+        :returns: a list of build data dictionaries
+
+        Returns all data for a specific build.
+        The values are not loaded.
+        The returned values can be filtered by name

--- a/master/docs/developer/database/build_data.rst
+++ b/master/docs/developer/database/build_data.rst
@@ -60,3 +60,12 @@ Build data connector
         Returns all data for a specific build.
         The values are not loaded.
         The returned values can be filtered by name
+
+    .. py:method:: deleteOldBuildData(older_than_timestamp)
+
+        :param integer older_than_timestamp: the build data whose build's ``complete_at`` is older than ``older_than_timestamp`` will be deleted.
+        :returns: Deferred
+
+        Delete old build data (helper for the ``build_data_horizon`` policy).
+        Old logs have their build data deleted from the database as they are only useful while build is running and shortly afterwards.
+

--- a/master/docs/developer/database/index.rst
+++ b/master/docs/developer/database/index.rst
@@ -10,6 +10,7 @@ This section documents the available database connector classes.
     buildrequests
     builders
     builds
+    build_data
     steps
     logs
     changes

--- a/master/docs/developer/raml/build_data.rst
+++ b/master/docs/developer/raml/build_data.rst
@@ -1,0 +1,2 @@
+.. jinja:: data_api_build_data
+    :file: templates/raml.jinja

--- a/master/docs/developer/raml/index.rst
+++ b/master/docs/developer/raml/index.rst
@@ -12,6 +12,7 @@ This section documents the available REST APIs according to the RAML specificati
     buildrequest
     build
     buildset
+    build_data
     change
     changesource
     forcescheduler


### PR DESCRIPTION
This PR adds a new database table and related APIs for steps to store master-side transient data that should be fetched by subsequent steps or reporters. It is effectively a per-build key-value store. We expect to store json data there. A separate table is used because the size of the data may be large and it is no longer needed after the build.

Currently there are no higher level APIs. 

There's one defect: currently steps are expected to serialize and deserialize the data themselves. We should do serialization in the DB layer. There's no data API, so there's no concern of repeatedly serializing/deserializing json, which was the primary reason why this design decision was done initially.

Also I don't think `build_data` is the best possible name for the APIs, but I haven't been able to think of anything better. Suggestions are welcome :-)