### PR TITLE
Fix missing VERSION file in buildbot_worker wheel package.

### DIFF
--- a/master/buildbot/newsfragments/worker-wheel-version.bugfix
+++ b/master/buildbot/newsfragments/worker-wheel-version.bugfix
@@ -1,0 +1,1 @@
+Fix missing VERSION file in buildbot_worker wheel package. :bug:`5948`, :bug:`4464`


### PR DESCRIPTION
Bug #5948, #4464

## Contributor Checklist:

* [ ] I have updated the unit tests
* [x] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
