### PR TITLE
Remove reference to twisted.python.compat.unicode

### DIFF
--- a/master/buildbot/test/unit/test_clients_tryclient.py
+++ b/master/buildbot/test/unit/test_clients_tryclient.py
@@ -17,7 +17,6 @@
 import json
 import sys
 
-from twisted.python.compat import unicode
 from twisted.trial import unittest
 
 from buildbot.clients import tryclient
@@ -172,12 +171,12 @@ class createJobfile(unittest.TestCase):
 
     def test_RemoteTryPP_encoding(self):
         rmt = tryclient.RemoteTryPP("job")
-        self.assertTrue(isinstance(rmt.job, unicode))
+        self.assertTrue(isinstance(rmt.job, str))
         rmt.transport = self.RemoteTryPP_TestStream()
         rmt.connectionMade()
         self.assertFalse(rmt.transport.is_open)
         self.assertEqual(len(rmt.transport.writes), 1)
-        self.assertFalse(isinstance(rmt.transport.writes[0], unicode))
+        self.assertFalse(isinstance(rmt.transport.writes[0], str))
         for streamname in "out", "err":
             sys_streamattr = "std" + streamname
             rmt_methodattr = streamname + "Received"
@@ -189,4 +188,4 @@ class createJobfile(unittest.TestCase):
             finally:
                 setattr(sys, sys_streamattr, saved_stream)
             self.assertEqual(len(teststream.writes), 1)
-            self.assertTrue(isinstance(teststream.writes[0], unicode))
+            self.assertTrue(isinstance(teststream.writes[0], str))


### PR DESCRIPTION
twisted.python.compat.unicode has been deprecated in https://github.com/twisted/twisted/pull/1364
See also: https://github.com/buildbot/buildbot/pull/5560

## Contributor Checklist:

* [X] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
