### PR TITLE
2.10: reporters: Move _matches_any_tag to BuildStatusGeneratorMixin

### DIFF
--- a/master/buildbot/newsfragments/reporter-buildset-generator-mode.bugfix
+++ b/master/buildbot/newsfragments/reporter-buildset-generator-mode.bugfix
@@ -1,0 +1,1 @@
+Fixed non-default mode support for ``BuildSetStatusGenerator``.

--- a/master/buildbot/reporters/generators/build.py
+++ b/master/buildbot/reporters/generators/build.py
@@ -79,9 +79,6 @@ class BuildStatusGenerator(BuildStatusGeneratorMixin):
     def _want_previous_build(self):
         return "change" in self.mode or "problem" in self.mode
 
-    def _matches_any_tag(self, tags):
-        return self.tags and any(tag for tag in self.tags if tag in tags)
-
 
 @implementer(interfaces.IReportGenerator)
 class BuildStartEndStatusGenerator(BuildStatusGeneratorMixin):
@@ -122,6 +119,3 @@ class BuildStartEndStatusGenerator(BuildStatusGeneratorMixin):
         report = yield self.build_message(formatter, master, reporter, build['builder']['name'],
                                           [build], build['results'])
         return report
-
-    def _matches_any_tag(self, tags):
-        return self.tags and any(tag for tag in self.tags if tag in tags)

--- a/master/buildbot/reporters/generators/utils.py
+++ b/master/buildbot/reporters/generators/utils.py
@@ -218,3 +218,6 @@ class BuildStatusGeneratorMixin(util.ComparableMixin):
             else:
                 mode = (mode,)
         return mode
+
+    def _matches_any_tag(self, tags):
+        return self.tags and any(tag for tag in self.tags if tag in tags)


### PR DESCRIPTION
This PR backports part of #5899 to 2.10.x.