### PR TITLE
Fix Bitbucket status push

### DIFF
--- a/master/buildbot/newsfragments/bitbucket-api-url-parsing.bugfix
+++ b/master/buildbot/newsfragments/bitbucket-api-url-parsing.bugfix
@@ -1,0 +1,2 @@
+Fixed parsing of URLs of the form https://api.bitbucket.org/2.0/repositories/OWNER/REPONAME in BitbucketStatusPush.
+These URLs are in the sourcestamps returned by the Bitbucket Cloud hook.

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -54,6 +54,7 @@ class BitbucketStatusPush(ReporterBase):
     def reconfigService(self, oauth_key, oauth_secret, base_url=_BASE_URL, oauth_url=_OAUTH_URL,
                         debug=None, verify=None, generators=None, **kwargs):
         oauth_key, oauth_secret = yield self.renderSecrets(oauth_key, oauth_secret)
+        self.base_url = base_url
         self.debug = debug
         self.verify = verify
 
@@ -62,8 +63,7 @@ class BitbucketStatusPush(ReporterBase):
 
         yield super().reconfigService(generators=generators, **kwargs)
 
-        if base_url.endswith('/'):
-            base_url = base_url[:-1]
+        base_url = base_url.rstrip('/')
 
         self._http = yield httpclientservice.HTTPClientService.getService(
             self.master, base_url,
@@ -80,8 +80,7 @@ class BitbucketStatusPush(ReporterBase):
     def sendMessage(self, reports):
         build = reports[0]['builds'][0]
         results = build['results']
-        oauth_request = yield self.oauthhttp.post("",
-                                                  data=_GET_TOKEN_DATA)
+        oauth_request = yield self.oauthhttp.post("", data=_GET_TOKEN_DATA)
         if oauth_request.code == 200:
             content_json = yield oauth_request.json()
             token = content_json['access_token']
@@ -118,8 +117,7 @@ class BitbucketStatusPush(ReporterBase):
                 log.error("{code}: unable to upload Bitbucket status {content}",
                           code=response.code, content=content)
 
-    @staticmethod
-    def get_owner_and_repo(repourl):
+    def get_owner_and_repo(self, repourl):
         """
         Takes a git repository URL from Bitbucket and tries to determine the owner and repository
         name
@@ -132,19 +130,19 @@ class BitbucketStatusPush(ReporterBase):
         """
         parsed = urlparse(repourl)
 
-        base_parsed = urlparse(_BASE_URL)
+        base_parsed = urlparse(self.base_url)
         if parsed.path.startswith(base_parsed.path):
-            path = parsed.path.replace(base_parsed.path, "")[1:]
+            path = parsed.path.replace(base_parsed.path, "")
         elif parsed.scheme:
-            path = parsed.path[1:]
+            path = parsed.path
         else:
             # we assume git@host:owner/repo.git here
             path = parsed.path.split(':', 1)[-1]
 
+        path = path.lstrip('/')
         if path.endswith('.git'):
             path = path[:-4]
-        while path.endswith('/'):
-            path = path[:-1]
+        path = path.rstrip('/')
 
         parts = path.split('/')
 

--- a/master/buildbot/reporters/bitbucket.py
+++ b/master/buildbot/reporters/bitbucket.py
@@ -124,14 +124,18 @@ class BitbucketStatusPush(ReporterBase):
         Takes a git repository URL from Bitbucket and tries to determine the owner and repository
         name
         :param repourl: Bitbucket git repo in the form of
-                    git@bitbucket.com:OWNER/REPONAME.git
-                    https://bitbucket.com/OWNER/REPONAME.git
-                    ssh://git@bitbucket.com/OWNER/REPONAME.git
+                    git@bitbucket.org:OWNER/REPONAME.git
+                    https://bitbucket.org/OWNER/REPONAME.git
+                    ssh://git@bitbucket.org/OWNER/REPONAME.git
+                    https://api.bitbucket.org/2.0/repositories/OWNER/REPONAME
         :return: owner, repo: The owner of the repository and the repository name
         """
         parsed = urlparse(repourl)
 
-        if parsed.scheme:
+        base_parsed = urlparse(_BASE_URL)
+        if parsed.path.startswith(base_parsed.path):
+            path = parsed.path.replace(base_parsed.path, "")[1:]
+        elif parsed.scheme:
             path = parsed.path[1:]
         else:
             # we assume git@host:owner/repo.git here

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -51,10 +51,10 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase, ConfigErrorsM
             self.master, self,
             _OAUTH_URL, auth=('key', 'secret'),
             debug=None, verify=None)
-        self.bsp = bsp = BitbucketStatusPush(
+        self.bsp = BitbucketStatusPush(
             Interpolate('key'), Interpolate('secret'))
-        yield bsp.setServiceParent(self.master)
-        yield bsp.startService()
+        yield self.bsp.setServiceParent(self.master)
+        yield self.bsp.startService()
 
     @defer.inlineCallbacks
     def tearDown(self):
@@ -186,10 +186,25 @@ class TestBitbucketStatusPush(TestReactorMixin, unittest.TestCase, ConfigErrorsM
         self.assertLogged('invalid_commit')
 
 
-class TestBitbucketStatusPushRepoParsing(unittest.TestCase):
+class TestBitbucketStatusPushRepoParsing(TestReactorMixin, unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.setUpTestReactor()
+        self.master = fakemaster.make_master(self, wantData=True, wantDb=True,
+                                             wantMq=True)
+
+        self.bsp = BitbucketStatusPush(
+            Interpolate('key'), Interpolate('secret'))
+        yield self.bsp.setServiceParent(self.master)
+        yield self.bsp.startService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.bsp.stopService()
 
     def parse(self, repourl):
-        return tuple(BitbucketStatusPush.get_owner_and_repo(repourl))
+        return tuple(self.bsp.get_owner_and_repo(repourl))
 
     def test_parse_no_scheme(self):
         self.assertEqual(

--- a/master/buildbot/test/unit/reporters/test_bitbucket.py
+++ b/master/buildbot/test/unit/reporters/test_bitbucket.py
@@ -200,10 +200,12 @@ class TestBitbucketStatusPushRepoParsing(unittest.TestCase):
     def test_parse_with_scheme(self):
         self.assertEqual(('user', 'repo'), self.parse(
             'https://bitbucket.com/user/repo.git'))
-        self.assertEqual(
-            ('user', 'repo'), self.parse('https://bitbucket.com/user/repo'))
+        self.assertEqual(('user', 'repo'), self.parse(
+            'https://bitbucket.com/user/repo'))
 
         self.assertEqual(('user', 'repo'), self.parse(
             'ssh://git@bitbucket.com/user/repo.git'))
-        self.assertEqual(
-            ('user', 'repo'), self.parse('ssh://git@bitbucket.com/user/repo'))
+        self.assertEqual(('user', 'repo'), self.parse(
+            'ssh://git@bitbucket.com/user/repo'))
+        self.assertEqual(('user', 'repo'), self.parse(
+            'https://api.bitbucket.org/2.0/repositories/user/repo'))


### PR DESCRIPTION
Not sure if this is the expected behavior, but the Bitbucket Cloud hook provides sourcestamps with API URLs. API URLs were not parsed successfully by the Bitbucket status push.

I've added two commits. The first one extends the method to support API URLs. The second one refactors the method by the use of a regex. If you don't like the regex, I can remove the commit.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
