### PR TITLE
Support option '--submodules' for git-repo

### DIFF
--- a/master/buildbot/newsfragments/support-repo-submodule-option.feature
+++ b/master/buildbot/newsfragments/support-repo-submodule-option.feature
@@ -1,0 +1,1 @@
+Add support "--submodule" option for repo init

--- a/master/buildbot/test/unit/steps/test_source_repo.py
+++ b/master/buildbot/test/unit/steps/test_source_repo.py
@@ -117,8 +117,10 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
             + 0,
         )
 
-    def expectRepoSync(self, which_fail=-1, breakatfail=False, depth=0,
+    def expectRepoSync(self, which_fail=-1, breakatfail=False, depth=0, initoptions=None,
                        syncoptions=None, override_commands=None):
+        if initoptions is None:
+            initoptions = []
         if syncoptions is None:
             syncoptions = ["-c"]
         if override_commands is None:
@@ -129,7 +131,7 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
                     'bash', '-c', self.step._getCleanupCommand()]),
             self.ExpectShell(
                 command=['repo', 'init', '-u', 'git://myrepo.com/manifest.git',
-                         '-b', 'mb', '-m', 'mf', '--depth', str(depth)])
+                         '-b', 'mb', '-m', 'mf', '--depth', str(depth)] + initoptions)
         ] + override_commands + [
             self.ExpectShell(command=['repo', 'sync', '--force-sync'] + syncoptions),
             self.ExpectShell(
@@ -152,6 +154,13 @@ class TestRepo(sourcesteps.SourceStepMixin, TestReactorMixin,
         self.mySetupStep(repoDownloads=None, depth=2)
         self.expectClobber()
         self.expectRepoSync(depth=2)
+        return self.myRunStep()
+
+    def test_basic_submodule(self):
+        """basic first time repo sync with submodule"""
+        self.mySetupStep(repoDownloads=None, submodules=True)
+        self.expectClobber()
+        self.expectRepoSync(initoptions=["--submodules"])
         return self.myRunStep()
 
     def test_update(self):

--- a/master/docs/manual/configuration/steps/source_repo.rst
+++ b/master/docs/manual/configuration/steps/source_repo.rst
@@ -47,6 +47,10 @@ The Repo step takes the following arguments:
     A depth of 1 is useful for shallow clones.
     This can save considerable disk space on very large projects.
 
+``submodules``
+    (optional, defaults to ``False``): sync any submodules associated with the manifest repo.
+    Corresponds to the ``--submodules`` argument to the :command:`repo init` command.
+
 ``updateTarballAge``
     (optional, defaults to "one week"): renderable to control the policy of updating of the tarball given properties.
     Returns: max age of tarball in seconds, or ``None``, if we want to skip tarball update.


### PR DESCRIPTION
This PR is based on the Hiraku's suggestion (https://github.com/buildbot/buildbot/pull/5066)

I fix the typo in original commit, update a document and add unit test, create a file under newsfragments directory.

## Contributor Checklist:

* [x] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
