### PR TITLE
Reduce buildbot_worker wheel package size by 40% by dropping tests fr…

### DIFF
--- a/master/buildbot/newsfragments/worker-wheel-size-reduction.feature
+++ b/master/buildbot/newsfragments/worker-wheel-size-reduction.feature
@@ -1,0 +1,1 @@
+Reduce buildbot_worker wheel package size by 40% by dropping tests from package.

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -39,6 +39,8 @@ except ImportError:
     from distutils.command.sdist import sdist
     from distutils.core import setup
 
+BUILDING_WHEEL = bool("bdist_wheel" in sys.argv)
+
 
 class our_install_data(install_data):
 
@@ -110,11 +112,12 @@ setup_args = {
         "buildbot_worker.commands",
         "buildbot_worker.scripts",
         "buildbot_worker.monkeypatches",
+    ] + ([] if BUILDING_WHEEL else [  # skip tests for wheels (save 40% of the archive)
         "buildbot_worker.test",
         "buildbot_worker.test.fake",
         "buildbot_worker.test.unit",
         "buildbot_worker.test.util",
-    ],
+    ]),
     # mention data_files, even if empty, so install_data is called and
     # VERSION gets copied
     'data_files': [("buildbot_worker", [])],


### PR DESCRIPTION
…om package.

This change is inspired by master commit 2d351c2270a22302149eecd11265ea2ce3ec6617

## Contributor Checklist:

* [ ] I have updated the unit tests
* [X] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
