### PR TITLE
www: Remove display of hidden steps in build summary tooltip

### DIFF
--- a/master/buildbot/newsfragments/buildsummary-tooltip-hidden-step.bugfix
+++ b/master/buildbot/newsfragments/buildsummary-tooltip-hidden-step.bugfix
@@ -1,0 +1,1 @@
+Remove display of hidden steps in the build summary tooltip.

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.js
@@ -137,6 +137,17 @@ class _buildsummary {
                 }
             };
 
+            this.assignDisplayedStepNumber = function (step) {
+                if (step.number === 0)
+                    this.display_count = 0
+                if (this.isStepDisplayed(step))
+                    step.display_num = (this.display_count)++;
+                return true;
+            };
+
+            this.getDisplayedStepCount = function () {
+                return self.steps.filter(this.isStepDisplayed).length;
+            };
 
             this.getBuildProperty = function (property) {
                 const hasProperty = self.properties && self.properties.hasOwnProperty(property);

--- a/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
+++ b/www/base/src/app/common/directives/buildsummary/buildsummary.directive.spec.js
@@ -68,4 +68,60 @@ describe('buildsummary controller', function() {
         expect(buildsummary.isStepDisplayed({results:results.FAILURE})).toBe(true);
         buildsummary.toggleDetails();
     });
+
+    it('should provide correct isStepDisplayed when details = EVERYTHING and when details = NONE', function() {
+        const element = $compile("<buildsummary buildid='buildid'></buildsummary>")($scope);
+        $scope.$apply();
+        const { buildsummary } = element.isolateScope();
+        // details = EVERYTHING
+        expect(buildsummary.isStepDisplayed({hidden: true})).toBe(false);
+        expect(buildsummary.isStepDisplayed({hidden: false})).toBe(true);
+        buildsummary.toggleDetails(); // set details = NONE
+        expect(buildsummary.isStepDisplayed({hidden: false, results:results.FAILURE})).toBe(false);
+    });
+
+    it('should provide correct getDisplayedStepCount', function() {
+        const element = $compile("<buildsummary buildid='buildid'></buildsummary>")($scope);
+        $scope.$apply();
+        const { buildsummary } = element.isolateScope();
+        buildsummary.steps = [{hidden: false}, {hidden: false}];
+        expect(buildsummary.getDisplayedStepCount()).toEqual(2);
+
+        buildsummary.steps = [{hidden: true}, {hidden: true}];
+        expect(buildsummary.getDisplayedStepCount()).toEqual(0);
+
+        buildsummary.steps = [{hidden: true}, {hidden: false}];
+        expect(buildsummary.getDisplayedStepCount()).toEqual(1);
+    });
+
+    it('assignDisplayedStepNumber should assign correct step display number', function() {
+        const element = $compile("<buildsummary buildid='buildid'></buildsummary>")($scope);
+        $scope.$apply();
+        const { buildsummary } = element.isolateScope();
+        var step;
+        step = {number: 0, hidden: true, display_num: null};
+        expect(buildsummary.assignDisplayedStepNumber(step)).toBe(true);
+        expect(step.display_num).toEqual(null);
+
+        step = {number: 1, hidden: false, display_num: null};
+        expect(buildsummary.assignDisplayedStepNumber(step)).toBe(true);
+        expect(step.display_num).toEqual(0);
+
+        step = {number: 2, hidden: false, display_num: null};
+        expect(buildsummary.assignDisplayedStepNumber(step)).toBe(true);
+        expect(step.display_num).toEqual(1);
+
+        step = {number: 3, hidden: false, display_num: null};
+        expect(buildsummary.assignDisplayedStepNumber(step)).toBe(true);
+        expect(step.display_num).toEqual(2);
+
+        // reset display_num to zero whenever step.number = 0
+        step = {number: 0, hidden: false, display_num: null};
+        expect(buildsummary.assignDisplayedStepNumber(step)).toBe(true);
+        expect(step.display_num).toEqual(0);
+
+        step = {number: 1, hidden: false, display_num: null};
+        expect(buildsummary.assignDisplayedStepNumber(step)).toBe(true);
+        expect(step.display_num).toEqual(1);
+    });
 });

--- a/www/base/src/app/common/directives/buildsummary/buildsummarytooltip.tpl.jade
+++ b/www/base/src/app/common/directives/buildsummary/buildsummarytooltip.tpl.jade
@@ -23,10 +23,11 @@
           | loading build details...
     ul.list-group
         li.list-group-item(ng-repeat="step in buildsummary.steps"
-                           ng-if="step.number <= 3 || step.number >= buildsummary.steps.length-3")
-            div.text-left(ng-if="buildsummary.steps.length > 7 && step.number === 3")
+                           ng-if="buildsummary.isStepDisplayed(step) && buildsummary.assignDisplayedStepNumber(step)" +
+                                 "&& (step.display_num <= 3 || step.display_num >= buildsummary.getDisplayedStepCount()-3)")
+            div.text-left(ng-if="buildsummary.getDisplayedStepCount() > 7 && step.display_num === 3")
                 span.fa-lg &vellip;
-            div.clearfix(ng-if="buildsummary.steps.length <= 7 || step.number !== 3")
+            div.clearfix(ng-if="buildsummary.getDisplayedStepCount() <= 7 || step.display_num !== 3")
                 span.pull-left
                     span.badge-status(ng-class="results2class(step, 'pulse')")
                         | {{step.number}}


### PR DESCRIPTION
www: Remove display of hidden steps in build summary tooltip

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
