### PR TITLE
misc: Improve poll method reaction to a request to stop

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -692,6 +692,7 @@ interruptable
 interruptsignal
 intialization
 intranet
+invariants
 io
 ip
 ippolito
@@ -815,6 +816,7 @@ lookahead
 lookup
 lookups
 loopback
+LoopingCall
 loseconnection
 lostremote
 lotem

--- a/master/buildbot/changes/base.py
+++ b/master/buildbot/changes/base.py
@@ -84,7 +84,7 @@ class ReconfigurablePollingChangeSource(ChangeSource):
         yield super().reconfigService(name=name)
 
         # pollInterval change is the only value which makes sense to reconfigure check.
-        if prevPollInterval != pollInterval and self.doPoll.started:
+        if prevPollInterval != pollInterval and self.doPoll.running:
             yield self.doPoll.stop()
             # As a implementation detail, poller will 'pollAtReconfigure' if poll interval changes
             # and pollAtLaunch=True

--- a/master/buildbot/newsfragments/misc-poll-method-stop-immediately.bugfix
+++ b/master/buildbot/newsfragments/misc-poll-method-stop-immediately.bugfix
@@ -1,0 +1,3 @@
+Improved ``buildbot.util.poll.method`` to react faster to a request to stop:
+ - New pending calls are no longer executed
+ - Calls whose interval but not random delay has already expired are no longer executed.

--- a/master/buildbot/test/unit/changes/test_base.py
+++ b/master/buildbot/test/unit/changes/test_base.py
@@ -96,7 +96,7 @@ class TestPollingChangeSource(changesource.ChangeSourceMixin,
 
     @defer.inlineCallbacks
     def runClockFor(self, _, secs):
-        yield self.reactor.pump([1.0] * secs)
+        yield self.reactor.pump([0] + [1.0] * secs)
 
     def test_loop_loops(self):
         # track when poll() gets called
@@ -203,7 +203,7 @@ class TestReconfigurablePollingChangeSource(changesource.ChangeSourceMixin,
 
     @defer.inlineCallbacks
     def runClockFor(self, secs):
-        yield self.reactor.pump([1.0] * secs)
+        yield self.reactor.pump([0] + [1.0] * secs)
 
     @defer.inlineCallbacks
     def test_config_negative_interval(self):

--- a/master/buildbot/test/unit/util/test_poll.py
+++ b/master/buildbot/test/unit/util/test_poll.py
@@ -13,6 +13,8 @@
 #
 # Copyright Buildbot Team Members
 
+from parameterized import parameterized
+
 import mock
 
 from twisted.internet import defer
@@ -27,7 +29,7 @@ class TestPollerSync(TestReactorMixin, unittest.TestCase):
     @poll.method
     def poll(self):
         self.calls += 1
-        if self.fail:
+        if self.fail_after_running:
             raise RuntimeError('oh noes')
 
     def setUp(self):
@@ -37,60 +39,59 @@ class TestPollerSync(TestReactorMixin, unittest.TestCase):
 
         poll.track_poll_methods()
         self.calls = 0
-        self.fail = False
+        self.fail_after_running = False
 
     def tearDown(self):
         poll.reset_poll_methods()
         self.assertEqual(self.reactor.getDelayedCalls(), [])
 
-    def test_not_started(self):
-        """If the poll method isn't started, nothing happens"""
+    def test_call_not_started_does_nothing(self):
         self.reactor.advance(100)
         self.assertEqual(self.calls, 0)
 
-    def test_call_when_stopped(self):
-        """Calling the poll method does nothing when stopped."""
+    def test_call_when_stopped_does_nothing(self):
         self.poll()
         self.assertEqual(self.calls, 0)
 
-    def test_call_when_started(self):
-        """Calling the poll method when started forces a run."""
+    @defer.inlineCallbacks
+    def test_call_when_started_forces_run(self):
         self.poll.start(interval=100, now=False)
         self.poll()
         self.reactor.advance(0)
         self.assertEqual(self.calls, 1)
-        return self.poll.stop()
+        yield self.poll.stop()
 
-    def test_run_now(self):
-        """If NOW is true, the poll runs immediately"""
+    @defer.inlineCallbacks
+    def test_start_with_now_forces_run_immediately(self):
         self.poll.start(interval=10, now=True)
+        self.reactor.advance(0)
         self.assertEqual(self.calls, 1)
-        return self.poll.stop()
+        yield self.poll.stop()
 
-    def test_no_run_now(self):
-        """If NOW is false, the poll does not run immediately"""
+    @defer.inlineCallbacks
+    def test_start_with_now_false_does_not_run(self):
         self.poll.start(interval=10, now=False)
         self.assertEqual(self.calls, 0)
-        return self.poll.stop()
+        yield self.poll.stop()
 
-    def test_stop_twice(self):
-        """Calling stop on a stopped poller does nothing"""
+    def test_stop_on_stopped_does_nothing(self):
         self.poll.start(interval=1)
         d = self.poll.stop()
         self.assertTrue(d.called)
         d = self.poll.stop()
         self.assertTrue(d.called)
 
-    def test_start_twice(self):
-        """Calling start on an already-started loop is an error."""
+    @defer.inlineCallbacks
+    def test_start_twice_error(self):
         self.poll.start(interval=1)
         with self.assertRaises(Exception):
             self.poll.start(interval=2)
-        return self.poll.stop()
+        yield self.poll.stop()
 
     def test_repeats_and_stops(self):
         """Polling repeats until stopped, and stop returns a Deferred"""
         self.poll.start(interval=10, now=True)
+        self.reactor.advance(0)
         while self.reactor.seconds() <= 200:
             self.assertEqual(self.calls, (self.reactor.seconds() // 10) + 1)
             self.reactor.advance(1)
@@ -102,50 +103,94 @@ class TestPollerSync(TestReactorMixin, unittest.TestCase):
         self.reactor.advance(10)
         self.assertEqual(self.calls, 21)
 
-    def test_fails(self):
-        """If the poll function fails, it is still called again, but
-        the exception is logged each time."""
-        self.fail = True
+    @defer.inlineCallbacks
+    def test_fail_reschedules_and_logs_exceptions(self):
+        self.fail_after_running = True
         self.poll.start(interval=1, now=True)
+        self.reactor.advance(0)
         self.assertEqual(self.calls, 1)
         self.reactor.advance(1)
         self.assertEqual(self.calls, 2)
         self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 2)
-        return self.poll.stop()
+        yield self.poll.stop()
 
-    def test_run_random_delay(self):
-        """Add a 5s delay before polling"""
-        random_delay_max = 5
+    @parameterized.expand([
+        ('shorter_than_interval_now_True', 5, True),
+        ('longer_than_interval_now_True', 15, True),
+        ('shorter_than_interval_now_False', 5, False),
+        ('longer_than_interval_now_False', 15, False),
+    ])
+    @defer.inlineCallbacks
+    def test_run_with_random_delay(self, name, random_delay_max, now):
+        interval = 10
+
         with mock.patch("buildbot.util.poll.randint", return_value=random_delay_max):
-            self.poll.start(interval=10, now=True, random_delay_max=random_delay_max)
+            self.poll.start(interval=interval, now=now, random_delay_max=random_delay_max)
+            self.reactor.advance(0)
+
+            if not now:
+                i = 0
+                while i < interval:
+                    self.assertEqual(self.calls, 0)
+                    self.reactor.advance(1)
+                    i += 1
+
             i = 0
             while i < random_delay_max:
                 self.assertEqual(self.calls, 0)
                 self.reactor.advance(1)
                 i += 1
             self.assertEqual(self.calls, 1)
-        return self.poll.stop()
+        yield self.poll.stop()
+
+    @parameterized.expand([
+        ('now_True', True),
+        ('now_False', False),
+    ])
+    @defer.inlineCallbacks
+    def test_run_with_random_delay_zero_interval_still_delays(self, name, now):
+        random_delay_max = 5
+        with mock.patch("buildbot.util.poll.randint", return_value=random_delay_max):
+            self.poll.start(interval=0, now=now, random_delay_max=random_delay_max)
+            self.reactor.advance(0)
+            self.assertEqual(self.calls, 0)
+
+            i = 0
+            while i < random_delay_max:
+                self.assertEqual(self.calls, 0)
+                self.reactor.advance(1)
+                i += 1
+            self.assertEqual(self.calls, 1)
+
+        yield self.poll.stop()
+
+    @defer.inlineCallbacks
+    def test_run_with_random_delay_stops_immediately_during_delay_phase(self):
+        random_delay_max = 5
+        with mock.patch("buildbot.util.poll.randint", return_value=random_delay_max):
+            self.poll.start(interval=10, now=True, random_delay_max=random_delay_max)
+            self.reactor.advance(1)
+            self.assertEqual(self.calls, 0)
+        yield self.poll.stop()
 
 
 class TestPollerAsync(TestReactorMixin, unittest.TestCase):
 
     @poll.method
+    @defer.inlineCallbacks
     def poll(self):
         assert not self.running, "overlapping call"
         self.running = True
+
         d = defer.Deferred()
         self.reactor.callLater(self.duration, d.callback, None)
+        yield d
 
-        @d.addCallback
-        def inc(_):
-            self.calls += 1
-            self.running = False
+        self.calls += 1
+        self.running = False
 
-        @d.addCallback
-        def maybeFail(_):
-            if self.fail:
-                raise RuntimeError('oh noes')
-        return d
+        if self.fail_after_running:
+            raise RuntimeError('oh noes')
 
     def setUp(self):
         self.setUpTestReactor()
@@ -156,37 +201,29 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
         self.calls = 0
         self.running = False
         self.duration = 1
-        self.fail = False
+        self.fail_after_running = False
 
     def tearDown(self):
         poll.reset_poll_methods()
 
-    def test_run_now(self):
-        """If NOW is true, the poll begins immediately"""
+    @defer.inlineCallbacks
+    def test_call_when_started_forces_run(self):
         self.poll.start(interval=10, now=True)
+        self.reactor.advance(0)
         self.assertEqual(self.calls, 0)
         self.assertTrue(self.running)
         self.reactor.advance(self.duration)
         self.assertEqual(self.calls, 1)
         self.assertFalse(self.running)
-
-    def test_no_run_now(self):
-        """If NOW is false, the poll begins after the interval"""
-        self.poll.start(interval=10, now=False)
-        self.assertEqual(self.calls, 0)
-        self.assertFalse(self.running)
-        self.reactor.advance(10)
-        self.assertEqual(self.calls, 0)
-        self.assertTrue(self.running)
-        self.reactor.advance(1)
-        self.assertEqual(self.calls, 1)
-        self.assertFalse(self.running)
+        yield self.poll.stop()
 
     def test_repeats_and_stops(self):
         """ Polling repeats until stopped, and stop returns a Deferred.  The
         duration of the function's execution does not affect the execution
         interval: executions occur every 10 seconds.  """
         self.poll.start(interval=10, now=True)
+        self.reactor.advance(0)
+
         while self.reactor.seconds() <= 200:
             self.assertEqual(self.calls, (self.reactor.seconds() + 9) // 10)
             self.assertEqual(self.running, self.reactor.seconds() % 10 == 0)
@@ -199,11 +236,35 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
         self.reactor.advance(10)
         self.assertEqual(self.calls, 21)
 
-    def test_fails(self):
-        """If the poll function fails, it is still called again, but
-        the exception is logged each time."""
-        self.fail = True
+    @parameterized.expand([
+        ('now_True', True),
+        ('now_False', False),
+    ])
+    @defer.inlineCallbacks
+    def test_zero_interval_starts_immediately(self, name, now):
+        self.poll.start(interval=0, now=now)
+        self.reactor.advance(0)
+
+        self.assertEqual(self.calls, 0)
+        self.assertTrue(self.running)
+        self.reactor.advance(1)
+        self.assertEqual(self.calls, 1)
+        self.assertTrue(self.running)
+        self.reactor.pump([1] * 10)
+        self.assertEqual(self.calls, 11)
+        self.assertTrue(self.running)
+        d = self.poll.stop()
+        self.assertTrue(self.running)
+        self.reactor.advance(1)
+        self.assertFalse(self.running)
+        yield d
+
+    @defer.inlineCallbacks
+    def test_fail_reschedules_and_logs_exceptions(self):
+        self.fail_after_running = True
         self.poll.start(interval=10, now=True)
+        self.reactor.advance(0)
+        self.assertTrue(self.running)
         self.reactor.advance(1)
         self.assertEqual(self.calls, 1)
         self.reactor.advance(10)
@@ -211,12 +272,13 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
         self.reactor.advance(1)
         self.assertEqual(self.calls, 2)
         self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 2)
+        yield self.poll.stop()
 
-    def test_stop_while_running(self):
-        """If stop is called while the poll function is running, then stop's
-        Deferred does not fire until the run is complete."""
+    def test_stop_while_running_waits_for_completion(self):
         self.duration = 2
         self.poll.start(interval=10)
+        self.reactor.advance(0)
+        self.assertFalse(self.running)
         self.reactor.advance(10)
         self.assertTrue(self.running)
         d = self.poll.stop()
@@ -226,11 +288,26 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
         self.reactor.advance(1)
         self.assertTrue(d.called)
 
-    def test_call_while_running(self):
-        """Calling the poll method while the decorated method is running causes
-        a second call as soon as the first is done."""
+    def test_call_while_waiting_schedules_immediately(self):
+        self.poll.start(interval=10)
+        self.reactor.advance(0)
+        self.reactor.advance(5)
+        self.poll()
+        self.reactor.advance(0)
+        self.assertTrue(self.running)
+        self.reactor.advance(1)
+        self.assertEqual(self.calls, 1)
+        self.assertFalse(self.running)
+        self.reactor.advance(4)
+        self.assertTrue(self.running)
+        self.reactor.advance(1)
+        self.assertEqual(self.calls, 2)
+
+    def test_call_while_running_reschedules_immediately_after(self):
         self.duration = 5
         self.poll.start(interval=10, now=True)
+        self.reactor.advance(0)
+        self.assertTrue(self.running)
         self.reactor.advance(3)
         self.poll()
         self.reactor.advance(2)
@@ -240,26 +317,29 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
 
     def test_call_while_running_then_stop(self):
         """Calling the poll method while the decorated method is running, then
-        calling stop will wait for both invocations to complete."""
+        calling stop will not wait for both invocations to complete."""
         self.duration = 5
         self.poll.start(interval=10, now=True)
+        self.reactor.advance(0)
+        self.assertTrue(self.running)
         self.reactor.advance(3)
+        self.assertTrue(self.running)
         self.poll()
         d = self.poll.stop()
         self.reactor.advance(2)
         self.assertEqual(self.calls, 1)
-        self.reactor.advance(4)
-        self.assertEqual(self.calls, 1)
-        self.assertFalse(d.called)
-        self.reactor.advance(1)
-        self.assertEqual(self.calls, 2)
         self.assertTrue(d.called)
+
+        self.reactor.advance(5)
+        self.assertEqual(self.calls, 1)
 
     def test_stop_twice_while_running(self):
         """If stop is called *twice* while the poll function is running, then
         neither Deferred fires until the run is complete."""
         self.duration = 2
         self.poll.start(interval=10)
+        self.reactor.advance(0)
+        self.assertFalse(self.running)
         self.reactor.advance(10)
         self.assertTrue(self.running)
         d1 = self.poll.stop()
@@ -271,29 +351,35 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
         self.assertTrue(d1.called)
         self.assertTrue(d2.called)
 
+    @defer.inlineCallbacks
     def test_stop_and_restart(self):
         """If the method is immediately restarted from a callback on a stop Deferred,
         the polling continues with the new start time."""
         self.duration = 6
         self.poll.start(interval=10)
+        self.reactor.advance(0)
+        self.assertFalse(self.running)
         self.reactor.advance(10)
         self.assertTrue(self.running)
         d = self.poll.stop()
-        d.addCallback(lambda _: self.poll.start(interval=10))
         self.assertFalse(d.called)  # not stopped yet
         self.reactor.advance(6)
         self.assertFalse(self.running)
         self.assertTrue(d.called)
+        yield d
+        self.poll.start(interval=10)
         self.reactor.advance(10)
         self.assertEqual(self.reactor.seconds(), 26)
         self.assertTrue(self.running)
 
-    def test_long_method(self):
-        """If the method takes more than INTERVAL seconds to execute, then it
-        is re-invoked at the next multiple of INTERVAL seconds"""
+        self.reactor.advance(6)
+        yield self.poll.stop()
 
+    def test_method_longer_than_interval_invoked_at_interval_multiples(self):
         self.duration = 4
         self.poll.start(interval=3, now=True)
+        self.reactor.advance(0)
+
         exp = [
             (0, True, 0),
             (1, True, 0),
@@ -312,19 +398,75 @@ class TestPollerAsync(TestReactorMixin, unittest.TestCase):
             self.assertEqual(self.running, running)
             self.assertEqual(self.calls, calls)
 
-    def test_run_random_delay(self):
-        """Add a 1s delay before polling"""
-        random_delay_max = 5
+    @parameterized.expand([
+        ('shorter_than_interval_now_True', 5, True),
+        ('longer_than_interval_now_True', 15, True),
+        ('shorter_than_interval_now_False', 5, False),
+        ('longer_than_interval_now_False', 15, False),
+    ])
+    @defer.inlineCallbacks
+    def test_run_with_random_delay(self, name, random_delay_max, now):
+        interval = 10
+
         with mock.patch("buildbot.util.poll.randint", return_value=random_delay_max):
-            self.poll.start(interval=10, now=True, random_delay_max=random_delay_max)
+            self.poll.start(interval=interval, now=now, random_delay_max=random_delay_max)
+            self.reactor.advance(0)
+
+            if not now:
+                i = 0
+                while i < interval:
+                    self.assertFalse(self.running)
+                    self.assertEqual(self.calls, 0)
+                    self.reactor.advance(1)
+                    i += 1
+
             i = 0
             while i < random_delay_max:
-                self.assertEqual(self.calls, 0)
                 self.assertFalse(self.running)
+                self.assertEqual(self.calls, 0)
                 self.reactor.advance(1)
                 i += 1
+
             self.assertEqual(self.calls, 0)
             self.assertTrue(self.running)
             self.reactor.advance(self.duration)
             self.assertEqual(self.calls, 1)
             self.assertFalse(self.running)
+        yield self.poll.stop()
+
+    @parameterized.expand([
+        ('now_True', True),
+        ('now_False', False),
+    ])
+    @defer.inlineCallbacks
+    def test_run_with_random_delay_zero_interval_still_delays(self, name, now):
+        random_delay_max = 5
+        with mock.patch("buildbot.util.poll.randint", return_value=random_delay_max):
+            self.poll.start(interval=0, now=now, random_delay_max=random_delay_max)
+            self.reactor.advance(0)
+            self.assertFalse(self.running)
+            self.assertEqual(self.calls, 0)
+
+            i = 0
+            while i < random_delay_max:
+                self.assertFalse(self.running)
+                self.assertEqual(self.calls, 0)
+                self.reactor.advance(1)
+                i += 1
+
+            self.assertTrue(self.running)
+            self.reactor.advance(1)
+            self.assertEqual(self.calls, 1)
+            self.assertFalse(self.running)
+
+        yield self.poll.stop()
+
+    @defer.inlineCallbacks
+    def test_run_with_random_delay_stops_immediately_during_delay_phase(self):
+        random_delay_max = 5
+        with mock.patch("buildbot.util.poll.randint", return_value=random_delay_max):
+            self.poll.start(interval=10, now=True, random_delay_max=random_delay_max)
+            self.reactor.advance(1)
+            self.assertFalse(self.running)
+            self.assertEqual(self.calls, 0)
+        yield self.poll.stop()

--- a/master/buildbot/util/poll.py
+++ b/master/buildbot/util/poll.py
@@ -1,3 +1,4 @@
+
 # This file is part of Buildbot.  Buildbot is free software: you can
 # redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation, version 2.
@@ -17,7 +18,6 @@
 from random import randint
 
 from twisted.internet import defer
-from twisted.internet import task
 from twisted.python import log
 
 _poller_instances = None
@@ -25,69 +25,107 @@ _poller_instances = None
 
 class Poller:
 
-    __slots__ = ['fn', 'instance', 'loop', 'started', 'running',
-                 'pending', 'stopDeferreds', '_reactor']
-
     def __init__(self, fn, instance, reactor):
         self.fn = fn
         self.instance = instance
-        self.loop = None
-        self.started = False
+
         self.running = False
         self.pending = False
-        self.stopDeferreds = []
+
+        # Invariants:
+        #   - If self._call is not None or self._currently_executing then it is guaranteed that
+        #     self.pending and self._run_complete_deferreds will be handled at some point in the
+        #     future.
+        #   - If self._call is not None then _run will be executed at some point, but it's not being
+        #     executed now.
+        self._currently_executing = False
+        self._call = None
+        self._next_call_time = None  # valid when self._call is not None
+
+        self._start_time = 0
+        self._interval = 0
+        self._random_delay_min = 0
+        self._random_delay_max = 0
+        self._run_complete_deferreds = []
+
         self._reactor = reactor
 
     @defer.inlineCallbacks
-    def _run(self, random_delay_min=0, random_delay_max=0):
-        self.running = True
-        if random_delay_max:
-            yield task.deferLater(self._reactor, randint(random_delay_min, random_delay_max),
-                                  lambda: None)
+    def _run(self):
+        self._call = None
+        self._currently_executing = True
+
         try:
             yield self.fn(self.instance)
         except Exception as e:
-            log.err(e, 'while running {}'.format(self.fn))
+            log.err(e, 'while executing {}'.format(self.fn))
+        finally:
+            self._currently_executing = False
 
-        self.running = False
-        # loop if there's another pending call
-        if self.pending:
-            self.pending = False
-            yield self._run(random_delay_min, random_delay_max)
+        was_pending = self.pending
+        self.pending = False
+
+        if self.running:
+            self._schedule(force_now=was_pending)
+
+        while self._run_complete_deferreds:
+            self._run_complete_deferreds.pop(0).callback(None)
+
+    def _get_wait_time(self, curr_time, force_now=False, force_initial_now=False):
+        if force_now:
+            return 0
+
+        extra_wait = randint(self._random_delay_min, self._random_delay_max)
+
+        if force_initial_now or self._interval == 0:
+            return extra_wait
+
+        # note that differently from twisted.internet.task.LoopingCall, we don't care about
+        # floating-point precision issues as we don't have the withCount feature.
+        running_time = curr_time - self._start_time
+        return self._interval - (running_time % self._interval) + extra_wait
+
+    def _schedule(self, force_now=False, force_initial_now=False):
+        curr_time = self._reactor.seconds()
+        wait_time = self._get_wait_time(curr_time, force_now=force_now,
+                                        force_initial_now=force_initial_now)
+        next_call_time = curr_time + wait_time
+
+        if self._call is not None:
+            # Note that self._call can ever be moved to earlier time, so we can always cancel it.
+            self._call.cancel()
+
+        self._next_call_time = next_call_time
+        self._call = self._reactor.callLater(wait_time, self._run)
 
     def __call__(self):
-        if self.started:
-            if self.running:
-                self.pending = True
-            else:
-                # terrible hack..
-                old_interval = self.loop.interval
-                self.loop.interval = 0
-                self.loop.reset()
-                self.loop.interval = old_interval
+        if not self.running:
+            return
+        if self._currently_executing:
+            self.pending = True
+        else:
+            self._schedule(force_now=True)
 
     def start(self, interval, now=False, random_delay_min=0, random_delay_max=0):
-        assert not self.started
-        if not self.loop:
-            self.loop = task.LoopingCall(self._run, random_delay_min, random_delay_max)
-            self.loop.clock = self._reactor
-        stopDeferred = self.loop.start(interval, now=now)
+        assert not self.running
+        self._interval = interval
+        self._random_delay_min = random_delay_min
+        self._random_delay_max = random_delay_max
+        self._start_time = self._reactor.seconds()
 
-        @stopDeferred.addCallback
-        def inform(_):
-            self.started = False
-            while self.stopDeferreds:
-                self.stopDeferreds.pop().callback(None)
-        self.started = True
+        self.running = True
+        self._schedule(force_initial_now=now)
 
+    @defer.inlineCallbacks
     def stop(self):
-        if self.loop and self.loop.running:
-            self.loop.stop()
-        if self.started:
+        self.running = False
+        if self._call is not None:
+            self._call.cancel()
+            self._call = None
+        if self._currently_executing:
             d = defer.Deferred()
-            self.stopDeferreds.append(d)
-            return d
-        return defer.succeed(None)
+            self._run_complete_deferreds.append(d)
+            yield d
 
 
 class _Descriptor:

--- a/master/docs/developer/utils.rst
+++ b/master/docs/developer/utils.rst
@@ -517,6 +517,8 @@ The ``@poll.method`` decorator makes this behavior easy and reliable.
     This decorator replaces the decorated method with a :py:class:`Poller` instance configured to call the decorated method periodically.
     The poller is initially stopped, so periodic calls will not begin until its ``start`` method is called.
     The start polling interval is specified when the poller is started.
+    A random delay may optionally be supplied.
+    This allows to avoid the situation of multiple services with the same interval are executing at exactly the same time.
 
     If the decorated method fails or raises an exception, the Poller logs the error and re-schedules the call for the next interval.
 
@@ -542,10 +544,12 @@ The ``@poll.method`` decorator makes this behavior easy and reliable.
 
 .. py:class:: Poller
 
-    .. py:method:: start(interval=N, now=False)
+    .. py:method:: start(interval=N, now=False, random_delay_min=0, random_delay_max=0)
 
         :param interval: time, in seconds, between invocations
         :param now: if true, call the decorated method immediately on startup.
+        :param random_delay_min: Minimum random delay to apply to the start time of the decorated method.
+        :param random_delay_min: Maximum random delay to apply to the start time of the decorated method.
 
         Start the poller.
 
@@ -559,7 +563,7 @@ The ``@poll.method`` decorator makes this behavior easy and reliable.
     .. py:method:: __call__()
 
         Force a call to the decorated method now.
-        If the decorated method is currently running, another call will begin as soon as it completes.
+        If the decorated method is currently running, another call will begin as soon as it completes unless the poller is currently stopping.
 
 :py:mod:`buildbot.util.maildir`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
buildbot.util.poll.method is used to implement polling change sources. Currently if a long random polling delay is configured it will cause the shutdown/reconfiguration of services to be very slow as all polling calls that have not yet been started, but have their interval already expired will still be started.

Unfortunately fixing this is impossible without rewriting the poll method implementation to not use task.LoopingCall as the underlying scheduling primitive.