### PR TITLE
graphql basic request parsing and error management

### DIFF
--- a/master/buildbot/test/fake/endpoint.py
+++ b/master/buildbot/test/fake/endpoint.py
@@ -35,6 +35,7 @@ testData = {
 class TestsEndpoint(base.Endpoint):
     isCollection = True
     pathPatterns = "/test"
+    rootLinkName = 'test'
 
     def get(self, resultSpec, kwargs):
         # results are sorted by ID for test stability
@@ -88,3 +89,20 @@ class Test(base.ResourceType):
         success = types.Boolean()
         tags = types.List(of=types.String())
     entityType = EntityType(name)
+
+
+graphql_schema = """
+# custom scalar types for buildbot data model
+scalar Date   # stored as utc unix timestamp
+scalar Binary # arbitrary data stored as base85
+scalar JSON  # arbitrary json stored as string, mainly used for properties values
+type Query {
+  tests: [Test]!
+}
+type Test {
+  id: Int!
+  info: String!
+  success: Boolean!
+  tags: [String]!
+}
+"""

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -22,6 +22,7 @@ from buildbot.data import connector
 from buildbot.db.buildrequests import AlreadyClaimedError
 from buildbot.test.util import validation
 from buildbot.util import service
+from buildbot.test.fake import endpoint
 
 
 class FakeUpdates(service.AsyncService):
@@ -509,3 +510,6 @@ class FakeDataConnector(service.AsyncMultiService):
         if not isinstance(path, tuple):
             raise TypeError('path must be a tuple')
         return self.realConnector.control(action, args, path)
+
+    def get_graphql_schema(self):
+        return endpoint.graphql_schema

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -20,9 +20,9 @@ from twisted.python import failure
 
 from buildbot.data import connector
 from buildbot.db.buildrequests import AlreadyClaimedError
+from buildbot.test.fake import endpoint
 from buildbot.test.util import validation
 from buildbot.util import service
-from buildbot.test.fake import endpoint
 
 
 class FakeUpdates(service.AsyncService):

--- a/master/buildbot/test/unit/data/test_connector.py
+++ b/master/buildbot/test/unit/data/test_connector.py
@@ -243,6 +243,15 @@ class DataConnector(TestReactorMixin, unittest.TestCase):
         """))
         schema = graphql.build_schema(schema)
 
+
+    def test_get_fake_graphql_schema(self):
+        # use the test module for basic graphQLSchema generation
+        mod = reflect.namedModule('buildbot.test.fake.endpoint')
+        self.data._scanModule(mod)
+        schema = self.data.get_graphql_schema()
+        self.assertEqual(schema, mod.graphql_schema)
+        schema = graphql.build_schema(schema)
+
 # classes discovered by test_scanModule, above
 
 

--- a/master/buildbot/test/unit/data/test_connector.py
+++ b/master/buildbot/test/unit/data/test_connector.py
@@ -243,7 +243,6 @@ class DataConnector(TestReactorMixin, unittest.TestCase):
         """))
         schema = graphql.build_schema(schema)
 
-
     def test_get_fake_graphql_schema(self):
         # use the test module for basic graphQLSchema generation
         mod = reflect.namedModule('buildbot.test.fake.endpoint')

--- a/master/buildbot/test/unit/www/test_graphql.py
+++ b/master/buildbot/test/unit/www/test_graphql.py
@@ -1,0 +1,108 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import json
+
+import mock
+
+from twisted.internet import defer
+from twisted.trial import unittest
+
+from buildbot.test.fake import endpoint
+from buildbot.test.util import www
+from buildbot.test.util.misc import TestReactorMixin
+from buildbot.util import unicode2bytes
+from buildbot.www import graphql
+
+
+class V3RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+    def setUp(self):
+        self.setUpTestReactor()
+        self.master = self.make_master(url="http://server/path/")
+        self.master.config.www["graphql"] = {"debug": True}
+        self.master.data._scanModule(endpoint)
+        self.rsrc = graphql.V3RootResource(self.master)
+        self.rsrc.reconfigResource(self.master.config)
+
+    def assertSimpleError(self, message_or_error, responseCode):
+        if isinstance(message_or_error, list):
+            errors = message_or_error
+        else:
+            errors = [{"message": message_or_error}]
+        content = json.dumps({"data": None, "errors": errors})
+        self.assertRequest(content=unicode2bytes(content), responseCode=responseCode)
+
+    @defer.inlineCallbacks
+    def test_failure(self):
+        self.rsrc.renderQuery = mock.Mock(
+            return_value=defer.fail(RuntimeError("oh noes"))
+        )
+        yield self.render_resource(
+            self.rsrc,
+            b"/?query={builders{name}}",
+        )
+        self.assertSimpleError("internal error - see logs", 500)
+        self.assertEqual(len(self.flushLoggedErrors(RuntimeError)), 1)
+
+    @defer.inlineCallbacks
+    def test_invalid_http_method(self):
+        yield self.render_resource(self.rsrc, b"/", method=b"PATCH")
+        self.assertSimpleError("invalid HTTP method", 400)
+
+    @defer.inlineCallbacks
+    def test_get_query(self):
+        yield self.render_resource(
+            self.rsrc,
+            b"/?query={tests{id}}",
+        )
+        # TODO verify results
+
+    @defer.inlineCallbacks
+    def test_get_bad_query(self):
+        yield self.render_resource(
+            self.rsrc,
+            b"/?query={notexistant{id}}",
+        )
+        self.assertSimpleError(
+            [
+                {
+                    "message": "Cannot query field 'notexistant' on type 'Query'.",
+                    "locations": [{"line": 1, "column": 2}],
+                    "path": None,
+                }
+            ],
+            400,
+        )
+
+
+class DisabledV3RootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
+    def setUp(self):
+        self.setUpTestReactor()
+        self.master = self.make_master(url="http://server/path/")
+        self.master.data._scanModule(endpoint)
+        self.rsrc = graphql.V3RootResource(self.master)
+        self.rsrc.reconfigResource(self.master.config)
+
+    @defer.inlineCallbacks
+    def test_basic_disabled(self):
+        yield self.render_resource(self.rsrc, b"/")
+        self.assertRequest(
+            content=unicode2bytes(
+                json.dumps(
+                    {"data": None, "errors": [{"message": "graphql not enabled"}]}
+                )
+            ),
+            responseCode=501,
+        )

--- a/master/buildbot/test/unit/www/test_rest.py
+++ b/master/buildbot/test/unit/www/test_rest.py
@@ -27,6 +27,7 @@ from buildbot.test.util.misc import TestReactorMixin
 from buildbot.util import bytes2unicode
 from buildbot.util import unicode2bytes
 from buildbot.www import authz
+from buildbot.www import graphql
 from buildbot.www import rest
 from buildbot.www.rest import JSONRPC_CODES
 from buildbot.www.rest import BadRequest
@@ -34,10 +35,11 @@ from buildbot.www.rest import BadRequest
 
 class RestRootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
-    maxVersion = 2
+    maxVersion = 3
 
     def setUp(self):
         self.setUpTestReactor()
+        [graphql] # used for import side effect
 
     @defer.inlineCallbacks
     def test_render(self):

--- a/master/buildbot/test/unit/www/test_rest.py
+++ b/master/buildbot/test/unit/www/test_rest.py
@@ -39,7 +39,7 @@ class RestRootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
 
     def setUp(self):
         self.setUpTestReactor()
-        [graphql] # used for import side effect
+        [graphql]  # used for import side effect
 
     @defer.inlineCallbacks
     def test_render(self):

--- a/master/buildbot/test/util/www.py
+++ b/master/buildbot/test/util/www.py
@@ -16,6 +16,7 @@
 import json
 import os
 import pkg_resources
+from io import BytesIO
 from io import StringIO
 from urllib.parse import parse_qs
 from urllib.parse import unquote as urlunquote
@@ -157,7 +158,8 @@ class WwwTestMixin(RequiresWwwMixin):
 
     def render_resource(self, rsrc, path=b'/', accept=None, method=b'GET',
                         origin=None, access_control_request_method=None,
-                        extraHeaders=None, request=None):
+                        extraHeaders=None, request=None,
+                        content=None, content_type=None):
         if not request:
             request = self.make_request(path, method=method)
             if accept:
@@ -169,6 +171,9 @@ class WwwTestMixin(RequiresWwwMixin):
                     access_control_request_method
             if extraHeaders is not None:
                 request.input_headers.update(extraHeaders)
+            if content_type is not None:
+                request.input_headers.update({b'content-type': content_type})
+                request.content = BytesIO(content)
 
         rv = rsrc.render(request)
         if rv != server.NOT_DONE_YET:

--- a/master/buildbot/www/graphql.py
+++ b/master/buildbot/www/graphql.py
@@ -1,0 +1,92 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import json
+
+from twisted.internet import defer
+from twisted.python import log
+from twisted.web.error import Error
+
+from buildbot.util import bytes2unicode
+from buildbot.util import unicode2bytes
+from buildbot.www import resource
+from buildbot.www.rest import RestRootResource
+
+
+class V3RootResource(resource.Resource):
+    isLeaf = True
+
+    # enable reconfigResource calls
+    needsReconfig = True
+
+    def reconfigResource(self, new_config):
+        # @todo v2 has cross origin support, which might need to be factorized
+        self.gql_config = new_config.www.get("graphql")
+        self.debug = True
+        self.graphql = None
+        if self.gql_config is not None:
+            try:
+                import graphql
+            except ImportError:
+                raise ImportError(
+                    "graphql is enabled but 'graphql-core' is not installed"
+                )
+            self.graphql = graphql
+            self.debug = self.gql_config.get("debug")
+            self.schema = graphql.build_schema(self.master.data.get_graphql_schema())
+
+    def render(self, request):
+        def writeError(msg, errcode=400):
+            if isinstance(msg, list):
+                errors = msg
+            else:
+                msg = bytes2unicode(msg)
+                errors = [{"message": msg}]
+            if self.debug:
+                log.msg("HTTP error: {}".format(errors))
+            request.setResponseCode(errcode)
+            request.setHeader(b"content-type", b"application/json; charset=utf-8")
+            data = json.dumps({"data": None, "errors": errors})
+            data = unicode2bytes(data)
+            request.write(data)
+            request.finish()
+
+        return self.asyncRenderHelper(request, self.asyncRender, writeError)
+
+    def renderQuery(self, query):
+        query = self.graphql.parse(query)
+        errors = self.graphql.validate(self.schema, query)
+        if errors:
+            raise Error(400, [e.formatted for e in errors])
+
+    @defer.inlineCallbacks
+    def asyncRender(self, request):
+        if self.graphql is None:
+            raise Error(501, "graphql not enabled")
+
+        # graphql accepts its query either in post data or get query
+        if request.method == b"POST":
+            query = request.content.read()
+        elif request.method in (b"GET"):
+            if b"query" not in request.args:
+                raise Error(400, b"GET request must contain a 'query' parameter")
+            query = request.args[b"query"][0].decode()
+        else:
+            raise Error(400, b"invalid HTTP method")
+
+        res = yield self.renderQuery(query)
+        return res
+
+RestRootResource.addApiVersion(3, V3RootResource)


### PR DESCRIPTION
Some basic infrastructure.

we had api/v2

graphql will be at api/v3

Goal is to let the user enable it via `c['www']['graphql'] = {'debug'=True}`

we make extra effort to not require graphql-core unless enabled
