### PR TITLE
GitHub hook: allow making certain GitHub API requests without API token

### DIFF
--- a/master/buildbot/newsfragments/fix-regression-in-GitHub-hook.bugfix
+++ b/master/buildbot/newsfragments/fix-regression-in-GitHub-hook.bugfix
@@ -1,0 +1,3 @@
+The change in :issue:`5508` broke some GitHub hook configurations because it
+make a code path require a GitHub token to make particular API requests. This
+fixes :issue:`5760`.

--- a/master/buildbot/test/unit/www/test_hooks_github.py
+++ b/master/buildbot/test/unit/www/test_hooks_github.py
@@ -874,9 +874,19 @@ class TestChangeHookConfiguredWithGitChange(unittest.TestCase,
         self.assertDictSubset(gitPRproperties, change["properties"])
 
     def test_git_with_pull_encoded(self):
+        commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_endpoint, content_json=gitJsonPayloadNotFound, code=404)
+        self._http.expect('get', files_endpoint, content_json=gitJsonPayloadNotFound, code=404)
+
         self._check_git_with_pull([gitJsonPayloadPullRequest])
 
     def test_git_with_pull_json(self):
+        commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_endpoint, content_json=gitJsonPayloadNotFound, code=404)
+        self._http.expect('get', files_endpoint, content_json=gitJsonPayloadNotFound, code=404)
+
         self._check_git_with_pull(gitJsonPayloadPullRequest)
 
     @defer.inlineCallbacks
@@ -920,6 +930,11 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRef(
     def test_git_pull_request_with_custom_ref(self):
         commit = deepcopy([gitJsonPayloadPullRequest])
 
+        commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_endpoint, content_json=gitJsonPayloadNotFound, code=404)
+        self._http.expect('get', files_endpoint, content_json=gitJsonPayloadNotFound, code=404)
+
         self.request = _prepare_request('pull_request', commit)
         yield self.request.test_render(self.changeHook)
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
@@ -939,8 +954,8 @@ class TestChangeHookConfiguredWithGitChangeCustomPullrequestRefWithAuth(
             pullrequest_ref="head", token=_token)
         self.master = self.changeHook.master
         fake_headers = {
-            'Authorization': 'token ' + _token,
             'User-Agent': 'Buildbot',
+            'Authorization': 'token ' + _token,
         }
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'https://api.github.com', headers=fake_headers,
@@ -978,8 +993,8 @@ class TestChangeHookConfiguredWithAuthAndCustomSkips(unittest.TestCase,
             self, strict=False, skips=[r'\[ *bb *skip *\]'], token=_token)
         self.master = self.changeHook.master
         fake_headers = {
-            'Authorization': 'token ' + _token,
             'User-Agent': 'Buildbot',
+            'Authorization': 'token ' + _token,
         }
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'https://api.github.com', headers=fake_headers,
@@ -1066,8 +1081,8 @@ class TestChangeHookConfiguredWithAuth(unittest.TestCase, TestReactorMixin):
             self, strict=False, token=_token, github_property_whitelist=["github.*"])
         self.master = self.changeHook.master
         fake_headers = {
-            'Authorization': 'token ' + _token,
             'User-Agent': 'Buildbot',
+            'Authorization': 'token ' + _token,
         }
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'https://api.github.com', headers=fake_headers,
@@ -1202,6 +1217,11 @@ class TestChangeHookConfiguredWithCustomApiRoot(unittest.TestCase,
         self.assertEqual(len(self.changeHook.master.data.updates.changesAdded), 1)
 
     def test_pull_request(self):
+        commit_endpoint = '/repos/defunkt/github/commits/05c588ba8cd510ecbe112d020f215facb17817a7'
+        files_endpoint = '/repos/defunkt/github/pulls/50/files'
+        self._http.expect('get', commit_endpoint, content_json=gitJsonPayloadNotFound, code=404)
+        self._http.expect('get', files_endpoint, content_json=gitJsonPayloadNotFound, code=404)
+
         self._check_pull_request(gitJsonPayloadPullRequest)
 
 
@@ -1218,8 +1238,8 @@ class TestChangeHookConfiguredWithCustomApiRootWithAuth(unittest.TestCase,
             token=_token)
         self.master = self.changeHook.master
         fake_headers = {
-            'Authorization': 'token ' + _token,
             'User-Agent': 'Buildbot',
+            'Authorization': 'token ' + _token,
         }
         self._http = yield fakehttpclientservice.HTTPClientService.getService(
             self.master, self, 'https://black.magic.io', headers=fake_headers,

--- a/master/buildbot/www/hooks/github.py
+++ b/master/buildbot/www/hooks/github.py
@@ -236,13 +236,12 @@ class GitHubEventHandler(PullRequestMixin):
         :param repo: the repo full name, ``{owner}/{project}``.
             e.g. ``buildbot/buildbot``
         '''
-        if not self._token:
-            return 'No message field'
 
         headers = {
-            'Authorization': 'token ' + self._token,
             'User-Agent': 'Buildbot',
         }
+        if self._token:
+            headers['Authorization'] = 'token ' + self._token
 
         url = '/repos/{}/commits/{}'.format(repo, sha)
         http = yield httpclientservice.HTTPClientService.getService(
@@ -264,13 +263,9 @@ class GitHubEventHandler(PullRequestMixin):
             e.g. ``buildbot/buildbot``
         :param number: the pull request number.
         """
-        if not self._token:
-            return []
-
-        headers = {
-            'Authorization': 'token ' + self._token,
-            'User-Agent': 'Buildbot',
-        }
+        headers = {"User-Agent": "Buildbot"}
+        if self._token:
+            headers["Authorization"] = "token " + self._token
 
         url = "/repos/{}/pulls/{}/files".format(repo, number)
         http = yield httpclientservice.HTTPClientService.getService(


### PR DESCRIPTION
The change https://github.com/buildbot/buildbot/pull/5508 was overly aggressive because it expected that the GitHub APIs for getting a commit and the changed files in a pull request needed a token to function. This is not the case for public repositories, and this change optimistically makes the API request. The status code checking added in that previous change handles the previous error that the change was meant to address.

fixes: #5760 

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
