### PR TITLE
Fix import sorting

### DIFF
--- a/master/buildbot/test/unit/test_plugins.py
+++ b/master/buildbot/test/unit/test_plugins.py
@@ -16,8 +16,9 @@
 Unit tests for the plugin framework
 """
 
-import mock
 import warnings
+
+import mock
 
 from twisted.trial import unittest
 from zope.interface import implementer


### PR DESCRIPTION
Recently a couple of PRs were merged without full testing as buildbot.buildbot.net was broken due to backwards-incompatible changes to buildbot master branch. This PR fixes one of the problems that made into the master branch.