### PR TITLE
Fix for ldap3.core.exceptions.LDAPInvalidFilterError: malformed filter

### DIFF
--- a/master/buildbot/newsfragments/fix-ldap3.core.exceptions.LDAPInvalidFilterError.bugfix
+++ b/master/buildbot/newsfragments/fix-ldap3.core.exceptions.LDAPInvalidFilterError.bugfix
@@ -1,0 +1,1 @@
+Fix ldap3.core.exceptions.LDAPInvalidFilterError if LDAP filter string contains characters that needs to be escaped.

--- a/master/buildbot/www/ldapuserinfo.py
+++ b/master/buildbot/www/ldapuserinfo.py
@@ -126,7 +126,7 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
                 return infos
 
             # needs double quoting of backslashing
-            pattern = self.groupMemberPattern % dict(dn=dn)
+            pattern = self.groupMemberPattern % dict(dn=ldap3.utils.conv.escape_filter_chars(dn))
             res = self.search(c, self.groupBase, pattern,
                               attributes=[self.groupName])
             infos['groups'] = flatten([group_infos['attributes'][self.groupName]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -33,6 +33,7 @@ Jinja2==2.11.2
 jmespath==0.10.0
 jsonref==0.2
 lazy-object-proxy==1.4.1  # pyup: ignore (required by astroid)
+ldap3==2.8.1
 lz4==3.1.1
 markdown2==2.3.10
 MarkupSafe==1.1.1


### PR DESCRIPTION
Fix ldap3.core.exceptions.LDAPInvalidFilterError if LDAP filter string contains characters that needs to be escaped. For example:

displayName: Lastname, Firstname

master.cfg

# Active Directory user information
userInfoProvider = util.LdapUserInfo(
    uri='ldap://ldap.local:3268',
    bindUser='user@ldap.local',
    bindPw='pass',
    accountBase='OU=Companies,DC=ldap,DC=local',
    groupBase='OU=Companies,DC=ldap,DC=local',
    accountPattern='(&(objectClass=user)(sAMAccountName=%(username)s))',
    accountFullName='displayName',
    accountEmail='mail',
    groupMemberPattern='(&(objectClass=group)(member=%(dn)s))',
    groupName='Name',
    avatarPattern='(&(objectClass=user)(mail=%(email)s))',
    avatarData='thumbnailPhoto',
)

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation (not applicable)
