### PR TITLE
2.10: setup: Add missing report generators to the plugin database

### DIFF
--- a/master/buildbot/newsfragments/report-generator-plugins.bugfix
+++ b/master/buildbot/newsfragments/report-generator-plugins.bugfix
@@ -1,0 +1,1 @@
+Added missing report generators to the Buildbot plugin database (:issue:`5892`)

--- a/master/setup.py
+++ b/master/setup.py
@@ -328,6 +328,12 @@ setup_args = {
                 'RemoveDirectory', 'MakeDirectory']),
         ]),
         ('buildbot.reporters', [
+            ('buildbot.reporters.generators.build', [
+                'BuildStatusGenerator',
+                'BuildStartEndStatusGenerator',
+            ]),
+            ('buildbot.reporters.generators.buildset', ['BuildSetStatusGenerator']),
+            ('buildbot.reporters.generators.worker', ['WorkerMissingGenerator']),
             ('buildbot.reporters.mail', ['MailNotifier']),
             ('buildbot.reporters.pushjet', ['PushjetNotifier']),
             ('buildbot.reporters.pushover', ['PushoverNotifier']),


### PR DESCRIPTION
This PR partially backports #5895.