### PR TITLE
Add option for hiding HTTP header values from log

### DIFF
--- a/master/buildbot/newsfragments/hide-http-headers.feature
+++ b/master/buildbot/newsfragments/hide-http-headers.feature
@@ -1,0 +1,1 @@
+:py:class:`~buildbot.steps.http.HTTPStep`: Add the option to hide sensitive HTTP header values from the log.

--- a/master/buildbot/steps/http.py
+++ b/master/buildbot/steps/http.py
@@ -113,10 +113,8 @@ class HTTPStepNewStyle(BuildStep):
         yield log.addHeader('Performing {} request to {}\n'.format(self.method, self.url))
         if self.params:
             yield log.addHeader('Parameters:\n')
-            params = requestkwargs.get("params", {})
-            if params:
-                params = sorted(params.items(), key=lambda x: x[0])
-                requestkwargs['params'] = params
+            params = sorted(self.params.items(), key=lambda x: x[0])
+            requestkwargs['params'] = params
             for k, v in params:
                 yield log.addHeader('\t{}: {}\n'.format(k, v))
         data = requestkwargs.get("data", None)

--- a/master/buildbot/steps/http.py
+++ b/master/buildbot/steps/http.py
@@ -151,7 +151,7 @@ class HTTPStepNewStyle(BuildStep):
     @defer.inlineCallbacks
     def log_response(self, log, response):
 
-        yield log.addHeader('Request Header:\n')
+        yield log.addHeader('Request Headers:\n')
         for k, v in response.request.headers.items():
             if k.casefold() in self.hide_request_headers:
                 v = '<HIDDEN>'
@@ -164,7 +164,7 @@ class HTTPStepNewStyle(BuildStep):
         else:
             yield log.addStderr('Status: {}\n'.format(response.status_code))
 
-        yield log.addHeader('Response Header:\n')
+        yield log.addHeader('Response Headers:\n')
         for k, v in response.headers.items():
             if k.casefold() in self.hide_response_headers:
                 v = '<HIDDEN>'

--- a/master/buildbot/test/unit/steps/test_http.py
+++ b/master/buildbot/test/unit/steps/test_http.py
@@ -192,6 +192,18 @@ OK:key1=value1'''.format(url))
         self.expectOutcome(result=SUCCESS, state_string="Status code: 200")
         return self.runStep()
 
+    @defer.inlineCallbacks
+    def test_hidden_header(self):
+        url = self.getURL("header")
+        self.setupStep(http.GETNewStyle(url, headers={"X-Test": "True"},
+                                        hide_request_headers=["X-Test"],
+                                        hide_response_headers=["Content-Length"]))
+        self.expectLogfile('log', "URL: {}\nStatus: 200\n ------ Content ------\nTrue".format(url))
+        self.expectOutcome(result=SUCCESS, state_string="Status code: 200")
+        yield self.runStep()
+        self.assertIn("X-Test: <HIDDEN>", self.step.logs['log'].header)
+        self.assertIn("Content-Length: <HIDDEN>", self.step.logs['log'].header)
+
     def test_params_renderable(self):
         url = self.getURL()
         self.setupStep(http.GETNewStyle(url, params=properties.Property("x")))

--- a/master/docs/manual/configuration/steps/http_step.rst
+++ b/master/docs/manual/configuration/steps/http_step.rst
@@ -42,6 +42,14 @@ The parameters are the following:
 ``headers``
     Dictionary of headers to send.
 
+``hide_request_headers``
+   Iterable of request headers to be hidden from the log.
+   The header will be listed in the log but the value will be shown as ``<HIDDEN>``.
+
+``hide_response_headers``
+   Iterable of response headers to be hidden from the log.
+   The header will be listed in the log but the value will be shown as ``<HIDDEN>``.
+
 ``other params``
     Any other keywords supported by the ``requests``
     `api <https://2.python-requests.org/en/master/api/#main-interface>`_


### PR DESCRIPTION
@de-vri-es implemented option for hiding HTTP header values from log (pull request #4792).
This PR takes @de-vri-es implementation and adds a missing test.

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
