### PR TITLE
www: Close waterfall modal when user clicks build summary link

### DIFF
--- a/master/buildbot/newsfragments/waterfall-modal-close-on-build-link.bugfix
+++ b/master/buildbot/newsfragments/waterfall-modal-close-on-build-link.bugfix
@@ -1,0 +1,1 @@
+Fix for :issue:4914, close waterfall modal upon clicking build summary link

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
@@ -166,6 +166,11 @@ class _buildsummary {
                     (step.fulldisplay = this.fulldisplay));
             };
 
+            this.closeParentModal = function () {
+                if ('modal' in $scope.$parent)
+                    return $scope.$parent.modal.close();
+            };
+
             const data = dataService.open().closeOnDestroy($scope);
             $scope.$watch((() => this.buildid), function (buildid) {
                 if ((buildid == null)) {

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.tpl.jade
@@ -9,7 +9,7 @@
                     | {{buildsummary.levelOfDetails()}}
                 | #{' '}
                 span(ng-if="buildsummary.prefix") {{buildsummary.prefix}}#{' '}
-                a(ui-sref="build({builder:buildsummary.build.builderid, build:buildsummary.build.number})")
+                a(ui-sref="build({builder:buildsummary.build.builderid, build:buildsummary.build.number})" ng-click="buildsummary.closeParentModal()")
                   | {{buildsummary.builder.name}}/{{buildsummary.build.number}}#{' '}
                 span(ng-if="buildsummary.reason") | {{buildsummary.reason}}
             .flex-grow-1.text-right


### PR DESCRIPTION
Fix for issue #4914 

## Contributor Checklist:
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
