### PR TITLE
reporters: Implement a report generator for build start/end pairs

### DIFF
--- a/master/buildbot/newsfragments/report-generator-build-start-end-status.feature
+++ b/master/buildbot/newsfragments/report-generator-build-start-end-status.feature
@@ -1,0 +1,1 @@
+Implemented a ``BuildStartEndStatusGenerator`` which ensures that a report is generated for either both build start and end events or neither of them.

--- a/master/buildbot/reporters/generators/buildset.py
+++ b/master/buildbot/reporters/generators/buildset.py
@@ -18,6 +18,7 @@ from zope.interface import implementer
 
 from buildbot import interfaces
 from buildbot.reporters import utils
+from buildbot.reporters.message import MessageFormatter
 
 from .utils import BuildStatusGeneratorMixin
 
@@ -29,12 +30,16 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
         ('buildsets', None, 'complete'),
     ]
 
+    compare_attrs = ['formatter']
+
     def __init__(self, mode=("failing", "passing", "warnings"),
                  tags=None, builders=None, schedulers=None, branches=None,
                  subject="Buildbot %(result)s in %(title)s on %(builder)s",
                  add_logs=False, add_patch=False, message_formatter=None):
-        super().__init__(mode, tags, builders, schedulers, branches, subject, add_logs, add_patch,
-                         message_formatter)
+        super().__init__(mode, tags, builders, schedulers, branches, subject, add_logs, add_patch)
+        self.formatter = message_formatter
+        if self.formatter is None:
+            self.formatter = MessageFormatter()
 
     @defer.inlineCallbacks
     def generate(self, master, reporter, key, message):
@@ -55,8 +60,8 @@ class BuildSetStatusGenerator(BuildStatusGeneratorMixin):
         if not builds:
             return None
 
-        report = yield self.build_message(master, reporter, "whole buildset", builds,
-                                          buildset['results'])
+        report = yield self.build_message(self.formatter, master, reporter, "whole buildset",
+                                          builds, buildset['results'])
         return report
 
     def _want_previous_build(self):

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -47,7 +47,7 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
     def check(self):
         self._verify_build_generator_mode(self.mode)
 
-        if '\n' in self.subject:
+        if self.subject is not None and '\n' in self.subject:
             config.error('Newlines are not allowed in message subjects')
 
         list_or_none_params = [
@@ -165,7 +165,7 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
             if buildmsg['subject'] is not None:
                 subject = buildmsg['subject']
 
-        if subject is None:
+        if subject is None and self.subject is not None:
             subject = self.subject % {'result': statusToString(results),
                                       'projectName': master.config.title,
                                       'title': master.config.title,

--- a/master/buildbot/reporters/message.py
+++ b/master/buildbot/reporters/message.py
@@ -217,7 +217,7 @@ class MessageFormatterRenderable(MessageFormatterBase):
 
     template_type = 'plain'
 
-    def __init__(self, template, subject):
+    def __init__(self, template, subject=None):
         super().__init__()
         self.template = template
         self.subject = subject

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -29,6 +29,7 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.reporters import utils
+from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
 from buildbot.reporters.generators.build import BuildStatusGenerator
 from buildbot.test.fake import fakemaster
 from buildbot.test.util.config import ConfigErrorsMixin
@@ -397,3 +398,196 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
             'patches': [],
             'logs': []
         })
+
+
+class TestBuildStartEndGenerator(ConfigErrorsMixin, TestReactorMixin,
+                                 unittest.TestCase, ReporterTestMixin):
+
+    all_messages = ('failing', 'passing', 'warnings', 'exception', 'cancelled')
+
+    def setUp(self):
+        self.setUpTestReactor()
+        self.setup_reporter_test()
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
+
+    @defer.inlineCallbacks
+    def insert_build_finished_get_props(self, results, **kwargs):
+        build = yield self.insert_build_finished(results, **kwargs)
+        yield utils.getDetailsForBuild(self.master, build, wantProperties=True)
+        return build
+
+    @parameterized.expand([
+        ('tags', 'tag'),
+        ('tags', 1),
+        ('builders', 'builder'),
+        ('builders', 1),
+        ('schedulers', 'scheduler'),
+        ('schedulers', 1),
+        ('branches', 'branch'),
+        ('branches', 1),
+    ])
+    def test_list_params_check_raises(self, arg_name, arg_value):
+        kwargs = {arg_name: arg_value}
+        g = BuildStartEndStatusGenerator(**kwargs)
+        with self.assertRaisesConfigError('must be a list or None'):
+            g.check()
+
+    def setup_generator(self, results=SUCCESS, start_message=None, end_message=None, **kwargs):
+        if start_message is None:
+            start_message = {
+                "body": "start body",
+                "type": "plain",
+                "subject": "start subject"
+            }
+
+        if end_message is None:
+            end_message = {
+                "body": "end body",
+                "type": "plain",
+                "subject": "end subject"
+            }
+
+        g = BuildStartEndStatusGenerator(**kwargs)
+
+        g.start_formatter = Mock(spec=g.start_formatter)
+        g.start_formatter.format_message_for_build.return_value = start_message
+        g.end_formatter = Mock(spec=g.end_formatter)
+        g.end_formatter.format_message_for_build.return_value = end_message
+
+        return g
+
+    @defer.inlineCallbacks
+    def build_message(self, g, builds, results=SUCCESS):
+        reporter = Mock()
+        reporter.getResponsibleUsersForBuild.return_value = []
+
+        report = yield g.build_message(g.start_formatter, self.master, reporter, "mybldr",
+                                       builds, results)
+        return report
+
+    @defer.inlineCallbacks
+    def generate(self, g, key, build):
+        reporter = Mock()
+        reporter.getResponsibleUsersForBuild.return_value = []
+
+        report = yield g.generate(self.master, reporter, key, build)
+        return report
+
+    @defer.inlineCallbacks
+    def test_build_message_start(self):
+        g = yield self.setup_generator()
+        build = yield self.insert_build_finished_get_props(SUCCESS)
+        report = yield self.build_message(g, [build])
+
+        g.start_formatter.format_message_for_build.assert_called_with(
+            self.all_messages, 'mybldr', build, self.master, [])
+
+        self.assertEqual(report, {
+            'body': 'start body',
+            'subject': 'start subject',
+            'type': 'plain',
+            'builder_name': 'mybldr',
+            'results': SUCCESS,
+            'builds': [build],
+            'users': [],
+            'patches': [],
+            'logs': []
+        })
+
+    @defer.inlineCallbacks
+    def test_build_message_start_no_result(self):
+        g = yield self.setup_generator(results=None)
+        build = yield self.insert_build_new()
+        report = yield self.build_message(g, [build], results=None)
+
+        g.start_formatter.format_message_for_build.assert_called_with(
+            self.all_messages, 'mybldr', build, self.master, [])
+
+        self.assertEqual(report, {
+            'body': 'start body',
+            'subject': 'start subject',
+            'type': 'plain',
+            'builder_name': 'mybldr',
+            'results': None,
+            'builds': [build],
+            'users': [],
+            'patches': [],
+            'logs': []
+        })
+
+    @defer.inlineCallbacks
+    def test_build_message_add_logs(self):
+        g = yield self.setup_generator(add_logs=True)
+        build = yield self.insert_build_finished_get_props(SUCCESS)
+        report = yield self.build_message(g, [build])
+
+        self.assertEqual(report['logs'][0]['logid'], 60)
+        self.assertIn("log with", report['logs'][0]['content']['content'])
+
+    @defer.inlineCallbacks
+    def test_build_message_add_patch(self):
+        g = yield self.setup_generator(add_patch=True)
+        build = yield self.insert_build_finished_get_props(SUCCESS, insert_patch=True)
+        report = yield self.build_message(g, [build])
+
+        patch_dict = {
+            'author': 'him@foo',
+            'body': b'hello, world',
+            'comment': 'foo',
+            'level': 3,
+            'patchid': 99,
+            'subdir': '/foo'
+        }
+        self.assertEqual(report['patches'], [patch_dict])
+
+    @defer.inlineCallbacks
+    def test_build_message_add_patch_no_patch(self):
+        g = yield self.setup_generator(add_patch=True)
+        build = yield self.insert_build_finished_get_props(SUCCESS, insert_patch=False)
+        report = yield self.build_message(g, [build])
+        self.assertEqual(report['patches'], [])
+
+    @defer.inlineCallbacks
+    def test_generate_new(self):
+        g = yield self.setup_generator()
+        build = yield self.insert_build_new()
+        report = yield self.generate(g, ('builds', 123, 'new'), build)
+
+        self.assertEqual(report, {
+            'body': 'start body',
+            'subject': 'start subject',
+            'type': 'plain',
+            'builder_name': 'Builder0',
+            'results': None,
+            'builds': [build],
+            'users': [],
+            'patches': [],
+            'logs': []
+        })
+
+    @defer.inlineCallbacks
+    def test_generate_finished(self):
+        g = yield self.setup_generator()
+        build = yield self.insert_build_finished_get_props(SUCCESS)
+        report = yield self.generate(g, ('builds', 123, 'finished'), build)
+
+        self.assertEqual(report, {
+            'body': 'end body',
+            'subject': 'end subject',
+            'type': 'plain',
+            'builder_name': 'Builder0',
+            'results': SUCCESS,
+            'builds': [build],
+            'users': [],
+            'patches': [],
+            'logs': []
+        })
+
+    @defer.inlineCallbacks
+    def test_generate_none(self):
+        g = yield self.setup_generator(builders=['other builder'])
+        build = yield self.insert_build_new()
+        report = yield self.generate(g, ('builds', 123, 'new'), build)
+
+        self.assertIsNone(report, None)

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -253,7 +253,8 @@ class TestBuildGenerator(ConfigErrorsMixin, TestReactorMixin,
         reporter = Mock()
         reporter.getResponsibleUsersForBuild.return_value = []
 
-        report = yield g.build_message(self.master, reporter, "mybldr", builds, results)
+        report = yield g.build_message(g.formatter, self.master, reporter, "mybldr", builds,
+                                       results)
         return report
 
     @defer.inlineCallbacks

--- a/master/docs/manual/configuration/report_generators/build.rst
+++ b/master/docs/manual/configuration/report_generators/build.rst
@@ -7,7 +7,8 @@ BuildStatusGenerator
 
 .. py:class:: buildbot.reporters.BuildStatusGenerator
 
-This report generator sends a message when a build finishes.
+This report generator sends a message when a build completes.
+In case a reporter is used to provide a live status notification for both build start and build completion, :ref:`Reportgen-BuildStartEndStatusGenerator` is a better option.
 
 The following parameters are supported:
 

--- a/master/docs/manual/configuration/report_generators/build_start_end.rst
+++ b/master/docs/manual/configuration/report_generators/build_start_end.rst
@@ -1,0 +1,55 @@
+.. bb:reportgen:: BuildStartEndStatusGenerator
+
+.. _Reportgen-BuildStartEndStatusGenerator:
+
+BuildStartEndStatusGenerator
+++++++++++++++++++++++++++++
+
+.. py:class:: buildbot.plugins.reporters.BuildStartEndStatusGenerator
+
+This report generator that sends a message both when a build starts and finishes.
+
+The following parameters are supported:
+
+``builders``
+    (list of strings, optional).
+    A list of builder names to serve build status information for.
+    Defaults to ``None`` (all builds).
+    Use either builders or tags, but not both.
+
+``tags``
+    (list of strings, optional).
+    A list of tag names to serve build status information for.
+    Defaults to ``None`` (all tags).
+    Use either builders or tags, but not both.
+
+``schedulers``
+    (list of strings, optional).
+    A list of scheduler names to serve build status information for.
+    Defaults to ``None`` (all schedulers).
+
+``branches``
+    (list of strings, optional).
+    A list of branch names to serve build status information for.
+    Defaults to ``None`` (all branches).
+
+``add_logs``
+    (boolean or a list of strings, optional).
+    If ``True``, include all build logs as attachments to the messages.
+    These can be quite large.
+    This can also be set to a list of log names, to send a subset of the logs.
+    Defaults to ``False``.
+
+``add_patch``
+    (boolean, optional).
+    If ``True``, include the patch content if a patch was present.
+    Patches are usually used on a :class:`Try` server.
+    Defaults to ``False``.
+
+``start_formatter``
+    (optional, instance of ``reporters.MessageFormatter`` or ``reporters.MessageFormatterRenderable``)
+    This is an optional message formatter that can be used to generate a custom message at the start of the build.
+
+``end_formatter``
+    (optional, instance of ``reporters.MessageFormatter`` or ``reporters.MessageFormatterRenderable``)
+    This is an optional message formatter that can be used to generate a custom message at the end of the build.

--- a/master/docs/manual/configuration/report_generators/index.rst
+++ b/master/docs/manual/configuration/report_generators/index.rst
@@ -8,6 +8,7 @@ Report Generators
     :maxdepth: 2
 
     build
+    build_start_end
     buildset
     worker
     formatter
@@ -34,12 +35,13 @@ Eventually report generator support will be added to the rest of the reporters.
 The following report generators are available:
 
  * :ref:`Reportgen-BuildStatusGenerator`
+ * :ref:`Reportgen-BuildStartEndStatusGenerator`
  * :ref:`Reportgen-BuildSetStatusGenerator`
  * :ref:`Reportgen-WorkerMissingGenerator`
 
 The report generators may customize the reports using message formatters.
 The following message formatter classes are provided:
 
- * :ref:`MessageFormatter` (used in ``BuildStatusGenerator`` and ``BuildSetStatusGenerator``)
- * :ref:`MessageFormatterRenderable` (used in ``BuildStatusGenerator``)
+ * :ref:`MessageFormatter` (used in ``BuildStatusGenerator``, ``BuildStartEndStatusGenerator`` and ``BuildSetStatusGenerator``)
+ * :ref:`MessageFormatterRenderable` (used in ``BuildStatusGenerator`` and ``BuildStartEndStatusGenerator``)
  * :ref:`MessageFormatterMissingWorkers` (used in ``WorkerMissingGenerator``)


### PR DESCRIPTION
The existing `BuildStatusGenerator` is not really well suited in cases when we want to report a notification for both build start and completion events or none of them. This is the case in `GitHubStatusPush and similar reporters where the build start event causes the GitHub UI to show the build as in progress and build completion event will cause the GitHub UI to complete the build. In these cases we don't want to miss an event under any circumstances.

The new `BuildStartEndStatusGenerator` is created to cater for this use case. It's more convenient too as separate formatters are provided for both build begin and completion events, just like `GitHubStatusPush` and similar reporters already have. The amount of additional code is very small as most of low-level details are already handled in `BuildStatusGeneratorMixin`.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
