### PR TITLE
common: Don't hardcode version number for package installation in tests

### DIFF
--- a/common/smokedist.sh
+++ b/common/smokedist.sh
@@ -18,7 +18,7 @@ do
     . $VE/bin/activate
     pip install -U pip
     pip install  mock requests flask
-    pip install dist/buildbot-2*.$suffix
+    pip install dist/buildbot-[0-9]*.$suffix
     pip install dist/buildbot?pkg*.$suffix
     pip install dist/*.$suffix
     smokes/run.sh


### PR DESCRIPTION
This fixes the smoke tests.