### PR TITLE
Deprecate send() of HttpStatusPushBase-based reporters

### DIFF
--- a/master/buildbot/newsfragments/reporters-old-api.removal
+++ b/master/buildbot/newsfragments/reporters-old-api.removal
@@ -28,3 +28,4 @@ The following reporters have been affected:
  - ``GitHubStatusPush``
  - ``GitLabStatusPush``
  - ``HipChatStatusPush``
+ - ``ZulipStatusPush``

--- a/master/buildbot/newsfragments/reporters-old-api.removal
+++ b/master/buildbot/newsfragments/reporters-old-api.removal
@@ -23,3 +23,4 @@ The following reporters have been affected:
 
  - ``BitbucketStatusPush``
  - ``BitbucketServerStatusPush``
+ - ``BitbucketServerCoreAPIStatusPush``

--- a/master/buildbot/newsfragments/reporters-old-api.removal
+++ b/master/buildbot/newsfragments/reporters-old-api.removal
@@ -27,3 +27,4 @@ The following reporters have been affected:
  - ``GerritVerifyStatusPush``
  - ``GitHubStatusPush``
  - ``GitLabStatusPush``
+ - ``HipChatStatusPush``

--- a/master/buildbot/newsfragments/reporters-old-api.removal
+++ b/master/buildbot/newsfragments/reporters-old-api.removal
@@ -15,3 +15,10 @@ The list of deprecated parameters is as follows:
  - ``branches``
  - ``watchedWorkers``
  - ``messageFormatterMissingWorker``
+
+The ``send`` method of the reporters based on ``HttpStatusPushBase`` has been deprecated.
+This affects only users who implemented custom reporters that directly or indirectly derive ``HttpStatusPushBase``.
+Please use ``sendMessage`` as the replacement.
+The following reporters have been affected:
+
+ - ``BitbucketStatusPush``

--- a/master/buildbot/newsfragments/reporters-old-api.removal
+++ b/master/buildbot/newsfragments/reporters-old-api.removal
@@ -26,3 +26,4 @@ The following reporters have been affected:
  - ``BitbucketServerCoreAPIStatusPush``
  - ``GerritVerifyStatusPush``
  - ``GitHubStatusPush``
+ - ``GitLabStatusPush``

--- a/master/buildbot/newsfragments/reporters-old-api.removal
+++ b/master/buildbot/newsfragments/reporters-old-api.removal
@@ -16,6 +16,8 @@ The list of deprecated parameters is as follows:
  - ``watchedWorkers``
  - ``messageFormatterMissingWorker``
 
+The undocumented ``HttpStatusPushBase`` class has been deprecated. Please use ``NotifierBase`` directly.
+
 The ``send`` method of the reporters based on ``HttpStatusPushBase`` has been deprecated.
 This affects only users who implemented custom reporters that directly or indirectly derive ``HttpStatusPushBase``.
 Please use ``sendMessage`` as the replacement.

--- a/master/buildbot/newsfragments/reporters-old-api.removal
+++ b/master/buildbot/newsfragments/reporters-old-api.removal
@@ -21,6 +21,7 @@ This affects only users who implemented custom reporters that directly or indire
 Please use ``sendMessage`` as the replacement.
 The following reporters have been affected:
 
+ - ``HttpStatusPush``
  - ``BitbucketStatusPush``
  - ``BitbucketServerStatusPush``
  - ``BitbucketServerCoreAPIStatusPush``

--- a/master/buildbot/newsfragments/reporters-old-api.removal
+++ b/master/buildbot/newsfragments/reporters-old-api.removal
@@ -22,3 +22,4 @@ Please use ``sendMessage`` as the replacement.
 The following reporters have been affected:
 
  - ``BitbucketStatusPush``
+ - ``BitbucketServerStatusPush``

--- a/master/buildbot/newsfragments/reporters-old-api.removal
+++ b/master/buildbot/newsfragments/reporters-old-api.removal
@@ -25,3 +25,4 @@ The following reporters have been affected:
  - ``BitbucketServerStatusPush``
  - ``BitbucketServerCoreAPIStatusPush``
  - ``GerritVerifyStatusPush``
+ - ``GitHubStatusPush``

--- a/master/buildbot/newsfragments/reporters-old-api.removal
+++ b/master/buildbot/newsfragments/reporters-old-api.removal
@@ -24,3 +24,4 @@ The following reporters have been affected:
  - ``BitbucketStatusPush``
  - ``BitbucketServerStatusPush``
  - ``BitbucketServerCoreAPIStatusPush``
+ - ``GerritVerifyStatusPush``

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -21,6 +21,7 @@ from buildbot.process.results import SUCCESS
 from buildbot.reporters import http
 from buildbot.util import httpclientservice
 from buildbot.util.logger import Logger
+from buildbot.warnings import warn_deprecated
 
 log = Logger()
 
@@ -64,6 +65,21 @@ class BitbucketStatusPush(http.HttpStatusPushBase):
 
     @defer.inlineCallbacks
     def send(self, build):
+        # the only case when this function is called is when the user derives this class, overrides
+        # send() and calls super().send(build) from there.
+        yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def sendMessage(self, reports):
+        build = reports[0]['builds'][0]
+        if self.send.__func__ is not BitbucketStatusPush.send:
+            warn_deprecated('2.9.0', 'send() in reporters has been deprecated. Use sendMessage()')
+            yield self.send(build)
+        else:
+            yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def _send_impl(self, build):
         results = build['results']
         oauth_request = yield self.oauthhttp.post("",
                                                   data=_GET_TOKEN_DATA)

--- a/master/buildbot/reporters/bitbucketserver.py
+++ b/master/buildbot/reporters/bitbucketserver.py
@@ -239,6 +239,21 @@ class BitbucketServerCoreAPIStatusPush(http.HttpStatusPushBase):
 
     @defer.inlineCallbacks
     def send(self, build):
+        # the only case when this function is called is when the user derives this class, overrides
+        # send() and calls super().send(build) from there.
+        yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def sendMessage(self, reports):
+        build = reports[0]['builds'][0]
+        if self.send.__func__ is not BitbucketServerCoreAPIStatusPush.send:
+            warn_deprecated('2.9.0', 'send() in reporters has been deprecated. Use sendMessage()')
+            yield self.send(build)
+        else:
+            yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def _send_impl(self, build):
         props = Properties.fromDict(build['properties'])
         props.master = self.master
 

--- a/master/buildbot/reporters/bitbucketserver.py
+++ b/master/buildbot/reporters/bitbucketserver.py
@@ -29,6 +29,7 @@ from buildbot.reporters import notifier
 from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
 from buildbot.util import unicode2bytes
+from buildbot.warnings import warn_deprecated
 
 from .utils import merge_reports_prop
 
@@ -83,6 +84,21 @@ class BitbucketServerStatusPush(http.HttpStatusPushBase):
 
     @defer.inlineCallbacks
     def send(self, build):
+        # the only case when this function is called is when the user derives this class, overrides
+        # send() and calls super().send(build) from there.
+        yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def sendMessage(self, reports):
+        build = reports[0]['builds'][0]
+        if self.send.__func__ is not BitbucketServerStatusPush.send:
+            warn_deprecated('2.9.0', 'send() in reporters has been deprecated. Use sendMessage()')
+            yield self.send(build)
+        else:
+            yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def _send_impl(self, build):
         props = Properties.fromDict(build['properties'])
         props.master = self.master
 

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -31,6 +31,7 @@ from buildbot.process.results import WARNINGS
 from buildbot.reporters import http
 from buildbot.util import httpclientservice
 from buildbot.util.giturlparse import giturlparse
+from buildbot.warnings import warn_deprecated
 
 HOSTED_BASE_URL = 'https://api.github.com'
 
@@ -106,6 +107,21 @@ class GitHubStatusPush(http.HttpStatusPushBase):
 
     @defer.inlineCallbacks
     def send(self, build):
+        # the only case when this function is called is when the user derives this class, overrides
+        # send() and calls super().send(build) from there.
+        yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def sendMessage(self, reports):
+        build = reports[0]['builds'][0]
+        if self.send.__func__ is not GitHubStatusPush.send:
+            warn_deprecated('2.9.0', 'send() in reporters has been deprecated. Use sendMessage()')
+            yield self.send(build)
+        else:
+            yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def _send_impl(self, build):
         props = Properties.fromDict(build['properties'])
         props.master = self.master
 

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -30,6 +30,7 @@ from buildbot.process.results import WARNINGS
 from buildbot.reporters import http
 from buildbot.util import giturlparse
 from buildbot.util import httpclientservice
+from buildbot.warnings import warn_deprecated
 
 HOSTED_BASE_URL = 'https://gitlab.com'
 
@@ -120,6 +121,21 @@ class GitLabStatusPush(http.HttpStatusPushBase):
 
     @defer.inlineCallbacks
     def send(self, build):
+        # the only case when this function is called is when the user derives this class, overrides
+        # send() and calls super().send(build) from there.
+        yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def sendMessage(self, reports):
+        build = reports[0]['builds'][0]
+        if self.send.__func__ is not GitLabStatusPush.send:
+            warn_deprecated('2.9.0', 'send() in reporters has been deprecated. Use sendMessage()')
+            yield self.send(build)
+        else:
+            yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def _send_impl(self, build):
         props = Properties.fromDict(build['properties'])
         props.master = self.master
 

--- a/master/buildbot/reporters/hipchat.py
+++ b/master/buildbot/reporters/hipchat.py
@@ -6,6 +6,7 @@ from buildbot.reporters import utils
 from buildbot.reporters.http import HttpStatusPushBase
 from buildbot.util import httpclientservice
 from buildbot.util.logger import Logger
+from buildbot.warnings import warn_deprecated
 
 log = Logger()
 
@@ -78,6 +79,21 @@ class HipChatStatusPush(HttpStatusPushBase):
 
     @defer.inlineCallbacks
     def send(self, build):
+        # the only case when this function is called is when the user derives this class, overrides
+        # send() and calls super().send(build) from there.
+        yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def sendMessage(self, reports):
+        build = reports[0]['builds'][0]
+        if self.send.__func__ is not HipChatStatusPush.send:
+            warn_deprecated('2.9.0', 'send() in reporters has been deprecated. Use sendMessage()')
+            yield self.send(build)
+        else:
+            yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def _send_impl(self, build):
         key = 'new' if build['complete'] is False else 'finished'
 
         postData = yield self.getBuildDetailsAndSendMessage(build, key)

--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -149,6 +149,7 @@ class HttpStatusPush(HttpStatusPushBase):
             auth = (user, password)
         if format_fn is None:
             format_fn = lambda x: x
+        self.format_fn = format_fn  # TODO: remove when send() is removed
 
         if generators is None:
             generators = self._create_generators_from_old_args(format_fn, builders, wantProperties,
@@ -173,7 +174,21 @@ class HttpStatusPush(HttpStatusPushBase):
         ]
 
     @defer.inlineCallbacks
+    def send(self, build):
+        # the only case when this function is called is when the user derives this class, overrides
+        # send() and calls super().send(build) from there. We'll call format_fn twice in that case,
+        # once in generators, once here.
+        response = yield self._http.post("", json=self.format_fn(build))
+        if not self.isStatus2XX(response.code):
+            log.msg("{}: unable to upload status: {}".format(response.code, response.content))
+
+    @defer.inlineCallbacks
     def sendMessage(self, reports):
+        if self.send.__func__ is not HttpStatusPush.send:
+            warn_deprecated('2.9.0', 'send() in reporters has been deprecated. Use sendMessage()')
+            yield self.send(reports[0]['builds'][0])
+            return
+
         response = yield self._http.post("", json=reports[0]['body'])
         if not self.isStatus2XX(response.code):
             log.msg("{}: unable to upload status: {}".format(response.code, response.content))

--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -88,6 +88,10 @@ class HttpStatusPushBase(notifier.NotifierBase):
         ]
 
     def sendMessage(self, reports):
+        # All reporters that subclass HttpStatusPushBase and are provided by Buildbot implement
+        # sendMessage. So the only case when this function is called is when we have a custom
+        # reporter that inherits from HttpStatusPushBase.
+        warn_deprecated('2.9.0', 'send() in reporters has been deprecated. Use sendMessage()')
         return self.send(reports[0]['builds'][0])
 
     # Deprecated overridden method, will be removed in Buildbot 3.0

--- a/master/buildbot/reporters/zulip.py
+++ b/master/buildbot/reporters/zulip.py
@@ -20,6 +20,7 @@ from buildbot import config
 from buildbot.reporters.http import HttpStatusPushBase
 from buildbot.util import httpclientservice
 from buildbot.util.logger import Logger
+from buildbot.warnings import warn_deprecated
 
 log = Logger()
 
@@ -45,6 +46,21 @@ class ZulipStatusPush(HttpStatusPushBase):
 
     @defer.inlineCallbacks
     def send(self, build):
+        # the only case when this function is called is when the user derives this class, overrides
+        # send() and calls super().send(build) from there.
+        yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def sendMessage(self, reports):
+        build = reports[0]['builds'][0]
+        if self.send.__func__ is not ZulipStatusPush.send:
+            warn_deprecated('2.9.0', 'send() in reporters has been deprecated. Use sendMessage()')
+            yield self.send(build)
+        else:
+            yield self._send_impl(build)
+
+    @defer.inlineCallbacks
+    def _send_impl(self, build):
         event = ("new", "finished")[0 if build["complete"] is False else 1]
         jsondata = dict(event=event, buildid=build["buildid"], buildername=build["builder"]["name"],
                         url=build["url"], project=build["properties"]["project"][0])

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -30,6 +30,8 @@ from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.util.logging import LoggingMixin
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
+from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
@@ -209,3 +211,101 @@ class TestBitbucketStatusPushRepoParsing(unittest.TestCase):
             'ssh://git@bitbucket.com/user/repo.git'))
         self.assertEqual(
             ('user', 'repo'), self.parse('ssh://git@bitbucket.com/user/repo'))
+
+
+class BitbucketStatusPushDeprecatedSend(BitbucketStatusPush):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.send_called_count = 0
+
+    @defer.inlineCallbacks
+    def send(self, build):
+        self.send_called_count += 1
+        yield super().send(build)
+
+
+class TestBitbucketStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
+                                            ReporterTestMixin, LoggingMixin):
+    TEST_REPO = 'https://example.org/user/repo'
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setUpTestReactor()
+
+        # ignore config error if txrequests is not installed
+        self.patch(config, '_errors', Mock())
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
+
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
+            self.master, self,
+            _BASE_URL,
+            debug=None, verify=None)
+        self.oauthhttp = yield fakehttpclientservice.HTTPClientService.getService(
+            self.master, self,
+            _OAUTH_URL, auth=('key', 'secret'),
+            debug=None, verify=None)
+        self.bsp = bsp = BitbucketStatusPushDeprecatedSend(
+            Interpolate('key'), Interpolate('secret'))
+        yield bsp.setServiceParent(self.master)
+        yield bsp.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.bsp.stopService()
+
+    @defer.inlineCallbacks
+    def test_basic(self):
+        build = yield self.insert_build_new()
+
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
+                              content_json={'access_token': 'foo'})
+        # we make sure proper calls to txrequests have been made
+        self._http.expect(
+            'post',
+            '/user/repo/commit/d34db33fd43db33f/statuses/build',
+            json={
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'state': 'INPROGRESS',
+                'key': 'Builder0',
+                'name': 'Builder0'},
+            code=201)
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
+                              content_json={'access_token': 'foo'})
+        self._http.expect(
+            'post',
+            '/user/repo/commit/d34db33fd43db33f/statuses/build',
+            json={
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'state': 'SUCCESSFUL',
+                'key': 'Builder0',
+                'name': 'Builder0'},
+            code=201)
+        self.oauthhttp.expect('post', '', data={'grant_type': 'client_credentials'},
+                              content_json={'access_token': 'foo'})
+        self._http.expect(
+            'post',
+            '/user/repo/commit/d34db33fd43db33f/statuses/build',
+            json={
+                'url': 'http://localhost:8080/#builders/79/builds/0',
+                'state': 'FAILED',
+                'key': 'Builder0',
+                'name': 'Builder0'},
+            code=201)
+
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='send\\(\\) in reporters has been deprecated'):
+            yield self.bsp._got_event(('builds', 20, 'new'), build)
+
+        build['complete'] = True
+        build['results'] = SUCCESS
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='send\\(\\) in reporters has been deprecated'):
+            yield self.bsp._got_event(('builds', 20, 'finished'), build)
+
+        build['results'] = FAILURE
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='send\\(\\) in reporters has been deprecated'):
+            yield self.bsp._got_event(('builds', 20, 'finished'), build)
+
+        self.assertEqual(self.bsp.send_called_count, 3)

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -73,6 +73,7 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
     def tearDown(self):
         yield self.master.stopService()
 
+    @defer.inlineCallbacks
     def _check_start_and_finish_build(self, build):
         # we make sure proper calls to txrequests have been made
         self._http.expect(
@@ -106,7 +107,7 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
     def test_basic(self):
         self.setupReporter()
         build = yield self.insert_build_finished(SUCCESS)
-        self._check_start_and_finish_build(build)
+        yield self._check_start_and_finish_build(build)
 
     @defer.inlineCallbacks
     def test_setting_options(self):
@@ -212,6 +213,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
         if self.master and self.master.running:
             yield self.master.stopService()
 
+    @defer.inlineCallbacks
     def _check_start_and_finish_build(self, build, parentPlan=False):
         # we make sure proper calls to txrequests have been made
 
@@ -264,19 +266,19 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
     def test_basic(self):
         yield self.setupReporter()
         build = yield self.insert_build_finished(SUCCESS)
-        self._check_start_and_finish_build(build)
+        yield self._check_start_and_finish_build(build)
 
     @defer.inlineCallbacks
     def test_with_parent(self):
         yield self.setupReporter()
         build = yield self.insert_build_finished(SUCCESS, parent_plan=True)
-        self._check_start_and_finish_build(build, parentPlan=True)
+        yield self._check_start_and_finish_build(build, parentPlan=True)
 
     @defer.inlineCallbacks
     def test_with_token(self):
         yield self.setupReporter(token='tokentoken')
         build = yield self.insert_build_finished(SUCCESS)
-        self._check_start_and_finish_build(build)
+        yield self._check_start_and_finish_build(build)
 
     @defer.inlineCallbacks
     def test_error_setup_status(self):
@@ -319,7 +321,7 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
             build = yield self.insert_build_finished(SUCCESS)
         finally:
             self.TEST_BRANCH = old_test_branch
-        self._check_start_and_finish_build(build)
+        yield self._check_start_and_finish_build(build)
 
     @defer.inlineCallbacks
     def test_with_no_ref(self):

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -172,3 +172,66 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
     @defer.inlineCallbacks
     def test_http202(self):
         yield self.http2XX(code=202, content="Accepted")
+
+
+class HttpStatusPushOverrideSend(HttpStatusPush):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.send_called_count = 0
+
+    @defer.inlineCallbacks
+    def send(self, build):
+        self.send_called_count += 1
+        yield super().send(build)
+
+
+class TestHttpStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase, ReporterTestMixin):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setUpTestReactor()
+        # ignore config error if txrequests is not installed
+        config._errors = Mock()
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
+        yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def createReporter(self, auth=("username", "passwd"), **kwargs):
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
+            self.master, self,
+            "serv", auth=auth,
+            debug=None, verify=None)
+
+        interpolated_auth = None
+        if auth is not None:
+            username, passwd = auth
+            passwd = Interpolate(passwd)
+            interpolated_auth = (username, passwd)
+
+        self.sp = HttpStatusPushOverrideSend("serv", auth=interpolated_auth, **kwargs)
+        yield self.sp.setServiceParent(self.master)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.master.stopService()
+        config._errors = None
+
+    @defer.inlineCallbacks
+    def test_basic(self):
+        yield self.createReporter()
+        self._http.expect("post", "", json=BuildLookAlike(complete=False))
+        self._http.expect("post", "", json=BuildLookAlike(complete=True))
+
+        build = yield self.insert_build_new()
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='send\\(\\) in reporters has been deprecated'):
+            yield self.sp._got_event(('builds', 20, 'new'), build)
+
+        build['complete'] = True
+        build['results'] = SUCCESS
+
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='send\\(\\) in reporters has been deprecated'):
+            yield self.sp._got_event(('builds', 20, 'finished'), build)
+        self.assertEqual(self.sp.send_called_count, 2)

--- a/master/buildbot/test/unit/reporters/test_zulip.py
+++ b/master/buildbot/test/unit/reporters/test_zulip.py
@@ -23,6 +23,8 @@ from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.logging import LoggingMixin
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
+from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, ConfigErrorsMixin,
@@ -167,3 +169,58 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
         self.setUpLogging()
         yield self.sp._got_event(('builds', 20, 'new'), build)
         self.assertLogged('401: Error pushing build status to Zulip')
+
+
+class ZulipStatusPushDeprecatedSend(ZulipStatusPush):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.send_called_count = 0
+
+    @defer.inlineCallbacks
+    def send(self, build):
+        self.send_called_count += 1
+        yield super().send(build)
+
+
+class TestZulipStatusPushDeprecatedSend(unittest.TestCase, ReporterTestMixin, LoggingMixin,
+                                        ConfigErrorsMixin, TestReactorMixin):
+
+    def setUp(self):
+        self.setUpTestReactor()
+        self.master = fakemaster.make_master(
+            testcase=self, wantData=True, wantDb=True, wantMq=True)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        if self.master.running:
+            yield self.master.stopService()
+
+    @defer.inlineCallbacks
+    def setupZulipStatusPush(self, endpoint="http://example.com", token="123", stream=None):
+        self.sp = ZulipStatusPushDeprecatedSend(
+            endpoint=endpoint, token=token, stream=stream)
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
+            self.master, self, endpoint, debug=None, verify=None)
+        yield self.sp.setServiceParent(self.master)
+        yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def test_build_started(self):
+        yield self.setupZulipStatusPush(stream="xyz")
+        build = yield self.insert_build_new()
+        self._http.expect(
+            'post',
+            '/api/v1/external/buildbot?api_key=123&stream=xyz',
+            json={
+                "event": 'new',
+                "buildid": 20,
+                "buildername": "Builder0",
+                "url": "http://localhost:8080/#builders/79/builds/0",
+                "project": "testProject",
+                "timestamp": 10000001
+            })
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='send\\(\\) in reporters has been deprecated'):
+            yield self.sp._got_event(('builds', 20, 'new'), build)
+
+        self.assertEqual(self.sp.send_called_count, 1)

--- a/master/docs/manual/configuration/reporters/index.rst
+++ b/master/docs/manual/configuration/reporters/index.rst
@@ -9,6 +9,7 @@ Reporters
     :hidden:
     :maxdepth: 2
 
+    notifier_base
     bitbucket_server_core_api_status
     bitbucket_server_pr_comment_push
     bitbucket_server_status
@@ -70,3 +71,5 @@ The following reporters are available:
  * :bb:reporter:`PushoverNotifier`
  * :bb:reporter:`TelegramBot`
  * :bb:reporter:`ZulipStatusPush`
+
+Most of the report generators derive from :class:`NotifierBase` which implements basic reporter management functionality.

--- a/master/docs/manual/configuration/reporters/notifier_base.rst
+++ b/master/docs/manual/configuration/reporters/notifier_base.rst
@@ -1,0 +1,20 @@
+NotifierBase
+++++++++++++
+
+.. py:currentmodule:: buildbot.reporters.notifier
+
+.. py:class:: NotifierBase
+
+:class:`NotifierBase` is a base class used to implement various reporters.
+It accepts a list of :ref:`report generators<Report-Generators>` which define what messages to issue on what events.
+If generators decide that an event needs a report, then the ``sendMessages`` function is called.
+The ``sendMessages`` function should be implemented by deriving classes.
+
+
+.. py:class:: NotifierBase(generators=None)
+    :noindex:
+
+``generators``
+    (optional until Buildbot 3.0 is released, then mandatory)
+    (a list of report generator instances)
+    A list of report generators to manage.


### PR DESCRIPTION
This is the next step of making reporters use `NotifierBase` as the base class. This PR replaces `send()` with `sendMessage()` in a backwards-compatible way which will also work with custom steps.

Tests depend on #5635 landing, so this PR includes an additional commit for compatibility with the current API which will be reverted once this PR is about to be merged.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
