### PR TITLE
Fix too early deprecations of HttpStatusPush arguments

### DIFF
--- a/master/buildbot/newsfragments/http-status-push-revert-deprecation.bugfix
+++ b/master/buildbot/newsfragments/http-status-push-revert-deprecation.bugfix
@@ -1,0 +1,1 @@
+Revert too early deprecation of the ``format_fn``, ``builders``, ``wantProperties``, ``wantSteps``, ``wantPreviousBuild``, ``wantLogs`` arguments of ``HttpStatusPush``.

--- a/master/buildbot/reporters/http.py
+++ b/master/buildbot/reporters/http.py
@@ -117,12 +117,12 @@ class HttpStatusPush(HttpStatusPushBase):
             config.error("format_fn must be a function")
 
         old_arg_names = {
-            'format_fn': format_fn is not None,
-            'builders': builders is not None,
-            'wantProperties': wantProperties is not False,
-            'wantSteps': wantSteps is not False,
-            'wantPreviousBuild': wantPreviousBuild is not False,
-            'wantLogs': wantLogs is not False,
+            'format_fn': False,
+            'builders': False,
+            'wantProperties': False,
+            'wantSteps': False,
+            'wantPreviousBuild': False,
+            'wantLogs': False,
         }
 
         passed_old_arg_names = [k for k, v in old_arg_names.items() if v]

--- a/master/buildbot/test/unit/reporters/test_base.py
+++ b/master/buildbot/test/unit/reporters/test_base.py
@@ -85,10 +85,7 @@ class TestReporterBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
         formatter.wantLogs = False
 
         if old_style:
-            with assertProducesWarnings(DeprecatedApiWarning,
-                                        message_pattern='have been deprecated'):
-                mn = yield self.setupNotifier(old_style=True, messageFormatter=formatter,
-                                              **mnKwargs)
+            mn = yield self.setupNotifier(old_style=True, messageFormatter=formatter, **mnKwargs)
         else:
             generator_kwargs = {}
             if 'mode' in mnKwargs:
@@ -122,10 +119,9 @@ class TestReporterBase(ConfigErrorsMixin, TestReactorMixin, LoggingMixin,
     ])
     def test_check_config_raises_error_when_deprecated_and_generator(self, arg_name, arg_value):
         notifier = ReporterBase()
-        with assertProducesWarnings(DeprecatedApiWarning, message_pattern='have been deprecated'):
-            with self.assertRaisesConfigError('can\'t specify generators and deprecated notifier'):
-                kwargs = {arg_name: arg_value}
-                notifier.checkConfig(generators=[mock.Mock()], **kwargs)
+        with self.assertRaisesConfigError('can\'t specify generators and deprecated notifier'):
+            kwargs = {arg_name: arg_value}
+            notifier.checkConfig(generators=[mock.Mock()], **kwargs)
 
     @parameterized.expand([
         ('mode', ('failing',)),

--- a/master/buildbot/test/unit/reporters/test_http.py
+++ b/master/buildbot/test/unit/reporters/test_http.py
@@ -121,35 +121,27 @@ class TestHttpStatusPush(TestReactorMixin, unittest.TestCase, ReporterTestMixin)
 
     @defer.inlineCallbacks
     def test_filtering(self):
-        with assertProducesWarnings(DeprecatedApiWarning,
-                                    message_pattern='have been deprecated'):
-            yield self.createReporter(builders=['foo'])
+        yield self.createReporter(builders=['foo'])
         build = yield self.insert_build_finished(SUCCESS)
         yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_filteringPass(self):
-        with assertProducesWarnings(DeprecatedApiWarning,
-                                    message_pattern='have been deprecated'):
-            yield self.createReporter(builders=['Builder0'])
+        yield self.createReporter(builders=['Builder0'])
         self._http.expect("post", "", json=BuildLookAlike())
         build = yield self.insert_build_finished(SUCCESS)
         yield self.sp._got_event(('builds', 20, 'finished'), build)
 
     @defer.inlineCallbacks
     def test_builderTypeCheck(self):
-        with assertProducesWarnings(DeprecatedApiWarning,
-                                    message_pattern='have been deprecated'):
-            yield self.createReporter(builders='Builder0')
+        yield self.createReporter(builders='Builder0')
         config._errors.addError.assert_any_call(
             "builders must be a list or None")
 
     @defer.inlineCallbacks
     def test_wantKwargsCheck(self):
-        with assertProducesWarnings(DeprecatedApiWarning,
-                                    message_pattern='have been deprecated'):
-            yield self.createReporter(builders='Builder0', wantProperties=True, wantSteps=True,
-                                      wantPreviousBuild=True, wantLogs=True)
+        yield self.createReporter(builders='Builder0', wantProperties=True, wantSteps=True,
+                                  wantPreviousBuild=True, wantLogs=True)
         self._http.expect("post", "", json=BuildLookAlike(
             keys=['steps', 'prev_build']))
         build = yield self.insert_build_finished(SUCCESS)

--- a/master/buildbot/test/unit/util/test_httpclientservice.py
+++ b/master/buildbot/test/unit/util/test_httpclientservice.py
@@ -28,12 +28,10 @@ from twisted.web import server
 
 from buildbot import interfaces
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
-from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.util import bytes2unicode
 from buildbot.util import httpclientservice
 from buildbot.util import service
 from buildbot.util import unicode2bytes
-from buildbot.warnings import DeprecatedApiWarning
 
 try:
     from requests.auth import HTTPDigestAuth
@@ -440,10 +438,9 @@ class HTTPClientServiceTestFakeE2E(HTTPClientServiceTestTxRequestE2E):
 
     @defer.inlineCallbacks
     def httpFactory(self, parent):
-        with assertProducesWarnings(DeprecatedApiWarning, message_pattern='getFakeService'):
-            service = yield fakehttpclientservice.HTTPClientService.getService(
-                parent, self, 'http://127.0.0.1:{}'.format(self.port))
-            return service
+        service = yield fakehttpclientservice.HTTPClientService.getService(
+            parent, self, 'http://127.0.0.1:{}'.format(self.port))
+        return service
 
     def expect(self, *arg, **kwargs):
         self._http.expect(*arg, **kwargs)

--- a/master/buildbot/test/util/warnings.py
+++ b/master/buildbot/test/util/warnings.py
@@ -66,16 +66,17 @@ def assertProducesWarnings(filter_category, num_warnings=None,
     with _recordWarnings(filter_category, warns):
         yield
 
-    if num_warnings is not None:
-        assert len(warns) == num_warnings, \
-            "Number of occurred warnings is not correct. " \
-            "Expected {num} warnings, received {num_received}:\n" \
-            "{warns}".format(
-                num=num_warnings,
-                num_received=len(warns),
-                warns="\n".join(map(str, warns)))
+    if num_warnings is None:
+        num_warnings = 1
 
-    num_warnings = len(warns)
+    assert len(warns) == num_warnings, \
+        "Number of occurred warnings is not correct. " \
+        "Expected {num} warnings, received {num_received}:\n" \
+        "{warns}".format(
+            num=num_warnings,
+            num_received=len(warns),
+            warns="\n".join(map(str, warns)))
+
     if messages_patterns is None and message_pattern is not None:
         messages_patterns = [message_pattern] * num_warnings
 


### PR DESCRIPTION
The deprecations of HttpStatusPush were done too early without a proper migration path and without documentation. Similar situation was with several other reporters, but the changes were reverted as part of #5661 before Buildbot 2.9.0. This PR does likewise for the HttpStatusPush class.

The APIs will be deprecated again in 2.10.0 release, but this time there will be a proper migration path.

This PR also fixes a bug in our warning testing code which caused expected warnings to not be required sometimes. 