### PR TITLE
HTTPStep - friendlier inheritance

### DIFF
--- a/master/buildbot/steps/http.py
+++ b/master/buildbot/steps/http.py
@@ -80,7 +80,7 @@ class HTTPStep(BuildStep):
         self.method = method
         self.url = url
 
-        for param in HTTPStep.requestsParams:
+        for param in self.requestsParams:
             setattr(self, param, kwargs.pop(param, None))
 
         super().__init__(**kwargs)


### PR DESCRIPTION
Hi! I'd like to base my class on `HTTPStep`, overriding `run` method. Because `requestsParams` are only used in `run` method, it would be convenient to make it overridable.