### PR TITLE
2.10: Clean up shell command tests and re-add support for lazylogfiles 

### DIFF
--- a/master/buildbot/newsfragments/shellcommand-lazylogfiles.bugfix
+++ b/master/buildbot/newsfragments/shellcommand-lazylogfiles.bugfix
@@ -1,0 +1,1 @@
+Re-added support for ``lazylogfiles`` argument of ``ShellCommand`` that was available in old style steps.

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -184,6 +184,7 @@ class ShellCommandNewStyle(buildstep.ShellMixin, buildstep.BuildStep):
                 'maxTime',
                 'sigtermTime',
                 'logfiles',
+                'lazylogfiles',
                 'usePTY',
                 'logEnviron',
                 'collectStdout',

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -128,6 +128,9 @@ class FakeRemoteShellCommand(FakeRemoteCommand):
                     initial_stdin=initialStdin,
                     timeout=timeout, maxTime=maxTime, logfiles=logfiles,
                     usePTY=usePTY, logEnviron=logEnviron)
+
+        if interruptSignal is not None and interruptSignal != 'KILL':
+            args['interruptSignal'] = interruptSignal
         super().__init__("shell", args,
                          collectStdout=collectStdout,
                          collectStderr=collectStderr,
@@ -325,7 +328,7 @@ class ExpectShell(Expect):
     def __init__(self, workdir, command, env=None,
                  want_stdout=1, want_stderr=1, initialStdin=None,
                  timeout=20 * 60, maxTime=None, logfiles=None,
-                 usePTY=None, logEnviron=True):
+                 usePTY=None, logEnviron=True, interruptSignal=None):
         if env is None:
             env = {}
         if logfiles is None:
@@ -335,6 +338,8 @@ class ExpectShell(Expect):
                     initial_stdin=initialStdin,
                     timeout=timeout, maxTime=maxTime, logfiles=logfiles,
                     usePTY=usePTY, logEnviron=logEnviron)
+        if interruptSignal is not None:
+            args['interruptSignal'] = interruptSignal
         super().__init__("shell", args)
 
     def __repr__(self):

--- a/master/buildbot/test/fake/remotecommand.py
+++ b/master/buildbot/test/fake/remotecommand.py
@@ -75,11 +75,46 @@ class FakeRemoteCommand:
     def useLog(self, log_, closeWhenFinished=False, logfileName=None):
         if not logfileName:
             logfileName = log_.getName()
+        assert logfileName not in self.logs
+        assert logfileName not in self.delayedLogs
         self.logs[logfileName] = log_
         self._log_close_when_finished[logfileName] = closeWhenFinished
 
     def useLogDelayed(self, logfileName, activateCallBack, closeWhenFinished=False):
+        assert logfileName not in self.logs
+        assert logfileName not in self.delayedLogs
         self.delayedLogs[logfileName] = (activateCallBack, closeWhenFinished)
+
+    def addStdout(self, data):
+        if self.collectStdout:
+            self.stdout += data
+        if self.stdioLogName is not None and self.stdioLogName in self.logs:
+            self.logs[self.stdioLogName].addStdout(data)
+
+    def addStderr(self, data):
+        if self.collectStderr:
+            self.stderr += data
+        if self.stdioLogName is not None and self.stdioLogName in self.logs:
+            self.logs[self.stdioLogName].addStderr(data)
+
+    def addHeader(self, data):
+        if self.stdioLogName is not None and self.stdioLogName in self.logs:
+            self.logs[self.stdioLogName].addHeader(data)
+
+    @defer.inlineCallbacks
+    def addToLog(self, logname, data):
+        # Activate delayed logs on first data.
+        if logname in self.delayedLogs:
+            (activate_callback, close_when_finished) = self.delayedLogs[logname]
+            del self.delayedLogs[logname]
+            loog = yield activate_callback(self)
+            self.logs[logname] = loog
+            self._log_close_when_finished[logname] = close_when_finished
+
+        if logname in self.logs:
+            self.logs[logname].addStdout(data)
+        else:
+            raise Exception("{}.addToLog: no such log {}".format(self, logname))
 
     def interrupt(self, why):
         if not self._waiting_for_interrupt:
@@ -238,16 +273,21 @@ class Expect:
             command.updates.setdefault(args[0], []).append(args[1])
         elif behavior == 'log':
             name, streams = args
-            if 'header' in streams:
-                command.logs[name].addHeader(streams['header'])
-            if 'stdout' in streams:
-                command.logs[name].addStdout(streams['stdout'])
-                if command.collectStdout:
-                    command.stdout += streams['stdout']
-            if 'stderr' in streams:
-                command.logs[name].addStderr(streams['stderr'])
-                if command.collectStderr:
-                    command.stderr += streams['stderr']
+            for stream in streams:
+                if stream not in ['header', 'stdout', 'stderr']:
+                    raise Exception('Log stream {} is not recognized'.format(stream))
+
+            if name == command.stdioLogName:
+                if 'header' in streams:
+                    command.addHeader(streams['header'])
+                if 'stdout' in streams:
+                    command.addStdout(streams['stdout'])
+                if 'stderr' in streams:
+                    command.addStderr(streams['stderr'])
+            else:
+                if 'header' in streams or 'stderr' in streams:
+                    raise Exception('Non stdio streams only support stdout')
+                return command.addToLog(name, streams['stdout'])
         elif behavior == 'callable':
             return defer.maybeDeferred(lambda: args[0](command))
         else:

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -1086,15 +1086,15 @@ class ShellMixinExample(buildstep.ShellMixin, buildstep.BuildStep):
 
 class SimpleShellCommand(buildstep.ShellMixin, buildstep.BuildStep):
 
-    def __init__(self, makeRemoteShellCommandKwargs=None, **kwargs):
-        self.makeRemoteShellCommandKwargs = makeRemoteShellCommandKwargs or {}
+    def __init__(self, make_cmd_kwargs=None, **kwargs):
+        self.make_cmd_kwargs = make_cmd_kwargs or {}
 
         kwargs = self.setupShellMixin(kwargs)
         super().__init__(**kwargs)
 
     @defer.inlineCallbacks
     def run(self):
-        cmd = yield self.makeRemoteShellCommand(**self.makeRemoteShellCommandKwargs)
+        cmd = yield self.makeRemoteShellCommand(**self.make_cmd_kwargs)
         yield self.runCommand(cmd)
         return cmd.results()
 
@@ -1244,7 +1244,7 @@ class TestShellMixin(steps.BuildStepMixin,
     def test_example_override_workdir(self):
         # Test that makeRemoteShellCommand(workdir=X) works.
         self.setupStep(SimpleShellCommand(
-            makeRemoteShellCommandKwargs={'workdir': '/alternate'},
+            make_cmd_kwargs={'workdir': '/alternate'},
             command=['foo', properties.Property('bar', 'BAR')]))
         self.expectCommands(
             ExpectShell(workdir='/alternate', command=['foo', 'BAR']) +

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -1271,8 +1271,8 @@ class TestShellMixin(steps.BuildStepMixin,
                                           interruptSignal='DIE'),
                        worker_version={'*': "3.0"})
         self.expectCommands(
-            ExpectShell(workdir='wkdir', usePTY=False, command=['cmd', 'arg']) +
-            # note missing parameters
+            ExpectShell(workdir='wkdir', usePTY=False, interruptSignal='DIE',
+                        command=['cmd', 'arg']) +
             0,
         )
         self.expectOutcome(result=SUCCESS)

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -1103,9 +1103,9 @@ class TestShellMixin(steps.BuildStepMixin,
                                   prohibitArgs=['logfiles'])
 
     def test_setupShellMixin_not_new_style(self):
-        self.patch(ShellMixinExample, 'isNewStyle', lambda self: False)
+        self.patch(SimpleShellCommand, 'isNewStyle', lambda self: False)
         with self.assertRaises(AssertionError):
-            ShellMixinExample()
+            SimpleShellCommand()
 
     def test_constructor_defaults(self):
         class MySubclass(SimpleShellCommand):
@@ -1229,7 +1229,7 @@ class TestShellMixin(steps.BuildStepMixin,
             ExpectShell(workdir='wkdir', command=['cmd', 'arg'],
                         logfiles={'logname': 'logpath.log'}) +
             Expect.log('logname', stdout='logline\nlogline2\n') +
-            Expect.log('stdio', stdio="some log\n") +
+            Expect.log('stdio', stdout="some log\n") +
             0,
         )
         self.expectOutcome(result=SUCCESS)

--- a/master/buildbot/test/unit/process/test_buildstep.py
+++ b/master/buildbot/test/unit/process/test_buildstep.py
@@ -1238,6 +1238,59 @@ class TestShellMixin(steps.BuildStepMixin,
                          'logline\nlogline2\n')
 
     @defer.inlineCallbacks
+    def test_lazy_logfiles_stdout_has_stdout(self):
+        self.setupStep(SimpleShellCommand(command=['cmd', 'arg'], lazylogfiles=True))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['cmd', 'arg']) +
+            Expect.log('stdio', stdout="some log\n") +
+            0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        yield self.runStep()
+        self.assertEqual(self.step.getLog('stdio').stdout, 'some log\n')
+
+    @defer.inlineCallbacks
+    def test_lazy_logfiles_stdout_no_stdout(self):
+        # lazy log files do not apply to stdout
+        self.setupStep(SimpleShellCommand(command=['cmd', 'arg'], lazylogfiles=True))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['cmd', 'arg']) +
+            0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        yield self.runStep()
+        self.assertEqual(self.step.getLog('stdio').stdout, '')
+
+    @defer.inlineCallbacks
+    def test_lazy_logfiles_logfile(self):
+        self.setupStep(SimpleShellCommand(command=['cmd', 'arg'], lazylogfiles=True,
+                                          logfiles={'logname': 'logpath.log'}))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['cmd', 'arg'],
+                        logfiles={'logname': 'logpath.log'}) +
+            Expect.log('logname', stdout='logline\nlogline2\n') +
+            0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        yield self.runStep()
+        self.assertEqual(self.step.getLog('logname').stdout,
+                         'logline\nlogline2\n')
+
+    @defer.inlineCallbacks
+    def test_lazy_logfiles_no_logfile(self):
+        self.setupStep(SimpleShellCommand(command=['cmd', 'arg'], lazylogfiles=True,
+                                          logfiles={'logname': 'logpath.log'}))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', command=['cmd', 'arg'],
+                        logfiles={'logname': 'logpath.log'}) +
+            0,
+        )
+        self.expectOutcome(result=SUCCESS)
+        yield self.runStep()
+        with self.assertRaises(KeyError):
+            self.step.getLog('logname')
+
+    @defer.inlineCallbacks
     def test_env(self):
         self.setupStep(SimpleShellCommand(command=['cmd', 'arg'], env={'BAR': 'BAR'}))
         self.build.builder.config.env = {'FOO': 'FOO'}

--- a/master/buildbot/test/unit/steps/test_shell.py
+++ b/master/buildbot/test/unit/steps/test_shell.py
@@ -230,7 +230,7 @@ class TreeSize(steps.BuildStepMixin, TestReactorMixin, unittest.TestCase):
         self.expectCommands(
             ExpectShell(workdir='wkdir',
                         command=['du', '-s', '-k', '.'])
-            + ExpectShell.log('stdio', stdio='abcdef\n')
+            + ExpectShell.log('stdio', stdout='abcdef\n')
             + 0
         )
         self.expectOutcome(result=WARNINGS,

--- a/master/buildbot/test/unit/steps/test_shellsequence.py
+++ b/master/buildbot/test/unit/steps/test_shellsequence.py
@@ -21,7 +21,6 @@ from buildbot.process.results import FAILURE
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import WARNINGS
 from buildbot.steps import shellsequence
-from buildbot.test.fake.remotecommand import Expect
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.util import config as configmixin
 from buildbot.test.util import steps
@@ -76,14 +75,12 @@ class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
             arg.validateAttributes()
 
     def testShellArgsAreRendered(self):
-        arg1 = shellsequence.ShellArg(command=WithProperties('make %s', 'project'),
-                                      logname=WithProperties('make %s', 'project'))
+        arg1 = shellsequence.ShellArg(command=WithProperties('make %s', 'project'))
         self.setupStep(
             shellsequence.ShellSequence(commands=[arg1],
                                         workdir='build'))
         self.properties.setProperty("project", "BUILDBOT-TEST", "TEST")
-        self.expectCommands(ExpectShell(workdir='build', command='make BUILDBOT-TEST')
-                            + 0 + Expect.log('stdio make BUILDBOT-TEST'))
+        self.expectCommands(ExpectShell(workdir='build', command='make BUILDBOT-TEST') + 0)
         # TODO: need to factor command-summary stuff into a utility method and
         # use it here
         self.expectOutcome(result=SUCCESS, state_string="'make BUILDBOT-TEST'")
@@ -114,13 +111,12 @@ class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
 
     def testMultipleCommandsAreRun(self):
         arg1 = shellsequence.ShellArg(command='make p1')
-        arg2 = shellsequence.ShellArg(command='deploy p1', logname='deploy')
+        arg2 = shellsequence.ShellArg(command='deploy p1')
         self.setupStep(
             shellsequence.ShellSequence(commands=[arg1, arg2],
                                         workdir='build'))
         self.expectCommands(ExpectShell(workdir='build', command='make p1') + 0,
-                            ExpectShell(workdir='build', command='deploy p1') + 0 +
-                            Expect.log('stdio deploy p1'))
+                            ExpectShell(workdir='build', command='deploy p1') + 0)
         self.expectOutcome(result=SUCCESS, state_string="'deploy p1'")
         return self.runStep()
 
@@ -166,16 +162,13 @@ class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
         This unit test makes sure that ShellArg instances are rendered anew at
         each new build.
         """
-        arg = shellsequence.ShellArg(command=WithProperties('make %s', 'project'),
-                                     logname=WithProperties('make %s', 'project'))
+        arg = shellsequence.ShellArg(command=WithProperties('make %s', 'project'))
         step = shellsequence.ShellSequence(commands=[arg], workdir='build')
 
         # First "build"
         self.setupStep(step)
         self.properties.setProperty("project", "BUILDBOT-TEST-1", "TEST")
-        self.expectCommands(ExpectShell(workdir='build',
-                            command='make BUILDBOT-TEST-1') + 0 +
-                            Expect.log('stdio make BUILDBOT-TEST-1'))
+        self.expectCommands(ExpectShell(workdir='build', command='make BUILDBOT-TEST-1') + 0)
         self.expectOutcome(result=SUCCESS,
                            state_string="'make BUILDBOT-TEST-1'")
         self.runStep()
@@ -183,9 +176,7 @@ class TestOneShellCommand(steps.BuildStepMixin, configmixin.ConfigErrorsMixin,
         # Second "build"
         self.setupStep(step)
         self.properties.setProperty("project", "BUILDBOT-TEST-2", "TEST")
-        self.expectCommands(ExpectShell(workdir='build',
-                            command='make BUILDBOT-TEST-2') + 0 +
-                            Expect.log('stdio make BUILDBOT-TEST-2'))
+        self.expectCommands(ExpectShell(workdir='build', command='make BUILDBOT-TEST-2') + 0)
         self.expectOutcome(result=SUCCESS,
                            state_string="'make BUILDBOT-TEST-2'")
 

--- a/master/buildbot/test/unit/steps/test_source_git.py
+++ b/master/buildbot/test/unit/steps/test_source_git.py
@@ -1673,7 +1673,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                            mode='incremental', progress=True))
         self.step.build.getWorkerCommandVersion = lambda cmd, oldversion: "2.15"
         self.expectCommands(
-            ExpectShell(workdir='wkdir',
+            ExpectShell(workdir='wkdir', interruptSignal='TERM',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 1.7.5')
@@ -1684,15 +1684,15 @@ class TestGit(sourcesteps.SourceStepMixin,
             Expect('stat', dict(file='wkdir/.git',
                                 logEnviron=True))
             + 0,
-            ExpectShell(workdir='wkdir',
+            ExpectShell(workdir='wkdir', interruptSignal='TERM',
                         command=['git', 'fetch', '-f', '-t',
                                  'http://github.com/buildbot/buildbot.git',
                                  'HEAD', '--progress'])
             + 0,
-            ExpectShell(workdir='wkdir',
+            ExpectShell(workdir='wkdir', interruptSignal='TERM',
                         command=['git', 'reset', '--hard', 'FETCH_HEAD', '--'])
             + 0,
-            ExpectShell(workdir='wkdir',
+            ExpectShell(workdir='wkdir', interruptSignal='TERM',
                         command=['git', 'rev-parse', 'HEAD'])
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')
@@ -2674,7 +2674,7 @@ class TestGit(sourcesteps.SourceStepMixin,
                            mode='incremental'))
         self.step.build.getWorkerCommandVersion = lambda cmd, oldversion: "2.15"
         self.expectCommands(
-            ExpectShell(workdir='wkdir',
+            ExpectShell(workdir='wkdir', interruptSignal='TERM',
                         command=['git', '--version'])
             + ExpectShell.log('stdio',
                               stdout='git version 1.7.5')
@@ -2685,12 +2685,12 @@ class TestGit(sourcesteps.SourceStepMixin,
             Expect('stat', dict(file='wkdir/.git',
                                 logEnviron=True))
             + 1,
-            ExpectShell(workdir='wkdir',
+            ExpectShell(workdir='wkdir', interruptSignal='TERM',
                         command=['git', 'clone',
                                  'http://github.com/buildbot/buildbot.git',
                                  '.', '--progress'])
             + 0,
-            ExpectShell(workdir='wkdir',
+            ExpectShell(workdir='wkdir', interruptSignal='TERM',
                         command=['git', 'rev-parse', 'HEAD'])
             + ExpectShell.log('stdio',
                               stdout='f6ad368298bd941e934a41f3babc827b2aa95a1d')


### PR DESCRIPTION
This PR backports #5970 to 2.10.x.
