### PR TITLE
Fix unwaited addCompleteLog in steps

### DIFF
--- a/master/buildbot/newsfragments/add-complete-log-race.bugfix
+++ b/master/buildbot/newsfragments/add-complete-log-race.bugfix
@@ -1,1 +1,1 @@
-Fix a race condition in log handling of ``RpmLint`` step resulting in steps crashing occasionally.
+Fix a race condition in log handling of ``RpmLint`` and ``WarningCountingShellCommand`` steps resulting in steps crashing occasionally.

--- a/master/buildbot/newsfragments/add-complete-log-race.bugfix
+++ b/master/buildbot/newsfragments/add-complete-log-race.bugfix
@@ -1,0 +1,1 @@
+Fix a race condition in log handling of ``RpmLint`` step resulting in steps crashing occasionally.

--- a/master/buildbot/steps/package/rpm/rpmlint.py
+++ b/master/buildbot/steps/package/rpm/rpmlint.py
@@ -17,6 +17,7 @@
 Steps and objects related to rpmlint.
 """
 
+from twisted.internet import defer
 
 from buildbot.steps.package import util as pkgutil
 from buildbot.steps.shell import Test
@@ -64,6 +65,7 @@ class RpmLint(Test):
         self.obs = pkgutil.WEObserver()
         self.addLogObserver('stdio', self.obs)
 
+    @defer.inlineCallbacks
     def createSummary(self):
         """
         Create nice summary logs.
@@ -73,6 +75,6 @@ class RpmLint(Test):
         warnings = self.obs.warnings
         errors = []
         if warnings:
-            self.addCompleteLog('%d Warnings' % len(warnings), "\n".join(warnings))
+            yield self.addCompleteLog('%d Warnings' % len(warnings), "\n".join(warnings))
         if errors:
-            self.addCompleteLog('%d Errors' % len(errors), "\n".join(errors))
+            yield self.addCompleteLog('%d Errors' % len(errors), "\n".join(errors))

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -452,6 +452,7 @@ class WarningCountingShellCommand(buildstep.ShellMixin, CompositeStepMixin, buil
         stdio_log = yield self.getLog('stdio')
         yield stdio_log.finish()
 
+    @defer.inlineCallbacks
     def createSummary(self):
         """
         Match log lines against warningPattern.
@@ -462,8 +463,8 @@ class WarningCountingShellCommand(buildstep.ShellMixin, CompositeStepMixin, buil
         # If there were any warnings, make the log if lines with warnings
         # available
         if self.warnCount:
-            self.addCompleteLog("warnings (%d)" % self.warnCount,
-                                "\n".join(self.loggedWarnings) + "\n")
+            yield self.addCompleteLog("warnings (%d)" % self.warnCount,
+                                      "\n".join(self.loggedWarnings) + "\n")
 
         warnings_stat = self.getStatistic('warnings', 0)
         self.setStatistic('warnings', warnings_stat + self.warnCount)


### PR DESCRIPTION
Not waiting for addCompleteLog may result in exception being thrown because the log may be finished during step completion before its contents have successfully been loaded.