### PR TITLE
pylint: Disable python3-specific warnings

### DIFF
--- a/common/pylintrc
+++ b/common/pylintrc
@@ -148,6 +148,8 @@ disable=
   duplicate-string-formatting-argument,
   cyclic-import,  # only happens when pylint is ran in non-parallel mode
   wrong-import-order, # we use isort for import orders
+  raise-missing-from, # TODO: remove when we no longer have Python 2 code
+  super-with-arguments, # TODO: remove when we no longer have Python 2 code
 
 [REPORTS]
 


### PR DESCRIPTION
Pylint raises `raise-missing-from` and `super-with-arguments` warnings on my dev environment which we can't fix as we still have Python 2.7 code. This PR disables these warnings for the time being.