### PR TITLE
Fix tests with Python 3.9

### DIFF
--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -134,3 +134,9 @@ warnings.filterwarnings('ignore', ".*Not importing directory .*/zope: missing __
                         category=ImportWarning)
 warnings.filterwarnings('ignore', ".*Not importing directory .*/sphinxcontrib: missing __init__",
                         category=ImportWarning)
+
+# ignore warnings from importing lib2to3 via buildbot_pkg ->
+# setuptools.command.build_py -> setuptools.lib2to3_ex -> lib2to3
+# https://github.com/pypa/setuptools/issues/2086
+warnings.filterwarnings('ignore', ".*lib2to3 package is deprecated",
+                        category=PendingDeprecationWarning)


### PR DESCRIPTION
Ref: https://github.com/pypa/setuptools/issues/2086

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

(I'm not sure if I should state Python 3.9 support in this pull request)