### PR TITLE
pkg: Remove leftover material design install test

### DIFF
--- a/pkg/test_buildbot_pkg.py
+++ b/pkg/test_buildbot_pkg.py
@@ -93,10 +93,6 @@ class BuildbotWWWPkg(unittest.TestCase):
         self.check_correct_installation()
 
 
-class BuildbotMDWWWPkg(BuildbotWWWPkg):
-    pkgPaths = ["www"]
-
-
 class BuildbotConsolePkg(BuildbotWWWPkg):
     pkgName = "buildbot-console-view"
     pkgPaths = ["www", "console_view"]


### PR DESCRIPTION
This breaks frontend install tests on he master branch.