### PR TITLE
Revert "process: add LoggingBuildStep as a subclass of BuildStep"

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -764,10 +764,6 @@ class BuildStep(results.ResultComputingConfigMixin,
                                       ).format(name, self.__class__.__name__))
 
 
-class LoggingBuildStep(BuildStep):
-    pass
-
-
 class CommandMixin:
 
     @defer.inlineCallbacks


### PR DESCRIPTION
This was temporary hack to fix buildbot.buildbot.net.