### PR TITLE
try: Fix errors when dryrun is enabled

### DIFF
--- a/master/buildbot/newsfragments/fix-tryclient-dryrun.bugfix
+++ b/master/buildbot/newsfragments/fix-tryclient-dryrun.bugfix
@@ -1,0 +1,1 @@
+Fix AssertionError when calling try client with ``--dryrun`` option (:issue: `5618`).

--- a/master/buildbot/test/integration/test_try_client.py
+++ b/master/buildbot/test/integration/test_try_client.py
@@ -161,6 +161,34 @@ class Schedulers(RunMasterBase, www.RequiresWwwMixin):
         self.assertEqual(len(buildsets), 1)
 
     @defer.inlineCallbacks
+    def test_userpass_wait_dryrun(self):
+        yield self.startMaster(
+            trysched.Try_Userpass('try', ['a'], 0, [('u', b'p')]))
+        yield self.runClient({
+            'connect': 'pb',
+            'master': '127.0.0.1:{}'.format(self.serverPort),
+            'username': 'u',
+            'passwd': b'p',
+            'wait': True,
+            'dryrun': True,
+        })
+        self.assertEqual(self.output, [
+            "using 'pb' connect method",
+            'job created',
+            'Job:\n'
+            '\tRepository: \n'
+            '\tProject: \n'
+            '\tBranch: br\n'
+            '\tRevision: rr\n'
+            '\tBuilders: None\n'
+            '++--',
+            'job has been delivered',
+            'All Builds Complete',
+        ])
+        buildsets = yield self.master.db.buildsets.getBuildsets()
+        self.assertEqual(len(buildsets), 0)
+
+    @defer.inlineCallbacks
     def test_userpass_list_builders(self):
         yield self.startMaster(
             trysched.Try_Userpass('try', ['a'], 0, [('u', b'p')]))

--- a/master/buildbot/test/integration/test_try_client_e2e.py
+++ b/master/buildbot/test/integration/test_try_client_e2e.py
@@ -32,7 +32,7 @@ class TryClientE2E(RunMasterBase):
 
         def trigger_callback():
             def thd():
-                os.system("buildbot try --connect=pb --master=127.0.0.1:8031 -b testy "
+                os.system("buildbot try --connect=pb --master=127.0.0.1:8030 -b testy "
                           "--property=foo:bar --username=alice --passwd=pw1 --vc=none")
             reactor.callInThread(thd)
 
@@ -51,7 +51,7 @@ def masterConfig():
     c['schedulers'] = [
         schedulers.Try_Userpass(name="try",
                                 builderNames=["testy"],
-                                port=8031,
+                                port=8030,
                                 userpass=[("alice", "pw1")])
     ]
     f = BuildFactory()


### PR DESCRIPTION
Fixes #5618 
## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
