### PR TITLE
Add a step that stores diff info about a pull/merge request

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -394,6 +394,7 @@ dict
 dicts
 dicttype
 diff
+diffinfo
 diffs
 dir
 directoryenterpattern

--- a/master/buildbot/newsfragments/step-diff-info.feature
+++ b/master/buildbot/newsfragments/step-diff-info.feature
@@ -1,0 +1,1 @@
+Implement ``GitDiffInfo`` step that would extract information about what code has been changed in a pull/merge request.

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -542,6 +542,10 @@ class BuildStep(results.ResultComputingConfigMixin,
 
         return self.results
 
+    def setBuildData(self, name, value, source):
+        # returns a Deferred that yields nothing
+        yield self.master.data.updates.setBuildData(self.build.buildid, name, value, source)
+
     @defer.inlineCallbacks
     def _cleanup_logs(self):
         all_success = True

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -544,7 +544,7 @@ class BuildStep(results.ResultComputingConfigMixin,
 
     def setBuildData(self, name, value, source):
         # returns a Deferred that yields nothing
-        yield self.master.data.updates.setBuildData(self.build.buildid, name, value, source)
+        return self.master.data.updates.setBuildData(self.build.buildid, name, value, source)
 
     @defer.inlineCallbacks
     def _cleanup_logs(self):

--- a/master/buildbot/steps/gitdiffinfo.py
+++ b/master/buildbot/steps/gitdiffinfo.py
@@ -1,0 +1,99 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import json
+
+from twisted.internet import defer
+
+from buildbot import config
+from buildbot.process import buildstep
+from buildbot.process import logobserver
+from buildbot.process import results
+
+
+class GitDiffInfo(buildstep.ShellMixin, buildstep.BuildStep):
+    name = 'GitDiffInfo'
+    description = 'running GitDiffInfo'
+    descriptionDone = 'GitDiffInfo'
+
+    def __init__(self, compareToRef='master', dataName='diffinfo-master', **kwargs):
+        try:
+            from unidiff import PatchSet
+            [PatchSet]  # silence pylint
+        except ImportError:
+            config.error('unidiff package must be installed in order to use GitDiffInfo')
+
+        kwargs = self.setupShellMixin(kwargs, prohibitArgs=['command'])
+        super().__init__(**kwargs)
+        self._compare_to_ref = compareToRef
+        self._data_name = dataName
+        self._observer = logobserver.BufferLogObserver()
+
+    def _convert_hunk(self, hunk):
+        # TODO: build an intermediate class that would handle serialization. We want to output
+        # as few data as possible, even if the json is not human-readable
+        return {
+            'ss': hunk.source_start,
+            'sl': hunk.source_length,
+            'ts': hunk.target_start,
+            'tl': hunk.target_length,
+        }
+
+    def _convert_file(self, file):
+        return {
+            'source_file': file.source_file,
+            'target_file': file.target_file,
+            'is_binary': file.is_binary_file,
+            'is_rename': file.is_rename,
+            'hunks': [self._convert_hunk(hunk) for hunk in file]
+        }
+
+    def _convert_patchset(self, patchset):
+        return [self._convert_file(file) for file in patchset]
+
+    @defer.inlineCallbacks
+    def run(self):
+        command = ['git', 'merge-base', 'HEAD', self._compare_to_ref]
+        cmd = yield self.makeRemoteShellCommand(command=command, stdioLogName='stdio-merge-base',
+                                                collectStdout=True)
+
+        yield self.runCommand(cmd)
+        log = yield self.getLog("stdio-merge-base")
+        log.finish()
+
+        if cmd.results() != results.SUCCESS:
+            return cmd.results()
+
+        commit = cmd.stdout.strip()
+        self.setProperty('diffinfo-merge-base-commit', commit, 'GitDiffInfo')
+
+        self.addLogObserver('stdio-diff', self._observer)
+
+        command = ['git', 'diff', '--no-prefix', '-U0', commit, 'HEAD']
+        cmd = yield self.makeRemoteShellCommand(command=command, stdioLogName='stdio-diff')
+
+        yield self.runCommand(cmd)
+
+        if cmd.results() != results.SUCCESS:
+            return cmd.results()
+
+        from unidiff import PatchSet
+        patchset = PatchSet(self._observer.getStdout(), metadata_only=True)
+
+        data = json.dumps(self._convert_patchset(patchset)).encode('utf-8')
+        yield self.setBuildData(self._data_name, data, 'GitDiffInfo')
+
+        return cmd.results()

--- a/master/buildbot/test/unit/test_steps_git_diffinfo.py
+++ b/master/buildbot/test/unit/test_steps_git_diffinfo.py
@@ -1,0 +1,135 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from twisted.trial import unittest
+
+from buildbot.process import results
+from buildbot.steps import gitdiffinfo
+from buildbot.test.fake.remotecommand import Expect
+from buildbot.test.fake.remotecommand import ExpectShell
+from buildbot.test.util import steps
+from buildbot.test.util.misc import TestReactorMixin
+
+
+class TestDiffInfo(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+
+    def setUp(self):
+        self.setUpTestReactor()
+        return self.setUpBuildStep()
+
+    def tearDown(self):
+        return self.tearDownBuildStep()
+
+    def test_merge_base_failure(self):
+        self.setupStep(gitdiffinfo.GitDiffInfo())
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['git', 'merge-base', 'HEAD', 'master'])
+            + Expect.log('stdio-merge-base', stderr='fatal: Not a valid object name')
+            + 128)
+        self.expect_log_file_stderr('stdio-merge-base', 'fatal: Not a valid object name')
+        self.expectOutcome(result=results.FAILURE, state_string="GitDiffInfo (failure)")
+        return self.runStep()
+
+    def test_diff_failure(self):
+        self.setupStep(gitdiffinfo.GitDiffInfo())
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['git', 'merge-base', 'HEAD', 'master'])
+            + Expect.log('stdio-merge-base', stdout='1234123412341234')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'diff', '--no-prefix', '-U0', '1234123412341234', 'HEAD'])
+            + Expect.log('stdio-diff', stderr='fatal: ambiguous argument')
+            + 1,
+            )
+        self.expectLogfile('stdio-merge-base', '1234123412341234')
+        self.expect_log_file_stderr('stdio-diff', 'fatal: ambiguous argument')
+        self.expectOutcome(result=results.FAILURE, state_string="GitDiffInfo (failure)")
+        return self.runStep()
+
+    def test_empty_diff(self):
+        self.setupStep(gitdiffinfo.GitDiffInfo())
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['git', 'merge-base', 'HEAD', 'master'])
+            + Expect.log('stdio-merge-base', stdout='1234123412341234')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'diff', '--no-prefix', '-U0', '1234123412341234', 'HEAD'])
+            + Expect.log('stdio-diff', stdout='')
+            + 0,
+            )
+        self.expectLogfile('stdio-merge-base', '1234123412341234')
+        self.expect_log_file_stderr('stdio-diff', '')
+        self.expectOutcome(result=results.SUCCESS, state_string="GitDiffInfo")
+        self.expect_build_data('diffinfo-master', b'[]', 'GitDiffInfo')
+        return self.runStep()
+
+    def test_complex_diff(self):
+        self.setupStep(gitdiffinfo.GitDiffInfo())
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['git', 'merge-base', 'HEAD', 'master'])
+            + Expect.log('stdio-merge-base', stdout='1234123412341234')
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        command=['git', 'diff', '--no-prefix', '-U0', '1234123412341234', 'HEAD'])
+            + Expect.log('stdio-diff', stdout='''\
+diff --git file1 file1
+deleted file mode 100644
+index 42f90fd..0000000
+--- file1
++++ /dev/null
+@@ -1,3 +0,0 @@
+-line11
+-line12
+-line13
+diff --git file2 file2
+index c337bf1..1cb02b9 100644
+--- file2
++++ file2
+@@ -4,0 +5,3 @@ line24
++line24n
++line24n2
++line24n3
+@@ -15,0 +19,3 @@ line215
++line215n
++line215n2
++line215n3
+diff --git file3 file3
+new file mode 100644
+index 0000000..632e269
+--- /dev/null
++++ file3
+@@ -0,0 +1,3 @@
++line31
++line32
++line33
+''')
+            + 0,
+            )
+        self.expectLogfile('stdio-merge-base', '1234123412341234')
+        self.expectOutcome(result=results.SUCCESS, state_string="GitDiffInfo")
+
+        diff_info = (
+            b'[{"source_file": "file1", "target_file": "/dev/null", ' +
+            b'"is_binary": false, "is_rename": false, ' +
+            b'"hunks": [{"ss": 1, "sl": 3, "ts": 0, "tl": 0}]}, ' +
+            b'{"source_file": "file2", "target_file": "file2", ' +
+            b'"is_binary": false, "is_rename": false, ' +
+            b'"hunks": [{"ss": 4, "sl": 0, "ts": 5, "tl": 3}, ' +
+            b'{"ss": 15, "sl": 0, "ts": 19, "tl": 3}]}, ' +
+            b'{"source_file": "/dev/null", "target_file": "file3", ' +
+            b'"is_binary": false, "is_rename": false, ' +
+            b'"hunks": [{"ss": 0, "sl": 0, "ts": 1, "tl": 3}]}]')
+        self.expect_build_data('diffinfo-master', diff_info, 'GitDiffInfo')
+        return self.runStep()

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -258,6 +258,14 @@ class BuildStepMixin:
                                            duration_ns))
         step.addTestResult = add_test_result
 
+        self._got_build_data = {}
+
+        def set_build_data(name, value, source):
+            self._got_build_data[name] = (value, source)
+            return defer.succeed(None)
+
+        step.setBuildData = set_build_data
+
         # expectations
 
         self.exp_result = None
@@ -270,6 +278,7 @@ class BuildStepMixin:
         self.exp_exception = None
         self._exp_test_result_sets = []
         self._exp_test_results = []
+        self._exp_build_data = {}
 
         # check that the step's name is not None
         self.assertNotEqual(step.name, None)
@@ -312,6 +321,9 @@ class BuildStepMixin:
 
     def expect_log_file_stderr(self, logfile, contents):
         self._exp_logfiles_stderr[logfile] = contents
+
+    def expect_build_data(self, name, value, source):
+        self._exp_build_data[name] = (value, source)
 
     def expectHidden(self, hidden):
         """
@@ -408,6 +420,7 @@ class BuildStepMixin:
 
         self.assertEqual(self._exp_test_result_sets, self._got_test_result_sets)
         self.assertEqual(self._exp_test_results, self._got_test_results)
+        self.assertEqual(self._exp_build_data, self._got_build_data)
 
         # XXX TODO: hidden
         # self.step_status.setHidden.assert_called_once_with(self.exp_hidden)

--- a/master/docs/developer/cls-buildsteps.rst
+++ b/master/docs/developer/cls-buildsteps.rst
@@ -336,6 +336,16 @@ BuildStep
     Build steps have statistics, a simple key/value store of data which can later be aggregated over all steps in a build.
     Note that statistics are not preserved after a build is complete.
 
+    .. py:method:: setBuildData(self, name, value, source)
+
+        :param unicode name: the name of the data
+        :param bytestr value: the value of the data as ``bytes``.
+        :parma unicode source: the source of the data
+        :returns: Deferred
+
+    Builds can have transient data attached to them which allows steps to communicate to reporters and among themselves.
+    The data is a byte string, its interpretation depends on the particular step or reporter.
+
     .. py:method:: hasStatistic(stat)
 
         :param string stat: name of the statistic

--- a/master/docs/manual/configuration/steps/git_diffinfo.rst
+++ b/master/docs/manual/configuration/steps/git_diffinfo.rst
@@ -1,0 +1,122 @@
+.. bb:step:: GitDiffInfo
+
+.. _Step-GitDiffInfo:
+
+GitDiffInfo
++++++++++++
+
+The `GitDiffInfo` step gathers information about differences between the current revision and the last common ancestor of this revision and another commit or branch.
+This information is useful for various reporters to be able to identify new warnings that appear in newly modified code.
+The diff information is stored as a custom json as transient build data via ``setBuildData`` function.
+
+Currently only git repositories are supported.
+
+The class inherits the arguments accepted by ``ShellMixin`` except ``command``.
+
+Additionally, it accepts the following arguments:
+
+``compareToRef``
+    (Optional, string, defaults to ``master``)
+    The commit or branch identifying the revision to get the last common ancestor to.
+    In most cases, this will be the target branch of a pull or merge request.
+
+``dataName``
+    (Optional, string, defaults to ``diffinfo-master``)
+    The name of the build data to save the diff json to.
+
+Build data specification
+------------------------
+
+This section documents the format of the data produced by the ``GitDiffInfo`` step and put into build data.
+Any future steps performing the same operation on different version control systems should produce data in the same format.
+Likewise, all consumers should expect the input data to be in the format as documented here.
+
+Conceptually, the diffinfo data is a list of file changes, each of which itself contain a list of diff hunks within that file.
+
+This data is stored as a JSON document.
+
+The root element is a list of objects, each of which represent a file where changes have been detected.
+Each of these **file** objects has the following keys:
+
+- ``source_file`` - a string representing path to the source file.
+  This does not include any prefixes such as ``a/``.
+  When there is no source file, e.g. when a new file is created, ``/dev/null`` is used.
+
+- ``target_file`` - a string representing path to the target file.
+  This does not include any prefixes such as ``b/``.
+  When there is no target file, e.g. when a file has been deleted, ``/dev/null`` is used.
+
+- ``is_binary`` - a boolean specifying whether this is a binary file or not.
+  Changes in binary files are not interpreted as hunks.
+
+- ``is_rename`` - a boolean specifying whether this file has been renamed
+
+- ``hunks`` - a list of objects (described below) specifying individual changes within the file.
+
+Each of the **hunk** objects has the following keys:
+
+- ``ss`` - an integer specifying the start line of the diff hunk in the source file
+
+- ``sl`` - an integer specifying the length of the hunk in the source file as a number of lines
+
+- ``ts`` - an integer specifying the start line of the diff hunk in the target file
+
+- ``tl`` - an integer specifying the length of the hunk in the target file as a number lines
+
+Example of produced build data
+------------------------------
+
+The following shows build data that is produced for a deleted file, a changed file and a new file.
+
+.. code-block:: python
+
+    [
+      {
+        "source_file": "file1",
+        "target_file": "/dev/null",
+        "is_binary": false,
+        "is_rename": false,
+        "hunks": [
+          {
+            "ss": 1,
+            "sl": 3,
+            "ts": 0,
+            "tl": 0
+          }
+        ]
+      },
+      {
+        "source_file": "file2",
+        "target_file": "file2",
+        "is_binary": false,
+        "is_rename": false,
+        "hunks": [
+          {
+            "ss": 4,
+            "sl": 0,
+            "ts": 5,
+            "tl": 3
+          },
+          {
+            "ss": 15,
+            "sl": 0,
+            "ts": 19,
+            "tl": 3
+          }
+        ]
+      },
+      {
+        "source_file": "/dev/null",
+        "target_file": "file3",
+        "is_binary": false,
+        "is_rename": false,
+        "hunks": [
+          {
+            "ss": 0,
+            "sl": 0,
+            "ts": 1,
+            "tl": 3
+          }
+        ]
+      }
+    ]

--- a/master/docs/manual/configuration/steps/index.rst
+++ b/master/docs/manual/configuration/steps/index.rst
@@ -24,6 +24,7 @@ Build Steps
     gitcommit
     gittag
     gitpush
+    git_diffinfo
     shell_command
     shell_sequence
     compile
@@ -120,6 +121,7 @@ The following build steps are available:
     * :ref:`Step-GitCommit`
     * :ref:`Step-GitTag`
     * :ref:`Step-GitPush`
+    * :ref:`Step-GitDiffInfo`
 
 * **ShellCommand steps** - used to perform various shell-based operations
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -256,6 +256,7 @@ dicts
 didn
 didn
 diff
+diffinfo
 diffs
 dirname
 dirwatcher

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -83,6 +83,7 @@ treq==20.9.0
 Twisted==21.2.0
 txaio==21.2.1
 txrequests==0.9.6
+unidiff==0.6.0
 webcolors==1.11.1
 Werkzeug==1.0.1
 wrapt==1.12.1


### PR DESCRIPTION
This step will be useful for reporters to know which warnings have been generated in changed code.

I think for now let's not merge the PR, it will become clear whether it works well enough or not once I'll have some reporters that could consume the data and will test everything end to end.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
