### PR TITLE
Transfer step improvements

### DIFF
--- a/master/buildbot/newsfragments/directory-upload-url-text-renderable.feature
+++ b/master/buildbot/newsfragments/directory-upload-url-text-renderable.feature
@@ -1,0 +1,1 @@
+The ``urlText`` parameter to the ``DirectoryUpload`` step is now renderable.

--- a/master/buildbot/newsfragments/multiple-file-upload-url-text.feature
+++ b/master/buildbot/newsfragments/multiple-file-upload-url-text.feature
@@ -1,0 +1,1 @@
+Allow ``urlText`` to be set on a url linked to a ``MultipleFileUpload`` step.

--- a/master/buildbot/newsfragments/transfer-step-interrupted-results.bugfix
+++ b/master/buildbot/newsfragments/transfer-step-interrupted-results.bugfix
@@ -1,0 +1,1 @@
+Transfer steps now return CANCELLED instead of SUCCESS when interrupted.

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -13,7 +13,6 @@
 #
 # Copyright Buildbot Team Members
 
-import inspect
 import re
 
 from twisted.python import failure
@@ -128,9 +127,23 @@ class ShellCommand(buildstep.LoggingBuildStep):
 
         # check validity of arguments being passed to RemoteShellCommand
         invalid_args = []
-        signature = inspect.signature(
-            remotecommand.RemoteShellCommand.__init__)
-        valid_rsc_args = signature.parameters.keys()
+        valid_rsc_args = [
+            'env',
+            'want_stdout',
+            'want_stderr',
+            'timeout',
+            'maxTime',
+            'sigtermTime',
+            'logfiles',
+            'usePTY',
+            'logEnviron',
+            'collectStdout',
+            'collectStderr',
+            'interruptSignal',
+            'initialStdin',
+            'decodeRC',
+            'stdioLogName',
+        ]
         for arg in kwargs:
             if arg not in valid_rsc_args:
                 invalid_args.append(arg)

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -63,7 +63,7 @@ class _TransferBuildStep(BuildStep):
         self.cmd = cmd
         try:
             yield self.runCommand(cmd)
-            return FAILURE if cmd.didFail() else SUCCESS
+            return cmd.results()
         finally:
             if writer:
                 writer.cancel()

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -174,7 +174,12 @@ class DirectoryUpload(_TransferBuildStep):
 
     name = 'upload'
 
-    renderables = ['workersrc', 'masterdest', 'url']
+    renderables = [
+        'workersrc',
+        'masterdest',
+        'url',
+        'urlText'
+    ]
 
     def __init__(self, workersrc=None, masterdest=None,
                  workdir=None, maxsize=None, blocksize=16 * 1024,

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -255,11 +255,16 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
     name = 'upload'
     logEnviron = False
 
-    renderables = ['workersrcs', 'masterdest', 'url']
+    renderables = [
+        'workersrcs',
+        'masterdest',
+        'url',
+        'urlText'
+    ]
 
     def __init__(self, workersrcs=None, masterdest=None,
                  workdir=None, maxsize=None, blocksize=16 * 1024, glob=False,
-                 mode=None, compress=None, keepstamp=False, url=None,
+                 mode=None, compress=None, keepstamp=False, url=None, urlText=None,
                  **buildstep_kwargs):
 
         # Emulate that first two arguments are positional.
@@ -283,6 +288,7 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
         self.glob = glob
         self.keepstamp = keepstamp
         self.url = url
+        self.urlText = urlText
 
     def uploadFile(self, source, masterdest):
         fileWriter = remotetransfer.FileWriter(
@@ -357,7 +363,12 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
     @defer.inlineCallbacks
     def allUploadsDone(self, result, sources, masterdest):
         if self.url is not None:
-            yield self.addURL(os.path.basename(os.path.normpath(masterdest)), self.url)
+            urlText = self.urlText
+
+            if urlText is None:
+                urlText = os.path.basename(os.path.normpath(masterdest))
+
+            yield self.addURL(urlText, self.url)
 
     @defer.inlineCallbacks
     def run(self):

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -341,8 +341,8 @@ class MultipleFileUpload(_TransferBuildStep, CompositeStepMixin):
         cmd = makeStatusRemoteCommand(self, 'stat', args)
         yield self.runCommand(cmd)
         if cmd.rc != 0:
-            yield self.addCompleteLog('stderr',
-                                      'File {} not available at worker'.format(args))
+            msg = 'File {}/{} not available at worker'.format(self.workdir, source)
+            yield self.addCompleteLog('stderr', msg)
             return FAILURE
         s = cmd.updates['stat'][-1]
         if stat.S_ISDIR(s[stat.ST_MODE]):

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -157,17 +157,11 @@ class Expect:
 
     """
 
-    def __init__(self, remote_command, args, incomparable_args=None):
+    def __init__(self, remote_command, args):
         """
-
-        Expect a command named C{remote_command}, with args C{args}.  Any args
-        in C{incomparable_args} are not cmopared, but must exist.
-
+        Expect a command named C{remote_command}, with args C{args}.
         """
-        if incomparable_args is None:
-            incomparable_args = []
         self.remote_command = remote_command
-        self.incomparable_args = incomparable_args
         self.args = args
         self.result = None
         self.behaviors = []

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -18,6 +18,7 @@ import functools
 from twisted.internet import defer
 from twisted.python import failure
 
+from buildbot.process.results import CANCELLED
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.test.fake import logfile
@@ -29,6 +30,10 @@ class FakeRemoteCommand:
     testcase = None
 
     active = False
+
+    interrupted = False
+
+    _waiting_for_interrupt = False
 
     def __init__(self, remote_command, args,
                  ignore_updates=False, collectStdout=False, collectStderr=False,
@@ -55,6 +60,11 @@ class FakeRemoteCommand:
 
     @defer.inlineCallbacks
     def run(self, step, conn, builder_name):
+        if self._waiting_for_interrupt:
+            yield step.interrupt('interrupt reason')
+            if not self.interrupted:
+                raise RuntimeError("Interrupted step, but command was not interrupted")
+
         # delegate back to the test case
         cmd = yield self.testcase._remotecommand_run(self, step, conn, builder_name)
         for name, log_ in self.logs.items():
@@ -72,9 +82,14 @@ class FakeRemoteCommand:
         self.delayedLogs[logfileName] = (activateCallBack, closeWhenFinished)
 
     def interrupt(self, why):
-        raise NotImplementedError
+        if not self._waiting_for_interrupt:
+            raise RuntimeError("Got interrupt, but FakeRemoteCommand was not expecting it")
+        self._waiting_for_interrupt = False
+        self.interrupted = True
 
     def results(self):
+        if self.interrupted:
+            return CANCELLED
         if self.rc in self.decodeRC:
             return self.decodeRC[self.rc]
         return FAILURE
@@ -87,6 +102,9 @@ class FakeRemoteCommand:
         self.logs[log] = fakelog = logfile.FakeLogFile(log)
         self._log_close_when_finished[log] = False
         fakelog.fakeData(header=header, stdout=stdout, stderr=stderr)
+
+    def set_run_interrupt(self):
+        self._waiting_for_interrupt = True
 
     def __repr__(self):
         return "FakeRemoteCommand(" + repr(self.remote_command) + "," + repr(self.args) + ")"
@@ -157,13 +175,14 @@ class Expect:
 
     """
 
-    def __init__(self, remote_command, args):
+    def __init__(self, remote_command, args, interrupted=False):
         """
         Expect a command named C{remote_command}, with args C{args}.
         """
         self.remote_command = remote_command
         self.args = args
         self.result = None
+        self.interrupted = interrupted
         self.behaviors = []
 
     @classmethod

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -411,6 +411,8 @@ class BuildStepMixin:
                 exp.raiseExpectationFailure(child_exp, e)
 
         if exp.shouldAssertCommandEqualExpectation():
+            self.assertEqual(exp.interrupted, command.interrupted)
+
             # first check any ExpectedRemoteReference instances
             exp_tup = (exp.remote_command, exp.args)
             if exp_tup != got:

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -411,11 +411,6 @@ class BuildStepMixin:
                 exp.raiseExpectationFailure(child_exp, e)
 
         if exp.shouldAssertCommandEqualExpectation():
-            # handle any incomparable args
-            for arg in exp.incomparable_args:
-                self.assertTrue(arg in got[1], "incomparable arg '{}' not received".format(arg))
-                del got[1][arg]
-
             # first check any ExpectedRemoteReference instances
             exp_tup = (exp.remote_command, exp.args)
             if exp_tup != got:

--- a/master/docs/manual/configuration/steps/file_transfer.rst
+++ b/master/docs/manual/configuration/steps/file_transfer.rst
@@ -167,6 +167,7 @@ The `uploadDone` method is called once for each uploaded file and can be used to
                 if numFiles:
                     self.addURL(self.url, '... %d more' % numFiles)
 
+For :bb:step:`MultipleFileUpload` the ``urlText=`` argument allows you to specify the url title that will be displayed in the web UI.
 
 .. bb:step:: StringDownload
 .. bb:step:: JSONStringDownload

--- a/master/docs/manual/configuration/steps/file_transfer.rst
+++ b/master/docs/manual/configuration/steps/file_transfer.rst
@@ -107,6 +107,8 @@ The ``maxsize`` and ``blocksize`` parameters are the same as for :bb:step:`FileU
 
 The optional ``compress`` argument can be given as ``'gz'`` or ``'bz2'`` to compress the datastream.
 
+For :bb:step:`DirectoryUpload` the ``urlText=`` argument allows you to specify the url title that will be displayed in the web UI.
+
 .. note::
 
    The permissions on the copied files will be the same on the master as originally on the worker, see option ``buildbot-worker create-worker --umask`` to change the default one.


### PR DESCRIPTION
This PR adds several improvements which were discovered while enhancing transfer steps:

 - Transfer step result was wrong in the case of step interruption.

 - urlText argument was not universally supported.

Also, the test framework enhanced to support step interruption and a number of new unit tests were written.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
