### PR TITLE
2.10: docs: Add missed 2.10.1 release note

### DIFF
--- a/master/docs/relnotes/index.rst
+++ b/master/docs/relnotes/index.rst
@@ -52,6 +52,7 @@ Bug fixes
 - Improved REST API to use username or full name of a logged in user when email is empty.
 - Worked around a bug in Python's urllib which caused Python clients not to accept basic authentication headers (:issue:`5743`)
 - Fixed crash in ``BuildStartEndStatusGenerator`` when tags filter is setup (:issue:`5766`).
+- Added missing ``MessageFormatterEmpty``, ``MessageFormatterFunction``, ``MessageFormatterMissingWorker``, and ``MessageFormatterRenderable`` to ``buildbot.reporters`` namespace
 
 Improved Documentation
 ----------------------


### PR DESCRIPTION
A newsfragment was not cherry-picked in #5755 and a release note was not included in the documentation.