### PR TITLE
Don't use adapters to convert between interfaces

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -467,7 +467,7 @@ class Build(properties.PropertiesMixin):
     def setupBuildSteps(self, step_factories):
         steps = []
         for factory in step_factories:
-            step = factory.buildStep()
+            step = buildstep.create_step_from_step_or_factory(factory)
             step.setBuild(self)
             step.setWorker(self.workerforbuilder.worker)
             steps.append(step)
@@ -489,18 +489,14 @@ class Build(properties.PropertiesMixin):
             self.setProperty('owners', sorted(owners), 'Build')
         self.text = []  # list of text string lists (text2)
 
-    def _addBuildSteps(self, step_factories):
-        factories = [interfaces.IBuildStepFactory(s) for s in step_factories]
-        return self.setupBuildSteps(factories)
-
     def addStepsAfterCurrentStep(self, step_factories):
         # Add the new steps after the step that is running.
         # The running step has already been popped from self.steps
-        self.steps[0:0] = self._addBuildSteps(step_factories)
+        self.steps[0:0] = self.setupBuildSteps(step_factories)
 
     def addStepsAfterLastStep(self, step_factories):
         # Add the new steps to the end.
-        self.steps.extend(self._addBuildSteps(step_factories))
+        self.steps.extend(self.setupBuildSteps(step_factories))
 
     def getNextStep(self):
         """This method is called to obtain the next BuildStep for this build.

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -18,7 +18,6 @@ from functools import reduce
 
 from twisted.internet import defer
 from twisted.internet import error
-from twisted.python import components
 from twisted.python import failure
 from twisted.python import log
 from twisted.python.failure import Failure
@@ -109,6 +108,9 @@ class Build(properties.PropertiesMixin):
 
         # tracks the config version for locks
         self.config_version = None
+
+    def getProperties(self):
+        return self.properties
 
     def setBuilder(self, builder):
         """
@@ -759,8 +761,3 @@ class Build(properties.PropertiesMixin):
         return self.build_status
 
     # stopBuild is defined earlier
-
-
-components.registerAdapter(
-    lambda build: interfaces.IProperties(build.properties),
-    Build, interfaces.IProperties)

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -421,10 +421,6 @@ class BuildStep(results.ResultComputingConfigMixin,
     def workdir(self, workdir):
         self._workdir = workdir
 
-    def addFactoryArguments(self, **kwargs):
-        # this is here for backwards compatibility
-        pass
-
     def _getStepFactory(self):
         return self._factory
 

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -20,7 +20,6 @@ from io import StringIO
 
 from twisted.internet import defer
 from twisted.internet import error
-from twisted.python import components
 from twisted.python import deprecate
 from twisted.python import failure
 from twisted.python import log
@@ -436,6 +435,9 @@ class BuildStep(results.ResultComputingConfigMixin,
     @workdir.setter
     def workdir(self, workdir):
         self._workdir = workdir
+
+    def getProperties(self):
+        return self.build.getProperties()
 
     def get_step_factory(self):
         return self._factory
@@ -972,11 +974,6 @@ class BuildStep(results.ResultComputingConfigMixin,
             warn_deprecated('2.9.0', ('Subclassing old-style step {0} in {1} is deprecated, '
                                       'please migrate to new-style equivalent {0}NewStyle'
                                       ).format(name, self.__class__.__name__))
-
-
-components.registerAdapter(
-    lambda step: interfaces.IProperties(step.build),
-    BuildStep, interfaces.IProperties)
 
 
 class LoggingBuildStep(BuildStep):

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -228,7 +228,7 @@ class PropertiesMixin:
 
     """
     A mixin to add L{IProperties} methods to a class which does not implement
-    the interface, but which can be coerced to the interface via an adapter.
+    the full interface, only getProperties() function.
 
     This is useful because L{IProperties} methods are often called on L{Build}
     and L{BuildStatus} objects without first coercing them.
@@ -240,29 +240,23 @@ class PropertiesMixin:
     set_runtime_properties = False
 
     def getProperty(self, propname, default=None):
-        props = IProperties(self)
-        return props.getProperty(propname, default)
+        return self.getProperties().getProperty(propname, default)
 
     def hasProperty(self, propname):
-        props = IProperties(self)
-        return props.hasProperty(propname)
+        return self.getProperties().hasProperty(propname)
 
     has_key = hasProperty
 
     def setProperty(self, propname, value, source='Unknown', runtime=None):
         # source is not optional in IProperties, but is optional here to avoid
         # breaking user-supplied code that fails to specify a source
-        props = IProperties(self)
+        props = self.getProperties()
         if runtime is None:
             runtime = self.set_runtime_properties
         props.setProperty(propname, value, source, runtime=runtime)
 
-    def getProperties(self):
-        return IProperties(self)
-
     def render(self, value):
-        props = IProperties(self)
-        return props.render(value)
+        return self.getProperties().render(value)
 
 
 @implementer(IRenderable)

--- a/master/buildbot/steps/package/rpm/rpmlint.py
+++ b/master/buildbot/steps/package/rpm/rpmlint.py
@@ -55,7 +55,6 @@ class RpmLint(TestNewStyle):
             self.fileloc = fileloc
         if config:
             self.config = config
-        self.addFactoryArguments(fileloc=fileloc, config=config)
 
         self.command = ["rpmlint", "-i"]
         if self.config:

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -17,10 +17,7 @@ import posixpath
 
 import mock
 
-from twisted.python import components
-
 from buildbot import config
-from buildbot import interfaces
 from buildbot.process import factory
 from buildbot.process import properties
 from buildbot.process import workerforbuilder
@@ -32,6 +29,9 @@ class FakeBuildStatus(properties.PropertiesMixin):
 
     def __init__(self):
         self.properties = properties.Properties()
+
+    def getProperties(self):
+        return self.properties
 
     def getInterestedUsers(self):
         return []
@@ -59,11 +59,6 @@ class FakeBuildStatus(properties.PropertiesMixin):
         pass
 
     getBuilder = mock.Mock()
-
-
-components.registerAdapter(
-    lambda build_status: build_status.properties,
-    FakeBuildStatus, interfaces.IProperties)
 
 
 class FakeWorkerStatus(properties.PropertiesMixin):
@@ -98,9 +93,15 @@ class FakeBuild(properties.PropertiesMixin):
             props = properties.Properties()
         props.build = self
         self.build_status.properties = props
-        self.properties = props
         self.master = None
         self.config_version = 0
+
+    def getProperties(self):
+        return self.build_status.getProperties()
+
+    @property
+    def properties(self):
+        return self.getProperties()
 
     def getSourceStamp(self, codebase):
         if codebase in self.sources:
@@ -130,11 +131,6 @@ class FakeBuild(properties.PropertiesMixin):
 
     def setUniqueStepName(self, step):
         pass
-
-
-components.registerAdapter(
-    lambda build: build.build_status.properties,
-    FakeBuild, interfaces.IProperties)
 
 
 class FakeBuildForRendering:

--- a/master/buildbot/test/unit/process/test_properties.py
+++ b/master/buildbot/test/unit/process/test_properties.py
@@ -18,11 +18,9 @@ from copy import deepcopy
 import mock
 
 from twisted.internet import defer
-from twisted.python import components
 from twisted.trial import unittest
 from zope.interface import implementer
 
-from buildbot.interfaces import IProperties
 from buildbot.interfaces import IRenderable
 from buildbot.process.buildrequest import TempChange
 from buildbot.process.buildrequest import TempSourceStamp
@@ -1078,12 +1076,8 @@ class TestProperties(unittest.TestCase):
 class MyPropertiesThing(PropertiesMixin):
     set_runtime_properties = True
 
-
-def adaptMyProperties(mp):
-    return mp.properties
-
-
-components.registerAdapter(adaptMyProperties, MyPropertiesThing, IProperties)
+    def getProperties(self):
+        return self.properties
 
 
 class TestPropertiesMixin(unittest.TestCase):

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -147,15 +147,6 @@ class BuildStepMixin:
     def tearDownBuildStep(self):
         pass
 
-    # utilities
-    def _getWorkerCommandVersionWrapper(self):
-        originalGetWorkerCommandVersion = self.step.build.getWorkerCommandVersion
-
-        def getWorkerCommandVersion(cmd, oldversion):
-            return originalGetWorkerCommandVersion(cmd, oldversion)
-
-        return getWorkerCommandVersion
-
     def setupStep(self, step, worker_version=None, worker_env=None,
                   buildFiles=None, wantDefaultWorkdir=True):
         """
@@ -350,8 +341,6 @@ class BuildStepMixin:
 
         @returns: Deferred
         """
-        self.step.build.getWorkerCommandVersion = self._getWorkerCommandVersionWrapper()
-
         self.conn = mock.Mock(name="WorkerForBuilder(connection)")
         self.step.setupProgress()
         result = yield self.step.startStep(self.conn)

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -19,7 +19,6 @@ from twisted.internet import defer
 from twisted.python import log
 from twisted.python.reflect import namedModule
 
-from buildbot import interfaces
 from buildbot.process import buildstep
 from buildbot.process import remotecommand as real_remotecommand
 from buildbot.process.results import EXCEPTION
@@ -200,7 +199,7 @@ class BuildStepMixin:
         self.build.builder.config.env = worker_env.copy()
 
         # watch for properties being set
-        self.properties = interfaces.IProperties(b)
+        self.properties = b.getProperties()
 
         # step.progress
 

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -175,9 +175,7 @@ class BuildStepMixin:
         if buildFiles is None:
             buildFiles = list()
 
-        factory = interfaces.IBuildStepFactory(step)
-
-        step = self.step = factory.buildStep()
+        step = self.step = buildstep.create_step_from_step_or_factory(step)
 
         # set defaults
         if wantDefaultWorkdir:


### PR DESCRIPTION
Currently the conversion between `BuildStep` and `IBuildStepFactory` or between `Build` or `BuildStatus` and `IProperties` is extremely convoluted. Without actually knowing how zope.interface and twisted work it's a black box without an easy way to figure out what's happening under the hood. One basically needs to accidentally stumble on  `twisted.python.components.registerAdapter`, then guess that it is somehow related to type coercions, then look up the documentation and only after understanding how this function is related to what's happening in Buildbot everything falls together.

To make life for future developers easier this PR replaces most usages of `registerAdapter` with a simplier alternatives.