### PR TITLE
Match result descriptions in new style ShellMixin steps to the old style ShellCommand steps

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -1288,6 +1288,8 @@ class ShellMixin:
         return cmd
 
     def getResultSummary(self):
+        if self.descriptionDone is not None:
+            return super().getResultSummary()
         summary = util.command_to_string(self.command)
         if not summary:
             return super(ShellMixin, self).getResultSummary()

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -1291,9 +1291,11 @@ class ShellMixin:
         if self.descriptionDone is not None:
             return super().getResultSummary()
         summary = util.command_to_string(self.command)
-        if not summary:
-            return super(ShellMixin, self).getResultSummary()
-        return {'step': summary}
+        if summary:
+            if self.results != SUCCESS:
+                summary += ' ({})'.format(Results[self.results])
+            return {'step': summary}
+        return super(ShellMixin, self).getResultSummary()
 
 # Parses the logs for a list of regexs. Meant to be invoked like:
 # regexes = ((re.compile(...), FAILURE), (re.compile(...), WARNINGS))

--- a/master/buildbot/test/unit/test_process_buildstep.py
+++ b/master/buildbot/test/unit/test_process_buildstep.py
@@ -1267,4 +1267,5 @@ class TestShellMixin(steps.BuildStepMixin,
 
     def test_getResultSummary(self):
         self.setupStep(SimpleShellCommand(command=['a', ['b', 'c']]))
+        self.step.results = SUCCESS
         self.assertEqual(self.step.getResultSummary(), {'step': "'a b ...'"})

--- a/master/buildbot/test/unit/test_steps_shellsequence.py
+++ b/master/buildbot/test/unit/test_steps_shellsequence.py
@@ -132,7 +132,7 @@ class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
                                         workdir='build'))
         self.expectCommands(ExpectShell(workdir='build', command='make p1') + 1,
                             ExpectShell(workdir='build', command='deploy p1') + 0)
-        self.expectOutcome(result=WARNINGS, state_string="'deploy p1'")
+        self.expectOutcome(result=WARNINGS, state_string="'deploy p1' (warnings)")
         return self.runStep()
 
     def testSequenceStopsOnHaltOnFailure(self):
@@ -143,7 +143,7 @@ class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
             shellsequence.ShellSequence(commands=[arg1, arg2],
                                         workdir='build'))
         self.expectCommands(ExpectShell(workdir='build', command='make p1') + 1)
-        self.expectOutcome(result=FAILURE, state_string="'make p1'")
+        self.expectOutcome(result=FAILURE, state_string="'make p1' (failure)")
         return self.runStep()
 
     def testShellArgsAreRenderedAnewAtEachBuild(self):


### PR DESCRIPTION
The new-style ShellMixin steps did not contain the same information as old style steps.

## Contributor Checklist:

* [x] I have updated the unit tests
* [not needed] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [not needed] I have updated the appropriate documentation
