### PR TITLE
plugins: Delay warnings emitted during load time to plugin access time

### DIFF
--- a/master/buildbot/newsfragments/plugindb-warnings-on-access.bugfix
+++ b/master/buildbot/newsfragments/plugindb-warnings-on-access.bugfix
@@ -1,0 +1,1 @@
+Plugin database will no longer issue warnings on load, but only when a particular entry is accessed.

--- a/master/buildbot/plugins/db.py
+++ b/master/buildbot/plugins/db.py
@@ -16,6 +16,7 @@
 # pylint: disable=C0111
 
 import traceback
+import warnings
 from pkg_resources import iter_entry_points
 
 from zope.interface import Invalid
@@ -35,10 +36,14 @@ class _PluginEntry:
         self._entry = entry
         self._value = None
         self._loader = loader
+        self._load_warnings = []
 
     def load(self):
         if self._value is None:
-            self._value = self._loader(self._entry)
+            with warnings.catch_warnings(record=True) as all_warnings:
+                warnings.simplefilter("always")
+                self._value = self._loader(self._entry)
+                self._load_warnings = list(all_warnings)
 
     @property
     def group(self):
@@ -59,6 +64,8 @@ class _PluginEntry:
     @property
     def value(self):
         self.load()
+        for w in self._load_warnings:
+            warnings.warn_explicit(w.message, w.category, w.filename, w.lineno)
         return self._value
 
 

--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -17,6 +17,7 @@ Unit tests for the plugin framework
 """
 
 import mock
+import warnings
 
 from twisted.trial import unittest
 from zope.interface import implementer
@@ -24,6 +25,7 @@ from zope.interface import implementer
 import buildbot.plugins.db
 from buildbot.errors import PluginDBError
 from buildbot.interfaces import IPlugin
+from buildbot.test.util.warnings import assertProducesWarning
 
 # buildbot.plugins.db needs to be imported for patching, however just 'db' is
 # much shorter for using in tests
@@ -36,13 +38,14 @@ class FakeEntry:
     An entry suitable for unit tests
     """
 
-    def __init__(self, name, project_name, version, fail_require, value):
+    def __init__(self, name, project_name, version, fail_require, value, warnings=[]):
         self._name = name
         self._dist = mock.Mock(spec_set=['project_name', 'version'])
         self._dist.project_name = project_name
         self._dist.version = version
         self._fail_require = fail_require
         self._value = value
+        self._warnings = warnings
 
     @property
     def name(self):
@@ -65,6 +68,8 @@ class FakeEntry:
         """
         handle loading
         """
+        for w in self._warnings:
+            warnings.warn(w, DeprecationWarning)
         return self._value
 
 
@@ -107,6 +112,12 @@ _FAKE_ENTRIES = {
                   ClassWithInterface),
         FakeEntry('deep.path', 'non-existent', 'irrelevant', False,
                   ClassWithInterface)
+    ],
+    'buildbot.interface_warnings': [
+        FakeEntry('good', 'non-existent', 'irrelevant', False,
+                  ClassWithInterface, warnings=['test warning']),
+        FakeEntry('deep.path', 'non-existent', 'irrelevant', False,
+                  ClassWithInterface, warnings=['test warning'])
     ],
     'buildbot.interface_failed': [
         FakeEntry('good', 'non-existent', 'irrelevant', True,
@@ -206,6 +217,22 @@ class TestBuildbotPlugins(unittest.TestCase):
         greeter = result_get('yes')
         self.assertEqual('yes', greeter.hello())
         self.assertEqual('no', greeter.hello('no'))
+
+    def test_interface_warnings(self):
+        # we should not get no warnings when not trying to access the plugin
+        plugins = db.get_plugins('interface_warnings', interface=ITestInterface)
+        self.assertTrue('good' in plugins.names)
+        self.assertTrue('deep.path' in plugins.names)
+
+        # we should get warning when trying to access the plugin
+        with assertProducesWarning(DeprecationWarning, "test warning"):
+            _ = plugins.get('good')
+        with assertProducesWarning(DeprecationWarning, "test warning"):
+            _ = plugins.good
+        with assertProducesWarning(DeprecationWarning, "test warning"):
+            _ = plugins.get('deep.path')
+        with assertProducesWarning(DeprecationWarning, "test warning"):
+            _ = plugins.deep.path
 
     def test_interface_provided_deps_failed(self):
         plugins = db.get_plugins('interface_failed', interface=ITestInterface,


### PR DESCRIPTION
Currently if the plugin database if forcefully loaded then all deprecation and similar warnings are emitted even though the plugins aren't actually used. We should emit warnings to the time when the actual plugin entry is accessed.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
