### PR TITLE
reporters: Deprecate HipChatStatusPush

### DIFF
--- a/master/buildbot/newsfragments/reporters-hipchat-deprecated.removal
+++ b/master/buildbot/newsfragments/reporters-hipchat-deprecated.removal
@@ -1,0 +1,2 @@
+``HipChatStatusPush`` has been deprecated because the public version of hipchat has been shut down.
+This reporter will be removed in Buildbot 3.0 unless there is someone who will upgrade the reporter to the new internal APIs present in Buildbot 3.0.

--- a/master/buildbot/reporters/hipchat.py
+++ b/master/buildbot/reporters/hipchat.py
@@ -20,6 +20,12 @@ class HipChatStatusPush(HttpStatusPushBase):
     def checkConfig(self, auth_token, endpoint=HOSTED_BASE_URL,
                     builder_room_map=None, builder_user_map=None,
                     event_messages=None, **kwargs):
+        warn_deprecated('2.10.0', 'HipChatStatusPush has been deprecated because the public ' +
+                                  'version of hipchat has been shut down. This reporter will ' +
+                                  'be removed in Buildbot 3.0 unless there is someone who will ' +
+                                  'upgrade the reporter to the new internal APIs present in ' +
+                                  'Buildbot 3.0')
+
         if not isinstance(auth_token, str) and not interfaces.IRenderable.providedBy(auth_token):
             config.error('auth_token must be a string')
         if not isinstance(endpoint, str):

--- a/master/buildbot/test/unit/reporters/test_hipchat.py
+++ b/master/buildbot/test/unit/reporters/test_hipchat.py
@@ -49,7 +49,11 @@ class TestHipchatStatusPush(ConfigErrorsMixin, TestReactorMixin, unittest.TestCa
     @defer.inlineCallbacks
     def createReporter(self, **kwargs):
         kwargs['auth_token'] = kwargs.get('auth_token', 'abc')
-        self.sp = HipChatStatusPush(**kwargs)
+
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='has been deprecated because the public'):
+            self.sp = HipChatStatusPush(**kwargs)
+
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
             kwargs.get('endpoint', HOSTED_BASE_URL),
@@ -64,7 +68,9 @@ class TestHipchatStatusPush(ConfigErrorsMixin, TestReactorMixin, unittest.TestCa
 
     def test_endpointTypeCheck(self):
         with self.assertRaisesConfigError('endpoint must be a string'):
-            HipChatStatusPush(auth_token="2", endpoint=2)
+            with assertProducesWarnings(DeprecatedApiWarning,
+                                        message_pattern='has been deprecated because the public'):
+                HipChatStatusPush(auth_token="2", endpoint=2)
 
     @defer.inlineCallbacks
     def test_builderRoomMapTypeCheck(self):
@@ -260,7 +266,11 @@ class TestHipchatStatusPushDeprecatedSend(TestReactorMixin, unittest.TestCase,
     @defer.inlineCallbacks
     def createReporter(self, **kwargs):
         kwargs['auth_token'] = kwargs.get('auth_token', 'abc')
-        self.sp = HipChatStatusPushDeprecatedSend(**kwargs)
+
+        with assertProducesWarnings(DeprecatedApiWarning,
+                                    message_pattern='has been deprecated because the public'):
+            self.sp = HipChatStatusPushDeprecatedSend(**kwargs)
+
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self,
             kwargs.get('endpoint', HOSTED_BASE_URL),


### PR DESCRIPTION
#5242 raised the question of what we will do with `HipChatStatusPush`. I was initially against removal of the reporter, but it turns out that there's some maintenance cost, so let's deprecate this reporter for Buildbot 2.10 and remove it in Buildbot 3.0 unless someone is willing to spend half a day porting the reporter to the report generator APIs.
