### PR TITLE
Fix several cases when extraneous messages were logged to stdout

### DIFF
--- a/master/buildbot/newsfragments/fix-spam-logging-stdout-operators-renderer.bugfix
+++ b/master/buildbot/newsfragments/fix-spam-logging-stdout-operators-renderer.bugfix
@@ -1,0 +1,1 @@
+Fixed spam messages to stdout when renderable operators were being used.

--- a/master/buildbot/newsfragments/print-old-git-progress.bugfix
+++ b/master/buildbot/newsfragments/print-old-git-progress.bugfix
@@ -1,0 +1,1 @@
+Fixed logging of error message to ``twistd.log`` in case of old git and ``progress`` option being enabled.

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -325,7 +325,6 @@ class _OperatorRenderer(RenderableOperatorsMixin, util.ComparableMixin):
     @defer.inlineCallbacks
     def getRenderingFor(self, props):
         v1, v2 = yield props.render((self.v1, self.v2))
-        print(v1, self.cstr, v2)
         return self.comparator(v1, v2)
 
     def __repr__(self):

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -323,7 +323,7 @@ class Git(Source, GitStepMixin):
                 if self.supportsProgress:
                     command.append('--progress')
                 else:
-                    print("Git versions < 1.7.2 don't support progress")
+                    log.msg("Git versions < 1.7.2 don't support progress")
 
             yield self._dovccmd(command)
 
@@ -385,7 +385,7 @@ class Git(Source, GitStepMixin):
             if self.supportsProgress:
                 command.append('--progress')
             else:
-                print("Git versions < 1.7.2 don't support progress")
+                log.msg("Git versions < 1.7.2 don't support progress")
         if self.retry:
             abandonOnFailure = (self.retry[1] <= 0)
         else:

--- a/master/buildbot/test/unit/data/test_workers.py
+++ b/master/buildbot/test/unit/data/test_workers.py
@@ -247,7 +247,6 @@ class WorkersEndpoint(endpoint.EndpointMixin, unittest.TestCase):
             filters=[resultspec.Filter('paused', 'eq', [True])])
 
         workers = yield self.callGet(('workers',), resultSpec=resultSpec)
-        print(workers)
         self.assertEqual(len(workers), 1)
         worker = workers[0]
         self.validateData(worker)


### PR DESCRIPTION
It seems that we've left a couple of debug `print(x)` in the codebase.