### PR TITLE
Show owners and worker columns on changes page

### DIFF
--- a/master/buildbot/newsfragments/empty_columns_on_changes_page.bugfix
+++ b/master/buildbot/newsfragments/empty_columns_on_changes_page.bugfix
@@ -1,0 +1,1 @@
+Fix changes page doesn't show data for Owners and Worker columns (:issue:`5888`)

--- a/www/base/src/app/changes/changebuilds/changebuilds.controller.js
+++ b/www/base/src/app/changes/changebuilds/changebuilds.controller.js
@@ -17,9 +17,9 @@ class ChangeBuildsController {
         }
 
         const getBuildsData = function() {
-            let requestUrl = `changes/${changeId}/builds`;
+            let requestUrl = `changes/${changeId}/builds?property=owners&property=workername`;
             if (!buildsFetchLimit == '') {
-                requestUrl = `changes/${changeId}/builds?limit=${buildsFetchLimit}`;
+                requestUrl = `changes/${changeId}/builds?property=owners&property=workername&limit=${buildsFetchLimit}`;
             }
             restService.get(requestUrl).then((data) => {
                 $scope.builds = data.builds;


### PR DESCRIPTION
Fetch required build properties.

Fix https://github.com/buildbot/buildbot/issues/5888