### PR TITLE
config: Allow ws_ping_interval in the configuration.

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -714,14 +714,28 @@ class MasterConfig(util.ComparableMixin):
         if 'www' not in config_dict:
             return
         www_cfg = config_dict['www']
-        allowed = {'port', 'debug', 'json_cache_seconds',
-                   'rest_minimum_version', 'allowed_origins', 'jsonp',
-                   'plugins', 'auth', 'authz', 'avatar_methods', 'logfileName',
-                   'logRotateLength', 'maxRotatedFiles', 'versions',
-                   'change_hook_dialects', 'change_hook_auth',
-                   'default_page',
-                   'custom_templates_dir', 'cookie_expiration_time',
-                   'ui_default_config'}
+        allowed = {
+            'allowed_origins',
+            'auth',
+            'authz',
+            'avatar_methods',
+            'change_hook_auth',
+            'change_hook_dialects',
+            'cookie_expiration_time',
+            'custom_templates_dir',
+            'debug',
+            'default_page',
+            'json_cache_seconds',
+            'jsonp',
+            'logRotateLength',
+            'logfileName',
+            'maxRotatedFiles',
+            'plugins',
+            'port',
+            'rest_minimum_version',
+            'ui_default_config',
+            'versions',
+        }
         unknown = set(list(www_cfg)) - allowed
 
         if unknown:

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -735,6 +735,7 @@ class MasterConfig(util.ComparableMixin):
             'rest_minimum_version',
             'ui_default_config',
             'versions',
+            'ws_ping_interval',
         }
         unknown = set(list(www_cfg)) - allowed
 

--- a/master/buildbot/newsfragments/www_ws_ping_interval_config.bugfix
+++ b/master/buildbot/newsfragments/www_ws_ping_interval_config.bugfix
@@ -1,0 +1,1 @@
+Fixed error when attempting to specify ``ws_ping_interval`` configuration option (:issue:`5991`).


### PR DESCRIPTION
Fixes https://github.com/buildbot/buildbot/issues/5991.