### PR TITLE
2.10: gerrit: Deduplicate only source-related gerrit events

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -163,7 +163,7 @@ class GerritChangeSourceBase(base.ChangeSource):
         return func(properties, event)
 
     @defer.inlineCallbacks
-    def addChange(self, chdict):
+    def addChange(self, event_type, chdict):
         stampdict = {
             "branch": chdict["branch"],
             "revision": chdict["revision"],
@@ -177,7 +177,7 @@ class GerritChangeSourceBase(base.ChangeSource):
         stampid, found_existing = yield(
              self.master.db.sourcestamps.findOrCreateId(**stampdict))
 
-        if found_existing:
+        if found_existing and event_type in ("patchset-created", "ref-updated"):
             if self.debug or True:
                 eventstr = "{}/{} -- {}:{}".format(
                     self.gitBaseURL, chdict["project"], chdict["branch"],
@@ -236,7 +236,7 @@ class GerritChangeSourceBase(base.ChangeSource):
                 patchset=event["patchSet"]["number"]
             )
 
-        yield self.addChange({
+        yield self.addChange(event['type'], {
             'author': _gerrit_user_to_author(event_change["owner"]),
             'project': util.bytes2unicode(event_change["project"]),
             'repository': "{}/{}".format(

--- a/master/buildbot/newsfragments/gerrit-deduplicate-only-source-events.bugfix
+++ b/master/buildbot/newsfragments/gerrit-deduplicate-only-source-events.bugfix
@@ -1,0 +1,2 @@
+Fixed a regression in ``GerritChangeSource`` since v2.6.0 that caused only the first event related to a Gerrit change to be reporter as a change to Buildbot (:issue:`5596`).
+Now such deduplication will be applied only to ``patchset-created`` and ``ref-updated`` events.

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -1234,6 +1234,9 @@ The :bb:chsrc:`GerritChangeSource` class connects to a Gerrit server by its SSH 
 
 Note that the Gerrit event stream is stateless and any events that occur while buildbot is not connected to Gerrit will be lost. See :bb:chsrc:`GerritEventLogPoller` for a stateful change source.
 
+The ``patchset-created`` and ``ref-updated`` events will be deduplicated, that is, if multiple events related to the same revision are received, only the first will be acted upon.
+This allows ``GerritChangeSource`` to be used together with :bb:chsrc:`GerritEventLogPoller`.
+
 The :bb:chsrc:`GerritChangeSource` accepts the following arguments:
 
 ``gerritserver``

--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -10,6 +10,110 @@ Release Notes
 
 .. towncrier release notes start
 
+Buildbot ``2.10.1-dev160`` ( ``2021-02-25`` )
+=============================================
+
+Bug fixes
+---------
+
+- Added ``MessageFormatterEmpty``, ``MessageFormatterFunction``, ``MessageFormatterMissingWorker``, and ``MessageFormatterRenderable`` to ``buildbot.reporters`` namespace
+- Avatar caching is now working properly and size argument is now correctly handled
+- Fixed build steps continuing running commands even if when they have been cancelled.
+- Remove display of hidden steps in the build summary tooltip.
+- Fixed a regression in ``GerritChangeSource`` since v2.6.0 that caused only the first event related to a Gerrit change to be reporter as a change to Buildbot (:issue:`5596`).
+  Now such deduplication will be applied only to ``patchset-created`` and ``ref-updated`` events.
+- ``GitHubPullrequestPoller`` now supports secrets in its ``token`` argument (:issue:`4921`)
+- Don't deactivate master as seen by the data API before builds are stopped.
+- Fixed a race condition that may result in a crash when build request distributor stops when its activity loop is running.
+- Fixed a crash when a manual step interruption is happening with master shutdown which tries to stop builds itself.
+- Fixed a race condition that may result in a deadlock if master is stopped at the same time a build is started.
+- Improved ``buildbot.util.poll.method`` to react faster to a request to stop:
+   - New pending calls are no longer executed
+   - Calls whose interval but not random delay has already expired are no longer executed.
+- Plugin database will no longer issue warnings on load, but only when a particular entry is accessed.
+
+Features
+--------
+
+- :py:class:`~buildbot.changes.BitbucketPullrequestPoller`, py:class:`~buildbot.www.BitbucketCloudEventHandler`, py:class:`~buildbot.www.BitbucketServerEventHandler` were enhanced to save PR entries matching provided masks as build properties.
+- :py:class:`~buildbot.changes.BitbucketPullrequestPoller` has been enhanced to optionally authorize Bitbucket API.
+- Added `pullrequesturl` property to the following pollers and change hooks: :py:class:`~buildbot.changes.BitbucketPullrequestPoller`, :py:class:`~buildbot.changes.GitHubPullrequestPoller`, :py:class:`~buildbot.changes.GitHubEventHandler`. This unifies all Bitbucket and GitHub pollers with the shared property interface.
+- AvatarGitHub class has been enhanced to handle avatar based on email requests and take size argument into account
+- A new ``www.ws_ping_interval`` configuration option was added to avoid websocket timeouts when using reverse proxies and CDNs. Fixes :issue:`4078`
+
+Deprecations and Removals
+-------------------------
+
+- ``LoggingBuildStep`` has been removed.
+- ``GET``, ``PUT``, ``POST``, ``DELETE``, ``HEAD``, ``OPTIONS`` steps now use new-style step implementation.
+- ``MasterShellCommand`` step now uses new-style step implementation.
+- ``Configure``, ``Compile``, ``ShellCommand``, ``SetPropertyFromCommand``, ``WarningCountingShellCommand``, ``Test`` steps now use new-style step implementation.
+- Support for old-style steps has been removed.
+- Python 3.5 is no longer supported for running Buildbot master.
+- The deprecated ``HipChatStatusPush`` reporter has been removed.
+- - Removed support for the following deprecated parameters of ``HttpStatusPush`` reporter: ``format_fn``, ``builders``, ``wantProperties``, ``wantSteps``, ``wantPreviousBuild``, ``wantLogs``, ``user``, ``password``.
+  - Removed support for the following deprecated parameters of ``BitbucketStatusPush`` reporter: ``builders``, ``wantProperties``, ``wantSteps``, ``wantPreviousBuild``, ``wantLogs``.
+  - Removed support for the following deprecated parameters of ``BitbucketServerStatusPush``, ``BitbucketServerCoreAPIStatusPush``, ``GerritVerifyStatusPush``, ``GitHubStatusPush``, ``GitHubCommentPush`` and ``GitLabStatusPush`` reporters: ``startDescription``, ``endDescription``, ``builders``, ``wantProperties``, ``wantSteps``, ``wantPreviousBuild``, ``wantLogs``.
+  - Removed support for the following deprecated parameters of ``BitbucketServerPRCommentPush``, ``MailNotifier``, ``PushjetNotifier`` and ``PushoverNotifier`` reporters: ``subject``, ``mode``, ``builders``, ``tags``, ``schedulers``, ``branches``, ``buildSetSummary``, ``messageFormatter``, ``watchedWorkers``, ``messageFormatterMissingWorker``.
+  - Removed support for the following deprecated parameters of ``MessageFormatter`` report formatter: ``template_name``.
+- The deprecated ``send()`` function that can be overridden by custom reporters has been removed.
+- The deprecated ``buildbot.status`` module has been removed.
+- The deprecated ``MTR`` step has been removed.
+  Contributors are welcome to step in, migrate this step to newer APIs and add a proper test suite to restore this step in Buildbot.
+
+
+Buildbot ``2.10.1-dev160`` ( ``2021-02-25`` )
+=============================================
+
+Bug fixes
+---------
+
+- Added ``MessageFormatterEmpty``, ``MessageFormatterFunction``, ``MessageFormatterMissingWorker``, and ``MessageFormatterRenderable`` to ``buildbot.reporters`` namespace
+- Avatar caching is now working properly and size argument is now correctly handled
+- Fixed build steps continuing running commands even if when they have been cancelled.
+- Remove display of hidden steps in the build summary tooltip.
+- Fixed a regression in ``GerritChangeSource`` since v2.6.0 that caused only the first event related to a Gerrit change to be reporter as a change to Buildbot (:issue:`5596`).
+  Now such deduplication will be applied only to ``patchset-created`` and ``ref-updated`` events.
+- ``GitHubPullrequestPoller`` now supports secrets in its ``token`` argument (:issue:`4921`)
+- Don't deactivate master as seen by the data API before builds are stopped.
+- Fixed a race condition that may result in a crash when build request distributor stops when its activity loop is running.
+- Fixed a crash when a manual step interruption is happening with master shutdown which tries to stop builds itself.
+- Fixed a race condition that may result in a deadlock if master is stopped at the same time a build is started.
+- Improved ``buildbot.util.poll.method`` to react faster to a request to stop:
+   - New pending calls are no longer executed
+   - Calls whose interval but not random delay has already expired are no longer executed.
+- Plugin database will no longer issue warnings on load, but only when a particular entry is accessed.
+
+Features
+--------
+
+- :py:class:`~buildbot.changes.BitbucketPullrequestPoller`, py:class:`~buildbot.www.BitbucketCloudEventHandler`, py:class:`~buildbot.www.BitbucketServerEventHandler` were enhanced to save PR entries matching provided masks as build properties.
+- :py:class:`~buildbot.changes.BitbucketPullrequestPoller` has been enhanced to optionally authorize Bitbucket API.
+- Added `pullrequesturl` property to the following pollers and change hooks: :py:class:`~buildbot.changes.BitbucketPullrequestPoller`, :py:class:`~buildbot.changes.GitHubPullrequestPoller`, :py:class:`~buildbot.changes.GitHubEventHandler`. This unifies all Bitbucket and GitHub pollers with the shared property interface.
+- AvatarGitHub class has been enhanced to handle avatar based on email requests and take size argument into account
+- A new ``www.ws_ping_interval`` configuration option was added to avoid websocket timeouts when using reverse proxies and CDNs. Fixes :issue:`4078`
+
+Deprecations and Removals
+-------------------------
+
+- ``LoggingBuildStep`` has been removed.
+- ``GET``, ``PUT``, ``POST``, ``DELETE``, ``HEAD``, ``OPTIONS`` steps now use new-style step implementation.
+- ``MasterShellCommand`` step now uses new-style step implementation.
+- ``Configure``, ``Compile``, ``ShellCommand``, ``SetPropertyFromCommand``, ``WarningCountingShellCommand``, ``Test`` steps now use new-style step implementation.
+- Support for old-style steps has been removed.
+- Python 3.5 is no longer supported for running Buildbot master.
+- The deprecated ``HipChatStatusPush`` reporter has been removed.
+- - Removed support for the following deprecated parameters of ``HttpStatusPush`` reporter: ``format_fn``, ``builders``, ``wantProperties``, ``wantSteps``, ``wantPreviousBuild``, ``wantLogs``, ``user``, ``password``.
+  - Removed support for the following deprecated parameters of ``BitbucketStatusPush`` reporter: ``builders``, ``wantProperties``, ``wantSteps``, ``wantPreviousBuild``, ``wantLogs``.
+  - Removed support for the following deprecated parameters of ``BitbucketServerStatusPush``, ``BitbucketServerCoreAPIStatusPush``, ``GerritVerifyStatusPush``, ``GitHubStatusPush``, ``GitHubCommentPush`` and ``GitLabStatusPush`` reporters: ``startDescription``, ``endDescription``, ``builders``, ``wantProperties``, ``wantSteps``, ``wantPreviousBuild``, ``wantLogs``.
+  - Removed support for the following deprecated parameters of ``BitbucketServerPRCommentPush``, ``MailNotifier``, ``PushjetNotifier`` and ``PushoverNotifier`` reporters: ``subject``, ``mode``, ``builders``, ``tags``, ``schedulers``, ``branches``, ``buildSetSummary``, ``messageFormatter``, ``watchedWorkers``, ``messageFormatterMissingWorker``.
+  - Removed support for the following deprecated parameters of ``MessageFormatter`` report formatter: ``template_name``.
+- The deprecated ``send()`` function that can be overridden by custom reporters has been removed.
+- The deprecated ``buildbot.status`` module has been removed.
+- The deprecated ``MTR`` step has been removed.
+  Contributors are welcome to step in, migrate this step to newer APIs and add a proper test suite to restore this step in Buildbot.
+
+
 Buildbot ``2.10.1`` ( ``2021-01-29`` )
 ======================================
 

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -241,6 +241,8 @@ debouncer
 debounces
 decodable
 decodeRC
+deduplicated
+deduplication
 deepcopy
 deferreds
 Deferreds


### PR DESCRIPTION
Backport of #5732 to 2.10.x.