### PR TITLE
Add support for addChange(..., src='fossil').

### DIFF
--- a/master/buildbot/newsfragments/fossil-users.feature
+++ b/master/buildbot/newsfragments/fossil-users.feature
@@ -1,0 +1,1 @@
+Added support for Fossil user objects for use by the buildbot-fossil plugin.

--- a/master/buildbot/process/users/users.py
+++ b/master/buildbot/process/users/users.py
@@ -25,7 +25,7 @@ from buildbot.util import bytes2unicode
 from buildbot.util import flatten
 from buildbot.util import unicode2bytes
 
-srcs = ['git', 'svn', 'hg', 'cvs', 'darcs', 'bzr']
+srcs = ['git', 'svn', 'hg', 'cvs', 'darcs', 'bzr', 'fossil']
 salt_len = 8
 
 

--- a/master/buildbot/process/users/users.py
+++ b/master/buildbot/process/users/users.py
@@ -25,6 +25,8 @@ from buildbot.util import bytes2unicode
 from buildbot.util import flatten
 from buildbot.util import unicode2bytes
 
+# TODO: fossil comes from a plugin. We should have an API that plugins could use to
+# register allowed user types.
 srcs = ['git', 'svn', 'hg', 'cvs', 'darcs', 'bzr', 'fossil']
 salt_len = 8
 


### PR DESCRIPTION
I just published a [buildbot-fossil](https://pypi.org/project/buildbot-fossil/) plugin on PyPI which enables Buildbot to be used with projects hosted in a [Fossil](https://fossil-scm.org/) repository.

Fossil uses usernames in the same style as Subversion. I ran into a problem when my Fossil change source calls `master.addChange()` with `src='fossil'`. No user object is created because `createUserObject()` doesn't know about Fossil users, and an error message is logged.

This PR crudely adds Fossil to the list of allowed user name sources. Do you have any suggestions for a better way of handling this problem in a third party plugin?
