### PR TITLE
reporters: Always provide checkConfig()

### DIFF
--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -39,6 +39,10 @@ _GET_TOKEN_DATA = {
 class BitbucketStatusPush(http.HttpStatusPushBase):
     name = "BitbucketStatusPush"
 
+    def checkConfig(self, oauth_key, oauth_secret, base_url=_BASE_URL, oauth_url=_OAUTH_URL,
+                    **kwargs):
+        super().checkConfig(**kwargs)
+
     @defer.inlineCallbacks
     def reconfigService(self, oauth_key, oauth_secret,
                         base_url=_BASE_URL,

--- a/master/buildbot/reporters/bitbucketserver.py
+++ b/master/buildbot/reporters/bitbucketserver.py
@@ -138,13 +138,18 @@ class BitbucketServerCoreAPIStatusPush(http.HttpStatusPushBase):
     name = "BitbucketServerCoreAPIStatusPush"
     secrets = ["token", "auth"]
 
-    def checkConfig(self, base_url, token=None, auth=None, **kwargs):
+    def checkConfig(self, base_url, token=None, auth=None,
+                    statusName=None, statusSuffix=None, startDescription=None,
+                    endDescription=None, key=None, parentName=None,
+                    buildNumber=None, ref=None, duration=None,
+                    testResults=None, verbose=False, debug=None,
+                    verify=None, **kwargs):
         if not base_url:
             config.error("Parameter base_url has to be given")
         if token is not None and auth is not None:
             config.error("Only one authentication method can be given "
                          "(token or auth)")
-        super().checkConfig(**kwargs)
+        super().checkConfig(wantProperties=True, **kwargs)
 
     @defer.inlineCallbacks
     def reconfigService(self, base_url, token=None, auth=None,

--- a/master/buildbot/reporters/bitbucketserver.py
+++ b/master/buildbot/reporters/bitbucketserver.py
@@ -46,6 +46,11 @@ HTTP_CREATED = 201
 class BitbucketServerStatusPush(http.HttpStatusPushBase):
     name = "BitbucketServerStatusPush"
 
+    def checkConfig(self, base_url, user, password, key=None, statusName=None,
+                    startDescription=None, endDescription=None, verbose=False,
+                    **kwargs):
+        super().checkConfig(wantProperties=True, **kwargs)
+
     @defer.inlineCallbacks
     def reconfigService(self, base_url, user, password, key=None,
                         statusName=None, startDescription=None,

--- a/master/buildbot/reporters/gerrit_verify_status.py
+++ b/master/buildbot/reporters/gerrit_verify_status.py
@@ -47,6 +47,11 @@ class GerritVerifyStatusPush(http.HttpStatusPushBase):
     }
     DEFAULT_RESULT = -1
 
+    def checkConfig(self, baseURL, auth, startDescription=None, endDescription=None,
+                    verification_name=None, abstain=False, category=None, reporter=None,
+                    verbose=False, wantProperties=True, **kwargs):
+        super().checkConfig(wantProperties=wantProperties, **kwargs)
+
     @defer.inlineCallbacks
     def reconfigService(self,
                         baseURL,

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -38,6 +38,10 @@ HOSTED_BASE_URL = 'https://api.github.com'
 class GitHubStatusPush(http.HttpStatusPushBase):
     name = "GitHubStatusPush"
 
+    def checkConfig(token, startDescription=None, endDescription=None,
+                    context=None, baseURL=None, verbose=False, wantProperties=True, **kwargs):
+        super().checkConfig(wantProperties=wantProperties, **kwargs)
+
     @defer.inlineCallbacks
     def reconfigService(self, token,
                         startDescription=None, endDescription=None,

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -37,6 +37,10 @@ HOSTED_BASE_URL = 'https://gitlab.com'
 class GitLabStatusPush(http.HttpStatusPushBase):
     name = "GitLabStatusPush"
 
+    def checkConfig(token, startDescription=None, endDescription=None,
+                    context=None, baseURL=None, verbose=False, wantProperties=True, **kwargs):
+        super().checkConfig(wantProperties=wantProperties, **kwargs)
+
     @defer.inlineCallbacks
     def reconfigService(self, token,
                         startDescription=None, endDescription=None,


### PR DESCRIPTION
An implementation of `checkConfig` is necessary whenever a service has custom arguments that are not passed to the superclass. If we don't provide `checkConfig`, wrong arguments will be passed to the superclass. This may have various side effects.

We should implement `checkConfig` in the same way how `reconfigService` handles its arguments.