### PR TITLE
2.10: Fix excessive debug logging in GerritEventLogPoller

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -178,7 +178,7 @@ class GerritChangeSourceBase(base.ChangeSource):
              self.master.db.sourcestamps.findOrCreateId(**stampdict))
 
         if found_existing and event_type in ("patchset-created", "ref-updated"):
-            if self.debug or True:
+            if self.debug:
                 eventstr = "{}/{} -- {}:{}".format(
                     self.gitBaseURL, chdict["project"], chdict["branch"],
                     chdict["revision"])

--- a/master/buildbot/newsfragments/gerriteventlogpoller-debug-logs.bugfix
+++ b/master/buildbot/newsfragments/gerriteventlogpoller-debug-logs.bugfix
@@ -1,0 +1,1 @@
+Fixed excessive debug logging in ``GerritEventLogPoller``.


### PR DESCRIPTION
This PR backports #5944 to 2.10.x.