### PR TITLE
2.10: gerrit: Fix crash when refupdated event is sent to GerritChangeSource

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -257,7 +257,7 @@ class GerritChangeSourceBase(base.ChangeSource):
         if "submitter" in event:
             author = _gerrit_user_to_author(event["submitter"], author)
 
-        return self.addChange(dict(
+        return self.addChange(event['type'], dict(
             author=author,
             project=ref["project"],
             repository="{}/{}".format(self.gitBaseURL, ref["project"]),


### PR DESCRIPTION
This PR back ports #5817 to 2.10.x branch.