### PR TITLE
fix: fix profile menu wrapping

### DIFF
--- a/master/buildbot/newsfragments/fix-profile-menu-wrapping.bugfix
+++ b/master/buildbot/newsfragments/fix-profile-menu-wrapping.bugfix
@@ -1,0 +1,1 @@
+Fixed the profile menu wrapping because the avatar shows more often and hiding the profile name was not kept in sync.

--- a/smokes/e2e/pages/base.ts
+++ b/smokes/e2e/pages/base.ts
@@ -12,7 +12,7 @@ export class BasePage {
     constructor() {}
 
     async logOut() {
-        await element(By.css('.avatar img')).click();
+        await element(By.css('.navbar-right a.dropdown-toggle')).click();
         await element(By.linkText('Logout')).click();
         const anonymousButton = element.all(By.css('.dropdown')).first();
         expect(await anonymousButton.getText()).toContain("Anonymous");

--- a/www/base/src/app/common/directives/loginbar/loginbar.tpl.jade
+++ b/www/base/src/app/common/directives/loginbar/loginbar.tpl.jade
@@ -15,9 +15,8 @@ ul.nav.navbar-nav.navbar-right(ng-show="config.auth.name != 'NoAuth'")
 
     li.dropdown(uib-dropdown, ng-hide="anonymous")
         a.dropdown-toggle(uib-dropdown-toggle)
-            .avatar()
-                img(ng-src="avatar?username={{username}}&email={{email}}")
-            span(ng-if="!email")
+            img.avatar(ng-if="config.avatar_methods.length" ng-src="avatar?username={{username}}&email={{email}}")
+            span(ng-if="!config.avatar_methods.length")
                 | {{full_name || username}}
                 b.caret
         ul.dropdown-menu(uib-dropdown-menu)

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -121,19 +121,12 @@ Firefox will insert newlines if the selection go over a no-select span, so we ne
   padding-right: 10px;
 }
 
-.avatar {
-  background-size: 32px 32px;
+img.avatar {
+  background-color: #ccc;
   border-radius: 50%;
-  display: block;
-  margin: -10px;
   height: 40px;
+  margin: -10px;
   width: 40px;
-  overflow: hidden;
-  img {
-    height: 40px;
-    width: 40px;
-    background-color: #ccc
-  }
 }
 
 .change-avatar {

--- a/www/guanlecoja-ui/src/module/topbar/topbar.less
+++ b/www/guanlecoja-ui/src/module/topbar/topbar.less
@@ -63,17 +63,10 @@
         padding-left: 0px;
     }
 }
-.avatar {
-  background-size: 32px 32px;
+img.avatar {
+  background-color: #ccc;
   border-radius: 50%;
-  display: block;
-  margin: -10px;
   height: 40px;
+  margin: -10px;
   width: 40px;
-  overflow: hidden;
-  img {
-    height: 40px;
-    width: 40px;
-    background-color: #ccc
-  }
 }


### PR DESCRIPTION
This change fixes the user profile name visibility which was not kept in (negated) sync with the avatar and causes the menu to wrap funny.

Changes:
![Screenshot from 2020-12-07 19-01-51](https://user-images.githubusercontent.com/438813/101516221-1054af00-3934-11eb-84c4-ef4729c91571.png)

"Back" to the following (expanded the menu to show the name is already there):
![Screenshot from 2020-12-08 08-52-34](https://user-images.githubusercontent.com/438813/101516235-15b1f980-3934-11eb-8fb0-2f69d7736c87.png)


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
