### PR TITLE
reporters: Deprecate template file support in message formatters

### DIFF
--- a/master/buildbot/newsfragments/reporters-message-file-templates.removal
+++ b/master/buildbot/newsfragments/reporters-message-file-templates.removal
@@ -1,0 +1,1 @@
+Support for passing paths to template files for rendering in message formatters has been deprecated.

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -302,8 +302,14 @@ class MessageFormatter(MessageFormatterBaseJinja):
     def __init__(self, template_name=None, **kwargs):
 
         if template_name is not None:
-            warn_deprecated('0.9.1', "template_name is deprecated, use template_filename")
+            warn_deprecated('0.9.1', "template_name is deprecated, supply the template as text")
             kwargs['template_filename'] = template_name
+        if 'template_filename' in kwargs:
+            warn_deprecated('2.10.0',
+                            "template_filename is deprecated, supply the template as text")
+        if 'subject_filename' in kwargs:
+            warn_deprecated('2.10.0',
+                            "subject_filename is deprecated, supply the template as text")
         super().__init__(**kwargs)
 
     @defer.inlineCallbacks

--- a/master/buildbot/reporters/pushjet.py
+++ b/master/buildbot/reporters/pushjet.py
@@ -23,7 +23,7 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.reporters.base import ReporterBase
-from buildbot.reporters.message import MessageFormatter as DefaultMessageFormatter
+from buildbot.reporters.message import MessageFormatter
 from buildbot.reporters.message import MessageFormatterMissingWorker
 from buildbot.util import httpclientservice
 
@@ -39,6 +39,14 @@ LEVELS = {
     SUCCESS: 'passing',
     WARNINGS: 'warnings'
 }
+
+DEFAULT_MSG_TEMPLATE = \
+    ('The Buildbot has detected a <a href="{{ build_url }}">{{ status_detected }}</a>' +
+     'of <i>{{ buildername }}</i> while building {{ projects }} on {{ workername }}.')
+
+DEFAULT_MSG_TEMPLATE_MISSING_WORKER = \
+    ('The Buildbot \'{{buildbot_title}}\' has noticed that the worker named ' +
+     '{{worker.name}} went away. It last disconnected at {{worker.last_connection}}.')
 
 
 class PushjetNotifier(ReporterBase):
@@ -74,11 +82,10 @@ class PushjetNotifier(ReporterBase):
                         generators=None):
         secret = yield self.renderSecrets(secret)
         if messageFormatter is None:
-            messageFormatter = DefaultMessageFormatter(template_type='html',
-                template_filename='default_notification.txt')
+            messageFormatter = MessageFormatter(template_type='html', template=DEFAULT_MSG_TEMPLATE)
         if messageFormatterMissingWorker is None:
-            messageFormatterMissingWorker = MessageFormatterMissingWorker(
-                template_filename='missing_notification.txt')
+            messageFormatterMissingWorker = \
+                MessageFormatterMissingWorker(template=DEFAULT_MSG_TEMPLATE_MISSING_WORKER)
         yield super().reconfigService(mode, tags, builders,
                                       buildSetSummary, messageFormatter,
                                       subject, False, False,

--- a/master/buildbot/reporters/pushover.py
+++ b/master/buildbot/reporters/pushover.py
@@ -24,7 +24,7 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.reporters.base import ReporterBase
-from buildbot.reporters.message import MessageFormatter as DefaultMessageFormatter
+from buildbot.reporters.message import MessageFormatter
 from buildbot.reporters.message import MessageFormatterMissingWorker
 from buildbot.util import httpclientservice
 
@@ -43,6 +43,14 @@ PRIORITIES = {
     SUCCESS: 'passing',
     WARNINGS: 'warnings'
 }
+
+DEFAULT_MSG_TEMPLATE = \
+    ('The Buildbot has detected a <a href="{{ build_url }}">{{ status_detected }}</a>' +
+     'of <i>{{ buildername }}</i> while building {{ projects }} on {{ workername }}.')
+
+DEFAULT_MSG_TEMPLATE_MISSING_WORKER = \
+    ('The Buildbot \'{{buildbot_title}}\' has noticed that the worker named ' +
+     '{{worker.name}} went away. It last disconnected at {{worker.last_connection}}.')
 
 
 class PushoverNotifier(ReporterBase):
@@ -82,11 +90,10 @@ class PushoverNotifier(ReporterBase):
                         generators=None):
         user_key, api_token = yield self.renderSecrets(user_key, api_token)
         if messageFormatter is None:
-            messageFormatter = DefaultMessageFormatter(template_type='html',
-                template_filename='default_notification.txt')
+            messageFormatter = MessageFormatter(template_type='html', template=DEFAULT_MSG_TEMPLATE)
         if messageFormatterMissingWorker is None:
-            messageFormatterMissingWorker = MessageFormatterMissingWorker(
-                template_filename='missing_notification.txt')
+            messageFormatterMissingWorker = \
+                MessageFormatterMissingWorker(template=DEFAULT_MSG_TEMPLATE_MISSING_WORKER)
         yield super().reconfigService(mode, tags, builders,
                                       buildSetSummary, messageFormatter,
                                       subject, False, False,

--- a/master/docs/manual/configuration/report_generators/formatter.rst
+++ b/master/docs/manual/configuration/report_generators/formatter.rst
@@ -13,10 +13,12 @@ The constructor of the class takes the following arguments:
 
 ``template_dir``
     The directory that is used to look for the various templates.
+    This argument is deprecated, please supply message templates as ``template`` directly.
 
 ``template_filename``
     This is the name of the file in the ``template_dir`` directory that will be used to generate the body of the mail.
     It defaults to ``default_mail.txt``.
+    This argument is deprecated, please supply message templates as ``template`` directly.
 
 ``template``
     If this parameter is set, this parameter indicates the content of the template used to generate the body of the mail as string.
@@ -27,6 +29,7 @@ The constructor of the class takes the following arguments:
 
 ``subject_filename``
     This is the name of the file in the ``template_dir`` directory that contains the content of the subject of the mail.
+    This argument is deprecated, please supply message templates as ``subject`` directly.
 
 ``subject``
     Alternatively, this is the content of the subject of the mail as string.

--- a/master/docs/manual/upgrading/3.0-upgrade.rst
+++ b/master/docs/manual/upgrading/3.0-upgrade.rst
@@ -146,11 +146,16 @@ The following arguments have been removed:
 * ``buildSetSummary``. Defines whether the *status generator* will be instance of :bb:reportgen:`BuildStatusGenerator` (value of ``True``, the default) or :bb:reportgen:`BuildSetStatusGenerator` (value of ``False``).
 
 * ``messageFormatter``. Replacement is ``message_formatter`` parameter of the *status generator*.
-  In the case of ``PushjetNotifier`` and ``PushoverNotifier``, the default message formatter is ``DefaultMessageFormatter(template_type='html', template_filename='default_notification.txt')``.
+  In the case of ``PushjetNotifier`` and ``PushoverNotifier``, the default message formatter is ``MessageFormatter(template_type='html', template=<default text>)``.
 
 * ``watchedWorkers``. Replacement is ``workers`` parameter of the *missing worker generator*.
   If the value was ``None``, then there's no *missing worker generator* and the value of ``messageFormatterMissingWorker`` is ignored.
 
 * ``messageFormatterMissingWorker``. Replacement is ``message_formatter`` parameter of the *missing worker generator*.
-  In the case of ``PushjetNotifier`` and ``PushoverNotifier``, the default message formatter is ``MessageFormatterMissingWorker(template_filename='missing_notification.txt')``.
+  In the case of ``PushjetNotifier`` and ``PushoverNotifier``, the default message formatter is ``MessageFormatterMissingWorker(template=<default text>)``.
 
+Template files in message formatters
+------------------------------------
+
+Paths to template files that are passed to message formatters for rendering are no longer supported.
+Please read the templates in the configuration file and pass strings instead.


### PR DESCRIPTION
Passing template paths to message formatters introduces an implicit dependency on the state of the filesystem to the configuration. This is error-prone in configurations such as when multimaster is used. It is easy enough to read a file master.cfg if needed, so Buildbot should only expose a string-based API.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
