### PR TITLE
Improve consistency in reporter tests

### DIFF
--- a/master/buildbot/reporters/gerrit.py
+++ b/master/buildbot/reporters/gerrit.py
@@ -281,6 +281,21 @@ class GerritStatusPush(service.BuildbotService):
         self._buildStartedConsumer.stopConsuming()
 
     @defer.inlineCallbacks
+    def _got_event(self, key, msg):
+        # This function is used only from tests
+        if key[0] == 'builds':
+            if key[2] == 'new':
+                yield self.buildStarted(key, msg)
+                return
+            elif key[2] == 'finished':
+                yield self.buildComplete(key, msg)
+                return
+        if key[0] == 'buildsets' and key[2] == 'complete':  # pragma: no cover
+            yield self.buildsetComplete(key, msg)
+            return
+        raise Exception('Invalid key for _got_event: {}'.format(key))  # pragma: no cover
+
+    @defer.inlineCallbacks
     def buildStarted(self, key, build):
         if self.startCB is None:
             return

--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -62,6 +62,18 @@ class HttpStatusPushBase(service.BuildbotService):
         self._buildCompleteConsumer.stopConsuming()
         self._buildStartedConsumer.stopConsuming()
 
+    @defer.inlineCallbacks
+    def _got_event(self, key, msg):
+        # This function is used only from tests
+        if key[0] != 'builds':  # pragma: no cover
+            raise Exception('Invalid key for _got_event: {}'.format(key))
+        if key[2] == 'new':
+            yield self.buildStarted(key, msg)
+        elif key[2] == 'finished':
+            yield self.buildFinished(key, msg)
+        else:  # pragma: no cover
+            raise Exception('Invalid key for _got_event: {}'.format(key))
+
     def buildStarted(self, key, build):
         return self.getMoreInfoAndSend(build)
 

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -108,13 +108,13 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
             code=201)
 
         build['complete'] = False
-        self.bsp.buildStarted(('build', 20, 'started'), build)
+        self.bsp._got_event(('builds', 20, 'new'), build)
 
         build['complete'] = True
-        self.bsp.buildFinished(('build', 20, 'finished'), build)
+        self.bsp._got_event(('builds', 20, 'finished'), build)
 
         build['results'] = FAILURE
-        self.bsp.buildFinished(('build', 20, 'finished'), build)
+        self.bsp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_success_return_codes(self):
@@ -135,7 +135,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
 
         build['complete'] = True
         self.setUpLogging()
-        self.bsp.buildStarted(('build', 20, 'started'), build)
+        self.bsp._got_event(('builds', 20, 'new'), build)
         self.assertNotLogged('201: unable to upload Bitbucket status')
 
         # make sure a 200 return code does not trigger an error
@@ -153,7 +153,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
 
         build['complete'] = True
         self.setUpLogging()
-        self.bsp.buildStarted(('build', 20, 'finished'), build)
+        self.bsp._got_event(('builds', 20, 'finished'), build)
         self.assertNotLogged('200: unable to upload Bitbucket status')
 
     @defer.inlineCallbacks
@@ -165,7 +165,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
                                   "error_description": "Unsupported grant type: None",
                                   "error": "invalid_grant"})
         self.setUpLogging()
-        self.bsp.buildStarted(('build', 20, 'started'), build)
+        self.bsp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('400: unable to authenticate to Bitbucket')
 
     @defer.inlineCallbacks
@@ -188,7 +188,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
                 "error_description": "This commit is unknown to us",
                 "error": "invalid_commit"})
         self.setUpLogging()
-        self.bsp.buildStarted(('build', 20, 'started'), build)
+        self.bsp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('404: unable to upload Bitbucket status')
         self.assertLogged('This commit is unknown to us')
         self.assertLogged('invalid_commit')

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -108,13 +108,13 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
             code=201)
 
         build['complete'] = False
-        self.bsp._got_event(('builds', 20, 'new'), build)
+        yield self.bsp._got_event(('builds', 20, 'new'), build)
 
         build['complete'] = True
-        self.bsp._got_event(('builds', 20, 'finished'), build)
+        yield self.bsp._got_event(('builds', 20, 'finished'), build)
 
         build['results'] = FAILURE
-        self.bsp._got_event(('builds', 20, 'finished'), build)
+        yield self.bsp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_success_return_codes(self):
@@ -135,7 +135,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
 
         build['complete'] = True
         self.setUpLogging()
-        self.bsp._got_event(('builds', 20, 'new'), build)
+        yield self.bsp._got_event(('builds', 20, 'new'), build)
         self.assertNotLogged('201: unable to upload Bitbucket status')
 
         # make sure a 200 return code does not trigger an error
@@ -153,7 +153,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
 
         build['complete'] = True
         self.setUpLogging()
-        self.bsp._got_event(('builds', 20, 'finished'), build)
+        yield self.bsp._got_event(('builds', 20, 'finished'), build)
         self.assertNotLogged('200: unable to upload Bitbucket status')
 
     @defer.inlineCallbacks
@@ -165,7 +165,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
                                   "error_description": "Unsupported grant type: None",
                                   "error": "invalid_grant"})
         self.setUpLogging()
-        self.bsp._got_event(('builds', 20, 'new'), build)
+        yield self.bsp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('400: unable to authenticate to Bitbucket')
 
     @defer.inlineCallbacks
@@ -188,7 +188,7 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
                 "error_description": "This commit is unknown to us",
                 "error": "invalid_commit"})
         self.setUpLogging()
-        self.bsp._got_event(('builds', 20, 'new'), build)
+        yield self.bsp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('404: unable to upload Bitbucket status')
         self.assertLogged('This commit is unknown to us')
         self.assertLogged('invalid_commit')

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -77,7 +77,7 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
     @defer.inlineCallbacks
     def setupBuildResults(self, buildResults):
         self.insertTestData([buildResults], buildResults)
-        build = yield self.master.data.get(("builds", 20))
+        build = yield self.master.data.get(('builds', 20))
         return build
 
     def _check_start_and_finish_build(self, build):
@@ -103,11 +103,11 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
                   'state': 'FAILED', 'key': 'Builder0',
                   'description': 'Build done.'})
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_basic(self):
@@ -143,11 +143,11 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
                   'name': 'Build', 'description': 'Build finished.'},
             code=HTTP_PROCESSED)
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_error(self):
@@ -166,7 +166,7 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
                 "error": "invalid_commit"})
         build['complete'] = False
         self.setUpLogging()
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('404: Unable to send Bitbucket Server status')
 
     @defer.inlineCallbacks
@@ -181,12 +181,12 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
         self.setUpLogging()
         # we don't expect any request
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Unable to get the commit hash")
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
 
 class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase,
@@ -222,7 +222,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
     @defer.inlineCallbacks
     def setupBuildResults(self, buildResults, parentPlan=False):
         self.insertTestData([buildResults], buildResults, parentPlan=parentPlan)
-        build = yield self.master.data.get(("builds", 20))
+        build = yield self.master.data.get(('builds', 20))
         return build
 
     def _check_start_and_finish_build(self, build, parentPlan=False):
@@ -257,12 +257,12 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
             code=HTTP_PROCESSED)
         build['started_at'] = datetime.datetime(2019, 4, 1, 23, 38, 33, 154354, tzinfo=tzutc())
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build["complete_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     def test_config_no_base_url(self):
         with self.assertRaisesConfigError("Parameter base_url has to be given"):
@@ -301,7 +301,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
 
         self.sp.createStatus = Mock(side_effect=raise_deferred_exception)
         build = yield self.setupBuildResults(SUCCESS)
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
 
         self.assertEqual(len(self.flushLoggedErrors(TestException)), 1)
 
@@ -320,7 +320,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
                   'parent': 'Builder0', 'duration': None, 'testResults': None},
             code=HTTP_NOT_FOUND)
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('404: Unable to send Bitbucket Server status')
 
     @defer.inlineCallbacks
@@ -353,7 +353,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
                   'parent': 'Builder0', 'duration': None, 'testResults': None},
             code=HTTP_PROCESSED)
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("WARNING: Unable to resolve ref for SSID: 234.")
 
     @defer.inlineCallbacks
@@ -368,7 +368,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
         self.setUpLogging()
         # we don't expect any request
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Unable to get the commit hash for SSID: 234")
 
     @defer.inlineCallbacks
@@ -383,7 +383,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
         self.setUpLogging()
         # we don't expect any request
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Unable to parse repository info from 'None' for SSID: 234")
 
     @defer.inlineCallbacks
@@ -427,7 +427,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
                   'skipped': 2, 'successful': 3}},
             code=HTTP_PROCESSED)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_with_test_results(self):
@@ -452,7 +452,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
         build['started_at'] = datetime.datetime(2019, 4, 1, 23, 38, 33, 154354, tzinfo=tzutc())
         build["complete_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_verbose(self):
@@ -468,7 +468,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
                   'parent': 'Builder0', 'duration': None, 'testResults': None},
             code=HTTP_PROCESSED)
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('Sending payload:')
         self.assertLogged('Status "INPROGRESS" sent for example.org/repo d34db33fd43db33f')
 
@@ -535,7 +535,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             code=HTTP_CREATED)
         build["complete"] = True
         self.setUpLogging()
-        yield self.cp._got_event(("builds", 20, "finished"), build)
+        yield self.cp._got_event(('builds', 20, 'finished'), build)
         self.assertLogged('Comment sent to {}'.format(PR_URL))
 
     @defer.inlineCallbacks
@@ -550,7 +550,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             code=HTTP_CREATED)
         build["complete"] = True
         self.setUpLogging()
-        yield self.cp._got_event(("builds", 20, "finished"), build)
+        yield self.cp._got_event(('builds', 20, 'finished'), build)
 
         self.assertNotLogged('Comment sent to {}'.format(PR_URL))
 
@@ -561,7 +561,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
         build = builds[0]
         build["complete"] = True
         # we don't expect any request
-        yield self.cp._got_event(("builds", 20, "finished"), build)
+        yield self.cp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_missing_worker_does_nothing(self):
@@ -597,7 +597,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             content_json=error_body)
         self.setUpLogging()
         build['complete'] = True
-        yield self.cp._got_event(("builds", 20, "finished"), build)
+        yield self.cp._got_event(('builds', 20, 'finished'), build)
 
         self.assertLogged(
             "^{}: Unable to send a comment: ".format(http_error_code))
@@ -616,7 +616,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             code=http_error_code)
         self.setUpLogging()
         build['complete'] = True
-        yield self.cp._got_event(("builds", 20, "finished"), build)
+        yield self.cp._got_event(('builds', 20, 'finished'), build)
         self.assertLogged("^{}: Unable to send a comment: ".format(
             http_error_code))
 
@@ -634,5 +634,5 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             code=http_code)
         self.setUpLogging()
         build['complete'] = True
-        yield self.cp._got_event(("builds", 20, "finished"), build)
+        yield self.cp._got_event(('builds', 20, 'finished'), build)
         self.assertNotLogged("^{}:".format(http_code))

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -103,11 +103,11 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
                   'state': 'FAILED', 'key': 'Builder0',
                   'description': 'Build done.'})
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_basic(self):
@@ -143,11 +143,11 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
                   'name': 'Build', 'description': 'Build finished.'},
             code=HTTP_PROCESSED)
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_error(self):
@@ -166,7 +166,7 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
                 "error": "invalid_commit"})
         build['complete'] = False
         self.setUpLogging()
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('404: Unable to send Bitbucket Server status')
 
     @defer.inlineCallbacks
@@ -181,12 +181,12 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
         self.setUpLogging()
         # we don't expect any request
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Unable to get the commit hash")
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
 
 class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase,
@@ -257,12 +257,12 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
             code=HTTP_PROCESSED)
         build['started_at'] = datetime.datetime(2019, 4, 1, 23, 38, 33, 154354, tzinfo=tzutc())
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build["complete_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     def test_config_no_base_url(self):
         with self.assertRaisesConfigError("Parameter base_url has to be given"):
@@ -301,7 +301,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
 
         self.sp.createStatus = Mock(side_effect=raise_deferred_exception)
         build = yield self.setupBuildResults(SUCCESS)
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
 
         self.assertEqual(len(self.flushLoggedErrors(TestException)), 1)
 
@@ -320,7 +320,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
                   'parent': 'Builder0', 'duration': None, 'testResults': None},
             code=HTTP_NOT_FOUND)
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('404: Unable to send Bitbucket Server status')
 
     @defer.inlineCallbacks
@@ -353,7 +353,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
                   'parent': 'Builder0', 'duration': None, 'testResults': None},
             code=HTTP_PROCESSED)
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("WARNING: Unable to resolve ref for SSID: 234.")
 
     @defer.inlineCallbacks
@@ -368,7 +368,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
         self.setUpLogging()
         # we don't expect any request
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Unable to get the commit hash for SSID: 234")
 
     @defer.inlineCallbacks
@@ -383,7 +383,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
         self.setUpLogging()
         # we don't expect any request
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Unable to parse repository info from 'None' for SSID: 234")
 
     @defer.inlineCallbacks
@@ -427,7 +427,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
                   'skipped': 2, 'successful': 3}},
             code=HTTP_PROCESSED)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_with_test_results(self):
@@ -452,7 +452,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
         build['started_at'] = datetime.datetime(2019, 4, 1, 23, 38, 33, 154354, tzinfo=tzutc())
         build["complete_at"] = datetime.datetime(2019, 4, 1, 23, 38, 43, 154354, tzinfo=tzutc())
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_verbose(self):
@@ -468,7 +468,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
                   'parent': 'Builder0', 'duration': None, 'testResults': None},
             code=HTTP_PROCESSED)
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('Sending payload:')
         self.assertLogged('Status "INPROGRESS" sent for example.org/repo d34db33fd43db33f')
 

--- a/master/buildbot/test/unit/reporters/test_gerrit.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit.py
@@ -342,8 +342,8 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase,
     def run_fake_single_build(self, gsp, buildResult, expWarning=False):
         buildset, builds = yield self.setupBuildResults([buildResult], buildResult)
 
-        yield gsp.buildStarted(None, builds[0])
-        yield gsp.buildComplete(None, builds[0])
+        yield gsp._got_event(('builds', builds[0]['buildid'], 'new'), builds[0])
+        yield gsp._got_event(('builds', builds[0]['buildid'], 'finished'), builds[0])
 
         if expWarning:
             self.assertEqual([w['message'] for w in self.flushWarnings()],

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -115,13 +115,13 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_custom_description(self):
@@ -156,11 +156,11 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_custom_name(self):
@@ -194,11 +194,11 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_custom_abstain(self):
@@ -232,11 +232,11 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_custom_category(self):
@@ -272,11 +272,11 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_custom_reporter(self):
@@ -310,11 +310,11 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_verbose(self):
@@ -333,7 +333,7 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
                 'duration': 'pending'
             })
         self.setUpLogging()
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Sending Gerrit status for")
 
     @defer.inlineCallbacks
@@ -354,7 +354,7 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         self.setUpLogging()
         self._http.quiet = True
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertWasQuiet()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -115,13 +115,13 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_custom_description(self):
@@ -156,11 +156,11 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_custom_name(self):
@@ -194,11 +194,11 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_custom_abstain(self):
@@ -232,11 +232,11 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_custom_category(self):
@@ -272,11 +272,11 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_custom_reporter(self):
@@ -310,11 +310,11 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         build['complete'] = False
         build['complete_at'] = None
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['complete_at'] = build['started_at'] + \
             datetime.timedelta(hours=2, minutes=1, seconds=4)
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_verbose(self):
@@ -333,7 +333,7 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
                 'duration': 'pending'
             })
         self.setUpLogging()
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Sending Gerrit status for")
 
     @defer.inlineCallbacks
@@ -354,7 +354,7 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             })
         self.setUpLogging()
         self._http.quiet = True
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertWasQuiet()
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -94,11 +94,11 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
                   'description': 'Build done.', 'context': 'buildbot/Builder0'})
 
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def setupBuildResultsMin(self, buildResults):
@@ -110,11 +110,11 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
     def test_empty(self):
         build = yield self.setupBuildResultsMin(SUCCESS)
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_source_stamp_no_props_nightly_scheduler(self):
@@ -144,11 +144,11 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
         build = yield self.master.data.get(("builds", 20))
 
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = SUCCESS
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_multiple_source_stamps_no_props(self):
@@ -220,11 +220,11 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
         build = yield self.master.data.get(("builds", 20))
 
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = SUCCESS
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
 
 class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
@@ -293,11 +293,11 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
                   'description': 'Build done.', 'context': 'buildbot/Builder0'})
 
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_https(self):
@@ -323,11 +323,11 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
                   'description': 'Build done.', 'context': 'buildbot/Builder0'})
 
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
 
 class TestGitHubCommentPush(TestGitHubStatusPush):
@@ -350,21 +350,21 @@ class TestGitHubCommentPush(TestGitHubStatusPush):
             json={'body': 'Build done.'})
 
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_empty(self):
         build = yield self.setupBuildResultsMin(SUCCESS)
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_multiple_source_stamps_no_props(self):
@@ -419,8 +419,8 @@ class TestGitHubCommentPush(TestGitHubStatusPush):
         build = yield self.master.data.get(("builds", 20))
 
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = SUCCESS
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -94,11 +94,11 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
                   'description': 'Build done.', 'context': 'buildbot/Builder0'})
 
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def setupBuildResultsMin(self, buildResults):
@@ -110,11 +110,11 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
     def test_empty(self):
         build = yield self.setupBuildResultsMin(SUCCESS)
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_source_stamp_no_props_nightly_scheduler(self):
@@ -144,11 +144,11 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
         build = yield self.master.data.get(("builds", 20))
 
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = SUCCESS
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_multiple_source_stamps_no_props(self):
@@ -220,11 +220,11 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
         build = yield self.master.data.get(("builds", 20))
 
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = SUCCESS
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
 
 class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
@@ -293,11 +293,11 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
                   'description': 'Build done.', 'context': 'buildbot/Builder0'})
 
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_https(self):
@@ -323,11 +323,11 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
                   'description': 'Build done.', 'context': 'buildbot/Builder0'})
 
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
 
 class TestGitHubCommentPush(TestGitHubStatusPush):
@@ -350,21 +350,21 @@ class TestGitHubCommentPush(TestGitHubStatusPush):
             json={'body': 'Build done.'})
 
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_empty(self):
         build = yield self.setupBuildResultsMin(SUCCESS)
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_multiple_source_stamps_no_props(self):
@@ -419,8 +419,8 @@ class TestGitHubCommentPush(TestGitHubStatusPush):
         build = yield self.master.data.get(("builds", 20))
 
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = SUCCESS
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -94,11 +94,11 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                   'description': 'Build done.', 'name': 'buildbot/Builder0'})
 
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_sshurl(self):
@@ -118,7 +118,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                   'ref': 'master',
                   'description': 'Build started.', 'name': 'buildbot/Builder0'})
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
 
     @defer.inlineCallbacks
     def test_merge_request_forked(self):
@@ -133,7 +133,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                   'ref': 'master',
                   'description': 'Build started.', 'name': 'buildbot/Builder0'})
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         # Don't run these tests in parallel!
         del self.TEST_PROPS['source_project_id']
 
@@ -149,7 +149,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                 "message": 'project not found'
             }, code=404)
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged(r"Unknown \(or hidden\) gitlab projectbuildbot%2Fbuildbot:"
                           r" project not found")
 
@@ -158,7 +158,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
         self.TEST_REPO = ''
         build = yield self.setupBuildResults(SUCCESS)
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         # implicit check that no http request is done
         # nothing is logged as well
 
@@ -182,7 +182,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
             content_json={'message': 'sha1 not found for branch master'},
             code=404)
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Could not send status \"running\" for"
                           " http://gitlab/buildbot/buildbot at d34db33fd43db33f:"
                           " sha1 not found for branch master")
@@ -198,7 +198,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                 "id": 1
             })
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "started"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Failed to send status \"running\" for"
                           " http://gitlab/buildbot/buildbot at d34db33fd43db33f\n"
                           "Traceback")

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -94,11 +94,11 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                   'description': 'Build done.', 'name': 'buildbot/Builder0'})
 
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
         build['results'] = FAILURE
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_sshurl(self):
@@ -118,7 +118,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                   'ref': 'master',
                   'description': 'Build started.', 'name': 'buildbot/Builder0'})
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
 
     @defer.inlineCallbacks
     def test_merge_request_forked(self):
@@ -133,7 +133,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                   'ref': 'master',
                   'description': 'Build started.', 'name': 'buildbot/Builder0'})
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         # Don't run these tests in parallel!
         del self.TEST_PROPS['source_project_id']
 
@@ -149,7 +149,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                 "message": 'project not found'
             }, code=404)
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged(r"Unknown \(or hidden\) gitlab projectbuildbot%2Fbuildbot:"
                           r" project not found")
 
@@ -158,7 +158,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
         self.TEST_REPO = ''
         build = yield self.setupBuildResults(SUCCESS)
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         # implicit check that no http request is done
         # nothing is logged as well
 
@@ -182,7 +182,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
             content_json={'message': 'sha1 not found for branch master'},
             code=404)
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Could not send status \"running\" for"
                           " http://gitlab/buildbot/buildbot at d34db33fd43db33f:"
                           " sha1 not found for branch master")
@@ -198,7 +198,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                 "id": 1
             })
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged("Failed to send status \"running\" for"
                           " http://gitlab/buildbot/buildbot at d34db33fd43db33f\n"
                           "Traceback")

--- a/master/buildbot/test/unit/reporters/test_hipchat.py
+++ b/master/buildbot/test/unit/reporters/test_hipchat.py
@@ -94,7 +94,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
             params=dict(auth_token='auth'),
             json={'message': 'Buildbot started build Builder0 here: '
                              'http://localhost:8080/#builders/79/builds/0'})
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
 
     @defer.inlineCallbacks
     def test_build_started(self):
@@ -106,7 +106,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
             params=dict(auth_token='abc'),
             json={'message': 'Buildbot started build Builder0 here: '
                              'http://localhost:8080/#builders/79/builds/0'})
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
 
     @defer.inlineCallbacks
     def test_build_finished(self):
@@ -119,7 +119,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
             json={'message':
                   'Buildbot finished build Builder0 with result success '
                   'here: http://localhost:8080/#builders/79/builds/0'})
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_inject_extra_params(self):
@@ -135,7 +135,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
                   'here: http://localhost:8080/#builders/79/builds/0',
                   'format': 'html'})
 
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_no_message_sent_empty_message(self):

--- a/master/buildbot/test/unit/reporters/test_hipchat.py
+++ b/master/buildbot/test/unit/reporters/test_hipchat.py
@@ -94,7 +94,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
             params=dict(auth_token='auth'),
             json={'message': 'Buildbot started build Builder0 here: '
                              'http://localhost:8080/#builders/79/builds/0'})
-        self.sp.buildStarted(('build', 20, 'new'), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
 
     @defer.inlineCallbacks
     def test_build_started(self):
@@ -106,7 +106,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
             params=dict(auth_token='abc'),
             json={'message': 'Buildbot started build Builder0 here: '
                              'http://localhost:8080/#builders/79/builds/0'})
-        self.sp.buildStarted(('build', 20, 'new'), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
 
     @defer.inlineCallbacks
     def test_build_finished(self):
@@ -119,7 +119,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
             json={'message':
                   'Buildbot finished build Builder0 with result success '
                   'here: http://localhost:8080/#builders/79/builds/0'})
-        self.sp.buildFinished(('build', 20, 'finished'), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_inject_extra_params(self):
@@ -135,7 +135,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
                   'here: http://localhost:8080/#builders/79/builds/0',
                   'format': 'html'})
 
-        self.sp.buildFinished(('build', 20, 'finished'), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_no_message_sent_empty_message(self):

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -106,9 +106,9 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
         self._http.expect("post", "", json=BuildLookAlike(complete=True))
         build = yield self.setupBuildResults(SUCCESS)
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_basic_noauth(self):
@@ -117,22 +117,22 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
         self._http.expect("post", "", json=BuildLookAlike(complete=True))
         build = yield self.setupBuildResults(SUCCESS)
         build['complete'] = False
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_filtering(self):
         yield self.createReporter(builders=['foo'])
         build = yield self.setupBuildResults(SUCCESS)
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_filteringPass(self):
         yield self.createReporter(builders=['Builder0'])
         self._http.expect("post", "", json=BuildLookAlike())
         build = yield self.setupBuildResults(SUCCESS)
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_builderTypeCheck(self):
@@ -148,7 +148,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
             keys=['steps', 'prev_build']))
         build = yield self.setupBuildResults(SUCCESS)
         build['complete'] = True
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def http2XX(self, code, content):
@@ -156,7 +156,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
         self._http.expect('post', '', code=code, content=content,
                           json=BuildLookAlike())
         build = yield self.setupBuildResults(SUCCESS)
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_http200(self):

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -106,9 +106,9 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
         self._http.expect("post", "", json=BuildLookAlike(complete=True))
         build = yield self.setupBuildResults(SUCCESS)
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "new"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_basic_noauth(self):
@@ -117,22 +117,22 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
         self._http.expect("post", "", json=BuildLookAlike(complete=True))
         build = yield self.setupBuildResults(SUCCESS)
         build['complete'] = False
-        self.sp.buildStarted(("build", 20, "new"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_filtering(self):
         yield self.createReporter(builders=['foo'])
         build = yield self.setupBuildResults(SUCCESS)
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_filteringPass(self):
         yield self.createReporter(builders=['Builder0'])
         self._http.expect("post", "", json=BuildLookAlike())
         build = yield self.setupBuildResults(SUCCESS)
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_builderTypeCheck(self):
@@ -148,7 +148,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
             keys=['steps', 'prev_build']))
         build = yield self.setupBuildResults(SUCCESS)
         build['complete'] = True
-        self.sp.buildFinished(("build", 20, "finished"), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def http2XX(self, code, content):
@@ -156,7 +156,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
         self._http.expect('post', '', code=code, content=content,
                           json=BuildLookAlike())
         build = yield self.setupBuildResults(SUCCESS)
-        self.sp.buildStarted(('build', 20, 'finished'), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_http200(self):

--- a/master/buildbot/test/unit/reporters/test_zulip.py
+++ b/master/buildbot/test/unit/reporters/test_zulip.py
@@ -68,14 +68,14 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
             'post',
             '/api/v1/external/buildbot?api_key=123&stream=xyz',
             json={
-                "event": "new",
+                "event": 'new',
                 "buildid": 20,
                 "buildername": "Builder0",
                 "url": "http://localhost:8080/#builders/79/builds/0",
                 "project": "testProject",
                 "timestamp": 1554161923
             })
-        self.sp.buildStarted(('build', 20, 'new'), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
 
     @defer.inlineCallbacks
     def test_build_finished(self):
@@ -95,7 +95,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
                 "timestamp": 1554161923,
                 "results": 0
             })
-        self.sp.buildFinished(('build', 20, 'finished'), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_stream_none(self):
@@ -115,7 +115,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
                 "timestamp": 1554161923,
                 "results": 0
             })
-        self.sp.buildFinished(('build', 20, 'finished'), build)
+        self.sp._got_event(('builds', 20, 'finished'), build)
 
     def test_endpoint_string(self):
         with self.assertRaisesConfigError(
@@ -137,7 +137,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
             'post',
             '/api/v1/external/buildbot?api_key=123&stream=xyz',
             json={
-                "event": "new",
+                "event": 'new',
                 "buildid": 20,
                 "buildername": "Builder0",
                 "url": "http://localhost:8080/#builders/79/builds/0",
@@ -145,7 +145,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
                 "timestamp": 1554161923
             }, code=500)
         self.setUpLogging()
-        self.sp.buildStarted(("build", 20, "new"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('500: Error pushing build status to Zulip')
 
     @defer.inlineCallbacks
@@ -158,7 +158,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
             'post',
             '/api/v1/external/buildbot?api_key=123&stream=xyz',
             json={
-                "event": "new",
+                "event": 'new',
                 "buildid": 20,
                 "buildername": "Builder0",
                 "url": "http://localhost:8080/#builders/79/builds/0",
@@ -166,7 +166,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
                 "timestamp": 1554161923
             }, code=404)
         self.setUpLogging()
-        self.sp.buildStarted(("build", 20, "new"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('404: Error pushing build status to Zulip')
 
     @defer.inlineCallbacks
@@ -179,7 +179,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
             'post',
             '/api/v1/external/buildbot?api_key=123&stream=xyz',
             json={
-                "event": "new",
+                "event": 'new',
                 "buildid": 20,
                 "buildername": "Builder0",
                 "url": "http://localhost:8080/#builders/79/builds/0",
@@ -188,5 +188,5 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
             }, code=401, content_json={"result": "error", "msg": "Invalid API key",
                                        "code": "INVALID_API_KEY"})
         self.setUpLogging()
-        self.sp.buildStarted(("build", 20, "new"), build)
+        self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('401: Error pushing build status to Zulip')

--- a/master/buildbot/test/unit/reporters/test_zulip.py
+++ b/master/buildbot/test/unit/reporters/test_zulip.py
@@ -75,7 +75,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
                 "project": "testProject",
                 "timestamp": 1554161923
             })
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
 
     @defer.inlineCallbacks
     def test_build_finished(self):
@@ -95,7 +95,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
                 "timestamp": 1554161923,
                 "results": 0
             })
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_stream_none(self):
@@ -115,7 +115,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
                 "timestamp": 1554161923,
                 "results": 0
             })
-        self.sp._got_event(('builds', 20, 'finished'), build)
+        yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     def test_endpoint_string(self):
         with self.assertRaisesConfigError(
@@ -145,7 +145,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
                 "timestamp": 1554161923
             }, code=500)
         self.setUpLogging()
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('500: Error pushing build status to Zulip')
 
     @defer.inlineCallbacks
@@ -166,7 +166,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
                 "timestamp": 1554161923
             }, code=404)
         self.setUpLogging()
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('404: Error pushing build status to Zulip')
 
     @defer.inlineCallbacks
@@ -188,5 +188,5 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
             }, code=401, content_json={"result": "error", "msg": "Invalid API key",
                                        "code": "INVALID_API_KEY"})
         self.setUpLogging()
-        self.sp._got_event(('builds', 20, 'new'), build)
+        yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('401: Error pushing build status to Zulip')


### PR DESCRIPTION
Currently there are two completely different ways to test reporters, which is not surprising since some reporters inherit from NotifierBase and others from HTTPStatusPushBase. It makes sense to make the tests more similar as it will be less changes to migrate HTTPStatusPushBase on top of NotifierBase.