### PR TITLE
  Rename logfile to logname in ShellArg 

### DIFF
--- a/master/buildbot/newsfragments/shellarg-rename-logfile-logname.bugfix
+++ b/master/buildbot/newsfragments/shellarg-rename-logfile-logname.bugfix
@@ -1,0 +1,1 @@
+Deprecated ShellArg's ``logfile`` argument over ``logname`` to reflect the actual meaning. (:issue:`3771`)

--- a/master/buildbot/test/unit/steps/test_shellsequence.py
+++ b/master/buildbot/test/unit/steps/test_shellsequence.py
@@ -26,6 +26,8 @@ from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import steps
 from buildbot.test.util.misc import TestReactorMixin
+from buildbot.test.util.warnings import assertProducesWarnings
+from buildbot.warnings import DeprecatedApiWarning
 
 
 class DynamicRun(shellsequence.ShellSequence):
@@ -43,6 +45,18 @@ class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
 
     def tearDown(self):
         return self.tearDownBuildStep()
+
+    def test_shell_arg_warn_deprecated_logfile(self):
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern="logfile is deprecated, use logname"):
+            shellsequence.ShellArg(command="command", logfile="logfile")
+
+    def test_shell_arg_error_logfile_and_logname(self):
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern="logfile is deprecated, use logname"):
+            with self.assertRaisesConfigError(
+                    "the 'logfile' parameter must not be specified when 'logname' is set"):
+                shellsequence.ShellArg(command="command", logname="logname", logfile="logfile")
 
     def testShellArgInput(self):
         with self.assertRaisesConfigError(

--- a/master/buildbot/test/unit/steps/test_shellsequence.py
+++ b/master/buildbot/test/unit/steps/test_shellsequence.py
@@ -63,7 +63,7 @@ class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
 
     def testShellArgsAreRendered(self):
         arg1 = shellsequence.ShellArg(command=WithProperties('make %s', 'project'),
-                                      logfile=WithProperties('make %s', 'project'))
+                                      logname=WithProperties('make %s', 'project'))
         self.setupStep(
             shellsequence.ShellSequence(commands=[arg1],
                                         workdir='build'))
@@ -100,7 +100,7 @@ class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
 
     def testMultipleCommandsAreRun(self):
         arg1 = shellsequence.ShellArg(command='make p1')
-        arg2 = shellsequence.ShellArg(command='deploy p1', logfile='deploy')
+        arg2 = shellsequence.ShellArg(command='deploy p1', logname='deploy')
         self.setupStep(
             shellsequence.ShellSequence(commands=[arg1, arg2],
                                         workdir='build'))
@@ -153,7 +153,7 @@ class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
         each new build.
         """
         arg = shellsequence.ShellArg(command=WithProperties('make %s', 'project'),
-                                     logfile=WithProperties('make %s', 'project'))
+                                     logname=WithProperties('make %s', 'project'))
         step = shellsequence.ShellSequence(commands=[arg], workdir='build')
 
         # First "build"

--- a/master/docs/manual/configuration/steps/shell_sequence.rst
+++ b/master/docs/manual/configuration/steps/shell_sequence.rst
@@ -32,25 +32,26 @@ A list of :class:`~buildbot.steps.shellsequence.ShellArg` objects or a renderabl
     f.addStep(steps.ShellSequence(
         commands=[
             util.ShellArg(command=['configure']),
-            util.ShellArg(command=['make'], logfile='make'),
-            util.ShellArg(
-                command=['make', 'check_warning'], logfile='warning', warnOnFailure=True),
-            util.ShellArg(command=['make', 'install'], logfile='make install')
+            util.ShellArg(command=['make'], logname='make'),
+            util.ShellArg(command=['make', 'check_warning'], logname='warning',
+                          warnOnFailure=True),
+            util.ShellArg(command=['make', 'install'], logname='make install')
         ]))
 
 All these commands share the same configuration of ``environment``, ``workdir`` and ``pty`` usage that can be setup the same way as in :bb:step:`ShellCommand`.
 
-.. py:class:: buildbot.steps.shellsequence.ShellArg(self, command=None, logfile=None, haltOnFailure=False, flunkOnWarnings=False, flunkOnFailure=False, warnOnWarnings=False, warnOnFailure=False)
+.. py:class:: buildbot.steps.shellsequence.ShellArg(self, command=None, logname=None, haltOnFailure=False, flunkOnWarnings=False, flunkOnFailure=False, warnOnWarnings=False, warnOnFailure=False)
 
     :param command: (see the :bb:step:`ShellCommand` ``command`` argument),
-    :param logfile: optional log file name, used as the stdio log of the command
+    :param logname: optional log name, used as the stdio log of the command
 
     The ``haltOnFailure``, ``flunkOnWarnings``, ``flunkOnFailure``, ``warnOnWarnings``, ``warnOnFailure`` parameters drive the execution of the sequence, the same way steps are scheduled in the build.
     They have the same default values as for buildsteps - see :ref:`Buildstep-Common-Parameters`.
 
     Any of the arguments to this class can be renderable.
 
-    Note that if ``logfile`` name does not start with the prefix ``stdio``, that prefix will be set like ``stdio <logfile>``.
+    Note that if ``logname`` name does not start with the prefix ``stdio``, that prefix will be set like ``stdio <logname>``.
+    If no ``logname`` is supplied, the output of the command will not be collected.
 
 
 The two :bb:step:`ShellSequence` methods below tune the behavior of how the list of shell commands are executed, and can be overridden in subclasses.


### PR DESCRIPTION
@chrspeich replaced logfile to logname in ShellArg  in PR  #3950.
This PR adds missing tests.

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation