### PR TITLE
Fix missing VS2017 entry_points

### DIFF
--- a/master/buildbot/newsfragments/vs2017-entry-points.bugfix
+++ b/master/buildbot/newsfragments/vs2017-entry-points.bugfix
@@ -1,0 +1,1 @@
+Add missing VS2017 entry_points

--- a/master/setup.py
+++ b/master/setup.py
@@ -316,7 +316,8 @@ setup_args = {
             ('buildbot.steps.vstudio', [
                 'VC6', 'VC7', 'VS2003', 'VC8', 'VS2005', 'VCExpress9', 'VC9',
                 'VS2008', 'VC10', 'VS2010', 'VC11', 'VS2012', 'VC12', 'VS2013',
-                'VC14', 'VS2015', 'MsBuild4', 'MsBuild', 'MsBuild12', 'MsBuild14']),
+                'VC14', 'VS2015', 'VC141', 'VS2017', 'MsBuild4', 'MsBuild',
+                'MsBuild12', 'MsBuild14', 'MsBuild141']),
             ('buildbot.steps.worker', [
                 'SetPropertiesFromEnv', 'FileExists', 'CopyDirectory',
                 'RemoveDirectory', 'MakeDirectory']),


### PR DESCRIPTION
Fix missing VS2017 entry_points in 'buildbot.steps'

## Contributor Checklist:

*  [ ] I have updated the unit tests
*  [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
*  [ ] I have updated the appropriate documentation
