### PR TITLE
Fix docker latent worker reconfig issues

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -268,11 +268,13 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
             yield self.mq.setup()
 
+            # the buildbot scripts send the SIGHUP signal to reconfig master
             if hasattr(signal, "SIGHUP"):
                 def sighup(*args):
                     eventually(self.reconfig)
                 signal.signal(signal.SIGHUP, sighup)
 
+            # the buildbot scripts send the SIGUSR1 signal to stop master
             if hasattr(signal, "SIGUSR1"):
                 def sigusr1(*args):
                     eventually(self.botmaster.cleanShutdown)

--- a/master/buildbot/newsfragments/latent-fix-build-stop-during-substantiation.bugfix
+++ b/master/buildbot/newsfragments/latent-fix-build-stop-during-substantiation.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug that caused builds running on latent workers to become unstoppable when an attempt was made to stop them while the latent worker was being substantiated :issue:`5136`.

--- a/master/buildbot/newsfragments/latent-fix-shutdown-after-reconfig.bugfix
+++ b/master/buildbot/newsfragments/latent-fix-shutdown-after-reconfig.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug that caused the buildmaster to be unable to restart if a latent worker was previously reconfigured during its substantiation.

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -346,7 +346,9 @@ class Build(properties.PropertiesMixin):
         yield self.master.data.updates.setBuildStateString(self.buildid,
                                                            'preparing worker')
         try:
-            ready_or_failure = yield workerforbuilder.prepare(self)
+            ready_or_failure = False
+            if workerforbuilder.worker and workerforbuilder.worker.acquireLocks():
+                ready_or_failure = yield workerforbuilder.substantiate_if_needed(self)
         except Exception:
             ready_or_failure = Failure()
 

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -110,6 +110,9 @@ class AbstractWorkerForBuilder:
     def substantiate_if_needed(self, build):
         return defer.succeed(True)
 
+    def insubstantiate_if_needed(self):
+        pass
+
     def ping(self, status=None):
         """Ping the worker to make sure it is still there. Returns a Deferred
         that fires with True if it is.
@@ -216,6 +219,9 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
         self.state = States.DETACHED
         d = self.substantiate(build)
         return d
+
+    def insubstantiate_if_needed(self):
+        self.worker.insubstantiate()
 
     def attached(self, worker, commands):
         # When a latent worker is attached, it is actually because it prepared for a build

--- a/master/buildbot/process/workerforbuilder.py
+++ b/master/buildbot/process/workerforbuilder.py
@@ -107,9 +107,7 @@ class AbstractWorkerForBuilder:
         yield self.worker.conn.remotePrint(message="attached")
         return self
 
-    def prepare(self, build):
-        if not self.worker or not self.worker.acquireLocks():
-            return defer.succeed(False)
+    def substantiate_if_needed(self, build):
         return defer.succeed(True)
 
     def ping(self, status=None):
@@ -214,11 +212,7 @@ class LatentWorkerForBuilder(AbstractWorkerForBuilder):
         self.worker.addWorkerForBuilder(self)
         log.msg("Latent worker {} attached to {}".format(worker.workername, self.builder_name))
 
-    def prepare(self, build):
-        # If we can't lock, then don't bother trying to substantiate
-        if not self.worker or not self.worker.acquireLocks():
-            return defer.succeed(False)
-
+    def substantiate_if_needed(self, build):
         self.state = States.DETACHED
         d = self.substantiate(build)
         return d

--- a/master/buildbot/test/fake/worker.py
+++ b/master/buildbot/test/fake/worker.py
@@ -42,7 +42,7 @@ class FakeWorker:
         self.workerid = 383
 
     def acquireLocks(self):
-        pass
+        return True
 
     def releaseLocks(self):
         pass

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -33,6 +33,7 @@ from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
 from buildbot.process.results import RETRY
 from buildbot.process.results import SUCCESS
+from buildbot.test.fake.latent import ControllableLatentWorker
 from buildbot.test.fake.latent import LatentController
 from buildbot.test.fake.machine import LatentMachineController
 from buildbot.test.fake.step import BuildStepController
@@ -539,6 +540,35 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.reactor.advance(1)  # force build to actually execute the stop instruction
 
         self.assertTrue(controller.stopped)
+
+    @parameterized.expand([
+        ('without_worker_connecting', False),
+        ('with_worker_connecting', True),
+    ])
+    @defer.inlineCallbacks
+    def test_reconfigservice_during_substantiation_clean_shutdown_after(self, name,
+                                                                        worker_connects):
+        """
+        When stopService is called and a worker is substantiating, we should wait for this
+        process to complete.
+        """
+        controller, builder_id = yield self.create_single_worker_config()
+        controller.auto_connect_worker = worker_connects
+        controller.auto_stop(True)
+
+        # Substantiate worker via a build
+        yield self.create_build_request([builder_id])
+        self.assertTrue(controller.starting)
+
+        yield controller.start_instance(True)
+
+        # change some unimportant property of the worker to force configuration
+        self.master.config_loader.config_dict['workers'] = [
+            ControllableLatentWorker('local', controller, max_builds=3)
+        ]
+        yield self.reconfig_master()
+
+        yield self.clean_master_shutdown(quick=True)
 
     @defer.inlineCallbacks
     def test_substantiation_cancelled_by_insubstantiation_when_waiting_for_insubstantiation(self):

--- a/master/buildbot/test/unit/process/test_build.py
+++ b/master/buildbot/test/unit/process/test_build.py
@@ -197,7 +197,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 
         self.workerforbuilder = Mock(name='workerforbuilder')
         self.workerforbuilder.worker = self.worker
-        self.workerforbuilder.prepare = lambda _: True
+        self.workerforbuilder.substantiate_if_needed = lambda _: True
         self.workerforbuilder.ping = lambda: True
 
         self.build.setBuilder(self.builder)
@@ -236,39 +236,39 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 
         self.assertIn('stop it', step.interrupted)
 
-    def testBuildRetryWhenWorkerPrepareReturnFalse(self):
+    def test_build_retry_when_worker_substantiate_returns_false(self):
         b = self.build
 
         step = FakeBuildStep()
         b.setStepFactories([FakeStepFactory(step)])
 
-        self.workerforbuilder.prepare = lambda _: False
+        self.workerforbuilder.substantiate_if_needed = lambda _: False
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
         self.assertEqual(b.results, RETRY)
         self.assertWorkerPreparationFailure('error while worker_prepare')
 
-    def testBuildCancelledWhenWorkerPrepareReturnFalseBecauseBuildStop(self):
+    def test_build_cancelled_when_worker_substantiate_returns_false_due_to_cancel(self):
         b = self.build
 
         step = FakeBuildStep()
         b.setStepFactories([FakeStepFactory(step)])
 
         d = defer.Deferred()
-        self.workerforbuilder.prepare = lambda _: d
+        self.workerforbuilder.substantiate_if_needed = lambda _: d
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
         b.stopBuild('Cancel Build', CANCELLED)
         d.callback(False)
         self.assertEqual(b.results, CANCELLED)
         self.assertWorkerPreparationFailure('error while worker_prepare')
 
-    def testBuildRetryWhenWorkerPrepareReturnFalseBecauseBuildStop(self):
+    def test_build_retry_when_worker_substantiate_returns_false_due_to_cancel(self):
         b = self.build
 
         step = FakeBuildStep()
         b.setStepFactories([FakeStepFactory(step)])
 
         d = defer.Deferred()
-        self.workerforbuilder.prepare = lambda _: d
+        self.workerforbuilder.substantiate_if_needed = lambda _: d
         b.startBuild(FakeBuildStatus(), self.workerforbuilder)
         b.stopBuild('Cancel Build', RETRY)
         d.callback(False)
@@ -448,7 +448,7 @@ class TestBuild(TestReactorMixin, unittest.TestCase):
 
         eWorker.worker = self.worker
         cWorker.worker = self.worker
-        eWorker.prepare = cWorker.prepare = lambda _: True
+        eWorker.substantiate_if_needed = cWorker.substantiate_if_needed = lambda _: True
         eWorker.ping = cWorker.ping = lambda: True
 
         lock = WorkerLock('lock', 2)

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -104,6 +104,10 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin,
             self.master.config_loader.config_dict = config_dict
         yield self.master.doReconfig()
 
+    @defer.inlineCallbacks
+    def clean_master_shutdown(self, quick=False):
+        yield self.master.botmaster.cleanShutdown(quickMode=quick, stopReactor=False)
+
     def createLocalWorker(self, name, **kwargs):
         workdir = FilePath(self.mktemp())
         workdir.createDirectory()

--- a/master/buildbot/worker/latent.py
+++ b/master/buildbot/worker/latent.py
@@ -158,6 +158,12 @@ class AbstractLatentWorker(AbstractWorker):
         NOT_SUBSTANTIATED -> SHUT_DOWN
     '''
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._substantiation_notifier = Notifier()
+        self._start_stop_lock = defer.DeferredLock()
+        self._deferwaiter = deferwaiter.DeferWaiter()
+
     def checkConfig(self, name, password,
                     build_wait_timeout=60 * 10,
                     **kwargs):
@@ -166,9 +172,6 @@ class AbstractLatentWorker(AbstractWorker):
     def reconfigService(self, name, password,
                         build_wait_timeout=60 * 10,
                         **kwargs):
-        self._substantiation_notifier = Notifier()
-        self._start_stop_lock = defer.DeferredLock()
-        self._deferwaiter = deferwaiter.DeferWaiter()
         self.build_wait_timeout = build_wait_timeout
         return super().reconfigService(name, password, **kwargs)
 


### PR DESCRIPTION
These commit attempts to fix two issues that we have been seeing with docker workers and reconfigurations:
1. reconfigurations can make buildbot unresponsive, i.e. it wouldn't pick up builds and it wouldn't gracefully restart
2. builds that are stuck in the preparation state (of the docker latent worker) cannot be stopped

I introduced these changes to the best of my understanding and I've tested them (details in the commit messages).
However, I'd appreciate a careful review because I am not very familiar with this complex piece of code.

This could help with fixing #3459 and seems related to #2948 (which is pretty old).

## Contributor Checklist:

* [ ] I have updated the unit tests
  - not yet, but I'd be happy to write tests if the fixes are deemed correct
* [ ] ~I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)~
* [ ] ~I have updated the appropriate documentation~
