### PR TITLE
Remove use of twisted.python.compat.intToBytes

### DIFF
--- a/master/buildbot/test/unit/util/test_httpclientservice.py
+++ b/master/buildbot/test/unit/util/test_httpclientservice.py
@@ -22,7 +22,6 @@ import mock
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.python import components
-from twisted.python.compat import intToBytes
 from twisted.trial import unittest
 from twisted.web import resource
 from twisted.web import server
@@ -293,7 +292,7 @@ class MyResource(resource.Resource):
         data = json.dumps(args)
         data = unicode2bytes(data)
         request.setHeader(b'content-type', b'application/json')
-        request.setHeader(b'content-length', intToBytes(len(data)))
+        request.setHeader(b'content-length', b"%d" % len(data))
         if request.method == b'HEAD':
             return b''
         return data


### PR DESCRIPTION
This is deprecated in latest Twisted.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
