### PR TITLE
Fix transient data api REST endpoint

### DIFF
--- a/master/buildbot/data/build_data.py
+++ b/master/buildbot/data/build_data.py
@@ -27,6 +27,7 @@ class Db2DataMixin:
             'buildid': dbdict['buildid'],
             'name': dbdict['name'],
             'value': dbdict['value'],
+            'length': dbdict['length'],
             'source': dbdict['source'],
         }
         return defer.succeed(data)
@@ -82,6 +83,7 @@ class BuildData(base.ResourceType):
     class EntityType(types.Entity):
         buildid = types.Integer()
         name = types.String()
+        length = types.Integer()
         value = types.NoneOk(types.Binary())
         source = types.String()
     entityType = EntityType(name)

--- a/master/buildbot/data/build_data.py
+++ b/master/buildbot/data/build_data.py
@@ -54,7 +54,7 @@ class BuildDatasNoValueEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpo
         return results
 
 
-class BuildDataEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
+class BuildDataNoValueEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
 
     isCollection = False
     pathPatterns = """
@@ -68,16 +68,40 @@ class BuildDataEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
         buildid = yield self.getBuildid(kwargs)
         name = kwargs['name']
 
-        build_datadict = yield self.master.db.build_data.getBuildData(buildid, name)
+        build_datadict = yield self.master.db.build_data.getBuildDataNoValue(buildid, name)
 
         return (yield self.db2data(build_datadict)) if build_datadict else None
+
+
+class BuildDataEndpoint(base.BuildNestingMixin, base.Endpoint):
+
+    isCollection = False
+    isRaw = True
+    pathPatterns = """
+        /builders/n:builderid/builds/n:build_number/data/i:name/value
+        /builders/i:buildername/builds/n:build_number/data/i:name/value
+        /builds/n:buildid/data/i:name/value
+    """
+
+    @defer.inlineCallbacks
+    def get(self, resultSpec, kwargs):
+        buildid = yield self.getBuildid(kwargs)
+        name = kwargs['name']
+
+        dbdict = yield self.master.db.build_data.getBuildData(buildid, name)
+        if not dbdict:
+            return None
+
+        return {'raw': dbdict['value'],
+                'mime-type': 'application/octet-stream',
+                'filename': dbdict['name']}
 
 
 class BuildData(base.ResourceType):
 
     name = "build_data"
     plural = "build_data"
-    endpoints = [BuildDatasNoValueEndpoint, BuildDataEndpoint]
+    endpoints = [BuildDatasNoValueEndpoint, BuildDataNoValueEndpoint, BuildDataEndpoint]
     keyFields = []
 
     class EntityType(types.Entity):

--- a/master/buildbot/db/build_data.py
+++ b/master/buildbot/db/build_data.py
@@ -38,13 +38,15 @@ class BuildDataConnectorComponent(base.DBConnectorComponent):
 
             update_values = {
                 'value': value,
-                'source': source
+                'length': len(value),
+                'source': source,
             }
 
             insert_values = {
                 'buildid': buildid,
                 'name': name,
                 'value': value,
+                'length': len(value),
                 'source': source,
             }
 
@@ -92,6 +94,7 @@ class BuildDataConnectorComponent(base.DBConnectorComponent):
 
             q = sa.select([build_data_table.c.buildid,
                            build_data_table.c.name,
+                           build_data_table.c.length,
                            build_data_table.c.source])
             q = q.where((build_data_table.c.buildid == buildid) &
                         (build_data_table.c.name == name))
@@ -110,6 +113,7 @@ class BuildDataConnectorComponent(base.DBConnectorComponent):
 
             q = sa.select([build_data_table.c.buildid,
                            build_data_table.c.name,
+                           build_data_table.c.length,
                            build_data_table.c.source])
             q = q.where(build_data_table.c.buildid == buildid)
 
@@ -159,10 +163,12 @@ class BuildDataConnectorComponent(base.DBConnectorComponent):
         return BuildDataDict(buildid=row.buildid,
                              name=row.name,
                              value=row.value,
+                             length=row.length,
                              source=row.source)
 
     def _row2dict_novalue(self, conn, row):
         return BuildDataDict(buildid=row.buildid,
                              name=row.name,
                              value=None,
+                             length=row.length,
                              source=row.source)

--- a/master/buildbot/db/migrate/versions/058_add_build_data_length.py
+++ b/master/buildbot/db/migrate/versions/058_add_build_data_length.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot. Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import sqlalchemy as sa
+
+from buildbot.util import sautils
+
+
+def upgrade(migrate_engine):
+    # build_data without the 'length' column has never been released, so we don't care about
+    # correct values there.
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+    build_data_table = sautils.Table('build_data', metadata, autoload=True)
+    length_column = sa.Column('length', sa.Integer, nullable=False, server_default='0')
+    length_column.create(build_data_table)

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -140,6 +140,7 @@ class Model(base.DBConnectorComponent):
         sa.Column('name', sa.String(256), nullable=False),
         sa.Column('value', sa.LargeBinary().with_variant(sa.dialects.mysql.LONGBLOB, "mysql"),
                   nullable=False),
+        sa.Column('length', sa.Integer, nullable=False),
         sa.Column('source', sa.String(256), nullable=False),
     )
 

--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -30,13 +30,15 @@ traits:
             200:
                 headers:
                     content-disposition:
-                        description: content disposition header allows browser to save log file with proper filename
+                        description: content disposition header allows browser to save data with proper filename
                         example: attachment; filename=stdio
                 body:
                     text/html:
                         description: "html data if the object is html"
                     text/plain:
                         description: "plain text data if the object is text"
+                    application/octet-stream:
+                        description: "binary data if binary is binary"
 
 types:
     build: !include types/build.raml
@@ -143,6 +145,11 @@ types:
                         get:
                             is:
                             - bbget: {bbtype: build_data}
+                        /value:
+                            description: This path returns the value of build data.
+                            get:
+                                is:
+                                - bbgetraw:
 
                 /steps:
                     description: This path selects all steps for the given build.
@@ -425,6 +432,11 @@ types:
                 get:
                     is:
                     - bbget: {bbtype: build_data}
+                /value:
+                    description: This path returns the value of build data.
+                    get:
+                        is:
+                        - bbgetraw:
 
         /steps:
             description: |

--- a/master/buildbot/spec/types/build_data.raml
+++ b/master/buildbot/spec/types/build_data.raml
@@ -6,7 +6,9 @@ description: |
     The data is intended to be used for temporary purposes, until the build and all actions associated to it (such as reporters) are finished.
 
     The value is a binary of potentially large size.
-    Certain APIs allow to retrieve the list of keys set to a build without fetching the values.
+    There are two sets of APIs.
+    One returns the properties of the key-value data pairs, such as key name and value length.
+    Another returns the actual value as binary data.
 
     Update Methods
     --------------
@@ -32,9 +34,6 @@ properties:
     name:
         description: the name of the build data.
         type: string
-    value?:
-        description: the value of the build data.
-        type: string
     length:
         description: the number of bytes in the build data
         type: integer
@@ -46,5 +45,4 @@ type: object
 example:
     buildid: 31
     name: "stored_data_name"
-    value: "stored data value"
     source: "Step XYZ"

--- a/master/buildbot/spec/types/build_data.raml
+++ b/master/buildbot/spec/types/build_data.raml
@@ -35,6 +35,9 @@ properties:
     value?:
         description: the value of the build data.
         type: string
+    length:
+        description: the number of bytes in the build data
+        type: integer
     source:
         description: a string identifying the source of the data
         type: string

--- a/master/buildbot/test/fakedb/build_data.py
+++ b/master/buildbot/test/fakedb/build_data.py
@@ -27,13 +27,17 @@ class BuildData(Row):
         'buildid': None,
         'name': None,
         'value': None,
+        'length': None,
         'source': None,
     }
 
     id_column = 'id'
     foreignKeys = ('buildid',)
-    required_columns = ('buildid', 'name', 'value', 'source')
+    required_columns = ('buildid', 'name', 'value', 'length', 'source')
     binary_columns = ('value',)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs, length=len(kwargs['value']))
 
 
 class FakeBuildDataComponent(FakeDBComponent):
@@ -57,6 +61,7 @@ class FakeBuildDataComponent(FakeDBComponent):
         row = self._get_build_data_row(buildid, name)
         if row is not None:
             row['value'] = value
+            row['length'] = len(value)
             row['source'] = source
             return
 
@@ -66,6 +71,7 @@ class FakeBuildDataComponent(FakeDBComponent):
             'buildid': buildid,
             'name': name,
             'value': value,
+            'length': len(value),
             'source': source
         }
 

--- a/master/buildbot/test/unit/test_data_build_data.py
+++ b/master/buildbot/test/unit/test_data_build_data.py
@@ -56,6 +56,7 @@ class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             'name': 'name1',
             'value': b'value1',
             'source': 'source1',
+            'length': 6,
         })
 
     @defer.inlineCallbacks
@@ -67,6 +68,7 @@ class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             'name': 'name1',
             'value': b'value1',
             'source': 'source1',
+            'length': 6,
         })
 
     @defer.inlineCallbacks
@@ -77,6 +79,7 @@ class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             'buildid': 30,
             'name': 'name1',
             'value': b'value1',
+            'length': 6,
             'source': 'source1',
         })
 
@@ -212,5 +215,6 @@ class TestBuildData(TestReactorMixin, interfaces.InterfaceTests, unittest.TestCa
             'buildid': 2,
             'name': 'name1',
             'value': b'value1',
+            'length': 6,
             'source': 'source1',
         })

--- a/master/buildbot/test/unit/test_data_build_data.py
+++ b/master/buildbot/test/unit/test_data_build_data.py
@@ -26,9 +26,9 @@ from buildbot.test.util import interfaces
 from buildbot.test.util.misc import TestReactorMixin
 
 
-class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
+class TestBuildDataNoValueEndpoint(endpoint.EndpointMixin, unittest.TestCase):
 
-    endpointClass = build_data.BuildDataEndpoint
+    endpointClass = build_data.BuildDataNoValueEndpoint
     resourceTypeClass = build_data.BuildData
 
     def setUp(self):
@@ -54,7 +54,7 @@ class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(result, {
             'buildid': 30,
             'name': 'name1',
-            'value': b'value1',
+            'value': None,
             'source': 'source1',
             'length': 6,
         })
@@ -66,7 +66,7 @@ class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(result, {
             'buildid': 30,
             'name': 'name1',
-            'value': b'value1',
+            'value': None,
             'source': 'source1',
             'length': 6,
         })
@@ -78,7 +78,7 @@ class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(result, {
             'buildid': 30,
             'name': 'name1',
-            'value': b'value1',
+            'value': None,
             'length': 6,
             'source': 'source1',
         })
@@ -121,6 +121,105 @@ class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_get_missing_by_builder_id_build_number_missing_name(self):
         result = yield self.callGet(('builders', 88, 'builds', 7, 'data', 'name_missing'))
+        self.assertIsNone(result)
+
+
+class TestBuildDataEndpoint(endpoint.EndpointMixin, unittest.TestCase):
+
+    endpointClass = build_data.BuildDataEndpoint
+    resourceTypeClass = build_data.BuildData
+
+    def setUp(self):
+        self.setUpEndpoint()
+        self.db.insertTestData([
+            fakedb.Worker(id=47, name='linux'),
+            fakedb.Buildset(id=20),
+            fakedb.Builder(id=88, name='b1'),
+            fakedb.BuildRequest(id=41, buildsetid=20, builderid=88),
+            fakedb.Master(id=88),
+            fakedb.Build(id=30, buildrequestid=41, number=7, masterid=88, builderid=88,
+                         workerid=47),
+            fakedb.BuildData(id=91, buildid=30, name='name1', value=b'value1', source='source1'),
+        ])
+
+    def tearDown(self):
+        self.tearDownEndpoint()
+
+    def validateData(self, data):
+        self.assertIsInstance(data['raw'], bytes)
+        self.assertIsInstance(data['mime-type'], str)
+        self.assertIsInstance(data['filename'], str)
+
+    @defer.inlineCallbacks
+    def test_get_existing_build_data_by_build_id(self):
+        result = yield self.callGet(('builds', 30, 'data', 'name1', 'value'))
+        self.validateData(result)
+        self.assertEqual(result, {
+            'raw': b'value1',
+            'mime-type': 'application/octet-stream',
+            'filename': 'name1',
+        })
+
+    @defer.inlineCallbacks
+    def test_get_existing_build_data_by_builder_name_build_number(self):
+        result = yield self.callGet(('builders', 'b1', 'builds', 7, 'data', 'name1', 'value'))
+        self.validateData(result)
+        self.assertEqual(result, {
+            'raw': b'value1',
+            'mime-type': 'application/octet-stream',
+            'filename': 'name1',
+        })
+
+    @defer.inlineCallbacks
+    def test_get_existing_build_data_by_builder_id_build_number(self):
+        result = yield self.callGet(('builders', 88, 'builds', 7, 'data', 'name1', 'value'))
+        self.validateData(result)
+        self.assertEqual(result, {
+            'raw': b'value1',
+            'mime-type': 'application/octet-stream',
+            'filename': 'name1',
+        })
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_build_id_missing_build(self):
+        result = yield self.callGet(('builds', 31, 'data', 'name1', 'value'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_build_id_missing_name(self):
+        result = yield self.callGet(('builds', 30, 'data', 'name_missing', 'value'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_name_build_number_missing_builder(self):
+        result = yield self.callGet(('builders', 'b_missing', 'builds', 7, 'data', 'name1',
+                                     'value'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_name_build_number_missing_build(self):
+        result = yield self.callGet(('builders', 'b1', 'builds', 17, 'data', 'name1', 'value'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_name_build_number_missing_name(self):
+        result = yield self.callGet(('builders', 'b1', 'builds', 7, 'data', 'name_missing',
+                                     'value'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_id_build_number_missing_builder(self):
+        result = yield self.callGet(('builders', 188, 'builds', 7, 'data', 'name1', 'value'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_id_build_number_missing_build(self):
+        result = yield self.callGet(('builders', 88, 'builds', 17, 'data', 'name1', 'value'))
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_get_missing_by_builder_id_build_number_missing_name(self):
+        result = yield self.callGet(('builders', 88, 'builds', 7, 'data', 'name_missing', 'value'))
         self.assertIsNone(result)
 
 

--- a/master/buildbot/test/unit/test_db_build_data.py
+++ b/master/buildbot/test/unit/test_db_build_data.py
@@ -72,6 +72,7 @@ class Tests(interfaces.InterfaceTests):
             'buildid': 30,
             'name': 'mykey',
             'value': b'myvalue',
+            'length': 7,
             'source': 'mysource'
         })
 
@@ -95,6 +96,7 @@ class Tests(interfaces.InterfaceTests):
             'buildid': 30,
             'name': 'mykey',
             'value': b'myvalue2',
+            'length': 8,
             'source': 'mysource2'
         })
 
@@ -103,10 +105,12 @@ class Tests(interfaces.InterfaceTests):
         yield self.insertTestData(self.common_data)
 
         def hook(conn):
+            value = b'myvalue_old'
             insert_values = {
                 'buildid': 30,
                 'name': 'mykey',
-                'value': b'myvalue_old',
+                'value': value,
+                'length': len(value),
                 'source': 'mysourec_old'
             }
             q = self.db.model.build_data.insert().values(insert_values)
@@ -122,6 +126,7 @@ class Tests(interfaces.InterfaceTests):
             'buildid': 30,
             'name': 'mykey',
             'value': b'myvalue',
+            'length': 7,
             'source': 'mysource'
         })
 
@@ -136,6 +141,7 @@ class Tests(interfaces.InterfaceTests):
             'buildid': 30,
             'name': 'mykey',
             'value': None,
+            'length': 7,
             'source': 'mysource'
         })
 
@@ -158,11 +164,12 @@ class Tests(interfaces.InterfaceTests):
         for d in data_dicts:
             validation.verifyDbDict(self, 'build_datadict', d)
 
-        # note that value is not in dict
+        # note that value is not in dict, but length is
         self.assertEqual(data_dicts[0], {
             'buildid': 30,
             'name': 'name1',
             'value': None,
+            'length': 6,
             'source': 'source1'
         })
 

--- a/master/buildbot/test/unit/test_db_migrate_versions_058_add_build_data_length.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_058_add_build_data_length.py
@@ -1,0 +1,82 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+
+from twisted.trial import unittest
+
+from buildbot.test.util import migration
+from buildbot.util import sautils
+
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def test_migration(self):
+        def setup_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            builds = sautils.Table(
+                'builds', metadata,
+                sa.Column('id', sa.Integer, primary_key=True),
+                # ...
+            )
+            builds.create()
+
+            build_data = sautils.Table(
+                'build_data', metadata,
+                sa.Column('id', sa.Integer, primary_key=True),
+                sa.Column('buildid', sa.Integer,
+                          sa.ForeignKey('builds.id', ondelete='CASCADE'),
+                          nullable=False),
+                sa.Column('name', sa.String(256), nullable=False),
+                sa.Column('value', sa.LargeBinary().with_variant(sa.dialects.mysql.LONGBLOB,
+                                                                 "mysql"),
+                          nullable=False),
+                sa.Column('source', sa.String(256), nullable=False),
+            )
+            build_data.create()
+
+            conn.execute(builds.insert(), [{'id': 3}])
+            conn.execute(build_data.insert(), [
+                {'id': 15, 'buildid': 3, 'name': 'name1',
+                 'value': b'value1', 'source': 'source1'}])
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            build_data = sautils.Table('build_data', metadata, autoload=True)
+
+            q = sa.select([
+                build_data.c.buildid,
+                build_data.c.name,
+                build_data.c.value,
+                build_data.c.length,
+                build_data.c.source,
+            ])
+            # build_data without the 'length' column has never been released, so we don't care about
+            # correct values there.
+            self.assertEqual(conn.execute(q).fetchall(), [
+                (3, 'name1', b'value1', 0, 'source1')
+            ])
+
+        return self.do_test_migration(57, 58, setup_thd, verify_thd)

--- a/master/buildbot/test/util/validation.py
+++ b/master/buildbot/test/util/validation.py
@@ -591,6 +591,7 @@ _build_data_msgdict = DictValidator(
     buildid=IntValidator(),
     name=StringValidator(),
     value=NoneOk(BinaryValidator()),
+    length=IntValidator(),
     source=StringValidator(),
 )
 
@@ -603,6 +604,7 @@ dbdict['build_datadict'] = DictValidator(
     buildid=IntValidator(),
     name=StringValidator(),
     value=NoneOk(BinaryValidator()),
+    length=IntValidator(),
     source=StringValidator(),
 )
 


### PR DESCRIPTION
There was an unresolved issue in #5371 of what we do with actually binary data. It looks like that the most sensible solution is to only offer a raw endpoint to actually download it. This way both the REST endpoint and internal data APIs can use the same representation of the data.

To make the other APIs that don't return the values more useful, a length field has been added. This way there's at least some information about what's in the data. The migration script is incomplete and just sets length values of all existing rows to zero.

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
