### PR TITLE
Convert WarningCountingShellCommand and subclasses to new style

### DIFF
--- a/master/buildbot/newsfragments/new-style-steps-migration.removal
+++ b/master/buildbot/newsfragments/new-style-steps-migration.removal
@@ -8,8 +8,10 @@ The list of old-style steps that have been converted to new style:
 
  - ``BuildEPYDoc``
  - ``Configure``
+ - ``Compile``
  - ``CopyDirectory``
  - ``DebLintian``
+ - ``DebPbuilder``
  - ``DirectoryUpload``
  - ``FileDownload``
  - ``FileExists``
@@ -25,15 +27,18 @@ The list of old-style steps that have been converted to new style:
  - ``MockBuildSRPM``
  - ``MsBuild``, ``MsBuild4``, ``MsBuild12``, ``MsBuild14``, ``MsBuild141``
  - ``MultipleFileUpload``
+ - ``PerlModuleTest``
  - ``PyFlakes``
  - ``PyLint``
  - ``RemoveDirectory``
  - ``RemovePYCs``
+ - ``RpmLint``
  - ``RpmBuild``
  - ``SetPropertiesFromEnv``
  - ``SetPropertyFromCommand``
  - ``Sphinx``
  - ``StringDownload``
+ - ``Test``
  - ``TreeSize``
  - ``Trial``
  - ``VC6``, ``VC7``, ``VC8``, ``VC9``, ``VC10``, ``VC11``, ``VC12``, ``VC14``, ``VC141``

--- a/master/buildbot/steps/package/deb/pbuilder.py
+++ b/master/buildbot/steps/package/deb/pbuilder.py
@@ -22,12 +22,13 @@ import re
 import stat
 import time
 
+from twisted.internet import defer
 from twisted.python import log
 
 from buildbot import config
 from buildbot.process import logobserver
 from buildbot.process import remotecommand
-from buildbot.process.buildstep import FAILURE
+from buildbot.process import results
 from buildbot.steps.shell import WarningCountingShellCommand
 
 
@@ -128,15 +129,20 @@ class DebPbuilder(WarningCountingShellCommand):
         self.addLogObserver(
             'stdio', logobserver.LineConsumerLogObserver(self.logConsumer))
 
-    # Check for Basetgz
-    def start(self):
-        cmd = remotecommand.RemoteCommand('stat', {'file': self.basetgz})
-        d = self.runCommand(cmd)
-        d.addCallback(lambda res: self.checkBasetgz(cmd))
-        d.addErrback(self.failed)
-        return d
+    @defer.inlineCallbacks
+    def run(self):
+        res = yield self.checkBasetgz()
+        if res != results.SUCCESS:
+            return res
 
-    def checkBasetgz(self, cmd):
+        res = yield super().run()
+        return res
+
+    @defer.inlineCallbacks
+    def checkBasetgz(self):
+        cmd = remotecommand.RemoteCommand('stat', {'file': self.basetgz})
+        yield self.runCommand(cmd)
+
         if cmd.rc != 0:
             log.msg("basetgz not found, initializing it.")
 
@@ -154,12 +160,18 @@ class DebPbuilder(WarningCountingShellCommand):
 
             cmd = remotecommand.RemoteShellCommand(self.workdir, command)
 
-            stdio_log = stdio_log = self.addLog("pbuilder")
+            stdio_log = yield self.addLog("pbuilder")
             cmd.useLog(stdio_log, True, "stdio")
-            d = self.runCommand(cmd)
-            self.step_status.setText(["PBuilder create."])
-            d.addCallback(lambda res: self.startBuild(cmd))
-            return d
+
+            self.description = ["PBuilder", "create."]
+            yield self.updateSummary()
+
+            yield self.runCommand(cmd)
+            if cmd.rc != 0:
+                log.msg("Failure when running {}.".format(cmd))
+                return results.FAILURE
+            return results.SUCCESS
+
         s = cmd.updates["stat"][-1]
         # basetgz will be a file when running in pbuilder
         # and a directory in case of cowbuilder
@@ -172,24 +184,17 @@ class DebPbuilder(WarningCountingShellCommand):
                            self.baseOption, self.basetgz]
 
                 cmd = remotecommand.RemoteShellCommand(self.workdir, command)
-                stdio_log = stdio_log = self.addLog("pbuilder")
+                stdio_log = yield self.addLog("pbuilder")
                 cmd.useLog(stdio_log, True, "stdio")
-                d = self.runCommand(cmd)
-                d.addCallback(lambda res: self.startBuild(cmd))
-                return d
-            return self.startBuild(cmd)
-        else:
-            log.msg("{} is not a file or a directory.".format(self.basetgz))
-            self.finished(FAILURE)
-        return None
 
-    def startBuild(self, cmd):
-        if cmd.rc != 0:
-            log.msg("Failure when running {}.".format(cmd))
-            self.finished(FAILURE)
-        else:
-            return super().start()
-        return None
+                yield self.runCommand(cmd)
+                if cmd.rc != 0:
+                    log.msg("Failure when running {}.".format(cmd))
+                    return results.FAILURE
+            return results.SUCCESS
+
+        log.msg("{} is not a file or a directory.".format(self.basetgz))
+        return results.FAILURE
 
     def logConsumer(self):
         r = re.compile(r"dpkg-genchanges  >\.\./(.+\.changes)")

--- a/master/buildbot/steps/package/rpm/rpmlint.py
+++ b/master/buildbot/steps/package/rpm/rpmlint.py
@@ -65,7 +65,7 @@ class RpmLint(Test):
         self.obs = pkgutil.WEObserver()
         self.addLogObserver('stdio', self.obs)
 
-    def createSummary(self, log):
+    def createSummary(self):
         """
         Create nice summary logs.
 

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -139,7 +139,7 @@ class OldBuildEPYDoc(shell.ShellCommand):
             assert line in ('some\n', 'output\n')
 
 
-class OldPerlModuleTest(shell.Test):
+class OldPerlModuleTest(shell.ShellCommand):
 
     command = ['perl']
 

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -952,9 +952,9 @@ class WarningCountingShellCommand(steps.BuildStepMixin,
         # call addSuppression "manually" from a subclass
         class MyWCSC(shell.WarningCountingShellCommand):
 
-            def start(self):
+            def run(self):
                 self.addSuppression([('.*', '.*unseen.*', None, None)])
-                return super().start()
+                return super().run()
 
         def warningExtractor(step, line, match):
             return line.split(':', 2)
@@ -1091,26 +1091,29 @@ class Test(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
 
     def test_describe_not_done(self):
         step = self.setupStep(shell.Test())
+        step.results = SUCCESS
         step.rendered = True
-        self.assertEqual(step.describe(), None)
+        self.assertEqual(step.getResultSummary(), {'step': 'test'})
 
     def test_describe_done(self):
         step = self.setupStep(shell.Test())
         step.rendered = True
+        step.results = SUCCESS
         step.statistics['tests-total'] = 93
         step.statistics['tests-failed'] = 10
         step.statistics['tests-passed'] = 20
         step.statistics['tests-warnings'] = 30
-        self.assertEqual(step.describe(done=True),
-                         ['93 tests', '20 passed', '30 warnings', '10 failed'])
+        self.assertEqual(step.getResultSummary(),
+                         {'step': '93 tests 20 passed 30 warnings 10 failed'})
 
     def test_describe_done_no_total(self):
         step = self.setupStep(shell.Test())
         step.rendered = True
+        step.results = SUCCESS
         step.statistics['tests-total'] = 0
         step.statistics['tests-failed'] = 10
         step.statistics['tests-passed'] = 20
         step.statistics['tests-warnings'] = 30
         # describe calculates 60 = 10+20+30
-        self.assertEqual(step.describe(done=True),
-                         ['60 tests', '20 passed', '30 warnings', '10 failed'])
+        self.assertEqual(step.getResultSummary(),
+                         {'step': '60 tests 20 passed 30 warnings 10 failed'})


### PR DESCRIPTION
This just converts the step to new style without careful consideration of how subclasses could migrate to new style. Unfortunately this class is very intertwined with how LoggingBuildStep works. Perhaps we should create a WarningCountingShellMixin or something like that.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
