### PR TITLE
2.10: setup: Require sqlalchemy older than 1.4

### DIFF
--- a/master/buildbot/newsfragments/sqlalchemy-1-4-compatibility.bugfix
+++ b/master/buildbot/newsfragments/sqlalchemy-1-4-compatibility.bugfix
@@ -1,0 +1,1 @@
+Updated Buildbot requirements to specify sqlalchemy 1.4 and newer as not supported yet.

--- a/master/setup.py
+++ b/master/setup.py
@@ -496,7 +496,7 @@ setup_args['install_requires'] = [
     'Jinja2 >= 2.1',
     # required for tests, but Twisted requires this anyway
     'zope.interface >= 4.1.1',
-    'sqlalchemy>=1.2.0',
+    'sqlalchemy >= 1.2.0, < 1.4',
     'sqlalchemy-migrate>=0.13',
     'python-dateutil>=1.5',
     'txaio ' + txaio_ver,


### PR DESCRIPTION
This PR backports #5912 to 2.10.x.