### PR TITLE
bug fix for api v4 in enterprise github

### DIFF
--- a/master/buildbot/newsfragments/githuboauth2apiv4.bugfix
+++ b/master/buildbot/newsfragments/githuboauth2apiv4.bugfix
@@ -1,0 +1,1 @@
+Fixed Github v4 API URL

--- a/master/buildbot/test/unit/www/test_oauth.py
+++ b/master/buildbot/test/unit/www/test_oauth.py
@@ -78,12 +78,16 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin,
             "ghclientID", "clientSECRET", apiVersion=4, getTeamsMembership=True)
         self.githubAuthEnt = oauth2.GitHubAuth(
             "ghclientID", "clientSECRET", serverURL="https://git.corp.fakecorp.com")
+        self.githubAuthEnt_v4 = oauth2.GitHubAuth(
+            "ghclientID", "clientSECRET", apiVersion=4, getTeamsMembership=True,
+            serverURL="https://git.corp.fakecorp.com")
         self.gitlabAuth = oauth2.GitLabAuth(
             "https://gitlab.test/", "glclientID", "clientSECRET")
         self.bitbucketAuth = oauth2.BitbucketAuth("bbclientID", "clientSECRET")
 
         for auth in [self.googleAuth, self.githubAuth, self.githubAuth_v4, self.githubAuth_v4_teams,
-                     self.githubAuthEnt, self.gitlabAuth, self.bitbucketAuth]:
+                     self.githubAuthEnt, self.gitlabAuth, self.bitbucketAuth,
+                     self.githubAuthEnt_v4]:
             self._master = master = self.make_master(url='h:/a/b/', auth=auth)
             auth.reconfigAuth(master, master.config)
 
@@ -152,6 +156,20 @@ class OAuth2Auth(TestReactorMixin, www.WwwTestMixin, ConfigErrorsMixin,
                "state=redirect%3Dhttp%253A%252F%252Fredir")
         self.assertEqual(res, exp)
         res = yield self.githubAuthEnt.getLoginURL(None)
+        exp = ("https://git.corp.fakecorp.com/login/oauth/authorize?client_id=ghclientID&"
+               "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
+               "scope=user%3Aemail+read%3Aorg")
+        self.assertEqual(res, exp)
+
+    @defer.inlineCallbacks
+    def test_getGithubLoginURL_v4(self):
+        res = yield self.githubAuthEnt_v4.getLoginURL('http://redir')
+        exp = ("https://git.corp.fakecorp.com/login/oauth/authorize?client_id=ghclientID&"
+               "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
+               "scope=user%3Aemail+read%3Aorg&"
+               "state=redirect%3Dhttp%253A%252F%252Fredir")
+        self.assertEqual(res, exp)
+        res = yield self.githubAuthEnt_v4.getLoginURL(None)
         exp = ("https://git.corp.fakecorp.com/login/oauth/authorize?client_id=ghclientID&"
                "redirect_uri=h%3A%2Fa%2Fb%2Fauth%2Flogin&response_type=code&"
                "scope=user%3Aemail+read%3Aorg")

--- a/master/buildbot/www/oauth2.py
+++ b/master/buildbot/www/oauth2.py
@@ -226,12 +226,14 @@ class GitHubAuth(OAuth2Auth):
                  **kwargs):
 
         super().__init__(clientId, clientSecret, autologin, **kwargs)
+        self.apiResourceEndpoint = None
         if serverURL is not None:
             # setup for enterprise github
-            if serverURL.endswith("/"):
-                serverURL = serverURL[:-1]
+            serverURL = serverURL.rstrip("/")
             # v3 is accessible directly at /api/v3 for enterprise, but directly for SaaS..
             self.resourceEndpoint = serverURL + '/api/v3'
+            # v4 is accessible endpoint for enterprise
+            self.apiResourceEndpoint = serverURL + '/api/graphql'
 
             self.authUri = '{0}/login/oauth/authorize'.format(serverURL)
             self.tokenUri = '{0}/login/oauth/access_token'.format(serverURL)
@@ -248,7 +250,8 @@ class GitHubAuth(OAuth2Auth):
                     'Retrieving team membership information using GitHubAuth is only '
                     'possible using GitHub api v4.')
         else:
-            self.apiResourceEndpoint = self.serverURL + '/graphql'
+            defaultGraphqlEndpoint = self.serverURL + '/graphql'
+            self.apiResourceEndpoint = self.apiResourceEndpoint or defaultGraphqlEndpoint
         if getTeamsMembership:
             # GraphQL name aliases must comply with /^[_a-zA-Z][_a-zA-Z0-9]*$/
             self._orgname_slug_sub_re = re.compile(r'[^_a-zA-Z0-9]')


### PR DESCRIPTION
Hi Github api fails for enterprise version. I found a fix by trying the graphQL query using a REST API and tested if it works with BuildBot as well... 
This is my first contribution to Buildbot Open Source Library


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ N/A ] I have updated the appropriate documentation
