### PR TITLE
docs: Add custom CSS to conserve horizontal space

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -1213,6 +1213,7 @@ rsa
 rsh
 rst
 rstrip
+rtd
 rtype
 rtypes
 runcommand

--- a/master/buildbot/newsfragments/docs-readability-horizontal-space.doc
+++ b/master/buildbot/newsfragments/docs-readability-horizontal-space.doc
@@ -1,0 +1,1 @@
+Improved the readability of the documentation by conserving horizontal space.

--- a/master/docs/_static/buildbot_rtd.css
+++ b/master/docs/_static/buildbot_rtd.css
@@ -1,0 +1,26 @@
+
+/* The RTD default uses a lot of horizontal space for the "Parameters" heading which is placed
+    to a separate column. The descriptions of parameters are often very long in Buildbot, so
+    just some indentation is fine
+*/
+
+html.writer-html5 .rst-content dl.field-list {
+    display: initial;
+}
+
+html.writer-html5 .rst-content dl.field-list dt {
+    padding-left: 0;
+}
+
+html.writer-html5 .rst-content dl.field-list dd {
+    margin-left: 0;
+}
+
+/* The left and right padding for the contents seems excessive
+*/
+
+.wy-nav-content {
+    /* the values used are the same as for top and bottom padding */
+    padding-right: 1.618em;
+    padding-left: 1.618em;
+}

--- a/master/docs/conf.py
+++ b/master/docs/conf.py
@@ -230,6 +230,9 @@ html_favicon = os.path.join('_static', 'icon.png')
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# We customize the rtd theme slightly
+html_css_files = ['buildbot_rtd.css']
+
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 # html_last_updated_fmt = '%b %d, %Y'


### PR DESCRIPTION
The default `sphinx_rtd_theme` theme that we're using does not conserve horizontal space. Given the style that the Buildbot documentation is written in this often results in hard to read documentation.

This PR adds several custom CSS rules that expand the horizontal space that can be used. The primary objective was to improve the readability of the class and function argument and member lists.

The following screenshots illustrate the differences:

Before:

<img width="611" alt="20201226_rtd_old_style" src="https://user-images.githubusercontent.com/1056711/103158953-41563000-47cc-11eb-8033-3bae7004ed9d.png">

After:

<img width="611" alt="20201226_rtd_new_style" src="https://user-images.githubusercontent.com/1056711/103158957-47e4a780-47cc-11eb-89fe-272f9c9c4936.png">

