### PR TITLE
Reconfig improvements for the cases when it takes a long time

### DIFF
--- a/master/buildbot/newsfragments/reconfig-log-messages.bugfix
+++ b/master/buildbot/newsfragments/reconfig-log-messages.bugfix
@@ -1,0 +1,2 @@
+Improved consistency of log messages produced by the reconfig script.
+Note that this output is not part of public API of Buildbot and may change at any time.

--- a/master/buildbot/newsfragments/reconfig-script-timeout.feature
+++ b/master/buildbot/newsfragments/reconfig-script-timeout.feature
@@ -1,0 +1,1 @@
+The reconfig script now supports ``progress_timeout`` command-line parameter which determines how long it waits between subsequent progress updates in the logs before declaring a timeout.

--- a/master/buildbot/scripts/reconfig.py
+++ b/master/buildbot/scripts/reconfig.py
@@ -18,6 +18,7 @@ import os
 import platform
 import signal
 
+from twisted.internet import defer
 from twisted.internet import reactor
 
 from buildbot.scripts.logwatcher import BuildmasterTimeoutError
@@ -29,8 +30,7 @@ from buildbot.util import rewrap
 
 class Reconfigurator:
 
-    rc = 0
-
+    @defer.inlineCallbacks
     def run(self, basedir, quiet, timeout=None):
         # Returns "Microsoft" for Vista and "Windows" for other versions
         if platform.system() in ("Windows", "Microsoft"):
@@ -52,10 +52,25 @@ class Reconfigurator:
         reactor.callLater(0.2, self.sighup)
 
         lw = LogWatcher(os.path.join(basedir, "twistd.log"), timeout=timeout)
-        d = lw.start()
-        d.addCallbacks(self.success, self.failure)
-        d.addBoth(lambda _: self.rc)
-        return d
+
+        try:
+            yield lw.start()
+            print("Reconfiguration appears to have completed successfully")
+            return 0
+        except BuildmasterTimeoutError:
+            print("Never saw reconfiguration finish.")
+        except ReconfigError:
+            print(rewrap("""\
+                Reconfiguration failed. Please inspect the master.cfg file for
+                errors, correct them, then try 'buildbot reconfig' again.
+                """))
+        except IOError:
+            # we were probably unable to open the file in the first place
+            self.sighup()
+        except Exception as e:
+            print("Error while following twistd.log: {}".format(e))
+
+        return 1
 
     def sighup(self):
         if self.sent_signal:
@@ -63,24 +78,6 @@ class Reconfigurator:
         print("sending SIGHUP to process %d" % self.pid)
         self.sent_signal = True
         os.kill(self.pid, signal.SIGHUP)
-
-    def success(self, res):
-        print("Reconfiguration appears to have completed successfully")
-
-    def failure(self, why):
-        self.rc = 1
-        if why.check(BuildmasterTimeoutError):
-            print("Never saw reconfiguration finish.")
-        elif why.check(ReconfigError):
-            print(rewrap("""\
-                Reconfiguration failed. Please inspect the master.cfg file for
-                errors, correct them, then try 'buildbot reconfig' again.
-                """))
-        elif why.check(IOError):
-            # we were probably unable to open the file in the first place
-            self.sighup()
-        else:
-            print("Error while following twistd.log: {}".format(why))
 
 
 @in_reactor

--- a/master/buildbot/scripts/runner.py
+++ b/master/buildbot/scripts/runner.py
@@ -218,6 +218,11 @@ class ReconfigOptions(base.BasedirMixin, base.SubcommandOptions):
         ['quiet', 'q', "Don't display log messages about reconfiguration"],
     ]
 
+    optParameters = [
+        ['progress_timeout', None, None,
+         'The amount of time the script waits for messages in the logs that indicate progress.'],
+    ]
+
     def getSynopsis(self):
         return "Usage:    buildbot reconfig [<basedir>]"
 

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -206,7 +206,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin,
 
         self.master.stopService()
 
-        self.assertLogged("reconfig aborted without")
+        self.assertLogged("configuration update aborted without")
         self.assertFalse(self.master.reconfigService.called)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
In very large Buildbot installations logs may not contain any progress markers for the current timeout of 10 seconds. This PR makes this configurable so that reconfig can still work in these cases.

Additionally, the log messages have been standardized and the reconfig duration has been included.
