### PR TITLE
Add Bitbucket.org revlink helper

### DIFF
--- a/master/buildbot/newsfragments/revlink_bitbucket.feature
+++ b/master/buildbot/newsfragments/revlink_bitbucket.feature
@@ -1,0 +1,1 @@
+Add rules for Bitbucket to default revlink helpers.

--- a/master/buildbot/revlinks.py
+++ b/master/buildbot/revlinks.py
@@ -41,6 +41,12 @@ GithubRevlink = RevlinkMatch(
     revlink=r'https://github.com/\1/\2/commit/%s')
 
 
+BitbucketRevlink = RevlinkMatch(
+        repo_urls=[r'https://[^@]*@bitbucket.org/([^/]*)/([^/]*?)(?:\.git)?$',
+                   r'git@bitbucket.org:([^/]*)/([^/]*?)(?:\.git)?$'],
+        revlink=r'https://bitbucket.org/\1/\2/commits/%s')
+
+
 class GitwebMatch(RevlinkMatch):
 
     def __init__(self, repo_urls, revlink):
@@ -82,5 +88,6 @@ class RevlinkMultiplexer:
 
 
 default_revlink_matcher = RevlinkMultiplexer(GithubRevlink,
+                                             BitbucketRevlink,
                                              SourceforgeGitRevlink,
                                              SourceforgeGitRevlink_AlluraPlatform)

--- a/master/buildbot/test/unit/test_revlinks.py
+++ b/master/buildbot/test/unit/test_revlinks.py
@@ -15,6 +15,7 @@
 
 from twisted.trial import unittest
 
+from buildbot.revlinks import BitbucketRevlink
 from buildbot.revlinks import GithubRevlink
 from buildbot.revlinks import GitwebMatch
 from buildbot.revlinks import RevlinkMatch
@@ -114,6 +115,21 @@ class TestGitwebMatch(unittest.TestCase):
                          'http://orgmode.org/w/?p=org-mode.git;a=commit;h=490d6ace10e0cfe74bab21c59e4b7bd6aa3c59b8')  # noqa pylint: disable=line-too-long
 
 
+class TestBitbucketRevlink(unittest.TestCase):
+    revision = '4d4284cf4fb49ce82fefb6cbac8e462073c5f106'
+    url = 'https://bitbucket.org/fakeproj/fakerepo/commits/4d4284cf4fb49ce82fefb6cbac8e462073c5f106'
+
+    def testHTTPS(self):
+        self.assertEqual(BitbucketRevlink(self.revision,
+                         'https://fakeuser@bitbucket.org/fakeproj/fakerepo.git'),
+                         self.url)
+
+    def testSSH(self):
+        self.assertEqual(BitbucketRevlink(self.revision,
+                         'git@bitbucket.org:fakeproj/fakerepo.git'),
+                         self.url)
+
+
 class TestDefaultRevlinkMultiPlexer(unittest.TestCase):
     revision = "0"
 
@@ -121,6 +137,9 @@ class TestDefaultRevlinkMultiPlexer(unittest.TestCase):
         # GithubRevlink
         self.assertTrue(default_revlink_matcher(
             self.revision, 'https://github.com/buildbot/buildbot.git'))
+        # BitbucketRevlink
+        self.assertTrue(default_revlink_matcher(
+            self.revision, 'git@bitbucket.org:fakeproj/fakerepo.git'))
         # SourceforgeGitRevlink
         self.assertTrue(default_revlink_matcher(
             self.revision, 'git://gemrb.git.sourceforge.net/gitroot/gemrb/gemrb'))

--- a/master/docs/manual/configuration/global.rst
+++ b/master/docs/manual/configuration/global.rst
@@ -1018,7 +1018,7 @@ Revision Links
 The :bb:cfg:`revlink` parameter is used to create links from revision IDs in the web status to a web-view of your source control system.
 The parameter's value must be a callable.
 
-By default, Buildbot is configured to generate revlinks for a number of open source hosting platforms.
+By default, Buildbot is configured to generate revlinks for a number of open source hosting platforms (https://github.com, https://sourceforge.net and https://bitbucket.org).
 
 The callable takes the revision id and repository argument, and should return an URL to the revision.
 Note that the revision id may not always be in the form you expect, so code defensively.


### PR DESCRIPTION
Add a bitbucket revlink helper to the default helper lists.
This is configurable with master.cfg, but it will be nice to builtin.

Two unit tests failed, but looks totally irrelevant.
