### PR TITLE
require latest sqlalchemy-migrate

### DIFF
--- a/master/buildbot/newsfragments/sqlalchemy-migrate-upgrade.removal
+++ b/master/buildbot/newsfragments/sqlalchemy-migrate-upgrade.removal
@@ -1,0 +1,1 @@
+Buildbot now requires at least the version 0.13 of sqlalchemy-migrate (:issue:`5669`).

--- a/master/setup.py
+++ b/master/setup.py
@@ -485,7 +485,7 @@ setup_args['install_requires'] = [
     # required for tests, but Twisted requires this anyway
     'zope.interface >= 4.1.1',
     'sqlalchemy>=1.2.0',
-    'sqlalchemy-migrate>=0.9',
+    'sqlalchemy-migrate>=0.13',
     'python-dateutil>=1.5',
     'txaio ' + txaio_ver,
     'autobahn ' + autobahn_ver,


### PR DESCRIPTION
waiting for alembic, we should require recent version of sqlalchemy
because 0.11 can corrupt the db

Fix: #5669
