### PR TITLE
2.10: Use username when email is empty in REST API

### DIFF
--- a/master/buildbot/newsfragments/handle-empty-email.bugfix
+++ b/master/buildbot/newsfragments/handle-empty-email.bugfix
@@ -1,0 +1,1 @@
+If logged in user has an empty email, use its username instead or its full name ultimately

--- a/master/buildbot/test/unit/www/test_rest.py
+++ b/master/buildbot/test/unit/www/test_rest.py
@@ -897,6 +897,72 @@ class V2RootResource_JSONRPC2(TestReactorMixin, www.WwwTestMixin,
             jsonrpccode=JSONRPC_CODES['invalid_request'],
             responseCode=403)
 
+    @defer.inlineCallbacks
+    def test_owner_without_email(self):
+        self.master.session.user_info = {
+            "username": "defunkt",
+            "full_name": "Defunkt user",
+        }
+
+        yield self.render_control_resource(self.rsrc, b'/test/13',
+                                           action="testy")
+        self.assertRequest(
+            contentJson={
+                'id': self.UUID,
+                'jsonrpc': '2.0',
+                'result': {
+                    'action': 'testy',
+                    'args': {'owner': 'defunkt'},
+                    'kwargs': {'testid': 13},
+                },
+            },
+            contentType=b'application/json',
+            responseCode=200)
+
+    @defer.inlineCallbacks
+    def test_owner_with_only_full_name(self):
+        self.master.session.user_info = {
+            "full_name": "Defunkt user",
+        }
+
+        yield self.render_control_resource(self.rsrc, b'/test/13',
+                                           action="testy")
+        self.assertRequest(
+            contentJson={
+                'id': self.UUID,
+                'jsonrpc': '2.0',
+                'result': {
+                    'action': 'testy',
+                    'args': {'owner': 'Defunkt user'},
+                    'kwargs': {'testid': 13},
+                },
+            },
+            contentType=b'application/json',
+            responseCode=200)
+
+    @defer.inlineCallbacks
+    def test_owner_with_email(self):
+        self.master.session.user_info = {
+            "email": "defunkt@example.org",
+            "username": "defunkt",
+            "full_name": "Defunkt user",
+        }
+
+        yield self.render_control_resource(self.rsrc, b'/test/13',
+                                           action="testy")
+        self.assertRequest(
+            contentJson={
+                'id': self.UUID,
+                'jsonrpc': '2.0',
+                'result': {
+                    'action': 'testy',
+                    'args': {'owner': 'defunkt@example.org'},
+                    'kwargs': {'testid': 13},
+                },
+            },
+            contentType=b'application/json',
+            responseCode=200)
+
 
 class ContentTypeParser(unittest.TestCase):
 

--- a/master/buildbot/www/rest.py
+++ b/master/buildbot/www/rest.py
@@ -231,7 +231,10 @@ class V2RootResource(resource.Resource):
             if 'anonymous' in userinfos and userinfos['anonymous']:
                 owner = "anonymous"
             else:
-                owner = userinfos['email']
+                for field in ('email', 'username', 'full_name'):
+                    owner = userinfos.get(field, None)
+                    if owner:
+                        break
             params['owner'] = owner
 
             result = yield ep.control(method, params, kwargs)


### PR DESCRIPTION
This PR backports #5756 to 2.10.