### PR TITLE
master: Fix multiple bugs in master deactivation code path

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -333,12 +333,19 @@ class BuildMaster(service.ReconfigurableServiceMixin, service.MasterService):
     def stopService(self):
         try:
             yield self.initLock.acquire()
+
+            if self.running:
+                yield self.botmaster.cleanShutdown(quickMode=True, stopReactor=False)
+
+            # Mark master as stopped only after all builds are shut down. Note that masterStopped
+            # would forcibly mark all related build requests, builds, steps, logs, etc. as
+            # complete, so this may make state inconsistent if done while the builds are still
+            # running.
             if self.masterid is not None:
                 yield self.data.updates.masterStopped(
                     name=self.name, masterid=self.masterid)
+
             if self.running:
-                yield self.botmaster.cleanShutdown(
-                    quickMode=True, stopReactor=False)
                 yield super().stopService()
 
             log.msg("BuildMaster is stopped")

--- a/master/buildbot/newsfragments/master-deactivate-after-builds-are-stopped.bugfix
+++ b/master/buildbot/newsfragments/master-deactivate-after-builds-are-stopped.bugfix
@@ -1,0 +1,1 @@
+Don't deactivate master as seen by the data API before builds are stopped.

--- a/master/buildbot/newsfragments/master-stop-crash-brd-disownserviceparent.bugfix
+++ b/master/buildbot/newsfragments/master-stop-crash-brd-disownserviceparent.bugfix
@@ -1,0 +1,1 @@
+Fixed a race condition that may result in a crash when build request distributor stops when its activity loop is running.

--- a/master/buildbot/newsfragments/master-stop-deadlock-wait-build.bugfix
+++ b/master/buildbot/newsfragments/master-stop-deadlock-wait-build.bugfix
@@ -1,0 +1,1 @@
+Fixed a race condition that may result in a deadlock if master is stopped at the same time a build is started.

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -166,6 +166,9 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin,
         d = self.master.stopService()
 
         self.assertFalse(d.called)
+
+        # master must only send shutdown once builds are completed
+        self.assertTrue(self.master.data.updates.thisMasterActive)
         self.master.botmaster.shutdownDeferred.callback(None)
         self.assertTrue(d.called)
 

--- a/master/buildbot/util/_notifier.py
+++ b/master/buildbot/util/_notifier.py
@@ -33,9 +33,10 @@ class Notifier:
         return d
 
     def notify(self, result):
-        waiters, self._waiters = self._waiters, []
-        for waiter in waiters:
-            waiter.callback(result)
+        if self._waiters:
+            waiters, self._waiters = self._waiters, []
+            for waiter in waiters:
+                waiter.callback(result)
 
     def __bool__(self):
         return bool(self._waiters)


### PR DESCRIPTION
This PR fixes multiple race conditions and other bugs in master deactivation code path:

 - The early state updates that updates.masterStopped() emit are incorrect as builds may still be running. We need to do that only after the builds have completed and we are sure that the state updates performed in that function correspond to real situation.

 - `_maybeStartBuildsOnBuilder` may sometimes crash during deactivation when the parent service is already removed and `self.master` is None.
 
 - Master may become stuck during deactivation if build request distributor is disabled at exactly the same time a build is starting. 

Only a single test needed to be updated as once masterStopped notifications were moved to after the builds are already stopped, existing tests caught all other problems.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
