### PR TITLE
Test py2.7 worker with Twisted 20.3.0

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -84,9 +84,10 @@ matrix:
     - python: "3.8"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=2.7
 
-    # keep worker supported on py2.7
+    # keep worker supported on py2.7.
+    # Twisted 20.3.0 is last version which supports py2.7.
     - python: "2.7"
-      env: TWISTED=latest SQLALCHEMY=latest TESTS=trial_worker
+      env: TWISTED=20.3.0 SQLALCHEMY=latest TESTS=trial_worker
 
 # Dependencies installation commands
 install:


### PR DESCRIPTION
This is the latest twisted version which supports Python 2.7

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
