### PR TITLE
Convert transfer steps to new style

### DIFF
--- a/master/buildbot/newsfragments/new-style-steps-migration.removal
+++ b/master/buildbot/newsfragments/new-style-steps-migration.removal
@@ -7,7 +7,14 @@ Users are advised to upgrade to new style steps as soon as possible.
 The list of old-style steps that have been converted to new style:
 
  - ``CopyDirectory``
+ - ``DirectoryUpload``
+ - ``FileDownload``
  - ``FileExists``
+ - ``FileUpload``
+ - ``JsonPropertiesDownload``
+ - ``JsonStringDownload``
  - ``MakeDirectory``
+ - ``MultipleFileUpload``
  - ``RemoveDirectory``
  - ``SetPropertiesFromEnv``
+ - ``StringDownload``

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -199,9 +199,10 @@ class DirectoryUpload(_TransferBuildStep):
         self.url = url
         self.urlText = urlText
 
-    def start(self):
+    @defer.inlineCallbacks
+    def run(self):
         self.checkWorkerHasCommand("uploadDirectory")
-        self.stdio_log = self.addLog("stdio")
+        self.stdio_log = yield self.addLog("stdio")
 
         source = self.workersrc
         masterdest = self.masterdest
@@ -220,7 +221,7 @@ class DirectoryUpload(_TransferBuildStep):
             if urlText is None:
                 urlText = os.path.basename(os.path.normpath(masterdest))
 
-            self.addURL(urlText, self.url)
+            yield self.addURL(urlText, self.url)
 
         # we use maxsize to limit the amount of data on both sides
         dirWriter = remotetransfer.DirectoryWriter(
@@ -241,8 +242,8 @@ class DirectoryUpload(_TransferBuildStep):
             args['workersrc'] = source
 
         cmd = makeStatusRemoteCommand(self, 'uploadDirectory', args)
-        d = self.runTransferCommand(cmd, dirWriter)
-        d.addCallback(self.finished).addErrback(self.failed)
+        res = yield self.runTransferCommand(cmd, dirWriter)
+        return res
 
 
 class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):


### PR DESCRIPTION
This PR depends on #5458 for the shared newsfragment for the new style conversion changes.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
