### PR TITLE
Improve AvatarGithub to handle emails

### DIFF
--- a/master/buildbot/newsfragments/avatar-cache-size.bugfix
+++ b/master/buildbot/newsfragments/avatar-cache-size.bugfix
@@ -1,0 +1,1 @@
+Avatar caching is now working properly and size argument is now correctly handled

--- a/master/buildbot/newsfragments/avatar-github-enhancement.feature
+++ b/master/buildbot/newsfragments/avatar-github-enhancement.feature
@@ -1,0 +1,1 @@
+AvatarGitHub class has been enhanced to handle avatar based on email requests and take size argument into account

--- a/master/buildbot/test/unit/www/test_avatar.py
+++ b/master/buildbot/test/unit/www/test_avatar.py
@@ -16,6 +16,7 @@
 from twisted.internet import defer
 from twisted.trial import unittest
 
+from buildbot.test.fake import httpclientservice as fakehttpclientservice
 from buildbot.test.util import www
 from buildbot.test.util.misc import TestReactorMixin
 from buildbot.www import auth
@@ -55,16 +56,6 @@ class AvatarResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         res = yield self.render_resource(rsrc, b'/?email=foo')
         self.assertEqual(res, dict(redirected=b'//www.gravatar.com/avatar/acbd18db4cc2f85ce'
                                    b'def654fccc4a4d8?d=retro&s=32'))
-
-    @defer.inlineCallbacks
-    def test_github(self):
-        master = self.make_master(
-            url='http://a/b/', auth=auth.NoAuth(), avatar_methods=[avatar.AvatarGitHub()])
-        rsrc = avatar.AvatarResource(master)
-        rsrc.reconfigResource(master.config)
-
-        res = yield self.render_resource(rsrc, b'/?username=warner')
-        self.assertEqual(res, dict(redirected=b'https://avatars.githubusercontent.com/warner'))
 
     @defer.inlineCallbacks
     def test_avatar_call(self):
@@ -112,3 +103,398 @@ class AvatarResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
         res = yield self.render_resource(rsrc, b'/?email=foo')
         self.assertEqual(res, dict(redirected=b'//www.gravatar.com/avatar/acbd18db4cc2f85ce'
                          b'def654fccc4a4d8?d=retro&s=32'))
+
+
+github_username_search_reply = {
+    "login": "defunkt",
+    "id": 42424242,
+    "node_id": "MDQ6VXNlcjQyNDI0MjQy",
+    "avatar_url": "https://avatars3.githubusercontent.com/u/42424242?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/defunkt",
+    "html_url": "https://github.com/defunkt",
+    "followers_url": "https://api.github.com/users/defunkt/followers",
+    "following_url": "https://api.github.com/users/defunkt/following{/other_user}",
+    "gists_url": "https://api.github.com/users/defunkt/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/defunkt/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/defunkt/subscriptions",
+    "organizations_url": "https://api.github.com/users/defunkt/orgs",
+    "repos_url": "https://api.github.com/users/defunkt/repos",
+    "events_url": "https://api.github.com/users/defunkt/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/defunkt/received_events",
+    "type": "User",
+    "site_admin": False,
+    "name": "Defunkt User",
+    "company": None,
+    "blog": "",
+    "location": None,
+    "email": None,
+    "hireable": None,
+    "bio": None,
+    "twitter_username": None,
+    "public_repos": 1,
+    "public_gists": 1,
+    "followers": 1,
+    "following": 1,
+    "created_at": "2000-01-01T00:00:00Z",
+    "updated_at": "2021-01-01T00:00:00Z"
+}
+
+github_username_not_found_reply = {
+    "message": "Not Found",
+    "documentation_url": "https://docs.github.com/rest/reference/users#get-a-user"
+}
+
+github_email_search_reply = {
+    "total_count": 1,
+    "incomplete_results": False,
+    "items": [
+        {
+            "login": "defunkt",
+            "id": 42424242,
+            "node_id": "MDQ6VXNlcjQyNDI0MjQy",
+            "avatar_url": "https://avatars3.githubusercontent.com/u/42424242?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/defunkt",
+            "html_url": "https://github.com/defunkt",
+            "followers_url": "https://api.github.com/users/defunkt/followers",
+            "following_url": "https://api.github.com/users/defunkt/following{/other_user}",
+            "gists_url": "https://api.github.com/users/defunkt/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/defunkt/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/defunkt/subscriptions",
+            "organizations_url": "https://api.github.com/users/defunkt/orgs",
+            "repos_url": "https://api.github.com/users/defunkt/repos",
+            "events_url": "https://api.github.com/users/defunkt/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/defunkt/received_events",
+            "type": "User",
+            "site_admin": False,
+            "score": 1.0
+        }
+    ]
+}
+
+github_email_search_not_found_reply = {
+    "total_count": 0,
+    "incomplete_results": False,
+    "items": [
+
+    ]
+}
+
+github_commit_search_reply = {
+    "total_count": 1,
+    "incomplete_results": False,
+    "items": [
+        {
+            "url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                   "commits/1111111111111111111111111111111111111111",
+            "sha": "1111111111111111111111111111111111111111",
+            "node_id":
+                "MDY6Q29tbWl0NDM0MzQzNDM6MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx",
+            "html_url": "https://github.com/defunkt-org/defunkt-repo/"
+                        "commit/1111111111111111111111111111111111111111",
+            "comments_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                            "commits/1111111111111111111111111111111111111111/comments",
+            "commit": {
+                "url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                       "git/commits/1111111111111111111111111111111111111111",
+                "author": {
+                    "date": "2021-01-01T01:01:01.000-01:00",
+                    "name": "Defunkt User",
+                    "email": "defunkt@defunkt.com"
+                },
+                "committer": {
+                    "date": "2021-01-01T01:01:01.000-01:00",
+                    "name": "Defunkt User",
+                    "email": "defunkt@defunkt.com"
+                },
+                "message": "defunkt message",
+                "tree": {
+                    "url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                           "git/trees/2222222222222222222222222222222222222222",
+                    "sha": "2222222222222222222222222222222222222222"
+                },
+                "comment_count": 0
+            },
+            "author": {
+                "login": "defunkt",
+                "id": 42424242,
+                "node_id": "MDQ6VXNlcjQyNDI0MjQy",
+                "avatar_url": "https://avatars3.githubusercontent.com/u/42424242?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/defunkt",
+                "html_url": "https://github.com/defunkt",
+                "followers_url": "https://api.github.com/users/defunkt/followers",
+                "following_url": "https://api.github.com/users/defunkt/following{/other_user}",
+                "gists_url": "https://api.github.com/users/defunkt/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/defunkt/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/defunkt/subscriptions",
+                "organizations_url": "https://api.github.com/users/defunkt/orgs",
+                "repos_url": "https://api.github.com/users/defunkt/repos",
+                "events_url": "https://api.github.com/users/defunkt/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/defunkt/received_events",
+                "type": "User",
+                "site_admin": False
+            },
+            "committer": {
+                "login": "defunkt",
+                "id": 42424242,
+                "node_id": "MDQ6VXNlcjQyNDI0MjQy",
+                "avatar_url": "https://avatars3.githubusercontent.com/u/42424242?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/defunkt",
+                "html_url": "https://github.com/defunkt",
+                "followers_url": "https://api.github.com/users/defunkt/followers",
+                "following_url": "https://api.github.com/users/defunkt/following{/other_user}",
+                "gists_url": "https://api.github.com/users/defunkt/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/defunkt/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/defunkt/subscriptions",
+                "organizations_url": "https://api.github.com/users/defunkt/orgs",
+                "repos_url": "https://api.github.com/users/defunkt/repos",
+                "events_url": "https://api.github.com/users/defunkt/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/defunkt/received_events",
+                "type": "User",
+                "site_admin": False
+            },
+            "parents": [
+                {
+                    "url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                           "commits/3333333333333333333333333333333333333333",
+                    "html_url": "https://github.com/defunkt-org/defunkt-repo/"
+                                "commit/3333333333333333333333333333333333333333",
+                    "sha": "3333333333333333333333333333333333333333"
+                }
+            ],
+            "repository": {
+                "id": 43434343,
+                "node_id": "MDEwOlJlcG9zaXRvcnk0MzQzNDM0Mw==",
+                "name": "defunkt-repo",
+                "full_name": "defunkt-org/defunkt-repo",
+                "private": False,
+                "owner": {
+                    "login": "defunkt-org",
+                    "id": 44444444,
+                    "node_id": "MDEyOk9yZ2FuaXphdGlvbjQ0NDQ0NDQ0",
+                    "avatar_url": "https://avatars2.githubusercontent.com/u/44444444?v=4",
+                    "gravatar_id": "",
+                    "url": "https://api.github.com/users/defunkt-org",
+                    "html_url": "https://github.com/defunkt-org",
+                    "followers_url": "https://api.github.com/users/defunkt-org/followers",
+                    "following_url": "https://api.github.com/users/defunkt-org/"
+                                     "following{/other_user}",
+                    "gists_url": "https://api.github.com/users/defunkt-org/gists{/gist_id}",
+                    "starred_url": "https://api.github.com/users/defunkt-org/"
+                                   "starred{/owner}{/repo}",
+                    "subscriptions_url": "https://api.github.com/users/defunkt-org/subscriptions",
+                    "organizations_url": "https://api.github.com/users/defunkt-org/orgs",
+                    "repos_url": "https://api.github.com/users/defunkt-org/repos",
+                    "events_url": "https://api.github.com/users/defunkt-org/events{/privacy}",
+                    "received_events_url": "https://api.github.com/users/defunkt-org/"
+                                           "received_events",
+                    "type": "Organization",
+                    "site_admin": False
+                },
+                "html_url": "https://github.com/defunkt-org/defunkt-repo",
+                "description": "defunkt project",
+                "fork": False,
+                "url": "https://api.github.com/repos/defunkt-org/defunkt-repo",
+                "forks_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/forks",
+                "keys_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/keys{/key_id}",
+                "collaborators_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                     "collaborators{/collaborator}",
+                "teams_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/teams",
+                "hooks_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/hooks",
+                "issue_events_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                    "issues/events{/number}",
+                "events_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/events",
+                "assignees_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                 "assignees{/user}",
+                "branches_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                "branches{/branch}",
+                "tags_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/tags",
+                "blobs_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                             "git/blobs{/sha}",
+                "git_tags_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                "git/tags{/sha}",
+                "git_refs_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                "git/refs{/sha}",
+                "trees_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                             "git/trees{/sha}",
+                "statuses_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                "statuses/{sha}",
+                "languages_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                 "languages",
+                "stargazers_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                  "stargazers",
+                "contributors_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                    "contributors",
+                "subscribers_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                   "subscribers",
+                "subscription_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                    "subscription",
+                "commits_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                               "commits{/sha}",
+                "git_commits_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                   "git/commits{/sha}",
+                "comments_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                "comments{/number}",
+                "issue_comment_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                     "issues/comments{/number}",
+                "contents_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                "contents/{+path}",
+                "compare_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                               "compare/{base}...{head}",
+                "merges_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/merges",
+                "archive_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                               "{archive_format}{/ref}",
+                "downloads_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                 "downloads",
+                "issues_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                              "issues{/number}",
+                "pulls_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                             "pulls{/number}",
+                "milestones_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                  "milestones{/number}",
+                "notifications_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                     "notifications{?since,all,participating}",
+                "labels_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                              "labels{/name}",
+                "releases_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                "releases{/id}",
+                "deployments_url": "https://api.github.com/repos/defunkt-org/defunkt-repo/"
+                                   "deployments"
+            },
+            "score": 1.0
+        }
+    ]
+}
+
+github_commit_search_not_found_reply = {
+    "total_count": 0,
+    "incomplete_results": False,
+    "items": [
+
+    ]
+}
+
+
+class GitHubAvatar(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setUpTestReactor()
+
+        master = self.make_master(
+            url='http://a/b/', auth=auth.NoAuth(),
+            avatar_methods=[avatar.AvatarGitHub(token="abcd")])
+
+        self.rsrc = avatar.AvatarResource(master)
+        self.rsrc.reconfigResource(master.config)
+
+        headers = {
+            'User-Agent': 'Buildbot',
+            'Authorization': 'token abcd',
+        }
+        self._http = yield fakehttpclientservice.HTTPClientService.getService(
+            master, self,
+            avatar.AvatarGitHub.DEFAULT_GITHUB_API_URL,
+            headers=headers,
+            debug=False, verify=False)
+        yield self.master.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.master.stopService()
+
+    @defer.inlineCallbacks
+    def test_username(self):
+        username_search_endpoint = '/users/defunkt'
+        self._http.expect('get', username_search_endpoint,
+            content_json=github_username_search_reply,
+            headers={'Accept': 'application/vnd.github.v3+json'})
+        res = yield self.render_resource(self.rsrc, b'/?username=defunkt')
+        self.assertEqual(res, dict(redirected=b'https://avatars3.githubusercontent.com/'
+            b'u/42424242?v=4&s=32'))
+
+    @defer.inlineCallbacks
+    def test_username_not_found(self):
+        username_search_endpoint = '/users/inexistent'
+        self._http.expect('get', username_search_endpoint, code=404,
+            content_json=github_username_not_found_reply,
+            headers={'Accept': 'application/vnd.github.v3+json'})
+        res = yield self.render_resource(self.rsrc, b'/?username=inexistent')
+        self.assertEqual(res, dict(redirected=b'img/nobody.png'))
+
+    @defer.inlineCallbacks
+    def test_username_error(self):
+        username_search_endpoint = '/users/error'
+        self._http.expect('get', username_search_endpoint, code=500,
+            headers={'Accept': 'application/vnd.github.v3+json'})
+        res = yield self.render_resource(self.rsrc, b'/?username=error')
+        self.assertEqual(res, dict(redirected=b'img/nobody.png'))
+
+    @defer.inlineCallbacks
+    def test_username_cached(self):
+        username_search_endpoint = '/users/defunkt'
+        self._http.expect('get', username_search_endpoint,
+            content_json=github_username_search_reply,
+            headers={'Accept': 'application/vnd.github.v3+json'})
+        res = yield self.render_resource(self.rsrc, b'/?username=defunkt')
+        self.assertEqual(res, dict(redirected=b'https://avatars3.githubusercontent.com/'
+            b'u/42424242?v=4&s=32'))
+        # Second request will give same result but without an HTTP request
+        res = yield self.render_resource(self.rsrc, b'/?username=defunkt')
+        self.assertEqual(res, dict(redirected=b'https://avatars3.githubusercontent.com/'
+            b'u/42424242?v=4&s=32'))
+
+    @defer.inlineCallbacks
+    def test_email(self):
+        email_search_endpoint = '/search/users?q=defunkt%40defunkt.com+in%3Aemail'
+        self._http.expect('get', email_search_endpoint, content_json=github_email_search_reply,
+            headers={'Accept': 'application/vnd.github.v3+json'})
+        res = yield self.render_resource(self.rsrc, b'/?email=defunkt@defunkt.com')
+        self.assertEqual(res, dict(redirected=b'https://avatars3.githubusercontent.com/'
+            b'u/42424242?v=4&s=32'))
+
+    @defer.inlineCallbacks
+    def test_email_commit(self):
+        email_search_endpoint = '/search/users?q=defunkt%40defunkt.com+in%3Aemail'
+        self._http.expect('get', email_search_endpoint,
+            content_json=github_email_search_not_found_reply,
+            headers={'Accept': 'application/vnd.github.v3+json'})
+        commit_search_endpoint = ('/search/commits?'
+            'per_page=1&q=author-email%3Adefunkt%40defunkt.com&sort=committer-date')
+        self._http.expect('get', commit_search_endpoint, content_json=github_commit_search_reply,
+            headers={'Accept': 'application/vnd.github.v3+json,'
+                'application/vnd.github.cloak-preview'})
+        res = yield self.render_resource(self.rsrc, b'/?email=defunkt@defunkt.com')
+        self.assertEqual(res, dict(redirected=b'https://avatars3.githubusercontent.com/'
+            b'u/42424242?v=4&s=32'))
+
+    @defer.inlineCallbacks
+    def test_email_not_found(self):
+        email_search_endpoint = '/search/users?q=notfound%40defunkt.com+in%3Aemail'
+        self._http.expect('get', email_search_endpoint,
+            content_json=github_email_search_not_found_reply,
+            headers={'Accept': 'application/vnd.github.v3+json'})
+        commit_search_endpoint = ('/search/commits?'
+            'per_page=1&q=author-email%3Anotfound%40defunkt.com&sort=committer-date')
+        self._http.expect('get', commit_search_endpoint,
+            content_json=github_commit_search_not_found_reply,
+            headers={'Accept': 'application/vnd.github.v3+json,'
+                'application/vnd.github.cloak-preview'})
+        res = yield self.render_resource(self.rsrc, b'/?email=notfound@defunkt.com')
+        self.assertEqual(res, dict(redirected=b'img/nobody.png'))
+
+    @defer.inlineCallbacks
+    def test_email_error(self):
+        email_search_endpoint = '/search/users?q=error%40defunkt.com+in%3Aemail'
+        self._http.expect('get', email_search_endpoint, code=500,
+            headers={'Accept': 'application/vnd.github.v3+json'})
+        commit_search_endpoint = ('/search/commits?'
+            'per_page=1&q=author-email%3Aerror%40defunkt.com&sort=committer-date')
+        self._http.expect('get', commit_search_endpoint, code=500,
+            headers={'Accept': 'application/vnd.github.v3+json,'
+                'application/vnd.github.cloak-preview'})
+        res = yield self.render_resource(self.rsrc, b'/?email=error@defunkt.com')
+        self.assertEqual(res, dict(redirected=b'img/nobody.png'))

--- a/master/buildbot/www/avatar.py
+++ b/master/buildbot/www/avatar.py
@@ -16,10 +16,14 @@
 import hashlib
 from urllib.parse import urlencode
 from urllib.parse import urljoin
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
 
 from twisted.internet import defer
+from twisted.python import log
 
 from buildbot.util import config
+from buildbot.util import httpclientservice
 from buildbot.util import unicode2bytes
 from buildbot.www import resource
 
@@ -34,11 +38,143 @@ class AvatarBase(config.ConfiguredMixin):
 class AvatarGitHub(AvatarBase):
     name = "github"
 
-    AVATAR_URL = 'https://avatars.githubusercontent.com/'
+    DEFAULT_GITHUB_API_URL = 'https://api.github.com'
 
+    def __init__(self,
+                 github_api_endpoint=None,
+                 token=None,
+                 debug=False,
+                 verify=False):
+        httpclientservice.HTTPClientService.checkAvailable(self.__class__.__name__)
+
+        self.github_api_endpoint = github_api_endpoint
+        if github_api_endpoint is None:
+            self.github_api_endpoint = self.DEFAULT_GITHUB_API_URL
+        self.token = token
+        self.debug = debug
+        self.verify = verify
+
+        self.master = None
+        self.client = None
+
+    @defer.inlineCallbacks
+    def _get_http_client(self):
+        if self.client is not None:
+            return self.client
+
+        headers = {
+            'User-Agent': 'Buildbot',
+        }
+        if self.token:
+            headers['Authorization'] = 'token ' + self.token
+
+        self.client = yield httpclientservice.HTTPClientService.getService(self.master,
+            self.github_api_endpoint, headers=headers,
+            debug=self.debug, verify=self.verify)
+
+        return self.client
+
+    @defer.inlineCallbacks
+    def _get_avatar_by_username(self, username):
+        headers = {
+            'Accept': 'application/vnd.github.v3+json',
+        }
+
+        url = '/users/{}'.format(username)
+        http = yield self._get_http_client()
+        res = yield http.get(url, headers=headers)
+        if res.code == 404:
+            # Not found
+            return None
+        if 200 <= res.code < 300:
+            data = yield res.json()
+            return data['avatar_url']
+
+        log.msg('Failed looking up user: response code {}'.format(res.code))
+        return None
+
+    @defer.inlineCallbacks
+    def _search_avatar_by_user_email(self, email):
+        headers = {
+            'Accept': 'application/vnd.github.v3+json',
+        }
+
+        query = '{} in:email'.format(email)
+        url = '/search/users?{}'.format(urlencode({
+            'q': query,
+        }))
+        http = yield self._get_http_client()
+        res = yield http.get(url, headers=headers)
+        if 200 <= res.code < 300:
+            data = yield res.json()
+            if data['total_count'] == 0:
+                # Not found
+                return None
+            return data['items'][0]['avatar_url']
+
+        log.msg('Failed searching user by email: response code {}'.format(res.code))
+        return None
+
+    @defer.inlineCallbacks
+    def _search_avatar_by_commit(self, email):
+        headers = {
+            'Accept': 'application/vnd.github.v3+json,application/vnd.github.cloak-preview',
+        }
+
+        query = {
+            'q': 'author-email:{}'.format(email),
+            'sort': 'committer-date',
+            'per_page': '1',
+        }
+        sorted_query = sorted(query.items(), key=lambda x: x[0])
+        url = '/search/commits?{}'.format(urlencode(sorted_query))
+        http = yield self._get_http_client()
+        res = yield http.get(url, headers=headers)
+        if 200 <= res.code < 300:
+            data = yield res.json()
+            if data['total_count'] == 0:
+                # Not found
+                return None
+            return data['items'][0]['author']['avatar_url']
+
+        log.msg('Failed searching user by commit: response code {}'.format(res.code))
+        return None
+
+    def _add_size_to_url(self, avatar, size):
+        parts = urlparse(avatar)
+        query = parts.query
+        if query:
+            query += '&'
+        query += 's={0}'.format(size)
+        return urlunparse((parts.scheme,
+            parts.netloc, parts.path, parts.params,
+            query, parts.fragment))
+
+    @defer.inlineCallbacks
     def getUserAvatar(self, email, username, size, defaultAvatarUrl):
-        github_url = self.AVATAR_URL + username.decode("utf-8")
-        raise resource.Redirect(github_url)
+        avatar = None
+        if username:
+            username = username.decode('utf-8')
+        if email:
+            email = email.decode('utf-8')
+
+        if username:
+            avatar = yield self._get_avatar_by_username(username)
+        if not avatar and email:
+            # Try searching a user with said mail
+            avatar = yield self._search_avatar_by_user_email(email)
+        if not avatar and email:
+            # No luck, try to find a commit with this email
+            avatar = yield self._search_avatar_by_commit(email)
+
+        if not avatar:
+            # No luck
+            return None
+
+        if size:
+            avatar = self._add_size_to_url(avatar, size)
+
+        raise resource.Redirect(avatar)
 
 
 class AvatarGravatar(AvatarBase):
@@ -74,6 +210,9 @@ class AvatarResource(resource.Resource):
         # ensure the avatarMethods is a iterable
         if isinstance(self.avatarMethods, AvatarBase):
             self.avatarMethods = (self.avatarMethods, )
+
+        for method in self.avatarMethods:
+            method.master = self.master
 
     def render_GET(self, request):
         return self.asyncRenderHelper(request, self.renderAvatar)

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -77,6 +77,17 @@ This server is configured with the ``www`` configuration key, which specifies a 
             'avatar_methods': [util.AvatarGitHub()]
         }
 
+    .. py:class:: AvatarGitHub(github_api_endpoint=None, token=None, debug=False, verify=False)
+
+        :param string github_api_endpoint: specify the github api endpoint if you work with GitHub Enterprise
+        :param string token: a GitHub API token to execute all requests to the API authenticated. It is strongly recommended to use a API token since it increases GitHub API rate limits significantly.
+        :param boolean debug: logs every requests and their response
+        :param boolean verify: disable ssl verification for the case you use temporary self signed certificates on a GitHub Enterprise installation
+
+        This class requires `txrequests`_ package to allow interaction with GitHub REST API.
+
+.. _txrequests: https://pypi.python.org/pypi/txrequests
+
     For use of corporate pictures, you can use LdapUserInfo, which can also acts as an avatar provider.
     See :ref:`Web-Authentication`.
 


### PR DESCRIPTION
This PR adds two fixes in avatar handling and enhance AvatarGitHub.
One fix is for cache which currently doesn't work and the other is for size handling which is broken when specified on URL.

AvatarGitHub gets email support. It queries GitHub REST API to find the correct avatar URL and doesn't try to build a URL from undocumented information.
For this, httpclientservice is used. It needs a BuildbotMaster object so it is added by AvatarResource on all AvatarBase object when configuring.
Fake httpclientservice didn't support headers in requests for testing. It's now checked from expect.
The size argument is now supported by appending s parameter to avatar URL. It doesn't seem documented but works.

AvatarGitHub documentation has been updated to add information on class constructor.

Migrating to GitHub GraphQL API may improve performance but it hasn't been tried.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
