### PR TITLE
Add release notes of 2.8.3 and 2.8.4 to master and update releasing procedure

### DIFF
--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -10,7 +10,9 @@ Step 1: Verify that external dependants can be built
 Verify that the following resources can be built from the latest master.
 This can be checked by looking into the dashboards (maintainer access may be needed).
 
- - Docker Hub (https://hub.docker.com/repository/docker/buildbot/buildbot-master/general)
+ - Docker Hub (buildbot-master) (https://hub.docker.com/repository/docker/buildbot/buildbot-master/general)
+
+ - Docker Hub (buildbot-worker) (https://hub.docker.com/repository/docker/buildbot/buildbot-worker/general)
 
  - Read the Docs (https://readthedocs.org/projects/buildbot/builds/)
 

--- a/master/buildbot/newsfragments/datachanges.bugfix
+++ b/master/buildbot/newsfragments/datachanges.bugfix
@@ -1,1 +1,0 @@
-fix 100% CPU on large installs when looking using the changes api (:issue:`5504`)

--- a/master/buildbot/newsfragments/docker-fix-master-image.bugfix
+++ b/master/buildbot/newsfragments/docker-fix-master-image.bugfix
@@ -1,1 +1,0 @@
-Fix Docker image building for the master which failed due to mismatching versions of Alpine (:issue:`5469`).

--- a/master/buildbot/newsfragments/handle-default-codebase-in-gerrit.bugfix
+++ b/master/buildbot/newsfragments/handle-default-codebase-in-gerrit.bugfix
@@ -1,2 +1,0 @@
-Work around incomplete support for codebases in GerritChangeSource (:issue:`5190`). This avoids an internal assertion when the configuration file does not specify any codebases.
-

--- a/master/buildbot/newsfragments/vs2017-entry-points.bugfix
+++ b/master/buildbot/newsfragments/vs2017-entry-points.bugfix
@@ -1,1 +1,0 @@
-Add missing VS2017 entry_points

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -10,6 +10,17 @@ Release Notes
 
 .. towncrier release notes start
 
+Buildbot ``2.8.4`` ( ``2020-08-29`` )
+=====================================
+
+Bug fixes
+---------
+
+- Fix 100% CPU on large installations when using the changes API (:issue:`5504`)
+- Work around incomplete support for codebases in ``GerritChangeSource`` (:issue:`5190`). This avoids an internal assertion when the configuration file does not specify any codebases.
+- Add missing VS2017 entry points.
+
+
 Buildbot ``2.8.3`` ( ``2020-08-22`` )
 =====================================
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -10,6 +10,15 @@ Release Notes
 
 .. towncrier release notes start
 
+Buildbot ``2.8.3`` ( ``2020-08-22`` )
+=====================================
+
+Bug fixes
+---------
+
+- Fix Docker image building for the master which failed due to mismatching versions of Alpine (:issue:`5469`).
+
+
 Buildbot ``2.8.2`` ( ``2020-06-14`` )
 =====================================
 


### PR DESCRIPTION
We should include release notes of 2.8.3 and 2.8.4 when we release 2.9.0 some time in the future.