### PR TITLE
test: Cleanup master setup in integration tests

### DIFF
--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -180,7 +180,7 @@ class RunSteps(RunFakeMasterTestCase):
             'multiMaster': True,
         }
 
-        yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
         builder_id = yield self.master.data.updates.findBuilderId('builder')
         return builder_id
 

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -196,7 +196,7 @@ class RunSteps(RunFakeMasterTestCase):
         consumer = yield self.master.mq.startConsuming(on_finished, ('builds', None, 'finished'))
 
         # start the builder
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         # and wait for build completion
         yield d_finished

--- a/master/buildbot/test/integration/test_locks.py
+++ b/master/buildbot/test/integration/test_locks.py
@@ -50,13 +50,13 @@ class Tests(RunFakeMasterTestCase):
             'protocols': {'null': {}},
             'multiMaster': True,
         }
-        master = yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
         builder_ids = [
-            (yield master.data.updates.findBuilderId('builder1')),
-            (yield master.data.updates.findBuilderId('builder2')),
+            (yield self.master.data.updates.findBuilderId('builder1')),
+            (yield self.master.data.updates.findBuilderId('builder2')),
         ]
 
-        return stepcontrollers, master, builder_ids
+        return stepcontrollers, builder_ids
 
     @defer.inlineCallbacks
     def create_single_worker_two_builder_step_lock_config(self, lock_cls, mode):
@@ -80,13 +80,13 @@ class Tests(RunFakeMasterTestCase):
             'protocols': {'null': {}},
             'multiMaster': True,
         }
-        master = yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
         builder_ids = [
-            (yield master.data.updates.findBuilderId('builder1')),
-            (yield master.data.updates.findBuilderId('builder2')),
+            (yield self.master.data.updates.findBuilderId('builder1')),
+            (yield self.master.data.updates.findBuilderId('builder2')),
         ]
 
-        return stepcontrollers, master, builder_ids
+        return stepcontrollers, builder_ids
 
     @defer.inlineCallbacks
     def create_two_worker_two_builder_lock_config(self, mode):
@@ -112,23 +112,22 @@ class Tests(RunFakeMasterTestCase):
             'protocols': {'null': {}},
             'multiMaster': True,
         }
-        master = yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
         builder_ids = [
-            (yield master.data.updates.findBuilderId('builder1')),
-            (yield master.data.updates.findBuilderId('builder2')),
+            (yield self.master.data.updates.findBuilderId('builder1')),
+            (yield self.master.data.updates.findBuilderId('builder2')),
         ]
 
-        return stepcontrollers, master, builder_ids
+        return stepcontrollers, builder_ids
 
     @defer.inlineCallbacks
-    def assert_two_builds_created_one_after_another(self, stepcontrollers,
-                                                    master, builder_ids):
+    def assert_two_builds_created_one_after_another(self, stepcontrollers, builder_ids):
         # start two builds and verify that a second build starts after the
         # first is finished
-        yield self.createBuildrequest(master, [builder_ids[0]])
-        yield self.createBuildrequest(master, [builder_ids[1]])
+        yield self.createBuildrequest(self.master, [builder_ids[0]])
+        yield self.createBuildrequest(self.master, [builder_ids[1]])
 
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), 1)
         self.assertEqual(builds[0]['results'], None)
         self.assertEqual(builds[0]['builderid'], builder_ids[0])
@@ -138,7 +137,7 @@ class Tests(RunFakeMasterTestCase):
         # execute Build.releaseLocks which is called eventually
         yield flushEventualQueue()
 
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), 2)
         self.assertEqual(builds[0]['results'], SUCCESS)
         self.assertEqual(builds[1]['results'], None)
@@ -146,20 +145,19 @@ class Tests(RunFakeMasterTestCase):
 
         stepcontrollers[1].finish_step(SUCCESS)
 
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), 2)
         self.assertEqual(builds[0]['results'], SUCCESS)
         self.assertEqual(builds[1]['results'], SUCCESS)
 
     @defer.inlineCallbacks
-    def assert_two_steps_created_one_after_another(self, stepcontrollers,
-                                                   master, builder_ids):
+    def assert_two_steps_created_one_after_another(self, stepcontrollers, builder_ids):
         # start two builds and verify that a second build starts after the
         # first is finished
-        yield self.createBuildrequest(master, [builder_ids[0]])
-        yield self.createBuildrequest(master, [builder_ids[1]])
+        yield self.createBuildrequest(self.master, [builder_ids[0]])
+        yield self.createBuildrequest(self.master, [builder_ids[1]])
 
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), 2)
         self.assertEqual(builds[0]['results'], None)
         self.assertEqual(builds[0]['builderid'], builder_ids[0])
@@ -175,7 +173,7 @@ class Tests(RunFakeMasterTestCase):
         self.assertFalse(stepcontrollers[0].running)
         self.assertTrue(stepcontrollers[1].running)
 
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), 2)
         self.assertEqual(builds[0]['results'], SUCCESS)
         self.assertEqual(builds[1]['results'], None)
@@ -183,7 +181,7 @@ class Tests(RunFakeMasterTestCase):
         stepcontrollers[1].finish_step(SUCCESS)
         yield flushEventualQueue()
 
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), 2)
         self.assertEqual(builds[0]['results'], SUCCESS)
         self.assertEqual(builds[1]['results'], SUCCESS)
@@ -200,12 +198,11 @@ class Tests(RunFakeMasterTestCase):
         Tests whether a builder lock works at all in preventing a build when
         the lock is taken.
         '''
-        stepcontrollers, master, builder_ids = \
+        stepcontrollers, builder_ids = \
             yield self.create_single_worker_two_builder_lock_config(lock_cls,
                                                                     mode)
 
-        yield self.assert_two_builds_created_one_after_another(
-            stepcontrollers, master, builder_ids)
+        yield self.assert_two_builds_created_one_after_another(stepcontrollers, builder_ids)
 
     @parameterized.expand([
         (util.MasterLock, 'counting'),
@@ -219,11 +216,10 @@ class Tests(RunFakeMasterTestCase):
         Tests whether a builder lock works at all in preventing a build when
         the lock is taken.
         '''
-        stepcontrollers, master, builder_ids = \
+        stepcontrollers, builder_ids = \
             yield self.create_single_worker_two_builder_step_lock_config(
                 lock_cls, mode)
-        yield self.assert_two_steps_created_one_after_another(
-            stepcontrollers, master, builder_ids)
+        yield self.assert_two_steps_created_one_after_another(stepcontrollers, builder_ids)
 
     @parameterized.expand(['counting', 'exclusive'])
     @defer.inlineCallbacks
@@ -233,11 +229,10 @@ class Tests(RunFakeMasterTestCase):
         must retry running any buildrequests that might have been not scheduled
         due to unavailability of that lock when the lock becomes available.
         """
-        stepcontrollers, master, builder_ids = \
+        stepcontrollers, builder_ids = \
             yield self.create_two_worker_two_builder_lock_config(mode)
 
-        yield self.assert_two_builds_created_one_after_another(
-            stepcontrollers, master, builder_ids)
+        yield self.assert_two_builds_created_one_after_another(stepcontrollers, builder_ids)
 
 
 class TestReconfig(RunFakeMasterTestCase):
@@ -276,14 +271,14 @@ class TestReconfig(RunFakeMasterTestCase):
         }
         self.update_builder_config(config_dict, stepcontrollers, lock, mode)
 
-        master = yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
 
         builder_ids = []
         for i in range(builder_count):
             builder_ids.append((
-                yield master.data.updates.findBuilderId('builder{}'.format(i))))
+                yield self.master.data.updates.findBuilderId('builder{}'.format(i))))
 
-        return stepcontrollers, master, config_dict, lock, builder_ids
+        return stepcontrollers, config_dict, lock, builder_ids
 
     @defer.inlineCallbacks
     def create_single_worker_n_builder_step_lock_config(self, builder_count,
@@ -302,14 +297,14 @@ class TestReconfig(RunFakeMasterTestCase):
         }
         self.update_builder_config(config_dict, stepcontrollers, None, None)
 
-        master = yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
 
         builder_ids = []
         for i in range(builder_count):
             builder_ids.append((
-                yield master.data.updates.findBuilderId('builder{}'.format(i))))
+                yield self.master.data.updates.findBuilderId('builder{}'.format(i))))
 
-        return stepcontrollers, master, config_dict, lock, builder_ids
+        return stepcontrollers, config_dict, lock, builder_ids
 
     @parameterized.expand([
         (3, util.MasterLock, 'counting', 1, 2, 1, 2),
@@ -331,26 +326,26 @@ class TestReconfig(RunFakeMasterTestCase):
         versions created a completely separate real lock after each maxCount
         change, which allowed to e.g. take an exclusive lock twice.
         '''
-        stepcontrollers, master, config_dict, lock, builder_ids = \
+        stepcontrollers, config_dict, lock, builder_ids = \
             yield self.create_single_worker_n_builder_lock_config(
                 builder_count, lock_cls, max_count_before, mode)
 
         # create a number of builds and check that the expected number of them
         # start
         for i in range(builder_count):
-            yield self.createBuildrequest(master, [builder_ids[i]])
+            yield self.createBuildrequest(self.master, [builder_ids[i]])
 
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), allowed_builds_before)
 
         # update the config and reconfig the master
         lock = lock_cls(lock.name, maxCount=max_count_after)
         self.update_builder_config(config_dict, stepcontrollers, lock, mode)
-        yield master.reconfig()
+        yield self.master.reconfig()
         yield flushEventualQueue()
 
         # check that the number of running builds matches expectation
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), allowed_builds_after)
 
         # finish the steps and check that builds finished as expected
@@ -358,7 +353,7 @@ class TestReconfig(RunFakeMasterTestCase):
             stepcontroller.finish_step(SUCCESS)
             yield flushEventualQueue()
 
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         for b in builds[allowed_builds_after:]:
             self.assertEqual(b['results'], SUCCESS)
 
@@ -382,16 +377,16 @@ class TestReconfig(RunFakeMasterTestCase):
         versions created a completely separate real lock after each maxCount
         change, which allowed to e.g. take an exclusive lock twice.
         '''
-        stepcontrollers, master, config_dict, lock, builder_ids = \
+        stepcontrollers, config_dict, lock, builder_ids = \
             yield self.create_single_worker_n_builder_step_lock_config(
                 builder_count, lock_cls, max_count_before, mode)
 
         # create a number of builds and check that the expected number of them
         # start their steps
         for i in range(builder_count):
-            yield self.createBuildrequest(master, [builder_ids[i]])
+            yield self.createBuildrequest(self.master, [builder_ids[i]])
 
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), builder_count)
 
         self.assertEqual(sum(sc.running for sc in stepcontrollers),
@@ -403,11 +398,11 @@ class TestReconfig(RunFakeMasterTestCase):
             self.create_stepcontrollers(builder_count, lock, mode)
 
         self.update_builder_config(config_dict, new_stepcontrollers, lock, mode)
-        yield master.reconfig()
+        yield self.master.reconfig()
         yield flushEventualQueue()
 
         # check that all builds are still running
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), builder_count)
 
         # check that the expected number of steps has been started and that
@@ -421,7 +416,7 @@ class TestReconfig(RunFakeMasterTestCase):
             stepcontroller.finish_step(SUCCESS)
             yield flushEventualQueue()
 
-        builds = yield master.data.get(("builds",))
+        builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), builder_count)
         for b in builds:
             self.assertEqual(b['results'], SUCCESS)

--- a/master/buildbot/test/integration/test_locks.py
+++ b/master/buildbot/test/integration/test_locks.py
@@ -124,8 +124,8 @@ class Tests(RunFakeMasterTestCase):
     def assert_two_builds_created_one_after_another(self, stepcontrollers, builder_ids):
         # start two builds and verify that a second build starts after the
         # first is finished
-        yield self.createBuildrequest(self.master, [builder_ids[0]])
-        yield self.createBuildrequest(self.master, [builder_ids[1]])
+        yield self.create_build_request([builder_ids[0]])
+        yield self.create_build_request([builder_ids[1]])
 
         builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), 1)
@@ -154,8 +154,8 @@ class Tests(RunFakeMasterTestCase):
     def assert_two_steps_created_one_after_another(self, stepcontrollers, builder_ids):
         # start two builds and verify that a second build starts after the
         # first is finished
-        yield self.createBuildrequest(self.master, [builder_ids[0]])
-        yield self.createBuildrequest(self.master, [builder_ids[1]])
+        yield self.create_build_request([builder_ids[0]])
+        yield self.create_build_request([builder_ids[1]])
 
         builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), 2)
@@ -333,7 +333,7 @@ class TestReconfig(RunFakeMasterTestCase):
         # create a number of builds and check that the expected number of them
         # start
         for i in range(builder_count):
-            yield self.createBuildrequest(self.master, [builder_ids[i]])
+            yield self.create_build_request([builder_ids[i]])
 
         builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), allowed_builds_before)
@@ -384,7 +384,7 @@ class TestReconfig(RunFakeMasterTestCase):
         # create a number of builds and check that the expected number of them
         # start their steps
         for i in range(builder_count):
-            yield self.createBuildrequest(self.master, [builder_ids[i]])
+            yield self.create_build_request([builder_ids[i]])
 
         builds = yield self.master.data.get(("builds",))
         self.assertEqual(len(builds), builder_count)

--- a/master/buildbot/test/integration/test_process_botmaster.py
+++ b/master/buildbot/test/integration/test_process_botmaster.py
@@ -42,17 +42,17 @@ class Tests(RunFakeMasterTestCase):
             'protocols': {'null': {}},
             'multiMaster': True,
         }
-        master = yield self.getMaster(config_dict)
-        builder_id = yield master.data.updates.findBuilderId('testy')
+        yield self.setup_master(config_dict)
+        builder_id = yield self.master.data.updates.findBuilderId('testy')
 
         controller.connect_worker()
         controller.sever_connection()
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         # give time for any delayed actions to complete
         self.reactor.advance(1)
 
-        yield master.botmaster.cleanShutdown(quickMode=quick_mode, stopReactor=False)
+        yield self.master.botmaster.cleanShutdown(quickMode=quick_mode, stopReactor=False)
         self.flushLoggedErrors(PingException)
 
     def test_terminates_ping_on_shutdown_quick_mode(self):

--- a/master/buildbot/test/integration/test_process_botmaster.py
+++ b/master/buildbot/test/integration/test_process_botmaster.py
@@ -47,7 +47,7 @@ class Tests(RunFakeMasterTestCase):
 
         controller.connect_worker()
         controller.sever_connection()
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         # give time for any delayed actions to complete
         self.reactor.advance(1)

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -84,19 +84,19 @@ class Tests(RunFakeMasterTestCase):
             'protocols': {'null': {}},
             'multiMaster': True,
         }
-        master = yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
         builder_ids = [
-            (yield master.data.updates.findBuilderId('testy-1')),
-            (yield master.data.updates.findBuilderId('testy-2')),
+            (yield self.master.data.updates.findBuilderId('testy-1')),
+            (yield self.master.data.updates.findBuilderId('testy-2')),
         ]
 
         started_builds = []
-        yield master.mq.startConsuming(
+        yield self.master.mq.startConsuming(
             lambda key, build: started_builds.append(build),
             ('builds', None, 'new'))
 
         # Trigger a buildrequest
-        bsid, brids = yield master.data.updates.addBuildset(
+        bsid, brids = yield self.master.data.updates.addBuildset(
             waited_for=False,
             builderids=builder_ids,
             sourcestamps=[
@@ -138,19 +138,19 @@ class Tests(RunFakeMasterTestCase):
             'protocols': {'null': {}},
             'multiMaster': True,
         }
-        master = yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
         builder_ids = [
-            (yield master.data.updates.findBuilderId('testy-1')),
-            (yield master.data.updates.findBuilderId('testy-2')),
+            (yield self.master.data.updates.findBuilderId('testy-1')),
+            (yield self.master.data.updates.findBuilderId('testy-2')),
         ]
 
         started_builds = []
-        yield master.mq.startConsuming(
+        yield self.master.mq.startConsuming(
             lambda key, build: started_builds.append(build),
             ('builds', None, 'new'))
 
         # Trigger a buildrequest
-        bsid, brids = yield master.data.updates.addBuildset(
+        bsid, brids = yield self.master.data.updates.addBuildset(
             waited_for=False,
             builderids=builder_ids,
             sourcestamps=[
@@ -182,7 +182,7 @@ class Tests(RunFakeMasterTestCase):
             'multiMaster': True,
         }
 
-        yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
 
         self.assertIs(worker.machine, machine)
 
@@ -202,7 +202,7 @@ class Tests(RunFakeMasterTestCase):
             # Disable checks about missing scheduler.
             'multiMaster': True,
         }
-        yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
 
         config_dict['builders'] += [
             BuilderConfig(name="builder2",
@@ -234,7 +234,7 @@ class Tests(RunFakeMasterTestCase):
             # Disable checks about missing scheduler.
             'multiMaster': True,
         }
-        yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
 
         props = worker.worker_status.info
 

--- a/master/buildbot/test/integration/test_worker.py
+++ b/master/buildbot/test/integration/test_worker.py
@@ -212,7 +212,7 @@ class Tests(RunFakeMasterTestCase):
         config_dict['workers'] = [self.createLocalWorker('local1', max_builds=2)]
 
         # reconfig should succeed
-        yield self.reconfigMaster(config_dict)
+        yield self.reconfig_master(config_dict)
 
     @defer.inlineCallbacks
     def test_worker_os_release_info_roundtrip(self):

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -168,7 +168,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
 
         # Request two builds.
         for i in range(2):
-            yield self.createBuildrequest(self.master, [builder_id])
+            yield self.create_build_request([builder_id])
 
         # Check that both workers were requested to start.
         self.assertEqual(controllers[0].starting, True)
@@ -186,7 +186,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
+        bsid, brids = yield self.create_build_request([builder_id])
 
         unclaimed_build_requests = []
         yield self.master.mq.startConsuming(
@@ -215,7 +215,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
+        bsid, brids = yield self.create_build_request([builder_id])
 
         unclaimed_build_requests = []
         yield self.master.mq.startConsuming(
@@ -244,7 +244,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         # The worker fails to substantiate.
         controller.start_instance(
@@ -266,7 +266,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
 
         yield controller.auto_stop(True)
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
+        bsid, brids = yield self.create_build_request([builder_id])
 
         unclaimed_build_requests = []
         yield self.master.mq.startConsuming(
@@ -318,7 +318,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_ids = yield self.create_single_worker_two_builder_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(self.master, builder_ids)
+        bsid, brids = yield self.create_build_request(builder_ids)
 
         # The worker succeeds to substantiate.
         controller.start_instance(True)
@@ -338,7 +338,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_id = yield self.create_single_worker_config(
             controller_kwargs=dict(build_wait_timeout=1))
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         self.assertTrue(controller.starting)
 
@@ -354,7 +354,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield controller.stop_instance(True)
 
         self.assertTrue(controller.stopped)
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         self.assertTrue(controller.starting)
         yield controller.disconnect_worker()
         yield controller.start_instance(True)
@@ -376,7 +376,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             controller_kwargs=dict(build_wait_timeout=1))
 
         # Trigger a single buildrequest
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         self.assertEqual(True, controller.starting)
 
@@ -393,7 +393,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         # either not start at all until the instance finished substantiating,
         # or the substantiation request needs to be recorded and start
         # immediately after stop_instance completes.
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.stop_instance(True)
 
         yield controller.start_instance(True)
@@ -418,7 +418,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             controller_kwargs=dict(build_wait_timeout=1))
 
         # Trigger a single buildrequest
-        yield self.createBuildrequest(self.master, [builder_ids[0]])
+        yield self.create_build_request([builder_ids[0]])
 
         self.assertEqual(True, controller.starting)
 
@@ -429,7 +429,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         with patchForDelay('buildbot.process.builder.Builder.maybeStartBuild') as delay:
             # create a build request which will result in a build, but it won't
             # attempt to substantiate until after stop_instance() is in progress
-            yield self.createBuildrequest(self.master, [builder_ids[1]])
+            yield self.create_build_request([builder_ids[1]])
             self.assertEqual(len(delay), 1)
             self.reactor.advance(1)
 
@@ -455,7 +455,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
 
         # insubstantiate during start_instance(). Note that failed substantiation is notified only
         # after the latent workers completes start-stop cycle.
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         d = controller.worker.insubstantiate()
         controller.start_instance(False)
         controller.stop_instance(True)
@@ -473,7 +473,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             controller_kwargs=dict(build_wait_timeout=1))
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.start_instance(True)
 
         yield self.assertBuildResults(1, SUCCESS)
@@ -505,7 +505,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller.auto_connect_worker = worker_connects
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         self.assertTrue(controller.starting)
 
         d = self.reconfig_workers_remove_all()
@@ -528,7 +528,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_id = yield self.create_single_worker_config(
             controller_kwargs=dict(build_wait_timeout=1))
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         # put the worker into insubstantiation phase
         controller.start_instance(True)
@@ -538,7 +538,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.assertTrue(controller.stopping)
 
         # build should wait on the insubstantiation
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         self.assertEqual(controller.worker.state, States.INSUBSTANTIATING_SUBSTANTIATING)
 
         # build should be requeued if we insubstantiate.
@@ -557,7 +557,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
+        bsid, brids = yield self.create_build_request([builder_id])
 
         unclaimed_build_requests = []
         yield self.master.mq.startConsuming(
@@ -587,7 +587,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_id = yield self.create_single_worker_config(
             controller_kwargs=dict(build_wait_timeout=1))
 
-        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
+        bsid, brids = yield self.create_build_request([builder_id])
 
         # sever connection just before ping()
         with patchForDelay(
@@ -622,7 +622,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
+        bsid, brids = yield self.create_build_request([builder_id])
 
         unclaimed_build_requests = []
         yield self.master.mq.startConsuming(
@@ -672,7 +672,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
+        bsid, brids = yield self.create_build_request([builder_id])
 
         unclaimed_build_requests = []
         yield self.master.mq.startConsuming(
@@ -725,7 +725,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
 
         # Request a build and disconnect midway
         controller.auto_disconnect_worker = False
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.auto_stop(True)
 
         self.assertTrue(controller.starting)
@@ -757,7 +757,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller.auto_connect_worker = False
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.start_instance(True)
         yield controller.connect_worker()
 
@@ -771,7 +771,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield controller.connect_worker()
         self.assertTrue(controller.started)
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield self.assertBuildResults(1, SUCCESS)
 
         # The only way to stop worker with negative build timeout is to
@@ -790,7 +790,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             controller_kwargs=dict(build_wait_timeout=0))
 
         # Request a build and disconnect midway
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.auto_stop(True)
 
         self.assertTrue(controller.starting)
@@ -805,7 +805,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield self.assertBuildResults(1, RETRY)
 
         # Request one build.
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         controller.start_instance(True)
         yield self.assertBuildResults(2, None)
         stepcontroller.finish_step(SUCCESS)
@@ -821,7 +821,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_id = yield self.create_single_worker_config(
             controller_kwargs=dict(build_wait_timeout=1))
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         controller.start_instance(True)
         yield self.assertBuildResults(1, SUCCESS)
@@ -839,7 +839,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield controller.disconnect_worker()
 
         # create new build request and verify it works
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         yield controller.start_instance(True)
         yield self.assertBuildResults(1, SUCCESS)
@@ -859,7 +859,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller, builder_id = yield self.create_single_worker_config(
             controller_kwargs=dict(build_wait_timeout=1))
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         controller.start_instance(True)
         yield self.assertBuildResults(1, SUCCESS)
@@ -869,7 +869,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         with patchForDelay('buildbot.worker.base.AbstractWorker.disconnect') as delay:
             self.reactor.advance(1)
             self.assertTrue(controller.stopping)
-            yield self.createBuildrequest(self.master, [builder_id])
+            yield self.create_build_request([builder_id])
             controller.sever_connection()
             delay.fire()
 
@@ -899,7 +899,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller.auto_connect_worker = False
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.start_instance(True)
         yield controller.connect_worker()
 
@@ -921,7 +921,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield controller.disconnect_worker()
 
         # Now substantiate the worker and verify build succeeds
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.start_instance(True)
         yield controller.connect_worker()
         yield self.assertBuildResults(1, SUCCESS)
@@ -943,7 +943,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller.auto_connect_worker = False
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.start_instance(True)
         yield controller.connect_worker()
 
@@ -959,7 +959,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.assertTrue(controller.stopped)
 
         # Now substantiate the worker without connecting it
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.start_instance(True)
         yield self.assertBuildResults(1, SUCCESS)
 
@@ -975,7 +975,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             controller_kwargs=dict(build_wait_timeout=-1))
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.start_instance(True)
 
         yield self.assertBuildResults(1, SUCCESS)
@@ -1004,7 +1004,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller.worker.stop_instance = raise_stop_instance
 
         # create a build and wait for stop
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.start_instance(True)
         self.reactor.advance(1)
         yield self.assertBuildResults(1, SUCCESS)
@@ -1017,7 +1017,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.reactor.advance(1)
 
         # subsequent build should succeed
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         yield controller.start_instance(True)
         self.reactor.advance(1)
         yield self.assertBuildResults(2, SUCCESS)
@@ -1033,7 +1033,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         builder = self.master.botmaster.builders['testy']
 
         # Trigger a buildrequest
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         # Stop the build
         build = builder.getBuild(0)
@@ -1057,7 +1057,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         builder = self.master.botmaster.builders['testy']
 
         # Trigger a buildrequest
-        _, brids = yield self.createBuildrequest(self.master, [builder_id])
+        _, brids = yield self.create_build_request([builder_id])
 
         unclaimed_build_requests = []
         yield self.master.mq.startConsuming(
@@ -1096,7 +1096,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             )
 
         # create build request
-        yield self.createBuildrequest(self.master, [builder_id],
+        yield self.create_build_request([builder_id],
                                       properties=Properties(worker_kind='a'))
 
         # start the build and verify the kind of the worker. Note that the
@@ -1110,7 +1110,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
                          'a')
 
         # before the other build finished, create another build request
-        yield self.createBuildrequest(self.master, [builder_id],
+        yield self.create_build_request([builder_id],
                                       properties=Properties(worker_kind='b'))
         stepcontroller.finish_step(SUCCESS)
 
@@ -1145,7 +1145,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             )
 
         # create build request
-        yield self.createBuildrequest(self.master, [builder_id],
+        yield self.create_build_request([builder_id],
                                       properties=Properties(worker_kind='a'))
 
         # start the build and verify the kind of the worker. Note that the
@@ -1159,7 +1159,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
                          'a')
 
         # before the other build finished, create another build request
-        yield self.createBuildrequest(self.master, [builder_id],
+        yield self.create_build_request([builder_id],
                                       properties=Properties(worker_kind='b'))
         stepcontroller.finish_step(SUCCESS)
 
@@ -1216,7 +1216,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller.start_instance(True)
         self.assertTrue(controller.started)
 
-        self.createBuildrequest(self.master, [builder_id])
+        self.create_build_request([builder_id])
         stepcontroller.finish_step(SUCCESS)
 
         self.reactor.advance(1)
@@ -1314,7 +1314,7 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         machine_controller.start_machine(True)
         self.assertTrue(worker_controller.started)
 
@@ -1333,7 +1333,7 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
         machine_controller.start_machine(True)
         self.assertTrue(worker_controller.started)
 
@@ -1352,7 +1352,7 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         machine_controller.start_machine(True)
         self.reactor.advance(10.0)
@@ -1382,7 +1382,7 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         machine_controller.start_machine(True)
         self.reactor.advance(10.0)
@@ -1395,7 +1395,7 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
         self.reactor.advance(4.9)
         self.assertEqual(machine_controller.machine.state,
                          MachineStates.STARTED)
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         self.reactor.advance(5.1)
         self.assertEqual(machine_controller.machine.state,
@@ -1425,7 +1425,7 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         machine_controller.start_machine(False)
         self.assertEqual(machine_controller.machine.state,
@@ -1441,7 +1441,7 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         class FakeError(Exception):
             pass
@@ -1461,7 +1461,7 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(self.master, [builder_id])
+        yield self.create_build_request([builder_id])
 
         machine_controller.start_machine(True)
         step_controller.finish_step(SUCCESS)
@@ -1486,7 +1486,7 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
             wc.auto_start(True)
             wc.auto_stop(True)
 
-        yield self.createBuildrequest(self.master, [builder_ids[0]])
+        yield self.create_build_request([builder_ids[0]])
 
         machine_controller.start_machine(True)
         for wc in worker_controllers:
@@ -1510,11 +1510,11 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
             wc.auto_start(True)
             wc.auto_stop(True)
 
-        yield self.createBuildrequest(self.master, [builder_ids[0]])
+        yield self.create_build_request([builder_ids[0]])
         self.assertEqual(machine_controller.machine.state,
                          MachineStates.STARTING)
 
-        yield self.createBuildrequest(self.master, [builder_ids[1]])
+        yield self.create_build_request([builder_ids[1]])
 
         machine_controller.start_machine(True)
         for wc in worker_controllers:
@@ -1540,7 +1540,7 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
             wc.auto_start(True)
             wc.auto_stop(True)
 
-        yield self.createBuildrequest(self.master, [builder_ids[0]])
+        yield self.create_build_request([builder_ids[0]])
 
         machine_controller.start_machine(False)
         self.assertEqual(machine_controller.machine.state,

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -74,10 +74,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             # Disable checks about missing scheduler.
             'multiMaster': True,
         }
-        master = yield self.getMaster(config_dict)
-        builder_id = yield master.data.updates.findBuilderId('testy')
+        yield self.setup_master(config_dict)
+        builder_id = yield self.master.data.updates.findBuilderId('testy')
 
-        return controller, master, builder_id
+        return controller, builder_id
 
     @defer.inlineCallbacks
     def create_single_worker_config_with_step(self, controller_kwargs=None):
@@ -98,10 +98,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             # Disable checks about missing scheduler.
             'multiMaster': True,
         }
-        master = yield self.getMaster(config_dict)
-        builder_id = yield master.data.updates.findBuilderId('testy')
+        yield self.setup_master(config_dict)
+        builder_id = yield self.master.data.updates.findBuilderId('testy')
 
-        return controller, stepcontroller, master, builder_id
+        return controller, stepcontroller, builder_id
 
     @defer.inlineCallbacks
     def create_single_worker_two_builder_config(self, controller_kwargs=None):
@@ -125,22 +125,22 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             # Disable checks about missing scheduler.
             'multiMaster': True,
         }
-        master = yield self.getMaster(config_dict)
+        yield self.setup_master(config_dict)
         builder_ids = [
-            (yield master.data.updates.findBuilderId('testy-1')),
-            (yield master.data.updates.findBuilderId('testy-2')),
+            (yield self.master.data.updates.findBuilderId('testy-1')),
+            (yield self.master.data.updates.findBuilderId('testy-2')),
         ]
 
-        return controller, master, builder_ids
+        return controller, builder_ids
 
-    def reconfig_workers_remove_all(self, master):
-        # returns a deferred that fires when the worker has been successfully removed
+    @defer.inlineCallbacks
+    def reconfig_workers_remove_all(self):
         config_dict = {
             'workers': [],
             'multiMaster': True
         }
         config = MasterConfig.loadFromDict(config_dict, '<dict>')
-        return master.workers.reconfigServiceWithBuildbotConfig(config)
+        yield self.master.workers.reconfigServiceWithBuildbotConfig(config)
 
     @defer.inlineCallbacks
     def test_latent_workers_start_in_parallel(self):
@@ -163,12 +163,12 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             'protocols': {'null': {}},
             'multiMaster': True,
         }
-        master = yield self.getMaster(config_dict)
-        builder_id = yield master.data.updates.findBuilderId('testy')
+        yield self.setup_master(config_dict)
+        builder_id = yield self.master.data.updates.findBuilderId('testy')
 
         # Request two builds.
         for i in range(2):
-            yield self.createBuildrequest(master, [builder_id])
+            yield self.createBuildrequest(self.master, [builder_id])
 
         # Check that both workers were requested to start.
         self.assertEqual(controllers[0].starting, True)
@@ -183,14 +183,13 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         If a latent worker refuses to substantiate, the build request becomes
         unclaimed.
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config()
+        controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(master, [builder_id])
+        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
 
         unclaimed_build_requests = []
-        yield master.mq.startConsuming(
+        yield self.master.mq.startConsuming(
             lambda key, request: unclaimed_build_requests.append(request),
             ('buildrequests', None, 'unclaimed'))
 
@@ -213,14 +212,13 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         If a latent worker fails to substantiate, the build request becomes
         unclaimed.
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config()
+        controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(master, [builder_id])
+        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
 
         unclaimed_build_requests = []
-        yield master.mq.startConsuming(
+        yield self.master.mq.startConsuming(
             lambda key, request: unclaimed_build_requests.append(request),
             ('buildrequests', None, 'unclaimed'))
 
@@ -243,11 +241,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         """
         If a latent worker fails to substantiate, the result is an exception.
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config()
+        controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         # The worker fails to substantiate.
         controller.start_instance(
@@ -265,15 +262,14 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         If a latent worker fails to substantiate, the worker is still able to
         accept jobs.
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config()
+        controller, builder_id = yield self.create_single_worker_config()
 
         yield controller.auto_stop(True)
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(master, [builder_id])
+        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
 
         unclaimed_build_requests = []
-        yield master.mq.startConsuming(
+        yield self.master.mq.startConsuming(
             lambda key, request: unclaimed_build_requests.append(request),
             ('buildrequests', None, 'unclaimed'))
         # The worker fails to substantiate.
@@ -319,11 +315,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         the same time, if the substantiation succeeds then all of
         the builds proceed.
         """
-        controller, master, builder_ids = \
-            yield self.create_single_worker_two_builder_config()
+        controller, builder_ids = yield self.create_single_worker_two_builder_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(master, builder_ids)
+        bsid, brids = yield self.createBuildrequest(self.master, builder_ids)
 
         # The worker succeeds to substantiate.
         controller.start_instance(True)
@@ -340,11 +335,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         Make sure it works at the most late detachment point, i.e. when we're
         substantiating again.
         '''
-        controller, master, builder_id = \
-            yield self.create_single_worker_config(
-                controller_kwargs=dict(build_wait_timeout=1))
+        controller, builder_id = yield self.create_single_worker_config(
+            controller_kwargs=dict(build_wait_timeout=1))
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         self.assertTrue(controller.starting)
 
@@ -360,7 +354,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield controller.stop_instance(True)
 
         self.assertTrue(controller.stopped)
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         self.assertTrue(controller.starting)
         yield controller.disconnect_worker()
         yield controller.start_instance(True)
@@ -378,12 +372,11 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         start a build then it should start successfully without causing an
         erroneous cancellation of the substantiation request.
         '''
-        controller, master, builder_id = \
-            yield self.create_single_worker_config(
-                controller_kwargs=dict(build_wait_timeout=1))
+        controller, builder_id = yield self.create_single_worker_config(
+            controller_kwargs=dict(build_wait_timeout=1))
 
         # Trigger a single buildrequest
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         self.assertEqual(True, controller.starting)
 
@@ -400,7 +393,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         # either not start at all until the instance finished substantiating,
         # or the substantiation request needs to be recorded and start
         # immediately after stop_instance completes.
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.stop_instance(True)
 
         yield controller.start_instance(True)
@@ -421,12 +414,11 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         before insubstantiation, its start could be delayed until when
         stop_instance() is in progress.
         '''
-        controller, master, builder_ids = \
-            yield self.create_single_worker_two_builder_config(
-                controller_kwargs=dict(build_wait_timeout=1))
+        controller, builder_ids = yield self.create_single_worker_two_builder_config(
+            controller_kwargs=dict(build_wait_timeout=1))
 
         # Trigger a single buildrequest
-        yield self.createBuildrequest(master, [builder_ids[0]])
+        yield self.createBuildrequest(self.master, [builder_ids[0]])
 
         self.assertEqual(True, controller.starting)
 
@@ -437,7 +429,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         with patchForDelay('buildbot.process.builder.Builder.maybeStartBuild') as delay:
             # create a build request which will result in a build, but it won't
             # attempt to substantiate until after stop_instance() is in progress
-            yield self.createBuildrequest(master, [builder_ids[1]])
+            yield self.createBuildrequest(self.master, [builder_ids[1]])
             self.assertEqual(len(delay), 1)
             self.reactor.advance(1)
 
@@ -458,12 +450,12 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         If a latent worker gets insubstantiation() during substantiation, then it should refuse
         to substantiate.
         """
-        controller, master, builder_id = yield self.create_single_worker_config(
+        controller, builder_id = yield self.create_single_worker_config(
             controller_kwargs=dict(build_wait_timeout=1))
 
         # insubstantiate during start_instance(). Note that failed substantiation is notified only
         # after the latent workers completes start-stop cycle.
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         d = controller.worker.insubstantiate()
         controller.start_instance(False)
         controller.stop_instance(True)
@@ -477,11 +469,11 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         When stopService is called and a worker is insubstantiating, we should wait for this
         process to complete.
         """
-        controller, master, builder_id = yield self.create_single_worker_config(
+        controller, builder_id = yield self.create_single_worker_config(
             controller_kwargs=dict(build_wait_timeout=1))
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.start_instance(True)
 
         yield self.assertBuildResults(1, SUCCESS)
@@ -491,7 +483,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.reactor.advance(1)
         self.assertTrue(controller.stopping)
 
-        d = self.reconfig_workers_remove_all(master)
+        d = self.reconfig_workers_remove_all()
         self.assertFalse(d.called)
         yield controller.stop_instance(True)
         yield d
@@ -508,15 +500,15 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         When stopService is called and a worker is substantiating, we should wait for this
         process to complete.
         """
-        controller, master, builder_id = yield self.create_single_worker_config(
+        controller, builder_id = yield self.create_single_worker_config(
             controller_kwargs=dict(build_wait_timeout=1))
         controller.auto_connect_worker = worker_connects
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         self.assertTrue(controller.starting)
 
-        d = self.reconfig_workers_remove_all(master)
+        d = self.reconfig_workers_remove_all()
         self.assertFalse(d.called)
 
         yield controller.start_instance(subst_success)
@@ -533,10 +525,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         We should cancel substantiation if we insubstantiate when that substantiation is waiting
         on current insubstantiation to finish
         """
-        controller, master, builder_id = yield self.create_single_worker_config(
+        controller, builder_id = yield self.create_single_worker_config(
             controller_kwargs=dict(build_wait_timeout=1))
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         # put the worker into insubstantiation phase
         controller.start_instance(True)
@@ -546,7 +538,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.assertTrue(controller.stopping)
 
         # build should wait on the insubstantiation
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         self.assertEqual(controller.worker.state, States.INSUBSTANTIATING_SUBSTANTIATING)
 
         # build should be requeued if we insubstantiate.
@@ -562,14 +554,13 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         If a latent worker substantiate, but not connect, and then be
         unsubstantiated, the build request becomes unclaimed.
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config()
+        controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(master, [builder_id])
+        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
 
         unclaimed_build_requests = []
-        yield master.mq.startConsuming(
+        yield self.master.mq.startConsuming(
             lambda key, request: unclaimed_build_requests.append(request),
             ('buildrequests', None, 'unclaimed'))
 
@@ -593,11 +584,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         notification in the TCP layer, we successfully wait until TCP times
         out and requeue the build.
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config(
-                controller_kwargs=dict(build_wait_timeout=1))
+        controller, builder_id = yield self.create_single_worker_config(
+            controller_kwargs=dict(build_wait_timeout=1))
 
-        bsid, brids = yield self.createBuildrequest(master, [builder_id])
+        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
 
         # sever connection just before ping()
         with patchForDelay(
@@ -629,18 +619,17 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         sendBuilderList can fail due to missing permissions on the workdir,
         the build request becomes unclaimed
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config()
+        controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(master, [builder_id])
+        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
 
         unclaimed_build_requests = []
-        yield master.mq.startConsuming(
+        yield self.master.mq.startConsuming(
             lambda key, request: unclaimed_build_requests.append(request),
             ('buildrequests', None, 'unclaimed'))
         logs = []
-        yield master.mq.startConsuming(
+        yield self.master.mq.startConsuming(
             lambda key, log: logs.append(log),
             ('logs', None, 'new'))
 
@@ -663,7 +652,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.assertEqual(len(logs), 2)
         logs_by_name = {}
         for _log in logs:
-            fulllog = yield master.data.get(("logs", str(_log['logid']),
+            fulllog = yield self.master.data.get(("logs", str(_log['logid']),
                                             "raw"))
             logs_by_name[fulllog['filename']] = fulllog['raw']
 
@@ -680,18 +669,17 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         sendBuilderList can fail due to missing permissions on the workdir,
         the build request becomes unclaimed
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config()
+        controller, builder_id = yield self.create_single_worker_config()
 
         # Trigger a buildrequest
-        bsid, brids = yield self.createBuildrequest(master, [builder_id])
+        bsid, brids = yield self.createBuildrequest(self.master, [builder_id])
 
         unclaimed_build_requests = []
-        yield master.mq.startConsuming(
+        yield self.master.mq.startConsuming(
             lambda key, request: unclaimed_build_requests.append(request),
             ('buildrequests', None, 'unclaimed'))
         logs = []
-        yield master.mq.startConsuming(
+        yield self.master.mq.startConsuming(
             lambda key, log: logs.append(log),
             ('logs', None, 'new'))
 
@@ -714,7 +702,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.assertEqual(len(logs), 2)
         logs_by_name = {}
         for _log in logs:
-            fulllog = yield master.data.get(("logs", str(_log['logid']),
+            fulllog = yield self.master.data.get(("logs", str(_log['logid']),
                                             "raw"))
             logs_by_name[fulllog['filename']] = fulllog['raw']
 
@@ -731,14 +719,13 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         If the worker close connection in the middle of the build, the next
         build can start correctly
         """
-        controller, stepcontroller, master, builder_id = \
-            yield self.create_single_worker_config_with_step(
-                controller_kwargs=dict(build_wait_timeout=0)
+        controller, stepcontroller, builder_id = yield self.create_single_worker_config_with_step(
+            controller_kwargs=dict(build_wait_timeout=0)
             )
 
         # Request a build and disconnect midway
         controller.auto_disconnect_worker = False
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.auto_stop(True)
 
         self.assertTrue(controller.starting)
@@ -763,16 +750,14 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         our side. We should still support accidental disconnections from
         worker side due to, e.g. network problems.
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config(
-                controller_kwargs=dict(build_wait_timeout=-1)
-            )
+        controller, builder_id = yield self.create_single_worker_config(
+            controller_kwargs=dict(build_wait_timeout=-1))
 
         controller.auto_disconnect_worker = False
         controller.auto_connect_worker = False
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.start_instance(True)
         yield controller.connect_worker()
 
@@ -786,7 +771,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield controller.connect_worker()
         self.assertTrue(controller.started)
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield self.assertBuildResults(1, SUCCESS)
 
         # The only way to stop worker with negative build timeout is to
@@ -801,13 +786,11 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         If the connection to worker is severed without TCP notification in the
         middle of the build, the build is re-queued and successfully restarted.
         """
-        controller, stepcontroller, master, builder_id = \
-            yield self.create_single_worker_config_with_step(
-                controller_kwargs=dict(build_wait_timeout=0)
-            )
+        controller, stepcontroller, builder_id = yield self.create_single_worker_config_with_step(
+            controller_kwargs=dict(build_wait_timeout=0))
 
         # Request a build and disconnect midway
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.auto_stop(True)
 
         self.assertTrue(controller.starting)
@@ -822,7 +805,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield self.assertBuildResults(1, RETRY)
 
         # Request one build.
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         controller.start_instance(True)
         yield self.assertBuildResults(2, None)
         stepcontroller.finish_step(SUCCESS)
@@ -835,11 +818,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         layer, we successfully wait until TCP times out, insubstantiate and
         can substantiate after that.
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config(
-                controller_kwargs=dict(build_wait_timeout=1))
+        controller, builder_id = yield self.create_single_worker_config(
+            controller_kwargs=dict(build_wait_timeout=1))
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         controller.start_instance(True)
         yield self.assertBuildResults(1, SUCCESS)
@@ -857,7 +839,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield controller.disconnect_worker()
 
         # create new build request and verify it works
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         yield controller.start_instance(True)
         yield self.assertBuildResults(1, SUCCESS)
@@ -874,11 +856,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         can substantiate after that. In this the subsequent build request is
         created during insubstantiation
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config(
-                controller_kwargs=dict(build_wait_timeout=1))
+        controller, builder_id = yield self.create_single_worker_config(
+            controller_kwargs=dict(build_wait_timeout=1))
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         controller.start_instance(True)
         yield self.assertBuildResults(1, SUCCESS)
@@ -888,7 +869,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         with patchForDelay('buildbot.worker.base.AbstractWorker.disconnect') as delay:
             self.reactor.advance(1)
             self.assertTrue(controller.stopping)
-            yield self.createBuildrequest(master, [builder_id])
+            yield self.createBuildrequest(self.master, [builder_id])
             controller.sever_connection()
             delay.fire()
 
@@ -911,16 +892,14 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         our side, but it can disconnect and reattach from worker side due to,
         e.g. network problems.
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config(
-                controller_kwargs=dict(build_wait_timeout=-1)
-            )
+        controller, builder_id = yield self.create_single_worker_config(
+            controller_kwargs=dict(build_wait_timeout=-1))
 
         controller.auto_disconnect_worker = False
         controller.auto_connect_worker = False
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.start_instance(True)
         yield controller.connect_worker()
 
@@ -942,7 +921,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield controller.disconnect_worker()
 
         # Now substantiate the worker and verify build succeeds
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.start_instance(True)
         yield controller.connect_worker()
         yield self.assertBuildResults(1, SUCCESS)
@@ -957,16 +936,14 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         our side, so it should be possible to insubstantiate and substantiate
         it without problems if the worker does not disconnect either.
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config(
-                controller_kwargs=dict(build_wait_timeout=-1)
-            )
+        controller, builder_id = yield self.create_single_worker_config(
+            controller_kwargs=dict(build_wait_timeout=-1))
 
         controller.auto_disconnect_worker = False
         controller.auto_connect_worker = False
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.start_instance(True)
         yield controller.connect_worker()
 
@@ -982,7 +959,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.assertTrue(controller.stopped)
 
         # Now substantiate the worker without connecting it
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.start_instance(True)
         yield self.assertBuildResults(1, SUCCESS)
 
@@ -994,18 +971,18 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         """
         When build_wait_timeout is negative, we should still insubstantiate when master shuts down.
         """
-        controller, master, builder_id = yield self.create_single_worker_config(
+        controller, builder_id = yield self.create_single_worker_config(
             controller_kwargs=dict(build_wait_timeout=-1))
 
         # Substantiate worker via a build
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.start_instance(True)
 
         yield self.assertBuildResults(1, SUCCESS)
         self.assertTrue(controller.started)
 
         # Shutdown master
-        d = master.stopService()
+        d = self.master.stopService()
         yield controller.stop_instance(True)
         yield d
 
@@ -1014,7 +991,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         """
         Throwing a synchronous exception from stop_instance should allow subsequent build to start.
         """
-        controller, master, builder_id = yield self.create_single_worker_config(
+        controller, builder_id = yield self.create_single_worker_config(
             controller_kwargs=dict(build_wait_timeout=1))
 
         controller.auto_stop(True)
@@ -1027,7 +1004,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller.worker.stop_instance = raise_stop_instance
 
         # create a build and wait for stop
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.start_instance(True)
         self.reactor.advance(1)
         yield self.assertBuildResults(1, SUCCESS)
@@ -1040,7 +1017,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.reactor.advance(1)
 
         # subsequent build should succeed
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         yield controller.start_instance(True)
         self.reactor.advance(1)
         yield self.assertBuildResults(2, SUCCESS)
@@ -1051,13 +1028,12 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         If a build is stopping during latent worker substantiating, the build
         becomes cancelled
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config()
+        controller, builder_id = yield self.create_single_worker_config()
 
-        builder = master.botmaster.builders['testy']
+        builder = self.master.botmaster.builders['testy']
 
         # Trigger a buildrequest
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         # Stop the build
         build = builder.getBuild(0)
@@ -1076,16 +1052,15 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         """
         If master is shutting down during latent worker substantiating, the build becomes retry.
         """
-        controller, master, builder_id = \
-            yield self.create_single_worker_config()
+        controller, builder_id = yield self.create_single_worker_config()
 
-        builder = master.botmaster.builders['testy']
+        builder = self.master.botmaster.builders['testy']
 
         # Trigger a buildrequest
-        _, brids = yield self.createBuildrequest(master, [builder_id])
+        _, brids = yield self.createBuildrequest(self.master, [builder_id])
 
         unclaimed_build_requests = []
-        yield master.mq.startConsuming(
+        yield self.master.mq.startConsuming(
             lambda key, request: unclaimed_build_requests.append(request),
             ('buildrequests', None, 'unclaimed'))
 
@@ -1112,7 +1087,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         schedule any builds on workers that are running different instance type
         than what these builds will require.
         """
-        controller, stepcontroller, master, builder_id = \
+        controller, stepcontroller, builder_id = \
             yield self.create_single_worker_config_with_step(
                 controller_kwargs=dict(
                     kind=Interpolate('%(prop:worker_kind)s'),
@@ -1121,7 +1096,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             )
 
         # create build request
-        yield self.createBuildrequest(master, [builder_id],
+        yield self.createBuildrequest(self.master, [builder_id],
                                       properties=Properties(worker_kind='a'))
 
         # start the build and verify the kind of the worker. Note that the
@@ -1135,7 +1110,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
                          'a')
 
         # before the other build finished, create another build request
-        yield self.createBuildrequest(master, [builder_id],
+        yield self.createBuildrequest(self.master, [builder_id],
                                       properties=Properties(worker_kind='b'))
         stepcontroller.finish_step(SUCCESS)
 
@@ -1161,7 +1136,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         than what these builds will require.
         """
 
-        controller, stepcontroller, master, builder_id = \
+        controller, stepcontroller, builder_id = \
             yield self.create_single_worker_config_with_step(
                 controller_kwargs=dict(
                     kind=Interpolate('%(prop:worker_kind)s'),
@@ -1170,7 +1145,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             )
 
         # create build request
-        yield self.createBuildrequest(master, [builder_id],
+        yield self.createBuildrequest(self.master, [builder_id],
                                       properties=Properties(worker_kind='a'))
 
         # start the build and verify the kind of the worker. Note that the
@@ -1184,7 +1159,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
                          'a')
 
         # before the other build finished, create another build request
-        yield self.createBuildrequest(master, [builder_id],
+        yield self.createBuildrequest(self.master, [builder_id],
                                       properties=Properties(worker_kind='b'))
         stepcontroller.finish_step(SUCCESS)
 
@@ -1194,13 +1169,13 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
 
         # verify build has not started, even though the worker is waiting
         # for one
-        self.assertIsNone((yield master.db.builds.getBuild(2)))
+        self.assertIsNone((yield self.master.db.builds.getBuild(2)))
         self.assertTrue(controller.started)
 
         # wait until the latent worker times out, is insubstantiated,
         # is substantiated because of pending buildrequest and starts the build
         self.reactor.advance(6)
-        self.assertIsNotNone((yield master.db.builds.getBuild(2)))
+        self.assertIsNotNone((yield self.master.db.builds.getBuild(2)))
 
         # verify that the second build restarted with the expected instance
         # kind
@@ -1217,8 +1192,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         Abstract latent worker should support being substantiated without a
         build and then insubstantiated.
         """
-        controller, _, _ = \
-            yield self.create_single_worker_config()
+        controller, _ = yield self.create_single_worker_config()
 
         controller.worker.substantiate(None, None)
         controller.start_instance(True)
@@ -1234,7 +1208,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         Abstract latent worker should support being substantiated without a
         build and then accept a build request.
         """
-        controller, stepcontroller, master, builder_id = \
+        controller, stepcontroller, builder_id = \
             yield self.create_single_worker_config_with_step(
                 controller_kwargs=dict(build_wait_timeout=1))
 
@@ -1242,7 +1216,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         controller.start_instance(True)
         self.assertTrue(controller.started)
 
-        self.createBuildrequest(master, [builder_id])
+        self.createBuildrequest(self.master, [builder_id])
         stepcontroller.finish_step(SUCCESS)
 
         self.reactor.advance(1)
@@ -1280,11 +1254,10 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
             'multiMaster': True,
         }
 
-        master = yield self.getMaster(config_dict)
-        builder_id = yield master.data.updates.findBuilderId('builder1')
+        yield self.setup_master(config_dict)
+        builder_id = yield self.master.data.updates.findBuilderId('builder1')
 
-        return (machine_controller, worker_controller, step_controller,
-                master, builder_id)
+        return machine_controller, worker_controller, step_controller, builder_id
 
     @defer.inlineCallbacks
     def create_two_worker_config(self, build_wait_timeout=0,
@@ -1324,25 +1297,24 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
             'multiMaster': True,
         }
 
-        master = yield self.getMaster(config_dict)
-        builder1_id = yield master.data.updates.findBuilderId('builder1')
-        builder2_id = yield master.data.updates.findBuilderId('builder2')
+        yield self.setup_master(config_dict)
+        builder1_id = yield self.master.data.updates.findBuilderId('builder1')
+        builder2_id = yield self.master.data.updates.findBuilderId('builder2')
 
         return (machine_controller,
                 [worker1_controller, worker2_controller],
                 [step1_controller, step2_controller],
-                master,
                 [builder1_id, builder2_id])
 
     @defer.inlineCallbacks
     def test_1worker_starts_and_stops_after_single_build_success(self):
-        machine_controller, worker_controller, step_controller, \
-            master, builder_id = yield self.create_single_worker_config()
+        machine_controller, worker_controller, step_controller, builder_id = \
+            yield self.create_single_worker_config()
 
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         machine_controller.start_machine(True)
         self.assertTrue(worker_controller.started)
 
@@ -1355,13 +1327,13 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
 
     @defer.inlineCallbacks
     def test_1worker_starts_and_stops_after_single_build_failure(self):
-        machine_controller, worker_controller, step_controller, \
-            master, builder_id = yield self.create_single_worker_config()
+        machine_controller, worker_controller, step_controller, builder_id = \
+            yield self.create_single_worker_config()
 
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
         machine_controller.start_machine(True)
         self.assertTrue(worker_controller.started)
 
@@ -1374,14 +1346,13 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
 
     @defer.inlineCallbacks
     def test_1worker_stops_machine_after_timeout(self):
-        machine_controller, worker_controller, step_controller, \
-            master, builder_id = yield self.create_single_worker_config(
-                build_wait_timeout=5)
+        machine_controller, worker_controller, step_controller, builder_id = \
+            yield self.create_single_worker_config(build_wait_timeout=5)
 
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         machine_controller.start_machine(True)
         self.reactor.advance(10.0)
@@ -1405,14 +1376,13 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
 
     @defer.inlineCallbacks
     def test_1worker_does_not_stop_machine_machine_after_timeout_during_build(self):
-        machine_controller, worker_controller, step_controller, \
-            master, builder_id = yield self.create_single_worker_config(
-                build_wait_timeout=5)
+        machine_controller, worker_controller, step_controller, builder_id = \
+            yield self.create_single_worker_config(build_wait_timeout=5)
 
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         machine_controller.start_machine(True)
         self.reactor.advance(10.0)
@@ -1425,7 +1395,7 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
         self.reactor.advance(4.9)
         self.assertEqual(machine_controller.machine.state,
                          MachineStates.STARTED)
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         self.reactor.advance(5.1)
         self.assertEqual(machine_controller.machine.state,
@@ -1448,14 +1418,14 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
 
     @defer.inlineCallbacks
     def test_1worker_insubstantiated_after_start_failure(self):
-        machine_controller, worker_controller, step_controller, \
-            master, builder_id = yield self.create_single_worker_config()
+        machine_controller, worker_controller, step_controller, builder_id = \
+            yield self.create_single_worker_config()
 
         worker_controller.auto_connect_worker = False
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         machine_controller.start_machine(False)
         self.assertEqual(machine_controller.machine.state,
@@ -1464,14 +1434,14 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
 
     @defer.inlineCallbacks
     def test_1worker_eats_exception_from_start_machine(self):
-        machine_controller, worker_controller, step_controller, \
-            master, builder_id = yield self.create_single_worker_config()
+        machine_controller, worker_controller, step_controller, builder_id = \
+            yield self.create_single_worker_config()
 
         worker_controller.auto_connect_worker = False
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         class FakeError(Exception):
             pass
@@ -1485,13 +1455,13 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
 
     @defer.inlineCallbacks
     def test_1worker_eats_exception_from_stop_machine(self):
-        machine_controller, worker_controller, step_controller, \
-            master, builder_id = yield self.create_single_worker_config()
+        machine_controller, worker_controller, step_controller, builder_id = \
+            yield self.create_single_worker_config()
 
         worker_controller.auto_start(True)
         worker_controller.auto_stop(True)
 
-        yield self.createBuildrequest(master, [builder_id])
+        yield self.createBuildrequest(self.master, [builder_id])
 
         machine_controller.start_machine(True)
         step_controller.finish_step(SUCCESS)
@@ -1508,15 +1478,15 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
 
     @defer.inlineCallbacks
     def test_2workers_build_substantiates_insubstantiates_both_workers(self):
-        machine_controller, worker_controllers, step_controllers, \
-            master, builder_ids = yield self.create_two_worker_config(
+        machine_controller, worker_controllers, step_controllers, builder_ids = \
+            yield self.create_two_worker_config(
                 controller_kwargs=dict(starts_without_substantiate=True))
 
         for wc in worker_controllers:
             wc.auto_start(True)
             wc.auto_stop(True)
 
-        yield self.createBuildrequest(master, [builder_ids[0]])
+        yield self.createBuildrequest(self.master, [builder_ids[0]])
 
         machine_controller.start_machine(True)
         for wc in worker_controllers:
@@ -1533,18 +1503,18 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
 
     @defer.inlineCallbacks
     def test_2workers_two_builds_start_machine_concurrently(self):
-        machine_controller, worker_controllers, step_controllers, \
-            master, builder_ids = yield self.create_two_worker_config()
+        machine_controller, worker_controllers, step_controllers, builder_ids = \
+            yield self.create_two_worker_config()
 
         for wc in worker_controllers:
             wc.auto_start(True)
             wc.auto_stop(True)
 
-        yield self.createBuildrequest(master, [builder_ids[0]])
+        yield self.createBuildrequest(self.master, [builder_ids[0]])
         self.assertEqual(machine_controller.machine.state,
                          MachineStates.STARTING)
 
-        yield self.createBuildrequest(master, [builder_ids[1]])
+        yield self.createBuildrequest(self.master, [builder_ids[1]])
 
         machine_controller.start_machine(True)
         for wc in worker_controllers:
@@ -1562,15 +1532,15 @@ class LatentWithLatentMachine(TimeoutableTestCase, RunFakeMasterTestCase):
 
     @defer.inlineCallbacks
     def test_2workers_insubstantiated_after_one_start_failure(self):
-        machine_controller, worker_controllers, step_controllers, \
-            master, builder_ids = yield self.create_two_worker_config()
+        machine_controller, worker_controllers, step_controllers, builder_ids = \
+            yield self.create_two_worker_config()
 
         for wc in worker_controllers:
             wc.auto_connect_worker = False
             wc.auto_start(True)
             wc.auto_stop(True)
 
-        yield self.createBuildrequest(master, [builder_ids[0]])
+        yield self.createBuildrequest(self.master, [builder_ids[0]])
 
         machine_controller.start_machine(False)
         self.assertEqual(machine_controller.machine.state,

--- a/master/buildbot/test/integration/test_worker_latent.py
+++ b/master/buildbot/test/integration/test_worker_latent.py
@@ -286,7 +286,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         self.assertEqual(controller.starting, False)
 
         # advance the time to the point where we should retry
-        master.reactor.advance(controller.worker.quarantine_initial_timeout)
+        self.reactor.advance(controller.worker.quarantine_initial_timeout)
 
         # If the worker started again after the failure, then the retry logic will have
         # already kicked in to start a new build on this (the only) worker. We check that
@@ -303,10 +303,10 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
         yield self.assertBuildResults(1, RETRY)
 
         # advance the time to the point where we should not retry
-        master.reactor.advance(controller.worker.quarantine_initial_timeout)
+        self.reactor.advance(controller.worker.quarantine_initial_timeout)
         self.assertEqual(controller.starting, False)
         # advance the time to the point where we should retry
-        master.reactor.advance(controller.worker.quarantine_initial_timeout)
+        self.reactor.advance(controller.worker.quarantine_initial_timeout)
         self.assertEqual(controller.starting, True)
 
         controller.auto_start(True)
@@ -574,7 +574,7 @@ class Latent(TimeoutableTestCase, RunFakeMasterTestCase):
             ('buildrequests', None, 'unclaimed'))
 
         # We never start the worker, rather timeout it.
-        master.reactor.advance(controller.worker.missing_timeout)
+        self.reactor.advance(controller.worker.missing_timeout)
         # Flush the errors logged by the failure.
         self.flushLoggedErrors(defer.TimeoutError)
 

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -132,9 +132,9 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin,
         self.assertEqual(got_logs, exp_logs)
 
     @defer.inlineCallbacks
-    def createBuildrequest(self, master, builder_ids, properties=None):
+    def create_build_request(self, builder_ids, properties=None):
         properties = properties.asDict() if properties is not None else None
-        ret = yield master.data.updates.addBuildset(
+        ret = yield self.master.data.updates.addBuildset(
             waited_for=False,
             builderids=builder_ids,
             sourcestamps=[

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -95,9 +95,8 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin,
         self.assertFalse(self.master.running, "master is still running!")
 
     @defer.inlineCallbacks
-    def getMaster(self, config_dict):
+    def setup_master(self, config_dict):
         self.master = yield getMaster(self, self.reactor, config_dict)
-        return self.master
 
     @defer.inlineCallbacks
     def reconfigMaster(self, config_dict):

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -99,8 +99,9 @@ class RunFakeMasterTestCase(unittest.TestCase, TestReactorMixin,
         self.master = yield getMaster(self, self.reactor, config_dict)
 
     @defer.inlineCallbacks
-    def reconfigMaster(self, config_dict):
-        self.master.config_loader.config_dict = config_dict
+    def reconfig_master(self, config_dict=None):
+        if config_dict is not None:
+            self.master.config_loader.config_dict = config_dict
         yield self.master.doReconfig()
 
     def createLocalWorker(self, name, **kwargs):


### PR DESCRIPTION
Currently the tested master instance is available through both `self.master` and `master` variable passed throughout functions. This PR cleans this up and uses only `self.master` for the master.