### PR TITLE
log: Decode bytes before line processing, not after

### DIFF
--- a/master/buildbot/newsfragments/logs-new-style-steps-bytes.bugfix
+++ b/master/buildbot/newsfragments/logs-new-style-steps-bytes.bugfix
@@ -1,0 +1,1 @@
+Handling of submission of non-decoded ``bytes`` logs has been fixed in new style steps.

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -119,13 +119,13 @@ class PlainLog(Log):
         super(PlainLog, self).__init__(master, name, type, logid, decoder)
 
         def wholeLines(lines):
-            if not isinstance(lines, str):
-                lines = self.decoder(lines)
             self.subPoint.deliver(None, lines)
             return self.addRawLines(lines)
         self.lbf = lineboundaries.LineBoundaryFinder(wholeLines)
 
     def addContent(self, text):
+        if not isinstance(text, str):
+            text = self.decoder(text)
         # add some text in the log's default stream
         return self.lbf.append(text)
 
@@ -164,8 +164,6 @@ class StreamLog(Log):
             return self.lbfs[stream]
         except KeyError:
             def wholeLines(lines):
-                if not isinstance(lines, str):
-                    lines = self.decoder(lines)
                 # deliver the un-annotated version to subscribers
                 self.subPoint.deliver(stream, lines)
                 # strip the last character, as the regexp will add a
@@ -176,12 +174,18 @@ class StreamLog(Log):
             return lbf
 
     def addStdout(self, text):
+        if not isinstance(text, str):
+            text = self.decoder(text)
         return self._getLbf('o').append(text)
 
     def addStderr(self, text):
+        if not isinstance(text, str):
+            text = self.decoder(text)
         return self._getLbf('e').append(text)
 
     def addHeader(self, text):
+        if not isinstance(text, str):
+            text = self.decoder(text)
         return self._getLbf('h').append(text)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/fake/logfile.py
+++ b/master/buildbot/test/fake/logfile.py
@@ -44,8 +44,6 @@ class FakeLogFile:
             return self.lbfs[stream]
         except KeyError:
             def wholeLines(lines):
-                if not isinstance(lines, str):
-                    lines = lines.decode('utf-8')
                 if self.name in self.step.logobservers:
                     for obs in self.step.logobservers[self.name]:
                         getattr(obs, meth)(lines)
@@ -54,16 +52,22 @@ class FakeLogFile:
             return lbf
 
     def addHeader(self, text):
+        if not isinstance(text, str):
+            text = text.decode('utf-8')
         self.header += text
         self._getLbf('h', 'headerReceived').append(text)
         return defer.succeed(None)
 
     def addStdout(self, text):
+        if not isinstance(text, str):
+            text = text.decode('utf-8')
         self.stdout += text
         self._getLbf('o', 'outReceived').append(text)
         return defer.succeed(None)
 
     def addStderr(self, text):
+        if not isinstance(text, str):
+            text = text.decode('utf-8')
         self.stderr += text
         self._getLbf('e', 'errReceived').append(text)
         return defer.succeed(None)


### PR DESCRIPTION
Turns out that we don't really support bytes in new style steps log processing. This PR fixes that. Nothing seems to cover this use case right now, but I did some old-style -> new-style step conversion work to understand how logs are handled and that code will cover it.


## Contributor Checklist:

* [not needed] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
