### PR TITLE
worker: Don't reuse the started latent worker when it's incompatible

### DIFF
--- a/master/buildbot/newsfragments/incompatible-worker-reused.bugfix
+++ b/master/buildbot/newsfragments/incompatible-worker-reused.bugfix
@@ -1,0 +1,1 @@
+Latent workers don't reuse the started worker when it's incompatible with the requested build.

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -84,6 +84,12 @@ class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
         self.assertEqual(bs.command, [])
 
     @defer.inlineCallbacks
+    def test_builds_may_be_incompatible(self):
+        # Minimal set of parameters
+        bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')
+        self.assertEqual(bs.builds_may_be_incompatible, True)
+
+    @defer.inlineCallbacks
     def test_contruction_minimal_docker_py(self):
         docker.version = "1.10.6"
         bs = yield self.setupWorker('bot', 'pass', 'tcp://1234:2375', 'worker')

--- a/master/buildbot/test/unit/worker/test_kubernetes.py
+++ b/master/buildbot/test/unit/worker/test_kubernetes.py
@@ -73,6 +73,12 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
         return self.setupWorker('worker')
 
     @defer.inlineCallbacks
+    def test_builds_may_be_incompatible(self):
+        yield self.setupWorker('worker')
+        # http is lazily created on worker substantiation
+        self.assertEqual(self.worker.builds_may_be_incompatible, True)
+
+    @defer.inlineCallbacks
     def test_start_service(self):
         yield self.setupWorker('worker')
         # http is lazily created on worker substantiation

--- a/master/buildbot/test/unit/worker/test_marathon.py
+++ b/master/buildbot/test/unit/worker/test_marathon.py
@@ -63,6 +63,12 @@ class TestMarathonLatentWorker(unittest.TestCase, TestReactorMixin):
         return worker
 
     @defer.inlineCallbacks
+    def test_builds_may_be_incompatible(self):
+        worker = self.worker = yield self.makeWorker()
+        # http is lazily created on worker substantiation
+        self.assertEqual(worker.builds_may_be_incompatible, True)
+
+    @defer.inlineCallbacks
     def test_start_service(self):
         worker = self.worker = yield self.makeWorker()
         # http is lazily created on worker substantiation

--- a/master/buildbot/test/unit/worker/test_openstack.py
+++ b/master/buildbot/test/unit/worker/test_openstack.py
@@ -87,6 +87,13 @@ class TestOpenStackWorker(TestReactorMixin, unittest.TestCase):
         self.assertIsInstance(bs.novaclient, novaclient.Client)
 
     @defer.inlineCallbacks
+    def test_builds_may_be_incompatible(self):
+        # Minimal set of parameters
+        bs = yield self.setupWorker(
+            'bot', 'pass', **self.bs_image_args)
+        self.assertEqual(bs.builds_may_be_incompatible, True)
+
+    @defer.inlineCallbacks
     def test_constructor_minimal_keystone_v3(self):
         bs = yield self.setupWorker(
             'bot', 'pass', os_user_domain='test_oud', os_project_domain='test_opd',

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -126,8 +126,8 @@ class DockerBaseWorker(AbstractLatentWorker):
             return fqdn
 
 
-class DockerLatentWorker(DockerBaseWorker,
-                         CompatibleLatentWorkerMixin):
+class DockerLatentWorker(CompatibleLatentWorkerMixin,
+                         DockerBaseWorker):
     instance = None
 
     def checkConfig(self, name, password, docker_host, image=None,

--- a/master/buildbot/worker/kubernetes.py
+++ b/master/buildbot/worker/kubernetes.py
@@ -24,10 +24,10 @@ from buildbot.worker.docker import DockerBaseWorker
 log = Logger()
 
 
-class KubeLatentWorker(DockerBaseWorker, CompatibleLatentWorkerMixin):
+class KubeLatentWorker(CompatibleLatentWorkerMixin,
+                       DockerBaseWorker):
 
     instance = None
-    builds_may_be_incompatible = True
 
     @defer.inlineCallbacks
     def getPodSpec(self, build):

--- a/master/buildbot/worker/marathon.py
+++ b/master/buildbot/worker/marathon.py
@@ -26,8 +26,8 @@ from buildbot.worker.docker import DockerBaseWorker
 log = Logger()
 
 
-class MarathonLatentWorker(DockerBaseWorker,
-                           CompatibleLatentWorkerMixin):
+class MarathonLatentWorker(CompatibleLatentWorkerMixin,
+                           DockerBaseWorker):
     """Marathon is a distributed docker container launcher for Mesos"""
     instance = None
     image = None

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -46,8 +46,8 @@ DELETED = 'DELETED'
 UNKNOWN = 'UNKNOWN'
 
 
-class OpenStackLatentWorker(AbstractLatentWorker,
-                            CompatibleLatentWorkerMixin):
+class OpenStackLatentWorker(CompatibleLatentWorkerMixin,
+                            AbstractLatentWorker):
 
     instance = None
     _poll_resolution = 5  # hook point for tests


### PR DESCRIPTION
When a LatentWorker is substanciated, it is reused even when the build properties are not compatible.
For example, if the Docker image name is set using build properties. When one worker is started, even if the newer build uses a different Docker image, the old one will get reused and obviously fail.

This is due to an error when specifying inheritance in various LatentWorker.
For example with DockerLatentWorker, the MRO used by Python 3 will be : DockerLatentWorker, DockerBaseWorker, AbstractLatentWorker, AbstractWorker, CompatibleLatentWorkerMixin.
With this fix it becomes: CompatibleLatentWorkerMixin, DockerLatentWorker, DockerBaseWorker, AbstractLatentWorker, AbstractWorker.
This lets builds_may_be_incompatible and isCompatibleWithBuild to be taken from CompatibleLatentWorkerMixin as it's intended.

I don't see which part of the documentation should be updated.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
