### PR TITLE
Update spelling ignored word list

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -385,6 +385,7 @@ deferreds
 defertothread
 delayedcall
 denormalized
+dependabot
 deprecatedmoduleattribute
 descriptionsuffix
 desynchronization


### PR DESCRIPTION
This fixes spellcheck failure on my Ubuntu 20.04 machine. Interestingly, this is while running the tools from virtualenv.