### PR TITLE
Fix bad fieldMapping in change data endpoint

### DIFF
--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -41,7 +41,7 @@ class FixerMixin:
             del change['sourcestampid']
         return change
     fieldMapping = {
-        'changeid': 'changes.id',
+        'changeid': 'changes.changeid',
     }
 
 

--- a/master/buildbot/newsfragments/datachanges.bugfix
+++ b/master/buildbot/newsfragments/datachanges.bugfix
@@ -1,0 +1,1 @@
+fix 100% CPU on large installs when looking using the changes api (:issue:`5504`)

--- a/master/buildbot/test/unit/db/test_changes.py
+++ b/master/buildbot/test/unit/db/test_changes.py
@@ -19,6 +19,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.data import resultspec
+from buildbot.data.changes import FixerMixin
 from buildbot.db import builds
 from buildbot.db import changes
 from buildbot.db import sourcestamps
@@ -277,7 +278,7 @@ class Tests(interfaces.InterfaceTests):
     def test_getChanges_subset(self):
         yield self.insert7Changes()
         rs = resultspec.ResultSpec(order=['-changeid'], limit=5)
-        rs.fieldMapping = {'changeid': 'changes.changeid'}
+        rs.fieldMapping = FixerMixin.fieldMapping
         changes = yield self.db.changes.getChanges(resultSpec=rs)
         changeids = [c['changeid'] for c in changes]
         self.assertEqual(changeids, [10, 11, 12, 13, 14])


### PR DESCRIPTION
This resulted in 100% CPU for large installs as the data filtered manually by python

Correct the test so that the actual fieldMapping is tested

Fix: #5504
