### PR TITLE
fix secret replacement for whitespace only / empty secrets

### DIFF
--- a/master/buildbot/newsfragments/whitespace-secret-replacement.bugfix
+++ b/master/buildbot/newsfragments/whitespace-secret-replacement.bugfix
@@ -1,0 +1,1 @@
+Fixed secret replacement for an empty string or whitespace which may have many matches and generally will not need to be redacted.

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -212,7 +212,8 @@ class Properties(util.ComparableMixin):
     # in the log of state strings
     # so we have the renderable record here which secrets are used that we must remove
     def useSecret(self, secret_value, secret_name):
-        self._used_secrets[secret_value] = "<" + secret_name + ">"
+        if secret_value.strip():
+            self._used_secrets[secret_value] = "<" + secret_name + ">"
 
     # This method shall then be called to remove secrets from any text that could be logged
     # somewhere and that could contain secrets

--- a/master/buildbot/test/unit/test_interpolate_secrets.py
+++ b/master/buildbot/test/unit/test_interpolate_secrets.py
@@ -74,8 +74,8 @@ class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
         self.master = fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage()
         password = "bar"
-        secretdict = {"foo": password, "other": password + 'random'}
-        fakeStorageService.reconfigService(secretdict=secretdict)
+        fakeStorageService.reconfigService(
+            secretdict={"foo": password, "other": password + "random", "empty": ""})
         self.secretsrv = SecretManager()
         self.secretsrv.services = [fakeStorageService]
         yield self.secretsrv.setServiceParent(self.master)
@@ -94,3 +94,10 @@ class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
         rendered = yield self.build.render(command)
         cleantext = self.build.properties.cleanupTextFromSecrets(rendered)
         self.assertEqual(cleantext, "echo <foo> <other>")
+
+    @defer.inlineCallbacks
+    def test_secret_replace_with_empty_secret(self):
+        command = Interpolate("echo %(secret:empty)s %(secret:other)s")
+        rendered = yield self.build.render(command)
+        cleantext = self.build.properties.cleanupTextFromSecrets(rendered)
+        self.assertEqual(cleantext, "echo  <other>")


### PR DESCRIPTION
I have a configuration for a testing environment which stubs out a secret with the empty string. This causes the status strings and logs to be replaced with a ton of `<SECRET_NAME> <SECRET_NAME>...` i.e.:

```python
>>> 'finished'.replace('', '<SECRET>')`
'<SECRET>f<SECRET>i<SECRET>n<SECRET>i<SECRET>s<SECRET>h<SECRET>e<SECRET>d<SECRET>'
```


## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
