### PR TITLE
2.10: master: Don't use rust to build cryptography yet

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -17,7 +17,7 @@ MAINTAINER  Buildbot maintainers
 
 # Last build date - this can be updated whenever there are security updates so
 # that everything is rebuilt
-ENV         security_updates_as_of 2020-05-01
+ENV         security_updates_as_of 2021-03-01
 
 
 COPY . /usr/src/buildbot
@@ -37,7 +37,7 @@ RUN \
         curl && \
 # install pip dependencies
     pip3 install --upgrade pip setuptools wheel && \
-    pip3 install "buildbot[bundle,tls]" && \
+    env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip3 install "buildbot[bundle,tls]" && \
     pip3 install -r /usr/src/buildbot/requirements-docker-extras.txt && \
     pip3 install "/usr/src/buildbot" && \
     mkdir -p wheels && \
@@ -59,7 +59,7 @@ MAINTAINER  Buildbot maintainers
 
 # Last build date - this can be updated whenever there are security updates so
 # that everything is rebuilt
-ENV         security_updates_as_of 2018-04-11
+ENV         security_updates_as_of 2021-03-01
 
 
 COPY . /usr/src/buildbot
@@ -85,7 +85,7 @@ RUN \
 # install pip dependencies
     pip3 install --upgrade pip setuptools && \
     pip3 install /wheels/*.whl && \
-    pip3 install "buildbot[bundle,tls]" && \
+    env CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip3 install "buildbot[bundle,tls]" && \
     pip3 install "/usr/src/buildbot" && \
     rm -r /root/.cache /wheels
 


### PR DESCRIPTION
Proper solution will be to install rust, but the rust in alpine 3.11 is too old, let's just work around this for now.