### PR TITLE
worker: Report exceptions raised during command startup

### DIFF
--- a/master/buildbot/newsfragments/worker-report-exceptions.bugfix
+++ b/master/buildbot/newsfragments/worker-report-exceptions.bugfix
@@ -1,0 +1,1 @@
+The worker will now report low level cause of errors during the command startup.

--- a/worker/buildbot_worker/exceptions.py
+++ b/worker/buildbot_worker/exceptions.py
@@ -21,8 +21,9 @@ class AbandonChain(Exception):
 
     """A series of chained steps can raise this exception to indicate that
     one of the intermediate RunProcesses has failed, such that there is no
-    point in running the remainder. 'rc' should be the non-zero exit code of
-    the failing ShellCommand."""
+    point in running the remainder. The first argument to the exception
+    is the 'rc' - the non-zero exit code of the failing ShellCommand.
+    The second is an optional error message."""
 
     def __repr__(self):
         return "<AbandonChain rc={0}>".format(self.args[0])

--- a/worker/buildbot_worker/runprocess.py
+++ b/worker/buildbot_worker/runprocess.py
@@ -451,13 +451,13 @@ class RunProcess(object):
         self.deferred = defer.Deferred()
         try:
             self._startCommand()
-        except Exception:
+        except Exception as e:
             log.err(failure.Failure(), "error in RunProcess._startCommand")
-            self._addToBuffers('stderr', "error in RunProcess._startCommand\n")
+            self._addToBuffers('stderr', "error in RunProcess._startCommand (%s)\n" % str(e))
             self._addToBuffers('stderr', traceback.format_exc())
             self._sendBuffers()
             # pretend it was a shell error
-            self.deferred.errback(AbandonChain(-1))
+            self.deferred.errback(AbandonChain(-1, 'Got exception (%s)' % str(e)))
         return self.deferred
 
     def _startCommand(self):

--- a/worker/buildbot_worker/test/unit/test_runprocess.py
+++ b/worker/buildbot_worker/test/unit/test_runprocess.py
@@ -354,10 +354,9 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
 
         # set up to cause an exception in _startCommand
         def _startCommand(*args, **kwargs):
-            raise RuntimeError()
+            raise RuntimeError('error message')
         s._startCommand = _startCommand
 
-        d = s.start()
         try:
             yield s.start()
         except AbandonChain:
@@ -370,7 +369,7 @@ class TestRunProcess(BasedirMixin, unittest.TestCase):
             if 'stderr' in u:
                 stderr.append(u['stderr'])
         stderr = ''.join(stderr)
-        self.assertTrue("RuntimeError" in stderr, stderr)
+        self.assertTrue(stderr.startswith('error in RunProcess._startCommand (error message)'))
 
         yield self.flushLoggedErrors()
 


### PR DESCRIPTION
This would make it much easier to debug issues like #5581.