### PR TITLE
Fix tour config file error in IRC setup.

### DIFF
--- a/master/buildbot/newsfragments/tour-irc-config.doc
+++ b/master/buildbot/newsfragments/tour-irc-config.doc
@@ -1,0 +1,1 @@
+Fix services config for IRC in tour.

--- a/master/docs/tutorial/tour.rst
+++ b/master/docs/tutorial/tour.rst
@@ -176,8 +176,8 @@ In this example we will use ``#buildbot-test``, so go join that channel.
 Edit :file:`master.cfg` and look for the *BUILDBOT SERVICES* section.
 At the end of that section add the lines::
 
-  c['services'].append(reporters.irc.IRC(host="irc.freenode.net", nick="bbtest",
-                                         channels=["#buildbot-test"]))
+  c['services'].append(reporters.IRC(host="irc.freenode.net", nick="bbtest",
+                                     channels=["#buildbot-test"]))
 
 Reconfigure the build master then do:
 


### PR DESCRIPTION
Fix for the following error in the quick tour's _Enabling the IRC Bot_ section:
```
(sandbox) debian ~/buildbot-test/master $ buildbot reconfig master
sending SIGHUP to process 22790
2021-01-20 13:51:10-0800 [-] beginning configuration update
2021-01-20 13:51:10-0800 [-] Loading configuration from '/home/doug/buildbot-test/master/master/master.cfg'
2021-01-20 13:51:10-0800 [-] error while parsing config file:
        Traceback (most recent call last):
          File "/home/doug/buildbot-test/master/sandbox/lib/python3.7/site-packages/twisted/python/threadpool.py", line 266, in <lambda>
            inContext.theWork = lambda: context.call(ctx, func, *args, **kw)
          File "/home/doug/buildbot-test/master/sandbox/lib/python3.7/site-packages/twisted/python/context.py", line 122, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/home/doug/buildbot-test/master/sandbox/lib/python3.7/site-packages/twisted/python/context.py", line 85, in callWithContext
            return func(*args,**kw)
          File "/home/doug/buildbot-test/master/sandbox/lib/python3.7/site-packages/buildbot/config.py", line 155, in loadConfig
            self.basedir, self.configFileName)
        --- <exception caught here> ---
          File "/home/doug/buildbot-test/master/sandbox/lib/python3.7/site-packages/buildbot/config.py", line 117, in loadConfigDict
            execfile(filename, localDict)
          File "/home/doug/buildbot-test/master/sandbox/lib/python3.7/site-packages/twisted/python/compat.py", line 247, in execfile
            exec(code, globals, locals)
          File "/home/doug/buildbot-test/master/master/master.cfg", line 82, in <module>
            ####### PROJECT IDENTITY
          File "/home/doug/buildbot-test/master/sandbox/lib/python3.7/site-packages/buildbot/plugins/db.py", line 271, in __getattr__
            raise AttributeError(str(e)) from e
        builtins.AttributeError: Unknown component name: irc

2021-01-20 13:51:10-0800 [-] error while parsing config file: Unknown component name: irc (traceback in logfile)
2021-01-20 13:51:10-0800 [-] reconfig aborted without making any changes
Reconfiguration failed. Please inspect the master.cfg file for errors, correct
them, then try 'buildbot reconfig' again.
```

## Contributor Checklist:

* [ ] (NOT APPLICABLE) I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
