### PR TITLE
buildrequest owners do not always exist

### DIFF
--- a/master/buildbot/newsfragments/requests-owners.bugfix
+++ b/master/buildbot/newsfragments/requests-owners.bugfix
@@ -1,0 +1,1 @@
+fix regression in pending buildrequests UI where owner is not displayed anymore (:issue:`5940`)

--- a/www/base/src/app/builders/builder/builder.tpl.jade
+++ b/www/base/src/app/builders/builder/builder.tpl.jade
@@ -20,6 +20,7 @@
                 span(title="{{br.submitted_at | dateformat:'LLL'}}")
                   | {{br.submitted_at | timeago }}
               td
+                span(ng-if="br.properties.owners === undefined") {{br.properties.owner[0]}}
                 span(ng-repeat="owner in br.properties.owners[0]") {{owner}}
               td
       uib-tab(heading="Build times")


### PR DESCRIPTION
use owner property if it is not present

fix #5940 