### PR TITLE
Allow secrets in token of GitHubPullrequestPoller

### DIFF
--- a/master/buildbot/changes/github.py
+++ b/master/buildbot/changes/github.py
@@ -106,6 +106,7 @@ class GitHubPullrequestPoller(base.ReconfigurablePollingChangeSource,
 
         http_headers = {'User-Agent': 'Buildbot'}
         if token is not None:
+            token = yield self.renderSecrets(token)
             http_headers.update({'Authorization': 'token ' + token})
 
         self._http = yield httpclientservice.HTTPClientService.getService(

--- a/master/buildbot/newsfragments/githubpullrequestpoller-secrets.bugfix
+++ b/master/buildbot/newsfragments/githubpullrequestpoller-secrets.bugfix
@@ -1,0 +1,1 @@
+``GitHubPullrequestPoller`` now supports secrets in its ``token`` argument (:issue:`4921`)


### PR DESCRIPTION
What it says in the title. I haven't updated the unit tests because I'm not very familiar with the codebase yet. I have some time to try on my own, but would appreciate any pointers.

Fixes #4921

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
