### PR TITLE
master/www: Optionally enable WS pings to avoid disconnects

### DIFF
--- a/master/buildbot/newsfragments/ws-ping-interval.feature
+++ b/master/buildbot/newsfragments/ws-ping-interval.feature
@@ -1,0 +1,1 @@
+A new ``www.ws_ping_interval`` configuration option was added to avoid websocket timeouts when using reverse proxies and CDNs. Fixes :issue:`4078`

--- a/master/buildbot/www/ws.py
+++ b/master/buildbot/www/ws.py
@@ -135,7 +135,8 @@ class WsProtocolFactory(WebSocketServerFactory):
     def __init__(self, master):
         super().__init__()
         self.master = master
-        self.setProtocolOptions(webStatus=False)
+        pingInterval = self.master.config.www.get('ws_ping_interval', 0)
+        self.setProtocolOptions(webStatus=False, autoPingInterval=pingInterval)
 
     def buildProtocol(self, addr):
         p = WsProtocol(self.master)

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -184,6 +184,14 @@ This server is configured with the ``www`` configuration key, which specifies a 
             'Workers.showWorkerBuilders': True,
         }
 
+``ws_ping_interval``
+
+    Send websocket pings every ``ws_ping_interval`` seconds.
+    This is useful to avoid websocket timeouts when using reverse proxies or CDNs.
+    If the value is 0, pings are disabled.
+
+    The default is 0.
+
 .. note::
 
     The :bb:cfg:`buildbotURL` configuration value gives the base URL that all masters will use to generate links.


### PR DESCRIPTION
This adds a configuration option for the websocket ping interval.

Pings are useful to keep the connection alive and avoid disconnects
when going through reverse web proxies. By default, nginx closes
websocket connections after 60 seconds of inactivity and CloudFlare
enforces a 100 second timeout for non-enterprise users.

Considering the web UI reloads everything when the websocket connection
is lost, adding this option would improve usability as it prevents
full page reloads from occurring every minute.

The option defaults to 0 (no ping) to match the existing behavior.

Fixes #4078.

## Contributor Checklist:

* [x] I have updated the unit tests *(not applicable)*
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
