### PR TITLE
Allow ReconfigurablePollingChangeSource in change_hook/poller.

### DIFF
--- a/master/buildbot/newsfragments/reconfigurable-poller.bugfix
+++ b/master/buildbot/newsfragments/reconfigurable-poller.bugfix
@@ -1,0 +1,3 @@
+Fixed :issue:`5727` which prevented polling change sources derived from
+:py:class:`~buildbot.changes.base.ReconfigurablePollingChangeSource` from
+working correctly with `/change_hook/poller`.

--- a/master/buildbot/www/hooks/poller.py
+++ b/master/buildbot/www/hooks/poller.py
@@ -17,7 +17,7 @@
 # the door" and trigger a change source to poll.
 
 
-from buildbot.changes.base import PollingChangeSource
+from buildbot.changes.base import ReconfigurablePollingChangeSource
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.www.hooks.base import BaseHookHandler
@@ -38,7 +38,7 @@ class PollingHandler(BaseHookHandler):
         pollers = []
 
         for source in change_svc:
-            if not isinstance(source, PollingChangeSource):
+            if not isinstance(source, ReconfigurablePollingChangeSource):
                 continue
             if not hasattr(source, "name"):
                 continue

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -564,7 +564,7 @@ Writing a Change Poller
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Polling is a very common means of seeking changes, so Buildbot supplies a utility parent class to make it easier.
-A poller should subclass :class:`buildbot.changes.base.PollingChangeSource`, which is a subclass of :class:`~buildbot.changes.base.ChangeSource`.
+A poller should subclass :class:`buildbot.changes.base.ReconfigurablePollingChangeSource`, which is a subclass of :class:`~buildbot.changes.base.ChangeSource`.
 This subclass implements the :meth:`Service` methods, and calls the :meth:`poll` method according to the ``pollInterval`` and ``pollAtLaunch`` options.
 The ``poll`` method should return a Deferred to signal its completion.
 


### PR DESCRIPTION
New change pollers are supposed to derive from `ReconfigurablePollingChangeSource`
which is now a superclass of the `PollingChangeSource` class used by old code.

Make sure that `/change_hook/poller` supports both kinds of poller classes.

Fixes #5727
