### PR TITLE
2.10: md5 -> MD5 to handle python bug

### DIFF
--- a/master/buildbot/newsfragments/md5-workaround-5743.bugfix
+++ b/master/buildbot/newsfragments/md5-workaround-5743.bugfix
@@ -1,0 +1,1 @@
+Worked around a bug in Python's urllib which caused Python clients not to accept basic authentication headers (:issue:`5743`)

--- a/master/buildbot/www/auth.py
+++ b/master/buildbot/www/auth.py
@@ -164,7 +164,7 @@ class TwistedICredAuthBase(AuthBase):
 class HTPasswdAuth(TwistedICredAuthBase):
 
     def __init__(self, passwdFile, **kwargs):
-        super().__init__([DigestCredentialFactory(b"md5", b"buildbot"),
+        super().__init__([DigestCredentialFactory(b"MD5", b"buildbot"),
              BasicCredentialFactory(b"buildbot")],
             [FilePasswordDB(passwdFile)],
             **kwargs)
@@ -177,7 +177,7 @@ class UserPasswordAuth(TwistedICredAuthBase):
             users = {user: unicode2bytes(pw) for user, pw in users.items()}
         elif isinstance(users, list):
             users = [(user, unicode2bytes(pw)) for user, pw in users]
-        super().__init__([DigestCredentialFactory(b"md5", b"buildbot"),
+        super().__init__([DigestCredentialFactory(b"MD5", b"buildbot"),
              BasicCredentialFactory(b"buildbot")],
             [InMemoryUsernamePasswordDatabaseDontUse(**dict(users))],
             **kwargs)


### PR DESCRIPTION
This PR backports #5746 to 2.10.x.