### PR TITLE
Convert several worker-related steps to new style

### DIFF
--- a/master/buildbot/newsfragments/new-style-steps-migration.removal
+++ b/master/buildbot/newsfragments/new-style-steps-migration.removal
@@ -1,0 +1,13 @@
+Many steps have been migrated to new style from old style.
+These steps exposed private APIs that could have been used in user code by means of inheritance.
+The old style steps have been deprecated since Buildbot v0.9.0 released in October 2016.
+The support for old style steps will be removed entirely in near future.
+Users are advised to upgrade to new style steps as soon as possible.
+
+The list of old-style steps that have been converted to new style:
+
+ - ``CopyDirectory``
+ - ``FileExists``
+ - ``MakeDirectory``
+ - ``RemoveDirectory``
+ - ``SetPropertiesFromEnv``

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -169,19 +169,18 @@ class RemoveDirectory(WorkerBuildStep):
         super().__init__(**kwargs)
         self.dir = dir
 
-    def start(self):
+    @defer.inlineCallbacks
+    def run(self):
         self.checkWorkerHasCommand('rmdir')
         cmd = remotecommand.RemoteCommand('rmdir', {'dir': self.dir})
-        d = self.runCommand(cmd)
-        d.addCallback(lambda res: self.commandComplete(cmd))
-        d.addErrback(self.failed)
 
-    def commandComplete(self, cmd):
+        yield self.runCommand(cmd)
+
         if cmd.didFail():
-            self.step_status.setText(["Delete failed."])
-            self.finished(FAILURE)
-            return
-        self.finished(SUCCESS)
+            self.descriptionDone = ["Delete failed."]
+            return FAILURE
+
+        return SUCCESS
 
 
 class MakeDirectory(WorkerBuildStep):

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -17,6 +17,8 @@
 import os
 import stat
 
+from twisted.internet import defer
+
 from buildbot.process import buildstep
 from buildbot.process import remotecommand
 from buildbot.process import remotetransfer
@@ -45,7 +47,8 @@ class SetPropertiesFromEnv(WorkerBuildStep):
         self.variables = variables
         self.source = source
 
-    def start(self):
+    @defer.inlineCallbacks
+    def run(self):
         # on Windows, environment variables are case-insensitive, but we have
         # a case-sensitive dictionary in worker_environ.  Fortunately, that
         # dictionary is also folded to uppercase, so we can simply fold the
@@ -68,8 +71,8 @@ class SetPropertiesFromEnv(WorkerBuildStep):
                 properties.setProperty(variable, value, self.source,
                                        runtime=True)
                 log.append("{} = {}".format(variable, repr(value)))
-        self.addCompleteLog("properties", "\n".join(log))
-        self.finished(SUCCESS)
+        yield self.addCompleteLog("properties", "\n".join(log))
+        return SUCCESS
 
 
 class FileExists(WorkerBuildStep):

--- a/master/buildbot/steps/worker.py
+++ b/master/buildbot/steps/worker.py
@@ -24,7 +24,6 @@ from buildbot.process import remotecommand
 from buildbot.process import remotetransfer
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
-from buildbot.util import bytes2unicode
 
 
 class WorkerBuildStep(buildstep.BuildStep):
@@ -201,19 +200,17 @@ class MakeDirectory(WorkerBuildStep):
         super().__init__(**kwargs)
         self.dir = dir
 
-    def start(self):
+    @defer.inlineCallbacks
+    def run(self):
         self.checkWorkerHasCommand('mkdir')
         cmd = remotecommand.RemoteCommand('mkdir', {'dir': self.dir})
-        d = self.runCommand(cmd)
-        d.addCallback(lambda res: self.commandComplete(cmd))
-        d.addErrback(self.failed)
+        yield self.runCommand(cmd)
 
-    def commandComplete(self, cmd):
         if cmd.didFail():
-            self.step_status.setText(["Create failed."])
-            self.finished(FAILURE)
-            return
-        self.finished(SUCCESS)
+            self.descriptionDone = ["Create failed."]
+            return FAILURE
+
+        return SUCCESS
 
 
 class CompositeStepMixin():

--- a/master/buildbot/test/unit/test_steps_worker.py
+++ b/master/buildbot/test/unit/test_steps_worker.py
@@ -234,7 +234,7 @@ class TestRemoveDirectory(steps.BuildStepMixin, TestReactorMixin,
             + 1
         )
         self.expectOutcome(result=FAILURE,
-                           state_string="Deleted (failure)")
+                           state_string="Delete failed. (failure)")
         return self.runStep()
 
     def test_render(self):

--- a/master/buildbot/test/unit/test_steps_worker.py
+++ b/master/buildbot/test/unit/test_steps_worker.py
@@ -274,7 +274,7 @@ class TestMakeDirectory(steps.BuildStepMixin, TestReactorMixin,
             Expect('mkdir', {'dir': 'd'})
             + 1
         )
-        self.expectOutcome(result=FAILURE, state_string="Created (failure)")
+        self.expectOutcome(result=FAILURE, state_string="Create failed. (failure)")
         return self.runStep()
 
     def test_render(self):

--- a/master/buildbot/test/unit/test_steps_worker.py
+++ b/master/buildbot/test/unit/test_steps_worker.py
@@ -191,7 +191,7 @@ class TestCopyDirectory(steps.BuildStepMixin, TestReactorMixin,
             + 1
         )
         self.expectOutcome(result=FAILURE,
-                           state_string="Copying s to d failed.")
+                           state_string="Copying s to d failed. (failure)")
         return self.runStep()
 
     def test_render(self):


### PR DESCRIPTION
The release notes advise users to upgrade to new style steps ASAP. I have already converted most of the existing steps to new style and will submit the PRs over the following days.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
