### PR TITLE
Fix exception in FileDownload when file doesn't exist on master

### DIFF
--- a/master/buildbot/newsfragments/file-download-exception.bugfix
+++ b/master/buildbot/newsfragments/file-download-exception.bugfix
@@ -1,0 +1,3 @@
+Brought back the old (pre v2.9.0) :py:class:`~buildbot.steps.transfer.FileDownload` behavior to act
+more gracefully by returning ``FAILURE`` instead of raising an exception when the file doesn't exist
+on master. This makes use cases such as ``FileDownload(haltOnFailure=False)`` possible again.

--- a/master/buildbot/steps/transfer.py
+++ b/master/buildbot/steps/transfer.py
@@ -460,7 +460,7 @@ class FileDownload(_TransferBuildStep):
         except IOError:
             # if file does not exist, bail out with an error
             yield self.addCompleteLog('stderr', 'File {!r} not available at master'.format(source))
-            raise
+            return FAILURE
 
         fileReader = remotetransfer.FileReader(fp)
 

--- a/master/buildbot/test/unit/steps/test_transfer.py
+++ b/master/buildbot/test/unit/steps/test_transfer.py
@@ -998,13 +998,12 @@ class TestFileDownload(steps.BuildStepMixin, TestReactorMixin,
 
         self.expectCommands()
 
-        self.expectOutcome(result=EXCEPTION,
-                           state_string="downloading to {0} (exception)".format(
+        self.expectOutcome(result=FAILURE,
+                           state_string="downloading to {0} (failure)".format(
                                os.path.basename(self.destfile)))
-        yield self.runStep()
         self.expectLogfile('stderr',
-                           "File wkdir/srcdir not available at worker")
-        self.assertEqual(len(self.flushLoggedErrors(FileNotFoundError)), 1)
+                           "File 'not existing file' not available at master")
+        yield self.runStep()
 
 
 class TestStringDownload(steps.BuildStepMixin, TestReactorMixin,


### PR DESCRIPTION
Raising an exception breaks use cases such as FileDownload(haltOnFailure=False).
Also, the behavior deviated unnecessarily from FileUpload. This regression was
made in 5c03c53a8cb245d9b288d2f371e829c545d1a1e3. The test didn't catch the
behavior change because it wasn't there yet.

The test, introduced in 86dfd8269b84ad0beb57dfeefbcd9b4adf18818e, was partly
broken due to misplaced and wrong expectLogfile call. This is now fixed too.