### PR TITLE
Extract jinja message formatter

### DIFF
--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -135,6 +135,7 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
 
     @defer.inlineCallbacks
     def build_message(self, master, reporter, name, builds, results):
+        # The given builds must refer to builds from a single buildset
         patches = []
         logs = []
         body = ""
@@ -155,13 +156,9 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
                     build_logs = [log for log in build_logs if self._should_attach_log(log)]
                 logs.extend(build_logs)
 
-            if 'prev_build' in build and build['prev_build'] is not None:
-                previous_results = build['prev_build']['results']
-            else:
-                previous_results = None
             blamelist = yield reporter.getResponsibleUsersForBuild(master, build['buildid'])
-            buildmsg = yield self.formatter.format_message_for_build(
-                self.mode, name, build['buildset'], build, master, previous_results, blamelist)
+            buildmsg = yield self.formatter.format_message_for_build(self.mode, name, build,
+                                                                     master, blamelist)
             users.update(set(blamelist))
             msgtype = buildmsg['type']
             body += buildmsg['body']

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -162,7 +162,7 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
             users.update(set(blamelist))
             msgtype = buildmsg['type']
             body += buildmsg['body']
-            if 'subject' in buildmsg:
+            if buildmsg['subject'] is not None:
                 subject = buildmsg['subject']
 
         if subject is None:

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -160,7 +160,7 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
             else:
                 previous_results = None
             blamelist = yield reporter.getResponsibleUsersForBuild(master, build['buildid'])
-            buildmsg = yield self.formatter.formatMessageForBuildResults(
+            buildmsg = yield self.formatter.format_message_for_build(
                 self.mode, name, build['buildset'], build, master, previous_results, blamelist)
             users.update(set(blamelist))
             msgtype = buildmsg['type']

--- a/master/buildbot/reporters/generators/worker.py
+++ b/master/buildbot/reporters/generators/worker.py
@@ -50,9 +50,8 @@ class WorkerMissingGenerator(util.ComparableMixin):
 
         msg = yield self.formatter.formatMessageForMissingWorker(master, worker)
         body = msg['body'].encode(ENCODING)
-        if 'subject' in msg:
-            subject = msg['subject']
-        else:
+        subject = msg['subject']
+        if subject is None:
             subject = "Buildbot worker {name} missing".format(**worker)
         assert msg['type'] in ('plain', 'html'), \
             "'{}' message type must be 'plain' or 'html'.".format(msg['type'])

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -203,8 +203,11 @@ class MessageFormatterBase(util.ComparableMixin):
         yield self.buildAdditionalContext(master, ctx)
         ctx.update(self.ctx)
 
-        body = self.body_template.render(ctx)
-        msgdict = {'body': body, 'type': self.template_type}
+        msgdict = {
+            'body': self.body_template.render(ctx),
+            'type': self.template_type,
+            'subject': None
+        }
         if self.subject_template is not None:
             msgdict['subject'] = self.subject_template.render(ctx)
         return msgdict

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -34,9 +34,8 @@ from buildbot.warnings import warn_deprecated
 
 def get_detected_status_text(mode, results, previous_results):
     if results == FAILURE:
-        if "change" in mode and previous_results is not None and previous_results != results:
-            text = "new failure"
-        elif "problem" in mode and previous_results and previous_results != FAILURE:
+        if ('change' in mode or 'problem' in mode) and previous_results is not None \
+                and previous_results != FAILURE:
             text = "new failure"
         else:
             text = "failed build"

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -190,8 +190,8 @@ class MessageFormatter(MessageFormatterBase):
         return text
 
     @defer.inlineCallbacks
-    def formatMessageForBuildResults(self, mode, buildername, buildset, build, master,
-                                     previous_results, blamelist):
+    def format_message_for_build(self, mode, buildername, buildset, build, master,
+                                 previous_results, blamelist):
         """Generate a buildbot mail message and return a dictionary
            containing the message body, type and subject."""
         ss_list = buildset['sourcestamps']

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -190,12 +190,17 @@ class MessageFormatter(MessageFormatterBase):
         return text
 
     @defer.inlineCallbacks
-    def format_message_for_build(self, mode, buildername, buildset, build, master,
-                                 previous_results, blamelist):
+    def format_message_for_build(self, mode, buildername, build, master, blamelist):
         """Generate a buildbot mail message and return a dictionary
            containing the message body, type and subject."""
+        buildset = build['buildset']
         ss_list = buildset['sourcestamps']
         results = build['results']
+
+        if 'prev_build' in build and build['prev_build'] is not None:
+            previous_results = build['prev_build']['results']
+        else:
+            previous_results = None
 
         ctx = dict(results=build['results'],
                    mode=mode,

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -497,9 +497,11 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
             verify=None)
 
         formatter = Mock(spec=MessageFormatter)
-        formatter.formatMessageForBuildResults.return_value = {"body": UNICODE_BODY,
-                                                               "type": "text",
-                                                               "subject": "subject"}
+        formatter.format_message_for_build.return_value = {
+            "body": UNICODE_BODY,
+            "type": "text",
+            "subject": "subject"
+        }
         formatter.wantProperties = True
         formatter.wantSteps = False
         formatter.wantLogs = False

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -272,8 +272,8 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield self.build_message(g, builds)
 
         build = builds[0]
-        g.formatter.format_message_for_build.assert_called_with(
-            ('change',), 'mybldr', build['buildset'], build, self.master, None, [])
+        g.formatter.format_message_for_build.assert_called_with(('change',), 'mybldr', build,
+                                                                self.master, [])
 
         self.assertEqual(report, {
             'body': 'body',
@@ -293,8 +293,8 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield self.build_message(g, builds, results=None)
 
         build = builds[0]
-        g.formatter.format_message_for_build.assert_called_with(
-            ('change',), 'mybldr', build['buildset'], build, self.master, None, [])
+        g.formatter.format_message_for_build.assert_called_with(('change',), 'mybldr', build,
+                                                                self.master, [])
 
         self.assertEqual(report, {
             'body': 'body',
@@ -321,8 +321,8 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield self.build_message(g, builds, results=None)
 
         build = builds[0]
-        g.formatter.format_message_for_build.assert_called_with(
-            ('change',), 'mybldr', build['buildset'], build, self.master, None, [])
+        g.formatter.format_message_for_build.assert_called_with(('change',), 'mybldr', build,
+                                                                self.master, [])
 
         self.assertEqual(report, {
             'body': 'body',

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -246,7 +246,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         g = BuildStatusGenerator(**kwargs)
 
         g.formatter = Mock(spec=g.formatter)
-        g.formatter.formatMessageForBuildResults.return_value = message
+        g.formatter.format_message_for_build.return_value = message
 
         return (g, builds)
 
@@ -272,7 +272,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield self.build_message(g, builds)
 
         build = builds[0]
-        g.formatter.formatMessageForBuildResults.assert_called_with(
+        g.formatter.format_message_for_build.assert_called_with(
             ('change',), 'mybldr', build['buildset'], build, self.master, None, [])
 
         self.assertEqual(report, {
@@ -293,7 +293,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield self.build_message(g, builds, results=None)
 
         build = builds[0]
-        g.formatter.formatMessageForBuildResults.assert_called_with(
+        g.formatter.format_message_for_build.assert_called_with(
             ('change',), 'mybldr', build['buildset'], build, self.master, None, [])
 
         self.assertEqual(report, {
@@ -321,7 +321,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         report = yield self.build_message(g, builds, results=None)
 
         build = builds[0]
-        g.formatter.formatMessageForBuildResults.assert_called_with(
+        g.formatter.format_message_for_build.assert_called_with(
             ('change',), 'mybldr', build['buildset'], build, self.master, None, [])
 
         self.assertEqual(report, {

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -313,7 +313,8 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         subject = 'result: %(result)s builder: %(builder)s title: %(title)s'
         message = {
             "body": "body",
-            "type": "text"
+            "type": "text",
+            "subject": None,
         }
 
         g, builds = yield self.setup_generator(results=None, subject=subject,

--- a/master/buildbot/test/unit/reporters/test_mail.py
+++ b/master/buildbot/test/unit/reporters/test_mail.py
@@ -193,9 +193,11 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
         _, builds = yield self.setupBuildResults(SUCCESS)
 
         formatter = Mock(spec=MessageFormatter)
-        formatter.formatMessageForBuildResults.return_value = {"body": "body",
-                                                               "type": "text",
-                                                               "subject": "subject"}
+        formatter.format_message_for_build.return_value = {
+            "body": "body",
+            "type": "text",
+            "subject": "subject"
+        }
         formatter.wantProperties = False
         formatter.wantSteps = False
         formatter.wantLogs = False
@@ -222,7 +224,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
         mn, builds, formatter = yield self.setupBuildMessage(mode=("passing",))
 
         build = builds[0]
-        formatter.formatMessageForBuildResults.assert_called_with(
+        formatter.format_message_for_build.assert_called_with(
             ('passing',), 'Builder1', build['buildset'], build, self.master,
             None, ['me@foo'])
 
@@ -332,9 +334,11 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
         _, builds = yield self.setupBuildResults(SUCCESS)
 
         formatter = Mock(spec=MessageFormatter)
-        formatter.formatMessageForBuildResults.return_value = {"body": "body",
-                                                               "type": "text",
-                                                               "subject": "subject"}
+        formatter.format_message_for_build.return_value = {
+            "body": "body",
+            "type": "text",
+            "subject": "subject"
+        }
         formatter.wantProperties = False
         formatter.wantSteps = False
         formatter.wantLogs = False

--- a/master/buildbot/test/unit/reporters/test_mail.py
+++ b/master/buildbot/test/unit/reporters/test_mail.py
@@ -224,9 +224,8 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
         mn, builds, formatter = yield self.setupBuildMessage(mode=("passing",))
 
         build = builds[0]
-        formatter.format_message_for_build.assert_called_with(
-            ('passing',), 'Builder1', build['buildset'], build, self.master,
-            None, ['me@foo'])
+        formatter.format_message_for_build.assert_called_with(('passing',), 'Builder1', build,
+                                                              self.master, ['me@foo'])
 
         mn.findInterrestedUsersEmails.assert_called_with(['me@foo'])
         mn.processRecipients.assert_called_with('<recipients>', '<email>')

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -67,7 +67,7 @@ class TestMessage(TestReactorMixin, unittest.TestCase):
         res = yield utils.getDetailsForBuildset(self.master, 99, wantProperties=True)
         build = res['builds'][0]
         buildset = res['buildset']
-        res = yield self.message.formatMessageForBuildResults(
+        res = yield self.message.format_message_for_build(
             mode, "Builder1", buildset, build, self.master,
             lastresults, ["him@bar", "me@foo"])
         return res

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -83,6 +83,47 @@ class TestMessageFormatting(unittest.TestCase):
                          'retry build')
         self.assertEqual(message.get_detected_status_text(['problem'], CANCELLED, None),
                          'cancelled build')
+
+    def test_get_message_summary_text_success(self):
+        self.assertEqual(message.get_message_summary_text({'state_string': 'mywarning'}, SUCCESS),
+                         'Build succeeded!')
+
+    def test_get_message_summary_text_warnings(self):
+        self.assertEqual(message.get_message_summary_text({'state_string': 'mywarning'}, WARNINGS),
+                         'Build Had Warnings: mywarning')
+        self.assertEqual(message.get_message_summary_text({'state_string': None}, WARNINGS),
+                         'Build Had Warnings')
+
+    def test_get_message_summary_text_cancelled(self):
+        self.assertEqual(message.get_message_summary_text({'state_string': 'mywarning'}, CANCELLED),
+                         'Build was cancelled')
+
+    def test_get_message_summary_text_skipped(self):
+        self.assertEqual(message.get_message_summary_text({'state_string': 'mywarning'}, SKIPPED),
+                         'BUILD FAILED: mywarning')
+        self.assertEqual(message.get_message_summary_text({'state_string': None}, SKIPPED),
+                         'BUILD FAILED')
+
+    def test_get_message_source_stamp_text_empty(self):
+        self.assertEqual(message.get_message_source_stamp_text([]), '')
+
+    def test_get_message_source_stamp_text_multiple(self):
+        stamps = [
+            {'codebase': 'a', 'branch': None, 'revision': None, 'patch': None},
+            {'codebase': 'b', 'branch': None, 'revision': None, 'patch': None},
+        ]
+        self.assertEqual(message.get_message_source_stamp_text(stamps),
+                         "Build Source Stamp 'a': HEAD\n"
+                         "Build Source Stamp 'b': HEAD\n")
+
+    def test_get_message_source_stamp_text_with_props(self):
+        stamps = [
+            {'codebase': 'a', 'branch': 'br', 'revision': 'abc', 'patch': 'patch'}
+        ]
+        self.assertEqual(message.get_message_source_stamp_text(stamps),
+                         "Build Source Stamp 'a': [branch br] abc (plus patch)\n")
+
+
 class TestMessage(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -51,7 +51,7 @@ class TestMessage(TestReactorMixin, unittest.TestCase):
             fakedb.Build(id=20, number=0, builderid=80, buildrequestid=11, workerid=13,
                          masterid=92, results=results1),
             fakedb.Build(id=21, number=1, builderid=80, buildrequestid=12, workerid=13,
-                         masterid=92, results=results1),
+                         masterid=92, results=results2),
         ])
         for _id in (20, 21):
             self.db.insertTestData([
@@ -63,7 +63,7 @@ class TestMessage(TestReactorMixin, unittest.TestCase):
 
     @defer.inlineCallbacks
     def doOneTest(self, lastresults, results, mode="all"):
-        self.setupDb(results, lastresults)
+        self.setupDb(lastresults, results)
         res = yield utils.getDetailsForBuildset(self.master, 99, wantProperties=True)
         build = res['builds'][0]
         buildset = res['buildset']

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -64,12 +64,11 @@ class TestMessage(TestReactorMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def doOneTest(self, lastresults, results, mode="all"):
         self.setupDb(lastresults, results)
-        res = yield utils.getDetailsForBuildset(self.master, 99, wantProperties=True)
+        res = yield utils.getDetailsForBuildset(self.master, 99, wantProperties=True,
+                                                wantPreviousBuild=True)
         build = res['builds'][0]
-        buildset = res['buildset']
-        res = yield self.message.format_message_for_build(
-            mode, "Builder1", buildset, build, self.master,
-            lastresults, ["him@bar", "me@foo"])
+        res = yield self.message.format_message_for_build(mode, "Builder1", build, self.master,
+                                                          ["him@bar", "me@foo"])
         return res
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -91,7 +91,7 @@ class TestMessage(TestReactorMixin, unittest.TestCase):
 
             Sincerely,
              -The Buildbot'''))
-        self.assertTrue('subject' not in res)
+        self.assertIsNone(res['subject'])
 
     @defer.inlineCallbacks
     def test_inline_template(self):

--- a/master/buildbot/test/unit/reporters/test_notifier.py
+++ b/master/buildbot/test/unit/reporters/test_notifier.py
@@ -75,9 +75,11 @@ class TestNotifierBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
         _, builds = yield self.setupBuildResults(FAILURE)
 
         formatter = mock.Mock(spec=MessageFormatter)
-        formatter.formatMessageForBuildResults.return_value = {"body": "body",
-                                                               "type": "text",
-                                                               "subject": "subject"}
+        formatter.format_message_for_build.return_value = {
+            "body": "body",
+            "type": "text",
+            "subject": "subject"
+        }
         formatter.wantProperties = False
         formatter.wantSteps = False
         formatter.wantLogs = False
@@ -154,7 +156,7 @@ class TestNotifierBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
         mn, builds, formatter = yield self.setupBuildMessage(old_style=old_style, mode=("change",))
 
         build = builds[0]
-        formatter.formatMessageForBuildResults.assert_called_with(
+        formatter.format_message_for_build.assert_called_with(
             ('change',), 'Builder1', build['buildset'], build, self.master, SUCCESS, ['me@foo'])
 
         report = {

--- a/master/buildbot/test/unit/reporters/test_notifier.py
+++ b/master/buildbot/test/unit/reporters/test_notifier.py
@@ -22,7 +22,6 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from buildbot.process.results import FAILURE
-from buildbot.process.results import SUCCESS
 from buildbot.reporters.generators.build import BuildStatusGenerator
 from buildbot.reporters.generators.worker import WorkerMissingGenerator
 from buildbot.reporters.message import MessageFormatter
@@ -156,8 +155,8 @@ class TestNotifierBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
         mn, builds, formatter = yield self.setupBuildMessage(old_style=old_style, mode=("change",))
 
         build = builds[0]
-        formatter.format_message_for_build.assert_called_with(
-            ('change',), 'Builder1', build['buildset'], build, self.master, SUCCESS, ['me@foo'])
+        formatter.format_message_for_build.assert_called_with(('change',), 'Builder1', build,
+                                                              self.master, ['me@foo'])
 
         report = {
             'body': 'body',


### PR DESCRIPTION
This PR makes possible to implement other message formatters that reuse the common functionality.

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
