### PR TITLE
fixed changes.HgPoller branch heads retrieval

### DIFF
--- a/master/buildbot/changes/hgpoller.py
+++ b/master/buildbot/changes/hgpoller.py
@@ -218,7 +218,7 @@ class HgPoller(base.PollingChangeSource, StateMixin):
         yet, one shouldn't be surprised to get errors)
         """
         d = utils.getProcessOutput(self.hgbin,
-                                   ['heads', '-r', branch,
+                                   ['heads', branch,
                                        '--template={rev}' + os.linesep],
                                    path=self._absWorkdir(), env=os.environ, errortoo=False)
 

--- a/master/buildbot/newsfragments/fix-hgpoller-heads-lookup.bugfix
+++ b/master/buildbot/newsfragments/fix-hgpoller-heads-lookup.bugfix
@@ -1,0 +1,1 @@
+fixed :py:class:`~buildbot.changes.HgPoller` misuse of `hg heads -r <branch>` to `hg heads <branch>` because `-r` option shows heads that may not be on the wanted branch.

--- a/master/buildbot/test/unit/changes/test_hgpoller.py
+++ b/master/buildbot/test/unit/changes/test_hgpoller.py
@@ -80,10 +80,10 @@ class TestHgPollerBranches(TestHgPollerBase):
                        'ssh://example.com/foo/baz')
             .path('/some/dir'),
             gpo.Expect(
-                'hg', 'heads', '-r', 'one', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'one', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b"73591"),
             gpo.Expect(
-                'hg', 'heads', '-r', 'two', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'two', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b"22341"),
         )
 
@@ -106,7 +106,7 @@ class TestHgPollerBranches(TestHgPollerBase):
                        'ssh://example.com/foo/baz')
             .path('/some/dir'),
             gpo.Expect(
-                'hg', 'heads', '-r', 'one', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'one', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b'6' + LINESEP_BYTES),
             gpo.Expect('hg', 'log', '-r', '4::6',
                        '--template={rev}:{node}\\n')
@@ -127,7 +127,7 @@ class TestHgPollerBranches(TestHgPollerBase):
                 b'Comment',
                 b''])),
             gpo.Expect(
-                'hg', 'heads', '-r', 'two', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'two', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b'3' + LINESEP_BYTES),
         )
 
@@ -154,10 +154,10 @@ class TestHgPollerBookmarks(TestHgPollerBase):
                        'ssh://example.com/foo/baz')
             .path('/some/dir'),
             gpo.Expect(
-                'hg', 'heads', '-r', 'one', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'one', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b"73591"),
             gpo.Expect(
-                'hg', 'heads', '-r', 'two', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'two', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b"22341"),
         )
 
@@ -180,7 +180,7 @@ class TestHgPollerBookmarks(TestHgPollerBase):
                        'ssh://example.com/foo/baz')
             .path('/some/dir'),
             gpo.Expect(
-                'hg', 'heads', '-r', 'one', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'one', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b'6' + LINESEP_BYTES),
             gpo.Expect('hg', 'log', '-r', '4::6',
                        '--template={rev}:{node}\\n')
@@ -201,7 +201,7 @@ class TestHgPollerBookmarks(TestHgPollerBase):
                 b'Comment',
                 b''])),
             gpo.Expect(
-                'hg', 'heads', '-r', 'two', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'two', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b'3' + LINESEP_BYTES),
         )
 
@@ -265,7 +265,7 @@ class TestHgPoller(TestHgPollerBase):
                        'ssh://example.com/foo/baz')
             .path('/some/dir'),
             gpo.Expect(
-                'hg', 'heads', '-r', 'default', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'default', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b"73591"),
         )
 
@@ -287,7 +287,7 @@ class TestHgPoller(TestHgPollerBase):
                        'ssh://example.com/foo/baz')
             .path('/some/dir'),
             gpo.Expect(
-                'hg', 'heads', '-r', 'default', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'default', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b'5' + LINESEP_BYTES + b'6' + LINESEP_BYTES)
         )
 
@@ -305,7 +305,7 @@ class TestHgPoller(TestHgPollerBase):
                        'ssh://example.com/foo/baz')
             .path('/some/dir'),
             gpo.Expect(
-                'hg', 'heads', '-r', 'default', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'default', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b'5' + LINESEP_BYTES),
             gpo.Expect('hg', 'log', '-r', '4::5',
                        '--template={rev}:{node}\\n')
@@ -345,7 +345,7 @@ class TestHgPoller(TestHgPollerBase):
                        'ssh://example.com/foo/baz')
             .path('/some/dir'),
             gpo.Expect(
-                'hg', 'heads', '-r', 'default', '--template={rev}' + os.linesep)
+                'hg', 'heads', 'default', '--template={rev}' + os.linesep)
             .path('/some/dir').stdout(b'5' + LINESEP_BYTES),
             gpo.Expect('hg', 'log', '-r', '4::5',
                        '--template={rev}:{node}\\n')


### PR DESCRIPTION
fixed `changes.HgPoller` misuse of `hg heads -r <branch>` to `hg heads <branch>` because `-r` option shows heads that may not be on the wanted branch.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
* [x] I have updated the tests
