### PR TITLE
Fix waterfall setting show_old_builders

### DIFF
--- a/master/buildbot/newsfragments/inactive_hide_waterfall.bugfix
+++ b/master/buildbot/newsfragments/inactive_hide_waterfall.bugfix
@@ -1,0 +1,1 @@
+Make sure old builders are shown in the waterfall if the setting ``show_old_builders`` is ``True``, and not if it is ``False``.

--- a/www/waterfall_view/src/module/main.module.js
+++ b/www/waterfall_view/src/module/main.module.js
@@ -122,7 +122,7 @@ var WaterfallController = (function() {
                 } else {
                     this.$scope.builders = (this.builders = this.dataProcessorService.filterBuilders(this.all_builders));
                 }
-                if (this.s.show_old_builders.value) {
+                if (!this.s.show_old_builders.value) {
                     const ret = [];
                     for (let builder of this.$scope.builders) {
                         if (this.hasActiveMaster(builder)) {
@@ -722,7 +722,7 @@ var WaterfallController = (function() {
             } else {
                 this.$scope.builders = (this.builders = this.dataProcessorService.filterBuilders(this.all_builders));
             }
-            if (this.s.show_old_builders.value) {
+            if (!this.s.show_old_builders.value) {
                 const ret = [];
                 for (let builder of this.$scope.builders) {
                     if (this.hasActiveMaster(builder)) {


### PR DESCRIPTION
This fixes a boolean error in #4957 which shows old builders in the waterfall iff the setting show_old_builders is off, and not iff it is on.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
