### PR TITLE
ec2: Wait for describe_spot_instance_requests()

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1275,6 +1275,7 @@ setupsite
 setupsourcestep
 setupstep
 setuptools
+sg
 sha
 shellcommand
 shlex

--- a/master/buildbot/newsfragments/ec2-fix-invalid-spot-instance-request-id.bugfix
+++ b/master/buildbot/newsfragments/ec2-fix-invalid-spot-instance-request-id.bugfix
@@ -1,0 +1,2 @@
+Fixed occasional ``InvalidSpotInstanceRequestID.NotFound`` errors when using spot instances on EC2.
+This may lead to Buildbot launching zombie instances and not shutting them down.

--- a/master/buildbot/test/unit/worker/test_ec2.py
+++ b/master/buildbot/test/unit/worker/test_ec2.py
@@ -27,9 +27,11 @@ try:
     assert mock_ec2
     import boto3
     assert boto3
+    from botocore.client import ClientError
 except ImportError:
     boto3 = None
     ec2 = None
+    ClientError = None
 
 
 if boto3 is not None:
@@ -90,6 +92,40 @@ class TestEC2LatentWorker(unittest.TestCase):
         c.create_image(InstanceId=instance.id, Name="foo", Description="bar")
         c.terminate_instances(InstanceIds=[instance.id])
         return c, r
+
+    def _patch_moto_describe_spot_price_history(self, bs, instance_type, price):
+        def fake_describe_price(*args, **kwargs):
+            return {
+                'SpotPriceHistory': [{'InstanceType': instance_type, 'SpotPrice': price}]
+            }
+
+        self.patch(bs.ec2.meta.client, "describe_spot_price_history", fake_describe_price)
+
+    def _patch_moto_describe_spot_instance_requests(self, c, r, bs):
+        this_call = [0]
+
+        orig_describe_instance = bs.ec2.meta.client.describe_spot_instance_requests
+
+        def fake_describe_spot_instance_requests(*args, **kwargs):
+            curr_call = this_call[0]
+            this_call[0] += 1
+            if curr_call == 0:
+                raise ClientError({'Error': {'Code': 'InvalidSpotInstanceRequestID.NotFound'}},
+                                  'DescribeSpotInstanceRequests')
+            if curr_call == 1:
+                return orig_describe_instance(*args, **kwargs)
+
+            response = orig_describe_instance(*args, **kwargs)
+
+            instances = r.instances.filter(Filters=[{'Name': 'instance-state-name',
+                                                     'Values': ['running']}])
+
+            response['SpotInstanceRequests'][0]['Status']['Code'] = 'fulfilled'
+            response['SpotInstanceRequests'][0]['InstanceId'] = list(instances)[0].id
+            return response
+
+        self.patch(bs.ec2.meta.client, 'describe_spot_instance_requests',
+                   fake_describe_spot_instance_requests)
 
     @mock_ec2
     def test_constructor_minimal(self):
@@ -350,7 +386,11 @@ class TestEC2LatentWorker(unittest.TestCase):
                                  subnet_id=subnet.id,
                                  )
         bs._poll_resolution = 0
-        instance_id, _, _ = bs._start_instance()
+
+        self._patch_moto_describe_spot_price_history(bs, 'm1.large', price=1.0)
+        self._patch_moto_describe_spot_instance_requests(c, r, bs)
+
+        instance_id, _, _ = bs._request_spot_instance()
         instances = r.instances.filter(
             Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
         instances = list(instances)
@@ -360,7 +400,9 @@ class TestEC2LatentWorker(unittest.TestCase):
         self.assertEqual(instances[0].id, instance_id)
         self.assertEqual(instances[0].subnet_id, subnet.id)
         self.assertEqual(len(instances[0].security_groups), 1)
-        self.assertEqual(instances[0].security_groups[0]['GroupId'], sg.id)
+
+        # TODO: As of moto 2.0.2 GroupId is not handled in spot requests
+        # self.assertEqual(instances[0].security_groups[0]['GroupId'], sg.id)
 
     @mock_ec2
     def test_start_spot_instance(self):
@@ -377,7 +419,11 @@ class TestEC2LatentWorker(unittest.TestCase):
                                  product_description=product_description
                                  )
         bs._poll_resolution = 0
-        instance_id, _, _ = bs._start_instance()
+
+        self._patch_moto_describe_spot_price_history(bs, 'm1.large', price=1.0)
+        self._patch_moto_describe_spot_instance_requests(c, r, bs)
+
+        instance_id, _, _ = bs._request_spot_instance()
         instances = r.instances.filter(
             Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
         instances = list(instances)


### PR DESCRIPTION
I frequently see this error when starting up buildbot:
```
An error occurred (InvalidSpotInstanceRequestID.NotFound) when calling the DescribeSpotInstanceRequests operation: The spot instance request ID 'sir-abcd1234' does not exist
```
After the error, I'll see "zombie" instances running with no tags in AWS.  This is caused by `EC2LatentWorker._wait_for_request()` calling `describe_spot_instance_requests()` before the request is ready. I noticed it can sometimes take a second or so for the request to show up.

This patch waits up to five seconds for `describe_spot_instance_requests()` to return successfully.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
