### PR TITLE
Make GerritEventLogPoller adhere to debug argument

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -178,7 +178,7 @@ class GerritChangeSourceBase(base.ChangeSource):
              self.master.db.sourcestamps.findOrCreateId(**stampdict))
 
         if found_existing and event_type in ("patchset-created", "ref-updated"):
-            if self.debug or True:
+            if self.debug:
                 eventstr = "{}/{} -- {}:{}".format(
                     self.gitBaseURL, chdict["project"], chdict["branch"],
                     chdict["revision"])

--- a/master/docs/manual/configuration/changesources.rst
+++ b/master/docs/manual/configuration/changesources.rst
@@ -1428,7 +1428,7 @@ You can use both at the same time to get the advantages of each. They will coord
 The :bb:chsrc:`GerritEventLogPoller` accepts the following arguments:
 
 ``baseURL``
-    The HTTP url where to find Gerrit. If the URL of the events-log endpoint for your server is ``https://example.com/a/plugins/events-log/events/`` then the ``baseURL`` is ``https://example.com/a``. Note that ``/a`` is included.
+    The HTTP url where to find Gerrit. If the URL of the events-log endpoint for your server is ``https://example.com/a/plugins/events-log/events/`` then the ``baseURL`` is ``https://example.com/a``. Ensure that ``/a`` is included.
 
 ``auth``
     A request's authentication configuration.


### PR DESCRIPTION
It appears that an {{or True}} was left behind in the source code that causes the logs to flood with duplicate change events from the Gerrit event log.

A minor doc tweak was also made.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
