### PR TITLE
fix renderable issue when using P4 stream

### DIFF
--- a/master/buildbot/newsfragments/p4-renderable.bugfix
+++ b/master/buildbot/newsfragments/p4-renderable.bugfix
@@ -1,0 +1,1 @@
+Fix support of renderables for `p4base`` and ``p4branch`` arguments of the P4 step.

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -117,8 +117,10 @@ class P4(Source):
                 config.error('You can\'t use p4extra_views not p4viewspec with stream')
             if not p4base or not p4branch:
                 config.error('You must specify both p4base and p4branch when using stream')
-            if " " in p4base or " " in p4branch:
-                config.error('p4base and p4branch must not contain any whitespace')
+            if not interfaces.IRenderable.providedBy(p4base) and " " in p4base:
+                config.error('p4base must not contain any whitespace')
+            if not interfaces.IRenderable.providedBy(p4branch) and " " in p4branch:
+                config.error('p4branch must not contain any whitespace')
 
         if self.p4client_spec_options is None:
             self.p4client_spec_options = ''

--- a/master/buildbot/test/unit/steps/test_source_p4.py
+++ b/master/buildbot/test/unit/steps/test_source_p4.py
@@ -897,6 +897,60 @@ class TestP4(sourcesteps.SourceStepMixin, TestReactorMixin, unittest.TestCase):
         ''' % root_dir)
         self._full(client_stdin=client_spec)
 
+    def test_mode_full_stream_renderable_p4base(self):
+        self.setupStep(P4(p4port='localhost:12000', mode='full',
+                          p4base=ConstantRenderable('//depot'), p4branch='trunk',
+                          p4user='user', p4client='p4_client1', p4passwd='pass',
+                          stream=True))
+
+        root_dir = '/home/user/workspace/wkdir'
+        if _is_windows:
+            root_dir = r'C:\Users\username\Workspace\wkdir'
+        client_spec = textwrap.dedent('''\
+        Client: p4_client1
+
+        Owner: user
+
+        Description:
+        \tCreated by user
+
+        Root:\t%s
+
+        Options:\tallwrite rmdir
+
+        LineEnd:\tlocal
+
+        Stream:\t//depot/trunk
+        ''' % root_dir)
+        self._full(client_stdin=client_spec)
+
+    def test_mode_full_stream_renderable_p4branch(self):
+        self.setupStep(P4(p4port='localhost:12000', mode='full',
+                          p4base='//depot', p4branch=ConstantRenderable('render_branch'),
+                          p4user='user', p4client='p4_client1', p4passwd='pass',
+                          stream=True))
+
+        root_dir = '/home/user/workspace/wkdir'
+        if _is_windows:
+            root_dir = r'C:\Users\username\Workspace\wkdir'
+        client_spec = textwrap.dedent('''\
+        Client: p4_client1
+
+        Owner: user
+
+        Description:
+        \tCreated by user
+
+        Root:\t%s
+
+        Options:\tallwrite rmdir
+
+        LineEnd:\tlocal
+
+        Stream:\t//depot/render_branch
+        ''' % root_dir)
+        self._full(client_stdin=client_spec)
+
     def test_worker_connection_lost(self):
         self.setupStep(P4(p4port='localhost:12000', mode='incremental',
                           p4base='//depot', p4branch='trunk',


### PR DESCRIPTION
Fixes this error when using a renderable for p4base or p4branch in stream mode.
```
  File "/home/buildbot/.local/lib/python3.7/site-packages/buildbot/steps/source/p4.py", line 119, in __init__
    if " " in p4base or " " in p4branch:
builtins.TypeError: argument of type '_Renderer' is not iterable
```
