### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/master/buildbot/scripts/windows_service.py
+++ b/master/buildbot/scripts/windows_service.py
@@ -296,7 +296,7 @@ class BBService(win32serviceutil.ServiceFramework):
             for i in range(5):
                 t.join(1)
                 self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
-                if not t.isAlive():
+                if not t.is_alive():
                     break
             else:
                 self.warning("Redirect thread did not stop!")

--- a/worker/buildbot_worker/scripts/windows_service.py
+++ b/worker/buildbot_worker/scripts/windows_service.py
@@ -301,7 +301,7 @@ class BBService(win32serviceutil.ServiceFramework):
             for i in range(5):
                 t.join(1)
                 self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
-                if not t.isAlive():
+                if not t.is_alive():
                     break
             else:
                 self.warning("Redirect thread did not stop!")


### PR DESCRIPTION
Fixes #5394 
