### PR TITLE
Implement worker HTTP tunneling

### DIFF
--- a/master/buildbot/newsfragments/worker-http-tunner.feature
+++ b/master/buildbot/newsfragments/worker-http-tunner.feature
@@ -1,0 +1,1 @@
+Implemented support for proxying worker connection through a HTTP proxy.

--- a/master/buildbot/test/__init__.py
+++ b/master/buildbot/test/__init__.py
@@ -114,6 +114,9 @@ warnings.filterwarnings('ignore', r".*unclosed .*socket.*raddr=.*, 8200[^\d]", R
 # Python 3.5-3.8 shows this warning
 warnings.filterwarnings('ignore', ".*the imp module is deprecated in favour of importlib*")
 
+# Python 3.3-3.7 show this warning and in invoked from autobahn
+warnings.filterwarnings('ignore', ".*time.clock has been deprecated in Python 3.3.*")
+
 # sqlalchemy-migrate uses deprecated api from sqlalchemy https://review.openstack.org/#/c/648072/
 warnings.filterwarnings('ignore', ".*Engine.contextual_connect.*", DeprecationWarning)
 

--- a/master/buildbot/test/integration/test_try_client_e2e.py
+++ b/master/buildbot/test/integration/test_try_client_e2e.py
@@ -31,8 +31,10 @@ class TryClientE2E(RunMasterBase):
         yield self.setupConfig(masterConfig())
 
         def trigger_callback():
+            port = self.master.pbmanager.dispatchers['tcp:0'].port.getHost().port
+
             def thd():
-                os.system("buildbot try --connect=pb --master=127.0.0.1:8030 -b testy "
+                os.system(f"buildbot try --connect=pb --master=127.0.0.1:{port} -b testy "
                           "--property=foo:bar --username=alice --passwd=pw1 --vc=none")
             reactor.callInThread(thd)
 
@@ -51,7 +53,7 @@ def masterConfig():
     c['schedulers'] = [
         schedulers.Try_Userpass(name="try",
                                 builderNames=["testy"],
-                                port=8030,
+                                port='tcp:0',
                                 userpass=[("alice", "pw1")])
     ]
     f = BuildFactory()

--- a/master/buildbot/test/integration/test_worker_proxy.py
+++ b/master/buildbot/test/integration/test_worker_proxy.py
@@ -88,7 +88,14 @@ def run_proxy(queue):
     write_to_log("run_proxy\n")
 
     try:
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # We can get RuntimeError due to current thread being not main thread on Python 3.8.
+            # It's not clear why that happens, so work around it.
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
         coro = asyncio.start_server(handle_client, host="127.0.0.1")
         server = loop.run_until_complete(coro)
 

--- a/master/buildbot/test/integration/test_worker_proxy.py
+++ b/master/buildbot/test/integration/test_worker_proxy.py
@@ -23,13 +23,13 @@ from twisted.internet import defer
 
 from buildbot.test.util.integration import RunMasterBase
 
-from .interop.test_commandmixin import CommandMixinMasterPB
-from .interop.test_compositestepmixin import CompositeStepMixinMasterPb
-from .interop.test_integration_secrets import SecretsConfigPB
-from .interop.test_interruptcommand import InterruptCommandPb
-from .interop.test_setpropertyfromcommand import SetPropertyFromCommandPB
-from .interop.test_transfer import TransferStepsMasterPb
-from .interop.test_worker_reconnect import WorkerReconnect
+from .interop import test_commandmixin
+from .interop import test_compositestepmixin
+from .interop import test_integration_secrets
+from .interop import test_interruptcommand
+from .interop import test_setpropertyfromcommand
+from .interop import test_transfer
+from .interop import test_worker_reconnect
 
 # This integration test puts HTTP proxy in between the master and worker.
 
@@ -155,29 +155,31 @@ class RunMasterBehindProxy(RunMasterBase):
 
 # Use interoperability test cases to test the HTTP proxy tunneling.
 
-class ProxyCommandMixinMasterPB(RunMasterBehindProxy, CommandMixinMasterPB):
+class ProxyCommandMixinMasterPB(RunMasterBehindProxy, test_commandmixin.CommandMixinMasterPB):
     pass
 
 
-class ProxyCompositeStepMixinMasterPb(RunMasterBehindProxy, CompositeStepMixinMasterPb):
+class ProxyCompositeStepMixinMasterPb(RunMasterBehindProxy,
+                                      test_compositestepmixin.CompositeStepMixinMasterPb):
     pass
 
 
-class ProxyInterruptCommandPb(RunMasterBehindProxy, InterruptCommandPb):
+class ProxyInterruptCommandPb(RunMasterBehindProxy, test_interruptcommand.InterruptCommandPb):
     pass
 
 
-class ProxySecretsConfigPB(RunMasterBehindProxy, SecretsConfigPB):
+class ProxySecretsConfigPB(RunMasterBehindProxy, test_integration_secrets.SecretsConfigPB):
     pass
 
 
-class ProxySetPropertyFromCommandPB(RunMasterBehindProxy, SetPropertyFromCommandPB):
+class ProxySetPropertyFromCommandPB(RunMasterBehindProxy,
+                                    test_setpropertyfromcommand.SetPropertyFromCommandPB):
     pass
 
 
-class ProxyTransferStepsMasterPb(RunMasterBehindProxy, TransferStepsMasterPb):
+class ProxyTransferStepsMasterPb(RunMasterBehindProxy, test_transfer.TransferStepsMasterPb):
     pass
 
 
-class ProxyWorkerReconnect(RunMasterBehindProxy, WorkerReconnect):
+class ProxyWorkerReconnect(RunMasterBehindProxy, test_worker_reconnect.WorkerReconnect):
     pass

--- a/master/buildbot/test/integration/test_worker_proxy.py
+++ b/master/buildbot/test/integration/test_worker_proxy.py
@@ -1,0 +1,173 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import asyncio
+import multiprocessing
+import signal
+import socket
+
+from twisted.internet import defer
+
+from buildbot.test.util.integration import RunMasterBase
+
+from .interop.test_commandmixin import CommandMixinMasterPB
+from .interop.test_compositestepmixin import CompositeStepMixinMasterPb
+from .interop.test_integration_secrets import SecretsConfigPB
+from .interop.test_interruptcommand import InterruptCommandPb
+from .interop.test_setpropertyfromcommand import SetPropertyFromCommandPB
+from .interop.test_transfer import TransferStepsMasterPb
+from .interop.test_worker_reconnect import WorkerReconnect
+
+# This integration test puts HTTP proxy in between the master and worker.
+
+import os
+CURRENT = os.path.dirname(os.path.abspath(__file__))
+
+
+async def handle_client(local_reader, local_writer):
+
+    async def pipe(reader, writer):
+        try:
+            while not reader.at_eof():
+                writer.write(await reader.read(2048))
+        except ConnectionResetError:
+            pass
+        finally:
+            writer.close()
+
+    try:
+        request = await local_reader.read(2048)
+        lines = request.split(b"\r\n")
+        if not lines[0].startswith(b"CONNECT "):
+            with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
+                outfile.write(f"bad request {request.decode()}\n")
+            local_writer.write(b"HTTP/1.1 407 Only CONNECT allowed\r\n\r\n")
+            return
+        host, port = lines[0].split(b" ")[1].split(b":")
+        try:
+            remote_reader, remote_writer = await asyncio.open_connection(
+                host.decode(), int(port)
+            )
+        except socket.gaierror:
+            with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
+                outfile.write(f"failed to relay to {host} {port}\n")
+            local_writer.write(b"HTTP/1.1 404 Not Found\r\n\r\n")
+            return
+
+        with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
+            outfile.write(f"relaying to {host} {port}\n")
+        local_writer.write(b"HTTP/1.1 200 Connection established\r\n\r\n")
+        pipe1 = pipe(local_reader, remote_writer)
+        pipe2 = pipe(remote_reader, local_writer)
+        await asyncio.gather(pipe1, pipe2)
+
+    finally:
+        local_writer.close()
+
+
+def run_proxy():
+    with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
+        outfile.write("run_proxy\n")
+
+    try:
+        loop = asyncio.get_event_loop()
+        coro = asyncio.start_server(handle_client, "127.0.0.1", 10080)
+        server = loop.run_until_complete(coro)
+
+        def signal_handler(sig, trace):
+            raise KeyboardInterrupt
+
+        signal.signal(signal.SIGTERM, signal_handler)
+
+        with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
+            outfile.write("Serving on {}\n".format(server.sockets[0].getsockname()))
+        try:
+            with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
+                outfile.write("Running forever\n")
+            loop.run_forever()
+        except KeyboardInterrupt:
+            with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
+                outfile.write("End\n")
+            pass
+
+        server.close()
+        loop.run_until_complete(server.wait_closed())
+        loop.close()
+
+    except BaseException as e:
+        with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
+            outfile.write(f"Exception Raised: {str(e)}\n")
+            import traceback
+            traceback.print_exc(file=outfile)
+
+
+class RunMasterBehindProxy(RunMasterBase):
+    # we need slightly longer timeout for proxy related tests
+    timeout = 30
+
+    def setUp(self):
+        with open(os.path.join(CURRENT, "stdout.txt"), "w") as outfile:
+            outfile.write("setUp\n")
+        self.proxy_process = multiprocessing.Process(target=run_proxy)
+        self.proxy_process.start()
+        with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
+            outfile.write(f"X {self.proxy_process.exitcode}\n")
+            outfile.write(f"Y {self.proxy_process.is_alive()}\n")
+
+    def tearDown(self):
+        with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
+            outfile.write("tearDown\n")
+        self.proxy_process.terminate()
+        self.proxy_process.join()
+        print("---- stdout ----")
+        with open(os.path.join(CURRENT, "stdout.txt")) as file:
+            print(file.read())
+        print("---- ------ ----")
+
+    @defer.inlineCallbacks
+    def setupConfig(self, config_dict, startWorker=True):
+        proxy_connection_string = "tcp:127.0.0.1:10080"
+        yield RunMasterBase.setupConfig(self, config_dict, startWorker,
+                                        proxy_connection_string=proxy_connection_string)
+
+
+# Use interoperability test cases to test the HTTP proxy tunneling.
+
+class ProxyCommandMixinMasterPB(RunMasterBehindProxy, CommandMixinMasterPB):
+    pass
+
+
+class ProxyCompositeStepMixinMasterPb(RunMasterBehindProxy, CompositeStepMixinMasterPb):
+    pass
+
+
+class ProxyInterruptCommandPb(RunMasterBehindProxy, InterruptCommandPb):
+    pass
+
+
+class ProxySecretsConfigPB(RunMasterBehindProxy, SecretsConfigPB):
+    pass
+
+
+class ProxySetPropertyFromCommandPB(RunMasterBehindProxy, SetPropertyFromCommandPB):
+    pass
+
+
+class ProxyTransferStepsMasterPb(RunMasterBehindProxy, TransferStepsMasterPb):
+    pass
+
+
+class ProxyWorkerReconnect(RunMasterBehindProxy, WorkerReconnect):
+    pass

--- a/master/buildbot/test/integration/test_worker_proxy.py
+++ b/master/buildbot/test/integration/test_worker_proxy.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import multiprocessing
+import os
 import signal
 import socket
 
@@ -32,8 +33,17 @@ from .interop.test_worker_reconnect import WorkerReconnect
 
 # This integration test puts HTTP proxy in between the master and worker.
 
-import os
-CURRENT = os.path.dirname(os.path.abspath(__file__))
+
+def get_log_path():
+    return f'test_worker_proxy_stdout_{os.getpid()}.txt'
+
+
+def write_to_log(msg, with_traceback=False):
+    with open(get_log_path(), 'a') as outfile:
+        outfile.write(msg)
+        if with_traceback:
+            import traceback
+            traceback.print_exc(file=outfile)
 
 
 async def handle_client(local_reader, local_writer):
@@ -51,8 +61,7 @@ async def handle_client(local_reader, local_writer):
         request = await local_reader.read(2048)
         lines = request.split(b"\r\n")
         if not lines[0].startswith(b"CONNECT "):
-            with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
-                outfile.write(f"bad request {request.decode()}\n")
+            write_to_log(f"bad request {request.decode()}\n")
             local_writer.write(b"HTTP/1.1 407 Only CONNECT allowed\r\n\r\n")
             return
         host, port = lines[0].split(b" ")[1].split(b":")
@@ -61,13 +70,11 @@ async def handle_client(local_reader, local_writer):
                 host.decode(), int(port)
             )
         except socket.gaierror:
-            with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
-                outfile.write(f"failed to relay to {host} {port}\n")
+            write_to_log(f"failed to relay to {host} {port}\n")
             local_writer.write(b"HTTP/1.1 404 Not Found\r\n\r\n")
             return
 
-        with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
-            outfile.write(f"relaying to {host} {port}\n")
+        write_to_log(f"relaying to {host} {port}\n")
         local_writer.write(b"HTTP/1.1 200 Connection established\r\n\r\n")
         pipe1 = pipe(local_reader, remote_writer)
         pipe2 = pipe(remote_reader, local_writer)
@@ -78,8 +85,7 @@ async def handle_client(local_reader, local_writer):
 
 
 def run_proxy():
-    with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
-        outfile.write("run_proxy\n")
+    write_to_log("run_proxy\n")
 
     try:
         loop = asyncio.get_event_loop()
@@ -91,50 +97,43 @@ def run_proxy():
 
         signal.signal(signal.SIGTERM, signal_handler)
 
-        with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
-            outfile.write("Serving on {}\n".format(server.sockets[0].getsockname()))
+        write_to_log("Serving on {}\n".format(server.sockets[0].getsockname()))
         try:
-            with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
-                outfile.write("Running forever\n")
+            write_to_log("Running forever\n")
             loop.run_forever()
         except KeyboardInterrupt:
-            with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
-                outfile.write("End\n")
-            pass
+            write_to_log("End\n")
 
         server.close()
         loop.run_until_complete(server.wait_closed())
         loop.close()
 
     except BaseException as e:
-        with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
-            outfile.write(f"Exception Raised: {str(e)}\n")
-            import traceback
-            traceback.print_exc(file=outfile)
+        write_to_log(f"Exception Raised: {str(e)}\n", with_traceback=True)
 
 
 class RunMasterBehindProxy(RunMasterBase):
     # we need slightly longer timeout for proxy related tests
     timeout = 30
+    debug = False
 
     def setUp(self):
-        with open(os.path.join(CURRENT, "stdout.txt"), "w") as outfile:
-            outfile.write("setUp\n")
+        write_to_log("setUp\n")
         self.proxy_process = multiprocessing.Process(target=run_proxy)
         self.proxy_process.start()
-        with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
-            outfile.write(f"X {self.proxy_process.exitcode}\n")
-            outfile.write(f"Y {self.proxy_process.is_alive()}\n")
+        self.target_port = self.queue.get()
+        write_to_log(f"got target_port {self.target_port}\n")
 
     def tearDown(self):
-        with open(os.path.join(CURRENT, "stdout.txt"), "a") as outfile:
-            outfile.write("tearDown\n")
+        write_to_log("tearDown\n")
         self.proxy_process.terminate()
         self.proxy_process.join()
-        print("---- stdout ----")
-        with open(os.path.join(CURRENT, "stdout.txt")) as file:
-            print(file.read())
-        print("---- ------ ----")
+        if self.debug:
+            print("---- stdout ----")
+            with open(get_log_path()) as file:
+                print(file.read())
+            print("---- ------ ----")
+            os.unlink(get_log_path())
 
     @defer.inlineCallbacks
     def setupConfig(self, config_dict, startWorker=True):

--- a/master/buildbot/test/util/integration.py
+++ b/master/buildbot/test/util/integration.py
@@ -184,7 +184,7 @@ class RunMasterBase(unittest.TestCase):
         skip = "buildbot-worker package is not installed"
 
     @defer.inlineCallbacks
-    def setupConfig(self, config_dict, startWorker=True):
+    def setupConfig(self, config_dict, startWorker=True, **worker_kwargs):
         """
         Setup and start a master configured
         by the function configFunc defined in the test module.
@@ -229,11 +229,11 @@ class RunMasterBase(unittest.TestCase):
             if sandboxed_worker_path is None:
                 self.w = Worker(
                     "127.0.0.1", workerPort, "local1", "localpw", worker_dir.path,
-                    False)
+                    False, **worker_kwargs)
             else:
                 self.w = SandboxedWorker(
                     "127.0.0.1", workerPort, "local1", "localpw", worker_dir.path,
-                    sandboxed_worker_path)
+                    sandboxed_worker_path, **worker_kwargs)
                 self.addCleanup(self.w.shutdownWorker)
 
         elif self.proto == 'null':

--- a/master/docs/manual/installation/worker.rst
+++ b/master/docs/manual/installation/worker.rst
@@ -178,6 +178,11 @@ To use these, just include them on the ``buildbot-worker create-worker`` command
     If set, unexpected directories in worker base directory will be removed.
     Otherwise, a warning will be displayed in :file:`twistd.log` so that you can manually remove them.
 
+.. option:: --proxy-connection-string
+
+    Can also be passed directly to the Worker constructor in :file:`buildbot.tac`.
+    If set, the worker connection will be tunneled through a HTTP proxy specified by the option value.
+
 .. _Other-Worker-Configuration:
 
 Other Worker Configuration

--- a/worker/buildbot_worker/scripts/create_worker.py
+++ b/worker/buildbot_worker/scripts/create_worker.py
@@ -60,12 +60,14 @@ allow_shutdown = %(allow-shutdown)s
 maxretries = %(maxretries)s
 use_tls = %(use-tls)s
 delete_leftover_dirs = %(delete-leftover-dirs)s
+proxy_connection_string = %(proxy-connection-string)s
 
 s = Worker(buildmaster_host, port, workername, passwd, basedir,
            keepalive, umask=umask, maxdelay=maxdelay,
            numcpus=numcpus, allow_shutdown=allow_shutdown,
            maxRetries=maxretries, useTls=use_tls,
-           delete_leftover_dirs=delete_leftover_dirs)
+           delete_leftover_dirs=delete_leftover_dirs,
+           proxy_connection_string=proxy_connection_string)
 s.setServiceParent(application)
 """]
 

--- a/worker/buildbot_worker/scripts/runner.py
+++ b/worker/buildbot_worker/scripts/runner.py
@@ -130,7 +130,9 @@ class CreateWorkerOptions(MakerBase):
          "(None for unlimited)"],
         ["allow-shutdown", "a", None,
          "Allows the worker to initiate a graceful shutdown. One of "
-         "'signal' or 'file'"]
+         "'signal' or 'file'"],
+        ["proxy-connection-string", None, None,
+         "Address of HTTP proxy to tunnel through"]
     ]
 
     longdesc = textwrap.dedent("""

--- a/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
+++ b/worker/buildbot_worker/test/unit/test_scripts_create_worker.py
@@ -491,6 +491,7 @@ class TestCreateWorker(misc.StdoutAssertionsMixin, unittest.TestCase):
         "maxdelay": 2,
         "numcpus": None,
         "maxretries": None,
+        "proxy-connection-string": None,
 
         # arguments
         "host": "masterhost",
@@ -625,6 +626,7 @@ class TestCreateWorker(misc.StdoutAssertionsMixin, unittest.TestCase):
             maxRetries=options["maxretries"],
             useTls=options["use-tls"],
             delete_leftover_dirs=options["delete-leftover-dirs"],
+            proxy_connection_string=options["proxy-connection-string"],
             )
 
         # check that Worker instance attached to application

--- a/worker/buildbot_worker/tunnel.py
+++ b/worker/buildbot_worker/tunnel.py
@@ -1,0 +1,133 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+#
+# Parts of this code were copied from Twisted Python.
+# Copyright (c) Twisted Matrix Laboratories.
+#
+
+from twisted.internet import defer
+from twisted.internet import interfaces
+from twisted.internet import protocol
+from zope.interface import implementer
+
+
+class HTTPTunnelClient(protocol.Protocol):
+    """
+    This protocol handles the HTTP communication with the proxy server
+    and subsequent creation of the tunnel.
+
+    Once the tunnel is established, all incoming communication is forwarded
+    directly to the wrapped protocol.
+    """
+
+    def __init__(self, connectedDeferred):
+        # this gets set once the tunnel is ready
+        self._proxyWrappedProtocol = None
+        self._connectedDeferred = connectedDeferred
+
+    def connectionMade(self):
+        request = "CONNECT {}:{} HTTP/1.1\r\n\r\n".format(
+            self.factory.host, self.factory.port)
+        self.transport.write(request.encode())
+
+    def connectionLost(self, reason):
+        if self._proxyWrappedProtocol:
+            # Proxy connectionLost to the wrapped protocol
+            self._proxyWrappedProtocol.connectionLost(reason)
+
+    def dataReceived(self, data):
+        if self._proxyWrappedProtocol is not None:
+            # If tunnel is already established, proxy dataReceived()
+            # calls to the wrapped protocol
+            return self._proxyWrappedProtocol.dataReceived(data)
+
+        # process data from the proxy server
+        _, status, _ = data.split(b"\r\n")[0].split(b" ", 2)
+        if status != b"200":
+            return self.transport.loseConnection()
+
+        self._proxyWrappedProtocol = (
+            self.factory._proxyWrappedFactory.buildProtocol(
+                self.transport.getPeer()))
+        self._proxyWrappedProtocol.makeConnection(self.transport)
+        self._connectedDeferred.callback(self._proxyWrappedProtocol)
+
+        # forward all traffic directly to the wrapped protocol
+        self.transport.protocol = self._proxyWrappedProtocol
+
+        # In case the server sent some data together with its response,
+        # forward those to the wrapped protocol.
+        remaining_data = data.split(b"\r\n\r\n", 2)[1]
+        if remaining_data:
+            return self._proxyWrappedProtocol.dataReceived(remaining_data)
+
+        return None
+
+
+class HTTPTunnelFactory(protocol.ClientFactory):
+    """The protocol factory for the HTTP tunnel.
+
+    It is used as a wrapper for BotFactory, which can hence be shielded
+    from all the proxy business.
+    """
+    protocol = HTTPTunnelClient
+
+    def __init__(self, host, port, wrappedFactory):
+        self.host = host
+        self.port = port
+
+        self._proxyWrappedFactory = wrappedFactory
+        self._onConnection = defer.Deferred()
+
+    def doStart(self):
+        super().doStart()
+        # forward start notifications through to the wrapped factory.
+        self._proxyWrappedFactory.doStart()
+
+    def doStop(self):
+        # forward stop notifications through to the wrapped factory.
+        self._proxyWrappedFactory.doStop()
+        super().doStop()
+
+    def buildProtocol(self, addr):
+        proto = self.protocol(self._onConnection)
+        proto.factory = self
+        return proto
+
+    def clientConnectionFailed(self, connector, reason):
+        if not self._onConnection.called:
+            self._onConnection.errback(reason)
+
+
+@implementer(interfaces.IStreamClientEndpoint)
+class HTTPTunnelEndpoint(object):
+    """This handles the connection to buildbot master on given 'host'
+    and 'port' through the proxy server given as 'proxyEndpoint'.
+    """
+
+    def __init__(self, host, port, proxyEndpoint):
+        self.host = host
+        self.port = port
+        self.proxyEndpoint = proxyEndpoint
+
+    def connect(self, protocolFactory):
+        """Connect to remote server through an HTTP tunnel."""
+        tunnel = HTTPTunnelFactory(self.host, self.port, protocolFactory)
+        d = self.proxyEndpoint.connect(tunnel)
+        # once tunnel connection is established,
+        # defer the subsequent server connection
+        d.addCallback(lambda result: tunnel._onConnection)
+        return d


### PR DESCRIPTION
We recently needed our worker to connect through an HTTP proxy, and thus I wrote the following patch that implements that. Since I don't know twisted much, I based it largely on twisteds' own `_WrappingFactory` and `_WrappingProtocol`.

I am not expecting it to be accepted in the current state; I am making this PR to find out whether you are interested in such functionality. If so, I can improve it such that it follows all the guidelines and your suggestions.

## Contributor Checklist:

* [ ] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
