### PR TITLE
Use @defer.inlineCallbacks in source steps

### DIFF
--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -253,9 +253,6 @@ class Source(LoggingBuildStep, CompositeStepMixin):
             self.build.path_module.join(self.workdir, '.buildbot-patched'))
         return d
 
-    def finish(self, res):
-        return self.finished(res)
-
     def start(self):
         if self.notReally:
             log.msg("faking {} checkout/update".format(self.name))
@@ -303,6 +300,6 @@ class Source(LoggingBuildStep, CompositeStepMixin):
             patch = None
 
         d = self.startVC(branch, revision, patch)
-        d.addCallback(self.finish)
+        d.addCallback(self.finished)
         d.addErrback(self.failed)
         return None

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 
+from twisted.internet import defer
 from twisted.python import log
 
 from buildbot.process import buildstep
@@ -198,6 +199,7 @@ class Source(LoggingBuildStep, CompositeStepMixin):
         self.checkoutDelay value."""
         return None
 
+    @defer.inlineCallbacks
     def applyPatch(self, patch):
         patch_command = ['patch', '-p{}'.format(patch[0]), '--remove-empty-files',
                          '--force', '--forward', '-i', '.buildbot-diff']
@@ -207,15 +209,12 @@ class Source(LoggingBuildStep, CompositeStepMixin):
                                                logEnviron=self.logEnviron)
 
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
+        yield self.runCommand(cmd)
+        if cmd.didFail():
+            raise buildstep.BuildStepFailed()
+        return cmd.rc
 
-        @d.addCallback
-        def evaluateCommand(_):
-            if cmd.didFail():
-                raise buildstep.BuildStepFailed()
-            return cmd.rc
-        return d
-
+    @defer.inlineCallbacks
     def patch(self, patch):
         diff = patch[1]
         root = None
@@ -230,23 +229,19 @@ class Source(LoggingBuildStep, CompositeStepMixin):
             if workdir_root_abspath.startswith(workdir_abspath):
                 self.workdir = workdir_root
 
-        d = self.downloadFileContentToWorker('.buildbot-diff', diff)
-        d.addCallback(
-            lambda _: self.downloadFileContentToWorker('.buildbot-patched', 'patched\n'))
-        d.addCallback(lambda _: self.applyPatch(patch))
+        yield self.downloadFileContentToWorker('.buildbot-diff', diff)
+        yield self.downloadFileContentToWorker('.buildbot-patched', 'patched\n')
+        yield self.applyPatch(patch)
         cmd = remotecommand.RemoteCommand('rmdir',
                                           {'dir': self.build.path_module.join(self.workdir,
                                                                               ".buildbot-diff"),
                                            'logEnviron': self.logEnviron})
         cmd.useLog(self.stdio_log, False)
-        d.addCallback(lambda _: self.runCommand(cmd))
+        yield self.runCommand(cmd)
 
-        @d.addCallback
-        def evaluateCommand(_):
-            if cmd.didFail():
-                raise buildstep.BuildStepFailed()
-            return cmd.rc
-        return d
+        if cmd.didFail():
+            raise buildstep.BuildStepFailed()
+        return cmd.rc
 
     def sourcedirIsPatched(self):
         d = self.pathExists(

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -253,6 +253,9 @@ class Source(LoggingBuildStep, CompositeStepMixin):
             self.build.path_module.join(self.workdir, '.buildbot-patched'))
         return d
 
+    def finish(self, res):
+        return self.finished(res)
+
     def start(self):
         if self.notReally:
             log.msg("faking {} checkout/update".format(self.name))
@@ -299,5 +302,7 @@ class Source(LoggingBuildStep, CompositeStepMixin):
             branch = self.branch
             patch = None
 
-        self.startVC(branch, revision, patch)
+        d = self.startVC(branch, revision, patch)
+        d.addCallback(self.finish)
+        d.addErrback(self.failed)
         return None

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -216,7 +216,7 @@ class Source(LoggingBuildStep, CompositeStepMixin):
             return cmd.rc
         return d
 
-    def patch(self, _, patch):
+    def patch(self, patch):
         diff = patch[1]
         root = None
         if len(patch) >= 3:

--- a/master/buildbot/steps/source/bzr.py
+++ b/master/buildbot/steps/source/bzr.py
@@ -89,8 +89,6 @@ class Bzr(Source):
         if patch:
             d.addCallback(self.patch, patch)
         d.addCallback(self.parseGotRevision)
-        d.addCallback(self.finish)
-        d.addErrback(self.failed)
         return d
 
     @defer.inlineCallbacks

--- a/master/buildbot/steps/source/bzr.py
+++ b/master/buildbot/steps/source/bzr.py
@@ -23,6 +23,7 @@ from twisted.python import log
 from buildbot.interfaces import WorkerTooOldError
 from buildbot.process import buildstep
 from buildbot.process import remotecommand
+from buildbot.process import results
 from buildbot.steps.source.base import Source
 
 
@@ -58,6 +59,7 @@ class Bzr(Source):
         if self.mode == 'full':
             assert self.method in ['clean', 'fresh', 'clobber', 'copy', None]
 
+    @defer.inlineCallbacks
     def startVC(self, branch, revision, patch):
         if branch:
             self.branch = branch
@@ -68,31 +70,25 @@ class Bzr(Source):
         if self.repourl is None:
             self.repourl = os.path.join(self.baseURL, self.branch)
 
-        d = self.checkBzr()
+        installed = yield self.checkBzr()
 
-        @d.addCallback
-        def checkInstall(bzrInstalled):
-            if not bzrInstalled:
-                raise WorkerTooOldError("bzr is not installed on worker")
-            return 0
+        if not installed:
+            raise WorkerTooOldError("bzr is not installed on worker")
 
-        d.addCallback(lambda _: self.sourcedirIsPatched())
+        patched = yield self.sourcedirIsPatched()
 
-        @d.addCallback
-        def checkPatched(patched):
-            if patched:
-                return self._dovccmd(['clean-tree', '--ignored', '--force'])
-            return 0
+        if patched:
+            yield self._dovccmd(['clean-tree', '--ignored', '--force'])
 
-        d.addCallback(self._getAttrGroupMember('mode', self.mode))
+        yield self._getAttrGroupMember('mode', self.mode)()
 
         if patch:
-            d.addCallback(self.patch, patch)
-        d.addCallback(self.parseGotRevision)
-        return d
+            yield self.patch(0, patch)
+        yield self.parseGotRevision()
+        return results.SUCCESS
 
     @defer.inlineCallbacks
-    def mode_incremental(self, _):
+    def mode_incremental(self):
         updatable = yield self._sourcedirIsUpdatable()
         if updatable:
             command = ['update']
@@ -103,7 +99,7 @@ class Bzr(Source):
             yield self._doFull()
 
     @defer.inlineCallbacks
-    def mode_full(self, _):
+    def mode_full(self):
         if self.method == 'clobber':
             yield self.clobber()
             return
@@ -123,41 +119,35 @@ class Bzr(Source):
         else:
             raise ValueError("Unknown method, check your configuration")
 
+    @defer.inlineCallbacks
     def _clobber(self):
         cmd = remotecommand.RemoteCommand('rmdir', {'dir': self.workdir,
                                                     'logEnviron': self.logEnviron, })
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
+        yield self.runCommand(cmd)
 
-        @d.addCallback
-        def checkRemoval(res):
-            if cmd.rc != 0:
-                raise RuntimeError("Failed to delete directory")
-            return cmd.rc
-        return d
+        if cmd.rc != 0:
+            raise RuntimeError("Failed to delete directory")
 
+    @defer.inlineCallbacks
     def clobber(self):
-        d = self._clobber()
-        d.addCallback(lambda _: self._doFull())
-        return d
+        yield self._clobber()
+        yield self._doFull()
 
+    @defer.inlineCallbacks
     def copy(self):
         cmd = remotecommand.RemoteCommand('rmdir', {'dir': 'build',
                                                     'logEnviron': self.logEnviron, })
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
-        d.addCallback(self.mode_incremental)
+        yield self.runCommand(cmd)
+        yield self.mode_incremental()
 
-        @d.addCallback
-        def copy(_):
-            cmd = remotecommand.RemoteCommand('cpdir',
-                                              {'fromdir': 'source',
-                                               'todir': 'build',
-                                               'logEnviron': self.logEnviron, })
-            cmd.useLog(self.stdio_log, False)
-            d = self.runCommand(cmd)
-            return d
-        return d
+        cmd = remotecommand.RemoteCommand('cpdir',
+                                          {'fromdir': 'source',
+                                           'todir': 'build',
+                                           'logEnviron': self.logEnviron, })
+        cmd.useLog(self.stdio_log, False)
+        yield self.runCommand(cmd)
 
     def clean(self):
         d = self._dovccmd(['clean-tree', '--ignored', '--force'])
@@ -175,6 +165,7 @@ class Bzr(Source):
         d.addCallback(lambda _: self._dovccmd(command))
         return d
 
+    @defer.inlineCallbacks
     def _doFull(self):
         command = ['checkout', self.repourl, '.']
         if self.revision:
@@ -184,9 +175,10 @@ class Bzr(Source):
             abandonOnFailure = (self.retry[1] <= 0)
         else:
             abandonOnFailure = True
-        d = self._dovccmd(command, abandonOnFailure=abandonOnFailure)
 
-        def _retry(res):
+        res = yield self._dovccmd(command, abandonOnFailure=abandonOnFailure)
+
+        if self.retry:
             if self.stopped or res == 0:
                 return res
             delay, repeats = self.retry
@@ -198,12 +190,9 @@ class Bzr(Source):
                 df.addCallback(lambda _: self._clobber())
                 df.addCallback(lambda _: self._doFull())
                 reactor.callLater(delay, df.callback, None)
-                return df
-            return res
+                res = yield df
 
-        if self.retry:
-            d.addCallback(_retry)
-        return d
+        return res
 
     def finish(self, res):
         d = defer.succeed(res)
@@ -261,20 +250,17 @@ class Bzr(Source):
             return 'fresh'
         return None
 
-    def parseGotRevision(self, _):
-        d = self._dovccmd(["version-info", "--custom", "--template='{revno}"],
-                          collectStdout=True)
+    @defer.inlineCallbacks
+    def parseGotRevision(self):
+        stdout = yield self._dovccmd(["version-info", "--custom", "--template='{revno}"],
+                                     collectStdout=True)
 
-        @d.addCallback
-        def setrev(stdout):
-            revision = stdout.strip("'")
-            try:
-                int(revision)
-            except ValueError:
-                log.msg("Invalid revision number")
-                raise buildstep.BuildStepFailed()
+        revision = stdout.strip("'")
+        try:
+            int(revision)
+        except ValueError:
+            log.msg("Invalid revision number")
+            raise buildstep.BuildStepFailed()
 
-            log.msg("Got Git revision {}".format(revision))
-            self.updateSourceProperty('got_revision', revision)
-            return 0
-        return d
+        log.msg("Got Git revision {}".format(revision))
+        self.updateSourceProperty('got_revision', revision)

--- a/master/buildbot/steps/source/bzr.py
+++ b/master/buildbot/steps/source/bzr.py
@@ -83,7 +83,7 @@ class Bzr(Source):
         yield self._getAttrGroupMember('mode', self.mode)()
 
         if patch:
-            yield self.patch(0, patch)
+            yield self.patch(patch)
         yield self.parseGotRevision()
         return results.SUCCESS
 

--- a/master/buildbot/steps/source/bzr.py
+++ b/master/buildbot/steps/source/bzr.py
@@ -194,17 +194,6 @@ class Bzr(Source):
 
         return res
 
-    def finish(self, res):
-        d = defer.succeed(res)
-
-        @d.addCallback
-        def _gotResults(results):
-            self.setStatus(self.cmd, results)
-            log.msg("Closing log, sending result of the command {} ".format(self.cmd))
-            return results
-        d.addCallback(self.finished)
-        return d
-
     def _sourcedirIsUpdatable(self):
         return self.pathExists(self.build.path_module.join(self.workdir, '.bzr'))
 

--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -80,7 +80,7 @@ class CVS(Source):
         yield self._getAttrGroupMember('mode', self.mode)()
 
         if patch:
-            yield self.patch(0, patch)
+            yield self.patch(patch)
         yield self.parseGotRevision()
         return results.SUCCESS
 

--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -84,8 +84,6 @@ class CVS(Source):
         if patch:
             d.addCallback(self.patch, patch)
         d.addCallback(self.parseGotRevision)
-        d.addCallback(self.finish)
-        d.addErrback(self.failed)
         return d
 
     @defer.inlineCallbacks

--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -226,10 +226,6 @@ class CVS(Source):
         res = yield self._dovccmd(command)
         return res
 
-    def finish(self, res):
-        self.setStatus(self.cmd, res)
-        self.finished(res)
-
     @defer.inlineCallbacks
     def checkLogin(self):
         if self.login:

--- a/master/buildbot/steps/source/darcs.py
+++ b/master/buildbot/steps/source/darcs.py
@@ -83,7 +83,7 @@ class Darcs(Source):
         yield self._getAttrGroupMember('mode', self.mode)()
 
         if patch:
-            yield self.patch(0, patch)
+            yield self.patch(patch)
         yield self.parseGotRevision()
         return results.SUCCESS
 

--- a/master/buildbot/steps/source/darcs.py
+++ b/master/buildbot/steps/source/darcs.py
@@ -89,8 +89,6 @@ class Darcs(Source):
         if patch:
             d.addCallback(self.patch, patch)
         d.addCallback(self.parseGotRevision)
-        d.addCallback(self.finish)
-        d.addErrback(self.failed)
         return d
 
     def checkDarcs(self):

--- a/master/buildbot/steps/source/darcs.py
+++ b/master/buildbot/steps/source/darcs.py
@@ -25,6 +25,7 @@ from buildbot.config import ConfigErrors
 from buildbot.interfaces import WorkerTooOldError
 from buildbot.process import buildstep
 from buildbot.process import remotecommand
+from buildbot.process import results
 from buildbot.process.results import SUCCESS
 from buildbot.steps.source.base import Source
 
@@ -65,47 +66,39 @@ class Darcs(Source):
         if errors:
             raise ConfigErrors(errors)
 
+    @defer.inlineCallbacks
     def startVC(self, branch, revision, patch):
         self.revision = revision
         self.stdio_log = self.addLogForRemoteCommands("stdio")
 
-        d = self.checkDarcs()
+        installed = yield self.checkDarcs()
+        if not installed:
+            raise WorkerTooOldError("Darcs is not installed on worker")
 
-        @d.addCallback
-        def checkInstall(darcsInstalled):
-            if not darcsInstalled:
-                raise WorkerTooOldError("Darcs is not installed on worker")
-            return 0
-        d.addCallback(lambda _: self.sourcedirIsPatched())
+        patched = yield self.sourcedirIsPatched()
 
-        @d.addCallback
-        def checkPatched(patched):
-            if patched:
-                return self.copy()
-            return 0
+        if patched:
+            yield self.copy()
 
-        d.addCallback(self._getAttrGroupMember('mode', self.mode))
+        yield self._getAttrGroupMember('mode', self.mode)()
 
         if patch:
-            d.addCallback(self.patch, patch)
-        d.addCallback(self.parseGotRevision)
-        return d
+            yield self.patch(0, patch)
+        yield self.parseGotRevision()
+        return results.SUCCESS
 
+    @defer.inlineCallbacks
     def checkDarcs(self):
         cmd = remotecommand.RemoteShellCommand(self.workdir, ['darcs', '--version'],
                                                env=self.env,
                                                logEnviron=self.logEnviron,
                                                timeout=self.timeout)
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
-
-        @d.addCallback
-        def evaluate(_):
-            return cmd.rc == 0
-        return d
+        yield self.runCommand(cmd)
+        return cmd.rc == 0
 
     @defer.inlineCallbacks
-    def mode_full(self, _):
+    def mode_full(self):
         if self.method == 'clobber':
             yield self.clobber()
             return
@@ -114,7 +107,7 @@ class Darcs(Source):
             return
 
     @defer.inlineCallbacks
-    def mode_incremental(self, _):
+    def mode_incremental(self):
         updatable = yield self._sourcedirIsUpdatable()
         if not updatable:
             yield self._checkout()
@@ -122,54 +115,46 @@ class Darcs(Source):
             command = ['darcs', 'pull', '--all', '--verbose']
             yield self._dovccmd(command)
 
+    @defer.inlineCallbacks
     def copy(self):
         cmd = remotecommand.RemoteCommand('rmdir', {'dir': self.workdir,
                                                     'logEnviron': self.logEnviron,
                                                     'timeout': self.timeout, })
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
+        yield self.runCommand(cmd)
 
         self.workdir = 'source'
-        d.addCallback(self.mode_incremental)
+        yield self.mode_incremental()
 
-        @d.addCallback
-        def copy(_):
-            cmd = remotecommand.RemoteCommand('cpdir',
-                                              {'fromdir': 'source',
-                                               'todir': 'build',
-                                               'logEnviron': self.logEnviron,
-                                               'timeout': self.timeout, })
-            cmd.useLog(self.stdio_log, False)
-            d = self.runCommand(cmd)
-            return d
+        cmd = remotecommand.RemoteCommand('cpdir',
+                                          {'fromdir': 'source',
+                                           'todir': 'build',
+                                           'logEnviron': self.logEnviron,
+                                           'timeout': self.timeout, })
+        cmd.useLog(self.stdio_log, False)
+        yield self.runCommand(cmd)
 
-        @d.addCallback
-        def resetWorkdir(_):
-            self.workdir = 'build'
-            return 0
-        return d
+        self.workdir = 'build'
 
+    @defer.inlineCallbacks
     def clobber(self):
-        d = self.runRmdir(self.workdir)
-        d.addCallback(lambda _: self._checkout())
-        return d
+        yield self.runRmdir(self.workdir)
+        yield self._checkout()
 
+    @defer.inlineCallbacks
     def _clone(self, abandonOnFailure=False):
         command = ['darcs', 'get', '--verbose',
                    '--lazy', '--repo-name', self.workdir]
-        d = defer.succeed(0)
+
         if self.revision:
-            d.addCallback(
-                lambda _: self.downloadFileContentToWorker('.darcs-context', self.revision))
+            yield self.downloadFileContentToWorker('.darcs-context', self.revision)
             command.append('--context')
             command.append('.darcs-context')
 
         command.append(self.repourl)
-        d.addCallback(lambda _: self._dovccmd(command, abandonOnFailure=abandonOnFailure,
-                                              wkdir='.'))
+        yield self._dovccmd(command, abandonOnFailure=abandonOnFailure, wkdir='.')
 
-        return d
-
+    @defer.inlineCallbacks
     def _checkout(self):
 
         if self.retry:
@@ -177,9 +162,9 @@ class Darcs(Source):
         else:
             abandonOnFailure = True
 
-        d = self._clone(abandonOnFailure)
+        res = yield self._clone(abandonOnFailure)
 
-        def _retry(res):
+        if self.retry:
             if self.stopped or res == 0:
                 return res
             delay, repeats = self.retry
@@ -191,30 +176,21 @@ class Darcs(Source):
                 df.addCallback(lambda _: self.runRmdir(self.workdir))
                 df.addCallback(lambda _: self._checkout())
                 reactor.callLater(delay, df.callback, None)
-                return df
-            return res
-
-        if self.retry:
-            d.addCallback(_retry)
-        return d
-
-    def finish(self, res):
-        d = defer.succeed(res)
-
-        @d.addCallback
-        def _gotResults(results):
-            self.setStatus(self.cmd, results)
-            log.msg("Closing log, sending result of the command {} ".format(self.cmd))
-            return results
-        d.addCallback(self.finished)
-        return d
+                res = yield df
+        return res
 
     @defer.inlineCallbacks
-    def parseGotRevision(self, _):
+    def finish(self, res):
+        self.setStatus(self.cmd, res)
+        log.msg("Closing log, sending result of the command {} ".format(self.cmd))
+        yield self.finished(res)
+
+    @defer.inlineCallbacks
+    def parseGotRevision(self):
         revision = yield self._dovccmd(['darcs', 'changes', '--max-count=1'], collectStdout=True)
         self.updateSourceProperty('got_revision', revision)
-        return 0
 
+    @defer.inlineCallbacks
     def _dovccmd(self, command, collectStdout=False, initialStdin=None, decodeRC=None,
                  abandonOnFailure=True, wkdir=None):
         if not command:
@@ -231,17 +207,14 @@ class Darcs(Source):
                                                initialStdin=initialStdin,
                                                decodeRC=decodeRC)
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
+        yield self.runCommand(cmd)
 
-        @d.addCallback
-        def evaluateCommand(_):
-            if abandonOnFailure and cmd.didFail():
-                log.msg("Source step failed while running command {}".format(cmd))
-                raise buildstep.BuildStepFailed()
-            if collectStdout:
-                return cmd.stdout
-            return cmd.rc
-        return d
+        if abandonOnFailure and cmd.didFail():
+            log.msg("Source step failed while running command {}".format(cmd))
+            raise buildstep.BuildStepFailed()
+        if collectStdout:
+            return cmd.stdout
+        return cmd.rc
 
     def _sourcedirIsUpdatable(self):
         return self.pathExists(self.build.path_module.join(self.workdir, '_darcs'))

--- a/master/buildbot/steps/source/darcs.py
+++ b/master/buildbot/steps/source/darcs.py
@@ -180,12 +180,6 @@ class Darcs(Source):
         return res
 
     @defer.inlineCallbacks
-    def finish(self, res):
-        self.setStatus(self.cmd, res)
-        log.msg("Closing log, sending result of the command {} ".format(self.cmd))
-        yield self.finished(res)
-
-    @defer.inlineCallbacks
     def parseGotRevision(self):
         revision = yield self._dovccmd(['darcs', 'changes', '--max-count=1'], collectStdout=True)
         self.updateSourceProperty('got_revision', revision)

--- a/master/buildbot/steps/source/gerrit.py
+++ b/master/buildbot/steps/source/gerrit.py
@@ -43,4 +43,4 @@ class Gerrit(Git):
                 pass
 
         branch = gerrit_branch or branch
-        super(Gerrit, self).startVC(branch, revision, patch)
+        return super().startVC(branch, revision, patch)

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -258,12 +258,6 @@ class Git(Source, GitStepMixin):
             self.workdir = old_workdir
 
     @defer.inlineCallbacks
-    def finish(self, res):
-        self.setStatus(self.cmd, res)
-        log.msg("Closing log, sending result of the command {} ".format(self.cmd))
-        yield self.finished(res)
-
-    @defer.inlineCallbacks
     def parseGotRevision(self, _=None):
         stdout = yield self._dovccmd(['rev-parse', 'HEAD'], collectStdout=True)
         revision = stdout.strip()

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -140,10 +140,10 @@ class Git(Source, GitStepMixin):
             yield self.parseGotRevision()
             res = yield self.parseCommitDescription()
             yield self._removeSshPrivateKeyIfNeeded()
-            yield self.finish(res)
-        except Exception as e:
+            return res
+        except Exception:
             yield self._removeSshPrivateKeyIfNeeded()
-            yield self.failed(e)
+            raise
 
     @defer.inlineCallbacks
     def mode_full(self):

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -136,7 +136,7 @@ class Git(Source, GitStepMixin):
             yield self._downloadSshPrivateKeyIfNeeded()
             yield self._getAttrGroupMember('mode', self.mode)()
             if patch:
-                yield self.patch(None, patch=patch)
+                yield self.patch(patch)
             yield self.parseGotRevision()
             res = yield self.parseCommitDescription()
             yield self._removeSshPrivateKeyIfNeeded()

--- a/master/buildbot/steps/source/github.py
+++ b/master/buildbot/steps/source/github.py
@@ -23,4 +23,4 @@ class GitHub(Git):
         # ignore the revision if the branch ends with /merge
         if branch.endswith("/merge"):
             revision = None
-        super(GitHub, self).startVC(branch, revision, patch)
+        return super().startVC(branch, revision, patch)

--- a/master/buildbot/steps/source/gitlab.py
+++ b/master/buildbot/steps/source/gitlab.py
@@ -45,4 +45,4 @@ class GitLab(Git):
             # so tell Git to not check.
             revision = None
 
-        super(GitLab, self).startVC(branch, revision, patch)
+        return super().startVC(branch, revision, patch)

--- a/master/buildbot/steps/source/mercurial.py
+++ b/master/buildbot/steps/source/mercurial.py
@@ -180,11 +180,6 @@ class Mercurial(Source):
         yield self._pullUpdate()
 
     @defer.inlineCallbacks
-    def finish(self, res):
-        self.setStatus(self.cmd, res)
-        yield self.finished(res)
-
-    @defer.inlineCallbacks
     def parseGotRevision(self):
         stdout = yield self._dovccmd(['parents', '--template', '{node}\\n'], collectStdout=True)
 

--- a/master/buildbot/steps/source/mercurial.py
+++ b/master/buildbot/steps/source/mercurial.py
@@ -118,7 +118,7 @@ class Mercurial(Source):
         yield self._getAttrGroupMember('mode', self.mode)()
 
         if patch:
-            yield self.patch(0, patch)
+            yield self.patch(patch)
 
         yield self.parseGotRevision()
         return results.SUCCESS

--- a/master/buildbot/steps/source/mercurial.py
+++ b/master/buildbot/steps/source/mercurial.py
@@ -120,8 +120,7 @@ class Mercurial(Source):
             d.addCallback(self.patch, patch)
 
         d.addCallback(self.parseGotRevision)
-        d.addCallback(self.finish)
-        d.addErrback(self.failed)
+        return d
 
     @defer.inlineCallbacks
     def mode_full(self, _):

--- a/master/buildbot/steps/source/mtn.py
+++ b/master/buildbot/steps/source/mtn.py
@@ -99,9 +99,9 @@ class Monotone(Source):
             if patch:
                 yield self.patch(None, patch)
             yield self.parseGotRevision()
-            self.finish()
-        except Exception as e:
-            self.failed(e)
+            return SUCCESS
+        finally:
+            pass  # FIXME: remove this try:raise block
 
     @defer.inlineCallbacks
     def mode_full(self):
@@ -341,7 +341,7 @@ class Monotone(Source):
 
         return workdir_exists
 
-    def finish(self):
+    def finish(self, _):
         self.setStatus(self.cmd, 0)
         log.msg("Closing log, sending result of the command {} ".format(self.cmd))
         return self.finished(0)

--- a/master/buildbot/steps/source/mtn.py
+++ b/master/buildbot/steps/source/mtn.py
@@ -97,7 +97,7 @@ class Monotone(Source):
             yield fn()
 
             if patch:
-                yield self.patch(None, patch)
+                yield self.patch(patch)
             yield self.parseGotRevision()
             return SUCCESS
         finally:

--- a/master/buildbot/steps/source/mtn.py
+++ b/master/buildbot/steps/source/mtn.py
@@ -340,8 +340,3 @@ class Monotone(Source):
             log.msg("Workdir does not exist, falling back to a fresh clone")
 
         return workdir_exists
-
-    def finish(self, _):
-        self.setStatus(self.cmd, 0)
-        log.msg("Closing log, sending result of the command {} ".format(self.cmd))
-        return self.finished(0)

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -153,8 +153,6 @@ class P4(Source):
         d.addCallback(self._getAttrGroupMember('mode', self.mode))
 
         d.addCallback(self.parseGotRevision)
-        d.addCallback(self.finish)
-        d.addErrback(self.failed)
         return d
 
     @defer.inlineCallbacks

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -23,6 +23,7 @@ from buildbot import config
 from buildbot import interfaces
 from buildbot.interfaces import WorkerTooOldError
 from buildbot.process import buildstep
+from buildbot.process import results
 from buildbot.process.properties import Interpolate
 from buildbot.steps.source import Source
 
@@ -122,6 +123,7 @@ class P4(Source):
         if self.p4client_spec_options is None:
             self.p4client_spec_options = ''
 
+    @defer.inlineCallbacks
     def startVC(self, branch, revision, patch):
         if debug_logging:
             log.msg('in startVC')
@@ -130,13 +132,9 @@ class P4(Source):
         self.method = self._getMethod()
         self.stdio_log = self.addLogForRemoteCommands("stdio")
 
-        d = self.checkP4()
-
-        @d.addCallback
-        def checkInstall(p4Installed):
-            if not p4Installed:
-                raise WorkerTooOldError("p4 is not installed on worker")
-            return 0
+        installed = yield self.checkP4()
+        if not installed:
+            raise WorkerTooOldError("p4 is not installed on worker")
 
         # Try to obfuscate the password when used as an argument to commands.
         if self.p4passwd is not None:
@@ -148,15 +146,14 @@ class P4(Source):
                         "p4 password will be logged")
 
         if self.use_tickets and self.p4passwd:
-            d.addCallback(self._acquireTicket)
+            yield self._acquireTicket()
 
-        d.addCallback(self._getAttrGroupMember('mode', self.mode))
-
-        d.addCallback(self.parseGotRevision)
-        return d
+        yield self._getAttrGroupMember('mode', self.mode)()
+        yield self.parseGotRevision()
+        return results.SUCCESS
 
     @defer.inlineCallbacks
-    def mode_full(self, _):
+    def mode_full(self):
         if debug_logging:
             log.msg("P4:full()..")
 
@@ -186,7 +183,7 @@ class P4(Source):
             log.msg("P4: full() sync done.")
 
     @defer.inlineCallbacks
-    def mode_incremental(self, _):
+    def mode_incremental(self):
         if debug_logging:
             log.msg("P4:incremental()")
 
@@ -204,15 +201,10 @@ class P4(Source):
                 "P4:incremental() command:%s revision:%s", command, self.revision)
         yield self._dovccmd(command)
 
+    @defer.inlineCallbacks
     def finish(self, res):
-        d = defer.succeed(res)
-
-        @d.addCallback
-        def _gotResults(results):
-            self.setStatus(self.cmd, results)
-            return results
-        d.addCallback(self.finished)
-        return d
+        self.setStatus(self.cmd, res)
+        yield self.finished(res)
 
     def _getP4BaseForLog(self):
         return self.p4base or '<custom viewspec>'
@@ -241,6 +233,7 @@ class P4(Source):
         command.extend(doCommand)
         return command
 
+    @defer.inlineCallbacks
     def _dovccmd(self, command, collectStdout=False, initialStdin=None):
         command = self._buildVCCommand(command)
 
@@ -257,18 +250,15 @@ class P4(Source):
         if debug_logging:
             log.msg("Starting p4 command : p4 {}".format(" ".join(command)))
 
-        d = self.runCommand(cmd)
+        yield self.runCommand(cmd)
 
-        @d.addCallback
-        def evaluateCommand(_):
-            if cmd.rc != 0:
-                if debug_logging:
-                    log.msg("P4:_dovccmd():Source step failed while running command {}".format(cmd))
-                raise buildstep.BuildStepFailed()
-            if collectStdout:
-                return cmd.stdout
-            return cmd.rc
-        return d
+        if cmd.rc != 0:
+            if debug_logging:
+                log.msg("P4:_dovccmd():Source step failed while running command {}".format(cmd))
+            raise buildstep.BuildStepFailed()
+        if collectStdout:
+            return cmd.stdout
+        return cmd.rc
 
     def _getMethod(self):
         if self.method is not None and self.mode != 'incremental':
@@ -364,7 +354,7 @@ class P4(Source):
         return mo and (mo.group(2) == 'saved.' or mo.group(2) == 'not changed.')
 
     @defer.inlineCallbacks
-    def _acquireTicket(self, _):
+    def _acquireTicket(self):
         if debug_logging:
             log.msg("P4:acquireTicket()")
 
@@ -372,7 +362,8 @@ class P4(Source):
         initialStdin = self.p4passwd + "\n"
         yield self._dovccmd(['login'], initialStdin=initialStdin)
 
-    def parseGotRevision(self, _):
+    @defer.inlineCallbacks
+    def parseGotRevision(self):
         command = self._buildVCCommand(['changes', '-m1', '#have'])
 
         cmd = buildstep.RemoteShellCommand(self.workdir, command,
@@ -381,54 +372,44 @@ class P4(Source):
                                            logEnviron=self.logEnviron,
                                            collectStdout=True)
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
+        yield self.runCommand(cmd)
 
-        @d.addCallback
-        def _setrev(_):
-            stdout = cmd.stdout.strip()
-            # Example output from p4 changes -m1 #have
-            # Change 212798 on 2012/04/13 by user@user-unix-bldng2 'change to
-            # pickup build'
-            revision = stdout.split()[1]
-            try:
-                int(revision)
-            except ValueError:
-                msg = (("p4.parseGotRevision unable to parse output "
-                        "of 'p4 changes -m1 \"#have\"': '{}'").format(stdout))
-                log.msg(msg)
-                raise buildstep.BuildStepFailed()
+        stdout = cmd.stdout.strip()
+        # Example output from p4 changes -m1 #have
+        # Change 212798 on 2012/04/13 by user@user-unix-bldng2 'change to
+        # pickup build'
+        revision = stdout.split()[1]
+        try:
+            int(revision)
+        except ValueError:
+            msg = (("p4.parseGotRevision unable to parse output "
+                    "of 'p4 changes -m1 \"#have\"': '{}'").format(stdout))
+            log.msg(msg)
+            raise buildstep.BuildStepFailed()
 
-            if debug_logging:
-                log.msg("Got p4 revision {}".format(revision))
-            self.updateSourceProperty('got_revision', revision)
-            return 0
-        return d
+        if debug_logging:
+            log.msg("Got p4 revision {}".format(revision))
+        self.updateSourceProperty('got_revision', revision)
 
+    @defer.inlineCallbacks
     def purge(self, ignore_ignores):
         """Delete everything that shown up on status."""
         command = ['sync', '#none']
         if ignore_ignores:
             command.append('--no-ignore')
-        d = self._dovccmd(command, collectStdout=True)
-
+        yield self._dovccmd(command, collectStdout=True)
+        # FIXME: do the following comments need addressing?
         # add deferred to rm tree
-
         # then add defer to sync to revision
-        return d
 
+    @defer.inlineCallbacks
     def checkP4(self):
         cmd = buildstep.RemoteShellCommand(self.workdir, ['p4', '-V'],
                                            env=self.env,
                                            logEnviron=self.logEnviron)
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
-
-        @d.addCallback
-        def evaluate(_):
-            if cmd.rc != 0:
-                return False
-            return True
-        return d
+        yield self.runCommand(cmd)
+        return cmd.rc == 0
 
     def computeSourceRevision(self, changes):
         if not changes or None in [c.revision for c in changes]:

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -201,11 +201,6 @@ class P4(Source):
                 "P4:incremental() command:%s revision:%s", command, self.revision)
         yield self._dovccmd(command)
 
-    @defer.inlineCallbacks
-    def finish(self, res):
-        self.setStatus(self.cmd, res)
-        yield self.finished(res)
-
     def _getP4BaseForLog(self):
         return self.p4base or '<custom viewspec>'
 

--- a/master/buildbot/steps/source/repo.py
+++ b/master/buildbot/steps/source/repo.py
@@ -24,6 +24,7 @@ from zope.interface import implementer
 from buildbot import util
 from buildbot.interfaces import IRenderable
 from buildbot.process import buildstep
+from buildbot.process import results
 from buildbot.steps.source.base import Source
 
 
@@ -238,8 +239,7 @@ class Repo(Source):
         return self.pathExists(self.repoDir())
 
     def startVC(self, branch, revision, patch):
-        d = self.doStartVC()
-        d.addErrback(self.failed)
+        return self.doStartVC()
 
     @defer.inlineCallbacks
     def doStartVC(self):
@@ -270,7 +270,7 @@ class Repo(Source):
         # starting from here, clobbering will not help
         yield self.doRepoDownloads()
         self.setStatus(self.lastCommand, 0)
-        yield self.finished(0)
+        return results.SUCCESS
 
     @defer.inlineCallbacks
     def doClobberStart(self):

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -196,11 +196,6 @@ class SVN(Source):
             raise buildstep.BuildStepFailed()
 
     @defer.inlineCallbacks
-    def finish(self, res):
-        self.setStatus(self.cmd, res)
-        yield self.finished(res)
-
-    @defer.inlineCallbacks
     def _dovccmd(self, command, collectStdout=False, collectStderr=False, abandonOnFailure=True):
         assert command, "No command specified"
         command.extend(['--non-interactive', '--no-auth-cache'])

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -94,7 +94,7 @@ class SVN(Source):
         yield self._getAttrGroupMember('mode', self.mode)()
 
         if patch:
-            yield self.patch(0, patch)
+            yield self.patch(patch)
         res = yield self.parseGotRevision()
         return res
 

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -68,6 +68,7 @@ class SVN(Source):
         if errors:
             raise ConfigErrors(errors)
 
+    @defer.inlineCallbacks
     def startVC(self, branch, revision, patch):
         self.revision = revision
         self.method = self._getMethod()
@@ -82,32 +83,23 @@ class SVN(Source):
                 log.msg("Worker does not understand obfuscation; "
                         "svn password will be logged")
 
-        d = self.checkSvn()
+        installed = yield self.checkSvn()
+        if not installed:
+            raise buildstep.BuildStepFailed("SVN is not installed on worker")
 
-        @d.addCallback
-        def checkInstall(svnInstalled):
-            if not svnInstalled:
-                raise buildstep.BuildStepFailed(
-                    "SVN is not installed on worker")
-            return 0
+        patched = yield self.sourcedirIsPatched()
+        if patched:
+            yield self.purge(False)
 
-        d.addCallback(lambda _: self.sourcedirIsPatched())
-
-        @d.addCallback
-        def checkPatched(patched):
-            if patched:
-                return self.purge(False)
-            return 0
-
-        d.addCallback(self._getAttrGroupMember('mode', self.mode))
+        yield self._getAttrGroupMember('mode', self.mode)()
 
         if patch:
-            d.addCallback(self.patch, patch)
-        d.addCallback(self.parseGotRevision)
-        return d
+            yield self.patch(0, patch)
+        res = yield self.parseGotRevision()
+        return res
 
     @defer.inlineCallbacks
-    def mode_full(self, _):
+    def mode_full(self):
         if self.method == 'clobber':
             yield self.clobber()
             return
@@ -125,7 +117,7 @@ class SVN(Source):
             yield self.fresh()
 
     @defer.inlineCallbacks
-    def mode_incremental(self, _):
+    def mode_incremental(self):
         updatable = yield self._sourcedirIsUpdatable()
 
         if not updatable:
@@ -138,26 +130,26 @@ class SVN(Source):
                 command.extend(['--revision', str(self.revision)])
             yield self._dovccmd(command)
 
+    @defer.inlineCallbacks
     def clobber(self):
-        d = self.runRmdir(self.workdir, timeout=self.timeout)
-        d.addCallback(lambda _: self._checkout())
-        return d
+        yield self.runRmdir(self.workdir, timeout=self.timeout)
+        yield self._checkout()
 
+    @defer.inlineCallbacks
     def fresh(self):
-        d = self.purge(True)
+        yield self.purge(True)
         cmd = ['update']
         if self.revision:
             cmd.extend(['--revision', str(self.revision)])
-        d.addCallback(lambda _: self._dovccmd(cmd))
-        return d
+        yield self._dovccmd(cmd)
 
+    @defer.inlineCallbacks
     def clean(self):
-        d = self.purge(False)
+        yield self.purge(False)
         cmd = ['update']
         if self.revision:
             cmd.extend(['--revision', str(self.revision)])
-        d.addCallback(lambda _: self._dovccmd(cmd))
-        return d
+        yield self._dovccmd(cmd)
 
     @defer.inlineCallbacks
     def copy(self):
@@ -171,7 +163,7 @@ class SVN(Source):
         try:
             old_workdir = self.workdir
             self.workdir = checkout_dir
-            yield self.mode_incremental(None)
+            yield self.mode_incremental()
         finally:
             self.workdir = old_workdir
         self.workdir = old_workdir
@@ -203,16 +195,12 @@ class SVN(Source):
         if cmd.didFail():
             raise buildstep.BuildStepFailed()
 
+    @defer.inlineCallbacks
     def finish(self, res):
-        d = defer.succeed(res)
+        self.setStatus(self.cmd, res)
+        yield self.finished(res)
 
-        @d.addCallback
-        def _gotResults(results):
-            self.setStatus(self.cmd, results)
-            return results
-        d.addCallback(self.finished)
-        return d
-
+    @defer.inlineCallbacks
     def _dovccmd(self, command, collectStdout=False, collectStderr=False, abandonOnFailure=True):
         assert command, "No command specified"
         command.extend(['--non-interactive', '--no-auth-cache'])
@@ -232,21 +220,18 @@ class SVN(Source):
                                                collectStdout=collectStdout,
                                                collectStderr=collectStderr)
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
+        yield self.runCommand(cmd)
 
-        @d.addCallback
-        def evaluateCommand(_):
-            if cmd.didFail() and abandonOnFailure:
-                log.msg("Source step failed while running command {}".format(cmd))
-                raise buildstep.BuildStepFailed()
-            if collectStdout and collectStderr:
-                return (cmd.stdout, cmd.stderr)
-            elif collectStdout:
-                return cmd.stdout
-            elif collectStderr:
-                return cmd.stderr
-            return cmd.rc
-        return d
+        if cmd.didFail() and abandonOnFailure:
+            log.msg("Source step failed while running command {}".format(cmd))
+            raise buildstep.BuildStepFailed()
+        if collectStdout and collectStderr:
+            return (cmd.stdout, cmd.stderr)
+        elif collectStdout:
+            return cmd.stdout
+        elif collectStderr:
+            return cmd.stderr
+        return cmd.rc
 
     def _getMethod(self):
         if self.method is not None and self.mode != 'incremental':
@@ -284,7 +269,7 @@ class SVN(Source):
         return extractedurl == self.svnUriCanonicalize(self.repourl)
 
     @defer.inlineCallbacks
-    def parseGotRevision(self, _):
+    def parseGotRevision(self):
         # if this was a full/export, then we need to check svnversion in the
         # *source* directory, not the build directory
         svnversion_dir = self.workdir
@@ -333,35 +318,26 @@ class SVN(Source):
 
         return cmd.rc
 
+    @defer.inlineCallbacks
     def purge(self, ignore_ignores):
         """Delete everything that shown up on status."""
         command = ['status', '--xml']
         if ignore_ignores:
             command.append('--no-ignore')
-        d = self._dovccmd(command, collectStdout=True)
+        stdout = yield self._dovccmd(command, collectStdout=True)
 
-        @d.addCallback
-        def parseAndRemove(stdout):
-            files = []
-            for filename in self.getUnversionedFiles(stdout, self.keep_on_purge):
-                filename = self.build.path_module.join(self.workdir, filename)
-                files.append(filename)
-            if not files:
-                d = defer.succeed(0)
+        files = []
+        for filename in self.getUnversionedFiles(stdout, self.keep_on_purge):
+            filename = self.build.path_module.join(self.workdir, filename)
+            files.append(filename)
+        if files:
+            if self.workerVersionIsOlderThan('rmdir', '2.14'):
+                rc = yield self.removeFiles(files)
             else:
-                if self.workerVersionIsOlderThan('rmdir', '2.14'):
-                    d = self.removeFiles(files)
-                else:
-                    d = self.runRmdir(files, abandonOnFailure=False, timeout=self.timeout)
-            return d
-
-        @d.addCallback
-        def evaluateCommand(rc):
+                rc = yield self.runRmdir(files, abandonOnFailure=False, timeout=self.timeout)
             if rc != 0:
                 log.msg("Failed removing files")
                 raise buildstep.BuildStepFailed()
-            return rc
-        return d
 
     @staticmethod
     def getUnversionedFiles(xmlStr, keep_on_purge):
@@ -390,18 +366,15 @@ class SVN(Source):
                 return res
         return 0
 
+    @defer.inlineCallbacks
     def checkSvn(self):
         cmd = remotecommand.RemoteShellCommand(self.workdir, ['svn', '--version'],
                                                env=self.env,
                                                logEnviron=self.logEnviron,
                                                timeout=self.timeout)
         cmd.useLog(self.stdio_log, False)
-        d = self.runCommand(cmd)
-
-        @d.addCallback
-        def evaluate(_):
-            return cmd.rc == 0
-        return d
+        yield self.runCommand(cmd)
+        return cmd.rc == 0
 
     def computeSourceRevision(self, changes):
         if not changes or None in [c.revision for c in changes]:
@@ -457,6 +430,7 @@ class SVN(Source):
             return canonical_uri[:-1]
         return canonical_uri
 
+    @defer.inlineCallbacks
     def _checkout(self):
         checkout_cmd = ['checkout', self.repourl, '.']
         if self.revision:
@@ -465,11 +439,11 @@ class SVN(Source):
             abandonOnFailure = (self.retry[1] <= 0)
         else:
             abandonOnFailure = True
-        d = self._dovccmd(checkout_cmd, abandonOnFailure=abandonOnFailure)
+        res = yield self._dovccmd(checkout_cmd, abandonOnFailure=abandonOnFailure)
 
-        def _retry(res):
+        if self.retry:
             if self.stopped or res == 0:
-                return res
+                return
             delay, repeats = self.retry
             if repeats > 0:
                 log.msg("Checkout failed, trying %d more times after %d seconds"
@@ -479,9 +453,4 @@ class SVN(Source):
                 df.addCallback(lambda _: self.runRmdir(self.workdir, timeout=self.timeout))
                 df.addCallback(lambda _: self._checkout())
                 reactor.callLater(delay, df.callback, None)
-                return df
-            return res
-
-        if self.retry:
-            d.addCallback(_retry)
-        return d
+                yield df

--- a/master/buildbot/steps/source/svn.py
+++ b/master/buildbot/steps/source/svn.py
@@ -104,8 +104,6 @@ class SVN(Source):
         if patch:
             d.addCallback(self.patch, patch)
         d.addCallback(self.parseGotRevision)
-        d.addCallback(self.finish)
-        d.addErrback(self.failed)
         return d
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/integration/test_integration_force_with_patch.py
+++ b/master/buildbot/test/integration/test_integration_force_with_patch.py
@@ -42,8 +42,6 @@ class MySource(Source):
         d = defer.succeed(SUCCESS)
         if patch:
             d.addCallback(self.patch, patch)
-        d.addCallback(self.finished)
-        d.addErrback(self.failed)
         return d
 
 

--- a/master/buildbot/test/integration/test_integration_force_with_patch.py
+++ b/master/buildbot/test/integration/test_integration_force_with_patch.py
@@ -37,12 +37,12 @@ index 0000000..8a5cf80
 class MySource(Source):
     """A source class which only applies the patch"""
 
+    @defer.inlineCallbacks
     def startVC(self, branch, revision, patch):
         self.stdio_log = self.addLogForRemoteCommands("stdio")
-        d = defer.succeed(SUCCESS)
         if patch:
-            d.addCallback(self.patch, patch)
-        return d
+            yield self.patch(patch)
+        return SUCCESS
 
 
 class ShellMaster(RunMasterBase):

--- a/master/buildbot/test/unit/test_steps_source_cvs.py
+++ b/master/buildbot/test/unit/test_steps_source_cvs.py
@@ -53,10 +53,9 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
 
         # make parseGotRevision return something consistent, patching the class
         # instead of the object since a new object is constructed by runTest.
-        def parseGotRevision(self, res):
+        def parseGotRevision(self):
             self.updateSourceProperty('got_revision',
                                       '2012-09-09 12:00:39 +0000')
-            return res
         self.patch(cvs.CVS, 'parseGotRevision', parseGotRevision)
 
     def test_parseGotRevision(self):
@@ -71,7 +70,7 @@ class TestCVS(sourcesteps.SourceStepMixin, TestReactorMixin,
             props.append((prop, name))
         step.updateSourceProperty = updateSourceProperty
 
-        self.assertEqual(step.parseGotRevision(10), 10)  # passes res along
+        step.parseGotRevision()
         self.assertEqual(props,
                          [('got_revision', '2012-09-09 12:09:33 +0000')])
 

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -3441,7 +3441,7 @@ class TestGit(sourcesteps.SourceStepMixin,
 
         gitStep._start_deferred = defer.Deferred()
         d = gitStep.startVC("branch", "revision", "patch")
-        d.addCallback(gitStep.finish)
+        d.addCallback(gitStep.finished)
         d.addErrback(gitStep.failed)
 
         d = gitStep._start_deferred.addBoth(check)

--- a/master/buildbot/test/unit/test_steps_source_git.py
+++ b/master/buildbot/test/unit/test_steps_source_git.py
@@ -3440,7 +3440,10 @@ class TestGit(sourcesteps.SourceStepMixin,
         gitStep = self.setupStep(step)
 
         gitStep._start_deferred = defer.Deferred()
-        gitStep.startVC("branch", "revision", "patch")
+        d = gitStep.startVC("branch", "revision", "patch")
+        d.addCallback(gitStep.finish)
+        d.addErrback(gitStep.failed)
+
         d = gitStep._start_deferred.addBoth(check)
         return d
 


### PR DESCRIPTION
This makes eventual migration to the new style steps much easier.

No functionality changes are expected.