### PR TITLE
forcedialog/forcefields: Allow browsers to implement field autocomple…

### DIFF
--- a/master/buildbot/newsfragments/autocomplete_forcedialog.feature
+++ b/master/buildbot/newsfragments/autocomplete_forcedialog.feature
@@ -1,0 +1,1 @@
+Add ability for the browser to auto-complete force dialog form fields.

--- a/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.tpl.jade
+++ b/www/base/src/app/builders/buildrequest/forcedialog/forcedialog.tpl.jade
@@ -1,4 +1,5 @@
 .modal-content
+  form
     .modal-body
         // put the header in the body in order to correctly display error popup
         h4 {{sch.label}}
@@ -9,4 +10,4 @@
             forcefield(field="rootfield" ng-if="rootfield")
     .modal-footer
       button.btn.btn-default(ng-click="cancel()") Cancel
-      button.btn.btn-primary(ng-click="ok()", ng-disabled="!sch.enabled || startDisabled") Start Build
+      button.btn.btn-primary(type="submit", ng-click="ok()", ng-disabled="!sch.enabled || startDisabled") Start Build

--- a/www/base/src/app/common/directives/forcefields/textfield.tpl.jade
+++ b/www/base/src/app/common/directives/forcefields/textfield.tpl.jade
@@ -2,4 +2,4 @@ basefield
     label.control-label.col-sm-2(for="{{field.name}}")
         | {{field.label}}
     .col-sm-10
-        input.form-control(type='text', ng-model="field.value")
+        input.form-control(type='text', ng-model="field.value", autocomplete="on" id="{{field.name}}")


### PR DESCRIPTION
…tion

In order for broswers to support autocomplete of form text fields, there
needs to be a form with a submit button, the input fields need ids and we
can hint with autocomplete="on". Add these things to the forms allowing
autocompletion to work.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

## Remove this paragraph

If you don't remove this paragraph from the pull request description, this means you didn't read our contributor documentation, and your patch will need more back and forth before it can be accepted!

Please have a look at our developer documentation before submitting your Pull Request.

http://docs.buildbot.net/latest/developer/quickstart.html

And especially:
http://docs.buildbot.net/latest/developer/pull-request.html


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
