### PR TITLE
Fix warnings of depretation of buildbot.status even when it's not used

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -43,7 +43,7 @@ from buildbot.process.botmaster import BotMaster
 from buildbot.process.users.manager import UserManagerManager
 from buildbot.schedulers.manager import SchedulerManager
 from buildbot.secrets.manager import SecretManager
-from buildbot.status.master import Status
+from buildbot.status.master_compat import Status
 from buildbot.util import check_functional_environment
 from buildbot.util import service
 from buildbot.util.eventual import eventually

--- a/master/buildbot/newsfragments/deprecated-status-warnings.bugfix
+++ b/master/buildbot/newsfragments/deprecated-status-warnings.bugfix
@@ -1,0 +1,1 @@
+Fixed extraneous warnings due to deprecation of ``buildbot.status`` module even when it's not used (:issue:`5693`).

--- a/master/buildbot/status/__init__.py
+++ b/master/buildbot/status/__init__.py
@@ -1,16 +1,16 @@
-from buildbot.status import build
-from buildbot.status import builder
-from buildbot.status import buildrequest
-from buildbot.status import buildset
-from buildbot.status import master
+from buildbot.status import build_compat
+from buildbot.status import builder_compat
+from buildbot.status import buildrequest_compat
+from buildbot.status import buildset_compat
+from buildbot.status import master_compat
 
 # styles.Versioned requires this, as it keys the version numbers on the fully
 # qualified class name; see master/buildbot/test/regressions/test_unpickling.py
-build.BuildStatus.__module__ = 'buildbot.status.builder'
+build_compat.BuildStatus.__module__ = 'buildbot.status.builder'
 
 # add all of these classes to builder; this is a form of late binding to allow
 # circular module references among the status modules
-builder.BuildSetStatus = buildset.BuildSetStatus
-builder.Status = master.Status
-builder.BuildStatus = build.BuildStatus
-builder.BuildRequestStatus = buildrequest.BuildRequestStatus
+builder_compat.BuildSetStatus = buildset_compat.BuildSetStatus
+builder_compat.Status = master_compat.Status
+builder_compat.BuildStatus = build_compat.BuildStatus
+builder_compat.BuildRequestStatus = buildrequest_compat.BuildRequestStatus

--- a/master/buildbot/status/base.py
+++ b/master/buildbot/status/base.py
@@ -1,0 +1,37 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.status.base_compat import StatusReceiver
+from buildbot.status.base_compat import StatusReceiverBase
+from buildbot.status.base_compat import StatusReceiverMultiService
+from buildbot.status.base_compat import StatusReceiverPerspective
+from buildbot.status.base_compat import StatusReceiverService
+from buildbot.warnings import warn_deprecated
+
+# This file is here to allow few remaining users of status within Buildbot to use it
+# without triggering deprecation warnings
+
+_hush_pyflakes = [
+    StatusReceiverMultiService,
+    StatusReceiverBase,
+    StatusReceiverService,
+    StatusReceiver,
+    StatusReceiverPerspective,
+]
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.base has been deprecated, consume the buildbot.data APIs'
+)

--- a/master/buildbot/status/base_compat.py
+++ b/master/buildbot/status/base_compat.py
@@ -20,12 +20,6 @@ from buildbot import pbutil
 from buildbot import util
 from buildbot.interfaces import IStatusReceiver
 from buildbot.util import service
-from buildbot.warnings import warn_deprecated
-
-warn_deprecated(
-    '0.9.0',
-    'buildbot.status.base has been deprecated, consume the buildbot.data APIs'
-)
 
 
 @implementer(IStatusReceiver)

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.status.build_compat import BuildStatus
+from buildbot.warnings import warn_deprecated
+
+# This file is here to allow few remaining users of status within Buildbot to use it
+# without triggering deprecation warnings
+
+_hush_pyflakes = [
+    BuildStatus,
+]
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.build has been deprecated, consume the buildbot.data APIs'
+)

--- a/master/buildbot/status/build_compat.py
+++ b/master/buildbot/status/build_compat.py
@@ -20,12 +20,6 @@ from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot import util
-from buildbot.warnings import warn_deprecated
-
-warn_deprecated(
-    '0.9.0',
-    'buildbot.status.build has been deprecated, consume the buildbot.data APIs'
-)
 
 
 @implementer(interfaces.IBuildStatus, interfaces.IStatusEvent)

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -1,0 +1,50 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.process.results import CANCELLED
+from buildbot.process.results import EXCEPTION
+from buildbot.process.results import FAILURE
+from buildbot.process.results import RETRY
+from buildbot.process.results import SKIPPED
+from buildbot.process.results import SUCCESS
+from buildbot.process.results import WARNINGS
+from buildbot.process.results import Results
+from buildbot.process.results import worst_status
+from buildbot.status.build_compat import BuildStatus
+from buildbot.status.builder_compat import BuilderStatus
+from buildbot.status.buildrequest_compat import BuildRequestStatus
+from buildbot.status.buildset_compat import BuildSetStatus
+from buildbot.status.event_compat import Event
+from buildbot.status.master_compat import Status
+from buildbot.warnings import warn_deprecated
+
+# This file is here to allow few remaining users of status within Buildbot to use it
+# without triggering deprecation warnings
+
+_hush_pyflakes = [
+    BuilderStatus,
+    Status,
+    BuildStatus,
+    BuildRequestStatus,
+    BuildSetStatus,
+    Event,
+    SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY, CANCELLED,
+    Results, worst_status
+]
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.builder has been deprecated, consume the buildbot.data APIs'
+)

--- a/master/buildbot/status/builder_compat.py
+++ b/master/buildbot/status/builder_compat.py
@@ -23,30 +23,10 @@ from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot import util
-# user modules expect these symbols to be present here
-from buildbot.process.results import CANCELLED
-from buildbot.process.results import EXCEPTION
-from buildbot.process.results import FAILURE
-from buildbot.process.results import RETRY
-from buildbot.process.results import SKIPPED
-from buildbot.process.results import SUCCESS
-from buildbot.process.results import WARNINGS
-from buildbot.process.results import Results
-from buildbot.process.results import worst_status
-from buildbot.status.build import BuildStatus
-from buildbot.status.buildrequest import BuildRequestStatus
-from buildbot.status.event import Event
+from buildbot.status.build_compat import BuildStatus
+from buildbot.status.buildrequest_compat import BuildRequestStatus
+from buildbot.status.event_compat import Event
 from buildbot.util.lru import LRUCache
-from buildbot.warnings import warn_deprecated
-
-_hush_pyflakes = [SUCCESS, WARNINGS, FAILURE, SKIPPED,
-                  EXCEPTION, RETRY, CANCELLED, Results, worst_status]
-
-
-warn_deprecated(
-    '0.9.0',
-    'buildbot.status.worker has been deprecated, consume the buildbot.data APIs'
-)
 
 
 @implementer(interfaces.IBuilderStatus, interfaces.IEventSource)

--- a/master/buildbot/status/buildrequest.py
+++ b/master/buildbot/status/buildrequest.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.status.buildrequest_compat import BuildRequestStatus
+from buildbot.warnings import warn_deprecated
+
+# This file is here to allow few remaining users of status within Buildbot to use it
+# without triggering deprecation warnings
+
+_hush_pyflakes = [
+    BuildRequestStatus,
+]
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.buildrequest has been deprecated, consume the buildbot.data APIs'
+)

--- a/master/buildbot/status/buildrequest_compat.py
+++ b/master/buildbot/status/buildrequest_compat.py
@@ -20,12 +20,6 @@ from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.util.eventual import eventually
-from buildbot.warnings import warn_deprecated
-
-warn_deprecated(
-    '0.9.0',
-    'buildbot.status.buildrequest has been deprecated, consume the buildbot.data APIs'
-)
 
 
 @implementer(interfaces.IBuildRequestStatus)

--- a/master/buildbot/status/buildset.py
+++ b/master/buildbot/status/buildset.py
@@ -1,0 +1,31 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.status.buildset_compat import BuildSetStatus
+from buildbot.status.buildset_compat import BuildSetSummaryNotifierMixin
+from buildbot.warnings import warn_deprecated
+
+# This file is here to allow few remaining users of status within Buildbot to use it
+# without triggering deprecation warnings
+
+_hush_pyflakes = [
+    BuildSetStatus,
+    BuildSetSummaryNotifierMixin,
+]
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.buildset has been deprecated, consume the buildbot.data APIs'
+)

--- a/master/buildbot/status/buildset_compat.py
+++ b/master/buildbot/status/buildset_compat.py
@@ -19,13 +19,7 @@ from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.data import resultspec
-from buildbot.status.buildrequest import BuildRequestStatus
-from buildbot.warnings import warn_deprecated
-
-warn_deprecated(
-    '0.9.0',
-    'buildbot.status.buildset has been deprecated, consume the buildbot.data APIs'
-)
+from buildbot.status.buildrequest_compat import BuildRequestStatus
 
 
 @implementer(interfaces.IBuildSetStatus)

--- a/master/buildbot/status/client.py
+++ b/master/buildbot/status/client.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.status.client_compat import PBListener
+from buildbot.warnings import warn_deprecated
+
+# This file is here to allow few remaining users of status within Buildbot to use it
+# without triggering deprecation warnings
+
+_hush_pyflakes = [
+    PBListener
+]
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.client has been deprecated, consume the buildbot.data APIs'
+)

--- a/master/buildbot/status/client_compat.py
+++ b/master/buildbot/status/client_compat.py
@@ -16,10 +16,10 @@
 
 from twisted.python import log
 
-from buildbot.status import base
+from buildbot.status import base_compat
 
 
-class PBListener(base.StatusReceiverBase):
+class PBListener(base_compat.StatusReceiverBase):
 
     # This class is still present in users' configs, so keep it here.
 

--- a/master/buildbot/status/event.py
+++ b/master/buildbot/status/event.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.status.event_compat import Event
+from buildbot.warnings import warn_deprecated
+
+# This file is here to allow few remaining users of status within Buildbot to use it
+# without triggering deprecation warnings
+
+_hush_pyflakes = [
+    Event
+]
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.event has been deprecated, consume the buildbot.data APIs'
+)

--- a/master/buildbot/status/event_compat.py
+++ b/master/buildbot/status/event_compat.py
@@ -18,12 +18,6 @@ from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot import util
-from buildbot.warnings import warn_deprecated
-
-warn_deprecated(
-    '0.9.0',
-    'buildbot.status.event has been deprecated, consume the buildbot.data APIs'
-)
 
 
 @implementer(interfaces.IStatusEvent)

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.status.master_compat import Status
+from buildbot.warnings import warn_deprecated
+
+# This file is here to allow few remaining users of status within Buildbot to use it
+# without triggering deprecation warnings
+
+_hush_pyflakes = [
+    Status
+]
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.master has been deprecated, consume the buildbot.data APIs'
+)

--- a/master/buildbot/status/worker.py
+++ b/master/buildbot/status/worker.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+from buildbot.status.worker_compat import WorkerStatus
+from buildbot.warnings import warn_deprecated
+
+# This file is here to allow few remaining users of status within Buildbot to use it
+# without triggering deprecation warnings
+
+_hush_pyflakes = [
+    WorkerStatus
+]
+
+warn_deprecated(
+    '0.9.0',
+    'buildbot.status.worker has been deprecated, consume the buildbot.data APIs'
+)

--- a/master/buildbot/status/worker_compat.py
+++ b/master/buildbot/status/worker_compat.py
@@ -13,6 +13,7 @@
 #
 # Copyright Buildbot Team Members
 
+# this file
 
 import time
 
@@ -22,12 +23,6 @@ from buildbot import interfaces
 from buildbot.process.properties import Properties
 from buildbot.util import bytes2unicode
 from buildbot.util.eventual import eventually
-from buildbot.warnings import warn_deprecated
-
-warn_deprecated(
-    '0.9.0',
-    'buildbot.status.worker has been deprecated, consume the buildbot.data APIs'
-)
 
 
 @implementer(interfaces.IWorkerStatus)

--- a/master/buildbot/steps/source/base.py
+++ b/master/buildbot/steps/source/base.py
@@ -21,7 +21,7 @@ from buildbot.process import buildstep
 from buildbot.process import properties
 from buildbot.process import remotecommand
 from buildbot.process.buildstep import LoggingBuildStep
-from buildbot.status.builder import FAILURE
+from buildbot.process.results import FAILURE
 from buildbot.steps.worker import CompositeStepMixin
 from buildbot.util import bytes2unicode
 

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -52,18 +52,20 @@ if parse_version(mock.__version__) < parse_version("0.8"):
 
 with assertProducesWarnings(DeprecatedApiWarning,
                             messages_patterns=[
+                                r" buildbot\.status\.base has been deprecated",
                                 r" buildbot\.status\.build has been deprecated",
                                 r" buildbot\.status\.buildrequest has been deprecated",
                                 r" buildbot\.status\.event has been deprecated",
-                                r" buildbot\.status\.worker has been deprecated",
                                 r" buildbot\.status\.buildset has been deprecated",
                                 r" buildbot\.status\.master has been deprecated",
-                                r" buildbot\.status\.base has been deprecated",
+                                r" buildbot\.status\.worker has been deprecated",
                             ]):
     import buildbot.status.base as _  # noqa
-
-with assertProducesWarning(DeprecatedApiWarning,
-                           message_pattern=r" buildbot\.status\.worker has been deprecated"):
+    import buildbot.status.build as _  # noqa
+    import buildbot.status.buildrequest as _  # noqa
+    import buildbot.status.event as _  # noqa
+    import buildbot.status.buildset as _  # noqa
+    import buildbot.status.master as _  # noqa
     import buildbot.status.worker as _  # noqa
 
 # All deprecated modules should be loaded, consider future warnings in tests as errors.

--- a/master/buildbot/test/regressions/test_oldpaths.py
+++ b/master/buildbot/test/regressions/test_oldpaths.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 
 
+import warnings
+
 from twisted.trial import unittest
 
 from buildbot.warnings import DeprecatedApiWarning
@@ -96,30 +98,55 @@ class OldImportPaths(unittest.TestCase):
         assert SubunitShellCommand
 
     def test_status_builder_results(self):
-        # these symbols are now in buildbot.process.results, but lots of user
-        # code references them here:
-        from buildbot.status.builder import SUCCESS, WARNINGS, FAILURE, SKIPPED
-        from buildbot.status.builder import EXCEPTION, RETRY, Results
-        from buildbot.status.builder import worst_status
-        # reference the symbols to avoid failure from pyflakes
-        (SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY, Results,
-         worst_status)
+        # We can't reliable check for these warnings as they depend on whether the tests are
+        # run in parallel mode
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecatedApiWarning)
+
+            # these symbols are now in buildbot.process.results, but lots of user
+            # code references them here:
+            from buildbot.status.builder import SUCCESS, WARNINGS, FAILURE, SKIPPED
+            from buildbot.status.builder import EXCEPTION, RETRY, Results
+            from buildbot.status.builder import worst_status
+            # reference the symbols to avoid failure from pyflakes
+            (SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY, Results,
+             worst_status)
 
     def test_status_builder_BuildSetStatus(self):
-        from buildbot.status.builder import BuildSetStatus
-        assert BuildSetStatus
+        # We can't reliable check for these warnings as they depend on whether the tests are
+        # run in parallel mode
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecatedApiWarning)
+
+            from buildbot.status.builder import BuildSetStatus
+            assert BuildSetStatus
 
     def test_status_builder_Status(self):
-        from buildbot.status.builder import Status
-        assert Status
+        # We can't reliable check for these warnings as they depend on whether the tests are
+        # run in parallel mode
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecatedApiWarning)
+
+            from buildbot.status.builder import Status
+            assert Status
 
     def test_status_builder_Event(self):
-        from buildbot.status.builder import Event
-        assert Event
+        # We can't reliable check for these warnings as they depend on whether the tests are
+        # run in parallel mode
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecatedApiWarning)
+
+            from buildbot.status.builder import Event
+            assert Event
 
     def test_status_builder_BuildStatus(self):
-        from buildbot.status.builder import BuildStatus
-        assert BuildStatus
+        # We can't reliable check for these warnings as they depend on whether the tests are
+        # run in parallel mode
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecatedApiWarning)
+
+            from buildbot.status.builder import BuildStatus
+            assert BuildStatus
 
     def test_steps_source_Source(self):
         from buildbot.steps.source import Source

--- a/master/buildbot/test/test_extra_coverage.py
+++ b/master/buildbot/test/test_extra_coverage.py
@@ -29,7 +29,7 @@ from buildbot.scripts import checkconfig
 from buildbot.scripts import logwatcher
 from buildbot.scripts import reconfig
 from buildbot.scripts import runner
-from buildbot.status import client
+from buildbot.status import client_compat
 from buildbot.steps import master
 from buildbot.steps import maxq
 from buildbot.steps import python
@@ -47,7 +47,7 @@ modules.extend([p4poller, svnpoller])
 modules.extend([base, sendchange, tryclient])
 modules.extend([subunitlogobserver])
 modules.extend([checkconfig, logwatcher, reconfig, runner])
-modules.extend([client])
+modules.extend([client_compat])
 modules.extend([master, maxq, python, python_twisted, subunit])
 modules.extend([trigger, vstudio])
 modules.extend([rpmbuild, rpmlint])

--- a/master/buildbot/worker/base.py
+++ b/master/buildbot/worker/base.py
@@ -25,7 +25,7 @@ from buildbot import config
 from buildbot.interfaces import IWorker
 from buildbot.process import metrics
 from buildbot.process.properties import Properties
-from buildbot.status.worker import WorkerStatus
+from buildbot.status.worker_compat import WorkerStatus
 from buildbot.util import Notifier
 from buildbot.util import bytes2unicode
 from buildbot.util import service


### PR DESCRIPTION
Fixes #5693. 

Turns out that when we added warnings for deprecation of `buildbot.status` we started spamming our users with unnecessary warnings. This PR makes sure that any imports internal to Buildbot don't trigger them.