### PR TITLE
Add option to set docker container's hostname

### DIFF
--- a/master/buildbot/newsfragments/docker-hostname.feature
+++ b/master/buildbot/newsfragments/docker-hostname.feature
@@ -1,0 +1,1 @@
+Implemented support for setting docker container's hostname

--- a/master/buildbot/test/unit/worker/test_docker.py
+++ b/master/buildbot/test/unit/worker/test_docker.py
@@ -390,6 +390,13 @@ class TestDockerLatentWorker(unittest.TestCase, TestReactorMixin):
         id, name = yield bs.start_instance(self.build)
         self.assertEqual(name, 'busybox:latest')
 
+    @defer.inlineCallbacks
+    def test_constructor_hostname(self):
+        bs = yield self.setupWorker(
+            'bot', 'pass', 'http://localhost:2375',
+            image="myworker_image", hostname="myworker_hostname")
+        self.assertEqual(bs.hostname, 'myworker_hostname')
+
 
 class testDockerPyStreamLogs(unittest.TestCase):
 

--- a/master/docs/manual/configuration/workers-docker.rst
+++ b/master/docs/manual/configuration/workers-docker.rst
@@ -249,6 +249,10 @@ In addition to the arguments available for any :ref:`Latent-Workers`, :class:`Do
 	(optional if ``custom_context`` is True)
 	Dictionary, passes information for the docker to build its environment. Eg. {'DISTRO':'ubuntu', 'RELEASE':'11.11'}. Defaults to None.
 
+``hostname``
+        (optional)
+        This will set container's hostname.
+
 Setting up Volumes
 ..................
 


### PR DESCRIPTION
This change allows you to set the hostname of the docker container.
We needed this option and maybe it helps others as well.

## Contributor Checklist:

* [x] I have updated the unit tests
* [ ] I have created a file in the `master/buildbot/newsfragments` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
