### PR TITLE
www: Escape avatar URL parameters to properly handle special characters in emails

### DIFF
--- a/master/buildbot/newsfragments/avatar-escape-parameters.bugfix
+++ b/master/buildbot/newsfragments/avatar-escape-parameters.bugfix
@@ -1,0 +1,1 @@
+Escape avatar URL parameters to properly handle special characters in emails

--- a/www/base/src/app/app.module.js
+++ b/www/base/src/app/app.module.js
@@ -66,6 +66,7 @@ require('./common/directives/loginbar/loginbar.directive.js');
 require('./common/directives/properties/properties.directive.js');
 require('./common/directives/rawdata/rawdata.directive.js');
 require('./common/directives/windowtitle/windowtitle.directive.js');
+require('./common/filters/encodeURI.filter.js');
 require('./common/filters/moment/moment.constant.js');
 require('./common/filters/moment/moment.filter.js');
 require('./common/filters/publicFields.filter.js');

--- a/www/base/src/app/builders/builds/build.tpl.jade
+++ b/www/base/src/app/builders/builds/build.tpl.jade
@@ -36,7 +36,7 @@
             ul.list-group
                 li.list-group-item(ng-repeat="(author, email) in responsibles")
                     .change-avatar
-                        img(ng-src="avatar?email={{email}}")
+                        img(ng-src="avatar?email={{email | encodeURI}}")
                     a(ng-href="mailto:{{email}}")
                         | {{ author }}
           uib-tab(heading="Changes")

--- a/www/base/src/app/common/directives/changedetails/changedetails.tpl.jade
+++ b/www/base/src/app/common/directives/changedetails/changedetails.tpl.jade
@@ -2,7 +2,7 @@ div.changedetails(style="width:100%;")
     div(style="width:100%;", ng-click="change.show_details = !change.show_details")
         .change-avatar(ng-if="!compact && change.author_email")
             a(ng-href="mailto:{{change.author_email}}", title="{{change.author_name}}")
-                img(ng-src="avatar?email={{change.author_email}}")
+                img(ng-src="avatar?email={{change.author_email | encodeURI}}")
         a(ng-if="change.revlink", ng-href="{{change.revlink}}", uib-tooltip="{{change.comments}}")
             | {{ change.comments.split("\n")[0] }}
         span(ng-if="!change.revlink", uib-tooltip="{{change.comments}}")

--- a/www/base/src/app/common/directives/loginbar/loginbar.tpl.jade
+++ b/www/base/src/app/common/directives/loginbar/loginbar.tpl.jade
@@ -15,7 +15,7 @@ ul.nav.navbar-nav.navbar-right(ng-show="config.auth.name != 'NoAuth'")
 
     li.dropdown(uib-dropdown, ng-hide="anonymous")
         a.dropdown-toggle(uib-dropdown-toggle)
-            img.avatar(ng-if="config.avatar_methods.length" ng-src="avatar?username={{username}}&email={{email}}")
+            img.avatar(ng-if="config.avatar_methods.length" ng-src="avatar?username={{username | encodeURI}}&email={{email | encodeURI}}")
             span(ng-if="!config.avatar_methods.length")
                 | {{full_name || username}}
                 b.caret

--- a/www/base/src/app/common/filters/encodeURI.filter.js
+++ b/www/base/src/app/common/filters/encodeURI.filter.js
@@ -1,0 +1,9 @@
+var encodeURI = function ($filter) {
+    function encodeURI(input) {
+        return window.encodeURIComponent((input == null) ? "" : input);
+    }
+    return encodeURI;
+}
+
+angular.module('common')
+    .filter('encodeURI', ['$filter', encodeURI]);


### PR DESCRIPTION
For example when a + sign is present in email address, without this fix it is used as is and Python side translates it to space character.
I didn't found unit tests for this.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
