### PR TITLE
reporters: Make wanted details an explicit argument list

### DIFF
--- a/master/buildbot/reporters/gerrit_verify_status.py
+++ b/master/buildbot/reporters/gerrit_verify_status.py
@@ -35,7 +35,6 @@ log = Logger()
 
 class GerritVerifyStatusPush(http.HttpStatusPushBase):
     name = "GerritVerifyStatusPush"
-    neededDetails = dict(wantProperties=True)
     # overridable constants
     RESULTS_TABLE = {
         SUCCESS: 1,
@@ -59,9 +58,10 @@ class GerritVerifyStatusPush(http.HttpStatusPushBase):
                         category=None,
                         reporter=None,
                         verbose=False,
+                        wantProperties=True,
                         **kwargs):
         auth = yield self.renderSecrets(auth)
-        yield super().reconfigService(**kwargs)
+        yield super().reconfigService(wantProperties=wantProperties, **kwargs)
 
         if baseURL.endswith('/'):
             baseURL = baseURL[:-1]

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -37,14 +37,13 @@ HOSTED_BASE_URL = 'https://api.github.com'
 
 class GitHubStatusPush(http. HttpStatusPushBase):
     name = "GitHubStatusPush"
-    neededDetails = dict(wantProperties=True)
 
     @defer.inlineCallbacks
     def reconfigService(self, token,
                         startDescription=None, endDescription=None,
-                        context=None, baseURL=None, verbose=False, **kwargs):
+                        context=None, baseURL=None, verbose=False, wantProperties=True, **kwargs):
         token = yield self.renderSecrets(token)
-        yield super().reconfigService(**kwargs)
+        yield super().reconfigService(wantProperties=wantProperties, **kwargs)
 
         self.setDefaults(context, startDescription, endDescription)
         if baseURL is None:
@@ -202,7 +201,6 @@ class GitHubStatusPush(http. HttpStatusPushBase):
 
 class GitHubCommentPush(GitHubStatusPush):
     name = "GitHubCommentPush"
-    neededDetails = dict(wantProperties=True)
 
     def setDefaults(self, context, startDescription, endDescription):
         self.context = ''

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -36,15 +36,14 @@ HOSTED_BASE_URL = 'https://gitlab.com'
 
 class GitLabStatusPush(http.HttpStatusPushBase):
     name = "GitLabStatusPush"
-    neededDetails = dict(wantProperties=True)
 
     @defer.inlineCallbacks
     def reconfigService(self, token,
                         startDescription=None, endDescription=None,
-                        context=None, baseURL=None, verbose=False, **kwargs):
+                        context=None, baseURL=None, verbose=False, wantProperties=True, **kwargs):
 
         token = yield self.renderSecrets(token)
-        yield super().reconfigService(**kwargs)
+        yield super().reconfigService(wantProperties=wantProperties, **kwargs)
 
         self.context = context or Interpolate('buildbot/%(prop:buildername)s')
         self.startDescription = startDescription or 'Build started.'

--- a/master/buildbot/reporters/hipchat.py
+++ b/master/buildbot/reporters/hipchat.py
@@ -51,7 +51,10 @@ class HipChatStatusPush(HttpStatusPushBase):
 
     @defer.inlineCallbacks
     def getBuildDetailsAndSendMessage(self, build, key):
-        yield utils.getDetailsForBuild(self.master, build, **self.neededDetails)
+        yield utils.getDetailsForBuild(self.master, build, wantProperties=self.wantProperties,
+                                       wantSteps=self.wantSteps,
+                                       wantPreviousBuild=self.wantPreviousBuild,
+                                       wantLogs=self.wantLogs)
         postData = yield self.getRecipientList(build, key)
         postData['message'] = yield self.getMessage(build, key)
         extra_params = yield self.getExtraParams(build, key)

--- a/master/buildbot/reporters/zulip.py
+++ b/master/buildbot/reporters/zulip.py
@@ -26,7 +26,6 @@ log = Logger()
 
 class ZulipStatusPush(HttpStatusPushBase):
     name = "ZulipStatusPush"
-    neededDetails = dict(wantProperties=True)
 
     def checkConfig(self, endpoint, token, stream=None, **kwargs):
         if not isinstance(endpoint, str):
@@ -36,8 +35,8 @@ class ZulipStatusPush(HttpStatusPushBase):
         super().checkConfig(**kwargs)
 
     @defer.inlineCallbacks
-    def reconfigService(self, endpoint, token, stream=None, **kwargs):
-        super().reconfigService(**kwargs)
+    def reconfigService(self, endpoint, token, stream=None, wantProperties=True, **kwargs):
+        super().reconfigService(wantProperties=wantProperties, **kwargs)
         self._http = yield httpclientservice.HTTPClientService.getService(
             self.master, endpoint,
             debug=self.debug, verify=self.verify)


### PR DESCRIPTION
This will help refactoring later, as the details arguments will be explicit and roughly match the API exposed by `NotifierBase`.

neededDetails is not documented anywhere, so we're free to change it as it's an internal detail.