### PR TITLE
Fix latent workers reject builds for prop mismatch

### DIFF
--- a/master/buildbot/test/fake/docker.py
+++ b/master/buildbot/test/fake/docker.py
@@ -19,6 +19,7 @@ version = "1.10.6"
 
 class Client:
     latest = None
+    containerCreated = False
 
     def __init__(self, base_url):
         Client.latest = self
@@ -30,6 +31,9 @@ class Client:
         self._pullable = ['alpine:latest', 'tester:latest']
         self._pullCount = 0
         self._containers = {}
+
+        if Client.containerCreated:
+            self.create_container("some-default-image")
 
     def images(self):
         return self._images

--- a/master/buildbot/util/latent.py
+++ b/master/buildbot/util/latent.py
@@ -40,6 +40,9 @@ class CompatibleLatentWorkerMixin:
         self._actual_build_props = copy.deepcopy(props)
         defer.returnValue(props)
 
+    def resetWorkerPropsOnStop(self):
+        self._actual_build_props = None
+
     @defer.inlineCallbacks
     def isCompatibleWithBuild(self, build):
         if self._actual_build_props is None:

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -333,6 +333,7 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
             return defer.succeed(None)
         instance = self.instance
         self.instance = None
+        self.resetWorkerPropsOnStop()
         return threads.deferToThread(self._thd_stop_instance, instance, fast)
 
     def _thd_stop_instance(self, instance, fast):

--- a/master/buildbot/worker/kubernetes.py
+++ b/master/buildbot/worker/kubernetes.py
@@ -115,6 +115,7 @@ class KubeLatentWorker(CompatibleLatentWorkerMixin,
     @defer.inlineCallbacks
     def stop_instance(self, fast=False, reportFailure=True):
         self.current_pod_spec = None
+        self.resetWorkerPropsOnStop()
         try:
             yield self._kube.deletePod(self.namespace, self.getContainerName())
         except kubeclientservice.KubeError as e:

--- a/master/buildbot/worker/marathon.py
+++ b/master/buildbot/worker/marathon.py
@@ -112,6 +112,7 @@ class MarathonLatentWorker(CompatibleLatentWorkerMixin,
         res = yield self._http.delete("/v2/apps/{}".format(
             self.getApplicationId()))
         self.instance = None
+        self.resetWorkerPropsOnStop()
 
         if res.code != 200 and reportFailure:
             res_json = yield res.json()

--- a/master/buildbot/worker/openstack.py
+++ b/master/buildbot/worker/openstack.py
@@ -315,6 +315,7 @@ class OpenStackLatentWorker(CompatibleLatentWorkerMixin,
             return defer.succeed(None)
         instance = self.instance
         self.instance = None
+        self.resetWorkerPropsOnStop()
         self._stop_instance(instance, fast)
         return None
 


### PR DESCRIPTION
This is a request of comments, because the logic of LatentWorker is quite complicated and I honestly cannot claim to understand it all in its depth. The issue this is trying to fix is as follows:

When a LatentWorker is taken down it does not clear its property list.
Then, when a new build tries to be scheduled on that worker it might be
rejected for a property mismatch, even though it would match because the
properties would be recreated when the latent worker is prepared for the
new build.

Note, that this is only an issue when the latent worker has been stopped
and the underlying instance, e.g. docker container, has been destroyed.
Otherwise, the worker would be correct to reject the not-matching build.

This has fixed an issue that we have been seeing with DockerLatentWorker, were workers had been scheduled with builds and then suddenly they wouldn't accept any new builds until Buildbot had been restarted.

## Contributor Checklist:

I will do these once I know that the general idea of this patch is valid:
* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
