### PR TITLE
Match .jpg not .jeg in webpack.config.js

### DIFF
--- a/www/base/webpack.config.js
+++ b/www/base/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = function() {
             test: /\.(ttf|eot|woff|woff2)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
             use: 'file-loader'
         }, {
-            test: /\.(jp?eg|png|svg|ico)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+            test: /\.(jpe?g|png|svg|ico)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
             use: [{
                 loader: 'file-loader',
                 options: {


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
