### PR TITLE
Sync release notes with 2.9.x branch

### DIFF
--- a/master/buildbot/newsfragments/deprecated-status-warnings.bugfix
+++ b/master/buildbot/newsfragments/deprecated-status-warnings.bugfix
@@ -1,1 +1,0 @@
-Fixed extraneous warnings due to deprecation of ``buildbot.status`` module even when it's not used (:issue:`5693`).

--- a/master/buildbot/newsfragments/fix-spam-logging-stdout-operators-renderer.bugfix
+++ b/master/buildbot/newsfragments/fix-spam-logging-stdout-operators-renderer.bugfix
@@ -1,1 +1,0 @@
-Fixed spam messages to stdout when renderable operators were being used.

--- a/master/buildbot/newsfragments/print-old-git-progress.bugfix
+++ b/master/buildbot/newsfragments/print-old-git-progress.bugfix
@@ -1,1 +1,0 @@
-Fixed logging of error message to ``twistd.log`` in case of old git and ``progress`` option being enabled.

--- a/master/buildbot/newsfragments/waterfall-view-fixes.bugfix
+++ b/master/buildbot/newsfragments/waterfall-view-fixes.bugfix
@@ -1,2 +1,0 @@
-Clear topbar zoom buttons when leaving waterfall view and re-render waterfall
-upon change to masters 

--- a/master/buildbot/newsfragments/websocket.removal
+++ b/master/buildbot/newsfragments/websocket.removal
@@ -1,1 +1,0 @@
-websocket: remove setup of web status feature of autobahn which is not used

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -10,6 +10,22 @@ Release Notes
 
 .. towncrier release notes start
 
+Buildbot ``2.9.4`` ( ``2020-12-26`` )
+=====================================
+
+Bug fixes
+---------
+
+- Fixed spam messages to stdout when renderable operators were being used.
+- Fixed handling of very long lines in the logs during Buildbot startup (:issue:`5706`).
+- Fixed logging of error message to ``twistd.log`` in case of old git and ``progress`` option being enabled.
+
+Deprecations and Removals
+-------------------------
+
+- Removed setup of unused ``webstatus`` feature of autobahn.
+
+
 Buildbot ``2.9.3`` ( ``2020-12-15`` )
 =====================================
 

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -10,6 +10,17 @@ Release Notes
 
 .. towncrier release notes start
 
+Buildbot ``2.9.3`` ( ``2020-12-15`` )
+=====================================
+
+Bug fixes
+---------
+
+- Fixed extraneous warnings due to deprecation of ``buildbot.status`` module even when it's not used (:issue:`5693`).
+- The topbar zoom buttons are now cleared when leaving waterfall view.
+- The waterfall is now re-rendered upon change to masters.
+
+
 Buildbot ``2.9.2`` ( ``2020-12-08`` )
 =====================================
 


### PR DESCRIPTION
This preserves linear history for the releases that have branched-off.