### PR TITLE
Fix deprecation messages for certain deprecated members of buildbot.process.buildstep

### DIFF
--- a/master/buildbot/newsfragments/old-buildstep-module-attributes.removal
+++ b/master/buildbot/newsfragments/old-buildstep-module-attributes.removal
@@ -1,0 +1,7 @@
+Added deprecation messages to the following members of ``buildbot.process.buildstep`` module that have been deprecated in Buildbot 0.8.9:
+ - ``RemoteCommand``
+ - ``LoggedRemoteCommand``
+ - ``RemoteShellCommand``
+ - ``LogObserver``
+ - ``LogLineObserver``
+ - ``OutputProgressObserver``

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -25,8 +25,10 @@ from twisted.python import failure
 from twisted.python import log
 from twisted.python import util as twutil
 from twisted.python import versions
+from twisted.python.deprecate import deprecatedModuleAttribute
 from twisted.python.failure import Failure
 from twisted.python.reflect import accumulateClassList
+from twisted.python.versions import Version
 from twisted.web.util import formatFailure
 from zope.interface import implementer
 
@@ -75,14 +77,52 @@ class CallableAttributeError(Exception):
 
 # old import paths for these classes
 RemoteCommand = remotecommand.RemoteCommand
+deprecatedModuleAttribute(
+    Version("buildbot", 2, 10, 1),
+    message="Use buildbot.process.remotecommand.RemoteCommand instead.",
+    moduleName="buildbot.process.buildstep",
+    name="RemoteCommand",
+)
+
 LoggedRemoteCommand = remotecommand.LoggedRemoteCommand
+deprecatedModuleAttribute(
+    Version("buildbot", 2, 10, 1),
+    message="Use buildbot.process.remotecommand.LoggedRemoteCommand instead.",
+    moduleName="buildbot.process.buildstep",
+    name="LoggedRemoteCommand",
+)
+
 RemoteShellCommand = remotecommand.RemoteShellCommand
+deprecatedModuleAttribute(
+    Version("buildbot", 2, 10, 1),
+    message="Use buildbot.process.remotecommand.RemoteShellCommand instead.",
+    moduleName="buildbot.process.buildstep",
+    name="RemoteShellCommand",
+)
+
 LogObserver = logobserver.LogObserver
+deprecatedModuleAttribute(
+    Version("buildbot", 2, 10, 1),
+    message="Use buildbot.process.logobserver.LogObserver instead.",
+    moduleName="buildbot.process.buildstep",
+    name="LogObserver",
+)
+
 LogLineObserver = logobserver.LogLineObserver
+deprecatedModuleAttribute(
+    Version("buildbot", 2, 10, 1),
+    message="Use buildbot.util.LogLineObserver instead.",
+    moduleName="buildbot.process.buildstep",
+    name="LogLineObserver",
+)
+
 OutputProgressObserver = logobserver.OutputProgressObserver
-_hush_pyflakes = [
-    RemoteCommand, LoggedRemoteCommand, RemoteShellCommand,
-    LogObserver, LogLineObserver, OutputProgressObserver]
+deprecatedModuleAttribute(
+    Version("buildbot", 2, 10, 1),
+    message="Use buildbot.process.logobserver.OutputProgressObserver instead.",
+    moduleName="buildbot.process.buildstep",
+    name="OutputProgressObserver",
+)
 
 
 @implementer(interfaces.IBuildStepFactory)

--- a/master/buildbot/steps/maxq.py
+++ b/master/buildbot/steps/maxq.py
@@ -18,11 +18,12 @@ from twisted.internet import defer
 
 from buildbot import config
 from buildbot.process import buildstep
+from buildbot.process import logobserver
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 
 
-class MaxQObserver(buildstep.LogLineObserver):
+class MaxQObserver(logobserver.LogLineObserver):
 
     def __init__(self):
         super().__init__()

--- a/master/buildbot/steps/package/deb/lintian.py
+++ b/master/buildbot/steps/package/deb/lintian.py
@@ -21,13 +21,14 @@ from twisted.internet import defer
 
 from buildbot import config
 from buildbot.process import buildstep
+from buildbot.process import logobserver
 from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.steps.package import util as pkgutil
 
 
-class MaxQObserver(buildstep.LogLineObserver):
+class MaxQObserver(logobserver.LogLineObserver):
 
     def __init__(self):
         super().__init__()

--- a/master/buildbot/steps/source/cvs.py
+++ b/master/buildbot/steps/source/cvs.py
@@ -309,9 +309,9 @@ class CVS(Source):
         # if there are sticky dates (from an earlier build with revision),
         # we can't update (unless we remove those tags with cvs update -A)
         myFileWriter.buffer = ""
-        cmd = buildstep.RemoteCommand('uploadFile',
-                                      uploadFileArgs('Entries'),
-                                      ignore_updates=True)
+        cmd = remotecommand.RemoteCommand('uploadFile',
+                                          uploadFileArgs('Entries'),
+                                          ignore_updates=True)
         yield self.runCommand(cmd)
         if cmd.rc is not None and cmd.rc != 0:
             return False

--- a/master/buildbot/steps/source/git.py
+++ b/master/buildbot/steps/source/git.py
@@ -20,6 +20,7 @@ from twisted.python import log
 from buildbot import config as bbconfig
 from buildbot.interfaces import WorkerSetupError
 from buildbot.process import buildstep
+from buildbot.process import remotecommand
 from buildbot.steps.source.base import Source
 from buildbot.steps.worker import CompositeStepMixin
 from buildbot.util.git import RC_SUCCESS
@@ -246,11 +247,11 @@ class Git(Source, GitStepMixin):
 
         try:
             yield self.mode_incremental()
-            cmd = buildstep.RemoteCommand('cpdir',
-                                          {'fromdir': self.srcdir,
-                                           'todir': old_workdir,
-                                           'logEnviron': self.logEnviron,
-                                           'timeout': self.timeout, })
+            cmd = remotecommand.RemoteCommand('cpdir',
+                                              {'fromdir': self.srcdir,
+                                               'todir': old_workdir,
+                                               'logEnviron': self.logEnviron,
+                                               'timeout': self.timeout, })
             cmd.useLog(self.stdio_log, False)
             yield self.runCommand(cmd)
             if cmd.didFail():
@@ -522,10 +523,10 @@ class Git(Source, GitStepMixin):
 
             return "clone"
 
-        cmd = buildstep.RemoteCommand('listdir',
-                                      {'dir': self.workdir,
-                                       'logEnviron': self.logEnviron,
-                                       'timeout': self.timeout, })
+        cmd = remotecommand.RemoteCommand('listdir',
+                                          {'dir': self.workdir,
+                                           'logEnviron': self.logEnviron,
+                                           'timeout': self.timeout, })
         cmd.useLog(self.stdio_log, False)
         yield self.runCommand(cmd)
 

--- a/master/buildbot/steps/source/mtn.py
+++ b/master/buildbot/steps/source/mtn.py
@@ -276,13 +276,13 @@ class Monotone(Source):
 
         if decodeRC is None:
             decodeRC = {0: SUCCESS}
-        cmd = buildstep.RemoteShellCommand(workdir, command,
-                                           env=self.env,
-                                           logEnviron=self.logEnviron,
-                                           timeout=self.timeout,
-                                           collectStdout=collectStdout,
-                                           initialStdin=initialStdin,
-                                           decodeRC=decodeRC)
+        cmd = remotecommand.RemoteShellCommand(workdir, command,
+                                               env=self.env,
+                                               logEnviron=self.logEnviron,
+                                               timeout=self.timeout,
+                                               collectStdout=collectStdout,
+                                               initialStdin=initialStdin,
+                                               decodeRC=decodeRC)
         cmd.useLog(self.stdio_log, False)
         yield self.runCommand(cmd)
 

--- a/master/buildbot/steps/source/p4.py
+++ b/master/buildbot/steps/source/p4.py
@@ -23,6 +23,7 @@ from buildbot import config
 from buildbot import interfaces
 from buildbot.interfaces import WorkerSetupError
 from buildbot.process import buildstep
+from buildbot.process import remotecommand
 from buildbot.process import results
 from buildbot.process.properties import Interpolate
 from buildbot.steps.source import Source
@@ -233,12 +234,12 @@ class P4(Source):
         if self.debug:
             log.msg("P4:_dovccmd():workdir->{}".format(self.workdir))
 
-        cmd = buildstep.RemoteShellCommand(self.workdir, command,
-                                           env=self.env,
-                                           logEnviron=self.logEnviron,
-                                           timeout=self.timeout,
-                                           collectStdout=collectStdout,
-                                           initialStdin=initialStdin,)
+        cmd = remotecommand.RemoteShellCommand(self.workdir, command,
+                                               env=self.env,
+                                               logEnviron=self.logEnviron,
+                                               timeout=self.timeout,
+                                               collectStdout=collectStdout,
+                                               initialStdin=initialStdin,)
         cmd.useLog(self.stdio_log, False)
         if self.debug:
             log.msg("Starting p4 command : p4 {}".format(" ".join(command)))
@@ -351,11 +352,11 @@ class P4(Source):
     def parseGotRevision(self):
         command = self._buildVCCommand(['changes', '-m1', '#have'])
 
-        cmd = buildstep.RemoteShellCommand(self.workdir, command,
-                                           env=self.env,
-                                           timeout=self.timeout,
-                                           logEnviron=self.logEnviron,
-                                           collectStdout=True)
+        cmd = remotecommand.RemoteShellCommand(self.workdir, command,
+                                               env=self.env,
+                                               timeout=self.timeout,
+                                               logEnviron=self.logEnviron,
+                                               collectStdout=True)
         cmd.useLog(self.stdio_log, False)
         yield self.runCommand(cmd)
 
@@ -389,9 +390,9 @@ class P4(Source):
 
     @defer.inlineCallbacks
     def checkP4(self):
-        cmd = buildstep.RemoteShellCommand(self.workdir, [self.p4bin, '-V'],
-                                           env=self.env,
-                                           logEnviron=self.logEnviron)
+        cmd = remotecommand.RemoteShellCommand(self.workdir, [self.p4bin, '-V'],
+                                               env=self.env,
+                                               logEnviron=self.logEnviron)
         cmd.useLog(self.stdio_log, False)
         yield self.runCommand(cmd)
         return cmd.rc == 0

--- a/master/buildbot/steps/source/repo.py
+++ b/master/buildbot/steps/source/repo.py
@@ -24,6 +24,7 @@ from zope.interface import implementer
 from buildbot import util
 from buildbot.interfaces import IRenderable
 from buildbot.process import buildstep
+from buildbot.process import remotecommand
 from buildbot.process import results
 from buildbot.steps.source.base import Source
 
@@ -211,10 +212,10 @@ class Repo(Source):
     def _Cmd(self, command, abandonOnFailure=True, workdir=None, **kwargs):
         if workdir is None:
             workdir = self.workdir
-        cmd = buildstep.RemoteShellCommand(workdir, command,
-                                           env=self.env,
-                                           logEnviron=self.logEnviron,
-                                           timeout=self.timeout, **kwargs)
+        cmd = remotecommand.RemoteShellCommand(workdir, command,
+                                               env=self.env,
+                                               logEnviron=self.logEnviron,
+                                               timeout=self.timeout, **kwargs)
         self.lastCommand = cmd
         # does not make sense to logEnviron for each command (just for first)
         self.logEnviron = False

--- a/master/buildbot/steps/vstudio.py
+++ b/master/buildbot/steps/vstudio.py
@@ -23,7 +23,7 @@ from twisted.internet import defer
 from buildbot import config
 from buildbot.process import buildstep
 from buildbot.process import results
-from buildbot.process.buildstep import LogLineObserver
+from buildbot.process.logobserver import LogLineObserver
 
 
 class MSLogLineObserver(LogLineObserver):

--- a/master/buildbot/test/integration/test_custom_buildstep.py
+++ b/master/buildbot/test/integration/test_custom_buildstep.py
@@ -31,7 +31,7 @@ from buildbot.test.util.warnings import assertProducesWarnings
 from buildbot.warnings import DeprecatedApiWarning
 
 
-class TestLogObserver(buildstep.LogObserver):
+class TestLogObserver(logobserver.LogObserver):
 
     def __init__(self):
         self.observed = []

--- a/master/buildbot/test/regressions/test_oldpaths.py
+++ b/master/buildbot/test/regressions/test_oldpaths.py
@@ -14,6 +14,8 @@
 # Copyright Buildbot Team Members
 
 
+import warnings
+
 from twisted.trial import unittest
 
 from buildbot.warnings import DeprecatedApiWarning
@@ -100,15 +102,21 @@ class OldImportPaths(unittest.TestCase):
         assert Source
 
     def test_buildstep_remotecommand(self):
-        from buildbot.process.buildstep import RemoteCommand, \
-            LoggedRemoteCommand, RemoteShellCommand
-        assert RemoteCommand
-        assert LoggedRemoteCommand
-        assert RemoteShellCommand
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecatedApiWarning)
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from buildbot.process.buildstep import RemoteCommand, \
+                LoggedRemoteCommand, RemoteShellCommand
+            assert RemoteCommand
+            assert LoggedRemoteCommand
+            assert RemoteShellCommand
 
     def test_buildstep_logobserver(self):
-        from buildbot.process.buildstep import LogObserver, \
-            LogLineObserver, OutputProgressObserver
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecatedApiWarning)
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from buildbot.process.buildstep import LogObserver, \
+                LogLineObserver, OutputProgressObserver
         assert LogObserver
         assert LogLineObserver
         assert OutputProgressObserver

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -139,9 +139,8 @@ class BuildStepMixin:
             self._next_remote_command_number += 1
             return cmd
 
-        for module in buildstep, real_remotecommand:
-            self.patch(module, 'RemoteCommand', create_fake_remote_command)
-            self.patch(module, 'RemoteShellCommand', create_fake_remote_shell_command)
+        self.patch(real_remotecommand, 'RemoteCommand', create_fake_remote_command)
+        self.patch(real_remotecommand, 'RemoteShellCommand', create_fake_remote_shell_command)
         self.expected_remote_commands = []
         self._expected_remote_commands_popped = 0
 

--- a/master/docs/manual/customization.rst
+++ b/master/docs/manual/customization.rst
@@ -1121,6 +1121,7 @@ If the path does not exist (or anything fails) we mark the step as failed; if th
 
 
     from buildbot.plugins import steps, util
+    from buildbot.process import remotecommand
     from buildbot.interfaces import WorkerSetupError
     import stat
 
@@ -1137,7 +1138,7 @@ If the path does not exist (or anything fails) we mark the step as failed; if th
             if not all(workerver):
                 raise WorkerSetupError('need stat and glob')
 
-            cmd = buildstep.RemoteCommand('stat', {'file': self.dirname})
+            cmd = remotecommand.RemoteCommand('stat', {'file': self.dirname})
 
             d = self.runCommand(cmd)
             d.addCallback(lambda res: self.evaluateStat(cmd))
@@ -1155,7 +1156,7 @@ If the path does not exist (or anything fails) we mark the step as failed; if th
                 self.finished(util.WARNINGS)
                 return
 
-            cmd = buildstep.RemoteCommand('glob', {'path': self.dirname + '/*.pyc'})
+            cmd = remotecommand.RemoteCommand('glob', {'path': self.dirname + '/*.pyc'})
 
             d = self.runCommand(cmd)
             d.addCallback(lambda res: self.evaluateGlob(cmd))


### PR DESCRIPTION
Certain members of buildbot.process.buildstep have been deprecated since 0.8.9, but had no deprecation messages. This PR deprecates them properly.