### PR TITLE
graphql schema generation using data type system

### DIFF
--- a/common/code_spelling_ignore_words.txt
+++ b/common/code_spelling_ignore_words.txt
@@ -613,6 +613,7 @@ gotperspective
 gotrootobject
 gpo
 gracefulshutdown
+graphql
 gravatar
 groupmemberpattern
 gtk
@@ -1092,6 +1093,7 @@ pyparsing
 pypugjs
 pythonpath
 qa
+queriable
 qmail
 quickmode
 quickstart

--- a/master/buildbot/data/steps.py
+++ b/master/buildbot/data/steps.py
@@ -91,6 +91,11 @@ class StepsEndpoint(Db2DataMixin, base.BuildNestingMixin, base.Endpoint):
         return results
 
 
+class UrlEntityType(types.Entity):
+    name = types.String()
+    url = types.String()
+
+
 class Step(base.ResourceType):
 
     name = "step"
@@ -113,10 +118,7 @@ class Step(base.ResourceType):
         results = types.NoneOk(types.Integer())
         state_string = types.String()
         urls = types.List(
-            of=types.Dict(
-                name=types.String(),
-                url=types.String()
-            ))
+            of=UrlEntityType("Url"))
         hidden = types.Boolean()
     entityType = EntityType(name)
 

--- a/master/buildbot/data/workers.py
+++ b/master/buildbot/data/workers.py
@@ -103,6 +103,15 @@ class WorkersEndpoint(Db2DataMixin, base.Endpoint):
         return [self.db2data(w) for w in workers_dicts]
 
 
+class MasterBuilderEntityType(types.Entity):
+    masterid = types.Integer()
+    builderid = types.Integer()
+
+
+class MasterIdEntityType(types.Entity):
+    masterid = types.Integer()
+
+
 class Worker(base.ResourceType):
 
     name = "worker"
@@ -116,11 +125,8 @@ class Worker(base.ResourceType):
     class EntityType(types.Entity):
         workerid = types.Integer()
         name = types.String()
-        connected_to = types.List(of=types.Dict(
-            masterid=types.Integer()))
-        configured_on = types.List(of=types.Dict(
-            masterid=types.Integer(),
-            builderid=types.Integer()))
+        connected_to = types.List(of=MasterIdEntityType("master_id"))
+        configured_on = types.List(of=MasterBuilderEntityType("master_builder"))
         workerinfo = types.JsonObject()
         paused = types.Boolean()
         graceful = types.Boolean()

--- a/master/buildbot/scripts/gengraphql.py
+++ b/master/buildbot/scripts/gengraphql.py
@@ -1,0 +1,43 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+
+import os
+import sys
+
+from twisted.internet import defer
+
+from buildbot.data import connector
+from buildbot.test.fake import fakemaster
+from buildbot.util import in_reactor
+
+
+@in_reactor
+@defer.inlineCallbacks
+def gengraphql(config):
+    master = yield fakemaster.make_master(None, wantRealReactor=True)
+    data = connector.DataConnector()
+    yield data.setServiceParent(master)
+
+    if config['out'] != '--':
+        dirs = os.path.dirname(config['out'])
+        if dirs and not os.path.exists(dirs):
+            os.makedirs(dirs)
+        f = open(config['out'], "w")
+    else:
+        f = sys.stdout
+    schema = data.genGraphQLSchema()
+    f.write(schema)
+    return 0

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -656,6 +656,16 @@ class DataSpecOption(base.BasedirMixin, base.SubcommandOptions):
         return "Usage:   buildbot dataspec [options]"
 
 
+class GenGraphQLOption(base.BasedirMixin, base.SubcommandOptions):
+    subcommandFunction = "buildbot.scripts.gengraphql.gengraphql"
+    optParameters = [
+        ['out', 'o', "graphql.schema", "output to specified path"],
+    ]
+
+    def getSynopsis(self):
+        return "Usage:   buildbot graphql-schema [options]"
+
+
 class DevProxyOptions(base.BasedirMixin, base.SubcommandOptions):
 
     """Run a fake web server serving the local ui frontend and a distant rest and websocket api.
@@ -742,6 +752,8 @@ class Options(usage.Options):
         ['dev-proxy', None, DevProxyOptions,
          "Run a fake web server serving the local ui frontend and a distant rest and websocket api."
          ],
+        ['graphql-schema', None, GenGraphQLOption,
+         "Output graphql api schema"],
         ['cleanupdb', None, CleanupDBOptions,
          "cleanup the database"
          ]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -25,6 +25,7 @@ flake8==3.9.0
 funcparserlib==0.3.6
 funcsigs==1.0.2
 future==0.18.2
+graphql-core==3.1.3
 idna==2.10  # pyup: ignore (conflicts with moto on master)
 imagesize==1.2.0
 incremental==17.5.0


### PR DESCRIPTION
This is the start of work to generate graphql api from our data type system.

This one generates a graphql schema for the current data model, which does not take in account the entity relationships.

Next step will be to add graph metadata to the type system, which can then be used to fulfil an actual query
