### PR TITLE
Read and store patches as binary instead of unicode.

### DIFF
--- a/master/buildbot/clients/tryclient.py
+++ b/master/buildbot/clients/tryclient.py
@@ -578,7 +578,7 @@ class Try(pb.Referenceable):
             if difffile == "-":
                 diff = sys.stdin.read()
             else:
-                with open(difffile, "r") as f:
+                with open(difffile, "rb") as f:
                     diff = f.read()
             if not diff:
                 diff = None

--- a/master/buildbot/newsfragments/buildbot_try_support_non_unicode.bugfix
+++ b/master/buildbot/newsfragments/buildbot_try_support_non_unicode.bugfix
@@ -1,0 +1,1 @@
+Fix buildbot try fails for files containing non utf-8 character (:issue:`5933`)

--- a/master/buildbot/schedulers/trysched.py
+++ b/master/buildbot/schedulers/trysched.py
@@ -393,7 +393,7 @@ class Try_Userpass_Perspective(pbutil.NewCredPerspective):
 
         branch = bytes2unicode(branch)
         revision = bytes2unicode(revision)
-        patch = patch[0], bytes2unicode(patch[1])
+        patch = patch[0], patch[1]
         repository = bytes2unicode(repository)
         project = bytes2unicode(project)
         who = bytes2unicode(who)


### PR DESCRIPTION
Read and store patches as binary instead of unicode.

Fix  'buildbot try fails for files containing non utf-8 characters #5933'