### PR TITLE
Fix inconsistent REST api, buildid vs build_number, see #3427

### DIFF
--- a/master/buildbot/data/changes.py
+++ b/master/buildbot/data/changes.py
@@ -58,11 +58,12 @@ class ChangeEndpoint(FixerMixin, base.Endpoint):
         return d
 
 
-class ChangesEndpoint(FixerMixin, base.Endpoint):
+class ChangesEndpoint(FixerMixin, base.BuildNestingMixin, base.Endpoint):
 
     isCollection = True
     pathPatterns = """
         /changes
+        /builders/n:builderid/builds/n:build_number/changes
         /builds/n:buildid/changes
         /sourcestamps/n:ssid/changes
     """
@@ -71,6 +72,8 @@ class ChangesEndpoint(FixerMixin, base.Endpoint):
     @defer.inlineCallbacks
     def get(self, resultSpec, kwargs):
         buildid = kwargs.get('buildid')
+        if 'build_number' in kwargs:
+            buildid = yield self.getBuildid(kwargs)
         ssid = kwargs.get('ssid')
         if buildid is not None:
             changes = yield self.master.db.changes.getChangesForBuild(buildid)

--- a/master/buildbot/data/properties.py
+++ b/master/buildbot/data/properties.py
@@ -34,11 +34,15 @@ class BuildPropertiesEndpoint(base.Endpoint):
 
     isCollection = False
     pathPatterns = """
+        /builders/n:builderid/builds/n:build_number/properties
         /builds/n:buildid/properties
     """
 
     def get(self, resultSpec, kwargs):
-        return self.master.db.builds.getBuildProperties(kwargs['buildid'])
+        buildid = kwargs.get("buildid", None)
+        if buildid is None:
+            buildid = kwargs.get("build_number")
+        return self.master.db.builds.getBuildProperties(buildid)
 
 
 class Properties(base.ResourceType):

--- a/master/buildbot/newsfragments/fix-inconsistent-rest-api.bugfix
+++ b/master/buildbot/newsfragments/fix-inconsistent-rest-api.bugfix
@@ -1,0 +1,1 @@
+Fix inconsistent REST api, buildid vs build_number, :issue: 3427

--- a/master/buildbot/spec/api.raml
+++ b/master/buildbot/spec/api.raml
@@ -150,6 +150,18 @@ types:
                             get:
                                 is:
                                 - bbgetraw:
+                /changes:
+                    description: |
+                        This path selects all changes tested by a build
+                    get:
+                        is:
+                        - bbget: {bbtype: change}
+                /properties:
+                    description: |
+                        This path selects all properties of a build
+                    get:
+                        is:
+                        - bbget: {bbtype: sourcedproperties}
 
                 /steps:
                     description: This path selects all steps for the given build.

--- a/master/buildbot/test/unit/data/test_properties.py
+++ b/master/buildbot/test/unit/data/test_properties.py
@@ -86,6 +86,12 @@ class BuildPropertiesEndpoint(endpoint.EndpointMixin, unittest.TestCase):
         self.assertEqual(props, {'year': (1651, 'Wikipedia'),
                          'island_name': ("despair", 'Book')})
 
+    @defer.inlineCallbacks
+    def test_get_properties_from_builder(self):
+        props = yield self.callGet(('builders', 1, 'builds', 786, 'properties'))
+        self.assertEqual(props, {'year': (1651, 'Wikipedia'),
+                         'island_name': ("despair", 'Book')})
+
 
 class Properties(interfaces.InterfaceTests, TestReactorMixin,
                  unittest.TestCase):


### PR DESCRIPTION
This commit enables folloing apis,
- buildbot.host/api/v2/builders/1/builds/1/properties
- buildbot.host/api/v2/builders/1/builds/1/changes

## Contributor Checklist:

* [ ] I have updated the unit tests
I have run all tests locally but, did not find any tests that verify the endpoints can someone point me to them if they exists

* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)

* [ ] I have updated the appropriate documentation
