### PR TITLE
Optimize builder reconfiguration

### DIFF
--- a/master/buildbot/newsfragments/builder-dont-update-reconfig-nothing-changed.bugfix
+++ b/master/buildbot/newsfragments/builder-dont-update-reconfig-nothing-changed.bugfix
@@ -1,0 +1,2 @@
+Optimized builder reconfiguration when configuration does not change.
+This leads to up to 6 times faster reconfiguration in Buildbot instances with many builders.

--- a/master/buildbot/test/unit/process/test_builder.py
+++ b/master/buildbot/test/unit/process/test_builder.py
@@ -46,10 +46,16 @@ class BuilderMixin:
                     **config_kwargs):
         """Set up C{self.bldr}"""
         # only include the necessary required config, plus user-requested
-        config_args = dict(name=name, workername="wrk", builddir="bdir",
-                           workerbuilddir="wbdir", factory=self.factory)
-        config_args.update(config_kwargs)
-        self.builder_config = config.BuilderConfig(**config_args)
+        self.config_args = {
+            'name': name,
+            'workername': 'wrk',
+            'builddir': 'bdir',
+            'workerbuilddir': "wbdir",
+            'factory': self.factory
+        }
+        self.config_args.update(config_kwargs)
+        self.builder_config = config.BuilderConfig(**self.config_args)
+
         self.bldr = builder.Builder(
             self.builder_config.name)
         self.bldr.master = self.master
@@ -598,10 +604,7 @@ class TestReconfig(TestReactorMixin, BuilderMixin, unittest.TestCase):
     @defer.inlineCallbacks
     def test_reconfig(self):
         yield self.makeBuilder(description="Old", tags=["OldTag"])
-        config_args = dict(name='bldr', workername="wrk", builddir="bdir",
-                           workerbuilddir="wbdir", factory=self.factory,
-                           description='Noe', tags=['OldTag'])
-        new_builder_config = config.BuilderConfig(**config_args)
+        new_builder_config = config.BuilderConfig(**self.config_args)
         new_builder_config.description = "New"
         new_builder_config.tags = ["NewTag"]
 


### PR DESCRIPTION
Currently we always do a database update and send a mq message whenever a builder is reconfigured. In most reconfigurations most builders will stay the same. However, in Buildbot instances with many builders a large part of reconfiguration latency comes due to these database operations. So it's worth to optimize for the common case of no-change builder reconfiguration.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [n/a] I have updated the appropriate documentation
