### PR TITLE
Correct formatting for code sample in Multi-master section.

### DIFF
--- a/master/buildbot/newsfragments/correct-code-block-format-in-docker-multi-master-section.doc
+++ b/master/buildbot/newsfragments/correct-code-block-format-in-docker-multi-master-section.doc
@@ -1,0 +1,1 @@
+Corrected the formatting for the code sample in the Docker Tutorial's Multi-master section.

--- a/master/docs/tutorial/docker.rst
+++ b/master/docs/tutorial/docker.rst
@@ -116,6 +116,8 @@ Multi-master
 ------------
 A multi-master environment can be setup using the ``multimaster/docker-compose.yml`` file in the example repository
 
+.. code-block:: bash
+
   # Build the Buildbot container (it will take a few minutes to download packages)
   cd buildbot-docker-example-config/simple
   docker-compose up -d


### PR DESCRIPTION
Corrected the formatting for the code sample in the Docker Tutorial's Multi-master section.

Issue can be seen here: http://docs.buildbot.net/current/tutorial/docker.html#multi-master

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation