### PR TITLE
wamp: Don't reconfigure router if settings have not changed

### DIFF
--- a/master/buildbot/newsfragments/improve-reconfig-reliability-mq-wamp.bugfix
+++ b/master/buildbot/newsfragments/improve-reconfig-reliability-mq-wamp.bugfix
@@ -1,0 +1,1 @@
+Reconfiguration reliability has been improved by not reconfiguring WAMP router if settings have not changed.


### PR DESCRIPTION
Previously wamp router was being reconfigured even if the config has not changed. This would break master on buildbot reconfig under certain circumstances.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
