### PR TITLE
Implement MessageFormatterRenderable

### DIFF
--- a/master/buildbot/newsfragments/message-formatter-renderable.feature
+++ b/master/buildbot/newsfragments/message-formatter-renderable.feature
@@ -1,0 +1,1 @@
+Implemented ``MessageFormatterRenderable`` that creates build report text by rendering build properties onto a renderable.

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -124,7 +124,7 @@ class TestMessageFormatting(unittest.TestCase):
                          "Build Source Stamp 'a': [branch br] abc (plus patch)\n")
 
 
-class TestMessage(TestReactorMixin, unittest.TestCase):
+class MessageFormatterTestBase(TestReactorMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
@@ -164,6 +164,8 @@ class TestMessage(TestReactorMixin, unittest.TestCase):
                                                        ["him@bar", "me@foo"])
         return res
 
+
+class TestMessageFormatter(MessageFormatterTestBase):
     @defer.inlineCallbacks
     def test_message_success(self):
         formatter = message.MessageFormatter()
@@ -236,8 +238,10 @@ class TestMessage(TestReactorMixin, unittest.TestCase):
         self.assertIn(
             "The Buildbot has detected a failed build on builder", res['body'])
 
+
+class TestMessageFormatterMissingWorker(MessageFormatterTestBase):
     @defer.inlineCallbacks
-    def test_missing_worker(self):
+    def test_basic(self):
         formatter = message.MessageFormatterMissingWorker()
         self.setupDb(SUCCESS, SUCCESS)
         workers = yield self.master.data.get(('workers',))

--- a/master/buildbot/test/unit/reporters/test_message.py
+++ b/master/buildbot/test/unit/reporters/test_message.py
@@ -18,6 +18,7 @@ import textwrap
 from twisted.internet import defer
 from twisted.trial import unittest
 
+from buildbot.process.properties import Interpolate
 from buildbot.process.results import CANCELLED
 from buildbot.process.results import EXCEPTION
 from buildbot.process.results import FAILURE
@@ -237,6 +238,20 @@ class TestMessageFormatter(MessageFormatterTestBase):
         res = yield self.do_one_test(formatter, FAILURE, FAILURE, "change")
         self.assertIn(
             "The Buildbot has detected a failed build on builder", res['body'])
+
+
+class TestMessageFormatterRenderable(MessageFormatterTestBase):
+    @defer.inlineCallbacks
+    def test_basic(self):
+        template = Interpolate('templ_%(prop:workername)s/%(prop:reason)s')
+        subject = Interpolate('subj_%(prop:workername)s/%(prop:reason)s')
+        formatter = message.MessageFormatterRenderable(template, subject)
+        res = yield self.do_one_test(formatter, SUCCESS, SUCCESS)
+        self.assertEqual(res, {
+            'body': 'templ_wrkr/because',
+            'type': 'plain',
+            'subject': 'subj_wrkr/because',
+        })
 
 
 class TestMessageFormatterMissingWorker(MessageFormatterTestBase):

--- a/master/docs/manual/configuration/report_generators/formatter_renderable.rst
+++ b/master/docs/manual/configuration/report_generators/formatter_renderable.rst
@@ -1,0 +1,18 @@
+.. _MessageFormatterRenderable:
+
+MessageFormatterRenderable
+++++++++++++++++++++++++++
+
+.. py:currentmodule:: buildbot.reporters.message
+
+This formatter is used to format messages in :ref:`Reportgen-BuildStatusGenerator`.
+
+It renders any renderable using the properties of the build that was passed by the status generator.
+
+The constructor of the class takes the following arguments:
+
+``template``
+    A renderable that is used to generate the body of the build report.
+
+``subject``
+    A renderable that is used to generate the subject of the build report.

--- a/master/docs/manual/configuration/report_generators/index.rst
+++ b/master/docs/manual/configuration/report_generators/index.rst
@@ -11,6 +11,7 @@ Report Generators
     buildset
     worker
     formatter
+    formatter_renderable
     formatter_missing_worker
 
 Report generators abstract the conditions of when a message is sent by a :ref:`Reporter <Reporters>` and the content of the message.
@@ -40,4 +41,5 @@ The report generators may customize the reports using message formatters.
 The following message formatter classes are provided:
 
  * :ref:`MessageFormatter` (used in ``BuildStatusGenerator`` and ``BuildSetStatusGenerator``)
+ * :ref:`MessageFormatterRenderable` (used in ``BuildStatusGenerator``)
  * :ref:`MessageFormatterMissingWorkers` (used in ``WorkerMissingGenerator``)


### PR DESCRIPTION
GitHubStatusPush and other reporters that handle simple messages are using simple renderables under the hood. `MessageFormatterRenderable` supports this use case for these reporters once they switch to report generators.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
