### PR TITLE
try: Fix bytes-related master crash when calling buildbot try

### DIFF
--- a/master/buildbot/newsfragments/try-crash-bytes.bugfix
+++ b/master/buildbot/newsfragments/try-crash-bytes.bugfix
@@ -1,0 +1,1 @@
+Fix bytes-related master crash when calling buildbot try (:issue:`4488`)

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -393,6 +393,14 @@ class Try_Userpass_Perspective(pbutil.NewCredPerspective):
         if not builderNames:
             return None
 
+        branch = bytes2unicode(branch)
+        revision = bytes2unicode(revision)
+        patch = patch[0], bytes2unicode(patch[1])
+        repository = bytes2unicode(repository)
+        project = bytes2unicode(project)
+        who = bytes2unicode(who)
+        comment = bytes2unicode(comment)
+
         reason = "'try' job"
 
         if who:


### PR DESCRIPTION
Fixed bug #4488
## Contributor Checklist:

* [ x ] I have updated the unit tests
* [ x ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)

