### PR TITLE
WWW: Add Basic authentication support for AvatarGitHub

### DIFF
--- a/master/buildbot/newsfragments/github-avatar-allow-basic.feature
+++ b/master/buildbot/newsfragments/github-avatar-allow-basic.feature
@@ -1,0 +1,1 @@
+Allow usage of Basic authentication to access GitHub API when looking for avatars

--- a/master/docs/manual/configuration/www.rst
+++ b/master/docs/manual/configuration/www.rst
@@ -80,7 +80,9 @@ This server is configured with the ``www`` configuration key, which specifies a 
     .. py:class:: AvatarGitHub(github_api_endpoint=None, token=None, debug=False, verify=False)
 
         :param string github_api_endpoint: specify the github api endpoint if you work with GitHub Enterprise
-        :param string token: a GitHub API token to execute all requests to the API authenticated. It is strongly recommended to use a API token since it increases GitHub API rate limits significantly.
+        :param string token: a GitHub API token to execute all requests to the API authenticated. It is strongly recommended to use a API token since it increases GitHub API rate limits significantly
+        :param string client_id: a GitHub OAuth client ID to use with client secret to execute all requests to the API authenticated in place of token
+        :param string client_secret: a GitHub OAuth client secret to use with client ID above
         :param boolean debug: logs every requests and their response
         :param boolean verify: disable ssl verification for the case you use temporary self signed certificates on a GitHub Enterprise installation
 


### PR DESCRIPTION
On GitHub, organizations cannot create personal access tokens to increase the rate limits.
This commit adds ability to login to GitHub using an OAuth client ID/client secret pair.
This one can be created by organizations (and it is to authenticate users).

## Contributor Checklist:

* [X] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [X] I have updated the appropriate documentation
