### PR TITLE
Merge HttpStatusPushBase and NotifierBase

### DIFF
--- a/master/buildbot/reporters/bitbucketserver.py
+++ b/master/buildbot/reporters/bitbucketserver.py
@@ -49,7 +49,8 @@ class BitbucketServerStatusPush(http.HttpStatusPushBase):
     def checkConfig(self, base_url, user, password, key=None, statusName=None,
                     startDescription=None, endDescription=None, verbose=False,
                     **kwargs):
-        super().checkConfig(wantProperties=True, **kwargs)
+        super().checkConfig(wantProperties=True, _has_old_arg_names={'wantProperties': False},
+                            **kwargs)
 
     @defer.inlineCallbacks
     def reconfigService(self, base_url, user, password, key=None,
@@ -149,7 +150,8 @@ class BitbucketServerCoreAPIStatusPush(http.HttpStatusPushBase):
         if token is not None and auth is not None:
             config.error("Only one authentication method can be given "
                          "(token or auth)")
-        super().checkConfig(wantProperties=True, **kwargs)
+        super().checkConfig(wantProperties=True, _has_old_arg_names={'wantProperties': False},
+                            **kwargs)
 
     @defer.inlineCallbacks
     def reconfigService(self, base_url, token=None, auth=None,

--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -32,10 +32,15 @@ class BuildStatusGenerator(BuildStatusGeneratorMixin):
     def __init__(self, mode=("failing", "passing", "warnings"),
                  tags=None, builders=None, schedulers=None, branches=None,
                  subject="Buildbot %(result)s in %(title)s on %(builder)s",
-                 add_logs=False, add_patch=False, report_new=False, message_formatter=None):
+                 add_logs=False, add_patch=False, report_new=False, message_formatter=None,
+                 _want_previous_build=None):
         super().__init__(mode, tags, builders, schedulers, branches, subject, add_logs, add_patch,
                          message_formatter)
         self._report_new = report_new
+
+        # TODO: private and deprecated, included only to support HttpStatusPushBase
+        self._want_previous_build_override = _want_previous_build
+
         if report_new:
             self.wanted_event_keys = [
                 ('builds', None, 'finished'),
@@ -47,6 +52,8 @@ class BuildStatusGenerator(BuildStatusGeneratorMixin):
         _, _, event = key
         is_new = event == 'new'
         want_previous_build = False if is_new else self._want_previous_build()
+        if self._want_previous_build_override is not None:
+            want_previous_build = self._want_previous_build_override
 
         yield utils.getDetailsForBuild(master, build,
                                        wantProperties=self.formatter.wantProperties,

--- a/master/buildbot/reporters/gerrit_verify_status.py
+++ b/master/buildbot/reporters/gerrit_verify_status.py
@@ -50,7 +50,10 @@ class GerritVerifyStatusPush(http.HttpStatusPushBase):
     def checkConfig(self, baseURL, auth, startDescription=None, endDescription=None,
                     verification_name=None, abstain=False, category=None, reporter=None,
                     verbose=False, wantProperties=True, **kwargs):
-        super().checkConfig(wantProperties=wantProperties, **kwargs)
+        super().checkConfig(wantProperties=wantProperties,
+                            _has_old_arg_names={
+                                'wantProperties': wantProperties is not True
+                            }, **kwargs)
 
     @defer.inlineCallbacks
     def reconfigService(self,

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -40,7 +40,10 @@ class GitHubStatusPush(http.HttpStatusPushBase):
 
     def checkConfig(token, startDescription=None, endDescription=None,
                     context=None, baseURL=None, verbose=False, wantProperties=True, **kwargs):
-        super().checkConfig(wantProperties=wantProperties, **kwargs)
+        super().checkConfig(wantProperties=wantProperties,
+                            _has_old_arg_names={
+                                'wantProperties': wantProperties is not True
+                            }, **kwargs)
 
     @defer.inlineCallbacks
     def reconfigService(self, token,

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -39,7 +39,10 @@ class GitLabStatusPush(http.HttpStatusPushBase):
 
     def checkConfig(token, startDescription=None, endDescription=None,
                     context=None, baseURL=None, verbose=False, wantProperties=True, **kwargs):
-        super().checkConfig(wantProperties=wantProperties, **kwargs)
+        super().checkConfig(wantProperties=wantProperties,
+                            _has_old_arg_names={
+                                'wantProperties': wantProperties is not True
+                            }, **kwargs)
 
     @defer.inlineCallbacks
     def reconfigService(self, token,

--- a/master/buildbot/reporters/hipchat.py
+++ b/master/buildbot/reporters/hipchat.py
@@ -41,14 +41,6 @@ class HipChatStatusPush(HttpStatusPushBase):
         self.builder_room_map = builder_room_map
         self.builder_user_map = builder_user_map
 
-    # returns a Deferred that returns None
-    def buildStarted(self, key, build):
-        return self.send(build, key[2])
-
-    # returns a Deferred that returns None
-    def buildFinished(self, key, build):
-        return self.send(build, key[2])
-
     @defer.inlineCallbacks
     def getBuildDetailsAndSendMessage(self, build, key):
         yield utils.getDetailsForBuild(self.master, build, wantProperties=self.wantProperties,
@@ -85,7 +77,9 @@ class HipChatStatusPush(HttpStatusPushBase):
         return {}
 
     @defer.inlineCallbacks
-    def send(self, build, key):
+    def send(self, build):
+        key = 'new' if build['complete'] is False else 'finished'
+
         postData = yield self.getBuildDetailsAndSendMessage(build, key)
         if not postData or 'message' not in postData or not postData['message']:
             return

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -183,6 +183,35 @@ class MessageFormatterBase(util.ComparableMixin):
         return None
 
 
+class MessageFormatterEmpty(MessageFormatterBase):
+    def format_message_for_build(self, mode, buildername, build, master, blamelist):
+        return {
+            'body': None,
+            'type': 'plain',
+            'subject': None
+        }
+
+
+class DeprecatedMessageFormatterBuildJson(MessageFormatterBase):
+
+    template_type = 'json'
+
+    def __init__(self, format_fn, **kwargs):
+        super().__init__(**kwargs)
+        self.format_fn = format_fn
+
+    @defer.inlineCallbacks
+    def format_message_for_build(self, mode, buildername, build, master, blamelist):
+        msgdict = yield self.render_message_dict(master, {'build': build})
+        return msgdict
+
+    def render_message_body(self, context):
+        return self.format_fn(context['build'])
+
+    def render_message_subject(self, context):
+        return None
+
+
 class MessageFormatterBaseJinja(MessageFormatterBase):
     template_filename = 'default_mail.txt'
 

--- a/master/buildbot/reporters/zulip.py
+++ b/master/buildbot/reporters/zulip.py
@@ -45,7 +45,7 @@ class ZulipStatusPush(HttpStatusPushBase):
 
     @defer.inlineCallbacks
     def send(self, build):
-        event = ("new", "finished")[0 if build["complete_at"] is None else 1]
+        event = ("new", "finished")[0 if build["complete"] is False else 1]
         jsondata = dict(event=event, buildid=build["buildid"], buildername=build["builder"]["name"],
                         url=build["url"], project=build["properties"]["project"][0])
         if event == "new":

--- a/master/buildbot/test/integration/interop/test_integration_secrets.py
+++ b/master/buildbot/test/integration/interop/test_integration_secrets.py
@@ -26,7 +26,7 @@ from buildbot.test.util.integration import RunMasterBase
 
 
 class FakeSecretReporter(HttpStatusPush):
-    def send(self, build):
+    def sendMessage(self, reports):
         assert self.auth == ('user', 'myhttppasswd')
         self.reported = True
 

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -129,6 +129,8 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
             fakedb.BuildProperty(buildid=20, name="revision", value=None),
         ])
 
+        self.setup_fake_get_changes_for_build(has_change=False)
+
         build = yield self.master.data.get(("builds", 20))
 
         build['complete'] = False
@@ -204,6 +206,8 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
                          workerid=13, masterid=92, results=SUCCESS, state_string="build_text"),
             fakedb.BuildProperty(buildid=20, name="buildername", value="Builder0"),
         ])
+
+        self.setup_fake_get_changes_for_build(has_change=False)
 
         build = yield self.master.data.get(("builds", 20))
 
@@ -398,6 +402,8 @@ class TestGitHubCommentPush(TestGitHubStatusPush):
             fakedb.BuildProperty(buildid=20, name="buildername", value="Builder0"),
             fakedb.BuildProperty(buildid=20, name="branch", value=branch2),
         ])
+
+        self.setup_fake_get_changes_for_build(has_change=False)
 
         build = yield self.master.data.get(("builds", 20))
 

--- a/master/buildbot/test/unit/reporters/test_hipchat.py
+++ b/master/buildbot/test/unit/reporters/test_hipchat.py
@@ -132,16 +132,10 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
         yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
-    def test_no_message_sent_empty_message(self):
-        yield self.createReporter()
-        build = yield self.insert_build_new()
-        self.sp.send(build, 'unknown')
-
-    @defer.inlineCallbacks
     def test_no_message_sent_without_id(self):
         yield self.createReporter()
         build = yield self.insert_build_new()
-        self.sp.send(build, 'new')
+        self.sp._got_event(('builds', 20, 'new'), build)
 
     @defer.inlineCallbacks
     def test_private_message_sent_with_user_id(self):
@@ -158,7 +152,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
             '/v2/user/123/message',
             params=dict(auth_token=token),
             json=message)
-        self.sp.send({}, 'test')
+        self.sp.send({'complete': True})
 
     @defer.inlineCallbacks
     def test_room_message_sent_with_room_id(self):
@@ -175,7 +169,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
             '/v2/room/123/notification',
             params=dict(auth_token=token),
             json=message)
-        self.sp.send({}, 'test')
+        self.sp.send({'complete': True})
 
     @defer.inlineCallbacks
     def test_private_and_room_message_sent_with_both_ids(self):
@@ -197,7 +191,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
             '/v2/room/123/notification',
             params=dict(auth_token=token),
             json=message)
-        self.sp.send({}, 'test')
+        self.sp.send({'complete': True})
 
     @defer.inlineCallbacks
     def test_postData_values_passed_through(self):
@@ -214,7 +208,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
             '/v2/user/123/message',
             params=dict(auth_token=token),
             json=message)
-        self.sp.send({}, 'test')
+        self.sp.send({'complete': True})
 
     @defer.inlineCallbacks
     def test_postData_error(self):
@@ -235,5 +229,5 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
                 "error_description": "This user is unknown to us",
                 "error": "invalid_user"})
         self.setUpLogging()
-        self.sp.send({}, 'test')
+        self.sp.send({'complete': True})
         self.assertLogged('404: unable to upload status')

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -27,6 +27,8 @@ from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
+from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class BuildLookAlike:
@@ -115,27 +117,35 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
 
     @defer.inlineCallbacks
     def test_filtering(self):
-        yield self.createReporter(builders=['foo'])
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='have been deprecated'):
+            yield self.createReporter(builders=['foo'])
         build = yield self.insert_build_finished(SUCCESS)
         yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_filteringPass(self):
-        yield self.createReporter(builders=['Builder0'])
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='have been deprecated'):
+            yield self.createReporter(builders=['Builder0'])
         self._http.expect("post", "", json=BuildLookAlike())
         build = yield self.insert_build_finished(SUCCESS)
         yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_builderTypeCheck(self):
-        yield self.createReporter(builders='Builder0')
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='have been deprecated'):
+            yield self.createReporter(builders='Builder0')
         config._errors.addError.assert_any_call(
             "builders must be a list or None")
 
     @defer.inlineCallbacks
     def test_wantKwargsCheck(self):
-        yield self.createReporter(builders='Builder0', wantProperties=True, wantSteps=True,
-                                  wantPreviousBuild=True, wantLogs=True)
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='have been deprecated'):
+            yield self.createReporter(builders='Builder0', wantProperties=True, wantSteps=True,
+                                      wantPreviousBuild=True, wantLogs=True)
         self._http.expect("post", "", json=BuildLookAlike(
             keys=['steps', 'prev_build']))
         build = yield self.insert_build_finished(SUCCESS)

--- a/master/buildbot/test/util/reporter.py
+++ b/master/buildbot/test/util/reporter.py
@@ -126,10 +126,16 @@ class ReporterTestMixin:
                     fakedb.BuildProperty(buildid=20 + i, name=k, value=v)
                 ])
 
-            @defer.inlineCallbacks
-            def getChangesForBuild(buildid):
-                assert buildid == 20
-                ch = yield self.master.db.changes.getChange(13)
-                return [ch]
+        self.setup_fake_get_changes_for_build()
 
-            self.master.db.changes.getChangesForBuild = getChangesForBuild
+    def setup_fake_get_changes_for_build(self, has_change=True):
+        @defer.inlineCallbacks
+        def getChangesForBuild(buildid):
+            if not has_change:
+                return []
+
+            assert buildid == 20
+            ch = yield self.master.db.changes.getChange(13)
+            return [ch]
+
+        self.master.db.changes.getChangesForBuild = getChangesForBuild


### PR DESCRIPTION
This PR makes HttpStatusPushBase to derive from NotifierBase and reuse the report generator functionality.

Documentation on newly exposed APIs will be updated in a subsequent PR.

## Contributor Checklist:

* [x] I have updated the unit tests
* [n/a] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
