### PR TITLE
Fix buildstep interruption

### DIFF
--- a/master/buildbot/newsfragments/buildstep-dont-run-command-after-stopped.bugfix
+++ b/master/buildbot/newsfragments/buildstep-dont-run-command-after-stopped.bugfix
@@ -1,0 +1,1 @@
+Fixed build steps continuing running commands even if when they have been cancelled.

--- a/master/buildbot/newsfragments/master-stop-crash-step-interrupt.bugfix
+++ b/master/buildbot/newsfragments/master-stop-crash-step-interrupt.bugfix
@@ -1,0 +1,1 @@
+Fixed a crash when a manual step interruption is happening with master shutdown which tries to stop builds itself.

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -976,6 +976,9 @@ class BuildStep(results.ResultComputingConfigMixin,
 
     @defer.inlineCallbacks
     def runCommand(self, command):
+        if self.stopped:
+            return CANCELLED
+
         self.cmd = command
         command.worker = self.worker
         try:

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -833,6 +833,8 @@ class BuildStep(results.ResultComputingConfigMixin,
         raise NotImplementedError("your subclass must implement run()")
 
     def interrupt(self, reason):
+        if self.stopped:
+            return
         self.stopped = True
         if self._acquiringLocks:
             for (lock, access, d) in self._acquiringLocks:

--- a/master/buildbot/test/util/steps.py
+++ b/master/buildbot/test/util/steps.py
@@ -232,6 +232,8 @@ class BuildStepMixin:
 
         def addCompleteLog(name, text):
             _log = logfile.FakeLogFile(name)
+            if name in self.step.logs:
+                raise Exception('Attempt to add log {} twice to the logs'.format(name))
             self.step.logs[name] = _log
             _log.addStdout(text)
             return defer.succeed(None)


### PR DESCRIPTION
This PR fixes a couple of problems with build step interruptions.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
