### PR TITLE
Update Subversion links in documentation

### DIFF
--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -27,7 +27,7 @@ For CVS, the static specifications are *repository* and *module*.
 In addition to those, each build uses a timestamp (or omits the timestamp to mean *the latest*) and *branch tag* (which defaults to ``HEAD``).
 These parameters collectively specify a set of sources from which a build may be performed.
 
-`Subversion <http://subversion.tigris.org>`_,  combines the repository, module, and branch into a single *Subversion URL* parameter.
+`Subversion <https://subversion.apache.org>`_ combines the repository, module, and branch into a single *Subversion URL* parameter.
 Within that scope, source checkouts can be specified by a numeric *revision number* (a repository-wide monotonically-increasing marker, such that each transaction that changes the repository is indexed by a different revision number), or a revision timestamp.
 When branches are used, the repository and module form a static ``baseURL``, while each build has a *revision number* and a *branch* (which defaults to a statically-specified ``defaultBranch``).
 The ``baseURL`` and ``branch`` are simply concatenated together to derive the ``repourl`` to use for the checkout.
@@ -688,7 +688,7 @@ SVNPoller
 
 .. py:class:: buildbot.changes.svnpoller.SVNPoller
 
-The :bb:chsrc:`SVNPoller` is a ChangeSource which periodically polls a `Subversion <http://subversion.tigris.org>`_ repository for new revisions, by running the ``svn log`` command in a subshell.
+The :bb:chsrc:`SVNPoller` is a ChangeSource which periodically polls a `Subversion <https://subversion.apache.org>`_ repository for new revisions, by running the ``svn log`` command in a subshell.
 It can watch a single branch or multiple branches.
 
 :bb:chsrc:`SVNPoller` accepts the following arguments:

--- a/master/docs/manual/configuration/steps/source_svn.rst
+++ b/master/docs/manual/configuration/steps/source_svn.rst
@@ -7,7 +7,7 @@ SVN
 
 .. py:class:: buildbot.steps.source.svn.SVN
 
-The :bb:step:`SVN` build step performs a `Subversion <http://subversion.tigris.org>`_ checkout or update.
+The :bb:step:`SVN` build step performs a `Subversion <https://subversion.apache.org>`_ checkout or update.
 There are two basic ways of setting up the checkout step, depending upon whether you are using multiple branches or not.
 
 The :bb:step:`SVN` step should be created with the ``repourl`` argument:


### PR DESCRIPTION
Tigris is gone. Subversion moved to Apache years ago.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
