### PR TITLE
refactor resultSpec build into data connector

### DIFF
--- a/master/buildbot/data/base.py
+++ b/master/buildbot/data/base.py
@@ -90,7 +90,7 @@ class Endpoint:
         return action_method(args, kwargs)
 
     def __repr__(self):
-        return "endpoint for " + self.pathPatterns
+        return "endpoint for " + ",".join(self.pathPatterns.split())
 
 
 class BuildNestingMixin:

--- a/master/buildbot/data/exceptions.py
+++ b/master/buildbot/data/exceptions.py
@@ -34,3 +34,7 @@ class InvalidPathError(DataException):
 
 class InvalidControlException(DataException):
     "Action is not supported"
+
+
+class InvalidQueryParameter(DataException):
+    "Query Parameter was invalid"

--- a/master/buildbot/test/fake/endpoint.py
+++ b/master/buildbot/test/fake/endpoint.py
@@ -34,8 +34,11 @@ testData = {
 
 class TestsEndpoint(base.Endpoint):
     isCollection = True
-    pathPatterns = "/test"
-    rootLinkName = 'test'
+    pathPatterns = """
+    /tests
+    /test
+    """
+    rootLinkName = 'tests'
 
     def get(self, resultSpec, kwargs):
         # results are sorted by ID for test stability
@@ -65,7 +68,10 @@ class FailEndpoint(base.Endpoint):
 
 class TestEndpoint(base.Endpoint):
     isCollection = False
-    pathPatterns = "/test/n:testid"
+    pathPatterns = """
+    /tests/n:testid
+    /test/n:testid
+    """
 
     def get(self, resultSpec, kwargs):
         if kwargs['testid'] == 0:

--- a/master/buildbot/test/fake/fakedata.py
+++ b/master/buildbot/test/fake/fakedata.py
@@ -19,6 +19,7 @@ from twisted.internet import defer
 from twisted.python import failure
 
 from buildbot.data import connector
+from buildbot.data import resultspec
 from buildbot.db.buildrequests import AlreadyClaimedError
 from buildbot.test.fake import endpoint
 from buildbot.test.util import validation
@@ -487,6 +488,7 @@ class FakeDataConnector(service.AsyncMultiService):
         self.realConnector = connector.DataConnector()
         self.realConnector.setServiceParent(self)
         self.rtypes = self.realConnector.rtypes
+        self.plural_rtypes = self.realConnector.plural_rtypes
 
     def _scanModule(self, mod):
         return self.realConnector._scanModule(mod)
@@ -506,6 +508,13 @@ class FakeDataConnector(service.AsyncMultiService):
         return self.realConnector.get(path, filters=filters, fields=fields,
                                       order=order, limit=limit, offset=offset)
 
+    def get_with_resultspec(self, path, rspec):
+        if not isinstance(path, tuple):
+            raise TypeError('path must be a tuple')
+        if not isinstance(rspec, resultspec.ResultSpec):
+            raise TypeError('rspec must be ResultSpec')
+        return self.realConnector.get_with_resultspec(path, rspec)
+
     def control(self, action, args, path):
         if not isinstance(path, tuple):
             raise TypeError('path must be a tuple')
@@ -513,3 +522,6 @@ class FakeDataConnector(service.AsyncMultiService):
 
     def get_graphql_schema(self):
         return endpoint.graphql_schema
+
+    def resultspec_from_jsonapi(self, args, entityType, is_collection):
+        return self.realConnector.resultspec_from_jsonapi(args, entityType, is_collection)

--- a/master/buildbot/test/unit/www/test_rest.py
+++ b/master/buildbot/test/unit/www/test_rest.py
@@ -21,6 +21,7 @@ import mock
 from twisted.internet import defer
 from twisted.trial import unittest
 
+from buildbot.data.exceptions import InvalidQueryParameter
 from buildbot.test.fake import endpoint
 from buildbot.test.util import www
 from buildbot.test.util.misc import TestReactorMixin
@@ -30,7 +31,6 @@ from buildbot.www import authz
 from buildbot.www import graphql
 from buildbot.www import rest
 from buildbot.www.rest import JSONRPC_CODES
-from buildbot.www.rest import BadRequest
 
 
 class RestRootResource(TestReactorMixin, www.WwwTestMixin, unittest.TestCase):
@@ -549,7 +549,7 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin,
         yield self.render_resource(self.rsrc, b'/test/0')
         self.assertRequest(
             contentJson={'error': "not found while getting from endpoint for "
-                                  "/test/n:testid with arguments"
+                                  "/tests/n:testid,/test/n:testid with arguments"
                                   " ResultSpec(**{'filters': [], 'fields': None, "
                                   "'properties': [], "
                                   "'order': None, 'limit': None, 'offset': None}) "
@@ -590,7 +590,7 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin,
         expected_props = [None, 'test2']
         self.make_request(b'/test')
         self.request.args = {b'property': expected_props}
-        with self.assertRaises(BadRequest):
+        with self.assertRaises(InvalidQueryParameter):
             self.rsrc.decodeResultSpec(self.request, endpoint.TestsEndpoint)
 
     def test_decode_result_spec_limit(self):
@@ -622,31 +622,31 @@ class V2RootResource_REST(TestReactorMixin, www.WwwTestMixin,
         self.assertEqual(spec.properties[0].values, expected_props)
 
     def test_decode_result_spec_not_a_collection_limit(self):
-        def expectRaiseBadRequest():
+        def expectRaiseInvalidQueryParameter():
             limit = 5
             self.make_request(b'/test')
             self.request.args = {b'limit': limit}
             self.rsrc.decodeResultSpec(self.request, endpoint.TestEndpoint)
-        with self.assertRaises(rest.BadRequest):
-            expectRaiseBadRequest()
+        with self.assertRaises(InvalidQueryParameter):
+            expectRaiseInvalidQueryParameter()
 
     def test_decode_result_spec_not_a_collection_order(self):
-        def expectRaiseBadRequest():
+        def expectRaiseInvalidQueryParameter():
             order = ('info',)
             self.make_request(b'/test')
             self.request.args = {b'order': order}
             self.rsrc.decodeResultSpec(self.request, endpoint.TestEndpoint)
-        with self.assertRaises(rest.BadRequest):
-            expectRaiseBadRequest()
+        with self.assertRaises(InvalidQueryParameter):
+            expectRaiseInvalidQueryParameter()
 
     def test_decode_result_spec_not_a_collection_offset(self):
-        def expectRaiseBadRequest():
+        def expectRaiseInvalidQueryParameter():
             offset = 0
             self.make_request(b'/test')
             self.request.args = {b'offset': offset}
             self.rsrc.decodeResultSpec(self.request, endpoint.TestEndpoint)
-        with self.assertRaises(rest.BadRequest):
-            expectRaiseBadRequest()
+        with self.assertRaises(InvalidQueryParameter):
+            expectRaiseInvalidQueryParameter()
 
     def test_decode_result_spec_not_a_collection_properties(self):
         expected_props = ['test1', 'test2']


### PR DESCRIPTION
so that it can be used by graphql

simple refacto independent from the other WIP

resultSpec building from a dictionary will be exactly the same in graphql, so we refactor it to be useable in both
