### PR TITLE
steps: Reduce duplication by reintroducing ShellCommandNewStyle

### DIFF
--- a/master/buildbot/steps/python_twisted.py
+++ b/master/buildbot/steps/python_twisted.py
@@ -29,6 +29,7 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SKIPPED
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
+from buildbot.steps import shell
 
 
 class HLint(buildstep.ShellMixin, buildstep.BuildStep):
@@ -431,18 +432,8 @@ class Trial(buildstep.ShellMixin, buildstep.BuildStep):
                     stream, line = yield
 
 
-class RemovePYCs(buildstep.ShellMixin, buildstep.BuildStep):
+class RemovePYCs(shell.ShellCommandNewStyle):
     name = "remove_pyc"
     command = ['find', '.', '-name', "'*.pyc'", '-exec', 'rm', '{}', ';']
     description = "removing .pyc files"
     descriptionDone = "remove .pycs"
-
-    def __init__(self, **kwargs):
-        kwargs = self.setupShellMixin(kwargs, prohibitArgs=['command'])
-        super().__init__(**kwargs)
-
-    @defer.inlineCallbacks
-    def run(self):
-        cmd = yield self.makeRemoteShellCommand()
-        yield self.runCommand(cmd)
-        return cmd.results()

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -396,15 +396,8 @@ deprecatedModuleAttribute(Version("Buildbot", 0, 8, 8),
                           "buildbot.steps.shell", "SetProperty")
 
 
-class Configure(buildstep.ShellMixin, buildstep.BuildStep):
-
-    name = "configure"
-    haltOnFailure = 1
-    flunkOnFailure = 1
-    description = "configuring"
-    descriptionDone = "configure"
-    command = ["./configure"]
-
+class ShellCommandNewStyle(buildstep.ShellMixin, buildstep.BuildStep):
+    # This is a temporary class until old ShellCommand is retired
     def __init__(self, **kwargs):
         kwargs = self.setupShellMixin(kwargs)
         super().__init__(**kwargs)
@@ -414,6 +407,15 @@ class Configure(buildstep.ShellMixin, buildstep.BuildStep):
         cmd = yield self.makeRemoteShellCommand()
         yield self.runCommand(cmd)
         return cmd.results()
+
+
+class Configure(ShellCommandNewStyle):
+    name = "configure"
+    haltOnFailure = 1
+    flunkOnFailure = 1
+    description = "configuring"
+    descriptionDone = "configure"
+    command = ["./configure"]
 
 
 class WarningCountingShellCommand(ShellCommand, CompositeStepMixin):


### PR DESCRIPTION
It looks like for simple commands it's worth keeping ShellCommand. This PR reintroduces a shell command, but in new style. The original ShellCommand will be replaced by ShellCommandNewStyle in Buildbot v3.0.