### PR TITLE
Rename getFakeService() of the fake HTTP service to getService()

### DIFF
--- a/master/buildbot/newsfragments/fakehttpservice-getfakeservice.removal
+++ b/master/buildbot/newsfragments/fakehttpservice-getfakeservice.removal
@@ -1,0 +1,2 @@
+``buildbot.test.fake.httpclientservice.HttpClientService.getFakeService()`` has been deprecated.
+Use ``getService`` method of the same class.

--- a/master/buildbot/test/fake/httpclientservice.py
+++ b/master/buildbot/test/fake/httpclientservice.py
@@ -27,6 +27,7 @@ from buildbot.util import service
 from buildbot.util import toJson
 from buildbot.util import unicode2bytes
 from buildbot.util.logger import Logger
+from buildbot.warnings import warn_deprecated
 
 log = Logger()
 
@@ -78,7 +79,12 @@ class HTTPClientService(service.SharedService):
 
     @classmethod
     def getFakeService(cls, master, case, *args, **kwargs):
-        ret = cls.getService(master, *args, **kwargs)
+        warn_deprecated('2.9.0', 'getFakeService() has been deprecated, use getService()')
+        return cls.getService(master, case, *args, **kwargs)
+
+    @classmethod
+    def getService(cls, master, case, *args, **kwargs):
+        ret = super().getService(master, *args, **kwargs)
 
         def assertNotCalled(self, *_args, **_kwargs):
             case.fail(("HTTPClientService called with *{!r}, **{!r}"

--- a/master/buildbot/test/integration/test_telegram_bot.py
+++ b/master/buildbot/test/integration/test_telegram_bot.py
@@ -64,7 +64,7 @@ class TelegramBot(db.RealDatabaseWithConnectorMixin, www.RequiresWwwMixin, unitt
     @defer.inlineCallbacks
     def get_http(self, bot_token):
         base_url = "https://api.telegram.org/telegram" + bot_token
-        http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, base_url)
         # This is necessary as Telegram will make requests in the reconfig
         http.expect("post", "/getMe",

--- a/master/buildbot/test/unit/changes/test_gerritchangesource.py
+++ b/master/buildbot/test/unit/changes/test_gerritchangesource.py
@@ -380,7 +380,7 @@ class TestGerritEventLogPoller(changesource.ChangeSourceMixin,
     @defer.inlineCallbacks
     def newChangeSource(self, **kwargs):
         auth = kwargs.pop('auth', ('log', 'pass'))
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'gerrit', auth=auth)
         self.changesource = gerritchangesource.GerritEventLogPoller(
             'gerrit', auth=auth, gitBaseURL="ssh://someuser@somehost:29418", pollAtLaunch=False,

--- a/master/buildbot/test/unit/changes/test_github.py
+++ b/master/buildbot/test/unit/changes/test_github.py
@@ -188,7 +188,7 @@ class TestGitHubPullrequestPoller(changesource.ChangeSourceMixin,
         token = kwargs.get('token', None)
         if token:
             http_headers.update({'Authorization': 'token ' + token})
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, endpoint, headers=http_headers)
         self.changesource = GitHubPullrequestPoller(owner, repo, **kwargs)
 

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -45,11 +45,11 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
             _BASE_URL,
             debug=None, verify=None)
-        self.oauthhttp = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self.oauthhttp = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
             _OAUTH_URL, auth=('key', 'secret'),
             debug=None, verify=None)

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -60,7 +60,7 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
             'serv', auth=('username', 'passwd'),
             debug=None, verify=None)
@@ -195,7 +195,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
 
         http_headers = {} if token is None else {'Authorization': 'Bearer tokentoken'}
 
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
             'serv', auth=('username', 'passwd'), headers=http_headers,
             debug=None, verify=None)
@@ -479,7 +479,7 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
 
     @defer.inlineCallbacks
     def setupReporter(self, verbose=True, generator_class=BuildStatusGenerator, **kwargs):
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'serv', auth=('username', 'passwd'), debug=None,
             verify=None)
 

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -56,7 +56,7 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
     def createGerritStatus(self, **kwargs):
         auth = kwargs.pop('auth', ('log', Interpolate('pass')))
 
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, "gerrit", auth=('log', 'pass'),
             debug=None, verify=None)
         self.sp = GerritVerifyStatusPush("gerrit", auth=auth, **kwargs)

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -46,7 +46,7 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
                                              wantMq=True)
 
         yield self.master.startService()
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
             HOSTED_BASE_URL, headers={
                 'Authorization': 'token XXYYZZ',
@@ -234,7 +234,7 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
                                              wantMq=True)
 
         yield self.master.startService()
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
             HOSTED_BASE_URL, headers={
                 'Authorization': 'token XXYYZZ',

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -45,7 +45,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                                              wantMq=True)
 
         yield self.master.startService()
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
             HOSTED_BASE_URL, headers={'PRIVATE-TOKEN': 'XXYYZZ'},
             debug=None, verify=None)

--- a/master/buildbot/test/unit/reporters/test_hipchat.py
+++ b/master/buildbot/test/unit/reporters/test_hipchat.py
@@ -49,7 +49,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
     def createReporter(self, **kwargs):
         kwargs['auth_token'] = kwargs.get('auth_token', 'abc')
         self.sp = HipChatStatusPush(**kwargs)
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
             kwargs.get('endpoint', HOSTED_BASE_URL),
             debug=None, verify=None)

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -76,8 +76,8 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
 
     @defer.inlineCallbacks
     def createReporter(self, auth=("username", "passwd"), **kwargs):
-        self._http = yield fakehttpclientservice.HTTPClientService.getService(
-            self.master,
+        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+            self.master, self,
             "serv", auth=auth,
             debug=None, verify=None)
 
@@ -103,6 +103,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
         build = yield self.insert_build_new()
         yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
+        build['results'] = SUCCESS
         yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
@@ -113,6 +114,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
         build = yield self.insert_build_new()
         yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
+        build['results'] = SUCCESS
         yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -76,7 +76,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
 
     @defer.inlineCallbacks
     def createReporter(self, auth=("username", "passwd"), **kwargs):
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
             "serv", auth=auth,
             debug=None, verify=None)

--- a/master/buildbot/test/unit/reporters/test_pushjet.py
+++ b/master/buildbot/test/unit/reporters/test_pushjet.py
@@ -39,7 +39,7 @@ class TestPushjetNotifier(ConfigErrorsMixin, TestReactorMixin,
 
     # returns a Deferred
     def setupFakeHttp(self, base_url='https://api.pushjet.io'):
-        return fakehttpclientservice.HTTPClientService.getFakeService(self.master, self, base_url)
+        return fakehttpclientservice.HTTPClientService.getService(self.master, self, base_url)
 
     @defer.inlineCallbacks
     def setupPushjetNotifier(self, secret=Interpolate("1234"), **kwargs):

--- a/master/buildbot/test/unit/reporters/test_pushover.py
+++ b/master/buildbot/test/unit/reporters/test_pushover.py
@@ -39,8 +39,8 @@ class TestPushoverNotifier(ConfigErrorsMixin, TestReactorMixin, unittest.TestCas
 
     # returns a Deferred
     def setupFakeHttp(self):
-        return fakehttpclientservice.HTTPClientService.getFakeService(self.master, self,
-                                                                      'https://api.pushover.net')
+        return fakehttpclientservice.HTTPClientService.getService(self.master, self,
+                                                                  'https://api.pushover.net')
 
     @defer.inlineCallbacks
     def setupPushoverNotifier(self, user_key="1234", api_token=Interpolate("abcd"), **kwargs):

--- a/master/buildbot/test/unit/reporters/test_telegram.py
+++ b/master/buildbot/test/unit/reporters/test_telegram.py
@@ -562,7 +562,7 @@ class TestTelegramService(TestReactorMixin, unittest.TestCase):
     # returns a Deferred
     def setupFakeHttp(self):
         url = 'https://api.telegram.org/bot12345:secret'
-        return fakehttpclientservice.HTTPClientService.getFakeService(self.master, self, url)
+        return fakehttpclientservice.HTTPClientService.getService(self.master, self, url)
 
     @defer.inlineCallbacks
     def makeBot(self, chat_ids=None, authz=None, *args, **kwargs):
@@ -907,7 +907,7 @@ class TestTelegramService(TestReactorMixin, unittest.TestCase):
     # returns a Deferred
     def setupFakeHttpWithErrors(self, skip, errs):
         url = 'https://api.telegram.org/bot12345:secret'
-        return self.HttpServiceWithErrors.getFakeService(self.master, self, skip, errs, url)
+        return self.HttpServiceWithErrors.getService(self.master, self, skip, errs, url)
 
     @defer.inlineCallbacks
     def test_post_not_ok(self):

--- a/master/buildbot/test/unit/reporters/test_zulip.py
+++ b/master/buildbot/test/unit/reporters/test_zulip.py
@@ -42,7 +42,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
     def setupZulipStatusPush(self, endpoint="http://example.com", token="123", stream=None):
         self.sp = ZulipStatusPush(
             endpoint=endpoint, token=token, stream=stream)
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, endpoint, debug=None, verify=None)
         yield self.sp.setServiceParent(self.master)
         yield self.master.startService()

--- a/master/buildbot/test/unit/test_secret_in_vault.py
+++ b/master/buildbot/test/unit/test_secret_in_vault.py
@@ -33,7 +33,7 @@ class TestSecretInVaultHttpFakeBase(ConfigErrorsMixin, TestReactorMixin,
                                                       vaultToken="someToken",
                                                       apiVersion=version)
         self.master = fakemaster.make_master(self, wantData=True)
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
                 self.master, self, 'http://vaultServer', headers={'X-Vault-Token': "someToken"})
         yield self.srvcVault.setServiceParent(self.master)
         yield self.master.startService()
@@ -109,7 +109,7 @@ class TestSecretInVaultV1(TestSecretInVaultHttpFakeBase):
 
     @defer.inlineCallbacks
     def testReconfigSecretInVaultService(self):
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
                 self.master, self, 'serveraddr', headers={'X-Vault-Token': "someToken"})
         yield self.srvcVault.reconfigService(vaultServer="serveraddr",
                                              vaultToken="someToken")

--- a/master/buildbot/test/unit/util/test_httpclientservice.py
+++ b/master/buildbot/test/unit/util/test_httpclientservice.py
@@ -28,10 +28,12 @@ from twisted.web import server
 
 from buildbot import interfaces
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
 from buildbot.util import service
 from buildbot.util import unicode2bytes
+from buildbot.warnings import DeprecatedApiWarning
 
 try:
     from requests.auth import HTTPDigestAuth
@@ -436,9 +438,12 @@ class HTTPClientServiceTestTReqE2E(HTTPClientServiceTestTxRequestE2E):
 
 class HTTPClientServiceTestFakeE2E(HTTPClientServiceTestTxRequestE2E):
 
+    @defer.inlineCallbacks
     def httpFactory(self, parent):
-        return fakehttpclientservice.HTTPClientService.getService(
-            parent, 'http://127.0.0.1:{}'.format(self.port))
+        with assertProducesWarnings(DeprecatedApiWarning, message_pattern='getFakeService'):
+            service = yield fakehttpclientservice.HTTPClientService.getService(
+                parent, self, 'http://127.0.0.1:{}'.format(self.port))
+            return service
 
     def expect(self, *arg, **kwargs):
         self._http.expect(*arg, **kwargs)

--- a/master/buildbot/test/unit/worker/test_kubernetes.py
+++ b/master/buildbot/test/unit/worker/test_kubernetes.py
@@ -49,7 +49,7 @@ class TestKubernetesWorker(TestReactorMixin, unittest.TestCase):
         self.worker = worker = kubernetes.KubeLatentWorker(
             *args, kube_config=config, **kwargs)
         master = fakemaster.make_master(self, wantData=True)
-        self._kube = yield KubeClientService.getFakeService(master, self, kube_config=config)
+        self._kube = yield KubeClientService.getService(master, self, kube_config=config)
         worker.setServiceParent(master)
         yield master.startService()
         self.assertTrue(config.running)

--- a/master/buildbot/test/unit/worker/test_marathon.py
+++ b/master/buildbot/test/unit/worker/test_marathon.py
@@ -54,7 +54,7 @@ class TestMarathonLatentWorker(unittest.TestCase, TestReactorMixin):
         worker = MarathonLatentWorker('bot', 'tcp://marathon.local', **kwargs)
         self.worker = worker
         master = fakemaster.make_master(self, wantData=True)
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
                 master, self, 'tcp://marathon.local', auth=kwargs.get('auth'))
         yield worker.setServiceParent(master)
         worker.reactor = self.reactor

--- a/master/buildbot/test/unit/worker/test_upcloud.py
+++ b/master/buildbot/test/unit/worker/test_upcloud.py
@@ -88,7 +88,7 @@ class TestUpcloudWorker(TestReactorMixin, unittest.TestCase):
         worker = upcloud.UpcloudLatentWorker(
                 *args, api_username='test-api-user', api_password='test-api-password', **kwargs)
         master = fakemaster.make_master(self, wantData=True)
-        self._http = worker.client = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = worker.client = yield fakehttpclientservice.HTTPClientService.getService(
             master, self, upcloud.DEFAULT_BASE_URL, auth=('test-api-user', 'test-api-password'),
             debug=False)
         worker.setServiceParent(master)

--- a/master/buildbot/test/unit/www/test_hooks_github.py
+++ b/master/buildbot/test/unit/www/test_hooks_github.py
@@ -624,7 +624,7 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
             self, strict=False, github_property_whitelist=["github.*"])
         self.master = self.changeHook.master
         fake_headers = {'User-Agent': 'Buildbot'}
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'https://api.github.com', headers=fake_headers,
             debug=False, verify=False)
         yield self.master.startService()
@@ -906,7 +906,7 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(
             pullrequest_ref="head")
         self.master = self.changeHook.master
         fake_headers = {'User-Agent': 'Buildbot'}
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'https://api.github.com', headers=fake_headers,
             debug=False, verify=False)
         yield self.master.startService()
@@ -941,7 +941,7 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRefWithAuth(
             'Authorization': 'token ' + _token,
             'User-Agent': 'Buildbot',
         }
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'https://api.github.com', headers=fake_headers,
             debug=False, verify=False)
         yield self.master.startService()
@@ -980,7 +980,7 @@ class TestChangeHookConfiguredWithAuthAndCustomSkips(unittest.TestCase,
             'Authorization': 'token ' + _token,
             'User-Agent': 'Buildbot',
         }
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'https://api.github.com', headers=fake_headers,
             debug=False, verify=False)
         yield self.master.startService()
@@ -1068,7 +1068,7 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
             'Authorization': 'token ' + _token,
             'User-Agent': 'Buildbot',
         }
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'https://api.github.com', headers=fake_headers,
             debug=False, verify=False)
         yield self.master.startService()
@@ -1185,7 +1185,7 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase,
             self, strict=False, github_api_endpoint='https://black.magic.io')
         self.master = self.changeHook.master
         fake_headers = {'User-Agent': 'Buildbot'}
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'https://black.magic.io', headers=fake_headers,
             debug=False, verify=False)
         yield self.master.startService()
@@ -1220,7 +1220,7 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase,
             'Authorization': 'token ' + _token,
             'User-Agent': 'Buildbot',
         }
-        self._http = yield fakehttpclientservice.HTTPClientService.getFakeService(
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'https://black.magic.io', headers=fake_headers,
             debug=False, verify=False)
         yield self.master.startService()

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -1269,14 +1269,14 @@ For example, a particular daily scheduler could be configured on multiple master
     It will then replace the original implementation automatically (no need to patch anything).
     The testing methodology is based on `AngularJS ngMock`_.
 
-    .. py:method:: getFakeService(cls, master, case, *args, **kwargs):
+    .. py:method:: getService(cls, master, case, *args, **kwargs):
 
         :param master: the instance of a fake master service
         :param case: a :py:class:`twisted.python.unittest.TestCase` instance
 
-        :py:meth:`getFakeService` returns a fake :py:class:`HTTPClientService`, and should be used in place of :py:meth:`getService`.
+        :py:meth:`getService` returns a fake :py:class:`HTTPClientService`, and should be used just like the regular :py:meth:`getService`.
 
-        on top of :py:meth:`getService` it will make sure the original :py:class:`HTTPClientService` is not called, and assert that all expected http requests have been described in the test case.
+        It will make sure the original :py:class:`HTTPClientService` is not called, and assert that all expected http requests have been described in the test case.
 
 
     .. py:method:: expect(self, method, ep, params=None, data=None, json=None, code=200,


### PR DESCRIPTION
Having `buildbot.test.util.fakehttpclientservice.HttpClientService.getFakeService()` named differently than `getService()` makes it easy to create non-working HTTP tests which don't actually check whether the requests have been executed. This PR fixes on such case.

After investigation, it does not seem that there's a reason for the difference. `super()` works as expected within classmethods, so it does not seem there's a way for the user of the API to shoot one's foot. This PR thus renames `getFakeService` to just `getService`.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
