### PR TITLE
2.8: fix github status breaking on Nightly scheduler sourcestamps

### DIFF
--- a/master/buildbot/newsfragments/fix-github-status-errors.bugfix
+++ b/master/buildbot/newsfragments/fix-github-status-errors.bugfix
@@ -1,0 +1,1 @@
+Fixed :py:class:`~GitHubStatusPush` logging an error when triggered by the NightlyScheduler

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -127,23 +127,28 @@ class GitHubStatusPush(http.HttpStatusPushBase):
             return
 
         for sourcestamp in sourcestamps:
-            project = sourcestamp['project']
-
             issue = None
-            if 'branch' in props:
-                m = re.search(r"refs/pull/([0-9]*)/merge", props['branch'])
+            branch = props.getProperty('branch')
+            if branch:
+                m = re.search(r"refs/pull/([0-9]*)/merge", branch)
                 if m:
                     issue = m.group(1)
 
             repo_owner = None
             repo_name = None
-            if "/" in project:
+            project = sourcestamp['project']
+            repository = sourcestamp['repository']
+            if project and "/" in project:
                 repo_owner, repo_name = project.split('/')
-            else:
-                giturl = giturlparse(sourcestamp['repository'])
+            elif repository:
+                giturl = giturlparse(repository)
                 if giturl:
                     repo_owner = giturl.owner
                     repo_name = giturl.repo
+
+            if not repo_owner or not repo_name:
+                log.msg('Skipped status update because required repo information is missing.')
+                continue
 
             sha = sourcestamp['revision']
             response = None

--- a/master/buildbot/test/unit/test_reporter_github.py
+++ b/master/buildbot/test/unit/test_reporter_github.py
@@ -117,6 +117,40 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
         self.sp.buildFinished(("build", 20, "finished"), build)
 
     @defer.inlineCallbacks
+    def test_source_stamp_no_props_nightly_scheduler(self):
+        # no status updates are expected
+
+        self.master.db.insertTestData([
+            fakedb.Master(id=92),
+            fakedb.Worker(id=13, name='wrk'),
+            fakedb.Builder(id=79, name='Builder0'),
+            fakedb.Buildset(id=98, results=SUCCESS, reason="test_reason1"),
+            fakedb.BuildsetSourceStamp(buildsetid=98, sourcestampid=234),
+            fakedb.SourceStamp(id=234, project=None, branch=None, revision=None,
+                               repository=None, codebase=None),
+            fakedb.BuildRequest(id=11, buildsetid=98, builderid=79),
+            fakedb.Build(id=20, number=0, builderid=79, buildrequestid=11,
+                         workerid=13, masterid=92, results=SUCCESS, state_string="build_text"),
+            fakedb.BuildProperty(buildid=20, name="workername", value="wrk"),
+            fakedb.BuildProperty(buildid=20, name="reason", value="because"),
+            fakedb.BuildProperty(buildid=20, name="buildername", value="Builder0"),
+            fakedb.BuildProperty(buildid=20, name="branch", value=None),
+            fakedb.BuildProperty(buildid=20, name="codebase", value=""),
+            fakedb.BuildProperty(buildid=20, name="project", value=""),
+            fakedb.BuildProperty(buildid=20, name="repository", value=""),
+            fakedb.BuildProperty(buildid=20, name="revision", value=None),
+        ])
+
+        build = yield self.master.data.get(("builds", 20))
+
+        build['complete'] = False
+        self.sp.buildStarted(("build", 20, "started"), build)
+        build['complete'] = True
+        self.sp.buildFinished(("build", 20, "finished"), build)
+        build['results'] = SUCCESS
+        self.sp.buildFinished(("build", 20, "finished"), build)
+
+    @defer.inlineCallbacks
     def test_multiple_source_stamps_no_props(self):
         repository = 'http://test_repo'
         project = 'test_user/test_project'


### PR DESCRIPTION
This is a backport of #5507.