### PR TITLE
Several fixes for critical reporter bugs

### DIFF
--- a/master/buildbot/newsfragments/fix-github-gitlab-checkconfig.bugfix
+++ b/master/buildbot/newsfragments/fix-github-gitlab-checkconfig.bugfix
@@ -1,0 +1,1 @@
+Fixed ``checkConfig`` failures in ``GitHubStatusPush`` and ``GitLabStatusPush`` (:issue:`5664`).

--- a/master/buildbot/newsfragments/fix-gitlab-builders-deprecation.bugfix
+++ b/master/buildbot/newsfragments/fix-gitlab-builders-deprecation.bugfix
@@ -1,0 +1,1 @@
+Fixed incorrect deprecation notice for the ``builders`` argument of ``GitLabStatusPush``.

--- a/master/buildbot/reporters/github.py
+++ b/master/buildbot/reporters/github.py
@@ -39,7 +39,7 @@ HOSTED_BASE_URL = 'https://api.github.com'
 class GitHubStatusPush(http.HttpStatusPushBase):
     name = "GitHubStatusPush"
 
-    def checkConfig(token, startDescription=None, endDescription=None,
+    def checkConfig(self, token, startDescription=None, endDescription=None,
                     context=None, baseURL=None, verbose=False, wantProperties=True, **kwargs):
         super().checkConfig(wantProperties=wantProperties,
                             _has_old_arg_names={

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -38,7 +38,7 @@ HOSTED_BASE_URL = 'https://gitlab.com'
 class GitLabStatusPush(http.HttpStatusPushBase):
     name = "GitLabStatusPush"
 
-    def checkConfig(token, startDescription=None, endDescription=None,
+    def checkConfig(self, token, startDescription=None, endDescription=None,
                     context=None, baseURL=None, verbose=False, wantProperties=True, **kwargs):
         super().checkConfig(wantProperties=wantProperties,
                             _has_old_arg_names={

--- a/master/buildbot/reporters/gitlab.py
+++ b/master/buildbot/reporters/gitlab.py
@@ -42,6 +42,7 @@ class GitLabStatusPush(http.HttpStatusPushBase):
                     context=None, baseURL=None, verbose=False, wantProperties=True, **kwargs):
         super().checkConfig(wantProperties=wantProperties,
                             _has_old_arg_names={
+                                'builders': False,
                                 'wantProperties': wantProperties is not True
                             }, **kwargs)
 

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -68,6 +68,14 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
     def tearDown(self):
         return self.master.stopService()
 
+    def test_check_config(self):
+        service = GitHubStatusPush(Interpolate('XXYYZZ'))
+        service.checkConfig(Interpolate('token'), startDescription=Interpolate('start'),
+                            endDescription=Interpolate('end'),
+                            context=Interpolate('context'),
+                            verbose=True,
+                            builders=['builder1'])
+
     @defer.inlineCallbacks
     def test_basic(self):
         build = yield self.insert_build_new()

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -61,6 +61,14 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
     def tearDown(self):
         return self.master.stopService()
 
+    def test_check_config(self):
+        service = GitLabStatusPush(Interpolate('XXYYZZ'))
+        service.checkConfig(Interpolate('token'), startDescription=Interpolate('start'),
+                            endDescription=Interpolate('end'),
+                            context=Interpolate('context'),
+                            verbose=True,
+                            builders=['builder1'])
+
     @defer.inlineCallbacks
     def test_basic(self):
         build = yield self.insert_build_new()


### PR DESCRIPTION
Fixes #5664 and too early deprecation notice for builders argument of `GitLabStatusPush`.