### PR TITLE
Fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,15 +16,15 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - 3-dependencies-{{ checksum "requirements-ci.txt" }}-{{ checksum "requirements-cidocs.txt" }}
+            - 37-dependencies-{{ checksum "requirements-ci.txt" }}-{{ checksum "requirements-cidocs.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - 3-dependencies-
+            - 37-dependencies-
 
       - run:
           name: install dependencies
           command: |
             env
-            python3 -m venv .venv
+            python3.7 -m venv .venv
             . .venv/bin/activate
             pip install -U pip 'setuptools<45.0.0'
             pip install -r requirements-ci.txt

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ docker-buildbot-master:
 	$(DOCKERBUILD) -t buildbot/buildbot-master:master master
 
 $(VENV_NAME):
-	virtualenv -p $(VENV_PY_VERSION) --no-site-packages $(VENV_NAME)
+	virtualenv -p $(VENV_PY_VERSION) $(VENV_NAME)
 	$(PIP) install -U pip setuptools
 
 # helper for virtualenv creation

--- a/master/docs/tutorial/firstrun.rst
+++ b/master/docs/tutorial/firstrun.rst
@@ -143,7 +143,7 @@ On Python 2:
 
 .. code-block:: bash
 
-  virtualenv --no-site-packages sandbox
+  virtualenv sandbox
   source sandbox/bin/activate
 
 On Python 3:

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -21,7 +21,7 @@ cryptography==3.0
 decorator==4.4.2
 dicttoxml==1.7.4
 docutils==0.16
-enum34==1.1.10
+enum34==1.1.10; python_version <= "3.4"
 flake8==3.8.3
 funcparserlib==0.3.6
 funcsigs==1.0.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -83,7 +83,7 @@ treq==20.4.1
 Twisted==20.3.0
 txaio==20.4.1
 txrequests==0.9.6
-typing==3.7.4.3
+typing==3.7.4.3; python_version < "3.5"
 webcolors==1.11.1
 Werkzeug==1.0.1
 wrapt==1.12.1


### PR DESCRIPTION
Here are some steps I did to upgrade our CI environment.

- rebuilt https://hub.docker.com/repository/docker/buildbot/metabbotcfg/builds
The build was broken for a while since the base image moved to ubuntu 18 (python-software-properties is not needed anymore)
I encountered various build issues, which made me upgrade a few other thing.
- updated node environment to node LTS (12 instead of 8), because chromedriver didn't want to install with node8.
- remove python 2.6, because we don't use it anymore

The next day, obviously all CI broke :(

- The new virtualenv do not want 'no-site-package- anymore. They way it was the default for years, this is why I removed it.
- circle-ci failed with a weird error. This took me a while to figure out, but this was due to cached .venv, which was for python 3.5 and now we use 3.7. So I did invalidate the cache.
- Then moving to 3.7 revealed a few issues in our requirement.txt (enum34 and typings shall not be installed there)
