### PR TITLE
process/build: Show workername in worker prepare step

### DIFF
--- a/master/buildbot/newsfragments/workername_prepare_step.feature
+++ b/master/buildbot/newsfragments/workername_prepare_step.feature
@@ -1,0 +1,1 @@
+Show the workername in the worker preparation step

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -402,8 +402,9 @@ class Build(properties.PropertiesMixin):
         yield self.master.data.updates.setBuildStateString(self.buildid,
                                                            'acquiring locks')
         yield self.acquireLocks()
-        yield self.master.data.updates.setStepStateString(self.preparation_step.stepid,
-                                                          "worker ready")
+
+        readymsg = "worker {} ready".format(self.getWorkerName())
+        yield self.master.data.updates.setStepStateString(self.preparation_step.stepid, readymsg)
         yield self.master.data.updates.finishStep(self.preparation_step.stepid, SUCCESS, False)
 
         yield self.master.data.updates.setBuildStateString(self.buildid,

--- a/master/buildbot/test/integration/test_trigger.py
+++ b/master/buildbot/test/integration/test_trigger.py
@@ -25,7 +25,7 @@ from buildbot.test.util.integration import RunMasterBase
 
 expectedOutputRegex = \
     r"""\*\*\* BUILD 1 \*\*\* ==> build successful \(success\)
-    \*\*\* STEP worker_preparation \*\*\* ==> worker ready \(success\)
+    \*\*\* STEP worker_preparation \*\*\* ==> worker local1 ready \(success\)
     \*\*\* STEP shell \*\*\* ==> 'echo hello' \(success\)
         log:stdio \({loglines}\)
     \*\*\* STEP trigger \*\*\* ==> triggered trigsched \(success\)
@@ -34,7 +34,7 @@ expectedOutputRegex = \
     \*\*\* STEP shell_1 \*\*\* ==> 'echo world' \(success\)
         log:stdio \({loglines}\)
 \*\*\* BUILD 2 \*\*\* ==> build successful \(success\)
-    \*\*\* STEP worker_preparation \*\*\* ==> worker ready \(success\)
+    \*\*\* STEP worker_preparation \*\*\* ==> worker local1 ready \(success\)
     \*\*\* STEP shell \*\*\* ==> 'echo ola' \(success\)
         log:stdio \({loglines}\)
 """


### PR DESCRIPTION
It's useful for some workflows to see which worker was used in the build summary
screen rather than having to click further into the UI. The easiest way to do this
is to show the worker name in the worker_preparation step description.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>