### PR TITLE
steps: Remove NewStyle build step aliases

### DIFF
--- a/master/buildbot/newsfragments/step-new-style.removal
+++ b/master/buildbot/newsfragments/step-new-style.removal
@@ -1,0 +1,2 @@
+The ``*NewStyle`` build step aliases have been removed.
+Please use equivalent steps without the ``NewStyle`` suffix in the name.

--- a/master/buildbot/steps/http.py
+++ b/master/buildbot/steps/http.py
@@ -15,8 +15,6 @@
 
 from twisted.internet import defer
 from twisted.internet import reactor
-from twisted.python.deprecate import deprecatedModuleAttribute
-from twisted.python.versions import Version
 
 from buildbot import config
 from buildbot.process.buildstep import FAILURE
@@ -180,28 +178,10 @@ class HTTPStep(BuildStep):
         yield content_log.addStdout(response.text)
 
 
-HTTPStepNewStyle = HTTPStep
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use HTTPStep instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.http",
-    name="HTTPStepNewStyle",
-)
-
-
 class POST(HTTPStep):
 
     def __init__(self, url, **kwargs):
         super().__init__(url, method='POST', **kwargs)
-
-
-POSTNewStyle = POST
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use POST instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.http",
-    name="POSTNewStyle",
-)
 
 
 class GET(HTTPStep):
@@ -210,28 +190,10 @@ class GET(HTTPStep):
         super().__init__(url, method='GET', **kwargs)
 
 
-GETNewStyle = GET
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use GET instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.http",
-    name="GETNewStyle",
-)
-
-
 class PUT(HTTPStep):
 
     def __init__(self, url, **kwargs):
         super().__init__(url, method='PUT', **kwargs)
-
-
-PUTNewStyle = PUT
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use PUT instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.http",
-    name="PUTNewStyle",
-)
 
 
 class DELETE(HTTPStep):
@@ -240,40 +202,13 @@ class DELETE(HTTPStep):
         super().__init__(url, method='DELETE', **kwargs)
 
 
-DELETENewStyle = DELETE
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use DELETE instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.http",
-    name="DELETENewStyle",
-)
-
-
 class HEAD(HTTPStep):
 
     def __init__(self, url, **kwargs):
         super().__init__(url, method='HEAD', **kwargs)
 
 
-HEADNewStyle = HEAD
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use HEAD instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.http",
-    name="HEADNewStyle",
-)
-
-
 class OPTIONS(HTTPStep):
 
     def __init__(self, url, **kwargs):
         super().__init__(url, method='OPTIONS', **kwargs)
-
-
-OPTIONSNewStyle = OPTIONS
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use OPTIONS instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.http",
-    name="OPTIONSNewStyle",
-)

--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -22,8 +22,6 @@ from twisted.internet import error
 from twisted.internet import reactor
 from twisted.internet.protocol import ProcessProtocol
 from twisted.python import runtime
-from twisted.python.deprecate import deprecatedModuleAttribute
-from twisted.python.versions import Version
 
 from buildbot.process.buildstep import FAILURE
 from buildbot.process.buildstep import SUCCESS
@@ -177,15 +175,6 @@ class MasterShellCommand(BuildStep):
         except error.ProcessExitedAlready:
             pass
         super().interrupt(reason)
-
-
-MasterShellCommandNewStyle = MasterShellCommand
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use MasterShellCommand instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.master",
-    name="MasterShellCommandNewStyle",
-)
 
 
 class SetProperty(BuildStep):

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -148,15 +148,6 @@ class SetPropertyFromCommand(buildstep.ShellMixin, buildstep.BuildStep):
         return SUCCESS
 
 
-SetPropertyFromCommandNewStyle = SetPropertyFromCommand
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use SetPropertyFromCommand instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.shell",
-    name="SetPropertyFromCommandNewStyle",
-)
-
-
 SetProperty = SetPropertyFromCommand
 deprecatedModuleAttribute(Version("Buildbot", 0, 8, 8),
                           "It has been renamed to SetPropertyFromCommand",
@@ -213,15 +204,6 @@ class ShellCommand(buildstep.ShellMixin, buildstep.BuildStep):
         return cmd.results()
 
 
-ShellCommandNewStyle = ShellCommand
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use ShellCommand instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.shell",
-    name="ShellCommandNewStyle",
-)
-
-
 class Configure(ShellCommand):
     name = "configure"
     haltOnFailure = 1
@@ -229,15 +211,6 @@ class Configure(ShellCommand):
     description = "configuring"
     descriptionDone = "configure"
     command = ["./configure"]
-
-
-ConfigureNewStyle = Configure
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use Configure instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.shell",
-    name="ConfigureNewStyle",
-)
 
 
 class WarningCountingShellCommand(buildstep.ShellMixin, CompositeStepMixin, buildstep.BuildStep):
@@ -483,15 +456,6 @@ class WarningCountingShellCommand(buildstep.ShellMixin, CompositeStepMixin, buil
         return result
 
 
-WarningCountingShellCommandNewStyle = WarningCountingShellCommand
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use WarningCountingShellCommand instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.shell",
-    name="WarningCountingShellCommandNewStyle",
-)
-
-
 class Compile(WarningCountingShellCommand):
 
     name = "compile"
@@ -500,15 +464,6 @@ class Compile(WarningCountingShellCommand):
     description = ["compiling"]
     descriptionDone = ["compile"]
     command = ["make", "all"]
-
-
-CompileNewStyle = Compile
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use Compile instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.shell",
-    name="CompileNewStyle",
-)
 
 
 class Test(WarningCountingShellCommand):
@@ -560,15 +515,6 @@ class Test(WarningCountingShellCommand):
                 return {'step': summary}
 
         return super().getResultSummary()
-
-
-TestNewStyle = Test
-deprecatedModuleAttribute(
-    Version("buildbot", 3, 0, 0),
-    message="Use Test instead. This step will be removed in Buildbot 3.2.",
-    moduleName="buildbot.steps.shell",
-    name="TestNewStyle",
-)
 
 
 class PerlModuleTestObserver(logobserver.LogLineObserver):

--- a/master/setup.py
+++ b/master/setup.py
@@ -270,13 +270,9 @@ setup_args = {
             ('buildbot.steps.cppcheck', ['Cppcheck']),
             ('buildbot.steps.gitdiffinfo', ['GitDiffInfo']),
             ('buildbot.steps.http', [
-                'HTTPStep', 'POST', 'GET', 'PUT', 'DELETE', 'HEAD',
-                'OPTIONS',
-                'HTTPStepNewStyle', 'POSTNewStyle', 'GETNewStyle', 'PUTNewStyle', 'DELETENewStyle',
-                'HEADNewStyle', 'OPTIONSNewStyle']),
+                'HTTPStep', 'POST', 'GET', 'PUT', 'DELETE', 'HEAD', 'OPTIONS']),
             ('buildbot.steps.master', [
-                'MasterShellCommand', 'MasterShellCommandNewStyle',
-                'SetProperty', 'SetProperties', 'LogRenderable', "Assert"]),
+                'MasterShellCommand', 'SetProperty', 'SetProperties', 'LogRenderable', "Assert"]),
             ('buildbot.steps.maxq', ['MaxQ']),
             ('buildbot.steps.mswin', ['Robocopy']),
             ('buildbot.steps.package.deb.lintian', ['DebLintian']),
@@ -292,12 +288,8 @@ setup_args = {
             ('buildbot.steps.python_twisted', [
                 'HLint', 'Trial', 'RemovePYCs']),
             ('buildbot.steps.shell', [
-                'ShellCommand', 'ShellCommandNewStyle', 'TreeSize',
-                'SetPropertyFromCommand', 'SetPropertyFromCommandNewStyle',
-                'Configure', 'ConfigureNewStyle',
-                'WarningCountingShellCommand', 'WarningCountingShellCommandNewStyle',
-                'Compile', 'CompileNewStyle',
-                'Test', 'TestNewStyle', 'PerlModuleTest']),
+                'ShellCommand', 'TreeSize', 'SetPropertyFromCommand', 'Configure',
+                'WarningCountingShellCommand', 'Compile', 'Test', 'PerlModuleTest']),
             ('buildbot.steps.shellsequence', ['ShellSequence']),
             ('buildbot.steps.source.bzr', ['Bzr']),
             ('buildbot.steps.source.cvs', ['CVS']),


### PR DESCRIPTION
This removes the last bits of old-new style migration that was scheduled for v3.2.