### PR TITLE
util: Fix permission denied in rmtree() usage in PrivateTemporaryDire…

### DIFF
--- a/master/buildbot/newsfragments/fix-rmtree-permission-error-on-windows.bugfix
+++ b/master/buildbot/newsfragments/fix-rmtree-permission-error-on-windows.bugfix
@@ -1,0 +1,1 @@
+Fix permission denied in rmtree() usage in PrivateTemporaryDirectory on Windows

--- a/master/buildbot/util/private_tempdir.py
+++ b/master/buildbot/util/private_tempdir.py
@@ -13,8 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
-
+import os
 import shutil
+import stat
 import tempfile
 
 
@@ -38,5 +39,12 @@ class PrivateTemporaryDirectory:
 
     def cleanup(self):
         if self._cleanup_needed:
-            shutil.rmtree(self.name)
+            def remove_readonly(func, path, _):
+                """ Workaround Permission Error on Windows if any files in path are read-only.
+
+                See https://docs.python.org/3/library/shutil.html#rmtree-example
+                """
+                os.chmod(path, stat.S_IWRITE)
+                func(path)
+            shutil.rmtree(self.name, onerror=remove_readonly)
             self._cleanup_needed = False

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -629,6 +629,7 @@ prepend
 prepended
 prepending
 prev
+PrivateTemporaryDirectory
 procmail
 prois
 propertiesDict
@@ -700,6 +701,7 @@ revlink
 revlinks
 rmdir
 rmfile
+rmtree
 Robocopy
 rootlink
 routingkeys


### PR DESCRIPTION


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
