### PR TITLE
docker: Add pullOnDemand option for DockerLatentWorker

### DIFF
--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -286,9 +286,9 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
                     log.msg("Image '{}' not found, pulling from registry".format(image))
                 docker_client.pull(image)
             elif imageExists and self.pullOnDemand:
-                img_data = docker_client.get(image)
-                repo_data = docker_client.get_repository_data(image)
-                if img_data.id != repo_data.id:
+                img_data = docker_client.inspect_image(image)["RepoDigests"]
+                repo_data = docker_client.inspect_distribution(image)["digest"]
+                if (not img_data) or img_data.split('@')[1] != repo_data["digest"]:
                     log.msg("Image '{}' updated in registry. pulling from registry")
                     docker_client.pull(image)
 

--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -287,10 +287,12 @@ class DockerLatentWorker(CompatibleLatentWorkerMixin,
                 docker_client.pull(image)
             elif imageExists and self.pullOnDemand:
                 img_data = docker_client.inspect_image(image)["RepoDigests"]
-                repo_data = docker_client.inspect_distribution(image)["digest"]
-                if (not img_data) or img_data.split('@')[1] != repo_data["digest"]:
-                    log.msg("Image '{}' updated in registry. pulling from registry")
+                repo_data = docker_client.inspect_distribution(image)["Descriptor"]["digest"]
+                if (not img_data) or img_data.split('@')[1] != repo_data:
+                    log.msg("Image '{}' updated in registry. pulling from registry".format(image))
                     docker_client.pull(image)
+                else:
+                    log.msg("Image '{}' is already available on the host as latest version".format(image))
 
 
         if (not self._image_exists(docker_client, image)):


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

To work with the rate limited approach (and in general be more nice for bandwidth) I implemented a mode which checks local and remote image digests and only attempts to pull an image if they differ.
This is WIP, I'll test the changes on my own instance first and add documentation, unit tests once I verified things are correct on my side.