### PR TITLE
test: Remove unnecessary local variables in reporter tests

### DIFF
--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -64,9 +64,9 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
             self.master, self,
             'serv', auth=('username', 'passwd'),
             debug=None, verify=None)
-        self.sp = sp = BitbucketServerStatusPush(
-            "serv", Interpolate("username"), Interpolate("passwd"), **kwargs)
-        yield sp.setServiceParent(self.master)
+        self.sp = BitbucketServerStatusPush("serv", Interpolate("username"),
+                                            Interpolate("passwd"), **kwargs)
+        yield self.sp.setServiceParent(self.master)
         yield self.master.startService()
 
     @defer.inlineCallbacks
@@ -199,9 +199,9 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
             self.master, self,
             'serv', auth=('username', 'passwd'), headers=http_headers,
             debug=None, verify=None)
-        self.sp = sp = BitbucketServerCoreAPIStatusPush(
+        self.sp = BitbucketServerCoreAPIStatusPush(
             "serv", token=token, auth=(Interpolate("username"), Interpolate("passwd")), **kwargs)
-        yield sp.setServiceParent(self.master)
+        yield self.sp.setServiceParent(self.master)
         yield self.master.startService()
 
     def setUp(self):

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -59,9 +59,9 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
         self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
             self.master, self, "gerrit", auth=('log', 'pass'),
             debug=None, verify=None)
-        self.sp = sp = GerritVerifyStatusPush("gerrit", auth=auth, **kwargs)
-        sp.sessionFactory = Mock(return_value=Mock())
-        yield sp.setServiceParent(self.master)
+        self.sp = GerritVerifyStatusPush("gerrit", auth=auth, **kwargs)
+        self.sp.sessionFactory = Mock(return_value=Mock())
+        yield self.sp.setServiceParent(self.master)
 
     def tearDown(self):
         return self.master.stopService()

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -53,13 +53,12 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
                 'User-Agent': 'Buildbot'
             },
             debug=None, verify=None)
-        sp = self.setService()
-        sp.sessionFactory = Mock(return_value=Mock())
-        yield sp.setServiceParent(self.master)
+        self.sp = self.createService()
+        self.sp.sessionFactory = Mock(return_value=Mock())
+        yield self.sp.setServiceParent(self.master)
 
-    def setService(self):
-        self.sp = GitHubStatusPush(Interpolate('XXYYZZ'))
-        return self.sp
+    def createService(self):
+        return GitHubStatusPush(Interpolate('XXYYZZ'))
 
     def tearDown(self):
         return self.master.stopService()
@@ -242,13 +241,12 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
                 'User-Agent': 'Buildbot'
             },
             debug=None, verify=None)
-        sp = self.setService()
-        sp.sessionFactory = Mock(return_value=Mock())
-        yield sp.setServiceParent(self.master)
+        self.sp = self.createService()
+        self.sp.sessionFactory = Mock(return_value=Mock())
+        yield self.sp.setServiceParent(self.master)
 
-    def setService(self):
-        self.sp = GitHubStatusPush('XXYYZZ')
-        return self.sp
+    def createService(self):
+        return GitHubStatusPush('XXYYZZ')
 
     def tearDown(self):
         return self.master.stopService()
@@ -318,9 +316,8 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
 
 class TestGitHubCommentPush(TestGitHubStatusPush):
 
-    def setService(self):
-        self.sp = GitHubCommentPush('XXYYZZ')
-        return self.sp
+    def createService(self):
+        return GitHubCommentPush('XXYYZZ')
 
     @defer.inlineCallbacks
     def test_basic(self):

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -49,9 +49,9 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
             self.master, self,
             HOSTED_BASE_URL, headers={'PRIVATE-TOKEN': 'XXYYZZ'},
             debug=None, verify=None)
-        self.sp = sp = GitLabStatusPush(Interpolate('XXYYZZ'))
-        sp.sessionFactory = Mock(return_value=Mock())
-        yield sp.setServiceParent(self.master)
+        self.sp = GitLabStatusPush(Interpolate('XXYYZZ'))
+        self.sp.sessionFactory = Mock(return_value=Mock())
+        yield self.sp.setServiceParent(self.master)
 
     def tearDown(self):
         return self.master.stopService()

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -87,8 +87,8 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
             passwd = Interpolate(passwd)
             interpolated_auth = (username, passwd)
 
-        self.sp = sp = HttpStatusPush("serv", auth=interpolated_auth, **kwargs)
-        yield sp.setServiceParent(self.master)
+        self.sp = HttpStatusPush("serv", auth=interpolated_auth, **kwargs)
+        yield self.sp.setServiceParent(self.master)
 
     @defer.inlineCallbacks
     def tearDown(self):


### PR DESCRIPTION
Exactly what the title says.