### PR TITLE
Use full signal names in scripts

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -268,11 +268,13 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
 
             yield self.mq.setup()
 
+            # the buildbot scripts send the SIGHUP signal to reconfig master
             if hasattr(signal, "SIGHUP"):
                 def sighup(*args):
                     eventually(self.reconfig)
                 signal.signal(signal.SIGHUP, sighup)
 
+            # the buildbot scripts send the SIGUSR1 signal to stop master
             if hasattr(signal, "SIGUSR1"):
                 def sigusr1(*args):
                     eventually(self.botmaster.cleanShutdown)

--- a/master/buildbot/scripts/stop.py
+++ b/master/buildbot/scripts/stop.py
@@ -24,7 +24,7 @@ from twisted.python.runtime import platformType
 from buildbot.scripts import base
 
 
-def stop(config, signame="TERM", wait=None):
+def stop(config, signame="SIGTERM", wait=None):
     basedir = config['basedir']
     quiet = config['quiet']
 
@@ -32,7 +32,7 @@ def stop(config, signame="TERM", wait=None):
         wait = not config['no-wait']
 
     if config['clean']:
-        signame = 'USR1'
+        signame = 'SIGUSR1'
 
     if not base.isBuildmasterDir(config['basedir']):
         return 1
@@ -46,7 +46,7 @@ def stop(config, signame="TERM", wait=None):
             print("buildmaster not running")
         return 0
 
-    signum = getattr(signal, "SIG" + signame)
+    signum = getattr(signal, signame)
     try:
         os.kill(pid, signum)
     except OSError as e:
@@ -63,7 +63,7 @@ def stop(config, signame="TERM", wait=None):
 
     if not wait:
         if not quiet:
-            print("sent SIG{} to process".format(signame))
+            print("sent {} to process".format(signame))
         return 0
 
     time.sleep(0.1)

--- a/worker/buildbot_worker/scripts/stop.py
+++ b/worker/buildbot_worker/scripts/stop.py
@@ -31,7 +31,7 @@ class WorkerNotRunning(Exception):
     """
 
 
-def stopWorker(basedir, quiet, signame="TERM"):
+def stopWorker(basedir, quiet, signame="SIGTERM"):
     """
     Stop worker process by sending it a signal.
 
@@ -52,7 +52,7 @@ def stopWorker(basedir, quiet, signame="TERM"):
         raise WorkerNotRunning()
 
     pid = int(f.read().strip())
-    signum = getattr(signal, "SIG" + signame)
+    signum = getattr(signal, signame)
     timer = 0
     try:
         os.kill(pid, signum)
@@ -76,7 +76,7 @@ def stopWorker(basedir, quiet, signame="TERM"):
     return 1
 
 
-def stop(config, signame="TERM"):
+def stop(config, signame="SIGTERM"):
     quiet = config['quiet']
     basedir = config['basedir']
 


### PR DESCRIPTION
This allows to run search for SIGXXX through the codebase and easily see where it's used. It was not clear e.g. what could send SIGUSR1 to the master.