### PR TITLE
fix: use `git fetch -f -t` to clobber existing tags instead of failing

### DIFF
--- a/master/buildbot/newsfragments/fix-git-fetch-breaking-on-changed-tags.bugfix
+++ b/master/buildbot/newsfragments/fix-git-fetch-breaking-on-changed-tags.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue where ``git fetch`` would break on tag changes by adding the ``-f`` option. This could previously be handled by manually specifying ``clobberOnFailure``, but as that is rather heavy handed and off by default, this new default functionality will keep Buildbot in sync with the repository it is fetching from.

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -312,7 +312,7 @@ class Git(Source, GitStepMixin):
                 fetch_required = False
 
         if fetch_required:
-            command = ['fetch', '-t', self.repourl, self.branch]
+            command = ['fetch', '-f', '-t', self.repourl, self.branch]
             # If the 'progress' option is set, tell git fetch to output
             # progress information to the log. This can solve issues with
             # long fetches killed due to lack of output, but only works

--- a/master/buildbot/test/unit/steps/test_source_gerrit.py
+++ b/master/buildbot/test/unit/steps/test_source_gerrit.py
@@ -59,7 +59,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'gerrit_branch', '--progress'])
             + 0,
@@ -105,7 +105,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'refs/changes/34/1234/567', '--progress'])
             + 0,
@@ -151,7 +151,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'refs/changes/34/1234/567', '--progress'])
             + 0,
@@ -197,7 +197,7 @@ class TestGerrit(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -74,7 +74,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -113,7 +113,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'])
             + 0,
@@ -169,7 +169,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', '-c', ssh_command_config,
-                                 'fetch', '-t',
+                                 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -226,7 +226,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'],
                         env={'GIT_SSH_COMMAND': ssh_command})
@@ -296,7 +296,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
                         env={'GIT_SSH': ssh_wrapper_path})
@@ -373,7 +373,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', '-c', ssh_command_config,
-                                 'fetch', '-t',
+                                 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -442,7 +442,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'],
                         env={'GIT_SSH_COMMAND': ssh_command})
@@ -521,7 +521,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
                         env={'GIT_SSH': ssh_wrapper_path})
@@ -600,7 +600,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
                         env={'GIT_SSH': ssh_wrapper_path})
@@ -674,7 +674,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + 0,
             ExpectShell(workdir=workdir,
                         command=['git', '-c', ssh_command_config,
-                                 'fetch', '-t',
+                                 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -717,7 +717,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -773,7 +773,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', '-c', ssh_command_config,
-                                 'fetch', '-t',
+                                 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -831,7 +831,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'],
                         env={'GIT_SSH_COMMAND': ssh_command})
@@ -897,7 +897,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD'],
                         env={'GIT_SSH': ssh_wrapper_path})
@@ -944,7 +944,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + 0,
             ExpectShell(workdir='wkdir',
                         timeout=1,
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -990,7 +990,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -1057,7 +1057,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -1119,7 +1119,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -1171,7 +1171,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'test-branch', '--progress'])
             + 0,
@@ -1249,7 +1249,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -1406,7 +1406,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -1558,7 +1558,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                  '.'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'test-branch'])
             + 0,
@@ -1597,7 +1597,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                                 logEnviron=True))
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -1634,7 +1634,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -1671,7 +1671,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -1750,7 +1750,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'test-branch', '--progress'])
             + 0,
@@ -1808,7 +1808,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + 0,
             ExpectShell(workdir='wkdir',
                         command=['git', '-c', ssh_command_config,
-                                 'fetch', '-t',
+                                 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'test-branch', '--progress'])
             + 0,
@@ -1853,7 +1853,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -1970,7 +1970,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'cat-file', '-e', 'abcdef01'])
             + 1,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -2009,7 +2009,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -2061,7 +2061,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -2115,7 +2115,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -2268,7 +2268,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -2276,7 +2276,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 1,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -2313,7 +2313,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'test-branch', '--progress'])
             + 0,
@@ -2321,7 +2321,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 1,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'test-branch', '--progress'])
             + 0,
@@ -2361,7 +2361,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -2407,7 +2407,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'test-branch', '--progress'])
             + 0,
@@ -2457,7 +2457,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='source',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -2516,7 +2516,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + 0,
             ExpectShell(workdir='source',
                         command=['git', '-c', ssh_command_config,
-                                 'fetch', '-t',
+                                 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -2883,7 +2883,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=['git', 'clean', '-f', '-f', '-d', '-x'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -2924,7 +2924,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         env={'abc': '123'})
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'],
                         env={'abc': '123'})
@@ -2968,7 +2968,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         logEnviron=False)
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'],
                         logEnviron=False)
@@ -3044,7 +3044,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -3096,7 +3096,7 @@ class TestGit(sourcesteps.SourceStepMixin,
             + Expect.update('files', ['.git'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
@@ -3431,7 +3431,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                         command=prefix + ['clean', '-f', '-f', '-d'])
             + 0,
             ExpectShell(workdir='wkdir',
-                        command=prefix + ['fetch', '-t',
+                        command=prefix + ['fetch', '-f', '-t',
                                           '{}/buildbot/buildbot.git'.format(value),
                                           'HEAD', '--progress'])
             + 0,

--- a/master/buildbot/test/unit/steps/test_source_github.py
+++ b/master/buildbot/test/unit/steps/test_source_github.py
@@ -48,7 +48,7 @@ class TestGitHub(test_source_git.TestGit):
             + 0,
             # here we always ignore revision, and fetch the merge branch
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'refs/pull/1234/merge', '--progress'])
             + 0,

--- a/master/buildbot/test/unit/steps/test_source_gitlab.py
+++ b/master/buildbot/test/unit/steps/test_source_gitlab.py
@@ -75,7 +75,7 @@ class TestGitLab(sourcesteps.SourceStepMixin, config.ConfigErrorsMixin,
             + 0,
             # here we always ignore revision, and fetch the merge branch
             ExpectShell(workdir='wkdir',
-                        command=['git', 'fetch', '-t',
+                        command=['git', 'fetch', '-f', '-t',
                                  'git@gitlab.example.com:build/awesome_project.git',
                                  'ms-viewport', '--progress'])
             + 0,


### PR DESCRIPTION
I believe this change should be acceptable, but before writing any tests or updating further I wanted to understand if this makes sense.

I'm not sure why `-t` (`--tags`) was originally provided since I believe `self.branch`, if a tag, would have worked as expected. However, when using `--tags` without `-f` (`--force`) I am getting a build error. I nuked the directory manually, and now see there are two retry options `retryFetch` and `clobberOnFailure`. The latter would do what I did manually and this **may** be the only reason that flag exists.

I'm not sure if a CI maintainer should have to run into this issue, and then fix it. So I would either suggest the `clobberOnFailure` default to `True` or that the `-f` flag be passed to `fetch`. I'm not sure if there is a good reason / likely case where a user would use `fetch` to detect tags changing so I don't think there is a strong reason not to accept this change.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
