### PR TITLE
Add Python 3.9 build

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -80,6 +80,8 @@ matrix:
       env: TWISTED=latest SQLALCHEMY=latest TESTS=trial
     - python: "3.8"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=trial
+    - python: "3.9"
+      env: TWISTED=latest SQLALCHEMY=latest TESTS=trial
 
     - python: "3.8"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=2.7


### PR DESCRIPTION
With Twisted 21.2.0 released, we can try building with Python 3.9

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
