### PR TITLE
www: Reduce flickering of buildsummary tooltip during mouseover

### DIFF
--- a/master/buildbot/newsfragments/buildsummary-tooltip-flicker-fix.bugfix
+++ b/master/buildbot/newsfragments/buildsummary-tooltip-flicker-fix.bugfix
@@ -1,0 +1,1 @@
+Fix for :issue:`5930`, reduce flickering of build summary tooltip during mouseover of build numbers.

--- a/master/docs/spelling_wordlist.txt
+++ b/master/docs/spelling_wordlist.txt
@@ -520,6 +520,7 @@ mistyped
 mixin
 Mixins
 mkdir
+mouseover
 mq
 Msbuild
 MsBuild

--- a/www/base/src/app/builders/builders.tpl.jade
+++ b/www/base/src/app/builders/builders.tpl.jade
@@ -53,7 +53,8 @@
                 span.badge-status(uib-tooltip-template="'buildsummarytooltip'"
                                   tooltip-class="buildsummarytooltipstyle"
                                   tooltip-placement="auto left-bottom"
-                                  tooltip-popup-close-delay="100"
+                                  tooltip-popup-delay="400"
+                                  tooltip-popup-close-delay="400"
                                   ng-class="results2class(build, 'pulse')")
                     | {{ build.number }}
           td(style="width:20%;")

--- a/www/base/src/app/common/directives/builds/buildstable.tpl.jade
+++ b/www/base/src/app/common/directives/builds/buildstable.tpl.jade
@@ -20,7 +20,8 @@
               span.badge-status(uib-tooltip-template="'buildsummarytooltip'"
                                 tooltip-class="buildsummarytooltipstyle"
                                 tooltip-placement="auto left-bottom"
-                                tooltip-popup-close-delay="100"
+                                tooltip-popup-delay="400"
+                                tooltip-popup-close-delay="400"
                                 ng-class="results2class(build, 'pulse')")
                 span.badge-inactive
                   | {{build.number}}

--- a/www/base/src/app/masters/masters.tpl.jade
+++ b/www/base/src/app/masters/masters.tpl.jade
@@ -19,7 +19,8 @@
                         span.badge-status(uib-tooltip-template="'buildsummarytooltip'"
                                           tooltip-class="buildsummarytooltipstyle"
                                           tooltip-placement="auto left-bottom"
-                                          tooltip-popup-close-delay="100"
+                                          tooltip-popup-delay="400"
+                                          tooltip-popup-close-delay="400"
                                           ng-class="results2class(build, 'pulse')")
                             | {{ builders.get(build.builderid).name }}/{{ build.number }}
                 td

--- a/www/base/src/app/workers/workers.tpl.jade
+++ b/www/base/src/app/workers/workers.tpl.jade
@@ -33,7 +33,8 @@
                         span.badge-status(uib-tooltip-template="'buildsummarytooltip'"
                                           tooltip-class="buildsummarytooltipstyle"
                                           tooltip-placement="auto left-bottom"
-                                          tooltip-popup-close-delay="100"
+                                          tooltip-popup-delay="400"
+                                          tooltip-popup-close-delay="400"
                                           ng-class="results2class(build, 'pulse')")
                             | {{ builders.get(build.builderid).name }}/{{ build.number }}
                 td(ng-if="settings.showWorkerBuilders.value")

--- a/www/base/src/styles/styles.less
+++ b/www/base/src/styles/styles.less
@@ -195,7 +195,7 @@ span:hover>.mouse-over-only  {display: inline;}
 .tooltip.buildsummarytooltipstyle .tooltip-inner {
     border: 1px;
     padding: 1px;
-    max-width: 100%;
+    min-width: 600px;
     color: #262626;
 }
 

--- a/www/console_view/src/module/console.tpl.jade
+++ b/www/console_view/src/module/console.tpl.jade
@@ -33,7 +33,8 @@
                                       uib-tooltip-template="'buildsummarytooltip'"
                                       tooltip-class="buildsummarytooltipstyle"
                                       tooltip-placement="auto left-bottom"
-                                      tooltip-popup-close-delay="100"
+                                      tooltip-popup-delay="400"
+                                      tooltip-popup-close-delay="400"
                                       ng-class="c.results2class(build, 'pulse')"
                                       ng-click='c.selectBuild(build)')
                         | {{ build.number }}

--- a/www/grid_view/src/module/grid.tpl.jade
+++ b/www/grid_view/src/module/grid.tpl.jade
@@ -51,6 +51,7 @@
                         span.badge-status(uib-tooltip-template="'buildsummarytooltip'"
                                           tooltip-class="buildsummarytooltipstyle"
                                           tooltip-placement="auto left-bottom"
-                                          tooltip-popup-close-delay="100"
+                                          tooltip-popup-delay="400"
+                                          tooltip-popup-close-delay="400"
                                           ng-class="results2class(build, 'pulse')")
                             | {{ build.number }}


### PR DESCRIPTION
Fix for #5930 

## Contributor Checklist:

* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)

