### PR TITLE
Log processing fixes in new style steps

### DIFF
--- a/master/buildbot/newsfragments/fail-step-when-log-observer-throws.bugfix
+++ b/master/buildbot/newsfragments/fail-step-when-log-observer-throws.bugfix
@@ -1,0 +1,1 @@
+Throwing an exception out of a log observer while processing logs will now correctly fail the step in the case of new style steps.

--- a/master/buildbot/newsfragments/step-summary-update-with-correct-results.bugfix
+++ b/master/buildbot/newsfragments/step-summary-update-with-correct-results.bugfix
@@ -1,0 +1,1 @@
+Step summary is now updated after the last point where the step status is changed. Previously exceptions in log finish methods would be ignored.

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -602,11 +602,6 @@ class BuildStep(results.ResultComputingConfigMixin,
             if self.results != CANCELLED:
                 self.results = EXCEPTION
 
-        # update the summary one last time, make sure that completes,
-        # and then don't update it any more.
-        self.realUpdateSummary()
-        yield self.realUpdateSummary.stop()
-
         # determine whether we should hide this step
         hidden = self.hideStepIf
         if callable(hidden):
@@ -625,6 +620,11 @@ class BuildStep(results.ResultComputingConfigMixin,
         success = yield self._cleanup_logs()
         if not success:
             self.results = EXCEPTION
+
+        # update the summary one last time, make sure that completes,
+        # and then don't update it any more.
+        self.realUpdateSummary()
+        yield self.realUpdateSummary.stop()
 
         for sub in self._test_result_submitters.values():
             yield sub.finish()

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -621,12 +621,11 @@ class BuildStep(results.ResultComputingConfigMixin,
 
         yield self.master.data.updates.finishStep(self.stepid, self.results,
                                                   hidden)
-        # finish unfinished logs
-        all_finished = yield self.finishUnfinishedLogs()
-        if not all_finished:
+        # perform final clean ups
+        success = yield self._cleanup_logs()
+        if not success:
             self.results = EXCEPTION
 
-        # finish unfinished test result submitters
         for sub in self._test_result_submitters.values():
             yield sub.finish()
 
@@ -635,17 +634,21 @@ class BuildStep(results.ResultComputingConfigMixin,
         return self.results
 
     @defer.inlineCallbacks
-    def finishUnfinishedLogs(self):
-        ok = True
-        not_finished_logs = [v for (k, v) in self.logs.items()
-                             if not v.finished]
+    def _cleanup_logs(self):
+        all_success = True
+        not_finished_logs = [v for (k, v) in self.logs.items() if not v.finished]
         finish_logs = yield defer.DeferredList([v.finish() for v in not_finished_logs],
                                                consumeErrors=True)
         for success, res in finish_logs:
             if not success:
                 log.err(res, "when trying to finish a log")
-                ok = False
-        return ok
+                all_success = False
+
+        for log_ in self.logs.values():
+            if log_.had_errors():
+                all_success = False
+
+        return all_success
 
     def addTestResultSets(self):
         return defer.succeed(None)

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -35,6 +35,7 @@ class Log:
         self.subscriptions = {}
         self.finished = False
         self.finishWaiters = []
+        self._had_errors = False
         self.lock = defer.DeferredLock()
         self.decoder = decoder
 
@@ -91,6 +92,9 @@ class Log:
             self.finishWaiters.append(d)
         return d
 
+    def had_errors(self):
+        return self._had_errors
+
     @defer.inlineCallbacks
     def finish(self):
         assert not self.finished
@@ -107,6 +111,8 @@ class Log:
         # notify those waiting for finish
         for d in self.finishWaiters:
             d.callback(None)
+
+        self._had_errors = len(self.subPoint.pop_exceptions()) > 0
 
         # start a compressLog call but don't make our caller wait for
         # it to complete

--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -102,6 +102,8 @@ class Log:
         # notify subscribers *after* finishing the log
         self.subPoint.deliver(None, None)
 
+        yield self.subPoint.waitForDeliveriesToFinish()
+
         # notify those waiting for finish
         for d in self.finishWaiters:
             d.callback(None)

--- a/master/buildbot/test/fake/logfile.py
+++ b/master/buildbot/test/fake/logfile.py
@@ -84,6 +84,7 @@ class FakeLogFile:
         for lbf in self.lbfs.values():
             lbf.flush()
 
+    @defer.inlineCallbacks
     def finish(self):
         assert not self.finished
 
@@ -93,11 +94,11 @@ class FakeLogFile:
         # notify subscribers *after* finishing the log
         self.subPoint.deliver(None, None)
 
+        yield self.subPoint.waitForDeliveriesToFinish()
+
         # notify those waiting for finish
         for d in self._finish_waiters:
             d.callback(None)
-
-        return defer.succeed(None)
 
     def fakeData(self, header='', stdout='', stderr=''):
         if header:

--- a/master/buildbot/test/fake/logfile.py
+++ b/master/buildbot/test/fake/logfile.py
@@ -29,6 +29,7 @@ class FakeLogFile:
         self.lbfs = {}
         self.finished = False
         self._finish_waiters = []
+        self._had_errors = False
         self.subPoint = util.subscription.SubscriptionPoint("%r log" % (name,))
 
     def getName(self):
@@ -84,6 +85,9 @@ class FakeLogFile:
         for lbf in self.lbfs.values():
             lbf.flush()
 
+    def had_errors(self):
+        return self._had_errors
+
     @defer.inlineCallbacks
     def finish(self):
         assert not self.finished
@@ -95,6 +99,7 @@ class FakeLogFile:
         self.subPoint.deliver(None, None)
 
         yield self.subPoint.waitForDeliveriesToFinish()
+        self._had_errors = len(self.subPoint.pop_exceptions()) > 0
 
         # notify those waiting for finish
         for d in self._finish_waiters:

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -84,7 +84,7 @@ class FakeRemoteCommand:
 
     def fakeLogData(self, step, log, header='', stdout='', stderr=''):
         # note that this should not be used in the same test as useLog(Delayed)
-        self.logs[log] = fakelog = logfile.FakeLogFile(log, step)
+        self.logs[log] = fakelog = logfile.FakeLogFile(log)
         self._log_close_when_finished[log] = False
         fakelog.fakeData(header=header, stdout=stdout, stderr=stderr)
 

--- a/master/buildbot/test/unit/test_process_log.py
+++ b/master/buildbot/test/unit/test_process_log.py
@@ -287,9 +287,7 @@ class TestProcessItfc(unittest.TestCase, InterfaceTests):
 class TestFakeLogFile(unittest.TestCase, InterfaceTests):
 
     def setUp(self):
-        step = mock.Mock(name='fake step')
-        step.logobservers = []
-        self.log = fakelogfile.FakeLogFile('stdio', step)
+        self.log = fakelogfile.FakeLogFile('stdio')
 
 
 class TestErrorRaised(unittest.TestCase):

--- a/master/buildbot/test/unit/test_process_remotecommand.py
+++ b/master/buildbot/test/unit/test_process_remotecommand.py
@@ -145,7 +145,7 @@ class TestRunCommand(unittest.TestCase, Tests):
     def test_notStdioLog(self):
         logname = 'notstdio'
         cmd = self.makeRemoteCommand(stdioLogName=logname)
-        log = logfile.FakeLogFile(logname, 'dummy')
+        log = logfile.FakeLogFile(logname)
         cmd.useLog(log)
         cmd.addStdout('some stdout')
         self.assertEqual(log.stdout, 'some stdout')

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -115,6 +115,11 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin,
         self.assertEqual(result, dbdict['results'])
 
     @defer.inlineCallbacks
+    def assertStepStateString(self, step_id, state_string):
+        datadict = yield self.master.data.get(('steps', step_id))
+        self.assertEqual(datadict['state_string'], state_string)
+
+    @defer.inlineCallbacks
     def assertLogs(self, build_id, exp_logs):
         got_logs = {}
         data_logs = yield self.master.data.get(('builds', build_id, 'steps', 1, 'logs'))

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -210,37 +210,26 @@ class BuildStepMixin:
         # step overrides
 
         def addLog(name, type='s', logEncoding=None):
-            _log = logfile.FakeLogFile(name, step)
+            _log = logfile.FakeLogFile(name)
             self.step.logs[name] = _log
+            self.step._connectPendingLogObservers()
             return defer.succeed(_log)
         step.addLog = addLog
         step.addLog_newStyle = addLog
 
         def addHTMLLog(name, html):
-            _log = logfile.FakeLogFile(name, step)
+            _log = logfile.FakeLogFile(name)
             html = bytes2unicode(html)
             _log.addStdout(html)
             return defer.succeed(None)
         step.addHTMLLog = addHTMLLog
 
         def addCompleteLog(name, text):
-            _log = logfile.FakeLogFile(name, step)
+            _log = logfile.FakeLogFile(name)
             self.step.logs[name] = _log
             _log.addStdout(text)
             return defer.succeed(None)
         step.addCompleteLog = addCompleteLog
-
-        step.logobservers = self.logobservers = {}
-
-        def addLogObserver(logname, observer):
-            self.logobservers.setdefault(logname, []).append(observer)
-            observer.step = step
-        step.addLogObserver = addLogObserver
-
-        # add any observers defined in the constructor, before this
-        # monkey-patch
-        for n, o in step._pendingLogObservers:
-            addLogObserver(n, o)
 
         self._got_test_result_sets = []
         self._next_test_result_set_id = 1000


### PR DESCRIPTION
This PR fixes the following related problems with logs:

 - Exceptions thrown by log observers were silently ignored in new style steps.
 - Step summary was updated before the final result of the step was known and any errors now visible due to the above fix were ignored.

Additionally, the `FakeLogFile` was improved to better match the real `Log`.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
