### PR TITLE
buildbot.data.types.DateTime is an integer

### DIFF
--- a/master/buildbot/data/types.py
+++ b/master/buildbot/data/types.py
@@ -116,8 +116,25 @@ class Integer(Instance):
 
 
 class DateTime(Instance):
+
     name = "datetime"
-    types = (datetime.datetime)
+    types = (datetime.datetime,)
+
+    def valueFromString(self, arg):
+        return int(arg)
+
+    def validate(self, name, object):
+        if isinstance(object, datetime.datetime):
+            return
+        if isinstance(object, int):
+            try:
+                datetime.datetime.fromtimestamp(object)
+            except (OverflowError, OSError):
+                pass
+            else:
+                return
+        yield "{} ({}) is not a valid timestamp".format(name, object)
+
     ramlType = "date"
 
 

--- a/master/buildbot/test/unit/data/test_types.py
+++ b/master/buildbot/test/unit/data/test_types.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from datetime import datetime
+
 from twisted.trial import unittest
 
 from buildbot.data import types
@@ -76,6 +78,17 @@ class Integer(TypeMixin, unittest.TestCase):
     stringValues = [('0', 0), ('-10', -10)]
     badStringValues = ['one', '', '0x10']
     cmpResults = [(10, '9', 1), (-2, '-1', -1)]
+
+
+class DateTime(TypeMixin, unittest.TestCase):
+
+    klass = types.DateTime
+    good = [0, 1604843464, datetime(2020, 11, 15, 18, 40, 1, 630219)]
+    bad = [int(1e60), 'bad', 1604843464.388657]
+    stringValues = [
+        ('1604843464', 1604843464),
+    ]
+    badStringValues = ['one', '', '0x10']
 
 
 class String(TypeMixin, unittest.TestCase):


### PR DESCRIPTION
fixes #5529 
The issue is that DateTime class has default `valueFromString` that throws `TypeError`.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
