### PR TITLE
Fix an issue of Github Oauth

### DIFF
--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -324,7 +324,7 @@ class GitHubAuth(OAuth2Auth):
                                  data['viewer']['organizations']['edges']])
         if self.getTeamsMembership:
             orgs_name_slug_mapping = {
-                self._orgname_slug_sub_re.sub('_', n): n
+                '_' + self._orgname_slug_sub_re.sub('_', n): n
                 for n in user_info['groups']}
             graphql_query = self.getUserTeamsGraphqlTplC.render(
                 {'user_info': user_info,


### PR DESCRIPTION
Fix an issue of Github Oauth that someone who has organizations like "01org" can't log in Buildbot master with Github Oauth.
Please check https://github.com/buildbot/buildbot/issues/5389 for details.


Signed-off-by: yinyangsx <yin.yang@intel.com>
