### PR TITLE
Allow user to set docker init conf default

### DIFF
--- a/master/buildbot/newsfragments/allow-init-flag-in-docker-hostconfig.feature
+++ b/master/buildbot/newsfragments/allow-init-flag-in-docker-hostconfig.feature
@@ -1,0 +1,1 @@
+Allow the init flag to be set to false in the hostconfig for :py:class:`~buildbot.plugins.worker.DockerLatentWorker`

--- a/master/buildbot/newsfragments/allow-init-flag-in-docker-hostconfig.feature
+++ b/master/buildbot/newsfragments/allow-init-flag-in-docker-hostconfig.feature
@@ -1,1 +1,1 @@
-Allow the init flag to be set to false in the hostconfig for :py:class:`~buildbot.plugins.worker.DockerLatentWorker`
+Allow the init flag to be set to false in the host config for :py:class:`~buildbot.plugins.worker.DockerLatentWorker`

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -169,7 +169,7 @@ class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
                                     dockerfile="FROM ubuntu",
                                     volumes=["/tmp:/tmp:ro"],
                                     hostconfig={'network_mode': 'fake',
-                                                'dns': ['1.1.1.1', '1.2.3.4'], 
+                                                'dns': ['1.1.1.1', '1.2.3.4'],
                                                 'init': False},
                                     custom_context=False, buildargs=None,
                                     encoding='gzip')

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -292,7 +292,7 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
         host_conf = self.hostconfig.copy()
         host_conf['binds'] = binds
         if docker_py_version >= 2.2:
-            host_conf['init'] = True
+            host_conf['init'] = host_conf.get('init', True)
         host_conf = docker_client.create_host_config(**host_conf)
 
         instance = docker_client.create_container(

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -291,8 +291,8 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
         volumes, binds = self._thd_parse_volumes(volumes)
         host_conf = self.hostconfig.copy()
         host_conf['binds'] = binds
-        if docker_py_version >= 2.2:
-            host_conf['init'] = host_conf.get('init', True)
+        if docker_py_version >= 2.2 and 'init' not in host_conf:
+            host_conf['init'] = True
         host_conf = docker_client.create_host_config(**host_conf)
 
         instance = docker_client.create_container(


### PR DESCRIPTION
I am trying to use docker latent workers to test a program that runs on systemd. But it seems that if init=True in the hostconfig, the docker container will terminate itself right after starting.

This change allows the setting of the init flag if the user wants. But it shouldn't affect anyone who doesn't explicitly set the flag, as the default is still the same.

There don't seem to be any documentation changes required related to this, as the only documentation to refer to hostconfig points to the docker-py documentation.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
