### PR TITLE
bitbucket server core api build status reporter

### DIFF
--- a/master/buildbot/newsfragments/bitbucketserver-build-status.feature
+++ b/master/buildbot/newsfragments/bitbucketserver-build-status.feature
@@ -1,0 +1,3 @@
+New reporter :py:class:`~buildbot.reporters.bitbucketserver.BitbucketServerCoreAPIStatusPush`.
+Reporting build status has been integrated into `BitbucketServer Core REST API <https://docs.atlassian.com/bitbucket-server/rest/7.4.0/bitbucket-rest.html#idp219>`_ in `Bitbucket Server 7.4 <https://confluence.atlassian.com/bitbucketserver/bitbucket-server-7-4-release-notes-1013849643.html#BitbucketServer7.4releasenotes-cicdStreamlineyourworkflowwithIntegratedCI/CD>`_.
+Old `BitbucketServer Build REST API <https://docs.atlassian.com/bitbucket-server/rest/7.4.0/bitbucket-build-rest.html#idp7>`_ is still working, but does not provide the new and improved functionality.

--- a/master/buildbot/reporters/utils.py
+++ b/master/buildbot/reporters/utils.py
@@ -72,6 +72,15 @@ def getDetailsForBuild(master, build, wantProperties=False, wantSteps=False,
     buildrequest = yield master.data.get(("buildrequests", build['buildrequestid']))
     buildset = yield master.data.get(("buildsets", buildrequest['buildsetid']))
     build['buildrequest'], build['buildset'] = buildrequest, buildset
+
+    parentbuild = None
+    parentbuilder = None
+    if buildset['parent_buildid']:
+        parentbuild = yield master.data.get(("builds", buildset['parent_buildid']))
+        parentbuilder = yield master.data.get(("builders", parentbuild['builderid']))
+    build['parentbuild'] = parentbuild
+    build['parentbuilder'] = parentbuilder
+
     ret = yield getDetailsForBuilds(master, buildset, [build],
                                     wantProperties=wantProperties, wantSteps=wantSteps,
                                     wantPreviousBuild=wantPreviousBuild, wantLogs=wantLogs)

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -13,17 +13,23 @@
 #
 # Copyright Buildbot Team Members
 
+import datetime
+
+from dateutil.tz import tzutc
+
 from mock import Mock
 
 from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot import config
+from buildbot.plugins import util
 from buildbot.process.properties import Interpolate
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.reporters.bitbucketserver import HTTP_CREATED
 from buildbot.reporters.bitbucketserver import HTTP_PROCESSED
+from buildbot.reporters.bitbucketserver import BitbucketServerCoreAPIStatusPush
 from buildbot.reporters.bitbucketserver import BitbucketServerPRCommentPush
 from buildbot.reporters.bitbucketserver import BitbucketServerStatusPush
 from buildbot.reporters.generators.build import BuildStatusGenerator
@@ -31,6 +37,7 @@ from buildbot.reporters.generators.buildset import BuildSetStatusGenerator
 from buildbot.reporters.message import MessageFormatter
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.logging import LoggingMixin
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.notifier import NotifierTestMixin
@@ -176,6 +183,268 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
         self.sp.buildFinished(("build", 20, "finished"), build)
         build['results'] = FAILURE
         self.sp.buildFinished(("build", 20, "finished"), build)
+
+
+class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase,
+                                           ReporterTestMixin, LoggingMixin):
+
+    @defer.inlineCallbacks
+    def setupReporter(self, **kwargs):
+        self.setUpTestReactor()
+        # ignore config error if txrequests is not installed
+        self.patch(config, '_errors', Mock())
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
+
+        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+            self.master, self,
+            'serv', auth=('username', 'passwd'), headers={},
+            debug=None, verify=None)
+        self.sp = sp = BitbucketServerCoreAPIStatusPush(
+            "serv", token=None, auth=(Interpolate("username"), Interpolate("passwd")), **kwargs)
+        yield sp.setServiceParent(self.master)
+        yield self.master.startService()
+
+    def setUp(self):
+        self.master = None
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        if self.master and self.master.running:
+            yield self.master.stopService()
+
+    @defer.inlineCallbacks
+    def setupBuildResults(self, buildResults, parentPlan=False):
+        self.insertTestData([buildResults], buildResults, parentPlan=parentPlan)
+        build = yield self.master.data.get(("builds", 20))
+        return build
+
+    def _check_start_and_finish_build(self, build, parentPlan=False):
+        # we make sure proper calls to txrequests have been made
+
+        _name = "Builder_parent #1 \u00BB Builder0 #0" if parentPlan else "Builder0 #0"
+        _parent = "Builder_parent" if parentPlan else "Builder0"
+
+        self._http.expect(
+            'post',
+            '/rest/api/1.0/projects/example.org/repos/repo/commits/d34db33fd43db33f/builds',
+            json={'name': _name, 'description': 'Build started.', 'key': 'Builder0',
+                  'url': 'http://localhost:8080/#builders/79/builds/0',
+                  'ref': 'refs/heads/master', 'buildNumber': '0', 'state': 'INPROGRESS',
+                  'parent': _parent, 'duration': None, 'testResults': None},
+            code=HTTP_PROCESSED)
+        self._http.expect(
+            'post',
+            '/rest/api/1.0/projects/example.org/repos/repo/commits/d34db33fd43db33f/builds',
+            json={'name': _name, 'description': 'Build done.', 'key': 'Builder0',
+                  'url': 'http://localhost:8080/#builders/79/builds/0',
+                  'ref': 'refs/heads/master', 'buildNumber': '0', 'state': 'SUCCESSFUL',
+                  'parent': _parent, 'duration': 10000, 'testResults': None},
+            code=HTTP_PROCESSED)
+        self._http.expect(
+            'post',
+            '/rest/api/1.0/projects/example.org/repos/repo/commits/d34db33fd43db33f/builds',
+            json={'name': _name, 'description': 'Build done.', 'key': 'Builder0',
+                  'url': 'http://localhost:8080/#builders/79/builds/0',
+                  'ref': 'refs/heads/master', 'buildNumber': '0', 'state': 'FAILED',
+                  'parent': _parent, 'duration': 10000, 'testResults': None},
+            code=HTTP_PROCESSED)
+        build['started_at'] = datetime.datetime(2019, 4, 1, 23, 38, 33, 154354, tzinfo=tzutc())
+        build['complete'] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        build["complete_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
+        build['complete'] = True
+        self.sp.buildFinished(("build", 20, "finished"), build)
+        build['results'] = FAILURE
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    def test_config_no_base_url(self):
+        with self.assertRaisesConfigError("Parameter base_url has to be given"):
+            BitbucketServerCoreAPIStatusPush(base_url=None)
+
+    def test_config_auth_and_token_mutually_exclusive(self):
+        with self.assertRaisesConfigError(
+                "Only one authentication method can be given (token or auth)"):
+            BitbucketServerCoreAPIStatusPush("serv", token="x", auth=("username", "passwd"))
+
+    @defer.inlineCallbacks
+    def test_basic(self):
+        yield self.setupReporter()
+        build = yield self.setupBuildResults(SUCCESS)
+        self._check_start_and_finish_build(build)
+
+    @defer.inlineCallbacks
+    def test_with_parent(self):
+        yield self.setupReporter()
+        build = yield self.setupBuildResults(SUCCESS, parentPlan=True)
+        self._check_start_and_finish_build(build, parentPlan=True)
+
+    @defer.inlineCallbacks
+    def test_error(self):
+        self.setupReporter()
+        build = yield self.setupBuildResults(SUCCESS)
+        self.setUpLogging()
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            'post',
+            '/rest/api/1.0/projects/example.org/repos/repo/commits/d34db33fd43db33f/builds',
+            json={'name': 'Builder0 #0', 'description': 'Build started.', 'key': 'Builder0',
+                  'url': 'http://localhost:8080/#builders/79/builds/0',
+                  'ref': 'refs/heads/master', 'buildNumber': '0', 'state': 'INPROGRESS',
+                  'parent': 'Builder0', 'duration': None, 'testResults': None},
+            code=HTTP_NOT_FOUND)
+        build['complete'] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        self.assertLogged('404: Unable to send Bitbucket Server status')
+
+    @defer.inlineCallbacks
+    def test_with_full_ref(self):
+        yield self.setupReporter()
+        old_test_branch = self.TEST_BRANCH
+        try:
+            self.TEST_BRANCH = "refs/heads/master"
+            build = yield self.setupBuildResults(SUCCESS)
+        finally:
+            self.TEST_BRANCH = old_test_branch
+        self._check_start_and_finish_build(build)
+
+    @defer.inlineCallbacks
+    def test_with_no_ref(self):
+        yield self.setupReporter()
+        old_test_branch = self.TEST_BRANCH
+        try:
+            self.TEST_BRANCH = None
+            build = yield self.setupBuildResults(SUCCESS)
+        finally:
+            self.TEST_BRANCH = old_test_branch
+        self.setUpLogging()
+        self._http.expect(
+            'post',
+            '/rest/api/1.0/projects/example.org/repos/repo/commits/d34db33fd43db33f/builds',
+            json={'name': 'Builder0 #0', 'description': 'Build started.', 'key': 'Builder0',
+                  'url': 'http://localhost:8080/#builders/79/builds/0',
+                  'ref': None, 'buildNumber': '0', 'state': 'INPROGRESS',
+                  'parent': 'Builder0', 'duration': None, 'testResults': None},
+            code=HTTP_PROCESSED)
+        build['complete'] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        self.assertLogged("WARNING: Unable to resolve ref for SSID: 234.")
+
+    @defer.inlineCallbacks
+    def test_with_no_revision(self):
+        yield self.setupReporter()
+        old_test_revision = self.TEST_REVISION
+        try:
+            self.TEST_REVISION = None
+            build = yield self.setupBuildResults(SUCCESS)
+        finally:
+            self.TEST_REVISION = old_test_revision
+        self.setUpLogging()
+        # we don't expect any request
+        build['complete'] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        self.assertLogged("Unable to get the commit hash for SSID: 234")
+
+    @defer.inlineCallbacks
+    def test_with_no_repo(self):
+        yield self.setupReporter()
+        old_test_repo = self.TEST_REPO
+        try:
+            self.TEST_REPO = None
+            build = yield self.setupBuildResults(SUCCESS)
+        finally:
+            self.TEST_REPO = old_test_repo
+        self.setUpLogging()
+        # we don't expect any request
+        build['complete'] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        self.assertLogged("Unable to parse repository info from 'None' for SSID: 234")
+
+    @defer.inlineCallbacks
+    def test_with_renderers(self):
+        @util.renderer
+        def r_testresults(props):
+            return {
+                "failed": props.getProperty("unittests_failed", 0),
+                "skipped": props.getProperty("unittests_skipped", 0),
+                "successful": props.getProperty("unittests_successful", 0),
+            }
+
+        @util.renderer
+        def r_duration(props):
+            return props.getProperty("unittests_runtime")
+
+        yield self.setupReporter(statusName=Interpolate("%(prop:plan_name)s"),
+            statusSuffix=Interpolate(" [%(prop:unittests_os)s]"), buildNumber=Interpolate('100'),
+            ref=Interpolate("%(prop:branch)s"), parentName=Interpolate("%(prop:master_plan)s"),
+            testResults=r_testresults, duration=r_duration)
+        old_test_props = self.TEST_PROPS
+        try:
+            self.TEST_PROPS = self.TEST_PROPS.copy()
+            self.TEST_PROPS['unittests_failed'] = 0
+            self.TEST_PROPS['unittests_skipped'] = 2
+            self.TEST_PROPS['unittests_successful'] = 3
+            self.TEST_PROPS['unittests_runtime'] = 50000
+            self.TEST_PROPS['unittests_os'] = "win10"
+            self.TEST_PROPS['plan_name'] = "Unittests"
+            self.TEST_PROPS['master_plan'] = "Unittests-master"
+            build = yield self.setupBuildResults(SUCCESS)
+        finally:
+            self.TEST_PROPS = old_test_props
+        self._http.expect(
+            'post',
+            '/rest/api/1.0/projects/example.org/repos/repo/commits/d34db33fd43db33f/builds',
+            json={'name': 'Unittests [win10]', 'description': 'Build done.', 'key': 'Builder0',
+                  'url': 'http://localhost:8080/#builders/79/builds/0',
+                  'ref': "refs/pull/34/merge", 'buildNumber': '100', 'state': 'SUCCESSFUL',
+                  'parent': 'Unittests-master', 'duration': 50000, 'testResults': {'failed': 0,
+                  'skipped': 2, 'successful': 3}},
+            code=HTTP_PROCESSED)
+        build['complete'] = True
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
+    def test_with_test_results(self):
+        yield self.setupReporter()
+        old_test_props = self.TEST_PROPS
+        try:
+            self.TEST_PROPS = self.TEST_PROPS.copy()
+            self.TEST_PROPS['tests_skipped'] = 2
+            self.TEST_PROPS['tests_successful'] = 3
+            build = yield self.setupBuildResults(SUCCESS)
+        finally:
+            self.TEST_PROPS = old_test_props
+        self._http.expect(
+            'post',
+            '/rest/api/1.0/projects/example.org/repos/repo/commits/d34db33fd43db33f/builds',
+            json={'name': 'Builder0 #0', 'description': 'Build done.', 'key': 'Builder0',
+                  'url': 'http://localhost:8080/#builders/79/builds/0',
+                  'ref': 'refs/heads/master', 'buildNumber': '0', 'state': 'SUCCESSFUL',
+                  'parent': 'Builder0', 'duration': 10000, 'testResults': {'failed': 0,
+                  'skipped': 2, 'successful': 3}},
+            code=HTTP_PROCESSED)
+        build['started_at'] = datetime.datetime(2019, 4, 1, 23, 38, 33, 154354, tzinfo=tzutc())
+        build["complete_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
+        build['complete'] = True
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
+    def test_verbose(self):
+        yield self.setupReporter(verbose=True)
+        build = yield self.setupBuildResults(SUCCESS)
+        self.setUpLogging()
+        self._http.expect(
+            'post',
+            '/rest/api/1.0/projects/example.org/repos/repo/commits/d34db33fd43db33f/builds',
+            json={'name': 'Builder0 #0', 'description': 'Build started.', 'key': 'Builder0',
+                  'url': 'http://localhost:8080/#builders/79/builds/0',
+                  'ref': "refs/heads/master", 'buildNumber': '0', 'state': 'INPROGRESS',
+                  'parent': 'Builder0', 'duration': None, 'testResults': None},
+            code=HTTP_PROCESSED)
+        build['complete'] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        self.assertLogged('Sending payload:')
+        self.assertLogged('Status "INPROGRESS" sent for example.org/repo d34db33fd43db33f')
 
 
 UNICODE_BODY = "body: \u00E5\u00E4\u00F6 text"

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -38,7 +38,9 @@ class BuildLookAlike:
         self.keys = [
             'builder', 'builderid', 'buildid', 'buildrequest', 'buildrequestid',
             'buildset', 'complete', 'complete_at', 'masterid', 'number',
-            'properties', 'results', 'started_at', 'state_string', 'url', 'workerid']
+            'parentbuild', 'parentbuilder', 'properties', 'results',
+            'started_at', 'state_string', 'url', 'workerid'
+            ]
         if keys:
             self.keys.extend(keys)
             self.keys.sort()

--- a/master/docs/manual/configuration/reporters.rst
+++ b/master/docs/manual/configuration/reporters.rst
@@ -1391,6 +1391,71 @@ As a result, we recommend you use https in your base_url rather than http.
     :param boolean verify: disable ssl verification for the case you use temporary self signed certificates
     :param boolean debug: logs every requests and their response
 
+.. bb:reporter:: BitbucketServerCoreAPIStatusPush
+
+BitbucketServerCoreAPIStatusPush
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from buildbot.plugins import reporters
+
+    ss = reporters.BitbucketServerCoreAPIStatusPush('https://bitbucketserver.example.com:8080/',
+                                                    auth=('bitbucketserver_username', 'secret_password'))
+    c['services'].append(ss)
+
+Or using `Bitbucket personal access token <https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html>`_
+
+.. code-block:: python
+
+    from buildbot.plugins import reporters
+
+    ss = reporters.BitbucketServerCoreAPIStatusPush('https://bitbucketserver.example.com:8080/',
+                                                    token='MDM0MjM5NDc2MDxxxxxxxxxxxxxxxxxxxxx')
+    c['services'].append(ss)
+
+
+:class:`BitbucketServerCoreAPIStatusPush` publishes build status using `BitbucketServer Core REST API <https://docs.atlassian.com/bitbucket-server/rest/7.4.0/bitbucket-rest.html#idp219>`_ into which it was integrated in `Bitbucket Server 7.4 <https://confluence.atlassian.com/bitbucketserver/bitbucket-server-7-4-release-notes-1013849643.html#BitbucketServer7.4releasenotes-cicdStreamlineyourworkflowwithIntegratedCI/CD>`_.
+The build status is published to a specific commit SHA in specific repository in Bitbucket Server with some additional information about reference name, build duration, parent relationship and also possibly test results.
+
+It requires `txrequests`_ package to allow interaction with Bitbucket Server REST API.
+
+.. py:class:: BitbucketServerCoreAPIStatusPush(base_url, token=None, auth=None, name=None, statusSuffix=None, startDescription=None, endDescription=None, key=None, parentName=None, buildNumber=None, ref=None, duration=None, testResults=None, verbose=False, debug=None, verify=None)
+
+    :param string base_url: The base url of the Bitbucket Server host.
+    :param string token: Bitbucket personal access token (mutually exclusive with `auth`) (can be a :ref:`Secret`)
+    :param tuple auth: A tuple of Bitbucket Server username and password (mutually exclusive with `token`) (can be a :ref:`Secret`)
+    :param renderable string statusName: The name that is displayed for this status.
+         If not defined it is constructed to look like `"%(prop:buildername)s #%(prop:buildnumber)s"`.
+         Or if the plan has a parent plan the default is constructed to look like `"<parent's buildername> #<parent's buildnumber> >> %(prop:buildername)s #%(prop:buildnumber)s"`.
+         Note: Parent information is not accessible as properties for user defined renderer.
+    :param renderable string statusSuffix: Additional string that is appended to `statusName`.
+         Empty by default.
+         It is useful when the same plan is launched multiple times for a single parent plan instance.
+         This way every instance of the child plan can have unique suffix and thus be more recognizable (than it would be just by the buildnumber).
+    :param renderable string startDescription: Custom start message (default: 'Build started.')
+    :param renderable string endDescription: Custom end message (default: 'Build done.')
+    :param renderable string key: Passed to Bitbucket Server to differentiate between statuses.
+         A static string can be passed or :class:`Interpolate` for dynamic substitution.
+         The default key is `%(prop:buildername)s`.
+    :param renderable string parentName: Defaults to parent's buildername if plan has a parent plan.
+         Otherwise plan's own buildername is used as default.
+    :param renderable string buildNumber: The default build number is `%(prop:buildername)s`.
+    :param renderable string ref: By default branch name from :class:`SourceStamp` is used.
+         If branch doesn't start with string `refs/` prefix `refs/heads/` is added to it's beginning.
+    :param renderable int duration: Computed for finished builds.
+         Otherwise None.
+         (value in milliseconds)
+    :param renderable dict testResults: Test results can be reported via this parameter.
+         Resulting dictionary must contain keys `failed`, `skipped`, `successful`.
+         By default these keys are filled with values from build properties (`tests_failed`, `tests_skipped`, `tests_successful`) if at least one of the properties is found (missing values will default to `0`).
+         Otherwise None.
+         Note: If you want to suppress the default behavior pass renderable that always interpolates to None.
+    :param boolean verbose: If True, logs a message for each successful status push.
+    :param list builders: Only send update for specified builders.
+    :param boolean verify: Disable ssl verification for the case you use temporary self signed certificates.
+    :param boolean debug: Logs every requests and their response.
+
 .. bb:reporter:: BitbucketServerPRCommentPush
 
 BitbucketServerPRCommentPush

--- a/master/setup.py
+++ b/master/setup.py
@@ -336,6 +336,7 @@ setup_args = {
             ('buildbot.reporters.stash', ['StashStatusPush']),
             ('buildbot.reporters.bitbucketserver', [
                 'BitbucketServerStatusPush',
+                'BitbucketServerCoreAPIStatusPush',
                 'BitbucketServerPRCommentPush'
             ]),
             ('buildbot.reporters.bitbucket', ['BitbucketStatusPush']),


### PR DESCRIPTION
There is a new API for reporting Build status to Bitbucket server v7.4
* Release notes: https://confluence.atlassian.com/bitbucketserver/bitbucket-server-7-4-release-notes-1013849643.html
* API docs: https://docs.atlassian.com/bitbucket-server/rest/7.4.0/bitbucket-rest.html#idp220

This PR implements **BitbucketServerCoreAPIStatusPush** reporter, that communicates with this new core API.
And also *getDetailsForBuild* now exposes info about parent build, that can be useful for reporters and is used in this new one.

**None**: If you are ok with the implementation, I will continue further with writing the documentation, newsfragments, etc.

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
