### PR TITLE
data: Add missed build_data data connectors

### DIFF
--- a/master/buildbot/data/connector.py
+++ b/master/buildbot/data/connector.py
@@ -38,6 +38,7 @@ class RTypes:
 class DataConnector(service.AsyncService):
 
     submodules = [
+        'buildbot.data.build_data',
         'buildbot.data.builders',
         'buildbot.data.builds',
         'buildbot.data.buildrequests',


### PR DESCRIPTION
Turns out we couldn't submit build data even if we wanted.