### PR TITLE
Makefile: Don't run smoke tests before releasing to pypi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,6 @@ finishrelease:
 	rm -rf dist
 	python3 ./common/download_release.py
 	rm -rf ./dist/v*
-	./common/smokedist.sh
 	twine upload --sign dist/*
 
 pyinstaller: virtualenv


### PR DESCRIPTION
We have smoke tests on CI which we check before making a release. Therefore running smoke tests locally before releasing is not necessary. The testing is being done after the bulk of the release actions have been done anyway, so it does not bring a lot of value.