### PR TITLE
www: add the ability to easily copy build properties to the clipboard

### DIFF
--- a/master/buildbot/newsfragments/copy-build-properties-to-clipboard.feature
+++ b/master/buildbot/newsfragments/copy-build-properties-to-clipboard.feature
@@ -1,0 +1,1 @@
+Add the ability to copy build properties to the clipboard.

--- a/www/base/src/app/common/directives/properties/properties.directive.js
+++ b/www/base/src/app/common/directives/properties/properties.directive.js
@@ -5,10 +5,30 @@ class Properties {
             restrict: 'E',
             scope: {properties: '='},
             template: require('./properties.tpl.jade'),
+            controller: '_propertiesController',
         };
+    }
+}
+
+function _properties($scope) {
+    $scope.copy = function(value) {
+        value = JSON.stringify(value);
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(value);
+        } else {
+            var element = document.createElement('textarea');
+            element.style = 'position:absolute; width:1px; height:1px; top:-10000px; left:-10000px';
+            element.value = value;
+            document.body.appendChild(element);
+            element.select();
+            document.execCommand('copy');
+            document.body.removeChild(element);
+        }
     }
 }
 
 
 angular.module('common')
-.directive('properties', [Properties]);
+.directive('properties', [Properties])
+.controller('_propertiesController', ['$scope', _properties]);

--- a/www/base/src/app/common/directives/properties/properties.tpl.jade
+++ b/www/base/src/app/common/directives/properties/properties.tpl.jade
@@ -8,6 +8,7 @@ table.table.table-hover.table-striped.table-condensed
     tr(ng-repeat="(name, value) in properties | publicFields")
       td.text-left {{ name }}
       td.text-left
-        pre(style="padding:unset; margin:unset; border:unset; background-color:unset")
+        pre(style="vertical-align:top; padding:unset; margin:unset; display:inline-block; border:unset; background-color:unset")
             | {{ value[0] | json }}
+        i.fa.fa-copy.clickable(style="vertical-align:top; padding:0 0.5ex" ng-click="copy(value[0])")
       td.text-right {{ value[1] }}


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
