### PR TITLE
tests: Fix testing of config errors

### DIFF
--- a/master/buildbot/reporters/hipchat.py
+++ b/master/buildbot/reporters/hipchat.py
@@ -1,6 +1,7 @@
 from twisted.internet import defer
 
 from buildbot import config
+from buildbot import interfaces
 from buildbot.process.results import statusToString
 from buildbot.reporters import utils
 from buildbot.reporters.http import HttpStatusPushBase
@@ -19,7 +20,7 @@ class HipChatStatusPush(HttpStatusPushBase):
     def checkConfig(self, auth_token, endpoint=HOSTED_BASE_URL,
                     builder_room_map=None, builder_user_map=None,
                     event_messages=None, **kwargs):
-        if not isinstance(auth_token, str):
+        if not isinstance(auth_token, str) and not interfaces.IRenderable.providedBy(auth_token):
             config.error('auth_token must be a string')
         if not isinstance(endpoint, str):
             config.error('endpoint must be a string')

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -13,12 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
-from mock import Mock
-
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config
 from buildbot.process.properties import Interpolate
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
@@ -44,8 +41,6 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase,
         self.setup_reporter_test()
         self.reporter_test_repo = 'https://example.org/user/repo'
 
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -236,8 +231,6 @@ class TestBitbucketStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
         self.setup_reporter_test()
         self.reporter_test_repo = 'https://example.org/user/repo'
 
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -22,7 +22,6 @@ from mock import Mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config
 from buildbot.plugins import util
 from buildbot.process.properties import Interpolate
 from buildbot.process.results import FAILURE
@@ -58,8 +57,6 @@ class TestBitbucketServerStatusPush(TestReactorMixin, unittest.TestCase,
     def setupReporter(self, **kwargs):
         self.setUpTestReactor()
         self.setup_reporter_test()
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -202,8 +199,6 @@ class TestBitbucketServerStatusPushDeprecatedSend(TestReactorMixin, unittest.Tes
     def setupReporter(self, **kwargs):
         self.setUpTestReactor()
         self.setup_reporter_test()
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -274,9 +269,6 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
     def setupReporter(self, token=None, **kwargs):
         self.setUpTestReactor()
         self.setup_reporter_test()
-
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -559,8 +551,6 @@ class TestBitbucketServerCoreAPIStatusPushDeprecatedSend(ConfigErrorsMixin, Test
     def setupReporter(self, token=None, **kwargs):
         self.setUpTestReactor()
         self.setup_reporter_test()
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -645,8 +635,6 @@ class TestBitbucketServerPRCommentPush(TestReactorMixin, unittest.TestCase,
     def setUp(self):
         self.setUpTestReactor()
         self.setup_reporter_test()
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
         yield self.master.startService()

--- a/master/buildbot/test/unit/reporters/test_bitbucketserver.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucketserver.py
@@ -281,13 +281,15 @@ class TestBitbucketServerCoreAPIStatusPush(ConfigErrorsMixin, TestReactorMixin, 
                                              wantMq=True)
 
         http_headers = {} if token is None else {'Authorization': 'Bearer tokentoken'}
+        http_auth = ('username', 'passwd') if token is None else None
 
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
-            self.master, self,
-            'serv', auth=('username', 'passwd'), headers=http_headers,
+            self.master, self, 'serv', auth=http_auth, headers=http_headers,
             debug=None, verify=None)
-        self.sp = BitbucketServerCoreAPIStatusPush(
-            "serv", token=token, auth=(Interpolate("username"), Interpolate("passwd")), **kwargs)
+
+        auth = (Interpolate("username"), Interpolate("passwd")) if token is None else None
+
+        self.sp = BitbucketServerCoreAPIStatusPush("serv", token=token, auth=auth, **kwargs)
         yield self.sp.setServiceParent(self.master)
         yield self.master.startService()
 

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -15,12 +15,9 @@
 
 import datetime
 
-from mock import Mock
-
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config
 from buildbot.process.properties import Interpolate
 from buildbot.process.properties import Properties
 from buildbot.process.properties import renderer
@@ -50,8 +47,6 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             'gerrit_changes': [{'change_id': 12, 'revision_id': 2}]
         }
 
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -401,8 +396,6 @@ class TestGerritVerifyStatusPushDeprecatedSend(TestReactorMixin, ReporterTestMix
         self.reporter_test_props = {
             'gerrit_changes': [{'change_id': 12, 'revision_id': 2}]
         }
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 

--- a/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
+++ b/master/buildbot/test/unit/reporters/test_gerrit_verify_status.py
@@ -60,7 +60,6 @@ class TestGerritVerifyStatusPush(TestReactorMixin,
             self.master, self, "gerrit", auth=('log', 'pass'),
             debug=None, verify=None)
         self.sp = GerritVerifyStatusPush("gerrit", auth=auth, **kwargs)
-        self.sp.sessionFactory = Mock(return_value=Mock())
         yield self.sp.setServiceParent(self.master)
 
     def tearDown(self):
@@ -409,7 +408,6 @@ class TestGerritVerifyStatusPushDeprecatedSend(TestReactorMixin, ReporterTestMix
             self.master, self, "gerrit", auth=('log', 'pass'),
             debug=None, verify=None)
         self.sp = GerritVerifyStatusPushDeprecatedSend("gerrit", auth=auth, **kwargs)
-        self.sp.sessionFactory = Mock(return_value=Mock())
         yield self.sp.setServiceParent(self.master)
 
     def tearDown(self):

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -13,12 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
-from mock import Mock
-
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config
 from buildbot.process.properties import Interpolate
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
@@ -45,8 +42,6 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
         # project must be in the form <owner>/<project>
         self.reporter_test_project = 'buildbot/buildbot'
 
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -245,8 +240,6 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
         self.reporter_test_project = 'buildbot'
         self.reporter_test_repo = 'https://github.com/buildbot1/buildbot1.git'
 
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -353,8 +346,6 @@ class TestGitHubStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
         # project must be in the form <owner>/<project>
         self.reporter_test_project = 'buildbot/buildbot'
 
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 

--- a/master/buildbot/test/unit/reporters/test_github.py
+++ b/master/buildbot/test/unit/reporters/test_github.py
@@ -54,7 +54,6 @@ class TestGitHubStatusPush(TestReactorMixin, unittest.TestCase,
             },
             debug=None, verify=None)
         self.sp = self.createService()
-        self.sp.sessionFactory = Mock(return_value=Mock())
         yield self.sp.setServiceParent(self.master)
 
     def createService(self):
@@ -252,7 +251,6 @@ class TestGitHubStatusPushURL(TestReactorMixin, unittest.TestCase,
             },
             debug=None, verify=None)
         self.sp = self.createService()
-        self.sp.sessionFactory = Mock(return_value=Mock())
         yield self.sp.setServiceParent(self.master)
 
     def createService(self):
@@ -358,7 +356,6 @@ class TestGitHubStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
             },
             debug=None, verify=None)
         self.sp = self.createService()
-        self.sp.sessionFactory = Mock(return_value=Mock())
         yield self.sp.setServiceParent(self.master)
 
     def createService(self):

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -13,12 +13,9 @@
 #
 # Copyright Buildbot Team Members
 
-from mock import Mock
-
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config
 from buildbot.process.properties import Interpolate
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
@@ -44,8 +41,6 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
         # repository must be in the form http://gitlab/<owner>/<project>
         self.reporter_test_repo = 'http://gitlab/buildbot/buildbot'
 
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -234,8 +229,6 @@ class TestGitLabStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
         # repository must be in the form http://gitlab/<owner>/<project>
         self.reporter_test_repo = 'http://gitlab/buildbot/buildbot'
 
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 

--- a/master/buildbot/test/unit/reporters/test_gitlab.py
+++ b/master/buildbot/test/unit/reporters/test_gitlab.py
@@ -50,7 +50,6 @@ class TestGitLabStatusPush(TestReactorMixin, unittest.TestCase,
             HOSTED_BASE_URL, headers={'PRIVATE-TOKEN': 'XXYYZZ'},
             debug=None, verify=None)
         self.sp = GitLabStatusPush(Interpolate('XXYYZZ'))
-        self.sp.sessionFactory = Mock(return_value=Mock())
         yield self.sp.setServiceParent(self.master)
 
     def tearDown(self):
@@ -238,7 +237,6 @@ class TestGitLabStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
             HOSTED_BASE_URL, headers={'PRIVATE-TOKEN': 'XXYYZZ'},
             debug=None, verify=None)
         self.sp = GitLabStatusPushDeprecatedSend(Interpolate('XXYYZZ'))
-        self.sp.sessionFactory = Mock(return_value=Mock())
         yield self.sp.setServiceParent(self.master)
 
     def tearDown(self):

--- a/master/buildbot/test/unit/reporters/test_hipchat.py
+++ b/master/buildbot/test/unit/reporters/test_hipchat.py
@@ -18,13 +18,13 @@ from mock import Mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from buildbot import config
 from buildbot.process.properties import Interpolate
 from buildbot.process.results import SUCCESS
 from buildbot.reporters.hipchat import HOSTED_BASE_URL
 from buildbot.reporters.hipchat import HipChatStatusPush
 from buildbot.test.fake import fakemaster
 from buildbot.test.fake import httpclientservice as fakehttpclientservice
+from buildbot.test.util.config import ConfigErrorsMixin
 from buildbot.test.util.logging import LoggingMixin
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.test.util.reporter import ReporterTestMixin
@@ -32,14 +32,12 @@ from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.warnings import DeprecatedApiWarning
 
 
-class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
+class TestHipchatStatusPush(ConfigErrorsMixin, TestReactorMixin, unittest.TestCase,
                             ReporterTestMixin, LoggingMixin):
 
     def setUp(self):
         self.setUpTestReactor()
         self.setup_reporter_test()
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 
@@ -61,24 +59,22 @@ class TestHipchatStatusPush(TestReactorMixin, unittest.TestCase,
 
     @defer.inlineCallbacks
     def test_authtokenTypeCheck(self):
-        yield self.createReporter(auth_token=2)
-        config._errors.addError.assert_any_call('auth_token must be a string')
+        with self.assertRaisesConfigError('auth_token must be a string'):
+            yield self.createReporter(auth_token=2)
 
     def test_endpointTypeCheck(self):
-        HipChatStatusPush(auth_token="2", endpoint=2)
-        config._errors.addError.assert_any_call('endpoint must be a string')
+        with self.assertRaisesConfigError('endpoint must be a string'):
+            HipChatStatusPush(auth_token="2", endpoint=2)
 
     @defer.inlineCallbacks
     def test_builderRoomMapTypeCheck(self):
-        yield self.createReporter(builder_room_map=2)
-        config._errors.addError.assert_any_call(
-            'builder_room_map must be a dict')
+        with self.assertRaisesConfigError('builder_room_map must be a dict'):
+            yield self.createReporter(builder_room_map=2)
 
     @defer.inlineCallbacks
     def test_builderUserMapTypeCheck(self):
-        yield self.createReporter(builder_user_map=2)
-        config._errors.addError.assert_any_call(
-            'builder_user_map must be a dict')
+        with self.assertRaisesConfigError('builder_user_map must be a dict'):
+            yield self.createReporter(builder_user_map=2)
 
     @defer.inlineCallbacks
     def test_interpolateAuth(self):
@@ -253,8 +249,6 @@ class TestHipchatStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
     def setUp(self):
         self.setUpTestReactor()
         self.setup_reporter_test()
-        # ignore config error if txrequests is not installed
-        self.patch(config, '_errors', Mock())
         self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
                                              wantMq=True)
 


### PR DESCRIPTION
Right now we patch `config._errors` in many tests which causes `config.error()` to not throw. Thus any `ConfigError` raised in the tests will be not noticed.