### PR TITLE
2.10: reporters: Fix crash in BuildStartEndStatusGenerator when tags are used

### DIFF
--- a/master/buildbot/newsfragments/reporters-build-start-end-generator-tags.bugfix
+++ b/master/buildbot/newsfragments/reporters-build-start-end-generator-tags.bugfix
@@ -1,0 +1,1 @@
+Fixed crash in ``BuildStartEndStatusGenerator`` when tags filter is setup (:issue:`5766`).

--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -122,3 +122,6 @@ class BuildStartEndStatusGenerator(BuildStatusGeneratorMixin):
         report = yield self.build_message(formatter, master, reporter, build['builder']['name'],
                                           [build], build['results'])
         return report
+
+    def _matches_any_tag(self, tags):
+        return self.tags and any(tag for tag in self.tags if tag in tags)

--- a/master/buildbot/test/unit/reporters/test_generators_build.py
+++ b/master/buildbot/test/unit/reporters/test_generators_build.py
@@ -517,6 +517,24 @@ class TestBuildStartEndGenerator(ConfigErrorsMixin, TestReactorMixin,
         })
 
     @defer.inlineCallbacks
+    def test_is_message_needed_ignores_unspecified_tags(self):
+        build = yield self.insert_build_finished_get_props(SUCCESS)
+
+        # force tags
+        build['builder']['tags'] = ['tag']
+        g = BuildStartEndStatusGenerator(tags=['not_existing_tag'])
+        self.assertFalse(g.is_message_needed_by_props(build))
+
+    @defer.inlineCallbacks
+    def test_is_message_needed_tags(self):
+        build = yield self.insert_build_finished_get_props(SUCCESS)
+
+        # force tags
+        build['builder']['tags'] = ['tag']
+        g = BuildStartEndStatusGenerator(tags=['tag'])
+        self.assertTrue(g.is_message_needed_by_props(build))
+
+    @defer.inlineCallbacks
     def test_build_message_add_logs(self):
         g = yield self.setup_generator(add_logs=True)
         build = yield self.insert_build_finished_get_props(SUCCESS)


### PR DESCRIPTION
This PR backports #5771 to 2.10.