### PR TITLE
master,docker: apply shellcheck to start script

### DIFF
--- a/master/docker/start_buildbot.sh
+++ b/master/docker/start_buildbot.sh
@@ -4,55 +4,55 @@
 
 # we download the config from an arbitrary curl accessible tar.gz file (which github can generate for us)
 
-B=`pwd`
+B=$(pwd)
 
 if [ -z "$BUILDBOT_CONFIG_URL" ]
 then
     if [ ! -f "$B/master.cfg" ]
     then
-        echo No master.cfg found nor $$BUILDBOT_CONFIG_URL !
-        echo Please provide a master.cfg file in $B or provide a $$BUILDBOT_CONFIG_URL variable via -e
+        echo "No master.cfg found nor \$BUILDBOT_CONFIG_URL!"
+        echo "Please provide a master.cfg file in $B or provide a \$BUILDBOT_CONFIG_URL variable via -e"
         exit 1
     fi
 
 else
     BUILDBOT_CONFIG_DIR=${BUILDBOT_CONFIG_DIR:-config}
-    mkdir -p $B/$BUILDBOT_CONFIG_DIR
+    mkdir -p "$B/$BUILDBOT_CONFIG_DIR"
     # if it ends with .tar.gz then its a tarball, else its directly the file
     if echo "$BUILDBOT_CONFIG_URL" | grep '.tar.gz$' >/dev/null
     then
-        until curl -sL $BUILDBOT_CONFIG_URL | tar -xz --strip-components=1 --directory=$B/$BUILDBOT_CONFIG_DIR
+        until curl -sL "$BUILDBOT_CONFIG_URL" | tar -xz --strip-components=1 --directory="$B/$BUILDBOT_CONFIG_DIR"
         do
             echo "Can't download from \$BUILDBOT_CONFIG_URL: $BUILDBOT_CONFIG_URL"
             sleep 1
         done
 
-        ln -sf $B/$BUILDBOT_CONFIG_DIR/master.cfg $B/master.cfg
+        ln -sf "$B/$BUILDBOT_CONFIG_DIR/master.cfg" "$B/master.cfg"
 
-        if [ -f $B/$BUILDBOT_CONFIG_DIR/buildbot.tac ]
+        if [ -f "$B/$BUILDBOT_CONFIG_DIR/buildbot.tac" ]
         then
-            ln -sf $B/$BUILDBOT_CONFIG_DIR/buildbot.tac $B/buildbot.tac
+            ln -sf "$B/$BUILDBOT_CONFIG_DIR/buildbot.tac" "$B/buildbot.tac"
         fi
     else
-        until curl -sL $BUILDBOT_CONFIG_URL > $B/master.cfg
+        until curl -sL "$BUILDBOT_CONFIG_URL" > "$B/master.cfg"
         do
             echo "Can't download from $$BUILDBOT_CONFIG_URL: $BUILDBOT_CONFIG_URL"
         done
     fi
 fi
 # copy the default buildbot.tac if not provided by the config
-if [ ! -f $B/buildbot.tac ]
+if [ ! -f "$B/buildbot.tac" ]
 then
-    cp /usr/src/buildbot/docker/buildbot.tac $B
+    cp /usr/src/buildbot/docker/buildbot.tac "$B"
 fi
 # Fixed buildbot master not start error in docker
-rm -f $B/twistd.pid
+rm -f "$B/twistd.pid"
 # wait for db to start by trying to upgrade the master
-until buildbot upgrade-master $B
+until buildbot upgrade-master "$B"
 do
     echo "Can't upgrade master yet. Waiting for database ready?"
     sleep 1
 done
 
 # we use exec so that twistd use the pid 1 of the container, and so that signals are properly forwarded
-exec twistd -ny $B/buildbot.tac
+exec twistd -ny "$B/buildbot.tac"


### PR DESCRIPTION
The script used to start the container contains some common shell flaws
which were detected via shellcheck and fixed.

Signed-off-by: Paul Spooren <mail@aparcar.org>

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation

**None of the points above seem to apply**