### PR TITLE
fix failing tests if dependencies are not available

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -83,6 +83,9 @@ matrix:
     - python: "3.9"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=trial
 
+    - python: "3.9"
+      env: TWISTED=latest SQLALCHEMY=latest TESTS=minimal_install
+
     - python: "3.8"
       env: TWISTED=latest SQLALCHEMY=latest TESTS=interop WORKER_PYTHON=2.7
 
@@ -94,8 +97,10 @@ matrix:
 # Dependencies installation commands
 install:
   - pip install -U pip
-  - condition: TESTS not in ("smokes", "trial_worker")
+  - condition: TESTS not in ("minimal_install", "smokes", "trial_worker")
     cmd: pip install -r requirements-ci.txt
+  - condition: TESTS == "minimal_install"
+    cmd: pip install -r requirements-minimal.txt
   - condition: TESTS == "trial_worker"
     cmd: pip install -r requirements-ciworker.txt
   - condition: TESTS == "docs"
@@ -149,7 +154,7 @@ script:
     cmd: make frontend_tests_headless
 
   - title: master and worker tests
-    condition: TESTS == "trial"
+    condition: TESTS in ("minimal_install", "trial")
     cmd: trial  --reporter=text --rterrors buildbot.test buildbot_worker.test
 
   - title: interop tests

--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,8 @@ $(VENV_NAME):
 
 # helper for virtualenv creation
 virtualenv: $(VENV_NAME)   # usage: make virtualenv VENV_PY_VERSION=python3.4
-	$(PIP) install -e pkg \
-		-e 'master[tls,test,docs]' \
-		-e 'worker[test]' \
-		buildbot_www packaging towncrier
+	$(PIP) install -r requirements-minimal.txt \
+		packaging towncrier
 	@echo now you can type following command  to activate your virtualenv
 	@echo . $(VENV_NAME)/bin/activate
 

--- a/master/buildbot/test/unit/data/test_connector.py
+++ b/master/buildbot/test/unit/data/test_connector.py
@@ -16,8 +16,6 @@
 
 import textwrap
 
-import graphql
-
 import mock
 
 from twisted.internet import defer
@@ -32,6 +30,11 @@ from buildbot.data import types
 from buildbot.test.fake import fakemaster
 from buildbot.test.util import interfaces
 from buildbot.test.util.misc import TestReactorMixin
+
+try:
+    import graphql
+except ImportError:
+    graphql = None
 
 
 class Tests(interfaces.InterfaceTests):
@@ -225,6 +228,9 @@ class DataConnector(TestReactorMixin, unittest.TestCase):
                                            {'fooid': 10})
 
     def test_get_graphql_schema(self):
+        if not graphql:
+            raise unittest.SkipTest('Test requires graphql')
+
         # use the test module for basic graphQLSchema generation
         mod = reflect.namedModule('buildbot.test.unit.data.test_connector')
         self.data._scanModule(mod)
@@ -255,6 +261,9 @@ class DataConnector(TestReactorMixin, unittest.TestCase):
         schema = graphql.build_schema(schema)
 
     def test_get_fake_graphql_schema(self):
+        if not graphql:
+            raise unittest.SkipTest('Test requires graphql')
+
         # use the test module for basic graphQLSchema generation
         mod = reflect.namedModule('buildbot.test.fake.endpoint')
         self.data._scanModule(mod)
@@ -312,6 +321,9 @@ class DataConnectorGraphQL(TestReactorMixin, unittest.TestCase):
         yield self.data.setServiceParent(self.master)
 
     def test_get_graphql_schema(self):
+        if not graphql:
+            raise unittest.SkipTest('Test requires graphql')
+
         schema = self.data.get_graphql_schema()
         # graphql parses the schema and raise an error if it is incorrect
         # or incoherent (e.g. missing type definition)

--- a/master/buildbot/test/unit/test_steps_git_diffinfo.py
+++ b/master/buildbot/test/unit/test_steps_git_diffinfo.py
@@ -22,8 +22,15 @@ from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import steps
 from buildbot.test.util.misc import TestReactorMixin
 
+try:
+    import unidiff
+except ImportError:
+    unidiff = None
+
 
 class TestDiffInfo(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
+    if not unidiff:
+        skip = 'unidiff is required for GitDiffInfo tests'
 
     def setUp(self):
         self.setUpTestReactor()

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -156,13 +156,14 @@ class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
                                     encoding='gzip')
         id, name = yield bs.start_instance(self.build)
         client = docker.APIClient.latest
-        self.assertEqual(client.call_args_create_host_config, [
-            {'network_mode': 'fake',
-             'dns': ['1.1.1.1', '1.2.3.4'],
-             'init': True,
-             'binds': ['/tmp:/tmp:ro'],
-             }
-        ])
+        expected = {
+            'network_mode': 'fake',
+            'dns': ['1.1.1.1', '1.2.3.4'],
+            'binds': ['/tmp:/tmp:ro'],
+        }
+        if dockerworker.docker_py_version >= 2.2:
+            expected['init'] = True
+        self.assertEqual(client.call_args_create_host_config, [expected])
 
     @defer.inlineCallbacks
     def test_constructor_host_config_build_set_init(self):

--- a/master/buildbot/test/unit/www/test_graphql.py
+++ b/master/buildbot/test/unit/www/test_graphql.py
@@ -26,8 +26,16 @@ from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import unicode2bytes
 from buildbot.www import graphql
 
+try:
+    import graphql as graphql_core
+except ImportError:
+    graphql_core = None
+
 
 class V3RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+    if not graphql_core:
+        skip = 'graphql is required for V3RootResource tests'
+
     def setUp(self):
         self.setUpTestReactor()
         self.master = self.make_master(url="http://server/path/")
@@ -159,6 +167,9 @@ class V3RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
 
 class DisabledV3RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+    if not graphql_core:
+        skip = 'graphql is required for V3RootResource tests'
+
     def setUp(self):
         self.setUpTestReactor()
         self.master = self.make_master(url="http://server/path/")

--- a/master/buildbot/test/unit/www/test_ldapuserinfo.py
+++ b/master/buildbot/test/unit/www/test_ldapuserinfo.py
@@ -26,6 +26,11 @@ from buildbot.test.util.www import WwwTestMixin
 from buildbot.www import avatar
 from buildbot.www import ldapuserinfo
 
+try:
+    import ldap3
+except ImportError:
+    ldap3 = None
+
 
 def get_config_parameter(p):
     params = {'DEFAULT_SERVER_ENCODING': 'utf-8'}
@@ -46,6 +51,8 @@ class FakeLdap:
 
 
 class CommonTestCase(unittest.TestCase):
+    if not ldap3:
+        skip = 'ldap3 is required for LdapUserInfo tests'
 
     """Common fixture for all ldapuserinfo tests
 
@@ -306,6 +313,8 @@ class LdapUserInfoNoGroups(CommonTestCase):
 
 
 class Config(unittest.TestCase):
+    if not ldap3:
+        skip = 'ldap3 is required for LdapUserInfo tests'
 
     def test_missing_group_name(self):
         with self.assertRaises(ValueError):

--- a/master/buildbot/www/ldapuserinfo.py
+++ b/master/buildbot/www/ldapuserinfo.py
@@ -26,14 +26,18 @@
 
 from urllib.parse import urlparse
 
-import ldap3
-
 from twisted.internet import threads
 
 from buildbot.util import bytes2unicode
 from buildbot.util import flatten
 from buildbot.www import auth
 from buildbot.www import avatar
+
+try:
+    import ldap3
+except ImportError:
+    import importlib
+    ldap3 = None
 
 
 class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
@@ -50,6 +54,9 @@ class LdapUserInfo(avatar.AvatarBase, auth.UserInfoProviderBase):
                  avatarPattern=None,
                  avatarData=None,
                  accountExtraFields=None):
+        # Throw import error now that this is being used
+        if not ldap3:
+            importlib.import_module('ldap3')
         self.uri = uri
         self.bindUser = bindUser
         self.bindPw = bindPw

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,0 +1,5 @@
+# Requirements list for minimal local development testing
+-e master[tls,test,docs]
+-e worker[test]
+-e pkg
+buildbot_www


### PR DESCRIPTION
The tests `master/buildbot/test/unit/www/test_ldapuserinfo.py` require `ldap3` or they will fail with an import error. This change allows the import to happen and will throw the error only if `LdapUserInfo` is used and `ldap3` is not available.

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
