### PR TITLE
process: Fix latent worker renderable locks

### DIFF
--- a/master/buildbot/newsfragments/fix-latent-worker-renderable-locks.bugfix
+++ b/master/buildbot/newsfragments/fix-latent-worker-renderable-locks.bugfix
@@ -1,0 +1,1 @@
+Fixed crash when using renderable locks with latent workers that may have incompatible builds (:issue:`5757`).

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -263,7 +263,7 @@ class Builder(util_service.ReconfigurableServiceMixin,
         # don't unnecessarily setup properties for build
         def setupPropsIfNeeded(props):
             if props is not None:
-                return None
+                return props
             props = Properties()
             Build.setupPropertiesKnownBeforeBuildStarts(props, [buildrequest],
                                                         self, workerforbuilder)

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -363,6 +363,35 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
         self.assertFalse(startable)
 
     @defer.inlineCallbacks
+    def test_canStartBuild_with_renderable_locks_with_compatible_latent_worker(self):
+        yield self.makeBuilder()
+
+        self.bldr.botmaster.getLockFromLockAccesses = mock.Mock(return_value=[mock.Mock()])
+
+        rendered_locks = [False]
+
+        @renderer
+        def locks_renderer(props):
+            rendered_locks[0] = True
+            return [mock.Mock()]
+
+        self.bldr.config.locks = locks_renderer
+
+        wfb = mock.Mock()
+        wfb.worker = FakeLatentWorker(is_compatible_with_build=True)
+
+        with mock.patch(
+                'buildbot.process.build.Build._canAcquireLocks',
+                mock.Mock(return_value=False)):
+            with mock.patch(
+                    'buildbot.process.build.Build.setupPropertiesKnownBeforeBuildStarts',
+                    mock.Mock()):
+                startable = yield self.bldr.canStartBuild(wfb, 100)
+                self.assertEqual(startable, False)
+        self.assertFalse(startable)
+        self.assertTrue(rendered_locks[0])
+
+    @defer.inlineCallbacks
     def test_canStartBuild_enforceChosenWorker(self):
         """enforceChosenWorker rejects and accepts builds"""
         yield self.makeBuilder()

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -84,6 +84,22 @@ class FakeWorker:
         self.workername = workername
 
 
+class FakeLatentWorker(AbstractLatentWorker):
+    builds_may_be_incompatible = True
+
+    def __init__(self, is_compatible_with_build):
+        self.is_compatible_with_build = is_compatible_with_build
+
+    def isCompatibleWithBuild(self, build_props):
+        return defer.succeed(self.is_compatible_with_build)
+
+    def checkConfig(self, name, _, **kwargs):
+        pass
+
+    def reconfigService(self, name, _, **kwargs):
+        pass
+
+
 class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
 
     def setUp(self):
@@ -337,23 +353,8 @@ class TestBuilder(TestReactorMixin, BuilderMixin, unittest.TestCase):
     def test_canStartBuild_with_incompatible_latent_worker(self):
         yield self.makeBuilder()
 
-        class FakeLatentWorker(AbstractLatentWorker):
-            builds_may_be_incompatible = True
-
-            def __init__(self):
-                pass
-
-            def isCompatibleWithBuild(self, build_props):
-                return defer.succeed(False)
-
-            def checkConfig(self, name, _, **kwargs):
-                pass
-
-            def reconfigService(self, name, _, **kwargs):
-                pass
-
         wfb = mock.Mock()
-        wfb.worker = FakeLatentWorker()
+        wfb.worker = FakeLatentWorker(is_compatible_with_build=False)
 
         with mock.patch(
                 'buildbot.process.build.Build.setupPropertiesKnownBeforeBuildStarts',


### PR DESCRIPTION
Looks like the code path that checks whether a build can start was broken when using renderable locks with types of latent workers that may have incompatible builds due to different properties.

Fixes #5757.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
