### PR TITLE
2.10: fix secret replacement for whitespace only / empty secrets

### DIFF
--- a/master/buildbot/newsfragments/whitespace-secret-replacement.bugfix
+++ b/master/buildbot/newsfragments/whitespace-secret-replacement.bugfix
@@ -1,0 +1,1 @@
+Fixed secret replacement for an empty string or whitespace which may have many matches and generally will not need to be redacted.

--- a/master/buildbot/process/properties.py
+++ b/master/buildbot/process/properties.py
@@ -212,7 +212,8 @@ class Properties(util.ComparableMixin):
     # in the log of state strings
     # so we have the renderable record here which secrets are used that we must remove
     def useSecret(self, secret_value, secret_name):
-        self._used_secrets[secret_value] = "<" + secret_name + ">"
+        if secret_value.strip():
+            self._used_secrets[secret_value] = "<" + secret_name + ">"
 
     # This method shall then be called to remove secrets from any text that could be logged
     # somewhere and that could contain secrets

--- a/master/buildbot/test/unit/test_interpolate_secrets.py
+++ b/master/buildbot/test/unit/test_interpolate_secrets.py
@@ -74,8 +74,8 @@ class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
         self.master = fakemaster.make_master(self)
         fakeStorageService = FakeSecretStorage()
         password = "bar"
-        secretdict = {"foo": password, "other": password + 'random'}
-        fakeStorageService.reconfigService(secretdict=secretdict)
+        fakeStorageService.reconfigService(
+            secretdict={"foo": password, "other": password + "random", "empty": ""})
         self.secretsrv = SecretManager()
         self.secretsrv.services = [fakeStorageService]
         yield self.secretsrv.setServiceParent(self.master)
@@ -94,3 +94,10 @@ class TestInterpolateSecretsHiddenSecrets(TestReactorMixin, unittest.TestCase):
         rendered = yield self.build.render(command)
         cleantext = self.build.build_status.properties.cleanupTextFromSecrets(rendered)
         self.assertEqual(cleantext, "echo <foo> <other>")
+
+    @defer.inlineCallbacks
+    def test_secret_replace_with_empty_secret(self):
+        command = Interpolate("echo %(secret:empty)s %(secret:other)s")
+        rendered = yield self.build.render(command)
+        cleantext = self.build.properties.cleanupTextFromSecrets(rendered)
+        self.assertEqual(cleantext, "echo  <other>")


### PR DESCRIPTION
This PR backports #5848 to 2.10.x.