### PR TITLE
Add check for double call to Log.finish

### DIFF
--- a/master/buildbot/process/log.py
+++ b/master/buildbot/process/log.py
@@ -33,6 +33,7 @@ class Log:
 
         self.subPoint = util.subscription.SubscriptionPoint("%r log" % (name,))
         self.subscriptions = {}
+        self._finishing = False
         self.finished = False
         self.finishWaiters = []
         self._had_errors = False
@@ -97,7 +98,9 @@ class Log:
 
     @defer.inlineCallbacks
     def finish(self):
+        assert not self._finishing, "Did you maybe forget to yield the method?"
         assert not self.finished
+        self._finishing = True
 
         def fToRun():
             self.finished = True
@@ -119,6 +122,7 @@ class Log:
         d = self.master.data.updates.compressLog(self.logid)
         d.addErrback(
             log.err, "while compressing log %d (ignored)" % self.logid)
+        self._finishing = False
 
 
 class PlainLog(Log):

--- a/master/buildbot/test/unit/process/test_log.py
+++ b/master/buildbot/test/unit/process/test_log.py
@@ -182,6 +182,13 @@ class Tests(TestReactorMixin, unittest.TestCase):
         })
 
     @defer.inlineCallbacks
+    def test_unyielded_finish(self):
+        _log = yield self.makeLog('s')
+        _log.finish()
+        with self.assertRaises(AssertionError):
+            yield _log.finish()
+
+    @defer.inlineCallbacks
     def test_isFinished(self):
         _log = yield self.makeLog('s')
         self.assertFalse(_log.isFinished())


### PR DESCRIPTION
I got the following exception:

```
2021-04-26 22:55:04+0200 [-] when trying to finish a log
	Traceback (most recent call last):
	  File "/usr/lib/python3/dist-packages/twisted/internet/defer.py", line 501, in errback
	    self._startRunCallbacks(fail)
	  File "/usr/lib/python3/dist-packages/twisted/internet/defer.py", line 568, in _startRunCallbacks
	    self._runCallbacks()
	  File "/usr/lib/python3/dist-packages/twisted/internet/defer.py", line 654, in _runCallbacks
	    current.result = callback(current.result, *args, **kw)
	  File "/usr/lib/python3/dist-packages/twisted/internet/defer.py", line 1475, in gotResult
	    _inlineCallbacks(r, g, status)
	--- <exception caught here> ---
	  File "/usr/lib/python3/dist-packages/twisted/internet/defer.py", line 1416, in _inlineCallbacks
	    result = result.throwExceptionIntoGenerator(g)
	  File "/usr/lib/python3/dist-packages/twisted/python/failure.py", line 491, in throwExceptionIntoGenerator
	    return g.throw(self.type, self.value, self.tb)
	  File "/usr/lib/python3/dist-packages/buildbot/process/log.py", line 203, in finish
	    yield super().finish()
	  File "/usr/lib/python3/dist-packages/twisted/internet/defer.py", line 1418, in _inlineCallbacks
	    result = g.send(result)
	  File "/usr/lib/python3/dist-packages/buildbot/process/log.py", line 115, in finish
	    self._had_errors = len(self.subPoint.pop_exceptions()) > 0
	builtins.TypeError: object of type 'NoneType' has no len()
```

while forgetting to yield log.finish() in a step

```
log = yield self.getLog("log")
log.finish()
output = cmd.stdout
```

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
