### PR TITLE
pyup: Reduce update frequency to 'every two weeks'

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,4 +1,4 @@
 # update schedule, default is not set
 # the bot will visit the repo once and bundle all updates in a single PR for the given
 # day/week/month
-schedule: "every week" # allowed ["every day", "every week", "every two weeks", "every month"]
+schedule: "every two weeks" # allowed ["every day", "every week", "every two weeks", "every month"]


### PR DESCRIPTION
We aren't currently using the information provided by pyup in an useful way, so it makes sense to reduce the frequency of updates a little, as it reduces the overhead of fixing all the upgrade problems.