### PR TITLE
Fix typos in documentation

### DIFF
--- a/master/docs/developer/quickstart.rst
+++ b/master/docs/developer/quickstart.rst
@@ -120,7 +120,7 @@ For a bit more detail, see the Buildbot tutorial (:ref:`first-run-label`).
 
 If all goes well, the master will start up and begin running in the background.
 During ``make frontend`` the www frontend was built using production mode, so everything is minified and hard to debug.
-However, the frontend was installed as a editable python package, so all changes in the artifacts (e.g. ``www/base/buildbot_www/static``) in the source directories will be observed in the browser.
+However, the frontend was installed as an editable python package, so all changes in the artifacts (e.g. ``www/base/buildbot_www/static``) in the source directories will be observed in the browser.
 Thus we can rebuild the JavaScript resources manually using development settings, so they are not minified and easier to debug.
 
 This can be done by running the following in e.g. ``www/base`` directory:
@@ -129,8 +129,8 @@ This can be done by running the following in e.g. ``www/base`` directory:
 
     yarn run build-dev
 
-The above rebuilds the resources only once, after each change you need to refresh the built resources.
-The actual commands that are ran are stored in the ``package.json`` file under the ``scripts`` key.
+The above rebuilds the resources only once. After each change you need to refresh the built resources.
+The actual commands that are run are stored in the ``package.json`` file under the ``scripts`` key.
 
 To avoid the need to type the above command after each change, you can use the following:
 

--- a/master/docs/manual/configuration/reporters.rst
+++ b/master/docs/manual/configuration/reporters.rst
@@ -468,7 +468,7 @@ Pushover Notifications
 
 Apart of sending mail, Buildbot can send Pushover_ notifications. It can be used by administrators to receive an instant message to an iPhone or an Android device if a build fails. The :class:`PushoverNotifier` reporter is used to accomplish this. Its configuration is very similar to the mail notifications, however—due to the notification size constrains—the logs and patches cannot be attached.
 
-To use this reporter, you need to generate and application on the Pushover website https://pushover.net/apps/ and provide your user key and the API token.
+To use this reporter, you need to generate an application on the Pushover website https://pushover.net/apps/ and provide your user key and the API token.
 
 The following simple example will send a Pushover notification upon the completion of each build.
 The notification contains a description of the :class:`Build`, its results, and URLs where more information can be obtained. The ``user_key`` and ``api_token`` values should be replaced with proper ones obtained from the Pushover website for your application.
@@ -1222,7 +1222,7 @@ It requires `txrequests`_ package to allow interaction with GitHub REST API.
 
 It is configured with at least a GitHub API token.
 
-You can create a token from you own `GitHub - Profile - Applications - Register new application <https://github.com/settings/applications>`_ or use an external tool to generate one.
+You can create a token from your own `GitHub - Profile - Applications - Register new application <https://github.com/settings/applications>`_ or use an external tool to generate one.
 
 .. py:class:: GitHubStatusPush(token, startDescription=None, endDescription=None, context=None, baseURL=None, verbose=False, builders=None)
 
@@ -1264,7 +1264,7 @@ It requires `txrequests`_ package to allow interaction with GitHub REST API.
 
 It is configured with at least a GitHub API token. By default, it will only comment at the end of a build unless a ``startDescription`` is provided.
 
-You can create a token from you own `GitHub - Profile - Applications - Register new application <https://github.com/settings/applications>`_ or use an external tool to generate one.
+You can create a token from your own `GitHub - Profile - Applications - Register new application <https://github.com/settings/applications>`_ or use an external tool to generate one.
 
 .. py:class:: GitHubCommentPush(token, startDescription=None, endDescription=None, baseURL=None, verbose=False, builders=None)
 

--- a/master/docs/manual/configuration/steps/set_property_from_command.rst
+++ b/master/docs/manual/configuration/steps/set_property_from_command.rst
@@ -19,7 +19,7 @@ It is usually used like this:
 This runs ``uname -a`` and captures its stdout, stripped of leading and trailing whitespace, in the property ``uname``.
 To avoid stripping, add ``strip=False``.
 
-The ``property`` argument can be specified as a  :ref:`Interpolate` object, allowing the property name to be built from other property values.
+The ``property`` argument can be specified as an :ref:`Interpolate` object, allowing the property name to be built from other property values.
 
 Passing ``includeStdout=False`` (default ``True``) stops capture from stdout.
 

--- a/master/docs/manual/configuration/steps/shell_command.rst
+++ b/master/docs/manual/configuration/steps/shell_command.rst
@@ -176,11 +176,11 @@ The :bb:step:`ShellCommand` arguments are:
     If None, ``interruptSignal`` will be fired immediately on interrupt.
 
 ``initialStdin``
-    If the command expects input on stdin, that can be supplied a a string with this parameter.
+    If the command expects input on stdin, that can be supplied as a string with this parameter.
     This value should not be excessively large, as it is handled as a single string throughout Buildbot -- for example, do not pass the contents of a tarball with this parameter.
 
 ``decodeRC``
     This is a dictionary that decodes exit codes into results value.
-    For example, ``{0:SUCCESS,1:FAILURE,2:WARNINGS}``, will treat the exit code ``2`` as WARNINGS.
-    The default is to treat just 0 as successful.
-    (``{0:SUCCESS}``) any exit code not present in the dictionary will be treated as ``FAILURE``
+    For example, ``{0:SUCCESS,1:FAILURE,2:WARNINGS}`` will treat the exit code ``2`` as ``WARNINGS``.
+    The default (``{0:SUCCESS}``) is to treat just 0 as successful.
+    Any exit code not present in the dictionary will be treated as ``FAILURE``.

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -653,7 +653,7 @@ Factory Workdir Functions
 
 .. note::
 
-    While factory workdir function is still supported, it is better to just use the fact that workdir is a :index:`renderables <renderable>` attribute of every steps.
+    While factory workdir function is still supported, it is better to just use the fact that workdir is a :index:`renderables <renderable>` attribute of every step.
     A Renderable has access to much more contextual information, and also can return a deferred.
     So you could say ``build_factory.workdir = util.Interpolate("%(src:repository)s`` to achieve similar goal.
 
@@ -731,7 +731,7 @@ Consider the use of a :class:`BuildStep` in :file:`master.cfg`:
 This creates a single instance of class ``MyStep``.
 However, Buildbot needs a new object each time the step is executed.
 An instance of :class:`~buildbot.process.buildstep.BuildStep` remembers how it was constructed, and can create copies of itself.
-When writing a new step class, then, keep in mind are that you cannot do anything "interesting" in the constructor -- limit yourself to checking and storing arguments.
+When writing a new step class, then, keep in mind that you cannot do anything "interesting" in the constructor -- limit yourself to checking and storing arguments.
 
 It is customary to call the parent class's constructor with all otherwise-unspecified keyword arguments.
 Keep a ``**kwargs`` argument on the end of your options, and pass that up to the parent class's constructor.
@@ -914,7 +914,7 @@ Again, note that the log input must be a unicode string.
 Finally, :meth:`~buildbot.process.buildstep.BuildStep.addHTMLLog` is similar to :meth:`~buildbot.process.buildstep.BuildStep.addCompleteLog`, but the resulting log will be tagged as containing HTML.
 The web UI will display the contents of the log using the browser.
 
-The ``logfiles=`` argument to :bb:step:`ShellCommand` and its subclasses creates new log files and fills them in realtime by asking the worker to watch a actual file on disk.
+The ``logfiles=`` argument to :bb:step:`ShellCommand` and its subclasses creates new log files and fills them in realtime by asking the worker to watch an actual file on disk.
 The worker will look for additions in the target file and report them back to the :class:`BuildStep`.
 These additions will be added to the log file by calling :meth:`addStdout`.
 


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
