### PR TITLE
Drop python 3.5 support on master

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -32,9 +32,9 @@ env:
 
   - TWISTED=17.9.0 SQLALCHEMY=latest TESTS=trial
 
+  - TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.8
   - TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.7
   - TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.6
-  - TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=3.5
 
   # Configuration when SQLite database is persistent between running tests
   # (by default in other tests in-memory SQLite database is used which is

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
   matrix:
     # For Python versions available on AppVeyor, see
     # http://www.appveyor.com/docs/installed-software#python
-    - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"

--- a/master/buildbot/newsfragments/python35-support.removal
+++ b/master/buildbot/newsfragments/python35-support.removal
@@ -1,0 +1,1 @@
+Python 3.5 is no longer supported for running Buildbot master.

--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -127,37 +127,9 @@ def launch(config):
             pidfile.write("{0}".format(proc.pid))
 
 
-def py2Warning(config):
-    if sys.version[0] == '2' and not config['quiet']:
-        print(textwrap.dedent("""\
-        WARNING: You are running Buildbot with Python 2.7.x !
-        -----------------------------------------------------
-
-        Python 2 is going unmaintained as soon as 2020: https://pythonclock.org/
-
-        To prepare for that transition, we recommend upgrading your buildmaster to run on
-        Python 3.6 now! Buildbot open source project is as well deprecating running buildmaster
-        on Python 2 for better maintainability.
-
-        Buildbot 2.0 going to be released in February 2019 will remove support for Python < 3.5
-        https://github.com/buildbot/buildbot/issues/4439
-
-        On most installations, switching to Python 3 can be accomplished by running the 2to3 tool
-        over the master.cfg file.
-
-        https://docs.python.org/3.7/library/2to3.html
-
-        Note that the above applies only for the buildmaster.
-        Workers will still support running under Python 2.7.
-        Additionally, the buildmaster still supports workers using old versions of Buildbot.
-        """))
-
-
 def start(config):
     if not base.isBuildmasterDir(config['basedir']):
         return 1
-
-    py2Warning(config)
 
     if config['nodaemon']:
         launchNoDaemon(config)

--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -16,7 +16,6 @@
 
 import os
 import sys
-import textwrap
 
 from twisted.internet import protocol
 from twisted.internet import reactor

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -108,7 +108,7 @@ warnings.filterwarnings('ignore', r".*Use 'list\(elem\)' or iteration over elem 
 if sys.version_info[0] >= 3 and "pg8000" in os.getenv("BUILDBOT_TEST_DB_URL", ""):
     warnings.filterwarnings('ignore', ".*unclosed .*socket", ResourceWarning)
 
-# Python 3.5 on CircleCI shows this warning
+# Python 3.5-3.8 shows this warning
 warnings.filterwarnings('ignore', ".*the imp module is deprecated in favour of importlib*")
 
 # sqlalchemy-migrate uses deprecated api from sqlalchemy https://review.openstack.org/#/c/648072/

--- a/master/docs/manual/installation/requirements.rst
+++ b/master/docs/manual/installation/requirements.rst
@@ -12,7 +12,7 @@ At a bare minimum, you'll need the following for both the buildmaster and a work
 
 Python: https://www.python.org
 
-  Buildbot master works with Python-3.5+.
+  Buildbot master works with Python-3.6+.
   Buildbot worker works with Python 2.7, or Python 3.5+.
 
   .. note::

--- a/master/setup.py
+++ b/master/setup.py
@@ -150,7 +150,9 @@ setup_args = {
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
     'packages': [

--- a/master/setup.py
+++ b/master/setup.py
@@ -150,7 +150,6 @@ setup_args = {
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6'
     ],
 
@@ -447,10 +446,10 @@ setup_args = {
 if sys.platform == "win32":
     setup_args['zip_safe'] = False
 
-py_35 = sys.version_info[0] > 3 or (
-    sys.version_info[0] == 3 and sys.version_info[1] >= 5)
-if not py_35:
-    raise RuntimeError("Buildbot master requires at least Python-3.5")
+py_36 = sys.version_info[0] > 3 or (
+    sys.version_info[0] == 3 and sys.version_info[1] >= 6)
+if not py_36:
+    raise RuntimeError("Buildbot master requires at least Python-3.6")
 
 # pip<1.4 doesn't have the --pre flag, and will thus attempt to install alpha
 # and beta versions of Buildbot.  Prevent that from happening.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -9,18 +9,14 @@ Babel==2.9.0
 backports.functools-lru-cache==1.6.1
 blockdiag==2.0.1
 boto==2.49.0
-boto3==1.16.40;  python_version >= "3.6"
-boto3==1.15.11;  python_version < "3.6"  # pyup: ignore
-botocore==1.19.40;  python_version >= "3.6"
-botocore==1.18.11;  python_version < "3.6"  # pyup: ignore
+boto3==1.16.40
+botocore==1.19.40
 cffi==1.14.4
 click==7.1.2
-# pin configparser, because 5.x no longer supports Python 3.5
-configparser==4.0.2  # pyup: ignore
+configparser==4.0.2
 constantly==15.1.0
 cookies==2.2.1
-cryptography==3.3.1; python_version >= "3.6"
-cryptography==3.2; python_version < "3.6"  # pyup: ignore
+cryptography==3.3.1
 decorator==4.4.2
 dicttoxml==1.7.4
 docutils==0.16
@@ -41,8 +37,7 @@ lz4==3.1.1
 markdown2==2.3.10
 MarkupSafe==1.1.1
 mccabe==0.6.1
-# pin mock, because 4.x no longer supports Python 3.5
-mock==3.0.5   # pyup: ignore
+mock==3.0.5
 moto==1.3.16
 olefile==0.46
 packaging==20.8
@@ -50,8 +45,7 @@ parameterized==0.7.4
 pathlib2==2.3.5
 pbr==5.5.1
 pep8==1.7.1
-Pillow==8.0.1;  python_version >= "3.6"
-Pillow==7.2;  python_version < "3.6"  # pyup: ignore
+Pillow==8.0.1
 pyaml==20.4.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
@@ -85,8 +79,7 @@ toml==0.10.2
 towncrier==19.2.0
 treq==20.9.0
 Twisted==20.3.0
-txaio==20.12.1;  python_version >= "3.6"
-txaio==20.4.1;  python_version < "3.6"  # pyup: ignore
+txaio==20.12.1
 txrequests==0.9.6
 webcolors==1.11.1
 Werkzeug==1.0.1

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -81,6 +81,8 @@ setup_args = {
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
     'packages': [


### PR DESCRIPTION
Python 3.5 is no longer maintained so spending time for testing it is not worthwhile. If users are able to upgrade Buildbot then upgrading to newer Python version is not a huge additional requirement.