### PR TITLE
Replace twisted.python.compat.NativeStringIO with io.StringIO

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -16,6 +16,7 @@
 import inspect
 import re
 import sys
+from io import StringIO
 
 from twisted.internet import defer
 from twisted.internet import error
@@ -25,7 +26,6 @@ from twisted.python import failure
 from twisted.python import log
 from twisted.python import util as twutil
 from twisted.python import versions
-from twisted.python.compat import NativeStringIO
 from twisted.python.failure import Failure
 from twisted.python.reflect import accumulateClassList
 from twisted.web.util import formatFailure
@@ -223,7 +223,7 @@ class SyncLogFileWrapper(logobserver.LogObserver):
 
     def readlines(self):
         alltext = "".join(self.getChunks([self.STDOUT], onlyText=True))
-        io = NativeStringIO(alltext)
+        io = StringIO(alltext)
         return io.readlines()
 
     def getChunks(self, channels=None, onlyText=False):

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -14,11 +14,11 @@
 # Copyright Buildbot Team Members
 
 import traceback
+from io import StringIO
 
 from twisted.internet import defer
 from twisted.internet import error
 from twisted.python import failure
-from twisted.python.compat import NativeStringIO
 
 from buildbot.config import BuilderConfig
 from buildbot.process import buildstep
@@ -134,7 +134,7 @@ class OldBuildEPYDoc(shell.ShellCommand):
         return defer.succeed(None)
 
     def createSummary(self, log):
-        for line in NativeStringIO(log.getText()):
+        for line in StringIO(log.getText()):
             # what we do with the line isn't important to the test
             assert line in ('some\n', 'output\n')
 

--- a/master/buildbot/test/unit/schedulers/test_trysched.py
+++ b/master/buildbot/test/unit/schedulers/test_trysched.py
@@ -17,13 +17,13 @@ import json
 import os
 import shutil
 import sys
+from io import StringIO
 
 import mock
 
 import twisted
 from twisted.internet import defer
 from twisted.protocols import basic
-from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot.schedulers import trysched
@@ -222,7 +222,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         sched = trysched.Try_Jobdir(
             name='tsched', builderNames=['a'], jobdir='foo')
         with self.assertRaises(trysched.BadJobfile):
-            sched.parseJob(NativeStringIO(''))
+            sched.parseJob(StringIO(''))
 
     def test_parseJob_longer_than_netstring_MAXLENGTH(self):
         self.patch(basic.NetstringReceiver, 'MAX_LENGTH', 100)
@@ -234,7 +234,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         )
         jobstr += 'x' * 200
 
-        test_temp_file = NativeStringIO(jobstr)
+        test_temp_file = StringIO(jobstr)
 
         with self.assertRaises(trysched.BadJobfile):
             sched.parseJob(test_temp_file)
@@ -243,13 +243,13 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         sched = trysched.Try_Jobdir(
             name='tsched', builderNames=['a'], jobdir='foo')
         with self.assertRaises(trysched.BadJobfile):
-            sched.parseJob(NativeStringIO('this is not a netstring'))
+            sched.parseJob(StringIO('this is not a netstring'))
 
     def test_parseJob_invalid_version(self):
         sched = trysched.Try_Jobdir(
             name='tsched', builderNames=['a'], jobdir='foo')
         with self.assertRaises(trysched.BadJobfile):
-            sched.parseJob(NativeStringIO('1:9,'))
+            sched.parseJob(StringIO('1:9,'))
 
     def makeNetstring(self, *strings):
         return ''.join(['{}:{},'.format(len(s), s) for s in strings])
@@ -261,7 +261,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             '1', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob, {
             'baserev': '1234',
             'branch': 'trunk',
@@ -284,7 +284,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             '1', 'extid', '', '', '1', 'this is my diff, -- ++, etc.',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['branch'], None)
         self.assertEqual(parsedjob['baserev'], None)
 
@@ -294,7 +294,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         jobstr = self.makeNetstring(
             '1', 'extid', '', '', '1', 'this is my diff, -- ++, etc.'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['builderNames'], [])
 
     def test_parseJob_v1_no_properties(self):
@@ -303,7 +303,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
         jobstr = self.makeNetstring(
             '1', 'extid', '', '', '1', 'this is my diff, -- ++, etc.'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['properties'], {})
 
     def test_parseJob_v2(self):
@@ -314,7 +314,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             'repo', 'proj',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob, {
             'baserev': '1234',
             'branch': 'trunk',
@@ -338,7 +338,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             'repo', 'proj',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['branch'], None)
         self.assertEqual(parsedjob['baserev'], None)
 
@@ -349,7 +349,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             '2', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj',
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['builderNames'], [])
 
     def test_parseJob_v2_no_properties(self):
@@ -359,7 +359,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             '2', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj',
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['properties'], {})
 
     def test_parseJob_v3(self):
@@ -370,7 +370,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             'repo', 'proj', 'who',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob, {
             'baserev': '1234',
             'branch': 'trunk',
@@ -394,7 +394,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             'repo', 'proj', 'who',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['branch'], None)
         self.assertEqual(parsedjob['baserev'], None)
 
@@ -405,7 +405,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             '3', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj', 'who'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['builderNames'], [])
 
     def test_parseJob_v3_no_properties(self):
@@ -415,7 +415,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             '3', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj', 'who'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['properties'], {})
 
     def test_parseJob_v4(self):
@@ -426,7 +426,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             'repo', 'proj', 'who', 'comment',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob, {
             'baserev': '1234',
             'branch': 'trunk',
@@ -450,7 +450,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             'repo', 'proj', 'who', 'comment',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['branch'], None)
         self.assertEqual(parsedjob['baserev'], None)
 
@@ -461,7 +461,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             '4', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj', 'who', 'comment'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['builderNames'], [])
 
     def test_parseJob_v4_no_properties(self):
@@ -471,7 +471,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             '4', 'extid', 'trunk', '1234', '1', 'this is my diff, -- ++, etc.',
             'repo', 'proj', 'who', 'comment'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['properties'], {})
 
     def test_parseJob_v5(self):
@@ -486,7 +486,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
                 'comment': 'comment', 'builderNames': ['buildera', 'builderc'],
                 'properties': {'foo': 'bar'},
             }))
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob, {
             'baserev': '1234',
             'branch': 'trunk',
@@ -510,7 +510,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             'repo', 'proj', 'who', 'comment',
             'buildera', 'builderc'
         )
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['branch'], None)
         self.assertEqual(parsedjob['baserev'], None)
 
@@ -526,7 +526,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
                 'comment': 'comment', 'builderNames': [],
                 'properties': {'foo': 'bar'},
             }))
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['builderNames'], [])
 
     def test_parseJob_v5_no_properties(self):
@@ -541,7 +541,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
                 'comment': 'comment', 'builderNames': ['buildera', 'builderb'],
                 'properties': {},
             }))
-        parsedjob = sched.parseJob(NativeStringIO(jobstr))
+        parsedjob = sched.parseJob(StringIO(jobstr))
         self.assertEqual(parsedjob['properties'], {})
 
     def test_parseJob_v5_invalid_json(self):
@@ -549,7 +549,7 @@ class Try_Jobdir(scheduler.SchedulerMixin, TestReactorMixin, unittest.TestCase):
             name='tsched', builderNames=['buildera', 'builderb'], jobdir='foo')
         jobstr = self.makeNetstring('5', '{"comment": "com}')
         with self.assertRaises(trysched.BadJobfile):
-            sched.parseJob(NativeStringIO(jobstr))
+            sched.parseJob(StringIO(jobstr))
 
     # handleJobFile
 

--- a/master/buildbot/test/unit/scripts/test_base.py
+++ b/master/buildbot/test/unit/scripts/test_base.py
@@ -17,10 +17,10 @@ import errno
 import os
 import string
 import textwrap
+from io import StringIO
 
 from twisted.python import runtime
 from twisted.python import usage
-from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot import config as config_module
@@ -34,7 +34,7 @@ class TestIBD(dirs.DirsMixin, misc.StdoutAssertionsMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpDirs('test')
-        self.stdout = NativeStringIO()
+        self.stdout = StringIO()
         self.setUpStdoutAssertions()
 
     def test_isBuildmasterDir_no_dir(self):

--- a/master/buildbot/test/unit/scripts/test_checkconfig.py
+++ b/master/buildbot/test/unit/scripts/test_checkconfig.py
@@ -17,10 +17,10 @@ import os
 import re
 import sys
 import textwrap
+from io import StringIO
 
 import mock
 
-from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot.scripts import base
@@ -59,8 +59,8 @@ class TestConfigLoader(dirs.DirsMixin, unittest.TestCase):
                 f.write(contents)
 
         old_stdout, old_stderr = sys.stdout, sys.stderr
-        stdout = sys.stdout = NativeStringIO()
-        stderr = sys.stderr = NativeStringIO()
+        stdout = sys.stdout = StringIO()
+        stderr = sys.stderr = StringIO()
         try:
             checkconfig._loadConfig(
                 basedir=self.configdir, configFile="master.cfg", quiet=False)

--- a/master/buildbot/test/unit/scripts/test_runner.py
+++ b/master/buildbot/test/unit/scripts/test_runner.py
@@ -16,13 +16,13 @@
 import getpass
 import os
 import sys
+from io import StringIO
 
 import mock
 
 from twisted.python import log
 from twisted.python import runtime
 from twisted.python import usage
-from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot.scripts import base
@@ -821,7 +821,7 @@ class TestRun(unittest.TestCase):
 
     def test_run_bad(self):
         self.patch(sys, 'argv', ['buildbot', 'my', '-l'])
-        stdout = NativeStringIO()
+        stdout = StringIO()
         self.patch(sys, 'stdout', stdout)
         try:
             runner.run()

--- a/master/buildbot/test/unit/scripts/test_tryserver.py
+++ b/master/buildbot/test/unit/scripts/test_tryserver.py
@@ -15,8 +15,8 @@
 
 import os
 import sys
+from io import StringIO
 
-from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot.scripts import tryserver
@@ -32,7 +32,7 @@ class TestStatusLog(dirs.DirsMixin, unittest.TestCase):
 
     def test_trycmd(self):
         config = dict(jobdir='jobdir')
-        inputfile = NativeStringIO('this is my try job')
+        inputfile = StringIO('this is my try job')
         self.patch(sys, 'stdin', inputfile)
 
         rc = tryserver.tryserver(config)

--- a/master/buildbot/test/unit/scripts/test_upgrade_master.py
+++ b/master/buildbot/test/unit/scripts/test_upgrade_master.py
@@ -15,11 +15,11 @@
 
 import os
 import sys
+from io import StringIO
 
 import mock
 
 from twisted.internet import defer
-from twisted.python.compat import NativeStringIO
 from twisted.trial import unittest
 
 from buildbot import config as config_module
@@ -202,7 +202,7 @@ class TestUpgradeMasterFunctions(www.WwwTestMixin, dirs.DirsMixin,
     def test_upgradeDatabaseFail(self):
         setup = mock.Mock(side_effect=lambda **kwargs: defer.succeed(None))
         self.patch(connector.DBConnector, 'setup', setup)
-        self.patch(sys, 'stderr', NativeStringIO())
+        self.patch(sys, 'stderr', StringIO())
         upgrade = mock.Mock(
             side_effect=lambda **kwargs: defer.fail(Exception("o noz")))
         self.patch(model.Model, 'upgrade', upgrade)

--- a/master/buildbot/test/unit/test_clients_tryclient.py
+++ b/master/buildbot/test/unit/test_clients_tryclient.py
@@ -17,7 +17,6 @@
 import json
 import sys
 
-from twisted.python.compat import unicode
 from twisted.trial import unittest
 
 from buildbot.clients import tryclient
@@ -172,12 +171,12 @@ class createJobfile(unittest.TestCase):
 
     def test_RemoteTryPP_encoding(self):
         rmt = tryclient.RemoteTryPP("job")
-        self.assertTrue(isinstance(rmt.job, unicode))
+        self.assertTrue(isinstance(rmt.job, str))
         rmt.transport = self.RemoteTryPP_TestStream()
         rmt.connectionMade()
         self.assertFalse(rmt.transport.is_open)
         self.assertEqual(len(rmt.transport.writes), 1)
-        self.assertFalse(isinstance(rmt.transport.writes[0], unicode))
+        self.assertFalse(isinstance(rmt.transport.writes[0], str))
         for streamname in "out", "err":
             sys_streamattr = "std" + streamname
             rmt_methodattr = streamname + "Received"
@@ -189,4 +188,4 @@ class createJobfile(unittest.TestCase):
             finally:
                 setattr(sys, sys_streamattr, saved_stream)
             self.assertEqual(len(teststream.writes), 1)
-            self.assertTrue(isinstance(teststream.writes[0], unicode))
+            self.assertTrue(isinstance(teststream.writes[0], str))

--- a/master/buildbot/test/util/misc.py
+++ b/master/buildbot/test/util/misc.py
@@ -15,11 +15,11 @@
 
 import os
 import sys
+from io import StringIO
 
 from twisted.internet import threads
 from twisted.python import log
 from twisted.python import threadpool
-from twisted.python.compat import NativeStringIO
 from twisted.trial.unittest import TestCase
 
 import buildbot
@@ -54,7 +54,7 @@ class StdoutAssertionsMixin:
     """
 
     def setUpStdoutAssertions(self):
-        self.stdout = NativeStringIO()
+        self.stdout = StringIO()
         self.patch(sys, 'stdout', self.stdout)
 
     def assertWasQuiet(self):

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -16,6 +16,7 @@
 import json
 import os
 import pkg_resources
+from io import StringIO
 from urllib.parse import parse_qs
 from urllib.parse import unquote as urlunquote
 from uuid import uuid1
@@ -23,7 +24,6 @@ from uuid import uuid1
 import mock
 
 from twisted.internet import defer
-from twisted.python.compat import NativeStringIO
 from twisted.web import server
 
 from buildbot.test.fake import fakemaster
@@ -187,7 +187,7 @@ class WwwTestMixin(RequiresWwwMixin):
         id = id or self.UUID
         request = self.make_request(path)
         request.method = b"POST"
-        request.content = NativeStringIO(requestJson or json.dumps(
+        request.content = StringIO(requestJson or json.dumps(
             {"jsonrpc": "2.0", "method": action, "params": params, "id": id}))
         request.input_headers = {b'content-type': content_type}
         rv = rsrc.render(request)


### PR DESCRIPTION
Buildbot master runs on Python 3+ so using io.StringIO is OK.
twisted.python.compat.NativeStringIO has been deprecatd in Twisted in https://github.com/twisted/twisted/pull/1364/



## Contributor Checklist:

* [X] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
