### PR TITLE
steps: Deprecate the MTR step due to lack of tests

### DIFF
--- a/master/buildbot/newsfragments/mtr-step.removal
+++ b/master/buildbot/newsfragments/mtr-step.removal
@@ -1,0 +1,3 @@
+The ``MTR`` step has been deprecated due to migration to new style steps and the build result APIs.
+The lack of proper unit tests made it too time-consuming to migrate this step along with other steps.
+Contributors are welcome to step in, migrate this step and add a proper test suite so that this situation never happens again.

--- a/master/buildbot/steps/mtrlogobserver.py
+++ b/master/buildbot/steps/mtrlogobserver.py
@@ -23,6 +23,7 @@ from twisted.python import log
 
 from buildbot.process.buildstep import LogLineObserver
 from buildbot.steps.shell import Test
+from buildbot.warnings import warn_deprecated
 
 
 class EqConnectionPool(adbapi.ConnectionPool):
@@ -286,6 +287,11 @@ class MTR(Test):
                  parallel=4, logfiles=None, lazylogfiles=True,
                  warningPattern="MTR's internal check of the test case '.*' failed",
                  mtr_subdir="mysql-test", **kwargs):
+
+        warn_deprecated('2.9.0', 'The MTR step has been deprecated due to migration to new style '
+                                 'steps and the build result APIs. It would be great if someone '
+                                 'steps up and migrates the step to newer APIs and adds a proper '
+                                 'test suite so that this situation never happens again.')
 
         if logfiles is None:
             logfiles = {}


### PR DESCRIPTION
The MTR step does not have proper unit tests, so it'll be too time consuming to migrate this step to new style as a test suite needs to be written in addition to the actual migration. The step has been written in 2009 and didn't have substantial changes ever since, so going extra mile ourselves is probably not a good use of resources.
