### PR TITLE
test: Fix entrypoint tests

### DIFF
--- a/master/buildbot/test/integration/test_setup_entrypoints.py
+++ b/master/buildbot/test/integration/test_setup_entrypoints.py
@@ -88,7 +88,6 @@ class TestSetupPyEntryPoints(unittest.TestCase):
             'buildbot.steps.download_secret_to_worker.RemoveWorkerFileSecret',
             'buildbot.steps.source.base.Source',
             'buildbot.steps.download_secret_to_worker.DownloadSecretsToWorker',
-            'buildbot.steps.gitdiffinfo.GitDiffInfo',
             'buildbot.steps.shell.SetProperty',
             'buildbot.steps.worker.WorkerBuildStep',
             'buildbot.steps.vstudio.VisualStudio',

--- a/master/setup.py
+++ b/master/setup.py
@@ -268,6 +268,7 @@ setup_args = {
             ('buildbot.process.buildstep', ['BuildStep']),
             ('buildbot.steps.cmake', ['CMake']),
             ('buildbot.steps.cppcheck', ['Cppcheck']),
+            ('buildbot.steps.gitdiffinfo', ['GitDiffInfo']),
             ('buildbot.steps.http', [
                 'HTTPStep', 'POST', 'GET', 'PUT', 'DELETE', 'HEAD',
                 'OPTIONS',


### PR DESCRIPTION
We should use the same API to check classes as the plugin DB uses. Otherwise we are going to check wrong things as zope interfaces are not directly inherited and thus are not recognized by `issubclass`.