### PR TITLE
smokes: try some fix according to SO

### DIFF
--- a/smokes/protractor-headless.conf.js
+++ b/smokes/protractor-headless.conf.js
@@ -24,6 +24,9 @@ exports.config = {
             'args': [
                 '--headless',
                 '--window-size=1200,1024',
+                '--disable-dev-shm-usage',
+                '--disable-gpu',
+                '--no-sandbox',
                 '--user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/56.0.2924.87"',
             ]
         }


### PR DESCRIPTION
https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t

now that libcairo2-dev is installed, we get this error:

```
13:13:14.079 INFO [ActiveSessionFactory.lambda$apply$11] - Matched factory org.openqa.selenium.grid.session.remote.ServicedSession$Factory (provider: org.openqa.selenium.chrome.ChromeDriverService)
Starting ChromeDriver 89.0.4389.23 (61b08ee2c50024bab004e48d2b1b083cdbdac579-refs/branch-heads/4389@{#294}) on port 27339
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
[1615036394.100][SEVERE]: bind() failed: Cannot assign requested address (99)
[13:13:14] E/runner - Unable to start a WebDriver session.
[13:13:14] E/launcher - Error: WebDriverError: unknown error: Chrome failed to start: exited abnormally.
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /usr/bin/chromium-browser is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:25:53'
System info: host: 'buildbot-kube16-01d6e7', ip: '10.16.90.62', os.name: 'Linux', os.arch: 'amd64', os.version: '4.19.112+', java.version: '11.0.10'
Driver info: driver.version: unknown
remote stacktrace: #0 0x55bf7cb172b9 <unknown>
    at Object.checkLegacyResponse (/buildbot/buildbot-job/build/smokes/node_modules/selenium-webdriver/lib/error.js:546:15)
    at parseHttpResponse (/buildbot/buildbot-job/build/smokes/node_modules/selenium-webdriver/lib/http.js:509:13)
    at /buildbot/buildbot-job/build/smokes/node_modules/selenium-webdriver/lib/http.js:441:30
    at processTicksAndRejections (internal/process/task_queues.js:93:5)

```