### PR TITLE
bbtravis: Update dabatase startup to match metabbot container image

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -123,10 +123,10 @@ install:
 before_script:
   # create real database for tests
   - condition: '"mysql" in BUILDBOT_TEST_DB_URL'
-    cmd: sudo /etc/init.d/mysql start
+    cmd: sudo /prepare_mysql
   - condition: '"postgresql" in BUILDBOT_TEST_DB_URL'
     cmd: |
-        sudo /etc/init.d/postgresql start
+        sudo /prepare_postgres
         # for pg8000 driver we can't use peer authentication or empty password, so set a dummy password
         # This also serves as a way to wait that the database is ready
         while ! psql -d bbtest -c 'ALTER USER "buildbot" WITH PASSWORD '"'x'"';' ; do sleep 1 ; done


### PR DESCRIPTION
This fixes breakage of database tests that got introduced due to changes in https://github.com/buildbot/metabbotcfg/commit/d2c34910fcaf89ba55b870d3668f25fde44c978e.