### PR TITLE
Attach reporter test data to test instance instead of class

### DIFF
--- a/master/buildbot/test/fake/httpclientservice.py
+++ b/master/buildbot/test/fake/httpclientservice.py
@@ -57,12 +57,14 @@ class ResponseWrapper:
 
 
 class HTTPClientService(service.SharedService):
-    """A SharedService class that fakes http requests for buildbot http service testing.
+    """ HTTPClientService is a SharedService class that fakes http requests for buildbot http
+        service testing.
 
-    It is called HTTPClientService so that it substitute the real HTTPClientService
-    if created earlier in the test.
-
-    getName from the fake and getName from the real must return the same values.
+        This class is named the same as the real HTTPClientService so that it could replace the real
+        class in tests. If a test creates this class earlier than the real one, fake is going to be
+        used until the master is destroyed. Whenever a master wants to create real
+        HTTPClientService, it will find an existing fake service with the same name and use it
+        instead.
     """
     quiet = False
 

--- a/master/buildbot/test/unit/reporters/test_base.py
+++ b/master/buildbot/test/unit/reporters/test_base.py
@@ -44,6 +44,7 @@ class TestReporterBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
 
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
         self.setUpLogging()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -36,11 +36,13 @@ from buildbot.warnings import DeprecatedApiWarning
 
 class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
                               ReporterTestMixin, LoggingMixin):
-    TEST_REPO = 'https://example.org/user/repo'
 
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+
+        self.setup_reporter_test()
+        self.reporter_test_repo = 'https://example.org/user/repo'
 
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
@@ -226,11 +228,13 @@ class BitbucketStatusPushDeprecatedSend(BitbucketStatusPush):
 
 class TestBitbucketStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
                                             ReporterTestMixin, LoggingMixin):
-    TEST_REPO = 'https://example.org/user/repo'
 
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+
+        self.setup_reporter_test()
+        self.reporter_test_repo = 'https://example.org/user/repo'
 
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -41,6 +41,7 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
 
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 

--- a/master/buildbot/test/unit/reporters/test_gerrit.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit.py
@@ -142,6 +142,7 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase,
 
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -214,8 +215,8 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase,
 
         result = makeReviewResult(msg,
                                   (GERRIT_LABEL_VERIFIED, verifiedScore))
-        gsp.sendCodeReview.assert_called_once_with(self.TEST_PROJECT,
-                                                   self.TEST_REVISION,
+        gsp.sendCodeReview.assert_called_once_with(self.reporter_test_project,
+                                                   self.reporter_test_revision,
                                                    result)
 
     @defer.inlineCallbacks
@@ -228,8 +229,8 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase,
 
         result = makeReviewResult(msg,
                                   (GERRIT_LABEL_VERIFIED, verifiedScore))
-        gsp.sendCodeReview.assert_called_once_with(self.TEST_PROJECT,
-                                                   self.TEST_REVISION,
+        gsp.sendCodeReview.assert_called_once_with(self.reporter_test_project,
+                                                   self.reporter_test_revision,
                                                    result)
 
     @defer.inlineCallbacks
@@ -243,8 +244,8 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase,
         result = makeReviewResult(msg,
                                   (GERRIT_LABEL_VERIFIED, verifiedScore),
                                   (GERRIT_LABEL_REVIEWED, 0))
-        gsp.sendCodeReview.assert_called_once_with(self.TEST_PROJECT,
-                                                   self.TEST_REVISION,
+        gsp.sendCodeReview.assert_called_once_with(self.reporter_test_project,
+                                                   self.reporter_test_revision,
                                                    result)
 
     @defer.inlineCallbacks
@@ -361,12 +362,12 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase,
                                                startCB=sampleStartCB)
 
         msg = yield self.run_fake_single_build(gsp, buildResult)
-        start = makeReviewResult(str({'name': self.TEST_BUILDER_NAME}),
+        start = makeReviewResult(str({'name': self.reporter_test_builder_name}),
                                  (GERRIT_LABEL_REVIEWED, 0))
         result = makeReviewResult(msg,
                                   (GERRIT_LABEL_VERIFIED, verifiedScore))
-        calls = [call(self.TEST_PROJECT, self.TEST_REVISION, start),
-                 call(self.TEST_PROJECT, self.TEST_REVISION, result)]
+        calls = [call(self.reporter_test_project, self.reporter_test_revision, start),
+                 call(self.reporter_test_project, self.reporter_test_revision, result)]
         gsp.sendCodeReview.assert_has_calls(calls)
 
     # same goes for check_single_build and check_single_build_legacy
@@ -377,12 +378,12 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase,
                                                startCB=sampleStartCBDeferred)
 
         msg = yield self.run_fake_single_build(gsp, buildResult)
-        start = makeReviewResult(str({'name': self.TEST_BUILDER_NAME}),
+        start = makeReviewResult(str({'name': self.reporter_test_builder_name}),
                                  (GERRIT_LABEL_REVIEWED, 0))
         result = makeReviewResult(msg,
                                   (GERRIT_LABEL_VERIFIED, verifiedScore))
-        calls = [call(self.TEST_PROJECT, self.TEST_REVISION, start),
-                 call(self.TEST_PROJECT, self.TEST_REVISION, result)]
+        calls = [call(self.reporter_test_project, self.reporter_test_revision, start),
+                 call(self.reporter_test_project, self.reporter_test_revision, result)]
         gsp.sendCodeReview.assert_has_calls(calls)
 
     @defer.inlineCallbacks
@@ -392,13 +393,13 @@ class TestGerritStatusPush(TestReactorMixin, unittest.TestCase,
 
         msg = yield self.run_fake_single_build(gsp, buildResult, expWarning=True)
 
-        start = makeReviewResult(str({'name': self.TEST_BUILDER_NAME}),
+        start = makeReviewResult(str({'name': self.reporter_test_builder_name}),
                                  (GERRIT_LABEL_REVIEWED, 0))
         result = makeReviewResult(msg,
                                   (GERRIT_LABEL_VERIFIED, verifiedScore),
                                   (GERRIT_LABEL_REVIEWED, 0))
-        calls = [call(self.TEST_PROJECT, self.TEST_REVISION, start),
-                 call(self.TEST_PROJECT, self.TEST_REVISION, result)]
+        calls = [call(self.reporter_test_project, self.reporter_test_revision, start),
+                 call(self.reporter_test_project, self.reporter_test_revision, result)]
         gsp.sendCodeReview.assert_has_calls(calls)
 
     def test_buildComplete_success_sends_review(self):

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -42,11 +42,14 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
                                  logging.LoggingMixin,
                                  unittest.TestCase):
 
-    TEST_PROPS = {'gerrit_changes': [{'change_id': 12, 'revision_id': 2}]}
-
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
+        self.reporter_test_props = {
+            'gerrit_changes': [{'change_id': 12, 'revision_id': 2}]
+        }
+
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
@@ -391,11 +394,13 @@ class GerritVerifyStatusPushDeprecatedSend(GerritVerifyStatusPush):
 class TestGerritVerifyStatusPushDeprecatedSend(TestReactorMixin, ReporterTestMixin,
                                                logging.LoggingMixin, unittest.TestCase):
 
-    TEST_PROPS = {'gerrit_changes': [{'change_id': 12, 'revision_id': 2}]}
-
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
+        self.reporter_test_props = {
+            'gerrit_changes': [{'change_id': 12, 'revision_id': 2}]
+        }
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -36,12 +36,15 @@ from buildbot.warnings import DeprecatedApiWarning
 
 class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
                            ReporterTestMixin):
-    # project must be in the form <owner>/<project>
-    TEST_PROJECT = 'buildbot/buildbot'
 
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+
+        self.setup_reporter_test()
+        # project must be in the form <owner>/<project>
+        self.reporter_test_project = 'buildbot/buildbot'
+
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
@@ -88,6 +91,8 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
                   'target_url': 'http://localhost:8080/#builders/79/builds/0',
                   'description': 'Build done.', 'context': 'buildbot/Builder0'})
 
+        build['complete'] = False
+        build['results'] = None
         yield self.sp._got_event(('builds', 20, 'new'), build)
         build['complete'] = True
         build['results'] = SUCCESS
@@ -222,13 +227,15 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
 
 class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
                               ReporterTestMixin):
-    # project must be in the form <owner>/<project>
-    TEST_PROJECT = 'buildbot'
-    TEST_REPO = 'https://github.com/buildbot1/buildbot1.git'
 
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+
+        self.setup_reporter_test()
+        # project must be in the form <owner>/<project>
+        self.reporter_test_project = 'buildbot'
+        self.reporter_test_repo = 'https://github.com/buildbot1/buildbot1.git'
 
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
@@ -255,7 +262,7 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
 
     @defer.inlineCallbacks
     def test_ssh(self):
-        self.TEST_REPO = 'git@github.com:buildbot2/buildbot2.git'
+        self.reporter_test_repo = 'git@github.com:buildbot2/buildbot2.git'
 
         build = yield self.insert_build_new()
         # we make sure proper calls to txrequests have been made
@@ -329,12 +336,15 @@ class GitHubStatusPushDeprecatedSend(GitHubStatusPush):
 
 class TestGitHubStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
                                          ReporterTestMixin):
-    # project must be in the form <owner>/<project>
-    TEST_PROJECT = 'buildbot/buildbot'
 
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+
+        self.setup_reporter_test()
+        # project must be in the form <owner>/<project>
+        self.reporter_test_project = 'buildbot/buildbot'
+
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -35,12 +35,15 @@ from buildbot.warnings import DeprecatedApiWarning
 
 class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
                            ReporterTestMixin, logging.LoggingMixin):
-    # repository must be in the form http://gitlab/<owner>/<project>
-    TEST_REPO = 'http://gitlab/buildbot/buildbot'
 
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+
+        self.setup_reporter_test()
+        # repository must be in the form http://gitlab/<owner>/<project>
+        self.reporter_test_repo = 'http://gitlab/buildbot/buildbot'
+
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
@@ -98,7 +101,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
 
     @defer.inlineCallbacks
     def test_sshurl(self):
-        self.TEST_REPO = 'git@gitlab:buildbot/buildbot.git'
+        self.reporter_test_repo = 'git@gitlab:buildbot/buildbot.git'
         build = yield self.insert_build_new()
         # we make sure proper calls to txrequests have been made
         self._http.expect(
@@ -118,8 +121,8 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
 
     @defer.inlineCallbacks
     def test_merge_request_forked(self):
-        self.TEST_REPO = 'git@gitlab:buildbot/buildbot.git'
-        self.TEST_PROPS['source_project_id'] = 20922342342
+        self.reporter_test_repo = 'git@gitlab:buildbot/buildbot.git'
+        self.reporter_test_props['source_project_id'] = 20922342342
         build = yield self.insert_build_new()
         self._http.expect(
             'post',
@@ -131,11 +134,11 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
         build['complete'] = False
         yield self.sp._got_event(('builds', 20, 'new'), build)
         # Don't run these tests in parallel!
-        del self.TEST_PROPS['source_project_id']
+        del self.reporter_test_props['source_project_id']
 
     @defer.inlineCallbacks
     def test_noproject(self):
-        self.TEST_REPO = 'git@gitlab:buildbot/buildbot.git'
+        self.reporter_test_repo = 'git@gitlab:buildbot/buildbot.git'
         self.setUpLogging()
         build = yield self.insert_build_new()
         # we make sure proper calls to txrequests have been made
@@ -151,7 +154,7 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
 
     @defer.inlineCallbacks
     def test_nourl(self):
-        self.TEST_REPO = ''
+        self.reporter_test_repo = ''
         build = yield self.insert_build_new()
         build['complete'] = False
         yield self.sp._got_event(('builds', 20, 'new'), build)
@@ -214,12 +217,15 @@ class GitLabStatusPushDeprecatedSend(GitLabStatusPush):
 
 class TestGitLabStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
                                          ReporterTestMixin, logging.LoggingMixin):
-    # repository must be in the form http://gitlab/<owner>/<project>
-    TEST_REPO = 'http://gitlab/buildbot/buildbot'
 
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+
+        self.setup_reporter_test()
+        # repository must be in the form http://gitlab/<owner>/<project>
+        self.reporter_test_repo = 'http://gitlab/buildbot/buildbot'
+
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,

--- a/master/buildbot/test/unit/reporters/test_hipchat.py
+++ b/master/buildbot/test/unit/reporters/test_hipchat.py
@@ -37,6 +37,7 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
 
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
@@ -251,6 +252,7 @@ class TestHipchatStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
 
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
         # ignore config error if txrequests is not installed
         self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -69,6 +69,7 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
         # ignore config error if txrequests is not installed
         config._errors = Mock()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
@@ -191,6 +192,7 @@ class TestHttpStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase, Repo
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
         # ignore config error if txrequests is not installed
         config._errors = Mock()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
@@ -252,6 +254,7 @@ class TestHttpStatusPushBaseDeprecatedSend(TestReactorMixin, unittest.TestCase, 
     @defer.inlineCallbacks
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
         yield self.master.startService()

--- a/master/buildbot/test/unit/reporters/test_mail.py
+++ b/master/buildbot/test/unit/reporters/test_mail.py
@@ -53,6 +53,7 @@ class TestMailNotifier(ConfigErrorsMixin, TestReactorMixin,
 
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 

--- a/master/buildbot/test/unit/reporters/test_zulip.py
+++ b/master/buildbot/test/unit/reporters/test_zulip.py
@@ -32,6 +32,7 @@ class TestZulipStatusPush(unittest.TestCase, ReporterTestMixin, LoggingMixin, Co
 
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
         self.master = fakemaster.make_master(
             testcase=self, wantData=True, wantDb=True, wantMq=True)
 
@@ -187,6 +188,7 @@ class TestZulipStatusPushDeprecatedSend(unittest.TestCase, ReporterTestMixin, Lo
 
     def setUp(self):
         self.setUpTestReactor()
+        self.setup_reporter_test()
         self.master = fakemaster.make_master(
             testcase=self, wantData=True, wantDb=True, wantMq=True)
 

--- a/master/buildbot/test/util/reporter.py
+++ b/master/buildbot/test/util/reporter.py
@@ -21,23 +21,24 @@ from buildbot.test import fakedb
 
 class ReporterTestMixin:
 
-    TEST_PROJECT = 'testProject'
-    TEST_REPO = 'https://example.org/repo'
-    TEST_REVISION = 'd34db33fd43db33f'
-    TEST_BRANCH = "master"
-    TEST_CODEBASE = 'cbgerrit'
-    TEST_CHANGE_ID = 'I5bdc2e500d00607af53f0fa4df661aada17f81fc'
-    TEST_BUILDER_NAME = 'Builder0'
-    TEST_PROPS = {
-        'Stash_branch': 'refs/changes/34/1234/1',
-        'project': TEST_PROJECT,
-        'got_revision': TEST_REVISION,
-        'revision': TEST_REVISION,
-        'event.change.id': TEST_CHANGE_ID,
-        'event.change.project': TEST_PROJECT,
-        'branch': 'refs/pull/34/merge',
-    }
-    THING_URL = 'http://thing.example.com'
+    def setup_reporter_test(self):
+        self.reporter_test_project = 'testProject'
+        self.reporter_test_repo = 'https://example.org/repo'
+        self.reporter_test_revision = 'd34db33fd43db33f'
+        self.reporter_test_branch = "master"
+        self.reporter_test_codebase = 'cbgerrit'
+        self.reporter_test_change_id = 'I5bdc2e500d00607af53f0fa4df661aada17f81fc'
+        self.reporter_test_builder_name = 'Builder0'
+        self.reporter_test_props = {
+            'Stash_branch': 'refs/changes/34/1234/1',
+            'project': self.reporter_test_project,
+            'got_revision': self.reporter_test_revision,
+            'revision': self.reporter_test_revision,
+            'event.change.id': self.reporter_test_change_id,
+            'event.change.project': self.reporter_test_project,
+            'branch': 'refs/pull/34/merge',
+        }
+        self.reporter_test_thing_url = 'http://thing.example.com'
 
     @defer.inlineCallbacks
     def insert_build(self, results, insert_ss=True, parent_plan=False, insert_patch=False):
@@ -64,9 +65,10 @@ class ReporterTestMixin:
             fakedb.Builder(id=80, name='Builder1'),
             fakedb.Buildset(id=98, results=finalResult, reason="testReason1",
                             parent_buildid=19 if parentPlan else None),
-            fakedb.Change(changeid=13, branch=self.TEST_BRANCH, revision='9283', author='me@foo',
-                          repository=self.TEST_REPO, codebase=self.TEST_CODEBASE,
-                          project='world-domination', sourcestampid=234),
+            fakedb.Change(changeid=13, branch=self.reporter_test_branch, revision='9283',
+                          author='me@foo', repository=self.reporter_test_repo,
+                          codebase=self.reporter_test_codebase, project='world-domination',
+                          sourcestampid=234),
         ])
 
         if parentPlan:
@@ -86,11 +88,11 @@ class ReporterTestMixin:
                 fakedb.BuildsetSourceStamp(buildsetid=98, sourcestampid=234),
                 fakedb.SourceStamp(
                     id=234,
-                    branch=self.TEST_BRANCH,
-                    project=self.TEST_PROJECT,
-                    revision=self.TEST_REVISION,
-                    repository=self.TEST_REPO,
-                    codebase=self.TEST_CODEBASE,
+                    branch=self.reporter_test_branch,
+                    project=self.reporter_test_project,
+                    revision=self.reporter_test_revision,
+                    repository=self.reporter_test_repo,
+                    codebase=self.reporter_test_codebase,
                     patchid=patchid),
                 fakedb.Patch(id=99, patch_base64='aGVsbG8sIHdvcmxk',
                              patch_author='him@foo', patch_comment='foo', subdir='/foo',
@@ -121,7 +123,7 @@ class ReporterTestMixin:
                     buildid=20 + i, name="buildnumber", value="{}".format(i)),
                 fakedb.BuildProperty(buildid=20 + i, name="scheduler", value="checkin"),
             ])
-            for k, v in self.TEST_PROPS.items():
+            for k, v in self.reporter_test_props.items():
                 self.db.insertTestData([
                     fakedb.BuildProperty(buildid=20 + i, name=k, value=v)
                 ])


### PR DESCRIPTION
This makes reporter tests easier to customize.