### PR TITLE
Docs: Add GNU make information on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ master/docs/buildbot.info-2
 .stgit-edit.txt
 .project
 .pydevproject
+.vscode
 .settings
 */build/
 master/docs/buildbot

--- a/master/docs/developer/quickstart.rst
+++ b/master/docs/developer/quickstart.rst
@@ -18,6 +18,9 @@ Create a Buildbot Python Environment
 ------------------------------------
 
 Buildbot uses Twisted `trial <http://twistedmatrix.com/trac/wiki/TwistedTrial>`_ to run its test suite.
+Windows users also need GNU make on their machines.
+The easiest way is to install it via choco package manager ``choco install make``.
+But WSL or MSYS2 is even a better option, because of integrated bash.
 
 Following is a quick shell session to put you on the right track, including running the test suite.
 

--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -26,8 +26,19 @@ Twisted: http://twistedmatrix.com
   In upcoming versions of Buildbot, a newer Twisted will also be required on the worker.
   As always, the most recent version is recommended.
 
+Certifi: https://github.com/certifi/python-certifi
+
+  Certifi provides collection of Root Certificates for validating the trustworthiness of SSL certificates. 
+  Unfortunately it does not support any addition of own company certificates.
+  At the moment you need to add your own .PEM content to cacert.pem manually.
+
 Of course, your project's build process will impose additional requirements on the workers.
 These hosts must have all the tools necessary to compile and test your project's source code.
+
+.. note::
+
+  If your internet connection is secured by a proxy server, please check your ``http_proxy`` and ``https_proxy`` environment variables.
+  Otherwise ``pip`` and other tools will fail to work.
 
 Windows Support
 ~~~~~~~~~~~~~~~
@@ -119,7 +130,7 @@ treq: https://github.com/twisted/treq
   +----------------------------------+------------+----------+
   | Unicode Response Bodies          | yes        | yes      |
   +----------------------------------+------------+----------+
-  | Multipart File Uploads           | yes        | yes      |
+  | Multi-part File Uploads          | yes        | yes      |
   +----------------------------------+------------+----------+
   | Connection Timeouts              | yes        | yes      |
   +----------------------------------+------------+----------+

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -123,6 +123,7 @@ bzr
 Bzr
 bzrignore
 CaaS
+cacert
 callables
 Callables
 called
@@ -136,6 +137,7 @@ canonicalize
 canStartBuild
 canStartWithWorkerForBuilder
 catchup
+Certifi
 cd
 cfg
 changehook

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -156,6 +156,7 @@ checkconfig
 checkConfig
 checkin
 childs
+choco
 chroot
 chroots
 ci
@@ -557,6 +558,7 @@ noticeOnChannel
 novaclient
 npm
 nullability
+nupkg
 oauth
 oAuth
 OAuth


### PR DESCRIPTION
GNU make is not part of the standard Windows installation. So the documentation should explain how to install it before starting with the Buildbot development environment.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
