### PR TITLE
Fix reference to tuplematch in base reporters

### DIFF
--- a/master/buildbot/newsfragments/basereporter-tuplematch.bugfix
+++ b/master/buildbot/newsfragments/basereporter-tuplematch.bugfix
@@ -1,0 +1,1 @@
+Fixed reference to ``tuplematch`` in the ``ReporterBase`` class (:issue:`5764`).

--- a/master/buildbot/reporters/base.py
+++ b/master/buildbot/reporters/base.py
@@ -19,9 +19,9 @@ from twisted.internet import defer
 from twisted.python import log
 
 from buildbot import config
-from buildbot import util
 from buildbot.reporters import utils
 from buildbot.util import service
+from buildbot.util import tuplematch
 
 ENCODING = 'utf-8'
 
@@ -75,7 +75,7 @@ class ReporterBase(service.BuildbotService):
 
     def _does_generator_want_key(self, generator, key):
         for filter in generator.wanted_event_keys:
-            if util.tuplematch.matchTuple(key, filter):
+            if tuplematch.matchTuple(key, filter):
                 return True
         return False
 


### PR DESCRIPTION
The tuplematch object was not referenced in the ReporterBase class when referenced from the GitHubStatusPush class.

It seems this is not an issue when it is executed from the test but only occures when called from GitHubStatusPush. I don't know how I can test this.

Fixes #5765 


## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
