### PR TITLE
fix github webhook expecting data from unsuccessful API calls

### DIFF
--- a/master/buildbot/newsfragments/fix-github-webhook-handler.bugfix
+++ b/master/buildbot/newsfragments/fix-github-webhook-handler.bugfix
@@ -1,0 +1,1 @@
+fix GitHub webhook event handler when no token has been set


### PR DESCRIPTION
The change #5300 does not check for an error code from GitHub and will break when trying to read the filenames from what it assumes is a successful API request. I don't know if these APIs work if there is no token provided (how I am running buildbot), and instead of optionally including the authorization it probably should bail immediately. This change will at least respect the status code from GitHub. However I don't know if there are any implications of the commit message being the replacement string or the files being an empty list.

The APIs in question are: 
- happens to work, but changed to check the response code: https://docs.github.com/en/rest/reference/repos#get-a-commit
- broken (expects an array, but gets a dict which iterates its keys): https://docs.github.com/rest/reference/pulls#list-pull-requests-files

HTTP tracing logs:

```
http https://api.github.com/repos/nexleaf/NexleafDP/commits/ac8a90c90b26cef97a9ee3e80214d24e1d5bd83a {'headers': {'User-Agent': 'Buildbot'}}
==> 404: b'{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#get-a-commit"}'
http https://api.github.com/repos/nexleaf/NexleafDP/pulls/1761/files {'headers': {'User-Agent': 'Buildbot'}}
==> 404: b'{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/pulls#list-pull-requests-files"}'
```

The error I recieved:

```
...
   File "/var/lib/buildbot/master.cfg", line 1045, in _get_pr_files
     return [f["filename"] for f in data]
   File "/var/lib/buildbot/master.cfg", line 1045, in <listcomp>
     return [f["filename"] for f in data]
 builtins.TypeError: string indices must be integers

```

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
