### PR TITLE
www: Fix LdapUserInfo.getUserAvatar to match AvatarResource expectations

### DIFF
--- a/master/buildbot/newsfragments/fix-builtins.TypeError-LdapUserInfo.bugfix
+++ b/master/buildbot/newsfragments/fix-builtins.TypeError-LdapUserInfo.bugfix
@@ -1,0 +1,1 @@
+Fix builtins.TypeError when using LdapUserInfo as avatar provider

--- a/master/buildbot/www/ldapuserinfo.py
+++ b/master/buildbot/www/ldapuserinfo.py
@@ -138,20 +138,28 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
     def findAvatarMime(self, data):
         # http://en.wikipedia.org/wiki/List_of_file_signatures
         if data.startswith(b"\xff\xd8\xff"):
-            return ("image/jpeg", data)
+            return (b"image/jpeg", data)
         if data.startswith(b"\x89PNG"):
-            return ("image/png", data)
+            return (b"image/png", data)
         if data.startswith(b"GIF8"):
-            return ("image/gif", data)
+            return (b"image/gif", data)
         # ignore unknown image format
         return None
 
-    def getUserAvatar(self, user_email, size, defaultAvatarUrl):
-        user_email = bytes2unicode(user_email)
+    def getUserAvatar(self, email, username, size, defaultAvatarUrl):
+        if username:
+            username = bytes2unicode(username)
+        if email:
+            email = bytes2unicode(email)
 
         def thd():
             c = self.connectLdap()
-            pattern = self.avatarPattern % dict(email=user_email)
+            if username:
+                pattern = self.accountPattern % dict(username=username)
+            elif email:
+                pattern = self.avatarPattern % dict(email=email)
+            else:
+                return None
             res = self.search(c, self.accountBase, pattern,
                               attributes=[self.avatarData])
             if not res:


### PR DESCRIPTION
This will fix #5793.

Tests have been updated to take the interaction between AvatarResource
and LdapUserInfo into account and prevent such problem to occur again.

They allowed to discover another incompatibility with Content-Type header which must be bytes.

As it's a bugfix, I don't think updating documentation is needed.

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
